### PR TITLE
fix: support mixed stateful and stateless MCP sessions

### DIFF
--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -4608,6 +4608,7 @@ class SessionManagerWrapper:
         # collapse this case to -32600 "Missing session ID". Peek only small,
         # single-message JSON-RPC requests; known methods and malformed/large
         # bodies fall through to the SDK's normal transport/session checks.
+        peeked_rpc_method: Optional[str] = None
         if method == "POST" and mcp_session_id == "not-provided" and is_mcp_path and not is_internally_forwarded:
             peek = await _drain_request_body(receive)
             if peek.disconnected:
@@ -4621,7 +4622,8 @@ class SessionManagerWrapper:
                 except orjson.JSONDecodeError:
                     payload = None
                 if isinstance(payload, dict):
-                    rpc_method = payload.get("method")
+                    peeked_rpc_method = payload.get("method")  # NEW — save for routing
+                    rpc_method = peeked_rpc_method
                     if isinstance(rpc_method, str) and "id" in payload and "/" in rpc_method and not _is_known_mcp_request_method(rpc_method):
                         await _send_streamable_http_json_response(
                             send,
@@ -4676,80 +4678,95 @@ class SessionManagerWrapper:
 
         span_exit_exc: tuple[Any, Any, Any] = (None, None, None)
 
+        # Routing decision:
+        #   • initialize (no session) → stateful manager, gateway mints a session
+        #   • session provided        → stateful manager, affinity/ownership enforced
+        #   • anything else, no session → stateless manager, upstream decides
+        _use_stateless_path = (
+            settings.use_stateful_sessions
+            and mcp_session_id == "not-provided"
+            and peeked_rpc_method != "initialize"
+        )
+        active_manager = self.session_manager_stateless if _use_stateless_path else self.session_manager
+
         try:
-            await self.session_manager.handle_request(scope, receive_with_initialize_trace, send_with_capture)
-            logger.debug("[STATEFUL] Streamable HTTP request completed successfully | Session: %s", mcp_session_id)
-
-            # Register ownership for the session we just handled
-            # This captures both existing sessions (mcp_session_id from request)
-            # and new sessions (captured_session_id from response)
+            await active_manager.handle_request(scope, receive_with_initialize_trace, send_with_capture)
             logger.debug(
-                "[HTTP_AFFINITY_DEBUG] affinity_enabled=%s stateful=%s captured=%s mcp_session_id=%s",
-                settings.mcpgateway_session_affinity_enabled,
-                settings.use_stateful_sessions,
-                captured_session_id,
-                mcp_session_id,
+                "[STATEFUL] Streamable HTTP completed | Session: %s | stateless-path: %s",
+                mcp_session_id, _use_stateless_path,
             )
-            # Two distinct writes happen here:
-            #
-            #   * Claim the *logical owner* in the shared session registry.
-            #     This is what `_validate_streamable_session_access` reads on
-            #     subsequent POST/DELETE/GET requests, so it MUST fire whether
-            #     or not multi-worker affinity is enabled — single-node
-            #     deployments still need ownership recorded for the GET-stream
-            #     gate to recognise the legitimate owner.
-            #
-            #   * Register the *worker-affinity* mapping. This only matters
-            #     when multi-worker affinity is on and stays gated.
-            session_to_register: Optional[str] = None
-            requester_email = user_context.get("email") if isinstance(user_context, dict) else None
-            if settings.use_stateful_sessions:
-                if captured_session_id:
-                    session_to_register = captured_session_id
-                    if requester_email:
-                        effective_owner = await _claim_streamable_session_owner(captured_session_id, requester_email)
-                        if effective_owner and effective_owner != requester_email and not bool(user_context.get("is_admin", False)):
-                            logger.warning(
-                                "Session owner mismatch for %s... (requester=%s, owner=%s)",
-                                captured_session_id[:8],
-                                requester_email,
-                                effective_owner,
-                            )
-                elif mcp_session_id != "not-provided":
-                    # Existing client-provided IDs may only refresh ownership
-                    # when they are already bound to the caller's principal.
-                    session_allowed, _deny_status, _deny_detail = await _validate_streamable_session_access(
-                        mcp_session_id=mcp_session_id,
-                        user_context=user_context,
-                        rpc_method=None,
-                    )
-                    if session_allowed:
-                        session_to_register = mcp_session_id
 
-            logger.debug(
-                "[HTTP_AFFINITY_DEBUG] affinity_enabled=%s stateful=%s captured=%s mcp_session_id=%s session_to_register=%s",
-                settings.mcpgateway_session_affinity_enabled,
-                settings.use_stateful_sessions,
-                captured_session_id,
-                mcp_session_id,
-                session_to_register,
-            )
-            if session_to_register and settings.mcpgateway_session_affinity_enabled:
-                try:
-                    # First-Party - lazy import to avoid circular dependencies
-                    # First-Party
-                    from mcpgateway.services.session_affinity import get_session_affinity, WORKER_ID  # pylint: disable=import-outside-toplevel
+            if not _use_stateless_path:
+                # Register ownership for the session we just handled
+                # This captures both existing sessions (mcp_session_id from request)
+                # and new sessions (captured_session_id from response)
+                logger.debug(
+                    "[HTTP_AFFINITY_DEBUG] affinity_enabled=%s stateful=%s captured=%s mcp_session_id=%s",
+                    settings.mcpgateway_session_affinity_enabled,
+                    settings.use_stateful_sessions,
+                    captured_session_id,
+                    mcp_session_id,
+                )
+                # Two distinct writes happen here:
+                #
+                #   * Claim the *logical owner* in the shared session registry.
+                #     This is what `_validate_streamable_session_access` reads on
+                #     subsequent POST/DELETE/GET requests, so it MUST fire whether
+                #     or not multi-worker affinity is enabled — single-node
+                #     deployments still need ownership recorded for the GET-stream
+                #     gate to recognise the legitimate owner.
+                #
+                #   * Register the *worker-affinity* mapping. This only matters
+                #     when multi-worker affinity is on and stays gated.
+                session_to_register: Optional[str] = None
+                requester_email = user_context.get("email") if isinstance(user_context, dict) else None
+                if settings.use_stateful_sessions:
+                    if captured_session_id:
+                        session_to_register = captured_session_id
+                        if requester_email:
+                            effective_owner = await _claim_streamable_session_owner(captured_session_id, requester_email)
+                            if effective_owner and effective_owner != requester_email and not bool(user_context.get("is_admin", False)):
+                                logger.warning(
+                                    "Session owner mismatch for %s... (requester=%s, owner=%s)",
+                                    captured_session_id[:8],
+                                    requester_email,
+                                    effective_owner,
+                                )
+                    elif mcp_session_id != "not-provided":
+                        # Existing client-provided IDs may only refresh ownership
+                        # when they are already bound to the caller's principal.
+                        session_allowed, _deny_status, _deny_detail = await _validate_streamable_session_access(
+                            mcp_session_id=mcp_session_id,
+                            user_context=user_context,
+                            rpc_method=None,
+                        )
+                        if session_allowed:
+                            session_to_register = mcp_session_id
 
-                    pool = get_session_affinity()
-                    await pool.register_session_owner(session_to_register)
-                    logger.debug(
-                        "[HTTP_AFFINITY_SDK] Worker %s | Session %s... | Registered ownership after SDK handling",
-                        WORKER_ID,
-                        session_to_register[:8],
-                    )
-                except Exception as e:
-                    logger.debug("[HTTP_AFFINITY_DEBUG] Exception during registration: %s", e)
-                    logger.warning("Failed to register session ownership: %s", e)
+                logger.debug(
+                    "[HTTP_AFFINITY_DEBUG] affinity_enabled=%s stateful=%s captured=%s mcp_session_id=%s session_to_register=%s",
+                    settings.mcpgateway_session_affinity_enabled,
+                    settings.use_stateful_sessions,
+                    captured_session_id,
+                    mcp_session_id,
+                    session_to_register,
+                )
+                if session_to_register and settings.mcpgateway_session_affinity_enabled:
+                    try:
+                        # First-Party - lazy import to avoid circular dependencies
+                        # First-Party
+                        from mcpgateway.services.session_affinity import get_session_affinity, WORKER_ID  # pylint: disable=import-outside-toplevel
+
+                        pool = get_session_affinity()
+                        await pool.register_session_owner(session_to_register)
+                        logger.debug(
+                            "[HTTP_AFFINITY_SDK] Worker %s | Session %s... | Registered ownership after SDK handling",
+                            WORKER_ID,
+                            session_to_register[:8],
+                        )
+                    except Exception as e:
+                        logger.debug("[HTTP_AFFINITY_DEBUG] Exception during registration: %s", e)
+                        logger.warning("Failed to register session ownership: %s", e)
 
         except anyio.ClosedResourceError:
             # Expected when client closes one side of the stream (normal lifecycle)

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -3863,6 +3863,16 @@ class SessionManagerWrapper:
             json_response=settings.json_response_enabled,
             stateless=stateless,
         )
