### PR TITLE
Fix/output length guard resource bypass

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-14T13:02:12Z",
+  "generated_at": "2026-07-14T12:28:30Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -116,7 +116,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 718,
+        "line_number": 708,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 952,
+        "line_number": 942,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1250,
+        "line_number": 1240,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1276,
+        "line_number": 1266,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1284,
+        "line_number": 1274,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1363,
+        "line_number": 1353,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1368,
+        "line_number": 1358,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1373,
+        "line_number": 1363,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1379,
+        "line_number": 1369,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1391,
+        "line_number": 1381,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1409,
+        "line_number": 1399,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -204,7 +204,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1470,
+        "line_number": 1460,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -910,7 +910,7 @@
         "hashed_secret": "32cedd1d512c32c41cf5aae15c03a74c806120d2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15,
+        "line_number": 14,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1078,16 +1078,6 @@
         "is_verified": false,
         "line_number": 173,
         "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "docs/docs/architecture/mcp-apps.md": [
-      {
-        "hashed_secret": "7f89c5fe5f113485339383ac7cca52e698544052",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 245,
-        "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],
@@ -2142,7 +2132,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 443,
+        "line_number": 432,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2150,7 +2140,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 809,
+        "line_number": 798,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2158,7 +2148,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1293,
+        "line_number": 1282,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2166,7 +2156,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1297,
+        "line_number": 1286,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4104,7 +4094,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4469,
+        "line_number": 4463,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4930,7 +4920,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 970,
+        "line_number": 952,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-14T12:28:30Z",
+  "generated_at": "2026-07-14T13:45:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -116,7 +116,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 708,
+        "line_number": 718,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 942,
+        "line_number": 952,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1240,
+        "line_number": 1250,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1266,
+        "line_number": 1276,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1274,
+        "line_number": 1284,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1353,
+        "line_number": 1363,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1358,
+        "line_number": 1368,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1363,
+        "line_number": 1373,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1369,
+        "line_number": 1379,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1381,
+        "line_number": 1391,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1399,
+        "line_number": 1409,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -204,7 +204,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1460,
+        "line_number": 1470,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -910,7 +910,7 @@
         "hashed_secret": "32cedd1d512c32c41cf5aae15c03a74c806120d2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14,
+        "line_number": 15,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1078,6 +1078,16 @@
         "is_verified": false,
         "line_number": 173,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "docs/docs/architecture/mcp-apps.md": [
+      {
+        "hashed_secret": "7f89c5fe5f113485339383ac7cca52e698544052",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 245,
+        "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],
@@ -2132,7 +2142,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 432,
+        "line_number": 443,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2140,7 +2150,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 798,
+        "line_number": 809,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2148,7 +2158,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1282,
+        "line_number": 1293,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2156,7 +2166,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1286,
+        "line_number": 1297,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4094,7 +4104,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4463,
+        "line_number": 4469,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4920,7 +4930,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 952,
+        "line_number": 970,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/plugins/output_length_guard/output_length_guard.py
+++ b/plugins/output_length_guard/output_length_guard.py
@@ -279,9 +279,9 @@ class OutputLengthGuardPlugin(Plugin):
                         "chars_per_token": cfg.chars_per_token,
                     },
                 )
-            return ToolPostInvokeResult(metadata={"mcp_result_processed": True, "items_modified": False, "structured_content_processed": False})
+            # structuredContent was within bounds: fall through to scan content array
 
-        # NO structuredContent: Process content array normally
+        # Always process content array regardless of whether structuredContent was present
         modified = False
         content_out: List[Any] = []
 
@@ -300,6 +300,26 @@ class OutputLengthGuardPlugin(Plugin):
                     content_out.append(new_item)
                 else:
                     content_out.append(item)
+            elif isinstance(item, dict) and item.get("type") == "resource":
+                resource = item.get("resource")
+                if isinstance(resource, dict) and isinstance(resource.get("text"), str):
+                    current_text = resource["text"]
+                    new_text, meta, violation = _handle_text(current_text, cfg, policy)
+
+                    if violation:
+                        return ToolPostInvokeResult(continue_processing=False, violation=violation, metadata=meta)
+
+                    if new_text != current_text:
+                        modified = True
+                        new_resource = dict(resource)
+                        new_resource["text"] = new_text
+                        new_item = dict(item)
+                        new_item["resource"] = new_resource
+                        content_out.append(new_item)
+                    else:
+                        content_out.append(item)
+                else:
+                    content_out.append(item)
             else:
                 content_out.append(item)
 
@@ -309,9 +329,9 @@ class OutputLengthGuardPlugin(Plugin):
 
             return ToolPostInvokeResult(
                 modified_payload=ToolPostInvokePayload(name=payload.name, result=new_result),
-                metadata={"mcp_result_processed": True, "items_modified": True, "structured_content_processed": False},
+                metadata={"mcp_result_processed": True, "items_modified": True, "structured_content_processed": struct_key is not None},
             )
-        return ToolPostInvokeResult(metadata={"mcp_result_processed": True, "items_modified": False})
+        return ToolPostInvokeResult(metadata={"mcp_result_processed": True, "items_modified": False, "structured_content_processed": struct_key is not None})
 
     def _handle_plain_string(self, payload: ToolPostInvokePayload, result: str) -> ToolPostInvokeResult:
         """Handle plain string result.
@@ -379,6 +399,26 @@ class OutputLengthGuardPlugin(Plugin):
                     new_item = dict(item)
                     new_item["text"] = new_text
                     mcp_out.append(new_item)
+                else:
+                    mcp_out.append(item)
+            elif isinstance(item, dict) and item.get("type") == "resource":
+                resource = item.get("resource")
+                if isinstance(resource, dict) and isinstance(resource.get("text"), str):
+                    current_text = resource["text"]
+                    new_text, meta, violation = _handle_text(current_text, self._cfg, self._policy)
+
+                    if violation:
+                        return ToolPostInvokeResult(continue_processing=False, violation=violation, metadata=meta)
+
+                    if new_text != current_text:
+                        modified = True
+                        new_resource = dict(resource)
+                        new_resource["text"] = new_text
+                        new_item = dict(item)
+                        new_item["resource"] = new_resource
+                        mcp_out.append(new_item)
+                    else:
+                        mcp_out.append(item)
                 else:
                     mcp_out.append(item)
             else:

--- a/tests/unit/plugins/test_output_length_guard.py
+++ b/tests/unit/plugins/test_output_length_guard.py
@@ -2005,13 +2005,7 @@ class TestPluginIntegration(BaseOutputLengthGuardTest):
         self.assertEqual(struct_result[2], "regular...")
 
     def test_content_field_not_truncated_after_regeneration(self):
-        """Regenerated content from structuredContent is not double-truncated (v0.3.3 fix).
-
-        When structuredContent strings exceed max_chars and get truncated, the plugin
-        replaces content[] with a JSON representation of the truncated struct.
-        That JSON text must NOT be run through the length guard a second time,
-        even though it is itself longer than max_chars.
-        """
+        """Regenerated content from structuredContent is not double-truncated"""
         payload = Mock()
         payload.name = "test_tool"
         # Both strings exceed max_chars=10, so struct_modified=True

--- a/tests/unit/plugins/test_output_length_guard.py
+++ b/tests/unit/plugins/test_output_length_guard.py
@@ -2005,24 +2005,35 @@ class TestPluginIntegration(BaseOutputLengthGuardTest):
         self.assertEqual(struct_result[2], "regular...")
 
     def test_content_field_not_truncated_after_regeneration(self):
-        """Test the critical v0.3.3 fix: regenerated content is not truncated."""
+        """Regenerated content from structuredContent is not double-truncated (v0.3.3 fix).
+
+        When structuredContent strings exceed max_chars and get truncated, the plugin
+        replaces content[] with a JSON representation of the truncated struct.
+        That JSON text must NOT be run through the length guard a second time,
+        even though it is itself longer than max_chars.
+        """
         payload = Mock()
         payload.name = "test_tool"
-        payload.result = {"content": [{"type": "text", "text": "ignored"}], "structuredContent": {"result": ["sff", "dffd"]}}
+        # Both strings exceed max_chars=10, so struct_modified=True
+        payload.result = {
+            "content": [{"type": "text", "text": "ignored"}],
+            "structuredContent": {"result": ["longer than ten", "also long text"]},
+        }
 
         result = asyncio.run(self.plugin.tool_post_invoke(payload, self.mock_context))
 
-        # Check if plugin made modifications
-        if result.modified_payload is None:
-            # If no modification, check if original content is correct
-            self.skipTest("Plugin did not modify payload - may be working as intended")
-
+        self.assertIsNotNone(result.modified_payload, "Plugin should modify payload when structuredContent strings exceed max_chars")
         modified_result = result.modified_payload.result
-        content_text = modified_result["content"][0]["text"]
 
-        # Content should be the full JSON representation
-        expected = '["sff","dffd"]'
-        self.assertEqual(content_text, expected)
+        # structuredContent strings should each be truncated to max_chars=10
+        struct_items = modified_result["structuredContent"]["result"]
+        self.assertEqual(struct_items[0], "longer ...")
+        self.assertEqual(struct_items[1], "also lo...")
+
+        # content[0]["text"] must be the JSON of the truncated struct and must NOT
+        # be truncated again — it is 27 chars but should survive intact
+        content_text = modified_result["content"][0]["text"]
+        self.assertEqual(content_text, '["longer ...","also lo..."]')
 
     def test_null_structured_content_processes_content_array(self):
         """Test that structuredContent: null allows content array processing (Issue #20 fix).
@@ -3854,12 +3865,7 @@ class TestResourceItemHandling(BaseOutputLengthGuardTest):
     # ------------------------------------------------------------------
 
     def test_struct_within_bounds_resource_text_truncated(self):
-        """structuredContent is small (within bounds); resource.text in content must still be truncated.
-
-        This is the primary regression from Issue #5602: when structuredContent was
-        present and passed the length check, the plugin returned early and never
-        enforced limits on the content array, allowing large resource.text through.
-        """
+        """structuredContent is small (within bounds); resource.text in content must still be truncated."""
         large_text = "x" * 500
         payload = Mock()
         payload.name = "file_download"

--- a/tests/unit/plugins/test_output_length_guard.py
+++ b/tests/unit/plugins/test_output_length_guard.py
@@ -3827,3 +3827,195 @@ class TestMalformedData:
         # Should handle gracefully
         assert isinstance(result, str)
         assert len(result) > 0
+
+
+# ============================================================================
+# SECTION: RESOURCE ITEM HANDLING TESTS (Issue #5602)
+# Bug 1: structuredContent within bounds caused early return, skipping content scan
+# Bug 2: type:"resource" items with resource.text were never length-checked
+# ============================================================================
+
+
+class TestResourceItemHandling(BaseOutputLengthGuardTest):
+    """Tests for Issue #5602: OutputLengthGuardPlugin bypasses embedded resource content.
+
+    Bug 1 — structuredContent present but within bounds → content array was silently skipped.
+    Bug 2 — type:"resource" items in content/mcp-list were passed through unchecked.
+    """
+
+    def setUp(self):
+        """Set up plugin with max_chars=20, truncate strategy."""
+        self.plugin = self.create_plugin(max_chars=20, strategy="truncate", ellipsis="...")
+        self.mock_context = Mock()
+        self.mock_context.logger = Mock()
+
+    # ------------------------------------------------------------------
+    # Bug 1: struct within bounds must not skip content scan
+    # ------------------------------------------------------------------
+
+    def test_struct_within_bounds_resource_text_truncated(self):
+        """structuredContent is small (within bounds); resource.text in content must still be truncated.
+
+        This is the primary regression from Issue #5602: when structuredContent was
+        present and passed the length check, the plugin returned early and never
+        enforced limits on the content array, allowing large resource.text through.
+        """
+        large_text = "x" * 500
+        payload = Mock()
+        payload.name = "file_download"
+        payload.result = {
+            "structuredContent": {"sha": "abc123", "path": "config.json", "size": 500},
+            "content": [
+                {"type": "text", "text": "downloaded ok"},
+                {"type": "resource", "resource": {"uri": "file:///config.json", "text": large_text}},
+            ],
+        }
+
+        result = self.invoke_plugin(payload)
+
+        self.assertIsNotNone(result.modified_payload, "Plugin should modify payload")
+        content = result.modified_payload.result["content"]
+        resource_text = content[1]["resource"]["text"]
+        self.assertLessEqual(len(resource_text), 23, f"resource.text should be truncated, got length {len(resource_text)}")
+        self.assertTrue(resource_text.endswith("..."), "Truncated resource.text should end with ellipsis")
+
+    def test_struct_within_bounds_resource_text_blocked(self):
+        """structuredContent within bounds; oversized resource.text must be blocked when strategy=block."""
+        large_text = "y" * 500
+        plugin = self.create_plugin(max_chars=20, strategy="block", ellipsis="...")
+        payload = Mock()
+        payload.name = "file_download"
+        payload.result = {
+            "structuredContent": {"sha": "abc123"},
+            "content": [
+                {"type": "resource", "resource": {"text": large_text}},
+            ],
+        }
+
+        result = asyncio.run(plugin.tool_post_invoke(payload, self.mock_context))
+
+        self.assertIsNotNone(result.violation, "Plugin should raise a violation")
+        self.assertFalse(result.continue_processing)
+
+    def test_struct_within_bounds_text_item_still_enforced(self):
+        """Regression: structuredContent within bounds; type:text items in content still truncated."""
+        payload = Mock()
+        payload.name = "tool"
+        payload.result = {
+            "structuredContent": {"ok": True},
+            "content": [{"type": "text", "text": "this text is definitely too long for the limit"}],
+        }
+
+        result = self.invoke_plugin(payload)
+
+        self.assertIsNotNone(result.modified_payload)
+        content_text = result.modified_payload.result["content"][0]["text"]
+        self.assertLessEqual(len(content_text), 23)
+        self.assertTrue(content_text.endswith("..."))
+
+    def test_struct_within_bounds_metadata_reflects_struct_processed(self):
+        """structured_content_processed flag is True when structuredContent was present but within bounds."""
+        payload = Mock()
+        payload.name = "tool"
+        payload.result = {
+            "structuredContent": {"ok": True},
+            "content": [{"type": "text", "text": "short"}],
+        }
+
+        result = self.invoke_plugin(payload)
+
+        self.assertTrue(result.metadata.get("structured_content_processed"), "structured_content_processed should be True")
+
+    # ------------------------------------------------------------------
+    # Bug 2: type:"resource" items must be length-checked
+    # ------------------------------------------------------------------
+
+    def test_resource_item_text_truncated_no_struct(self):
+        """type:resource item with large resource.text is truncated (no structuredContent)."""
+        large_text = "z" * 500
+        payload = Mock()
+        payload.name = "tool"
+        payload.result = {
+            "content": [{"type": "resource", "resource": {"uri": "file:///data.txt", "text": large_text}}],
+        }
+
+        result = self.invoke_plugin(payload)
+
+        self.assertIsNotNone(result.modified_payload)
+        resource_text = result.modified_payload.result["content"][0]["resource"]["text"]
+        self.assertLessEqual(len(resource_text), 23)
+        self.assertTrue(resource_text.endswith("..."))
+
+    def test_resource_item_text_blocked_no_struct(self):
+        """type:resource item with large resource.text is blocked when strategy=block."""
+        large_text = "z" * 500
+        plugin = self.create_plugin(max_chars=20, strategy="block", ellipsis="...")
+        payload = Mock()
+        payload.name = "tool"
+        payload.result = {
+            "content": [{"type": "resource", "resource": {"text": large_text}}],
+        }
+
+        result = asyncio.run(plugin.tool_post_invoke(payload, self.mock_context))
+
+        self.assertIsNotNone(result.violation)
+        self.assertFalse(result.continue_processing)
+
+    def test_resource_item_within_bounds_passthrough(self):
+        """type:resource item whose resource.text is within bounds is passed through unchanged."""
+        short_text = "hello"
+        payload = Mock()
+        payload.name = "tool"
+        payload.result = {
+            "content": [{"type": "resource", "resource": {"uri": "file:///x", "text": short_text}}],
+        }
+
+        result = self.invoke_plugin(payload)
+
+        # No modification expected
+        self.assertIsNone(result.modified_payload)
+        self.assertFalse(result.metadata.get("items_modified", False))
+
+    def test_resource_item_no_text_field_passthrough(self):
+        """type:resource item without a text field (e.g. blob/uri resource) is passed through unchanged."""
+        payload = Mock()
+        payload.name = "tool"
+        payload.result = {
+            "content": [{"type": "resource", "resource": {"uri": "file:///image.png", "blob": "base64data=="}}],
+        }
+
+        result = self.invoke_plugin(payload)
+
+        # No modification — no text to check
+        self.assertIsNone(result.modified_payload)
+
+    def test_mcp_list_resource_item_truncated(self):
+        """_handle_mcp_list path: bare list containing a type:resource item truncates resource.text."""
+        large_text = "q" * 500
+        payload = Mock()
+        payload.name = "tool"
+        # A bare list (not wrapped in a dict) triggers _handle_mcp_list
+        payload.result = [
+            {"type": "text", "text": "ok"},
+            {"type": "resource", "resource": {"uri": "file:///data.txt", "text": large_text}},
+        ]
+
+        result = self.invoke_plugin(payload)
+
+        self.assertIsNotNone(result.modified_payload)
+        items = result.modified_payload.result
+        resource_text = items[1]["resource"]["text"]
+        self.assertLessEqual(len(resource_text), 23)
+        self.assertTrue(resource_text.endswith("..."))
+
+    def test_mcp_list_resource_item_within_bounds_passthrough(self):
+        """_handle_mcp_list: type:resource item within bounds is unchanged."""
+        payload = Mock()
+        payload.name = "tool"
+        payload.result = [
+            {"type": "resource", "resource": {"text": "tiny"}},
+        ]
+
+        result = self.invoke_plugin(payload)
+
+        self.assertIsNone(result.modified_payload)


### PR DESCRIPTION
## 🔗 Related Issue

Closes #5602 [#72396](https://github.ibm.com/WatsonOrchestrate/wo-tracker/issues/72396)

---

## 📝 Summary

The `OutputLengthGuardPlugin` was silently bypassing length enforcement for two related but distinct cases involving MCP tool results that contain embedded resource content:

**Bug 1 — Early return when `structuredContent` is within bounds**
When a result contained `structuredContent` that was within the configured limits, the plugin returned immediately with `items_modified: False` — never scanning the `content` array at all. Any `resource` items (or even `text` items) in `content` escaped enforcement entirely.

**Bug 2 — `type: "resource"` items never enforced**
The loop over the `content` array only handled `type: "text"` items. Items of `type: "resource"` fell through the `else` branch unconditionally, meaning `resource.text` (which can contain arbitrary tool output) was never truncated or blocked, regardless of its length.

**Additionally fixed:**
- The `structured_content_processed` metadata flag was hardcoded to `False` even when `structuredContent` was actually processed. It now reflects whether a `structuredContent` key was present.
- A pre-existing always-skipping test (`test_content_field_not_truncated_after_regeneration`) was silently passing because its fixture data was too short to trigger the code path under test. Fixed to use strings that actually exceed `max_chars`.

**Files changed:**
- `plugins/output_length_guard/output_length_guard.py` — removed early return, added `resource` item branch in both `_handle_mcp_content_dict()` and `_handle_mcp_list()`, fixed metadata flag
- `tests/unit/plugins/test_output_length_guard.py` — added `TestResourceItemHandling` class (10 tests), fixed always-skipping double-truncation test

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix

---

## 🧪 Verification

### Reproduction (before fix)

```python
# structuredContent within bounds → content array silently skipped (Bug 1)
payload.result = {
    "content": [{"type": "resource", "resource": {"uri": "file://out.txt", "text": "A" * 10000}}],
    "structuredContent": {"status": "ok"},  # within limits
}
# resource.text is returned untruncated — no enforcement occurs

# resource item in content array → always passes through (Bug 2)
payload.result = {
    "content": [{"type": "resource", "resource": {"uri": "file://data.json", "text": "B" * 50000}}],
}
# resource.text is returned untruncated regardless of max_chars
```

### Fix verification

```bash
# Run the new resource-handling tests
python -m pytest tests/unit/plugins/test_output_length_guard.py::TestResourceItemHandling -v

# Run the full plugin test suite
python -m pytest tests/unit/plugins/test_output_length_guard.py -v

# Run all unit tests
make test
```

| Check          | Command                                                                                      | Status |
|----------------|----------------------------------------------------------------------------------------------|--------|
| New tests pass | `pytest tests/unit/plugins/test_output_length_guard.py::TestResourceItemHandling -v`        | ✅ 10/10 |
| Full suite     | `pytest tests/unit/plugins/test_output_length_guard.py -v`                                   | ✅     |
| Lint suite     | `make lint`                                                                                  |        |
| Unit tests     | `make test`                                                                                  |        |
| Coverage ≥ 80% | `make coverage`                                                                              |        |

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes