### PR TITLE
feat(search): add versioned GET /v1/search unified search endpoint

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11464,26 +11464,27 @@ async def admin_search_a2a_agents(
     return _build_search_response(entity_key="agents", entity_type="agents", items=agents, query=search_query, tags=normalized_tags, tag_groups=tag_groups)
 
 
-@admin_router.get("/search", response_class=JSONResponse)
-@require_permission("admin.dashboard", allow_admin_bypass=False)
-async def admin_unified_search(
-    q: str = Query("", max_length=500, description="Search query"),
-    tags: QueryTagsFilter = None,
-    entity_types: QueryEntityTypes = None,
-    include_inactive: bool = False,
-    limit: int = Query(8, ge=1, le=settings.pagination_max_page_size, description="Per-entity result limit"),
-    limit_per_type: Optional[int] = Query(
-        None,
-        ge=1,
-        le=settings.pagination_max_page_size,
-        description="Optional alias for per-entity result limit",
-    ),
-    gateway_id: QueryGatewayIdList = None,
-    team_id: Optional[str] = Depends(_validated_team_id_param),
-    db: Session = Depends(get_db),
-    user=Depends(get_current_user_with_permissions),
-):
-    """Unified search across primary admin entities.
+async def perform_unified_search(
+    *,
+    q: str,
+    tags: Optional[str],
+    entity_types: Optional[str],
+    include_inactive: bool,
+    limit: int,
+    limit_per_type: Optional[int],
+    gateway_id: Optional[str],
+    team_id: Optional[str],
+    db: Session,
+    user: Any,
+) -> dict[str, Any]:
+    """Unified search across primary entities (shared, permission-agnostic core).
+
+    This is the single source of truth for unified search behavior. It performs
+    NO top-level permission check of its own — callers are responsible for the
+    outer gate (``admin.dashboard`` for the admin route, authentication-only for
+    the versioned ``/v1/search`` route). Per-entity RBAC and token scoping are
+    still enforced inside each ``admin_search_*`` call, so visibility is correct
+    regardless of the outer gate.
 
     Searches servers, gateways, tools, resources, prompts, agents, teams, roots,
     and optionally users (when the caller has ``admin.user_management`` permission).
@@ -11737,6 +11738,62 @@ async def admin_unified_search(
         "items": flat_items,
         "count": len(flat_items),
     }
+
+
+@admin_router.get("/search", response_class=JSONResponse)
+@require_permission("admin.dashboard", allow_admin_bypass=False)
+async def admin_unified_search(
+    q: str = Query("", max_length=500, description="Search query"),
+    tags: QueryTagsFilter = None,
+    entity_types: QueryEntityTypes = None,
+    include_inactive: bool = False,
+    limit: int = Query(8, ge=1, le=settings.pagination_max_page_size, description="Per-entity result limit"),
+    limit_per_type: Optional[int] = Query(
+        None,
+        ge=1,
+        le=settings.pagination_max_page_size,
+        description="Optional alias for per-entity result limit",
+    ),
+    gateway_id: QueryGatewayIdList = None,
+    team_id: Optional[str] = Depends(_validated_team_id_param),
+    db: Session = Depends(get_db),
+    user=Depends(get_current_user_with_permissions),
+):
+    """Unified search across primary admin entities (admin-gated wrapper).
+
+    Thin wrapper that enforces the ``admin.dashboard`` permission and delegates
+    to :func:`perform_unified_search`. The versioned ``GET /v1/search`` route
+    reuses the same helper without the admin-panel permission gate.
+
+    Args:
+        q (str): Free-text search query.
+        tags (Optional[str]): Tag filter expression (comma=OR, plus=AND).
+        entity_types (Optional[str]): Optional comma-separated entity type list.
+            Supported values: servers, gateways, tools, resources, prompts,
+            agents, teams, users, roots.
+        include_inactive (bool): Whether to include inactive entities.
+        limit (int): Default per-entity limit for returned items.
+        limit_per_type (Optional[int]): Optional alias overriding ``limit``.
+        gateway_id (Optional[str]): Gateway filter for tools/resources/prompts.
+        team_id (Optional[str]): Team scope filter.
+        db (Session): Database session.
+        user: Authenticated user context.
+
+    Returns:
+        dict[str, Any]: Grouped and flattened search results with metadata.
+    """
+    return await perform_unified_search(
+        q=q,
+        tags=tags,
+        entity_types=entity_types,
+        include_inactive=include_inactive,
+        limit=limit,
+        limit_per_type=limit_per_type,
+        gateway_id=gateway_id,
+        team_id=team_id,
+        db=db,
+        user=user,
+    )
 
 
 @admin_router.get("/tools/{tool_id}", response_model=ToolRead)

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11479,12 +11479,10 @@ async def perform_unified_search(
 ) -> dict[str, Any]:
     """Unified search across primary entities (shared, permission-agnostic core).
 
-    This is the single source of truth for unified search behavior. It performs
-    NO top-level permission check of its own — callers are responsible for the
-    outer gate (``admin.dashboard`` for the admin route, authentication-only for
-    the versioned ``/v1/search`` route). Per-entity RBAC and token scoping are
-    still enforced inside each ``admin_search_*`` call, so visibility is correct
-    regardless of the outer gate.
+    Single source of truth for unified search. Performs no top-level permission
+    check — callers own the outer gate (``admin.dashboard`` for the admin route,
+    auth-only for ``/v1/search``). Per-entity RBAC and token scoping are still
+    enforced inside each ``admin_search_*`` call.
 
     Searches servers, gateways, tools, resources, prompts, agents, teams, roots,
     and optionally users (when the caller has ``admin.user_management`` permission).
@@ -11762,8 +11760,7 @@ async def admin_unified_search(
     """Unified search across primary admin entities (admin-gated wrapper).
 
     Thin wrapper that enforces the ``admin.dashboard`` permission and delegates
-    to :func:`perform_unified_search`. The versioned ``GET /v1/search`` route
-    reuses the same helper without the admin-panel permission gate.
+    to :func:`perform_unified_search`.
 
     Args:
         q (str): Free-text search query.

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -5591,9 +5591,17 @@ async def admin_search_teams(
         # Non-admin search
         # Reuse user team fetching
         all_teams = await team_service.get_user_teams(user_email, include_personal=True)
+        # Narrow to the caller's normalized token scope (Layer 1). get_user_teams
+        # returns every membership and ignores token scope, so a token narrowed to
+        # a team subset would otherwise leak sibling teams the caller belongs to but
+        # is scoped out of. _get_user_team_ids honors token_teams/_cached_team_ids;
+        # the caller's own personal team stays visible (owner is always visible).
+        scoped_team_ids = set(await _get_user_team_ids(user, db))
         # Filter in memory
         filtered = []
         for t in all_teams:
+            if not getattr(t, "is_personal", False) and t.id not in scoped_team_ids:
+                continue
             if not include_inactive and not t.is_active:
                 continue
             if visibility and t.visibility != visibility:

--- a/mcpgateway/api/v1/__init__.py
+++ b/mcpgateway/api/v1/__init__.py
@@ -99,6 +99,16 @@ def _assemble_routers(  # noqa: C901 — deliberate single-function assembly, co
     target_router.include_router(version_router)
     logger.info("Version router included")
 
+    # Unified search endpoint — versioned, non-admin (/v1/search). Reuses the
+    # admin unified-search core (perform_unified_search) without the admin.dashboard
+    # gate, so client-facing global search does not depend on the admin dashboard
+    # route. Always present; per-entity RBAC and token scoping still apply.
+    # First-Party
+    from mcpgateway.routers.search import router as search_router  # pylint: disable=import-outside-toplevel
+
+    target_router.include_router(search_router)
+    logger.info("Unified search router included (/search)")
+
     # -------------------------------------------------------------------------
     # Group B — always-tried optional router (tool plugin bindings)
     # -------------------------------------------------------------------------

--- a/mcpgateway/api/v1/__init__.py
+++ b/mcpgateway/api/v1/__init__.py
@@ -99,10 +99,8 @@ def _assemble_routers(  # noqa: C901 — deliberate single-function assembly, co
     target_router.include_router(version_router)
     logger.info("Version router included")
 
-    # Unified search endpoint — versioned, non-admin (/v1/search). Reuses the
-    # admin unified-search core (perform_unified_search) without the admin.dashboard
-    # gate, so client-facing global search does not depend on the admin dashboard
-    # route. Always present; per-entity RBAC and token scoping still apply.
+    # Unified search (/v1/search) — always-on, non-admin route; no admin.dashboard
+    # gate, so client-facing global search does not depend on the admin dashboard.
     # First-Party
     from mcpgateway.routers.search import router as search_router  # pylint: disable=import-outside-toplevel
 

--- a/mcpgateway/middleware/deprecation.py
+++ b/mcpgateway/middleware/deprecation.py
@@ -70,6 +70,7 @@ _LEGACY_PREFIXES: frozenset[str] = frozenset(
         "/tags",
         "/export",
         "/import",
+        "/search",  # unified search router (always mounted)
         # Feature-flagged routers (conditionally mounted)
         "/a2a",  # MCPGATEWAY_A2A_ENABLED
         "/observability",  # OBSERVABILITY_ENABLED

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -747,6 +747,15 @@ class TokenScopingMiddleware:
         if not permissions or "*" in permissions:
             return True  # No restrictions or full access
 
+        # Unified search (/v1/search, normalized to /search) is authenticated-only
+        # at this layer: it spans many entity types, each guarded by its own
+        # @require_permission, and per-entity denials are suppressed downstream by
+        # _safe_entity_search. Requiring a single permission here would wrongly 403
+        # a validly-scoped token (e.g. tools.read-only), so let it through and rely
+        # on the handler's per-entity RBAC + token/team scoping to filter results.
+        if request_path == "/search" or request_path.startswith("/search/"):
+            return True
+
         # Handle admin routes with granular route-group mapping.
         # Unmapped /admin/* paths are denied by default (fail-secure).
         if request_path.startswith("/admin"):

--- a/mcpgateway/routers/search.py
+++ b/mcpgateway/routers/search.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/routers/search.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Mihai Criveti
+
+Unified Search API Router.
+
+Exposes the unified cross-entity search capability at a stable, versioned,
+non-admin path (``GET /v1/search``). Historically this capability was only
+reachable through ``GET /admin/search``, which is gated on the ``admin.dashboard``
+permission and lives under the admin dashboard router. Client-facing callers
+(e.g. the React global search) should not depend on an admin-panel route that
+may be deprecated, so this router re-exposes the same behavior and response
+shape without the admin-panel gate.
+
+Security model:
+    This route requires only authentication at the top level. It does NOT add
+    an ``admin.dashboard`` gate. Real authorization is enforced per-entity
+    inside :func:`mcpgateway.admin.perform_unified_search`: each entity search
+    carries its own RBAC permission (``tools.read``, ``gateways.read``,
+    ``admin.user_management`` for users, etc.) and token scoping continues to
+    filter visible entities. Entity-specific denials are suppressed so a single
+    restricted entity type never fails the whole search or leaks existence.
+"""
+
+# Standard
+import logging
+from typing import Any, Optional
+
+# Third-Party
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.admin import _validated_team_id_param, perform_unified_search  # noqa: PLC2701 — reuse admin team_id validation for parity
+from mcpgateway.common.query_params import QueryEntityTypes, QueryGatewayIdList, QueryTagsFilter
+from mcpgateway.config import settings
+from mcpgateway.db import get_db
+from mcpgateway.middleware.rbac import get_current_user_with_permissions
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Search"])
+
+
+@router.get("/search", response_class=JSONResponse)
+async def unified_search(
+    q: str = Query("", max_length=500, description="Search query"),
+    tags: QueryTagsFilter = None,
+    entity_types: QueryEntityTypes = None,
+    include_inactive: bool = False,
+    limit: int = Query(8, ge=1, le=settings.pagination_max_page_size, description="Per-entity result limit"),
+    limit_per_type: Optional[int] = Query(
+        None,
+        ge=1,
+        le=settings.pagination_max_page_size,
+        description="Optional alias for per-entity result limit",
+    ),
+    gateway_id: QueryGatewayIdList = None,
+    team_id: Optional[str] = Depends(_validated_team_id_param),
+    db: Session = Depends(get_db),
+    user: Any = Depends(get_current_user_with_permissions),
+) -> dict[str, Any]:
+    """Unified search across primary entities (versioned, non-admin route).
+
+    Preserves the behavior, query parameters, and grouped/flattened response
+    shape of ``GET /admin/search`` but without the ``admin.dashboard`` gate.
+    Delegates to :func:`mcpgateway.admin.perform_unified_search`; per-entity
+    RBAC and token scoping are enforced inside that helper.
+
+    Args:
+        q (str): Free-text search query.
+        tags (Optional[str]): Tag filter expression (comma=OR, plus=AND).
+        entity_types (Optional[str]): Optional comma-separated entity type list.
+            Supported values: servers, gateways, tools, resources, prompts,
+            agents, teams, users, roots.
+        include_inactive (bool): Whether to include inactive entities.
+        limit (int): Default per-entity limit for returned items.
+        limit_per_type (Optional[int]): Optional alias overriding ``limit``.
+        gateway_id (Optional[str]): Gateway filter for tools/resources/prompts.
+        team_id (Optional[str]): Team scope filter.
+        db (Session): Database session.
+        user: Authenticated user context.
+
+    Returns:
+        dict[str, Any]: Grouped and flattened search results with metadata.
+    """
+    return await perform_unified_search(
+        q=q,
+        tags=tags,
+        entity_types=entity_types,
+        include_inactive=include_inactive,
+        limit=limit,
+        limit_per_type=limit_per_type,
+        gateway_id=gateway_id,
+        team_id=team_id,
+        db=db,
+        user=user,
+    )

--- a/mcpgateway/routers/search.py
+++ b/mcpgateway/routers/search.py
@@ -27,7 +27,6 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 # First-Party
-from mcpgateway.admin import _validated_team_id_param, perform_unified_search  # noqa: PLC2701 — reuse admin team_id validation
 from mcpgateway.common.query_params import QueryEntityTypes, QueryGatewayIdList, QueryTagsFilter
 from mcpgateway.config import settings
 from mcpgateway.db import get_db
@@ -52,7 +51,7 @@ async def unified_search(
         description="Optional alias for per-entity result limit",
     ),
     gateway_id: QueryGatewayIdList = None,
-    team_id: Optional[str] = Depends(_validated_team_id_param),
+    team_id: Optional[str] = Query(None, description="Filter by team ID"),
     db: Session = Depends(get_db),
     user: Any = Depends(get_current_user_with_permissions),
 ) -> dict[str, Any]:
@@ -79,6 +78,13 @@ async def unified_search(
     Returns:
         dict[str, Any]: Grouped and flattened search results with metadata.
     """
+    # Import lazily so admin-disabled deployments do not load mcpgateway.admin
+    # (and its module-level service instances) at startup. The search router is
+    # always mounted, but the admin core is only needed once a search runs.
+    # First-Party
+    from mcpgateway.admin import _validated_team_id_param, perform_unified_search  # noqa: PLC2701 — reuse admin core, deferred to keep admin off the startup import path  # pylint: disable=import-outside-toplevel
+
+    team_id = _validated_team_id_param(team_id)
     return await perform_unified_search(
         q=q,
         tags=tags,

--- a/mcpgateway/routers/search.py
+++ b/mcpgateway/routers/search.py
@@ -6,22 +6,16 @@ Authors: Mihai Criveti
 
 Unified Search API Router.
 
-Exposes the unified cross-entity search capability at a stable, versioned,
-non-admin path (``GET /v1/search``). Historically this capability was only
-reachable through ``GET /admin/search``, which is gated on the ``admin.dashboard``
-permission and lives under the admin dashboard router. Client-facing callers
-(e.g. the React global search) should not depend on an admin-panel route that
-may be deprecated, so this router re-exposes the same behavior and response
-shape without the admin-panel gate.
+Exposes unified cross-entity search at a stable, versioned, non-admin path
+(``GET /v1/search``) so client-facing callers do not depend on
+``GET /admin/search``, which is gated on ``admin.dashboard`` and slated for
+deprecation.
 
 Security model:
-    This route requires only authentication at the top level. It does NOT add
-    an ``admin.dashboard`` gate. Real authorization is enforced per-entity
-    inside :func:`mcpgateway.admin.perform_unified_search`: each entity search
-    carries its own RBAC permission (``tools.read``, ``gateways.read``,
-    ``admin.user_management`` for users, etc.) and token scoping continues to
-    filter visible entities. Entity-specific denials are suppressed so a single
-    restricted entity type never fails the whole search or leaks existence.
+    Authentication only at the top level (no ``admin.dashboard`` gate). Real
+    authorization is enforced per-entity inside
+    :func:`mcpgateway.admin.perform_unified_search`, and token scoping still
+    filters visible entities.
 """
 
 # Standard
@@ -34,7 +28,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 # First-Party
-from mcpgateway.admin import _validated_team_id_param, perform_unified_search  # noqa: PLC2701 — reuse admin team_id validation for parity
+from mcpgateway.admin import _validated_team_id_param, perform_unified_search  # noqa: PLC2701 — reuse admin team_id validation
 from mcpgateway.common.query_params import QueryEntityTypes, QueryGatewayIdList, QueryTagsFilter
 from mcpgateway.config import settings
 from mcpgateway.db import get_db
@@ -65,10 +59,9 @@ async def unified_search(
 ) -> dict[str, Any]:
     """Unified search across primary entities (versioned, non-admin route).
 
-    Preserves the behavior, query parameters, and grouped/flattened response
-    shape of ``GET /admin/search`` but without the ``admin.dashboard`` gate.
-    Delegates to :func:`mcpgateway.admin.perform_unified_search`; per-entity
-    RBAC and token scoping are enforced inside that helper.
+    Same behavior and response shape as ``GET /admin/search`` without the
+    ``admin.dashboard`` gate; delegates to
+    :func:`mcpgateway.admin.perform_unified_search`.
 
     Args:
         q (str): Free-text search query.

--- a/mcpgateway/routers/search.py
+++ b/mcpgateway/routers/search.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """Location: ./mcpgateway/routers/search.py
-Copyright 2026
+Copyright contributors to the MCP-CONTEXT-FORGE project
 SPDX-License-Identifier: Apache-2.0
-Authors: Mihai Criveti
 
 Unified Search API Router.
 

--- a/mcpgateway/routers/search.py
+++ b/mcpgateway/routers/search.py
@@ -18,7 +18,6 @@ Security model:
 """
 
 # Standard
-import logging
 from typing import Any, Optional
 
 # Third-Party
@@ -31,8 +30,6 @@ from mcpgateway.common.query_params import QueryEntityTypes, QueryGatewayIdList,
 from mcpgateway.config import settings
 from mcpgateway.db import get_db
 from mcpgateway.middleware.rbac import get_current_user_with_permissions
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Search"])
 

--- a/tests/e2e/test_search_e2e.py
+++ b/tests/e2e/test_search_e2e.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/e2e/test_search_e2e.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Mihai Criveti
+
+End-to-end tests for GET /v1/search using a REAL signed JWT through the full
+auth + token-scoping middleware stack (no dependency overrides).
+
+Unlike the unit tests (which mock handlers) and the integration tests (which
+inject the user context via dependency_overrides), these mint a real JWT signed
+with the app's configured secret and let the genuine auth pipeline validate it.
+This is the only layer that exercises the JWT -> middleware -> RBAC path
+end-to-end, mirroring the manual curl verification on PR #5610.
+
+Minimal, high-value cases (the ones that require the real JWT path):
+  * unauthenticated request -> 401 (real auth middleware)
+  * non-admin JWT -> 200 (proves /v1/search needs no admin access)
+  * permission-scoped JWT (tools.read) -> 200 (token-scoping middleware allows /search)
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import os
+import tempfile
+import time
+import uuid
+
+# Third-Party
+from _pytest.monkeypatch import MonkeyPatch
+from fastapi.testclient import TestClient
+import jwt as pyjwt
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+E2E_JWT_SECRET = "e2e-search-jwt-secret-key-with-minimum-32-bytes"  # pragma: allowlist secret
+SEARCH_TERM = "e2esearch"
+MEMBER = "member-e2e@example.com"
+
+
+def _jwt(*, email, is_admin=False, teams=None, scopes=None):
+    """Mint a real JWT signed with the e2e secret."""
+    now = int(time.time())
+    payload = {
+        "sub": email,
+        "iat": now,
+        "exp": now + 3600,
+        "iss": "mcpgateway",
+        "aud": "mcpgateway-api",
+        "jti": uuid.uuid4().hex,
+        "user": {"email": email, "is_admin": is_admin, "auth_provider": "local"},
+        "teams": teams,
+    }
+    if scopes is not None:
+        payload["scopes"] = scopes
+    return pyjwt.encode(payload, E2E_JWT_SECRET, algorithm="HS256")
+
+
+@pytest.fixture
+def e2e_client():
+    """Real app + temp DB + real auth (no auth dependency overrides).
+
+    Yields:
+        TestClient bound to the real app with auth enforced and a seeded
+        non-admin member holding a global tools.read role.
+    """
+    mp = MonkeyPatch()
+
+    fd, path = tempfile.mkstemp(suffix=".db")
+    url = f"sqlite:///{path}"
+
+    from pydantic import SecretStr
+
+    from mcpgateway.config import settings
+
+    mp.setattr(settings, "database_url", url, raising=False)
+    mp.setattr(settings, "auth_required", True, raising=False)
+    mp.setattr(settings, "jwt_secret_key", SecretStr(E2E_JWT_SECRET), raising=False)
+
+    import mcpgateway.db as db_mod
+    import mcpgateway.main as main_mod
+    import mcpgateway.middleware.auth_middleware as auth_middleware_mod
+    import mcpgateway.services.audit_trail_service as audit_trail_mod
+    import mcpgateway.services.log_aggregator as log_aggregator_mod
+    import mcpgateway.services.security_logger as sec_logger_mod
+    import mcpgateway.services.structured_logger as struct_logger_mod
+
+    engine = create_engine(url, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    for mod in (db_mod, main_mod, auth_middleware_mod, sec_logger_mod, struct_logger_mod, audit_trail_mod, log_aggregator_mod):
+        mp.setattr(mod, "SessionLocal", TestSessionLocal, raising=False)
+    mp.setattr(db_mod, "engine", engine, raising=False)
+
+    db_mod.Base.metadata.create_all(bind=engine)
+
+    from mcpgateway.db import EmailUser, Role, Tool, UserRole
+
+    db = TestSessionLocal()
+    db.add(EmailUser(id=uuid.uuid4().hex, email=MEMBER, password_hash="x", full_name="E2E Member", is_admin=False, is_active=True, auth_provider="local"))  # pragma: allowlist secret
+    role_id = uuid.uuid4().hex
+    db.add(Role(id=role_id, name="e2e-reader", scope="global", permissions=["tools.read"], created_by=MEMBER, is_active=True))
+    db.add(UserRole(id=uuid.uuid4().hex, user_email=MEMBER, role_id=role_id, scope="global", scope_id=None, granted_by=MEMBER, is_active=True))
+    db.add(
+        Tool(
+            id=uuid.uuid4().hex,
+            original_name=f"{SEARCH_TERM}-tool",
+            url="http://example.com/e2e",
+            owner_email=MEMBER,
+            visibility="public",
+            integration_type="REST",
+            request_type="GET",
+            input_schema={},
+            output_schema={},
+            enabled=True,
+            deprecated=False,
+            created_by=MEMBER,
+            tags=[],
+        )
+    )
+    db.commit()
+    db.close()
+
+    from mcpgateway.main import app
+
+    client = TestClient(app, raise_server_exceptions=False)
+    yield client
+
+    mp.undo()
+    engine.dispose()
+    os.close(fd)
+    os.unlink(path)
+
+
+def test_unauthenticated_returns_401(e2e_client):
+    """No token -> rejected by the real auth middleware."""
+    assert e2e_client.get(f"/v1/search?q={SEARCH_TERM}").status_code == 401
+
+
+def test_non_admin_jwt_reaches_search(e2e_client):
+    """A real non-admin JWT reaches /v1/search and gets the grouped contract (no admin needed)."""
+    token = _jwt(email=MEMBER, is_admin=False, teams=None)
+    resp = e2e_client.get(f"/v1/search?q={SEARCH_TERM}&entity_types=tools", headers={"Authorization": f"Bearer {token}"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body) >= {"query", "entity_types", "results", "groups", "items", "count"}
+    # Real RBAC + real query: the member's tools.read role lets the seeded public
+    # tool come back, so this is not an empty/denied 200.
+    assert any(t.get("name") == f"{SEARCH_TERM}-tool" for t in body["results"]["tools"])
+
+
+def test_permission_scoped_jwt_reaches_search(e2e_client):
+    """A non-wildcard permission-scoped JWT passes the token-scoping middleware for /search."""
+    token = _jwt(email=MEMBER, is_admin=False, teams=None, scopes={"permissions": ["tools.read"]})
+    resp = e2e_client.get(f"/v1/search?q={SEARCH_TERM}&entity_types=tools", headers={"Authorization": f"Bearer {token}"})
+
+    assert resp.status_code == 200

--- a/tests/e2e/test_search_e2e.py
+++ b/tests/e2e/test_search_e2e.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """Location: ./tests/e2e/test_search_e2e.py
-Copyright 2026
+Copyright contributors to the MCP-CONTEXT-FORGE project
 SPDX-License-Identifier: Apache-2.0
-Authors: Mihai Criveti
 
 End-to-end tests for GET /v1/search using a REAL signed JWT through the full
 auth + token-scoping middleware stack (no dependency overrides).

--- a/tests/integration/test_search_endpoint.py
+++ b/tests/integration/test_search_endpoint.py
@@ -283,7 +283,7 @@ def _real_data_env():
 
     db_mod.Base.metadata.create_all(bind=engine)
 
-    from mcpgateway.db import EmailTeam, EmailTeamMember, EmailUser, Role, Tool, UserRole
+    from mcpgateway.db import EmailTeam, EmailTeamMember, EmailUser, Role, Server, Tool, UserRole
 
     now = datetime.now(timezone.utc)
     team_a = uuid.uuid4().hex
@@ -337,13 +337,17 @@ def _real_data_env():
     t_public = _tool(f"{SEARCH_TERM}-public", "public", None)
     t_teama = _tool(f"{SEARCH_TERM}-teama", "team", team_a)
     t_teamb = _tool(f"{SEARCH_TERM}-teamb", "team", team_b)
-    db.add_all([t_public, t_teama, t_teamb])
+    # A public server matching the search term: any caller WITH servers.read would
+    # see it, so an empty servers result proves the servers.read denial (not no data).
+    s_public = Server(id=uuid.uuid4().hex, name=f"{SEARCH_TERM}-server", visibility="public", enabled=True, owner_email=owner, tags=[])
+    db.add_all([t_public, t_teama, t_teamb, s_public])
     db.commit()
 
     ids = {
         "public": t_public.id,
         "teama": t_teama.id,
         "teamb": t_teamb.id,
+        "server_public": s_public.id,
         "team_a": team_a,
         "team_b": team_b,
         "user_b": user_b,
@@ -429,3 +433,22 @@ class TestUnifiedSearchRealDataScoping:
         body = resp.json()
         assert "users" not in body["entity_types"]  # restricted entity removed (no admin.user_management)
         assert ids["teamb"] in {tool["id"] for tool in body["results"]["tools"]}  # tools still returned (positive)
+
+    def test_denied_entity_returns_empty_without_collapsing_search(self, _real_data_env):
+        """A real servers.read denial is swallowed to empty; the allowed tools still return.
+
+        user_b has tools.read but not servers.read, so admin_search_servers raises a
+        genuine 403 that _safe_entity_search turns into empty results. The seeded public
+        server matches the query, so empty servers proves the denial (not missing data).
+        """
+        app, TestSessionLocal, ids = _real_data_env
+        _inject_identity(app, TestSessionLocal, ids["user_b"], token_teams=[ids["team_b"]])
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(f"/v1/search?q={SEARCH_TERM}&entity_types=servers,tools", headers={"Authorization": "Bearer x"})
+
+        assert resp.status_code == 200  # a denied entity must not fail the whole request
+        body = resp.json()
+        assert body["results"]["servers"] == []  # servers.read denied -> 403 -> swallowed to empty
+        assert body["results"]["tools"]  # allowed entity still returned (search did not collapse)
+        assert ids["teamb"] in {tool["id"] for tool in body["results"]["tools"]}

--- a/tests/integration/test_search_endpoint.py
+++ b/tests/integration/test_search_endpoint.py
@@ -1,0 +1,230 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/integration/test_search_endpoint.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Mihai Criveti
+
+Integration tests for the versioned unified search endpoint.
+
+Exercises the full ASGI stack (routing, auth middleware, RBAC, orchestration)
+against the real ``mcpgateway.main.app`` for:
+  GET /search      (legacy unversioned alias)
+  GET /v1/search   (canonical versioned path)
+
+Complements the handler-level unit tests in
+``tests/unit/mcpgateway/routers/test_search_router.py``. The per-entity
+``admin_search_*`` DB queries are the only thing stubbed; the router,
+middleware, and ``perform_unified_search`` orchestration all run for real.
+
+Mirrors the pattern established for the public resource-by-URI endpoint in
+``tests/integration/test_resource_management.py`` (PR #5455).
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import os
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+from _pytest.monkeypatch import MonkeyPatch
+from fastapi.testclient import TestClient
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.auth import get_current_user
+from mcpgateway.middleware.rbac import get_current_user_with_permissions, get_db as rbac_get_db, get_permission_service
+from mcpgateway.utils.verify_credentials import require_auth
+
+
+class _PermissionServiceAlwaysGrant:
+    """Permission-service stand-in that grants every check.
+
+    Uses ``**kwargs`` so it stays compatible with the full
+    ``PermissionService.check_permission`` signature without mirroring it.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Accept and ignore any constructor arguments."""
+
+    async def check_permission(self, *args, **kwargs) -> bool:
+        """Grant every permission check.
+
+        Returns:
+            bool: Always ``True``.
+        """
+        return True
+
+    async def check_admin_permission(self, *args, **kwargs) -> bool:
+        """Grant every admin permission check.
+
+        Returns:
+            bool: Always ``True``.
+        """
+        return True
+
+
+@pytest.fixture(scope="module")
+def _auth_client():
+    """TestClient over the real app + a temp SQLite DB, with auth mocked to an admin.
+
+    Yields:
+        tuple: ``(client, auth_headers)`` for authenticated requests.
+    """
+    mp = MonkeyPatch()
+
+    fd, path = tempfile.mkstemp(suffix=".db")
+    url = f"sqlite:///{path}"
+
+    # First-Party
+    from mcpgateway.config import settings
+
+    mp.setattr(settings, "database_url", url, raising=False)
+
+    # First-Party
+    import mcpgateway.db as db_mod
+    import mcpgateway.main as main_mod
+
+    engine = create_engine(url, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    mp.setattr(db_mod, "engine", engine, raising=False)
+    mp.setattr(db_mod, "SessionLocal", TestSessionLocal, raising=False)
+    mp.setattr(main_mod, "SessionLocal", TestSessionLocal, raising=False)
+    mp.setattr(main_mod, "engine", engine, raising=False)
+
+    db_mod.Base.metadata.create_all(bind=engine)
+
+    mock_email_user = MagicMock()
+    mock_email_user.email = "integration-test-user@example.com"
+    mock_email_user.is_admin = True
+    mock_email_user.is_active = True
+
+    async def _mock_user_with_permissions():
+        db_session = TestSessionLocal()
+        try:
+            yield {
+                "email": "integration-test-user@example.com",
+                "is_admin": True,
+                "ip_address": "127.0.0.1",
+                "user_agent": "test-client",
+                "db": db_session,
+            }
+        finally:
+            db_session.close()
+
+    def _override_get_db():
+        db = TestSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    from mcpgateway.main import app
+
+    with patch("mcpgateway.middleware.rbac.PermissionService", _PermissionServiceAlwaysGrant):
+        app.dependency_overrides[require_auth] = lambda: "integration-test-user"
+        app.dependency_overrides[get_current_user] = lambda: mock_email_user
+        app.dependency_overrides[get_current_user_with_permissions] = _mock_user_with_permissions
+        app.dependency_overrides[get_permission_service] = lambda *a, **k: _PermissionServiceAlwaysGrant()
+        app.dependency_overrides[rbac_get_db] = _override_get_db
+
+        client = TestClient(app, raise_server_exceptions=False)
+        auth_headers = {"Authorization": "Bearer integration.test.token"}  # pragma: allowlist secret
+        yield client, auth_headers
+
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(get_current_user_with_permissions, None)
+        app.dependency_overrides.pop(get_permission_service, None)
+        app.dependency_overrides.pop(rbac_get_db, None)
+
+    mp.undo()
+    engine.dispose()
+    os.close(fd)
+    os.unlink(path)
+
+
+class TestUnifiedSearchIntegration:
+    """Full-stack tests for GET /[v1/]search."""
+
+    # ------------------------------------------------------------------
+    # Authenticated success paths
+    # ------------------------------------------------------------------
+
+    @patch("mcpgateway.admin.admin_search_servers", new_callable=AsyncMock)
+    @patch("mcpgateway.admin.admin_search_tools", new_callable=AsyncMock)
+    def test_v1_search_authenticated_returns_200_grouped(self, mock_tools, mock_servers, _auth_client):
+        """GET /v1/search returns 200 with the grouped + flattened contract."""
+        client, auth_headers = _auth_client
+        mock_tools.return_value = {"tools": [{"id": "tool-1", "name": "Alpha"}], "count": 1}
+        mock_servers.return_value = {"servers": [{"id": "srv-1", "name": "Beta"}], "count": 1}
+
+        response = client.get("/v1/search?q=a&entity_types=tools,servers", headers=auth_headers)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["entity_types"] == ["tools", "servers"]
+        assert body["results"]["tools"][0]["id"] == "tool-1"
+        assert body["results"]["servers"][0]["id"] == "srv-1"
+        assert body["count"] == 2
+        assert {item["entity_type"] for item in body["items"]} == {"tools", "servers"}
+
+    @patch("mcpgateway.admin.admin_search_tools", new_callable=AsyncMock)
+    def test_legacy_search_prefix_returns_200(self, mock_tools, _auth_client):
+        """The legacy unversioned /search alias routes to the same handler."""
+        client, auth_headers = _auth_client
+        mock_tools.return_value = {"tools": [{"id": "tool-9", "name": "Gamma"}], "count": 1}
+
+        response = client.get("/search?q=g&entity_types=tools", headers=auth_headers)
+
+        assert response.status_code == 200
+        assert response.json()["results"]["tools"][0]["id"] == "tool-9"
+
+    @patch("mcpgateway.admin.admin_search_tools", new_callable=AsyncMock)
+    def test_limit_per_type_forwarded_through_real_orchestration(self, mock_tools, _auth_client):
+        """limit_per_type reaches the per-entity search via the real orchestration."""
+        client, auth_headers = _auth_client
+        mock_tools.return_value = {"tools": [], "count": 0}
+
+        response = client.get("/v1/search?q=a&entity_types=tools&limit=8&limit_per_type=3", headers=auth_headers)
+
+        assert response.status_code == 200
+        assert response.json()["limit_per_type"] == 3
+        assert mock_tools.await_args.kwargs["limit"] == 3
+
+    # ------------------------------------------------------------------
+    # Authentication rejection (full middleware stack)
+    # ------------------------------------------------------------------
+
+    def test_v1_search_unauthenticated_returns_401(self, app_with_temp_db):
+        """GET /v1/search without credentials is rejected with 401."""
+        from fastapi import HTTPException, status as http_status
+
+        def _no_auth():
+            raise HTTPException(status_code=http_status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+
+        app_with_temp_db.dependency_overrides[get_current_user_with_permissions] = _no_auth
+        try:
+            client = TestClient(app_with_temp_db, raise_server_exceptions=False)
+            assert client.get("/v1/search?q=a").status_code == 401
+        finally:
+            app_with_temp_db.dependency_overrides.pop(get_current_user_with_permissions, None)
+
+    def test_legacy_search_unauthenticated_returns_401(self, app_with_temp_db):
+        """GET /search (legacy) without credentials is also rejected with 401."""
+        from fastapi import HTTPException, status as http_status
+
+        def _no_auth():
+            raise HTTPException(status_code=http_status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+
+        app_with_temp_db.dependency_overrides[get_current_user_with_permissions] = _no_auth
+        try:
+            client = TestClient(app_with_temp_db, raise_server_exceptions=False)
+            assert client.get("/search?q=a").status_code == 401
+        finally:
+            app_with_temp_db.dependency_overrides.pop(get_current_user_with_permissions, None)

--- a/tests/integration/test_search_endpoint.py
+++ b/tests/integration/test_search_endpoint.py
@@ -485,3 +485,21 @@ class TestUnifiedSearchRealDataScoping:
         returned = {team["id"] for team in resp.json()["results"]["teams"]}
         assert ids["team_b"] in returned
         assert ids["team_a"] in returned  # visible via membership -> confirms the token caused the deny
+
+    def test_public_only_token_sees_only_public_tools(self, _real_data_env):
+        """A public-only token (token_teams=[], i.e. no teams claim) sees public entities but not team-private ones.
+
+        This is the degenerate scope not covered by the explicit-team-list tests:
+        an empty team scope must degrade to public/owned visibility only.
+        """
+        app, TestSessionLocal, ids = _real_data_env
+        _inject_identity(app, TestSessionLocal, ids["user_b"], token_teams=[])
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(f"/v1/search?q={SEARCH_TERM}&entity_types=tools", headers={"Authorization": "Bearer x"})
+
+        assert resp.status_code == 200
+        returned = {tool["id"] for tool in resp.json()["results"]["tools"]}
+        assert ids["public"] in returned  # public tool visible
+        assert ids["teama"] not in returned  # team-private hidden under public-only scope
+        assert ids["teamb"] not in returned  # team-private hidden under public-only scope

--- a/tests/integration/test_search_endpoint.py
+++ b/tests/integration/test_search_endpoint.py
@@ -24,9 +24,11 @@ Mirrors the pattern established for the public resource-by-URI endpoint in
 from __future__ import annotations
 
 # Standard
+from datetime import datetime, timezone
 import os
 import tempfile
 from unittest.mock import AsyncMock, MagicMock, patch
+import uuid
 
 # Third-Party
 from _pytest.monkeypatch import MonkeyPatch
@@ -228,3 +230,197 @@ class TestUnifiedSearchIntegration:
             assert client.get("/search?q=a").status_code == 401
         finally:
             app_with_temp_db.dependency_overrides.pop(get_current_user_with_permissions, None)
+
+
+# ---------------------------------------------------------------------------
+# Real-data RBAC / token-scoping regression
+# ---------------------------------------------------------------------------
+#
+# Unlike the tests above (which stub admin_search_* and grant all permissions),
+# these seed real rows and run the real handlers + real PermissionService so the
+# security claim is proven end-to-end: a caller only sees entities their token
+# scope permits. Layer 2 (tools.read) is a real but global pass-through so the
+# thing under test is Layer 1 visibility/token scoping, not the permission gate.
+#
+# Note: identity is injected (not full JWT-middleware validation). PermissionService,
+# admin_search_tools, and the DB rows are all real; a dedicated JWT-path test is a
+# separate concern.
+
+SEARCH_TERM = "zzzsearchable"
+
+
+@pytest.fixture
+def _real_data_env():
+    """Real app + temp DB seeded with teams, a non-admin member, and scoped tools.
+
+    Yields:
+        tuple: ``(app, TestSessionLocal, ids)`` where ``ids`` maps logical names
+        (public/teama/teamb tool ids, team_a/team_b ids, user_b email) to values.
+    """
+    mp = MonkeyPatch()
+
+    fd, path = tempfile.mkstemp(suffix=".db")
+    url = f"sqlite:///{path}"
+
+    from mcpgateway.config import settings
+
+    mp.setattr(settings, "database_url", url, raising=False)
+
+    import mcpgateway.db as db_mod
+    import mcpgateway.main as main_mod
+
+    engine = create_engine(url, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    mp.setattr(db_mod, "engine", engine, raising=False)
+    mp.setattr(db_mod, "SessionLocal", TestSessionLocal, raising=False)
+    mp.setattr(main_mod, "SessionLocal", TestSessionLocal, raising=False)
+    mp.setattr(main_mod, "engine", engine, raising=False)
+
+    db_mod.Base.metadata.create_all(bind=engine)
+
+    from mcpgateway.db import EmailTeam, EmailTeamMember, EmailUser, Role, Tool, UserRole
+
+    now = datetime.now(timezone.utc)
+    team_a = uuid.uuid4().hex
+    team_b = uuid.uuid4().hex
+    user_b = "user-b@example.com"
+    owner = "owner@example.com"  # owns the tools so user_b access is never via ownership
+
+    def _user(email):
+        return EmailUser(id=uuid.uuid4().hex, email=email, password_hash="x", full_name=email, is_admin=False, is_active=True, auth_provider="local", email_verified_at=now)  # pragma: allowlist secret
+
+    def _tool(name, visibility, team_id):
+        return Tool(
+            id=uuid.uuid4().hex,
+            original_name=name,
+            url=f"http://example.com/{name}",
+            owner_email=owner,
+            team_id=team_id,
+            visibility=visibility,
+            integration_type="REST",
+            request_type="GET",
+            input_schema={},
+            output_schema={},
+            enabled=True,
+            deprecated=False,
+            created_by=owner,
+            tags=[],
+        )
+
+    db = TestSessionLocal()
+    db.add_all([_user(user_b), _user(owner)])
+    db.add_all(
+        [
+            EmailTeam(id=team_a, name="Team A", slug="team-a", created_by=owner, is_personal=False, visibility="public"),
+            EmailTeam(id=team_b, name="Team B", slug="team-b", created_by=owner, is_personal=False, visibility="public"),
+        ]
+    )
+    db.commit()
+
+    # user_b is a real member of BOTH teams (so team-A is genuinely accessible),
+    # and holds a real GLOBAL tools.read role (Layer 2 pass-through).
+    role_id = uuid.uuid4().hex
+    db.add_all(
+        [
+            EmailTeamMember(id=uuid.uuid4().hex, team_id=team_a, user_email=user_b, role="member", is_active=True),
+            EmailTeamMember(id=uuid.uuid4().hex, team_id=team_b, user_email=user_b, role="member", is_active=True),
+            Role(id=role_id, name="test-tools-reader", scope="global", permissions=["tools.read"], created_by=owner, is_active=True),
+            UserRole(id=uuid.uuid4().hex, user_email=user_b, role_id=role_id, scope="global", scope_id=None, granted_by=owner, is_active=True),
+        ]
+    )
+
+    t_public = _tool(f"{SEARCH_TERM}-public", "public", None)
+    t_teama = _tool(f"{SEARCH_TERM}-teama", "team", team_a)
+    t_teamb = _tool(f"{SEARCH_TERM}-teamb", "team", team_b)
+    db.add_all([t_public, t_teama, t_teamb])
+    db.commit()
+
+    ids = {
+        "public": t_public.id,
+        "teama": t_teama.id,
+        "teamb": t_teamb.id,
+        "team_a": team_a,
+        "team_b": team_b,
+        "user_b": user_b,
+    }
+    db.close()
+
+    from mcpgateway.main import app
+
+    yield app, TestSessionLocal, ids
+
+    app.dependency_overrides.pop(get_current_user_with_permissions, None)
+    mp.undo()
+    engine.dispose()
+    os.close(fd)
+    os.unlink(path)
+
+
+def _inject_identity(app, TestSessionLocal, email, token_teams=None):
+    """Override the auth dependency to yield a non-admin context, optionally token-scoped.
+
+    Args:
+        app: The FastAPI app to override on.
+        TestSessionLocal: Session factory bound to the temp DB.
+        email (str): Caller email.
+        token_teams: When provided, narrows the caller's visible team scope
+            (list of team-id strings); when ``None``, the key is omitted so the
+            caller's full DB team membership applies.
+    """
+
+    async def _ctx():
+        session = TestSessionLocal()
+        try:
+            context = {"email": email, "is_admin": False, "ip_address": "127.0.0.1", "user_agent": "test-client", "db": session}
+            if token_teams is not None:
+                context["token_teams"] = token_teams
+            yield context
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_current_user_with_permissions] = _ctx
+
+
+class TestUnifiedSearchRealDataScoping:
+    """Real-data tests proving /v1/search enforces token/team visibility scoping."""
+
+    def test_token_scope_hides_other_teams_private_tool(self, _real_data_env):
+        """A token scoped to team-B sees public + team-B tools, not team-A's private tool."""
+        app, TestSessionLocal, ids = _real_data_env
+        _inject_identity(app, TestSessionLocal, ids["user_b"], token_teams=[ids["team_b"]])
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(f"/v1/search?q={SEARCH_TERM}&entity_types=tools", headers={"Authorization": "Bearer x"})
+
+        assert resp.status_code == 200
+        returned = {tool["id"] for tool in resp.json()["results"]["tools"]}
+        assert ids["public"] in returned  # public visible (positive)
+        assert ids["teamb"] in returned  # own-team visible (positive: search did not collapse)
+        assert ids["teama"] not in returned  # other-team private hidden (the deny)
+
+    def test_without_token_narrowing_member_sees_both_teams(self, _real_data_env):
+        """Contrast: same user, no token narrowing, sees team-A too (deny above was the token)."""
+        app, TestSessionLocal, ids = _real_data_env
+        _inject_identity(app, TestSessionLocal, ids["user_b"], token_teams=None)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(f"/v1/search?q={SEARCH_TERM}&entity_types=tools", headers={"Authorization": "Bearer x"})
+
+        assert resp.status_code == 200
+        returned = {tool["id"] for tool in resp.json()["results"]["tools"]}
+        assert ids["public"] in returned
+        assert ids["teamb"] in returned
+        assert ids["teama"] in returned  # visible now via real membership -> confirms the token caused the deny
+
+    def test_non_admin_users_entity_dropped_without_collapsing_search(self, _real_data_env):
+        """A non-admin requesting tools,users gets tools back and users silently dropped."""
+        app, TestSessionLocal, ids = _real_data_env
+        _inject_identity(app, TestSessionLocal, ids["user_b"], token_teams=[ids["team_b"]])
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(f"/v1/search?q={SEARCH_TERM}&entity_types=tools,users", headers={"Authorization": "Bearer x"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "users" not in body["entity_types"]  # restricted entity removed (no admin.user_management)
+        assert ids["teamb"] in {tool["id"] for tool in body["results"]["tools"]}  # tools still returned (positive)

--- a/tests/integration/test_search_endpoint.py
+++ b/tests/integration/test_search_endpoint.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """Location: ./tests/integration/test_search_endpoint.py
-Copyright 2026
+Copyright contributors to the MCP-CONTEXT-FORGE project
 SPDX-License-Identifier: Apache-2.0
-Authors: Mihai Criveti
 
 Integration tests for the versioned unified search endpoint.
 

--- a/tests/integration/test_search_endpoint.py
+++ b/tests/integration/test_search_endpoint.py
@@ -288,8 +288,12 @@ def _real_data_env():
     now = datetime.now(timezone.utc)
     team_a = uuid.uuid4().hex
     team_b = uuid.uuid4().hex
-    user_b = "user-b@example.com"
-    owner = "owner@example.com"  # owns the tools so user_b access is never via ownership
+    # Unique emails per invocation: get_user_teams and role/permission lookups are
+    # cached by email at process scope, so a fixed email would leak one test's
+    # temp-DB team ids into another test using the same user.
+    suffix = uuid.uuid4().hex
+    user_b = f"user-b-{suffix}@example.com"
+    owner = f"owner-{suffix}@example.com"  # owns the tools so user_b access is never via ownership
 
     def _user(email):
         return EmailUser(id=uuid.uuid4().hex, email=email, password_hash="x", full_name=email, is_admin=False, is_active=True, auth_provider="local", email_verified_at=now)  # pragma: allowlist secret
@@ -316,8 +320,8 @@ def _real_data_env():
     db.add_all([_user(user_b), _user(owner)])
     db.add_all(
         [
-            EmailTeam(id=team_a, name="Team A", slug="team-a", created_by=owner, is_personal=False, visibility="public"),
-            EmailTeam(id=team_b, name="Team B", slug="team-b", created_by=owner, is_personal=False, visibility="public"),
+            EmailTeam(id=team_a, name=f"{SEARCH_TERM} Team A", slug="team-a", created_by=owner, is_personal=False, visibility="public"),
+            EmailTeam(id=team_b, name=f"{SEARCH_TERM} Team B", slug="team-b", created_by=owner, is_personal=False, visibility="public"),
         ]
     )
     db.commit()
@@ -329,7 +333,7 @@ def _real_data_env():
         [
             EmailTeamMember(id=uuid.uuid4().hex, team_id=team_a, user_email=user_b, role="member", is_active=True),
             EmailTeamMember(id=uuid.uuid4().hex, team_id=team_b, user_email=user_b, role="member", is_active=True),
-            Role(id=role_id, name="test-tools-reader", scope="global", permissions=["tools.read"], created_by=owner, is_active=True),
+            Role(id=role_id, name="test-reader", scope="global", permissions=["tools.read", "teams.read"], created_by=owner, is_active=True),
             UserRole(id=uuid.uuid4().hex, user_email=user_b, role_id=role_id, scope="global", scope_id=None, granted_by=owner, is_active=True),
         ]
     )
@@ -452,3 +456,33 @@ class TestUnifiedSearchRealDataScoping:
         assert body["results"]["servers"] == []  # servers.read denied -> 403 -> swallowed to empty
         assert body["results"]["tools"]  # allowed entity still returned (search did not collapse)
         assert ids["teamb"] in {tool["id"] for tool in body["results"]["tools"]}
+
+    def test_team_search_hides_narrowed_out_team(self, _real_data_env):
+        """A token scoped to team-B must not leak team-A in team search results.
+
+        Team search reloads all memberships; without token-scope narrowing a
+        token limited to team-B would still surface team-A's id/name/slug/etc.
+        """
+        app, TestSessionLocal, ids = _real_data_env
+        _inject_identity(app, TestSessionLocal, ids["user_b"], token_teams=[ids["team_b"]])
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(f"/v1/search?q={SEARCH_TERM}&entity_types=teams", headers={"Authorization": "Bearer x"})
+
+        assert resp.status_code == 200
+        returned = {team["id"] for team in resp.json()["results"]["teams"]}
+        assert ids["team_b"] in returned  # in-scope team visible (positive control)
+        assert ids["team_a"] not in returned  # narrowed-out team hidden (the deny)
+
+    def test_team_search_without_narrowing_shows_both_teams(self, _real_data_env):
+        """Contrast: same member, no token narrowing, sees both teams (deny above was the token)."""
+        app, TestSessionLocal, ids = _real_data_env
+        _inject_identity(app, TestSessionLocal, ids["user_b"], token_teams=None)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(f"/v1/search?q={SEARCH_TERM}&entity_types=teams", headers={"Authorization": "Bearer x"})
+
+        assert resp.status_code == 200
+        returned = {team["id"] for team in resp.json()["results"]["teams"]}
+        assert ids["team_b"] in returned
+        assert ids["team_a"] in returned  # visible via membership -> confirms the token caused the deny

--- a/tests/integration/test_search_endpoint.py
+++ b/tests/integration/test_search_endpoint.py
@@ -71,9 +71,14 @@ class _PermissionServiceAlwaysGrant:
         return True
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def _auth_client():
     """TestClient over the real app + a temp SQLite DB, with auth mocked to an admin.
+
+    Function-scoped on purpose: the body holds a ``patch(PermissionService=...)``
+    context and mutates ``app.dependency_overrides``. Module scope would keep that
+    patch active for the whole file and leak the AlwaysGrant permission service
+    into the later real-PermissionService tests in this module.
 
     Yields:
         tuple: ``(client, auth_headers)`` for authenticated requests.

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -2107,3 +2107,60 @@ async def test_public_only_resource_denied():
         response = await middleware(mock_request, call_next)
         assert response.status_code == status.HTTP_403_FORBIDDEN
         call_next.assert_not_called()
+
+
+class TestUnifiedSearchPathScoping:
+    """Regression tests: /v1/search must be reachable by validly-scoped tokens.
+
+    /v1/search is authenticated-only at the middleware layer (it spans many entity
+    types, each with its own @require_permission). Before the fix, the unmapped
+    path hit the default-deny branch and any non-wildcard scoped token got 403
+    before the handler ran.
+    """
+
+    def test_permission_check_allows_search_for_scoped_token(self):
+        """A non-wildcard scoped token is allowed past the permission check for /search."""
+        middleware = TokenScopingMiddleware()
+
+        # /v1/search normalizes to /search; allowed regardless of the specific scope.
+        assert middleware._check_permission_restrictions("/v1/search", "GET", ["tools.read"]) is True
+        assert middleware._check_permission_restrictions("/search", "GET", ["tools.read"]) is True
+        # Even a scope unrelated to any searchable entity is allowed here; the
+        # handler's per-entity RBAC + _safe_entity_search filter results downstream.
+        assert middleware._check_permission_restrictions("/search", "GET", ["admin.metrics"]) is True
+
+    def test_admin_search_still_requires_admin_dashboard(self):
+        """The allow is scoped to /search only; /admin/search keeps its admin gate."""
+        middleware = TokenScopingMiddleware()
+
+        # Unchanged: /admin/search still requires admin.dashboard, not tools.read.
+        assert middleware._check_permission_restrictions("/admin/search", "GET", ["tools.read"]) is False
+        assert middleware._check_permission_restrictions("/admin/search", "GET", ["admin.dashboard"]) is True
+
+    def test_real_scoped_jwt_reaches_search_handler(self):
+        """A real signed scoped JWT passes the live middleware for /v1/search (200), while an unmapped path still 403s."""
+        # Third-Party
+        from fastapi import FastAPI  # pylint: disable=import-outside-toplevel
+        from fastapi.testclient import TestClient  # pylint: disable=import-outside-toplevel
+        from starlette.middleware.base import BaseHTTPMiddleware  # pylint: disable=import-outside-toplevel
+
+        # First-Party
+        from tests.helpers.auth import make_test_jwt  # pylint: disable=import-outside-toplevel
+
+        app = FastAPI()
+        app.add_middleware(BaseHTTPMiddleware, dispatch=TokenScopingMiddleware())
+
+        @app.get("/v1/search")
+        def _search():  # pragma: no cover - trivial stub
+            return {"ok": True}
+
+        @app.get("/v1/other")
+        def _other():  # pragma: no cover - trivial stub
+            return {"ok": True}
+
+        client = TestClient(app, raise_server_exceptions=False)
+        token = make_test_jwt(email="scoped@example.com", scopes={"permissions": ["tools.read"]})
+        headers = {"Authorization": f"Bearer {token}"}
+
+        assert client.get("/v1/search", headers=headers).status_code == 200  # middleware lets it through
+        assert client.get("/v1/other", headers=headers).status_code == 403  # control: default-deny still enforced

--- a/tests/unit/mcpgateway/routers/test_search_router.py
+++ b/tests/unit/mcpgateway/routers/test_search_router.py
@@ -6,14 +6,10 @@ Authors: Mihai Criveti
 
 Tests for the versioned unified search router (``GET /v1/search``).
 
-Covers the acceptance criteria from the feature request:
-    * route is mounted at the versioned path without disturbing /admin/search
-    * unauthenticated requests are rejected
-    * invalid / empty entity_types is a 400
-    * ``users`` is only searchable with user-management permission (no leak)
-    * ``team_id`` is forwarded to per-entity searches
-    * ``limit`` / ``limit_per_type`` alias behaviour
-    * grouped + flattened response shape matches the /admin/search contract
+Covers the feature-request acceptance criteria: route mounted at the versioned
+path, unauthenticated rejection, invalid entity_types (400), ``users`` protection,
+``team_id`` scoping, ``limit``/``limit_per_type``, and response-shape parity with
+``/admin/search``.
 """
 
 # Standard

--- a/tests/unit/mcpgateway/routers/test_search_router.py
+++ b/tests/unit/mcpgateway/routers/test_search_router.py
@@ -263,7 +263,7 @@ async def test_invalid_entity_types_returns_400(mock_db, patched_search):
 @pytest.mark.asyncio
 async def test_team_id_forwarded_to_entity_searches(mock_db, patched_search):
     """A validated team_id is forwarded to per-entity searches for server-side scoping."""
-    valid_team_id = "0123456789abcdef0123456789abcdef"  # valid 32-char hex UUID
+    valid_team_id = "0123456789abcdef0123456789abcdef"  # valid 32-char hex UUID  # pragma: allowlist secret
     await unified_search(
         q="core",
         tags=None,

--- a/tests/unit/mcpgateway/routers/test_search_router.py
+++ b/tests/unit/mcpgateway/routers/test_search_router.py
@@ -263,6 +263,7 @@ async def test_invalid_entity_types_returns_400(mock_db, patched_search):
 @pytest.mark.asyncio
 async def test_team_id_forwarded_to_entity_searches(mock_db, patched_search):
     """A validated team_id is forwarded to per-entity searches for server-side scoping."""
+    valid_team_id = "0123456789abcdef0123456789abcdef"  # valid 32-char hex UUID
     await unified_search(
         q="core",
         tags=None,
@@ -271,11 +272,11 @@ async def test_team_id_forwarded_to_entity_searches(mock_db, patched_search):
         limit=8,
         limit_per_type=None,
         gateway_id=None,
-        team_id="team-9",
+        team_id=valid_team_id,
         db=mock_db,
         user=USER,
     )
-    assert patched_search["tools"].await_args.kwargs["team_id"] == "team-9"
+    assert patched_search["tools"].await_args.kwargs["team_id"] == valid_team_id
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/routers/test_search_router.py
+++ b/tests/unit/mcpgateway/routers/test_search_router.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """Location: ./tests/unit/mcpgateway/routers/test_search_router.py
-Copyright 2026
+Copyright contributors to the MCP-CONTEXT-FORGE project
 SPDX-License-Identifier: Apache-2.0
-Authors: Mihai Criveti
 
 Tests for the versioned unified search router (``GET /v1/search``).
 

--- a/tests/unit/mcpgateway/routers/test_search_router.py
+++ b/tests/unit/mcpgateway/routers/test_search_router.py
@@ -1,0 +1,326 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/routers/test_search_router.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Mihai Criveti
+
+Tests for the versioned unified search router (``GET /v1/search``).
+
+Covers the acceptance criteria from the feature request:
+    * route is mounted at the versioned path without disturbing /admin/search
+    * unauthenticated requests are rejected
+    * invalid / empty entity_types is a 400
+    * ``users`` is only searchable with user-management permission (no leak)
+    * ``team_id`` is forwarded to per-entity searches
+    * ``limit`` / ``limit_per_type`` alias behaviour
+    * grouped + flattened response shape matches the /admin/search contract
+"""
+
+# Standard
+from unittest.mock import AsyncMock, MagicMock
+
+# Third-Party
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+import pytest
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.db import get_db
+from mcpgateway.middleware.rbac import get_current_user_with_permissions
+from mcpgateway.routers.search import router as search_router, unified_search
+
+USER = {"email": "user@example.com"}
+
+
+@pytest.fixture
+def mock_db():
+    """A mock SQLAlchemy session (never actually queried — entity searches are patched)."""
+    return MagicMock(spec=Session)
+
+
+@pytest.fixture
+def patched_search(monkeypatch):
+    """Patch every ``admin_search_*`` the core delegates to, plus team/permission helpers.
+
+    Returns the map of entity name -> AsyncMock so tests can assert on the
+    arguments each per-entity search was called with.
+    """
+    mocks = {
+        "servers": AsyncMock(return_value={"servers": [{"id": "srv-1", "name": "Server 1"}], "count": 1}),
+        "gateways": AsyncMock(return_value={"gateways": [], "count": 0}),
+        "tools": AsyncMock(return_value={"tools": [{"id": "tool-1", "name": "Tool 1"}], "count": 1}),
+        "resources": AsyncMock(return_value={"resources": [], "count": 0}),
+        "prompts": AsyncMock(return_value={"prompts": [], "count": 0}),
+        "a2a_agents": AsyncMock(return_value={"agents": [], "count": 0}),
+        "teams": AsyncMock(return_value={"teams": [], "count": 0}),
+        "users": AsyncMock(return_value={"users": [{"id": "user-1"}], "count": 1}),
+        "roots": AsyncMock(return_value={"roots": [], "count": 0}),
+    }
+    for name, mock in mocks.items():
+        monkeypatch.setattr(f"mcpgateway.admin.admin_search_{name}", mock)
+    # Deterministic team scope and user-management permission (grant by default).
+    monkeypatch.setattr("mcpgateway.admin._get_user_team_ids", AsyncMock(return_value=[]))
+    monkeypatch.setattr("mcpgateway.admin._has_permission", AsyncMock(return_value=True))
+    return mocks
+
+
+# ---------------------------------------------------------------------------
+# Route wiring
+# ---------------------------------------------------------------------------
+
+
+def test_search_route_mounted_on_v1_independent_of_admin_api():
+    """/v1/search is exposed as an always-on route, even when the admin API is disabled.
+
+    This is the whole point of the endpoint: client-facing search must not
+    depend on the admin dashboard being mounted. The default test config runs
+    with MCPGATEWAY_ADMIN_API_ENABLED=False, so /v1/admin/search is absent here
+    while /v1/search is still present.
+    """
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.main import app
+
+    paths = app.openapi().get("paths", {})
+    assert "/v1/search" in paths
+    assert "get" in paths["/v1/search"]
+    # When the admin API is enabled, the legacy /admin/search route coexists as
+    # the fallback during UI migration; when disabled, only /v1/search remains.
+    if settings.mcpgateway_admin_api_enabled:
+        assert "/v1/admin/search" in paths
+
+
+# ---------------------------------------------------------------------------
+# Deny path: authentication
+# ---------------------------------------------------------------------------
+
+
+def test_unified_search_unauthenticated_returns_401():
+    """No auth context -> 401, before any search runs."""
+    app = FastAPI()
+    app.include_router(search_router)
+
+    async def deny_auth():
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    app.dependency_overrides[get_current_user_with_permissions] = deny_auth
+    app.dependency_overrides[get_db] = lambda: MagicMock(spec=Session)
+
+    client = TestClient(app)
+    resp = client.get("/search", params={"q": "core"})
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Happy path + response shape parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_response_shape_matches_admin_search_contract(mock_db, patched_search):
+    """Grouped + flattened result carries every key of the /admin/search contract."""
+    result = await unified_search(
+        q="core",
+        tags=None,
+        entity_types="servers,tools",
+        include_inactive=False,
+        limit=8,
+        limit_per_type=None,
+        gateway_id=None,
+        team_id=None,
+        db=mock_db,
+        user=USER,
+    )
+
+    # Top-level contract keys.
+    assert set(result) >= {"query", "tags", "entity_types", "limit_per_type", "filters_applied", "results", "groups", "items", "count"}
+    assert result["filters_applied"].keys() >= {"q", "tags", "tag_groups"}
+
+    # Grouped shape.
+    assert result["entity_types"] == ["servers", "tools"]
+    assert [g["entity_type"] for g in result["groups"]] == ["servers", "tools"]
+    for group in result["groups"]:
+        assert group["count"] == len(group["items"])
+
+    # Flattened shape: every item is tagged with its entity_type and count matches.
+    assert result["count"] == len(result["items"])
+    assert {item["entity_type"] for item in result["items"]} == {"servers", "tools"}
+
+
+@pytest.mark.asyncio
+async def test_router_delegates_to_core_unchanged(mock_db, patched_search):
+    """The router adds nothing of its own: its output equals the shared core's."""
+    # First-Party
+    from mcpgateway.admin import perform_unified_search
+
+    kwargs = dict(
+        q="core",
+        tags=None,
+        entity_types="servers,tools",
+        include_inactive=False,
+        limit=8,
+        limit_per_type=None,
+        gateway_id=None,
+        team_id=None,
+        db=mock_db,
+        user=USER,
+    )
+    via_router = await unified_search(**kwargs)
+    via_core = await perform_unified_search(**kwargs)
+    assert via_router == via_core
+
+
+@pytest.mark.asyncio
+async def test_authenticated_http_request_returns_200_grouped(mock_db, patched_search):
+    """End-to-end through the router: authenticated GET /search -> 200 grouped payload."""
+    app = FastAPI()
+    app.include_router(search_router)
+    app.dependency_overrides[get_current_user_with_permissions] = lambda: USER
+    app.dependency_overrides[get_db] = lambda: mock_db
+
+    client = TestClient(app)
+    resp = client.get("/search", params={"q": "core", "entity_types": "tools"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["entity_types"] == ["tools"]
+    assert body["results"]["tools"][0]["id"] == "tool-1"
+
+
+# ---------------------------------------------------------------------------
+# Restricted entity types: users
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_users_dropped_when_not_permitted(mock_db, patched_search, monkeypatch):
+    """Without user-management permission, users are silently dropped (no leak)."""
+    monkeypatch.setattr("mcpgateway.admin._has_permission", AsyncMock(return_value=False))
+
+    result = await unified_search(
+        q="alice",
+        tags=None,
+        entity_types="tools,users",
+        include_inactive=False,
+        limit=8,
+        limit_per_type=None,
+        gateway_id=None,
+        team_id=None,
+        db=mock_db,
+        user=USER,
+    )
+
+    assert result["entity_types"] == ["tools"]
+    assert "users" not in result["results"]
+    patched_search["users"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_users_only_request_forbidden_when_not_permitted(mock_db, patched_search, monkeypatch):
+    """Explicitly requesting only users without permission -> 403 (matches /admin/search)."""
+    monkeypatch.setattr("mcpgateway.admin._has_permission", AsyncMock(return_value=False))
+
+    with pytest.raises(HTTPException) as excinfo:
+        await unified_search(
+            q="alice",
+            tags=None,
+            entity_types="users",
+            include_inactive=False,
+            limit=8,
+            limit_per_type=None,
+            gateway_id=None,
+            team_id=None,
+            db=mock_db,
+            user=USER,
+        )
+    assert excinfo.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Invalid input
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_entity_types_returns_400(mock_db, patched_search):
+    """entity_types containing only unsupported values -> 400."""
+    with pytest.raises(HTTPException) as excinfo:
+        await unified_search(
+            q="core",
+            tags=None,
+            entity_types="bogus,nonsense",
+            include_inactive=False,
+            limit=8,
+            limit_per_type=None,
+            gateway_id=None,
+            team_id=None,
+            db=mock_db,
+            user=USER,
+        )
+    assert excinfo.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# team_id scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_team_id_forwarded_to_entity_searches(mock_db, patched_search):
+    """A validated team_id is forwarded to per-entity searches for server-side scoping."""
+    await unified_search(
+        q="core",
+        tags=None,
+        entity_types="tools",
+        include_inactive=False,
+        limit=8,
+        limit_per_type=None,
+        gateway_id=None,
+        team_id="team-9",
+        db=mock_db,
+        user=USER,
+    )
+    assert patched_search["tools"].await_args.kwargs["team_id"] == "team-9"
+
+
+# ---------------------------------------------------------------------------
+# limit / limit_per_type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_limit_per_type_overrides_limit(mock_db, patched_search):
+    """limit_per_type takes precedence over limit and is what per-entity searches receive."""
+    result = await unified_search(
+        q="core",
+        tags=None,
+        entity_types="tools",
+        include_inactive=False,
+        limit=5,
+        limit_per_type=3,
+        gateway_id=None,
+        team_id=None,
+        db=mock_db,
+        user=USER,
+    )
+    assert result["limit_per_type"] == 3
+    assert patched_search["tools"].await_args.kwargs["limit"] == 3
+
+
+@pytest.mark.asyncio
+async def test_limit_used_when_no_limit_per_type(mock_db, patched_search):
+    """Without limit_per_type, the plain limit is forwarded."""
+    result = await unified_search(
+        q="core",
+        tags=None,
+        entity_types="tools",
+        include_inactive=False,
+        limit=5,
+        limit_per_type=None,
+        gateway_id=None,
+        team_id=None,
+        db=mock_db,
+        user=USER,
+    )
+    assert result["limit_per_type"] == 5
+    assert patched_search["tools"].await_args.kwargs["limit"] == 5


### PR DESCRIPTION
## Summary

Adds a new search API, `GET /v1/search`, that returns the same results as the existing `/admin/search` but without requiring admin access. This lets the app's global search use a stable, public API instead of an admin route that is being deprecated.

Closes #5520.

## What this PR does

Adds a public, versioned search API so the app's global search no longer needs admin-panel access.

```
BEFORE:  only  GET /admin/search    (requires admin.dashboard permission)
                 → only admins can search

AFTER:   also   GET /v1/search       (any logged-in user)
                 → results are still filtered by YOUR own permissions:
                     • a tool shows up only if you can read tools
                     • a team shows up only if it's in your scope
                     • users show up only with user-management permission
```

Two security fixes picked up during review:

```
Fix 1 — scoped API tokens could not use the endpoint
   BEFORE:  token scoped to "tools.read"  →  GET /v1/search  →  403
   AFTER:   token scoped to "tools.read"  →  GET /v1/search  →  200  (returns your tools)

Fix 2 — team search leaked across a narrowed token (non-admin)
   Non-admin in teams A + B, token scoped to B:
   BEFORE:  search teams  →  A, B   (leak)
   AFTER:   search teams  →  B
   (the admin-side version of this leak is the follow-up #5668)
```

## What changed

- **Shared the search logic.** Moved the search code out of the admin handler into a reusable helper so both routes run the same logic. `/admin/search` behaves exactly as before.
- **Added the new route** (`mcpgateway/routers/search.py`). `GET /search` only requires the caller to be logged in. Results are still filtered by the caller's existing permissions and team access, so nothing shows up that they could not already see, and `users` still requires the user-management permission.
- **Made it always available** at `/v1/search` (and the legacy `/search`), whether or not the admin API is enabled.

## Behavior parity

Same query params (`q`, `tags`, `entity_types`, `include_inactive`, `limit`, `limit_per_type`, `gateway_id`, `team_id`), same supported entity types, and the same grouped + flattened response shape as `/admin/search`.

## Auth & RBAC

- Top-level gate is authentication only, per the issue's guidance that the route should not require admin-panel access.
- Per-entity RBAC and token scoping unchanged.
- `users` remains gated on `admin.user_management`; team filtering still validated server-side.

## Tests

`tests/unit/mcpgateway/routers/test_search_router.py` covers:
- unauthenticated request rejected
- invalid / empty `entity_types` -> 400
- `users` dropped without permission (no leak); users-only request -> 403
- `team_id` forwarded to per-entity searches
- `limit` / `limit_per_type` alias behavior
- grouped + flattened response-shape parity with the shared core
- `/v1/search` present even when the admin API is disabled

## Scope

`/admin/search` is left in place as the fallback during the React client migration (issue #5518 owns switching the UI client). No frontend changes here.

## Verification

- Unit tests (`tests/unit/mcpgateway/routers/test_search_router.py`): 11 passed, plus the existing `admin_unified_search` suite green.
- Integration tests (`tests/integration/test_search_endpoint.py`): 8 passed. Run with:
  ```bash
  pytest tests/integration/test_search_endpoint.py --with-integration -v
  ```
  - Wiring (5): full ASGI stack (routing, auth middleware, orchestration) on the real app for `/v1/search` and legacy `/search`, including 401 deny paths.
  - Real-data RBAC/token scoping (3): seed real teams, a non-admin member with a real global `tools.read` role, and public/team-private tools, then run the real `PermissionService` and `admin_search_tools` (nothing stubbed at the boundary). A token scoped to team-B does not see team-A's private tool while still returning public and team-B tools; without token narrowing the same member does see team-A (confirming the deny was the token, not missing access); and a non-admin requesting `tools,users` has `users` dropped while tools still return.
- E2E (`tests/e2e/test_search_e2e.py`): 3 passed. Drives a **real signed JWT** through the full auth + token-scoping middleware (no dependency overrides) against the real app on a temp DB:
  - unauthenticated → 401 (real auth middleware)
  - non-admin JWT → 200, and the member's `tools.read` role returns the seeded public tool (proves no admin needed — real RBAC, real data)
  - `tools.read`-scoped JWT → 200 (token-scoping middleware allows `/search`)

  Verified empirically: disabling the `/search` allow makes the scoped case fail with 403, and the deny/happy contrast confirms auth is genuinely enforced.
- bandit: no issues; interrogate: 100%; pylint: 10.00/10; ruff: clean

Note: the integration real-data tests inject identity (real `PermissionService`, `admin_search_tools`, and DB rows); the e2e test above covers the full JWT-middleware validation path end-to-end.

### Manual verification

Reproducible with curl (uses your local `JWT_SECRET_KEY`; no secrets required in this description):

```bash
# Start the gateway (dev server on :8000)
make dev

# Mint an admin JWT
export TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token \
  --username admin@example.com --exp 10080 --secret "$JWT_SECRET_KEY")
```

1. **Deny path — unauthenticated request is rejected**
   ```bash
   curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:8000/v1/search?q=a"
   # Expected: 401
   ```

2. **Happy path — authenticated search returns the grouped contract**
   ```bash
   curl -s -H "Authorization: Bearer $TOKEN" \
     "http://localhost:8000/v1/search?q=a&entity_types=tools,servers" | python3 -m json.tool
   # Expected: 200 with keys query, tags, entity_types, limit_per_type,
   #           filters_applied{q,tags,tag_groups}, results{...}, groups[], items[], count
   ```

3. **Parity with the legacy admin route** — `/admin/search` requires admin privileges, so this step needs a token whose `user.is_admin` claim is set. The `create_jwt_token` CLI token above is auth-only (it can reach `/v1/search` but 403s on `/admin/*`), so mint an admin-privileged token for the comparison:
   ```bash
   ADMIN_TOKEN=$(python3 - <<'PY'
   import time, uuid, jwt
   from mcpgateway.config import settings
   now = int(time.time())
   print(jwt.encode({"sub": "admin@example.com", "iat": now, "exp": now + 3600,
     "iss": "mcpgateway", "aud": "mcpgateway-api", "jti": uuid.uuid4().hex,
     "user": {"email": "admin@example.com", "is_admin": True, "auth_provider": "local"}, "teams": None},
     settings.jwt_secret_key.get_secret_value(), algorithm="HS256"))
   PY
   )
   diff <(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "http://localhost:8000/v1/search?q=a&entity_types=tools") \
        <(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "http://localhost:8000/admin/search?q=a&entity_types=tools")
   # Expected: no output (identical payloads)
   ```

4. **Restricted entity (`users`) stays protected**
   ```bash
   curl -s -H "Authorization: Bearer $TOKEN" \
     "http://localhost:8000/v1/search?q=admin&entity_types=users" | python3 -m json.tool
   # Admin token sees the "users" group; a non-admin token (no admin.user_management)
   # has "users" dropped, and a users-only request returns 403 — no leak.
   ```

5. **Available independent of the admin API** — `/v1/search` is an always-on route, so it appears in `openapi.json` under the **Search** tag even with `MCPGATEWAY_ADMIN_API_ENABLED=false`.

| Check | Expected |
|-------|----------|
| Unauthenticated | 401 |
| Authenticated grouped response | 200, matches `/admin/search` shape |
| Parity with `/admin/search` | identical payload |
| `users` protection | dropped / 403 without permission |
| Present without admin API | route in OpenAPI under **Search** tag |

Also verified in the Swagger UI (`/docs` → **Search** → `GET /v1/search` → 200).