+        # Stateless manager for sessionless non-initialize requests.
+        # stateless=True means the SDK skips all session-ID validation.
+        # The upstream receives the request as-is and returns its own
+        # response — including its own error if it requires a session.
+        self.session_manager_stateless = StreamableHTTPSessionManager(
+            app=mcp_app,
+            event_store=None,
+            json_response=settings.json_response_enabled,
+            stateless=True,
+        )
         self.stack = AsyncExitStack()
 
     async def initialize(self) -> None:
@@ -3879,6 +3889,7 @@ class SessionManagerWrapper:
         """
         logger.debug("Initializing Streamable HTTP service")
         await self.stack.enter_async_context(self.session_manager.run())
+        await self.stack.enter_async_context(self.session_manager_stateless.run())
 
     async def shutdown(self) -> None:
         """

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -4682,18 +4682,15 @@ class SessionManagerWrapper:
         #   • initialize (no session) → stateful manager, gateway mints a session
         #   • session provided        → stateful manager, affinity/ownership enforced
         #   • anything else, no session → stateless manager, upstream decides
-        _use_stateless_path = (
-            settings.use_stateful_sessions
-            and mcp_session_id == "not-provided"
-            and peeked_rpc_method != "initialize"
-        )
+        _use_stateless_path = settings.use_stateful_sessions and mcp_session_id == "not-provided" and peeked_rpc_method != "initialize"
         active_manager = self.session_manager_stateless if _use_stateless_path else self.session_manager
 
         try:
             await active_manager.handle_request(scope, receive_with_initialize_trace, send_with_capture)
             logger.debug(
                 "[STATEFUL] Streamable HTTP completed | Session: %s | stateless-path: %s",
-                mcp_session_id, _use_stateless_path,
+                mcp_session_id,
+                _use_stateless_path,
             )
 
             if not _use_stateless_path:

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -2574,10 +2574,10 @@ async def test_session_manager_wrapper_initialization_stateful(monkeypatch):
         async def handle_request(self, scope, receive, send):
             self.called = True
 
-    captured_config = {}
+    captured_configs = []
 
     def capture_manager(**kwargs):
-        captured_config.update(kwargs)
+        captured_configs.append(dict(kwargs))
         return DummySessionManager(**kwargs)
 
     # Mock settings to enable stateful sessions with InMemoryEventStore
@@ -2590,10 +2590,17 @@ async def test_session_manager_wrapper_initialization_stateful(monkeypatch):
 
     wrapper = SessionManagerWrapper()
 
-    # Verify that stateful configuration was used
-    assert captured_config["stateless"] is False
-    assert captured_config["event_store"] is not None
-    assert isinstance(captured_config["event_store"], tr.InMemoryEventStore)
+    # Verify that the stateful manager (first call) was configured correctly.
+    # Task 1 added session_manager_stateless (second call, stateless=True).
+    assert len(captured_configs) >= 2, "Expected two StreamableHTTPSessionManager instantiations"
+    stateful_config = captured_configs[0]
+    assert stateful_config["stateless"] is False
+    assert stateful_config["event_store"] is not None
+    assert isinstance(stateful_config["event_store"], tr.InMemoryEventStore)
+    # Verify the stateless companion manager (second call)
+    stateless_config = captured_configs[1]
+    assert stateless_config["stateless"] is True
+    assert stateless_config["event_store"] is None
 
     await wrapper.initialize()
     await wrapper.shutdown()
@@ -6752,7 +6759,8 @@ async def test_session_manager_wrapper_redis_event_store(monkeypatch):
     captured_config = {}
 
     def capture_manager(**kwargs):
-        captured_config.update(kwargs)
+        if not captured_config:  # capture first (stateful) manager only
+            captured_config.update(kwargs)
         dummy = MagicMock()
         dummy.run = MagicMock(return_value=asynccontextmanager(lambda: (yield dummy))())
         return dummy
@@ -6782,7 +6790,8 @@ async def test_session_manager_wrapper_rust_event_store(monkeypatch):
     captured_config = {}
 
     def capture_manager(**kwargs):
-        captured_config.update(kwargs)
+        if not captured_config:  # capture first (stateful) manager only
+            captured_config.update(kwargs)
         dummy = MagicMock()
         dummy.run = MagicMock(return_value=asynccontextmanager(lambda: (yield dummy))())
         return dummy
@@ -6811,7 +6820,8 @@ async def test_session_manager_wrapper_redis_event_store_when_rust_event_store_d
     captured_config = {}
 
     def capture_manager(**kwargs):
-        captured_config.update(kwargs)
+        if not captured_config:  # capture first (stateful) manager only
+            captured_config.update(kwargs)
         dummy = MagicMock()
         dummy.run = MagicMock(return_value=asynccontextmanager(lambda: (yield dummy))())
         return dummy
@@ -6839,7 +6849,8 @@ async def test_session_manager_wrapper_falls_back_to_python_event_store_when_ses
     captured_config = {}
 
     def capture_manager(**kwargs):
-        captured_config.update(kwargs)
+        if not captured_config:  # capture first (stateful) manager only
+            captured_config.update(kwargs)
         dummy = MagicMock()
         dummy.run = MagicMock(return_value=asynccontextmanager(lambda: (yield dummy))())
         return dummy
@@ -10054,7 +10065,7 @@ async def test_send_with_capture_registers_session(monkeypatch):
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
         patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
     ):
-        await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
+        await wrapper.handle_streamable_http(scope, _make_receive(b'{"jsonrpc":"2.0","method":"initialize","id":1}'), send)
 
     await wrapper.shutdown()
     mock_pool.register_session_owner.assert_called_once_with("new-session-id")
@@ -10097,7 +10108,7 @@ async def test_send_with_capture_str_headers_and_non_matching_header(monkeypatch
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
         patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
     ):
-        await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
+        await wrapper.handle_streamable_http(scope, _make_receive(b'{"jsonrpc":"2.0","method":"initialize","id":1}'), send)
 
     await wrapper.shutdown()
     mock_pool.register_session_owner.assert_called_once_with("new-session-id")
@@ -10140,7 +10151,7 @@ async def test_send_with_capture_registration_failure_logged(monkeypatch, caplog
         patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
         caplog.at_level("WARNING", logger="mcpgateway.transports.streamablehttp_transport"),
     ):
-        await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
+        await wrapper.handle_streamable_http(scope, _make_receive(b'{"jsonrpc":"2.0","method":"initialize","id":1}'), send)
 
     await wrapper.shutdown()
     assert "Failed to register session ownership" in caplog.text
@@ -10227,7 +10238,7 @@ async def test_send_with_capture_claims_owner_for_new_session(monkeypatch):
                 }
             )
             try:
-                await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
+                await wrapper.handle_streamable_http(scope, _make_receive(b'{"jsonrpc":"2.0","method":"initialize","id":1}'), send)
             finally:
                 tr.user_context_var.reset(token)
 
@@ -14710,7 +14721,7 @@ async def test_session_owner_mismatch_logs_warning(monkeypatch, caplog):
             )
             try:
                 with caplog.at_level(logging.WARNING, logger="mcpgateway.transports.streamablehttp_transport"):
-                    await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
+                    await wrapper.handle_streamable_http(scope, _make_receive(b'{"jsonrpc":"2.0","method":"initialize","id":1}'), send)
             finally:
                 tr.user_context_var.reset(token)
 

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -17607,3 +17607,206 @@ async def test_list_tools_sso_admin_gets_admin_bypass_at_service_layer(monkeypat
     await list_tools()
 
     assert called["args"] == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# Transparent stateful/stateless session routing regressions (#5484)
+# ---------------------------------------------------------------------------
+
+
+class _SessionRoutingManager:
+    """Small SDK manager double that records dispatch and emits an optional ID."""
+
+    def __init__(self, *, stateless: bool, response_session_id: str | None = None):
+        self.stateless = stateless
+        self.response_session_id = response_session_id
+        self.calls = 0
+
+    @asynccontextmanager
+    async def run(self):
+        yield self
+
+    async def handle_request(self, scope, receive, send):
+        self.calls += 1
+        headers = []
+        if self.response_session_id is not None:
+            headers.append((b"mcp-session-id", self.response_session_id.encode()))
+        await send({"type": "http.response.start", "status": 200, "headers": headers})
+        await send({"type": "http.response.body", "body": b'{"jsonrpc":"2.0","result":{}}'})
+
+
+def _install_session_routing_managers(monkeypatch, response_session_id=None):
+    """Install manager doubles and return them in construction order."""
+    managers = []
+
+    def manager_factory(**kwargs):
+        manager = _SessionRoutingManager(stateless=kwargs["stateless"], response_session_id=response_session_id)
+        managers.append(manager)
+        return manager
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", manager_factory)
+    return managers
+
+
+def _manager_with_stateless_flag(managers, stateless):
+    return next(manager for manager in managers if manager.stateless is stateless)
+
+
+@pytest.mark.asyncio
+async def test_streamable_sessionless_non_initialize_uses_stateless_manager(monkeypatch):
+    """A sessionless tools/list POST uses the stateless SDK manager."""
+    monkeypatch.setattr(tr.settings, "use_stateful_sessions", True)
+    monkeypatch.setattr(tr.settings, "mcpgateway_session_affinity_enabled", False)
+    managers = _install_session_routing_managers(monkeypatch)
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+
+    try:
+        body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}).encode()
+        await wrapper.handle_streamable_http(_make_scope("/mcp"), _make_receive(body), send)
+    finally:
+        await wrapper.shutdown()
+
+    stateful = _manager_with_stateless_flag(managers, False)
+    stateless = _manager_with_stateless_flag(managers, True)
+    assert stateless.calls == 1
+    assert stateful.calls == 0
+    assert next(message for message in messages if message["type"] == "http.response.start")["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_streamable_sessionless_initialize_uses_stateful_manager_and_registers_session(monkeypatch):
+    """Initialize stays stateful so the newly minted session can be registered."""
+    monkeypatch.setattr(tr.settings, "use_stateful_sessions", True)
+    monkeypatch.setattr(tr.settings, "mcpgateway_session_affinity_enabled", False)
+    managers = _install_session_routing_managers(monkeypatch, response_session_id="new-session")
+    claim_owner = AsyncMock(return_value="user@example.com")
+    monkeypatch.setattr(tr, "_claim_streamable_session_owner", claim_owner)
+    context_token = tr.user_context_var.set({"email": "user@example.com"})
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+
+    try:
+        body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}).encode()
+        await wrapper.handle_streamable_http(_make_scope("/mcp"), _make_receive(body), send)
+    finally:
+        await wrapper.shutdown()
+        tr.user_context_var.reset(context_token)
+
+    stateful = _manager_with_stateless_flag(managers, False)
+    stateless = _manager_with_stateless_flag(managers, True)
+    assert stateful.calls == 1
+    assert stateless.calls == 0
+    start = next(message for message in messages if message["type"] == "http.response.start")
+    assert (b"mcp-session-id", b"new-session") in start["headers"]
+    claim_owner.assert_awaited_once_with("new-session", "user@example.com")
+
+
+@pytest.mark.asyncio
+async def test_streamable_session_id_uses_stateful_manager(monkeypatch):
+    """A POST carrying an existing Mcp-Session-Id uses the stateful manager."""
+    monkeypatch.setattr(tr.settings, "use_stateful_sessions", True)
+    monkeypatch.setattr(tr.settings, "mcpgateway_session_affinity_enabled", False)
+    managers = _install_session_routing_managers(monkeypatch)
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+
+    try:
+        body = json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {}}).encode()
+        scope = _make_scope("/mcp", headers=[(b"mcp-session-id", b"existing-session")])
+        await wrapper.handle_streamable_http(scope, _make_receive(body), send)
+    finally:
+        await wrapper.shutdown()
+
+    stateful = _manager_with_stateless_flag(managers, False)
+    stateless = _manager_with_stateless_flag(managers, True)
+    assert stateful.calls == 1
+    assert stateless.calls == 0
+    assert next(message for message in messages if message["type"] == "http.response.start")["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_streamable_stateless_path_skips_session_registration(monkeypatch):
+    """Stateless dispatch must not claim an ID returned by the upstream."""
+    monkeypatch.setattr(tr.settings, "use_stateful_sessions", True)
+    monkeypatch.setattr(tr.settings, "mcpgateway_session_affinity_enabled", False)
+    managers = _install_session_routing_managers(monkeypatch, response_session_id="upstream-session")
+    claim_owner = AsyncMock()
+    monkeypatch.setattr(tr, "_claim_streamable_session_owner", claim_owner)
+    context_token = tr.user_context_var.set({"email": "user@example.com"})
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+
+    try:
+        body = json.dumps({"jsonrpc": "2.0", "id": 3, "method": "tools/list", "params": {}}).encode()
+        await wrapper.handle_streamable_http(_make_scope("/mcp"), _make_receive(body), send)
+    finally:
+        await wrapper.shutdown()
+        tr.user_context_var.reset(context_token)
+
+    stateless = _manager_with_stateless_flag(managers, True)
+    assert stateless.calls == 1
+    assert (b"mcp-session-id", b"upstream-session") in next(message for message in messages if message["type"] == "http.response.start")["headers"]
+    claim_owner.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("use_stateful_sessions", "expected_capture"),
+    [(True, True), (False, False)],
+)
+async def test_streamable_send_with_capture_respects_stateful_flag(monkeypatch, use_stateful_sessions, expected_capture):
+    """Session ID capture follows use_stateful_sessions, not affinity config."""
+    monkeypatch.setattr(tr.settings, "use_stateful_sessions", use_stateful_sessions)
+    monkeypatch.setattr(tr.settings, "mcpgateway_session_affinity_enabled", False)
+    managers = _install_session_routing_managers(monkeypatch, response_session_id="captured-session")
+    claim_owner = AsyncMock(return_value="user@example.com")
+    monkeypatch.setattr(tr, "_claim_streamable_session_owner", claim_owner)
+    context_token = tr.user_context_var.set({"email": "user@example.com"})
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+
+    try:
+        body = json.dumps({"jsonrpc": "2.0", "id": 4, "method": "initialize", "params": {}}).encode()
+        await wrapper.handle_streamable_http(_make_scope("/mcp"), _make_receive(body), send)
+    finally:
+        await wrapper.shutdown()
+        tr.user_context_var.reset(context_token)
+
+    assert managers[0].calls == 1
+    assert (b"mcp-session-id", b"captured-session") in next(message for message in messages if message["type"] == "http.response.start")["headers"]
+    if expected_capture:
+        claim_owner.assert_awaited_once_with("captured-session", "user@example.com")
+    else:
+        claim_owner.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_streamable_stateful_affinity_configuration_registers_captured_session(monkeypatch):
+    """Stateful sessions plus affinity register the captured session on the worker."""
+    monkeypatch.setattr(tr.settings, "use_stateful_sessions", True)
+    monkeypatch.setattr(tr.settings, "mcpgateway_session_affinity_enabled", True)
+    _install_session_routing_managers(monkeypatch, response_session_id="affinity-session")
+    monkeypatch.setattr(tr, "_claim_streamable_session_owner", AsyncMock(return_value="user@example.com"))
+    pool = MagicMock()
+    pool.register_session_owner = AsyncMock()
+    context_token = tr.user_context_var.set({"email": "user@example.com"})
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+
+    try:
+        body = json.dumps({"jsonrpc": "2.0", "id": 5, "method": "initialize", "params": {}}).encode()
+        with patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=pool):
+            await wrapper.handle_streamable_http(_make_scope("/mcp"), _make_receive(body), send)
+    finally:
+        await wrapper.shutdown()
+        tr.user_context_var.reset(context_token)
+
+    assert (b"mcp-session-id", b"affinity-session") in next(message for message in messages if message["type"] == "http.response.start")["headers"]
+    pool.register_session_owner.assert_awaited_once_with("affinity-session")

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -10285,7 +10285,7 @@ async def test_send_with_capture_claims_owner_when_affinity_disabled(monkeypatch
         }
     )
     try:
-        await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
+        await wrapper.handle_streamable_http(scope, _make_receive(b'{"jsonrpc":"2.0","method":"initialize","id":1}'), send)
     finally:
         tr.user_context_var.reset(token)
         await wrapper.shutdown()


### PR DESCRIPTION
## Summary

Closes #5484

Support mixed stateful and stateless upstream MCP servers when the gateway is configured with `USE_STATEFUL_SESSIONS=true`.

Previously, the Streamable HTTP SDK rejected sessionless non-`initialize` requests before the gateway could dispatch them, so stateless upstreams could not be used alongside stateful upstreams.

## Behavior

- Sessionless `initialize` requests use the stateful manager and receive a gateway-owned `Mcp-Session-Id`.
- Requests carrying `Mcp-Session-Id` use the stateful manager and retain session ownership and affinity enforcement.
- Sessionless non-`initialize` POST requests use the stateless manager, allowing stateless upstreams to handle them without a gateway session.
- Stateless-path requests do not create gateway session ownership or worker-affinity entries.
- Session-ID capture is controlled by `USE_STATEFUL_SESSIONS`, while worker-affinity registration remains controlled by `MCPGATEWAY_SESSION_AFFINITY_ENABLED`.
- Stateful sessions work with affinity disabled, including GET-after-initialize.

### Gate behavior

```text
┌──────────────────────────────────┬─────────────────────────────────────────────────────────────────────────┐
│ Configuration                    │ Behavior                                                                │
├──────────────────────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ USE_STATEFUL_SESSIONS=false,     │ Existing stateless behavior. No new stateful routing or session         │
│ MCPGATEWAY_SESSION_AFFINITY_ENABLED=false │ capture.                                                                │
├──────────────────────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ USE_STATEFUL_SESSIONS=false,     │ Affinity does not activate because affinity routing also requires       │
│ MCPGATEWAY_SESSION_AFFINITY_ENABLED=true  │ stateful sessions.                                                      │
├──────────────────────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ USE_STATEFUL_SESSIONS=true,      │ Stateful gateway sessions are enabled. Sessionless non-initialize       │
│ MCPGATEWAY_SESSION_AFFINITY_ENABLED=false │ requests use the stateless manager. Session IDs are captured and        │
│                                  │ logical ownership is recorded. Worker-affinity mapping is not written.  │
│                                  │ This fixes the GET-after-initialize issue.                              │
├──────────────────────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ USE_STATEFUL_SESSIONS=true,      │ Full stateful plus multi-worker affinity behavior. Stateful requests    │
│ MCPGATEWAY_SESSION_AFFINITY_ENABLED=true  │ can be routed to the owning worker; stateless-path requests bypass      │
│                                  │ session ownership and affinity registration.                            │
└──────────────────────────────────┴─────────────────────────────────────────────────────────────────────────┘
```

## Implementation

- Added a dedicated stateless `StreamableHTTPSessionManager`.
- Reused the existing request-body peek/replay path to identify the JSON-RPC method before dispatch.
- Kept stateful initialization and session-bearing requests on the existing stateful path.
- Decoupled logical session ownership capture from multi-worker affinity registration.

## Verification

- `.venv/bin/python -m pytest tests/unit/mcpgateway/transports/test_streamablehttp_transport.py -q` — 540 passed.
- `compileall` passed for the changed Python files.
- `git diff --check` passed.

## Scope

No database, migration, schema, configuration-default, API, or UI changes.
