### PR TITLE
feat(teams): support bulk member creation in TeamCreateRequest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1571,6 +1571,11 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # MAX_TEAMS_PER_USER=50
 # MAX_MEMBERS_PER_TEAM=100
 
+# Hard ceiling on how many members can be seeded in a single POST /teams request
+# (the `members` array). Validated at the request boundary before any write; the
+# per-team MAX_MEMBERS_PER_TEAM limit still applies underneath.
+# MAX_TEAM_MEMBER_SEEDS=500
+
 # Team Invitation Settings
 # INVITATION_EXPIRY_DAYS=7
 # REQUIRE_EMAIL_VERIFICATION_FOR_INVITES=true

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,6 +1,6 @@
 {
   "exclude": {
-    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
+    "files": "(?x)(package-lock\\.json$|Cargo\\.lock$|uv\\.lock$|go\\.sum$|mcpgateway/sri_hashes\\.json$)|^.secrets.baseline$",
     "lines": null
   },
   "generated_at": "2026-07-17T13:06:41Z",

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,6 +1,6 @@
 {
   "exclude": {
-    "files": "(?x)(package-lock\\.json$|Cargo\\.lock$|uv\\.lock$|go\\.sum$|mcpgateway/sri_hashes\\.json$)|^.secrets.baseline$",
+    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
   "generated_at": "2026-07-17T13:06:41Z",
@@ -2060,7 +2060,7 @@
         "hashed_secret": "91174c4e6859da80df4e7ce9d45b35501f591210",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1432,
+        "line_number": 1558,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2068,7 +2068,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1473,
+        "line_number": 1599,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2060,7 +2060,7 @@
         "hashed_secret": "91174c4e6859da80df4e7ce9d45b35501f591210",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1558,
+        "line_number": 1559,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2068,7 +2068,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1599,
+        "line_number": 1600,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2140,7 +2140,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 820,
+        "line_number": 821,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2148,7 +2148,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1327,
+        "line_number": 1328,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2156,7 +2156,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1331,
+        "line_number": 1332,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/manage/api-usage.md
+++ b/docs/docs/manage/api-usage.md
@@ -1407,12 +1407,12 @@ Each `TeamMemberSeed` object:
 
 **Configuration notes:**
 
-| Setting | Effect on `POST /teams` |
-|---------|------------------------|
-| `ALLOW_TEAM_CREATION=false` | Non-admin callers receive `403`. Platform admins bypass this flag. |
-| `ALLOW_TEAM_INVITATIONS=false` | Seeded addresses that would normally become invitations instead fail the whole request with `400`. |
-| `MAX_TEAM_MEMBER_SEEDS=500` | Hard ceiling on the `members` array length (validated before any write). |
-| `MAX_MEMBERS_PER_TEAM` | Seed count + creator must not exceed this limit (or the per-team `max_members` override). |
+| Setting | Default | Effect on `POST /teams` |
+|---------|---------|------------------------|
+| `ALLOW_TEAM_CREATION` | `true` | When `false`, non-admin callers receive `403`. Platform admins bypass this flag. |
+| `ALLOW_TEAM_INVITATIONS` | `true` | When `false`, seeded addresses that would normally become invitations instead fail the whole request with `400`. |
+| `MAX_TEAM_MEMBER_SEEDS` | `500` | Hard ceiling on the `members` array length (validated before any write). |
+| `MAX_MEMBERS_PER_TEAM` | `100` | Seed count + creator must not exceed this limit (or the per-team `max_members` override). |
 
 **Minimal create (no members):**
 
@@ -1443,7 +1443,7 @@ curl -s -X POST \
 
 **Response (`TeamCreateResponse`):**
 
-`TeamCreateResponse` is a superset of `TeamResponse`. All `TeamResponse` fields are present; two extra arrays report how each seeded member was resolved. Both arrays are always present (empty when no members were seeded), so clients that only care about the team itself can ignore them.
+`TeamCreateResponse` extends `TeamResponse` through Pydantic subclassing, so it is a strict superset: every `TeamResponse` field is present unchanged, plus two extra arrays that report how each seeded member was resolved. Both arrays are always present (empty when no members were seeded), so clients that only care about the team itself can ignore them.
 
 ```json
 {

--- a/docs/docs/manage/api-usage.md
+++ b/docs/docs/manage/api-usage.md
@@ -1403,6 +1403,7 @@ Each `TeamMemberSeed` object:
 - Email addresses are normalised to lowercase before lookup; `ALICE@example.com` and `alice@example.com` are treated as the same address.
 - Duplicate addresses (case-insensitive) in a single request are rejected with a row-indexed error.
 - The whole operation is **atomic**: a failure on any seed rolls back the team and all prior seeds.
+- Deleting a team also deactivates its **pending invitations**, so an invitation cannot outlive (or be revived alongside) the team it points at.
 
 **Configuration notes:**
 

--- a/docs/docs/manage/api-usage.md
+++ b/docs/docs/manage/api-usage.md
@@ -1367,7 +1367,135 @@ curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
 
 ## Team Management
 
-Teams are the unit of multi-tenancy in ContextForge. The `GET /teams` endpoint lists the teams visible to the caller and is the same endpoint that backs the Admin UI Teams page and the team switcher.
+Teams are the unit of multi-tenancy in ContextForge. Endpoints require a valid Bearer token and the caller must hold the `teams.create` or `teams.read` RBAC permission respectively.
+
+### Create Team
+
+```bash
+POST /teams
+Authorization: Bearer $TOKEN
+Content-Type: application/json
+```
+
+**Request body (`TeamCreateRequest`):**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | ✓ | – | Display name (1–255 chars, letters/numbers/spaces/`_`/`.`/`-`). |
+| `slug` | string | – | auto-generated | URL-friendly identifier (`[a-z0-9-]+`, 2–255 chars). |
+| `description` | string | – | `null` | Team description (max 1 000 chars). |
+| `visibility` | `"private"` \| `"public"` | – | `"private"` | Who can see the team. |
+| `max_members` | int ≥ 1 | – | global setting | Per-team member cap. Omit to inherit `MAX_MEMBERS_PER_TEAM`. |
+| `members` | array of `TeamMemberSeed` | – | `null` | Up to `MAX_TEAM_MEMBER_SEEDS` (500) addresses to seed. |
+
+Each `TeamMemberSeed` object:
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `email` | string (email) | ✓ | – | Address to add or invite. Normalised to lowercase. |
+| `role` | `"owner"` \| `"member"` | – | `"member"` | Role to assign. |
+
+**Seed routing rules (server-decided, not caller-controlled):**
+
+- An address that matches an **active** `EmailUser` record is added as a direct member.
+- Any other address (unknown, or known but deactivated) receives an invitation.
+- The creator's own address is silently skipped — team creation already makes the creator an owner.
+- Email addresses are normalised to lowercase before lookup; `ALICE@example.com` and `alice@example.com` are treated as the same address.
+- Duplicate addresses (case-insensitive) in a single request are rejected with a row-indexed error.
+- The whole operation is **atomic**: a failure on any seed rolls back the team and all prior seeds.
+
+**Configuration notes:**
+
+| Setting | Effect on `POST /teams` |
+|---------|------------------------|
+| `ALLOW_TEAM_CREATION=false` | Non-admin callers receive `403`. Platform admins bypass this flag. |
+| `ALLOW_TEAM_INVITATIONS=false` | Seeded addresses that would normally become invitations instead fail the whole request with `400`. |
+| `MAX_TEAM_MEMBER_SEEDS=500` | Hard ceiling on the `members` array length (validated before any write). |
+| `MAX_MEMBERS_PER_TEAM` | Seed count + creator must not exceed this limit (or the per-team `max_members` override). |
+
+**Minimal create (no members):**
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Engineering", "visibility": "private"}' \
+  $BASE_URL/teams | jq '.'
+```
+
+**Create with seeded members:**
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Engineering",
+    "visibility": "private",
+    "members": [
+      {"email": "alice@example.com", "role": "owner"},
+      {"email": "external@partner.com"}
+    ]
+  }' \
+  $BASE_URL/teams | jq '.'
+```
+
+**Response (`TeamCreateResponse`):**
+
+`TeamCreateResponse` is a superset of `TeamResponse`. All `TeamResponse` fields are present; two extra arrays report how each seeded member was resolved. Both arrays are always present (empty when no members were seeded), so clients that only care about the team itself can ignore them.
+
+```json
+{
+  "id": "team-abc123",
+  "name": "Engineering",
+  "slug": "engineering",
+  "description": null,
+  "created_by": "admin@example.com",
+  "is_personal": false,
+  "visibility": "private",
+  "max_members": null,
+  "member_count": 2,
+  "created_at": "2026-01-15T10:00:00Z",
+  "updated_at": "2026-01-15T10:00:00Z",
+  "is_active": true,
+  "members_added": [
+    {"email": "alice@example.com", "role": "owner"}
+  ],
+  "invitations_sent": [
+    {"email": "external@partner.com", "role": "member", "invitation_id": "inv-xyz789"}
+  ]
+}
+```
+
+`members_added` entries (`SeededMemberResponse`):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `email` | string | Canonical lowercase email of the user added directly. |
+| `role` | `"owner"` \| `"member"` | Role assigned. |
+
+`invitations_sent` entries (`SeededInvitationResponse`):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `email` | string | Canonical lowercase email the invitation was sent to. |
+| `role` | `"owner"` \| `"member"` | Role the invitee will hold after accepting. |
+| `invitation_id` | string | UUID of the created invitation record. |
+
+**Error responses:**
+
+| HTTP status | Condition | Example `detail` |
+|-------------|-----------|-----------------|
+| `400` | Duplicate email in `members` | `members[1] (alice@example.com): duplicate address, already listed at members[0]` |
+| `400` | Seed count + 1 exceeds capacity | `Team would start with 6 members, exceeding the maximum of 5` |
+| `400` | Invalid role value | `Input should be 'owner' or 'member'` |
+| `400` | Invitations disabled and unknown address seeded | `members[1] (external@partner.com): invitations are currently disabled` |
+| `403` | `ALLOW_TEAM_CREATION=false` and caller is not admin | `Team creation is currently disabled` |
+| `422` | `members` array exceeds 500 entries | Pydantic validation error |
+
+### List Teams
+
+The `GET /teams` endpoint lists the teams visible to the caller and is the same endpoint that backs the Admin UI Teams page and the team switcher.
 
 Visibility follows the two-layer security model:
 
@@ -1375,8 +1503,6 @@ Visibility follows the two-layer security model:
 - **Regular users** see only the teams they are a member of (including their own personal team).
 
 The caller's own personal team is derived from the authenticated identity, never from client input, so this endpoint cannot be used to enumerate other users' personal teams.
-
-### List Teams
 
 ```bash
 # List teams visible to the caller (non-paginated response - default)

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -553,6 +553,7 @@ ContextForge implements **OAuth 2.0 Dynamic Client Registration (RFC 7591)** and
 | `PERSONAL_TEAM_PREFIX`                   | Personal team naming prefix (empty = derive from display name) | `""` | string  |
 | `MAX_TEAMS_PER_USER`                     | Maximum number of teams a user can belong to    | `50`       | int > 0 |
 | `MAX_MEMBERS_PER_TEAM`                   | Default maximum members per team, resolved at check time. Teams without an explicit per-team override use this value. Platform admins are exempt from this limit. | `100`      | int > 0 |
+| `MAX_TEAM_MEMBER_SEEDS`                  | Hard ceiling on how many members can be seeded in a single `POST /teams` request (the `members` array), validated at the request boundary before any write. `MAX_MEMBERS_PER_TEAM` still applies underneath. | `500`      | int > 0 |
 | `INVITATION_EXPIRY_DAYS`                 | Number of days before team invitations expire   | `7`        | int > 0 |
 | `REQUIRE_EMAIL_VERIFICATION_FOR_INVITES` | Require email verification for team invitations | `true`     | bool    |
 | `ALLOW_TEAM_CREATION`                    | Allow users to create organizational teams (admins always can) | `true`  | bool    |

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1039,6 +1039,7 @@ class Settings(BaseSettings):
     personal_team_prefix: str = Field(default="", description="Personal team naming prefix")
     max_teams_per_user: int = Field(default=50, description="Maximum number of teams a user can belong to")
     max_members_per_team: int = Field(default=100, description="Maximum number of members per team")
+    max_team_member_seeds: int = Field(default=500, description="Hard ceiling on how many members can be seeded in a single POST /teams request (validated before any write)")
     invitation_expiry_days: int = Field(default=7, description="Number of days before team invitations expire")
     require_email_verification_for_invites: bool = Field(default=True, description="Require email verification for team invitations")
 

--- a/mcpgateway/routers/teams.py
+++ b/mcpgateway/routers/teams.py
@@ -34,8 +34,11 @@ from mcpgateway.middleware.rbac import _ACCESS_DENIED_MSG, get_current_user_with
 from mcpgateway.schemas import (
     CursorPaginatedTeamsResponse,
     PaginatedTeamMembersResponse,
+    SeededInvitationResponse,
+    SeededMemberResponse,
     SuccessResponse,
     TeamCreateRequest,
+    TeamCreateResponse,
     TeamDiscoveryResponse,
     TeamInvitationResponse,
     TeamInviteRequest,
@@ -76,10 +79,16 @@ teams_router = APIRouter()
 # ---------------------------------------------------------------------------
 
 
-@teams_router.post("/", response_model=TeamResponse, status_code=status.HTTP_201_CREATED)
+@teams_router.post("/", response_model=TeamCreateResponse, status_code=status.HTTP_201_CREATED)
 @require_permission("teams.create")
-async def create_team(request: TeamCreateRequest, current_user_ctx: dict = Depends(get_current_user_with_permissions), db: Session = Depends(get_db)) -> TeamResponse:
-    """Create a new team.
+async def create_team(request: TeamCreateRequest, current_user_ctx: dict = Depends(get_current_user_with_permissions), db: Session = Depends(get_db)) -> TeamCreateResponse:
+    """Create a new team, optionally seeding it with members.
+
+    Members supplied in the request are routed by the server: an address that
+    belongs to an active user is added to the team directly, anything else is
+    sent an invitation. Team, memberships and invitations are written as one
+    transaction, so a bad row fails the whole request rather than leaving a
+    half-populated team behind.
 
     Args:
         request: Team creation request data
@@ -87,7 +96,7 @@ async def create_team(request: TeamCreateRequest, current_user_ctx: dict = Depen
         db: Database session
 
     Returns:
-        TeamResponse: Created team data
+        TeamCreateResponse: Created team data, plus how each seeded member was resolved
 
     Raises:
         HTTPException: If team creation fails
@@ -109,17 +118,19 @@ async def create_team(request: TeamCreateRequest, current_user_ctx: dict = Depen
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Team creation is currently disabled")
 
         service = TeamManagementService(db)
-        team = await service.create_team(
+        result = await service.create_team_with_members(
             name=request.name,
             description=request.description,
             created_by=current_user_ctx["email"],
             visibility=request.visibility,
             max_members=request.max_members,
             skip_limits=is_admin,
+            members=request.members,
         )
+        team = result.team
 
         # Build response BEFORE closing session to avoid lazy-load issues with get_member_count()
-        response = TeamResponse(
+        response = TeamCreateResponse(
             id=team.id,
             name=team.name,
             slug=team.slug,
@@ -132,13 +143,16 @@ async def create_team(request: TeamCreateRequest, current_user_ctx: dict = Depen
             created_at=team.created_at,
             updated_at=team.updated_at,
             is_active=team.is_active,
+            members_added=[SeededMemberResponse(email=member.email, role=member.role) for member in result.members_added],
+            invitations_sent=[SeededInvitationResponse(email=invite.email, role=invite.role, invitation_id=invite.invitation_id) for invite in result.invitations_sent],
         )
         db.commit()
         db.close()
         return response
     except HTTPException:
         raise
-    except ValueError as e:
+    except (ValueError, TeamManagementError) as e:
+        # TeamManagementError covers the member-seeding failures (capacity, team limits)
         logger.error(f"Team creation failed: {e}")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -6519,7 +6519,9 @@ class SuccessResponse(BaseModel):
 # Hard ceiling on how many people can be seeded in one create-team call. The real
 # limit is the team's own max_members, checked server-side; this only stops an
 # unbounded request from being accepted when that limit is configured as unlimited.
-MAX_TEAM_MEMBER_SEEDS = 500
+# Configurable via the MAX_TEAM_MEMBER_SEEDS environment variable (default 500),
+# resolved at import time.
+MAX_TEAM_MEMBER_SEEDS = settings.max_team_member_seeds
 
 
 class TeamMemberSeed(BaseModel):

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -6516,6 +6516,37 @@ class SuccessResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+# Hard ceiling on how many people can be seeded in one create-team call. The real
+# limit is the team's own max_members, checked server-side; this only stops an
+# unbounded request from being accepted when that limit is configured as unlimited.
+MAX_TEAM_MEMBER_SEEDS = 500
+
+
+class TeamMemberSeed(BaseModel):
+    """Schema for a member to seed into a team at creation time.
+
+    The server decides how each seed is applied: an email that matches an
+    active user becomes a membership directly, any other address gets an
+    invitation instead. Callers do not need to know which is which.
+
+    Attributes:
+        email: Email address of the person to add or invite
+        role: Role to assign in the team
+
+    Examples:
+        >>> seed = TeamMemberSeed(email="alice@example.com")
+        >>> seed.email
+        'alice@example.com'
+        >>> seed.role
+        'member'
+        >>> TeamMemberSeed(email="lead@example.com", role="owner").role
+        'owner'
+    """
+
+    email: EmailStr = Field(..., description="Email address of the person to add or invite")
+    role: Literal["owner", "member"] = Field("member", description="Role to assign in the team")
+
+
 class TeamCreateRequest(BaseModel):
     """Schema for creating a new team.
 
@@ -6525,6 +6556,7 @@ class TeamCreateRequest(BaseModel):
         description: Team description
         visibility: Team visibility level
         max_members: Maximum number of members allowed
+        members: Optional people to seed the team with (added or invited by the server)
 
     Examples:
         >>> request = TeamCreateRequest(
@@ -6537,6 +6569,19 @@ class TeamCreateRequest(BaseModel):
         'private'
         >>> request.slug is None
         True
+        >>> request.members is None
+        True
+        >>>
+        >>> # Seed the team with members in the same request
+        >>> seeded = TeamCreateRequest(
+        ...     name="Engineering Team",
+        ...     members=[
+        ...         {"email": "alice@example.com", "role": "owner"},
+        ...         {"email": "external@partner.com"},
+        ...     ],
+        ... )
+        >>> [m.role for m in seeded.members]
+        ['owner', 'member']
         >>>
         >>> # Test with all fields
         >>> full_request = TeamCreateRequest(
@@ -6578,6 +6623,11 @@ class TeamCreateRequest(BaseModel):
     description: Optional[str] = Field(None, max_length=1000, description="Team description")
     visibility: Literal["private", "public"] = Field("private", description="Team visibility level")
     max_members: Optional[int] = Field(default=None, ge=1, description="Maximum number of team members. If omitted, the team inherits the global MAX_MEMBERS_PER_TEAM setting at check time.")
+    members: Optional[List[TeamMemberSeed]] = Field(
+        default=None,
+        max_length=MAX_TEAM_MEMBER_SEEDS,
+        description="People to seed the team with. Each entry is routed by the server: active users become members directly, everyone else is sent an invitation.",
+    )
 
     @field_validator("name")
     @classmethod
@@ -6772,6 +6822,84 @@ class TeamResponse(BaseModel):
     created_at: datetime = Field(..., description="Team creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")
     is_active: bool = Field(..., description="Whether the team is active")
+
+
+class SeededMemberResponse(BaseModel):
+    """Schema for a member added directly during team creation.
+
+    Attributes:
+        email: Email address of the member
+        role: Role assigned in the team
+
+    Examples:
+        >>> added = SeededMemberResponse(email="alice@example.com", role="member")
+        >>> added.email
+        'alice@example.com'
+    """
+
+    email: str = Field(..., description="Email address of the member")
+    role: Literal["owner", "member"] = Field(..., description="Role assigned in the team")
+
+
+class SeededInvitationResponse(BaseModel):
+    """Schema for an invitation sent during team creation.
+
+    Attributes:
+        email: Email address the invitation was sent to
+        role: Role the invitee will have once they accept
+        invitation_id: UUID of the created invitation
+
+    Examples:
+        >>> sent = SeededInvitationResponse(
+        ...     email="external@partner.com",
+        ...     role="member",
+        ...     invitation_id="inv-123",
+        ... )
+        >>> sent.invitation_id
+        'inv-123'
+    """
+
+    email: str = Field(..., description="Email address the invitation was sent to")
+    role: Literal["owner", "member"] = Field(..., description="Role the invitee will have once they accept")
+    invitation_id: str = Field(..., description="UUID of the created invitation")
+
+
+class TeamCreateResponse(TeamResponse):
+    """Schema for the team creation response.
+
+    A superset of :class:`TeamResponse`: every existing field stays where it
+    was, with two extra arrays reporting how each seeded member was resolved,
+    so a create-team form can confirm "3 added, 2 invited" without re-querying.
+    Both arrays are empty when no members were seeded.
+
+    Attributes:
+        members_added: Members added to the team directly
+        invitations_sent: Invitations created for addresses that are not active users
+
+    Examples:
+        >>> response = TeamCreateResponse(
+        ...     id="team-123",
+        ...     name="Engineering Team",
+        ...     slug="engineering-team",
+        ...     created_by="admin@example.com",
+        ...     is_personal=False,
+        ...     visibility="private",
+        ...     member_count=2,
+        ...     created_at=datetime.now(timezone.utc),
+        ...     updated_at=datetime.now(timezone.utc),
+        ...     is_active=True,
+        ...     members_added=[{"email": "alice@example.com", "role": "member"}],
+        ... )
+        >>> response.name
+        'Engineering Team'
+        >>> len(response.members_added)
+        1
+        >>> response.invitations_sent
+        []
+    """
+
+    members_added: List[SeededMemberResponse] = Field(default_factory=list, description="Members added to the team directly")
+    invitations_sent: List[SeededInvitationResponse] = Field(default_factory=list, description="Invitations created for addresses that are not active users")
 
 
 class TeamMemberResponse(BaseModel):

--- a/mcpgateway/services/team_invitation_service.py
+++ b/mcpgateway/services/team_invitation_service.py
@@ -149,7 +149,7 @@ class TeamInvitationService:
         """
         return secrets.token_urlsafe(32)
 
-    async def create_invitation(self, team_id: str, email: str, role: str, invited_by: str, expiry_days: Optional[int] = None) -> Optional[EmailTeamInvitation]:
+    async def create_invitation(self, team_id: str, email: str, role: str, invited_by: str, expiry_days: Optional[int] = None, commit: bool = True) -> Optional[EmailTeamInvitation]:
         """Create a team invitation.
 
         Args:
@@ -158,6 +158,10 @@ class TeamInvitationService:
             role: Role to assign (owner, member)
             invited_by: Email of user sending the invitation
             expiry_days: Days until invitation expires (default from settings)
+            commit: Commit the invitation immediately. Pass ``False`` to flush it
+                into an outer transaction instead, so the caller can create the
+                invitation atomically alongside other rows (see
+                ``TeamManagementService.create_team_with_members``).
 
         Returns:
             EmailTeamInvitation: The created invitation or None if failed
@@ -249,7 +253,10 @@ class TeamInvitationService:
             )
 
             self.db.add(invitation)
-            self.db.commit()
+            if commit:
+                self.db.commit()
+            else:
+                self.db.flush()
 
             logger.info(
                 "Created invitation for %s to team %s by %s",
@@ -260,7 +267,10 @@ class TeamInvitationService:
             return invitation
 
         except Exception as e:
-            self.db.rollback()
+            # Only unwind the transaction when we own it. With commit=False the
+            # caller is mid-transaction and decides what to roll back.
+            if commit:
+                self.db.rollback()
             logger.error("Failed to create invitation for %s to team %s: %s", SecurityValidator.sanitize_log_message(email), SecurityValidator.sanitize_log_message(team_id), e)
             raise
 

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -19,8 +19,9 @@ Examples:
 # Standard
 import asyncio
 import base64
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 # Third-Party
 import orjson
@@ -32,7 +33,8 @@ from mcpgateway.cache.admin_stats_cache import admin_stats_cache
 from mcpgateway.cache.auth_cache import auth_cache, get_auth_cache
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
-from mcpgateway.db import EmailTeam, EmailTeamJoinRequest, EmailTeamMember, EmailTeamMemberHistory, EmailUser, utc_now
+from mcpgateway.db import EmailTeam, EmailTeamInvitation, EmailTeamJoinRequest, EmailTeamMember, EmailTeamMemberHistory, EmailUser, utc_now
+from mcpgateway.schemas import MAX_TEAM_MEMBER_SEEDS, TeamMemberSeed
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.utils.create_slug import slugify
 from mcpgateway.utils.pagination import unified_paginate
@@ -173,6 +175,104 @@ class TeamMemberAddError(TeamManagementError):
         >>> isinstance(error, TeamManagementError)
         True
     """
+
+
+class TeamMemberSeedError(TeamManagementError):
+    """Raised when a member listed at team creation cannot be applied.
+
+    Names the offending row so a create-team form can highlight the line the
+    admin typed, rather than reporting a failure with no idea which of ten
+    addresses caused it.
+
+    Attributes:
+        index: Position of the offending row in the caller's request.
+        email: Email address of the offending row.
+        reason: Why the row could not be applied.
+
+    Examples:
+        >>> error = TeamMemberSeedError(2, "bob@example.com", "User not found")
+        >>> str(error)
+        'members[2] (bob@example.com): User not found'
+        >>> error.index
+        2
+        >>> isinstance(error, TeamManagementError)
+        True
+    """
+
+    def __init__(self, index: int, email: str, reason: str):
+        """Initialize the error.
+
+        Args:
+            index: Position of the offending row in the caller's request.
+            email: Email address of the offending row.
+            reason: Why the row could not be applied.
+        """
+        self.index = index
+        self.email = email
+        self.reason = reason
+        super().__init__(f"members[{index}] ({email}): {reason}")
+
+
+@dataclass(frozen=True)
+class _NormalizedSeed:
+    """A member seed with its position in the caller's request preserved.
+
+    The creator's row is dropped during normalization, so the index of a seed in
+    the list no longer matches the row the caller sent. Carrying the original
+    index means an error can still point at the right line.
+
+    Attributes:
+        index: Position of this row in the caller's request.
+        email: Email address to add or invite.
+        role: Role to assign in the team.
+    """
+
+    index: int
+    email: str
+    role: str
+
+
+@dataclass
+class SeededMember:
+    """A membership created directly while seeding a new team.
+
+    Attributes:
+        email: Email address of the member.
+        role: Role assigned in the team.
+    """
+
+    email: str
+    role: str
+
+
+@dataclass
+class SeededInvitation:
+    """An invitation created while seeding a new team.
+
+    Attributes:
+        email: Email address the invitation was sent to.
+        role: Role the invitee will hold once they accept.
+        invitation_id: ID of the created invitation.
+    """
+
+    email: str
+    role: str
+    invitation_id: str
+
+
+@dataclass
+class TeamSeedResult:
+    """Outcome of creating a team together with its initial members.
+
+    Attributes:
+        team: The created (or reactivated) team.
+        members_added: Seeds that resolved to a direct membership.
+        invitations_sent: Seeds that resolved to an invitation.
+    """
+
+    team: EmailTeam
+    members_added: List[SeededMember] = field(default_factory=list)
+    invitations_sent: List[SeededInvitation] = field(default_factory=list)
 
 
 class _Unset:
@@ -468,10 +568,138 @@ class TeamManagementService:
         if self._get_user_team_count(user_email) >= max_teams:
             raise TeamManagementError(f"User has reached the maximum team limit of {max_teams}")
 
+    @staticmethod
+    def _normalize_member_seeds(members: Optional[Sequence[TeamMemberSeed]], created_by: str) -> List[_NormalizedSeed]:
+        """Validate and de-duplicate the members requested for a new team.
+
+        The creator's own address is dropped: they are added as owner by team
+        creation itself, so listing them is a no-op rather than an error. Each
+        surviving seed keeps the index of the row the caller sent it in.
+
+        Args:
+            members: Seeds requested by the caller, if any.
+            created_by: Email of the user creating the team.
+
+        Returns:
+            List[_NormalizedSeed]: The seeds to apply, creator excluded.
+
+        Raises:
+            TeamMemberSeedError: If the same address appears more than once.
+            TeamMemberLimitExceededError: If the request lists more rows than can ever be applied.
+        """
+        if not members:
+            return []
+
+        # HTTP callers are already capped by max_length on TeamCreateRequest.members (a 422);
+        # this catches callers that reach the service directly, where nothing has validated the list.
+        if len(members) > MAX_TEAM_MEMBER_SEEDS:
+            raise TeamMemberLimitExceededError(f"A team cannot be created with more than {MAX_TEAM_MEMBER_SEEDS} members at once (got {len(members)})")
+
+        creator = created_by.strip().lower()
+        seeds: List[_NormalizedSeed] = []
+        seen: Dict[str, int] = {}
+
+        for index, seed in enumerate(members):
+            email = str(seed.email).strip()
+            key = email.lower()
+
+            if key == creator:
+                continue
+
+            if key in seen:
+                raise TeamMemberSeedError(index, email, f"duplicate address, already listed at members[{seen[key]}]")
+
+            seen[key] = index
+            seeds.append(_NormalizedSeed(index=index, email=email, role=seed.role))
+
+        return seeds
+
+    @staticmethod
+    def _check_seed_capacity(seed_count: int, max_members: Optional[int]) -> None:
+        """Raise if the creator plus the seeded members would exceed the team limit.
+
+        Checked before anything is written so an oversized request fails cleanly
+        instead of part-way through.
+
+        Args:
+            seed_count: Number of members being seeded.
+            max_members: Explicit per-team limit, or None to use the global default.
+
+        Raises:
+            TeamMemberLimitExceededError: If the team would start over capacity.
+        """
+        effective_max = max_members if max_members is not None else settings.max_members_per_team
+        if effective_max <= 0:
+            return
+
+        total = seed_count + 1  # the creator is always added as owner
+        if total > effective_max:
+            raise TeamMemberLimitExceededError(f"Team would start with {total} members, exceeding the maximum of {effective_max}")
+
+    async def _seed_members(self, team: EmailTeam, seeds: List[_NormalizedSeed], created_by: str) -> Tuple[List[Tuple[EmailTeamMember, str]], List[EmailTeamInvitation]]:
+        """Route each seed to a membership or an invitation, without committing.
+
+        An address belonging to an active user becomes a membership directly;
+        anything else (unknown address, deactivated account) gets an invitation.
+        Rows are flushed into the caller's transaction, so a failure on any seed
+        rolls the whole team creation back.
+
+        Args:
+            team: The team being created, already flushed so it has an ID.
+            seeds: Normalized seeds to apply.
+            created_by: Email of the user creating the team (the team owner).
+
+        Returns:
+            Tuple: The (membership, history action) pairs and the invitation rows.
+
+        Raises:
+            TeamMemberSeedError: If a seed could not be applied, naming the offending row.
+        """
+        memberships: List[Tuple[EmailTeamMember, str]] = []
+        invitations: List[EmailTeamInvitation] = []
+
+        if not seeds:
+            return memberships, invitations
+
+        # First-Party
+        from mcpgateway.services.team_invitation_service import TeamInvitationService  # pylint: disable=import-outside-toplevel,cyclic-import
+
+        invitation_service = TeamInvitationService(self.db)
+
+        # The creator's ownership row must be visible to the invitation service,
+        # which only lets team owners invite.
+        self.db.flush()
+
+        # One lookup for the whole batch, rather than one per row
+        known_users = {user.email: user for user in self.db.query(EmailUser).filter(EmailUser.email.in_([seed.email for seed in seeds])).all()}
+
+        for seed in seeds:
+            user = known_users.get(seed.email)
+            try:
+                if user and user.is_active:
+                    self._check_user_team_limit(seed.email)
+                    memberships.append(self._upsert_membership(team.id, seed.email, seed.role, invited_by=created_by))
+                    continue
+
+                invitation = await invitation_service.create_invitation(team_id=team.id, email=seed.email, role=seed.role, invited_by=created_by, commit=False)
+                if not invitation:
+                    raise TeamMemberSeedError(seed.index, seed.email, "invitation could not be created")
+                invitations.append(invitation)
+            except TeamMemberSeedError:
+                raise
+            except (ValueError, TeamManagementError) as exc:
+                # Attach the row the admin typed to whatever the underlying service objected to
+                raise TeamMemberSeedError(seed.index, seed.email, str(exc)) from exc
+
+        return memberships, invitations
+
     async def create_team(
         self, name: str, description: Optional[str], created_by: str, visibility: Optional[str] = "public", max_members: Optional[int] = None, skip_limits: bool = False
     ) -> EmailTeam:
         """Create a new team.
+
+        Thin wrapper over :meth:`create_team_with_members` for callers that only
+        need the team itself.
 
         Args:
             name: Team name
@@ -535,11 +763,61 @@ class TeamManagementService:
             >>> description_none is None
             True
         """
+        result = await self.create_team_with_members(name=name, description=description, created_by=created_by, visibility=visibility, max_members=max_members, skip_limits=skip_limits)
+        return result.team
+
+    async def create_team_with_members(
+        self,
+        name: str,
+        description: Optional[str],
+        created_by: str,
+        visibility: Optional[str] = "public",
+        max_members: Optional[int] = None,
+        skip_limits: bool = False,
+        members: Optional[Sequence[TeamMemberSeed]] = None,
+    ) -> TeamSeedResult:
+        """Create a team and, optionally, seed it with members in one transaction.
+
+        Each seed is routed by the server rather than the caller: an address that
+        belongs to an active user becomes a membership, anything else gets an
+        invitation. The team, the creator's ownership, the memberships and the
+        invitations are all written in a single transaction, so a bad row leaves
+        nothing behind rather than a half-populated team.
+
+        Args:
+            name: Team name
+            description: Team description
+            created_by: Email of the user creating the team
+            visibility: Team visibility (private, public)
+            max_members: Maximum number of team members allowed
+            skip_limits: Skip max_teams_per_user check (for admin bypass)
+            members: People to seed the team with. The creator is ignored if
+                listed, since team creation already makes them the owner.
+
+        Returns:
+            TeamSeedResult: The team plus how each seed was resolved.
+
+        Raises:
+            ValueError: If team name, visibility or member list is invalid
+            TeamMemberLimitExceededError: If the seeded team would exceed its member limit
+            Exception: If team creation fails
+
+        Examples:
+            >>> import asyncio
+            >>> from unittest.mock import Mock
+            >>> service = TeamManagementService(Mock())
+            >>> asyncio.iscoroutinefunction(service.create_team_with_members)
+            True
+        """
         try:
             # Validate visibility
             valid_visibilities = ["private", "public"]
             if visibility not in valid_visibilities:
                 raise ValueError(f"Invalid visibility. Must be one of: {', '.join(valid_visibilities)}")
+
+            # Validate the member list before writing anything
+            seeds = self._normalize_member_seeds(members, created_by)
+            self._check_seed_capacity(len(seeds), max_members)
 
             # Check max teams per user
             if not skip_limits:
@@ -599,23 +877,38 @@ class TeamManagementService:
                 membership = EmailTeamMember(team_id=team.id, user_email=created_by, role="owner", joined_at=utc_now(), is_active=True)
                 self.db.add(membership)
 
+            # Memberships and invitations join the same transaction as the team
+            memberships, invitations = await self._seed_members(team, seeds, created_by)
+
             self.db.commit()
 
+            team_id = str(team.id)
+
+            # Post-commit bookkeeping for each seeded member, matching add_member_to_team()
+            for member, action in memberships:
+                self._log_team_member_action(member.id, team_id, member.user_email, member.role, action, created_by)
+                await self._assign_team_rbac_role(member.user_email, team_id, member.role, granted_by=created_by)
+                self._invalidate_membership_caches(member.user_email, team_id)
+
             # Invalidate member count cache for the new team
-            await self.invalidate_team_member_count_cache(str(team.id))
+            await self.invalidate_team_member_count_cache(team_id)
 
             # Invalidate auth cache for creator's team membership
             # Without this, the cache won't know the user belongs to this new team
             try:
                 await auth_cache.invalidate_user_teams(created_by)
                 await auth_cache.invalidate_team_membership(created_by)
-                await auth_cache.invalidate_user_role(created_by, str(team.id))
+                await auth_cache.invalidate_user_role(created_by, team_id)
                 await admin_stats_cache.invalidate_teams()
             except Exception as cache_error:
                 logger.debug("Failed to invalidate cache on team create: %s", cache_error)
 
-            logger.info("Created team '%s' by %s", SecurityValidator.sanitize_log_message(team.name), SecurityValidator.sanitize_log_message(created_by))
-            return team
+            logger.info("Created team '%s' by %s (%d members added, %d invited)", SecurityValidator.sanitize_log_message(team.name), created_by, len(memberships), len(invitations))
+            return TeamSeedResult(
+                team=team,
+                members_added=[SeededMember(email=member.user_email, role=member.role) for member, _ in memberships],
+                invitations_sent=[SeededInvitation(email=invitation.email, role=invitation.role, invitation_id=invitation.id) for invitation in invitations],
+            )
 
         except Exception as e:
             self.db.rollback()
@@ -805,6 +1098,13 @@ class TeamManagementService:
             # Bulk update: deactivate all memberships in single query instead of looping
             self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team_id, EmailTeamMember.is_active.is_(True)).update({EmailTeamMember.is_active: False}, synchronize_session=False)
 
+            # Pending invitations must not outlive the team. Creating a team whose slug matches
+            # a deleted one reactivates that row, and a surviving invitation would let someone
+            # invited to the old team walk into the new one.
+            self.db.query(EmailTeamInvitation).filter(EmailTeamInvitation.team_id == team_id, EmailTeamInvitation.is_active.is_(True)).update(
+                {EmailTeamInvitation.is_active: False}, synchronize_session=False
+            )
+
             self.db.commit()
 
             # Invalidate all role caches for this team
@@ -826,6 +1126,46 @@ class TeamManagementService:
             self.db.rollback()
             logger.error("Failed to delete team %s: %s", SecurityValidator.sanitize_log_message(team_id), e)
             return False
+
+    def _upsert_membership(
+        self, team_id: str, user_email: str, role: str, invited_by: Optional[str] = None, grant_source: Optional[str] = None, existing: Union[EmailTeamMember, None, _Unset] = UNSET
+    ) -> Tuple[EmailTeamMember, str]:
+        """Create or reactivate a membership row without committing.
+
+        The row is flushed so its ID is available for history logging, but the
+        transaction is left open for the caller to commit. This lets a caller
+        write several memberships (and other rows) as one atomic unit.
+
+        Args:
+            team_id: ID of the team.
+            user_email: Email of the user to add.
+            role: Role to assign ('owner' or 'member').
+            invited_by: Email of the user performing the add.
+            grant_source: Origin of grant (e.g., 'sso', 'manual', 'bootstrap', 'auto').
+            existing: The user's current membership row, if the caller already looked
+                it up. Omit to have it looked up here.
+
+        Returns:
+            Tuple[EmailTeamMember, str]: The membership row, and the history action
+            describing it ('added' for a new row, 'reactivated' for a revived one).
+        """
+        if isinstance(existing, _Unset):
+            existing = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team_id, EmailTeamMember.user_email == user_email).first()
+
+        if existing:
+            existing.is_active = True
+            existing.role = role
+            existing.joined_at = utc_now()
+            existing.invited_by = invited_by
+            if grant_source is not None:
+                existing.grant_source = grant_source
+            self.db.flush()
+            return existing, "reactivated"
+
+        membership = EmailTeamMember(team_id=team_id, user_email=user_email, role=role, joined_at=utc_now(), invited_by=invited_by, grant_source=grant_source, is_active=True)
+        self.db.add(membership)
+        self.db.flush()
+        return membership, "added"
 
     async def add_member_to_team(self, team_id: str, user_email: str, role: str = "member", invited_by: Optional[str] = None, grant_source: Optional[str] = None) -> EmailTeamMember:
         """Add a member to a team.
@@ -894,22 +1234,9 @@ class TeamManagementService:
 
         # Add or reactivate membership
         try:
-            if existing_membership:
-                existing_membership.is_active = True
-                existing_membership.role = role
-                existing_membership.joined_at = utc_now()
-                existing_membership.invited_by = invited_by
-                if grant_source is not None:
-                    existing_membership.grant_source = grant_source
-                self.db.commit()
-                self._log_team_member_action(existing_membership.id, team_id, user_email, role, "reactivated", invited_by)
-                member = existing_membership
-            else:
-                membership = EmailTeamMember(team_id=team_id, user_email=user_email, role=role, joined_at=utc_now(), invited_by=invited_by, grant_source=grant_source, is_active=True)
-                self.db.add(membership)
-                self.db.commit()
-                self._log_team_member_action(membership.id, team_id, user_email, role, "added", invited_by)
-                member = membership
+            member, action = self._upsert_membership(team_id, user_email, role, invited_by=invited_by, grant_source=grant_source, existing=existing_membership)
+            self.db.commit()
+            self._log_team_member_action(member.id, team_id, user_email, role, action, invited_by)
 
             await self._assign_team_rbac_role(user_email, team_id, role, granted_by=invited_by)
             self._invalidate_membership_caches(user_email, team_id)

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -852,19 +852,8 @@ class TeamManagementService:
                 existing_inactive_team.updated_at = utc_now()
                 team = existing_inactive_team
 
-                # Check if the creator already has an inactive membership
-                existing_membership = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team.id, EmailTeamMember.user_email == created_by).first()
-
-                if existing_membership:
-                    # Reactivate existing membership as owner
-                    existing_membership.role = "owner"
-                    existing_membership.joined_at = utc_now()
-                    existing_membership.is_active = True
-                    membership = existing_membership
-                else:
-                    # Create new membership
-                    membership = EmailTeamMember(team_id=team.id, user_email=created_by, role="owner", joined_at=utc_now(), is_active=True)
-                    self.db.add(membership)
+                # Reactivate the creator's prior membership (if any) or create a fresh one, as owner
+                self._upsert_membership(team.id, created_by, "owner")
 
                 logger.info("Reactivated existing team with slug %s", potential_slug)
             else:
@@ -874,9 +863,8 @@ class TeamManagementService:
 
                 self.db.flush()  # Get the team ID
 
-                # Add the creator as owner
-                membership = EmailTeamMember(team_id=team.id, user_email=created_by, role="owner", joined_at=utc_now(), is_active=True)
-                self.db.add(membership)
+                # Add the creator as owner (brand-new team, so no prior membership to look up)
+                self._upsert_membership(team.id, created_by, "owner", existing=None)
 
             # Memberships and invitations join the same transaction as the team
             memberships, invitations = await self._seed_members(team, seeds, created_by)

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -600,16 +600,17 @@ class TeamManagementService:
         seen: Dict[str, int] = {}
 
         for index, seed in enumerate(members):
-            email = str(seed.email).strip()
-            key = email.lower()
+            # Canonicalise to lowercase so DB lookups, dedup checks, and invitation
+            # storage all use the same form as EmailUser.email (always lowercase).
+            email = str(seed.email).strip().lower()
 
-            if key == creator:
+            if email == creator:
                 continue
 
-            if key in seen:
-                raise TeamMemberSeedError(index, email, f"duplicate address, already listed at members[{seen[key]}]")
+            if email in seen:
+                raise TeamMemberSeedError(index, email, f"duplicate address, already listed at members[{seen[email]}]")
 
-            seen[key] = index
+            seen[email] = index
             seeds.append(_NormalizedSeed(index=index, email=email, role=seed.role))
 
         return seeds

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -1153,12 +1153,12 @@ class TeamManagementService:
             existing = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team_id, EmailTeamMember.user_email == user_email).first()
 
         if existing:
-            existing.is_active = True
-            existing.role = role
-            existing.joined_at = utc_now()
-            existing.invited_by = invited_by
+            existing.is_active = True  # pylint: disable=attribute-defined-outside-init
+            existing.role = role  # pylint: disable=attribute-defined-outside-init
+            existing.joined_at = utc_now()  # pylint: disable=attribute-defined-outside-init
+            existing.invited_by = invited_by  # pylint: disable=attribute-defined-outside-init
             if grant_source is not None:
-                existing.grant_source = grant_source
+                existing.grant_source = grant_source  # pylint: disable=attribute-defined-outside-init
             self.db.flush()
             return existing, "reactivated"
 

--- a/tests/unit/mcpgateway/routers/test_teams.py
+++ b/tests/unit/mcpgateway/routers/test_teams.py
@@ -26,7 +26,7 @@ from mcpgateway.schemas import (
     TeamUpdateRequest,
 )
 from mcpgateway.services.team_invitation_service import TeamInvitationService
-from mcpgateway.services.team_management_service import TeamManagementService
+from mcpgateway.services.team_management_service import SeededInvitation, SeededMember, TeamManagementService, TeamMemberLimitExceededError, TeamSeedResult
 
 from tests.utils.rbac_mocks import patch_rbac_decorators, restore_rbac_decorators
 
@@ -227,7 +227,7 @@ class TestTeamsRouter:
 
             # Mock TeamManagementService
             mock_service = AsyncMock(spec=TeamManagementService)
-            mock_service.create_team = AsyncMock(return_value=mock_team)
+            mock_service.create_team_with_members = AsyncMock(return_value=TeamSeedResult(team=mock_team))
             MockService.return_value = mock_service
 
             # Import the function to test
@@ -238,9 +238,68 @@ class TestTeamsRouter:
             assert result.id == mock_team.id
             assert result.name == mock_team.name
             assert result.description == mock_team.description
-            mock_service.create_team.assert_called_once_with(
-                name=request.name, description=request.description, created_by=mock_user_context["email"], visibility=request.visibility, max_members=request.max_members, skip_limits=False
+            mock_service.create_team_with_members.assert_called_once_with(
+                name=request.name,
+                description=request.description,
+                created_by=mock_user_context["email"],
+                visibility=request.visibility,
+                max_members=request.max_members,
+                skip_limits=False,
+                members=request.members,
             )
+
+    @pytest.mark.asyncio
+    async def test_create_team_reports_seeded_members_and_invitations(self, mock_user_context, mock_team, mock_db):
+        """Seeded members are reported back so the form can confirm without re-querying."""
+        request = TeamCreateRequest(
+            name="New Team",
+            visibility="private",
+            members=[
+                {"email": "alice@example.com", "role": "member"},
+                {"email": "external@partner.com", "role": "owner"},
+            ],
+        )
+
+        seed_result = TeamSeedResult(
+            team=mock_team,
+            members_added=[SeededMember(email="alice@example.com", role="member")],
+            invitations_sent=[SeededInvitation(email="external@partner.com", role="owner", invitation_id="inv-1")],
+        )
+
+        with mock_permission_check(is_admin=False), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
+            mock_service = AsyncMock(spec=TeamManagementService)
+            mock_service.create_team_with_members = AsyncMock(return_value=seed_result)
+            MockService.return_value = mock_service
+
+            from mcpgateway.routers.teams import create_team
+
+            result = await create_team(request, current_user_ctx=mock_user_context, db=mock_db)
+
+            # The team fields stay at the top level, so existing clients keep working
+            assert result.id == mock_team.id
+
+            assert [(m.email, m.role) for m in result.members_added] == [("alice@example.com", "member")]
+            assert [(i.email, i.role, i.invitation_id) for i in result.invitations_sent] == [("external@partner.com", "owner", "inv-1")]
+
+            assert mock_service.create_team_with_members.call_args.kwargs["members"] == request.members
+
+    @pytest.mark.asyncio
+    async def test_create_team_seed_failure_returns_400(self, mock_user_context, mock_db):
+        """A member row the server cannot apply fails the whole request."""
+        request = TeamCreateRequest(name="New Team", visibility="private", members=[{"email": "alice@example.com"}])
+
+        with mock_permission_check(is_admin=False), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
+            mock_service = AsyncMock(spec=TeamManagementService)
+            mock_service.create_team_with_members = AsyncMock(side_effect=TeamMemberLimitExceededError("Team would start with 5 members, exceeding the maximum of 3"))
+            MockService.return_value = mock_service
+
+            from mcpgateway.routers.teams import create_team
+
+            with pytest.raises(HTTPException) as exc_info:
+                await create_team(request, current_user_ctx=mock_user_context, db=mock_db)
+
+            assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+            assert "exceeding the maximum" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
     async def test_create_team_value_error(self, mock_user_context, mock_db):
@@ -255,7 +314,7 @@ class TestTeamsRouter:
         with mock_permission_check(is_admin=False), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
 
             mock_service = AsyncMock(spec=TeamManagementService)
-            mock_service.create_team = AsyncMock(side_effect=ValueError("Service validation error"))
+            mock_service.create_team_with_members = AsyncMock(side_effect=ValueError("Service validation error"))
             MockService.return_value = mock_service
 
             from mcpgateway.routers.teams import create_team
@@ -274,7 +333,7 @@ class TestTeamsRouter:
         with mock_permission_check(is_admin=False), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
 
             mock_service = AsyncMock(spec=TeamManagementService)
-            mock_service.create_team = AsyncMock(side_effect=Exception("Database error"))
+            mock_service.create_team_with_members = AsyncMock(side_effect=Exception("Database error"))
             MockService.return_value = mock_service
 
             from mcpgateway.routers.teams import create_team
@@ -563,7 +622,7 @@ class TestTeamsRouter:
 
             # Mock TeamManagementService
             mock_service = AsyncMock(spec=TeamManagementService)
-            mock_service.create_team = AsyncMock(return_value=mock_team)
+            mock_service.create_team_with_members = AsyncMock(return_value=TeamSeedResult(team=mock_team))
             MockService.return_value = mock_service
 
             from mcpgateway.routers.teams import create_team
@@ -577,8 +636,8 @@ class TestTeamsRouter:
                 token_teams=mock_sso_platform_admin_context.get("token_teams"),
             )
             # Verify skip_limits=True was passed
-            mock_service.create_team.assert_called_once()
-            call_kwargs = mock_service.create_team.call_args.kwargs
+            mock_service.create_team_with_members.assert_called_once()
+            call_kwargs = mock_service.create_team_with_members.call_args.kwargs
             assert call_kwargs["skip_limits"] is True
 
     @pytest.mark.asyncio
@@ -1423,7 +1482,7 @@ class TestTeamsRouter:
 
             mock_settings.allow_team_creation = True
             mock_service = AsyncMock(spec=TeamManagementService)
-            mock_service.create_team = AsyncMock(side_effect=ValueError("max_members cannot exceed the configured limit of 100"))
+            mock_service.create_team_with_members = AsyncMock(side_effect=ValueError("max_members cannot exceed the configured limit of 100"))
             MockService.return_value = mock_service
 
             from mcpgateway.routers.teams import create_team
@@ -1444,7 +1503,7 @@ class TestTeamsRouter:
             mock_settings.allow_team_creation = True
             mock_settings.max_members_per_team = 100
             mock_service = AsyncMock(spec=TeamManagementService)
-            mock_service.create_team = AsyncMock(return_value=mock_team)
+            mock_service.create_team_with_members = AsyncMock(return_value=TeamSeedResult(team=mock_team))
             MockService.return_value = mock_service
 
             from mcpgateway.routers.teams import create_team
@@ -1461,14 +1520,14 @@ class TestTeamsRouter:
             mock_settings.allow_team_creation = True
             mock_settings.max_members_per_team = 100
             mock_service = AsyncMock(spec=TeamManagementService)
-            mock_service.create_team = AsyncMock(return_value=mock_team)
+            mock_service.create_team_with_members = AsyncMock(return_value=TeamSeedResult(team=mock_team))
             MockService.return_value = mock_service
 
             from mcpgateway.routers.teams import create_team
 
             result = await create_team(request, current_user_ctx=mock_admin_context, db=mock_db)
             assert result.id == mock_team.id
-            mock_service.create_team.assert_called_once()
+            mock_service.create_team_with_members.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_update_team_non_admin_max_members_too_high(self, mock_user_context, mock_db):

--- a/tests/unit/mcpgateway/routers/test_teams.py
+++ b/tests/unit/mcpgateway/routers/test_teams.py
@@ -284,6 +284,24 @@ class TestTeamsRouter:
             assert mock_service.create_team_with_members.call_args.kwargs["members"] == request.members
 
     @pytest.mark.asyncio
+    async def test_create_team_with_explicit_empty_members(self, mock_user_context, mock_team, mock_db):
+        """An explicit ``members=[]`` is passed through and returns empty result arrays, not None."""
+        request = TeamCreateRequest(name="New Team", visibility="private", members=[])
+
+        with mock_permission_check(is_admin=False), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
+            mock_service = AsyncMock(spec=TeamManagementService)
+            mock_service.create_team_with_members = AsyncMock(return_value=TeamSeedResult(team=mock_team))
+            MockService.return_value = mock_service
+
+            from mcpgateway.routers.teams import create_team
+
+            result = await create_team(request, current_user_ctx=mock_user_context, db=mock_db)
+
+            assert result.members_added == []
+            assert result.invitations_sent == []
+            assert mock_service.create_team_with_members.call_args.kwargs["members"] == []
+
+    @pytest.mark.asyncio
     async def test_create_team_seed_failure_returns_400(self, mock_user_context, mock_db):
         """A member row the server cannot apply fails the whole request."""
         request = TeamCreateRequest(name="New Team", visibility="private", members=[{"email": "alice@example.com"}])

--- a/tests/unit/mcpgateway/routers/test_teams_coverage.py
+++ b/tests/unit/mcpgateway/routers/test_teams_coverage.py
@@ -31,7 +31,7 @@ with patch("mcpgateway.middleware.rbac.require_permission", _noop_decorator):
         from mcpgateway.db import EmailTeam, EmailTeamInvitation, EmailTeamMember, EmailUser
         from mcpgateway.routers import teams
         from mcpgateway.services.team_invitation_service import TeamInvitationService
-        from mcpgateway.services.team_management_service import JoinRequestNotFoundError, TeamManagementService
+        from mcpgateway.services.team_management_service import JoinRequestNotFoundError, TeamManagementService, TeamSeedResult
 
         importlib.reload(teams)
 
@@ -160,7 +160,7 @@ class TestUpdateTeamMaxMembersCap:
     @pytest.mark.asyncio
     async def test_non_admin_create_exceeds_cap_rejected(self, user_ctx, db):
         """Non-admin create with max_members > cap returns 400."""
-        with mock_permission_check(is_admin=user_ctx.get("is_admin", False)), _svc(create_team=AsyncMock(side_effect=ValueError("max_members cannot exceed the configured limit of 100"))):
+        with mock_permission_check(is_admin=user_ctx.get("is_admin", False)), _svc(create_team_with_members=AsyncMock(side_effect=ValueError("max_members cannot exceed the configured limit of 100"))):
             from mcpgateway.schemas import TeamCreateRequest
 
             req = TeamCreateRequest(name="BigTeam", max_members=200)
@@ -173,7 +173,7 @@ class TestUpdateTeamMaxMembersCap:
     async def test_admin_create_exceeds_cap_allowed(self, admin_ctx, db, mock_team):
         """Admin create with max_members > cap succeeds."""
         mock_team.max_members = 500
-        with mock_permission_check(is_admin=admin_ctx.get("is_admin", False)), _svc(create_team=AsyncMock(return_value=mock_team), get_member_counts_batch_cached=AsyncMock(return_value={})):
+        with mock_permission_check(is_admin=admin_ctx.get("is_admin", False)), _svc(create_team_with_members=AsyncMock(return_value=TeamSeedResult(team=mock_team)), get_member_counts_batch_cached=AsyncMock(return_value={})):
             from mcpgateway.schemas import TeamCreateRequest
 
             req = TeamCreateRequest(name="BigTeam", max_members=500)
@@ -184,7 +184,7 @@ class TestUpdateTeamMaxMembersCap:
     async def test_non_admin_create_at_cap_allowed(self, user_ctx, db, mock_team):
         """Non-admin create with max_members == cap succeeds."""
         mock_team.max_members = 100
-        with mock_permission_check(is_admin=user_ctx.get("is_admin", False)), _svc(create_team=AsyncMock(return_value=mock_team)):
+        with mock_permission_check(is_admin=user_ctx.get("is_admin", False)), _svc(create_team_with_members=AsyncMock(return_value=TeamSeedResult(team=mock_team))):
             from mcpgateway.schemas import TeamCreateRequest
 
             req = TeamCreateRequest(name="Team", max_members=100)

--- a/tests/unit/mcpgateway/routers/test_teams_v2.py
+++ b/tests/unit/mcpgateway/routers/test_teams_v2.py
@@ -51,7 +51,7 @@ with patch("mcpgateway.middleware.rbac.require_permission", mock_require_permiss
             TeamMemberUpdateRequest,
             TeamUpdateRequest,
         )
-        from mcpgateway.services.team_management_service import TeamManagementService
+        from mcpgateway.services.team_management_service import TeamManagementService, TeamSeedResult
 
 
 def mock_permission_check(is_admin=False):
@@ -136,7 +136,7 @@ class TestTeamsRouterV2:
              patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
 
             mock_service = AsyncMock(spec=TeamManagementService)
-            mock_service.create_team = AsyncMock(return_value=mock_team)
+            mock_service.create_team_with_members = AsyncMock(return_value=TeamSeedResult(team=mock_team))
             MockService.return_value = mock_service
 
             result = await teams.create_team(request, current_user_ctx=mock_user_context, db=mock_db)
@@ -144,8 +144,14 @@ class TestTeamsRouterV2:
             assert result.id == mock_team.id
             assert result.name == mock_team.name
             assert result.description == mock_team.description
-            mock_service.create_team.assert_called_once_with(
-                name=request.name, description=request.description, created_by=mock_user_context["email"], visibility=request.visibility, max_members=request.max_members, skip_limits=False
+            mock_service.create_team_with_members.assert_called_once_with(
+                name=request.name,
+                description=request.description,
+                created_by=mock_user_context["email"],
+                visibility=request.visibility,
+                max_members=request.max_members,
+                skip_limits=False,
+                members=request.members,
             )
 
     @pytest.mark.asyncio
@@ -162,7 +168,7 @@ class TestTeamsRouterV2:
              patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
 
             mock_service = AsyncMock(spec=TeamManagementService)
-            mock_service.create_team = AsyncMock(side_effect=ValueError("Team name cannot be empty"))
+            mock_service.create_team_with_members = AsyncMock(side_effect=ValueError("Team name cannot be empty"))
             MockService.return_value = mock_service
 
             with pytest.raises(HTTPException) as exc_info:

--- a/tests/unit/mcpgateway/services/test_team_management_service.py
+++ b/tests/unit/mcpgateway/services/test_team_management_service.py
@@ -208,7 +208,7 @@ class TestTeamManagementService:
 
             assert result == mock_team
             mock_db.add.assert_called()
-            mock_db.flush.assert_called_once()
+            mock_db.flush.assert_called()
             mock_db.commit.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/services/test_team_member_seeding.py
+++ b/tests/unit/mcpgateway/services/test_team_member_seeding.py
@@ -175,6 +175,77 @@ class TestMemberSeedRouting:
         assert membership.role == "owner"
 
 
+class TestMixedCaseEmailNormalisation:
+    """Seed emails with uppercase characters are handled as their lowercase canonical form."""
+
+    @pytest.mark.asyncio
+    async def test_uppercase_active_user_is_matched_and_added(self, service, test_db):
+        """An active user whose address is supplied in mixed-case is added as a member.
+
+        Regression: before the fix, str(seed.email).strip() preserved case, so the
+        EmailUser.email.in_([...]) query returned nothing for 'ALICE@example.com'
+        (the canonical record is 'alice@example.com'), and the seed fell through to
+        the invitation path — storing 'ALICE@example.com' in the invitation.  That
+        invitation could never be accepted because accept_invitation() compares
+        invitation.email against the lowercase authenticated identity.
+        """
+        make_user(test_db, "alice@example.com")
+
+        result = await service.create_team_with_members(
+            name="Engineering",
+            description=None,
+            created_by=CREATOR,
+            visibility="private",
+            members=[TeamMemberSeed(email="ALICE@example.com", role="member")],
+        )
+
+        # Must be a membership, not an invitation
+        assert [m.email for m in result.members_added] == ["alice@example.com"]
+        assert result.invitations_sent == []
+
+        # Canonical lowercase address stored in the membership row
+        member = test_db.query(EmailTeamMember).filter(EmailTeamMember.team_id == result.team.id, EmailTeamMember.user_email == "alice@example.com").one()
+        assert member.role == "member"
+
+    @pytest.mark.asyncio
+    async def test_uppercase_unknown_email_invitation_is_stored_lowercase(self, service, test_db):
+        """An unknown address supplied in mixed-case is invited using its canonical lowercase form."""
+        result = await service.create_team_with_members(
+            name="Engineering",
+            description=None,
+            created_by=CREATOR,
+            visibility="private",
+            members=[TeamMemberSeed(email="External@Partner.com", role="member")],
+        )
+
+        assert result.members_added == []
+        assert [i.email for i in result.invitations_sent] == ["external@partner.com"]
+
+        invitation = test_db.query(EmailTeamInvitation).filter(EmailTeamInvitation.team_id == result.team.id).one()
+        assert invitation.email == "external@partner.com"
+
+    @pytest.mark.asyncio
+    async def test_mixed_case_duplicate_is_rejected(self, service, test_db):
+        """alice@example.com and ALICE@example.com are the same address and must be de-duped."""
+        make_user(test_db, "alice@example.com")
+
+        with pytest.raises(TeamMemberSeedError) as exc_info:
+            await service.create_team_with_members(
+                name="Engineering",
+                description=None,
+                created_by=CREATOR,
+                visibility="private",
+                members=[
+                    TeamMemberSeed(email="alice@example.com", role="member"),
+                    TeamMemberSeed(email="ALICE@example.com", role="owner"),
+                ],
+            )
+
+        assert exc_info.value.index == 1
+        assert "already listed at members[0]" in str(exc_info.value)
+        assert not team_exists(test_db, "Engineering")
+
+
 class TestMemberSeedAtomicity:
     """A bad row leaves nothing behind — no team, no members, no invitations."""
 

--- a/tests/unit/mcpgateway/services/test_team_member_seeding.py
+++ b/tests/unit/mcpgateway/services/test_team_member_seeding.py
@@ -1,0 +1,431 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_team_member_seeding.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Mihai Criveti
+
+Tests for seeding members into a team at creation time.
+
+These run against a real session rather than mocks: the point of the feature is
+that the team, its memberships and its invitations are written as one atomic
+unit, and only a real transaction can show that.
+"""
+
+# Standard
+from unittest.mock import patch
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.config import settings
+from mcpgateway.db import EmailTeam, EmailTeamInvitation, EmailTeamMember, EmailTeamMemberHistory, EmailUser, utc_now
+from mcpgateway.schemas import MAX_TEAM_MEMBER_SEEDS, TeamMemberSeed
+from mcpgateway.services.team_management_service import TeamManagementService, TeamMemberLimitExceededError, TeamMemberSeedError
+
+CREATOR = "creator@example.com"
+
+# The test engine is session-scoped, so each test starts from a clean slate itself.
+TABLES_TO_CLEAR = (EmailTeamMemberHistory, EmailTeamInvitation, EmailTeamMember, EmailTeam, EmailUser)
+
+
+def make_user(db, email, *, is_active=True, verified=True):
+    """Persist an EmailUser for the tests to route against.
+
+    Args:
+        db: Database session.
+        email: Email address of the user.
+        is_active: Whether the account is active.
+        verified: Whether the email address is verified.
+
+    Returns:
+        EmailUser: The persisted user.
+    """
+    user = EmailUser(
+        email=email,
+        password_hash="x",  # pragma: allowlist secret
+        is_admin=False,
+        is_active=is_active,
+        email_verified_at=utc_now() if verified else None,
+    )
+    db.add(user)
+    db.commit()
+    return user
+
+
+@pytest.fixture
+def service(test_db):
+    """Team management service bound to a freshly emptied test session.
+
+    Args:
+        test_db: Database session fixture.
+
+    Returns:
+        TeamManagementService: Service under test, with the creator already registered.
+    """
+    for model in TABLES_TO_CLEAR:
+        test_db.query(model).delete()
+    test_db.commit()
+
+    make_user(test_db, CREATOR)
+    return TeamManagementService(test_db)
+
+
+def team_exists(db, name):
+    """Report whether a team with this name survived the call.
+
+    Args:
+        db: Database session.
+        name: Team name to look for.
+
+    Returns:
+        bool: True if the team is present.
+    """
+    return db.query(EmailTeam).filter(EmailTeam.name == name).first() is not None
+
+
+class TestMemberSeedRouting:
+    """The server decides member vs. invitation; the caller does not."""
+
+    @pytest.mark.asyncio
+    async def test_active_user_is_added_unknown_email_is_invited(self, service, test_db):
+        """An active user becomes a member; an unknown address gets an invitation."""
+        make_user(test_db, "alice@example.com")
+
+        result = await service.create_team_with_members(
+            name="Engineering",
+            description=None,
+            created_by=CREATOR,
+            visibility="private",
+            members=[
+                TeamMemberSeed(email="alice@example.com", role="member"),
+                TeamMemberSeed(email="external@partner.com", role="member"),
+            ],
+        )
+
+        assert [m.email for m in result.members_added] == ["alice@example.com"]
+        assert [i.email for i in result.invitations_sent] == ["external@partner.com"]
+        assert result.invitations_sent[0].invitation_id
+
+        # Creator is the owner, alice is a member, the outsider is not a member at all
+        members = {m.user_email: m.role for m in test_db.query(EmailTeamMember).filter(EmailTeamMember.team_id == result.team.id, EmailTeamMember.is_active.is_(True)).all()}
+        assert members == {CREATOR: "owner", "alice@example.com": "member"}
+
+        invitation = test_db.query(EmailTeamInvitation).filter(EmailTeamInvitation.team_id == result.team.id).one()
+        assert invitation.email == "external@partner.com"
+        assert invitation.invited_by == CREATOR
+        assert invitation.token
+
+    @pytest.mark.asyncio
+    async def test_deactivated_user_is_invited_not_added(self, service, test_db):
+        """A known but deactivated account is invited rather than silently re-added."""
+        make_user(test_db, "gone@example.com", is_active=False)
+
+        result = await service.create_team_with_members(
+            name="Engineering",
+            description=None,
+            created_by=CREATOR,
+            visibility="private",
+            members=[TeamMemberSeed(email="gone@example.com", role="member")],
+        )
+
+        assert result.members_added == []
+        assert [i.email for i in result.invitations_sent] == ["gone@example.com"]
+
+    @pytest.mark.asyncio
+    async def test_seeded_role_is_honoured(self, service, test_db):
+        """Owner seeds land as owners, for members and invitees alike."""
+        make_user(test_db, "lead@example.com")
+
+        result = await service.create_team_with_members(
+            name="Engineering",
+            description=None,
+            created_by=CREATOR,
+            visibility="private",
+            members=[
+                TeamMemberSeed(email="lead@example.com", role="owner"),
+                TeamMemberSeed(email="external@partner.com", role="owner"),
+            ],
+        )
+
+        assert result.members_added[0].role == "owner"
+        assert result.invitations_sent[0].role == "owner"
+
+        membership = test_db.query(EmailTeamMember).filter(EmailTeamMember.team_id == result.team.id, EmailTeamMember.user_email == "lead@example.com").one()
+        assert membership.role == "owner"
+
+    @pytest.mark.asyncio
+    async def test_creator_row_is_skipped(self, service, test_db):
+        """Listing yourself is a no-op: team creation already makes you the owner."""
+        result = await service.create_team_with_members(
+            name="Engineering",
+            description=None,
+            created_by=CREATOR,
+            visibility="private",
+            members=[
+                TeamMemberSeed(email=CREATOR.upper(), role="member"),
+                TeamMemberSeed(email="external@partner.com", role="member"),
+            ],
+        )
+
+        assert result.members_added == []
+        assert [i.email for i in result.invitations_sent] == ["external@partner.com"]
+
+        membership = test_db.query(EmailTeamMember).filter(EmailTeamMember.team_id == result.team.id, EmailTeamMember.user_email == CREATOR).one()
+        assert membership.role == "owner"
+
+
+class TestMemberSeedAtomicity:
+    """A bad row leaves nothing behind — no team, no members, no invitations."""
+
+    @pytest.mark.asyncio
+    async def test_duplicate_emails_are_rejected(self, service, test_db):
+        """The same address twice is a caller error, and creates nothing."""
+        make_user(test_db, "alice@example.com")
+
+        with pytest.raises(TeamMemberSeedError) as exc_info:
+            await service.create_team_with_members(
+                name="Engineering",
+                description=None,
+                created_by=CREATOR,
+                visibility="private",
+                members=[
+                    TeamMemberSeed(email="alice@example.com", role="member"),
+                    TeamMemberSeed(email="ALICE@example.com", role="owner"),
+                ],
+            )
+
+        assert exc_info.value.index == 1
+        assert "already listed at members[0]" in str(exc_info.value)
+        assert not team_exists(test_db, "Engineering")
+
+    @pytest.mark.asyncio
+    async def test_more_seeds_than_allowed_in_one_call(self, service):
+        """A request larger than the hard ceiling is refused outright."""
+        members = [TeamMemberSeed(email=f"user{i}@example.com") for i in range(MAX_TEAM_MEMBER_SEEDS + 1)]
+
+        with pytest.raises(TeamMemberLimitExceededError, match="more than"):
+            await service.create_team_with_members(name="Huge", description=None, created_by=CREATOR, visibility="private", max_members=0, members=members)
+
+
+class TestSeedErrorsIdentifyTheRow:
+    """A failing row is reported by the position the caller sent it in."""
+
+    @pytest.mark.asyncio
+    async def test_failing_row_is_named_by_request_index(self, service, test_db):
+        """The reported index is the caller's row, not the position after filtering."""
+        make_user(test_db, "alice@example.com")
+
+        # The creator's row is dropped during normalization, so the failing invitation
+        # is the 2nd surviving seed but the 3rd row the caller actually typed.
+        with patch.object(settings, "allow_team_invitations", False):
+            with pytest.raises(TeamMemberSeedError) as exc_info:
+                await service.create_team_with_members(
+                    name="Engineering",
+                    description=None,
+                    created_by=CREATOR,
+                    visibility="private",
+                    members=[
+                        TeamMemberSeed(email=CREATOR, role="member"),
+                        TeamMemberSeed(email="alice@example.com", role="member"),
+                        TeamMemberSeed(email="external@partner.com", role="member"),
+                    ],
+                )
+
+        error = exc_info.value
+        assert error.index == 2
+        assert error.email == "external@partner.com"
+        assert str(error).startswith("members[2] (external@partner.com):")
+        assert "invitations are currently disabled" in error.reason
+
+    @pytest.mark.asyncio
+    async def test_member_at_team_limit_is_named(self, service, test_db):
+        """A user who cannot join another team is identified, not reported anonymously."""
+        make_user(test_db, "alice@example.com")
+        make_user(test_db, "bob@example.com")
+
+        # Bob is already in as many teams as he is allowed
+        with patch.object(settings, "max_teams_per_user", 0):
+            with pytest.raises(TeamMemberSeedError) as exc_info:
+                await service.create_team_with_members(
+                    name="Engineering",
+                    description=None,
+                    created_by=CREATOR,
+                    visibility="private",
+                    skip_limits=True,  # the creator bypasses the limit; the seeded member must not
+                    members=[TeamMemberSeed(email="bob@example.com", role="member")],
+                )
+
+        assert exc_info.value.email == "bob@example.com"
+        assert "maximum team limit" in exc_info.value.reason
+        assert not team_exists(test_db, "Engineering")
+
+
+class TestInvitationTransactionOwnership:
+    """create_invitation(commit=False) must not unwind a transaction it does not own."""
+
+    @pytest.mark.asyncio
+    async def test_failure_leaves_the_callers_transaction_intact(self, service, test_db):
+        """A failing invitation leaves the caller's pending rows for the caller to deal with."""
+        # First-Party
+        from mcpgateway.services.team_invitation_service import TeamInvitationService
+
+        team = await service.create_team(name="Engineering", description=None, created_by=CREATOR, visibility="private")
+
+        # An uncommitted row belonging to the caller's transaction
+        test_db.add(EmailUser(email="pending@example.com", password_hash="x", is_admin=False, is_active=True))  # pragma: allowlist secret
+        test_db.flush()
+
+        with pytest.raises(ValueError):
+            await TeamInvitationService(test_db).create_invitation(team_id=team.id, email="x@example.com", role="bogus-role", invited_by=CREATOR, commit=False)
+
+        # Still there: the callee did not roll the caller's work back
+        assert test_db.query(EmailUser).filter(EmailUser.email == "pending@example.com").first() is not None
+
+    @pytest.mark.asyncio
+    async def test_failure_still_rolls_back_when_it_owns_the_transaction(self, service, test_db):
+        """The default path is unchanged: create_invitation rolls its own work back."""
+        # First-Party
+        from mcpgateway.services.team_invitation_service import TeamInvitationService
+
+        team = await service.create_team(name="Engineering", description=None, created_by=CREATOR, visibility="private")
+
+        test_db.add(EmailUser(email="pending@example.com", password_hash="x", is_admin=False, is_active=True))  # pragma: allowlist secret
+        test_db.flush()
+
+        with pytest.raises(ValueError):
+            await TeamInvitationService(test_db).create_invitation(team_id=team.id, email="x@example.com", role="bogus-role", invited_by=CREATOR)
+
+        assert test_db.query(EmailUser).filter(EmailUser.email == "pending@example.com").first() is None
+
+
+class TestSeedRollback:
+    """A row that cannot be applied takes the whole team with it."""
+
+    @pytest.mark.asyncio
+    async def test_seeds_over_capacity_are_rejected(self, service, test_db):
+        """Creator plus seeds must fit the member limit, checked before any write."""
+        make_user(test_db, "alice@example.com")
+
+        with pytest.raises(TeamMemberLimitExceededError):
+            await service.create_team_with_members(
+                name="Engineering",
+                description=None,
+                created_by=CREATOR,
+                visibility="private",
+                max_members=2,
+                members=[
+                    TeamMemberSeed(email="alice@example.com", role="member"),
+                    TeamMemberSeed(email="external@partner.com", role="member"),
+                ],
+            )
+
+        assert not team_exists(test_db, "Engineering")
+
+    @pytest.mark.asyncio
+    async def test_failed_invitation_rolls_back_the_whole_team(self, service, test_db):
+        """An invitation that cannot be sent takes the team and the members with it."""
+        make_user(test_db, "alice@example.com")
+
+        with patch.object(settings, "allow_team_invitations", False):
+            with pytest.raises(TeamMemberSeedError, match="invitations are currently disabled"):
+                await service.create_team_with_members(
+                    name="Engineering",
+                    description=None,
+                    created_by=CREATOR,
+                    visibility="private",
+                    members=[
+                        TeamMemberSeed(email="alice@example.com", role="member"),
+                        TeamMemberSeed(email="external@partner.com", role="member"),
+                    ],
+                )
+
+        # The membership for alice was written before the failing row, and must be gone too
+        assert not team_exists(test_db, "Engineering")
+        assert test_db.query(EmailTeamMember).filter(EmailTeamMember.user_email == "alice@example.com").first() is None
+        assert test_db.query(EmailTeamInvitation).count() == 0
+
+
+class TestSeedingAReactivatedTeam:
+    """Creating a team whose slug matches a deleted one revives that row — seeds must survive it."""
+
+    @pytest.mark.asyncio
+    async def test_deleting_a_team_deactivates_its_pending_invitations(self, service, test_db):
+        """An invitation must not outlive the team it points at."""
+        result = await service.create_team_with_members(
+            name="Engineering",
+            description=None,
+            created_by=CREATOR,
+            visibility="private",
+            members=[TeamMemberSeed(email="external@partner.com", role="member")],
+        )
+
+        await service.delete_team(result.team.id, deleted_by=CREATOR)
+
+        invitation = test_db.query(EmailTeamInvitation).filter(EmailTeamInvitation.team_id == result.team.id).one()
+        assert invitation.is_active is False
+
+    @pytest.mark.asyncio
+    async def test_recreating_a_deleted_team_with_the_same_people(self, service, test_db):
+        """The same name and the same members, after a delete, must not collide with the old rows."""
+        make_user(test_db, "alice@example.com")
+
+        first = await service.create_team_with_members(
+            name="Engineering",
+            description=None,
+            created_by=CREATOR,
+            visibility="private",
+            members=[
+                TeamMemberSeed(email="alice@example.com", role="member"),
+                TeamMemberSeed(email="external@partner.com", role="member"),
+            ],
+        )
+        await service.delete_team(first.team.id, deleted_by=CREATOR)
+
+        # Same team, same people. Alice's membership and the partner's invitation both
+        # have stale rows from the previous incarnation.
+        second = await service.create_team_with_members(
+            name="Engineering",
+            description=None,
+            created_by=CREATOR,
+            visibility="private",
+            members=[
+                TeamMemberSeed(email="alice@example.com", role="owner"),
+                TeamMemberSeed(email="external@partner.com", role="member"),
+            ],
+        )
+
+        assert second.team.id == first.team.id  # the slug collision reactivated the original row
+        assert [m.email for m in second.members_added] == ["alice@example.com"]
+        assert [i.email for i in second.invitations_sent] == ["external@partner.com"]
+
+        # Alice comes back with her new role, not the one she had before
+        members = {m.user_email: m.role for m in test_db.query(EmailTeamMember).filter(EmailTeamMember.team_id == second.team.id, EmailTeamMember.is_active.is_(True)).all()}
+        assert members == {CREATOR: "owner", "alice@example.com": "owner"}
+
+        # Exactly one live invitation: the new one, not the resurrected old one
+        active = test_db.query(EmailTeamInvitation).filter(EmailTeamInvitation.team_id == second.team.id, EmailTeamInvitation.is_active.is_(True)).all()
+        assert [i.id for i in active] == [second.invitations_sent[0].invitation_id]
+
+
+class TestCreateTeamUnchanged:
+    """Existing callers that do not seed members are unaffected."""
+
+    @pytest.mark.asyncio
+    async def test_create_team_still_returns_the_team(self, service, test_db):
+        """create_team keeps its old signature and return type."""
+        team = await service.create_team(name="Engineering", description="Software", created_by=CREATOR, visibility="private")
+
+        assert isinstance(team, EmailTeam)
+        assert team.name == "Engineering"
+
+        members = test_db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team.id).all()
+        assert [(m.user_email, m.role) for m in members] == [(CREATOR, "owner")]
+
+    @pytest.mark.asyncio
+    async def test_no_members_seeds_nothing(self, service):
+        """An omitted members list produces empty result arrays, not None."""
+        result = await service.create_team_with_members(name="Engineering", description=None, created_by=CREATOR, visibility="private")
+
+        assert result.members_added == []
+        assert result.invitations_sent == []

--- a/tests/unit/mcpgateway/services/test_team_member_seeding.py
+++ b/tests/unit/mcpgateway/services/test_team_member_seeding.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """Location: ./tests/unit/mcpgateway/services/test_team_member_seeding.py
-Copyright 2026
+Copyright contributors to the MCP-CONTEXT-FORGE project
 SPDX-License-Identifier: Apache-2.0
-Authors: Mihai Criveti
 
 Tests for seeding members into a team at creation time.
 

--- a/tests/unit/mcpgateway/services/test_team_member_seeding.py
+++ b/tests/unit/mcpgateway/services/test_team_member_seeding.py
@@ -12,7 +12,7 @@ unit, and only a real transaction can show that.
 """
 
 # Standard
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 import pytest
@@ -394,6 +394,25 @@ class TestSeedRollback:
         assert not team_exists(test_db, "Engineering")
 
     @pytest.mark.asyncio
+    async def test_creator_plus_seeds_exactly_at_the_limit_is_allowed(self, service, test_db):
+        """The boundary is inclusive: creator + seeds may equal max_members exactly."""
+        make_user(test_db, "alice@example.com")
+
+        # max_members=2 leaves room for the creator (owner) plus exactly one seed.
+        result = await service.create_team_with_members(
+            name="Engineering",
+            description=None,
+            created_by=CREATOR,
+            visibility="private",
+            max_members=2,
+            members=[TeamMemberSeed(email="alice@example.com", role="member")],
+        )
+
+        assert [m.email for m in result.members_added] == ["alice@example.com"]
+        members = test_db.query(EmailTeamMember).filter(EmailTeamMember.team_id == result.team.id, EmailTeamMember.is_active.is_(True)).count()
+        assert members == 2
+
+    @pytest.mark.asyncio
     async def test_failed_invitation_rolls_back_the_whole_team(self, service, test_db):
         """An invitation that cannot be sent takes the team and the members with it."""
         make_user(test_db, "alice@example.com")
@@ -477,6 +496,61 @@ class TestSeedingAReactivatedTeam:
         # Exactly one live invitation: the new one, not the resurrected old one
         active = test_db.query(EmailTeamInvitation).filter(EmailTeamInvitation.team_id == second.team.id, EmailTeamInvitation.is_active.is_(True)).all()
         assert [i.id for i in active] == [second.invitations_sent[0].invitation_id]
+
+
+class TestSeededMembershipCrossServiceEffects:
+    """Seeding a member must reach the same RBAC and cache side effects as add_member_to_team()."""
+
+    @pytest.mark.asyncio
+    async def test_seeded_members_get_an_rbac_role_invitees_do_not(self, service, test_db):
+        """Each added member is granted the matching RBAC role; invited addresses are not."""
+        make_user(test_db, "alice@example.com")
+        make_user(test_db, "lead@example.com")
+
+        with patch.object(service, "_assign_team_rbac_role", new_callable=AsyncMock) as assign_role:
+            result = await service.create_team_with_members(
+                name="Engineering",
+                description=None,
+                created_by=CREATOR,
+                visibility="private",
+                members=[
+                    TeamMemberSeed(email="alice@example.com", role="member"),
+                    TeamMemberSeed(email="lead@example.com", role="owner"),
+                    TeamMemberSeed(email="external@partner.com", role="member"),
+                ],
+            )
+
+        team_id = str(result.team.id)
+        granted = {(call.args[0], call.args[1], call.args[2]) for call in assign_role.call_args_list}
+        # Both known users are granted their seeded role against the new team.
+        assert ("alice@example.com", team_id, "member") in granted
+        assert ("lead@example.com", team_id, "owner") in granted
+        # The invited outsider never became a member, so no role is assigned for them.
+        assert not any(call.args[0] == "external@partner.com" for call in assign_role.call_args_list)
+
+    @pytest.mark.asyncio
+    async def test_auth_caches_are_invalidated_for_each_seeded_member(self, service, test_db):
+        """Adding a member must invalidate that member's auth caches, or a stale cache hides the new team."""
+        make_user(test_db, "alice@example.com")
+
+        with patch.object(service, "_invalidate_membership_caches", new=MagicMock()) as invalidate:
+            result = await service.create_team_with_members(
+                name="Engineering",
+                description=None,
+                created_by=CREATOR,
+                visibility="private",
+                members=[
+                    TeamMemberSeed(email="alice@example.com", role="member"),
+                    TeamMemberSeed(email="external@partner.com", role="member"),
+                ],
+            )
+
+        team_id = str(result.team.id)
+        invalidated = {call.args[0] for call in invalidate.call_args_list}
+        # The added member's caches are cleared; the invited outsider has no membership to clear.
+        assert "alice@example.com" in invalidated
+        assert "external@partner.com" not in invalidated
+        assert all(call.args[1] == team_id for call in invalidate.call_args_list)
 
 
 class TestCreateTeamUnchanged:

--- a/tests/unit/mcpgateway/services/test_team_member_seeding.py
+++ b/tests/unit/mcpgateway/services/test_team_member_seeding.py
@@ -12,6 +12,7 @@ unit, and only a real transaction can show that.
 """
 
 # Standard
+import re
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
@@ -551,6 +552,60 @@ class TestSeededMembershipCrossServiceEffects:
         assert "alice@example.com" in invalidated
         assert "external@partner.com" not in invalidated
         assert all(call.args[1] == team_id for call in invalidate.call_args_list)
+
+    @pytest.mark.asyncio
+    async def test_seeded_members_leave_an_audit_trail(self, service, test_db):
+        """Each added member gets an 'added' history row; invited addresses (no membership) do not."""
+        make_user(test_db, "alice@example.com")
+        make_user(test_db, "lead@example.com")
+
+        result = await service.create_team_with_members(
+            name="Engineering",
+            description=None,
+            created_by=CREATOR,
+            visibility="private",
+            members=[
+                TeamMemberSeed(email="alice@example.com", role="member"),
+                TeamMemberSeed(email="lead@example.com", role="owner"),
+                TeamMemberSeed(email="external@partner.com", role="member"),
+            ],
+        )
+
+        team_id = str(result.team.id)
+        history = test_db.query(EmailTeamMemberHistory).filter(EmailTeamMemberHistory.team_id == team_id).all()
+        logged = {(h.user_email, h.role, h.action, h.action_by) for h in history}
+
+        # Both known users are recorded as added, with the actor and seeded role captured.
+        assert ("alice@example.com", "member", "added", CREATOR) in logged
+        assert ("lead@example.com", "owner", "added", CREATOR) in logged
+        # The invited outsider never became a member, so there is no membership history for them.
+        assert not any(h.user_email == "external@partner.com" for h in history)
+
+
+class TestSeededInvitationTokens:
+    """Invitations minted during seeding must carry a usable, unique token."""
+
+    @pytest.mark.asyncio
+    async def test_seeded_invitation_tokens_are_nonempty_urlsafe_and_unique(self, service, test_db):
+        """Every seeded invitation gets a distinct, URL-safe, non-empty token."""
+        result = await service.create_team_with_members(
+            name="Engineering",
+            description=None,
+            created_by=CREATOR,
+            visibility="private",
+            members=[
+                TeamMemberSeed(email="first@partner.com", role="member"),
+                TeamMemberSeed(email="second@partner.com", role="member"),
+            ],
+        )
+
+        tokens = [inv.token for inv in test_db.query(EmailTeamInvitation).filter(EmailTeamInvitation.team_id == result.team.id).all()]
+
+        assert len(tokens) == 2
+        assert all(tokens), "every invitation must carry a non-empty token"
+        # URL-safe base64 alphabet (secrets.token_urlsafe): letters, digits, '-' and '_'.
+        assert all(re.fullmatch(r"[A-Za-z0-9_-]+", token) for token in tokens)
+        assert len(set(tokens)) == len(tokens), "tokens must be unique across invitations"
 
 
 class TestCreateTeamUnchanged:

--- a/tests/unit/mcpgateway/test_team_governance_flags.py
+++ b/tests/unit/mcpgateway/test_team_governance_flags.py
@@ -707,3 +707,109 @@ class TestUpdateUserEmailVerified:
         await service.update_user(email="user@example.com", email_verified=False)
 
         assert mock_user.email_verified_at is None
+
+
+class TestCreateTeamWithMembersDenyPaths:
+    """Deny-path regression tests for POST /teams with members.
+
+    AGENTS.md requires security-sensitive changes to include deny-path coverage
+    for unauthenticated, insufficient-permission, and feature-flag-disabled paths.
+    """
+
+    @pytest.fixture(autouse=True)
+    async def drain_fire_and_forget_tasks(self):
+        """Give fire-and-forget cache invalidation tasks one loop turn to complete."""
+        yield
+        await asyncio.sleep(0)
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.routers.teams.settings")
+    @patch("mcpgateway.routers.teams.PermissionService")
+    async def test_unauthenticated_create_with_members_raises_401(self, MockPermissionService, mock_settings):
+        """create_team with members raises 401 when the caller is not authenticated.
+
+        The RBAC decorator (@require_permission) raises 401/403 before the
+        function body runs.  We reproduce that by having PermissionService raise
+        HTTPException(401).
+        """
+        mock_settings.allow_team_creation = True
+        mock_perm_service = AsyncMock()
+        mock_perm_service.check_platform_admin_permission = AsyncMock(side_effect=HTTPException(status_code=401, detail="Not authenticated"))
+        MockPermissionService.return_value = mock_perm_service
+
+        from mcpgateway.routers.teams import create_team
+        from mcpgateway.schemas import TeamCreateRequest, TeamMemberSeed
+
+        request = TeamCreateRequest(
+            name="Engineering",
+            visibility="private",
+            members=[TeamMemberSeed(email="alice@example.com", role="member")],
+        )
+        db = MagicMock(spec=Session)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await create_team(request=request, current_user_ctx={"email": "", "token_teams": None}, db=db)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.routers.teams.settings")
+    @patch("mcpgateway.routers.teams.PermissionService")
+    async def test_team_creation_disabled_with_members_raises_403(self, MockPermissionService, mock_settings):
+        """POST /teams with members returns 403 for non-admin when ALLOW_TEAM_CREATION=false."""
+        mock_settings.allow_team_creation = False
+        mock_perm_service = AsyncMock()
+        mock_perm_service.check_platform_admin_permission = AsyncMock(return_value=False)
+        MockPermissionService.return_value = mock_perm_service
+
+        from mcpgateway.routers.teams import create_team
+        from mcpgateway.schemas import TeamCreateRequest, TeamMemberSeed
+
+        request = TeamCreateRequest(
+            name="Engineering",
+            visibility="private",
+            members=[TeamMemberSeed(email="alice@example.com", role="member")],
+        )
+        db = MagicMock(spec=Session)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await create_team(request=request, current_user_ctx={"email": "user@example.com", "token_teams": None}, db=db)
+        assert exc_info.value.status_code == 403
+        assert "disabled" in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.routers.teams.TeamManagementService")
+    @patch("mcpgateway.routers.teams.settings")
+    @patch("mcpgateway.routers.teams.PermissionService")
+    async def test_invitations_disabled_with_unknown_seed_raises_400(self, MockPermissionService, mock_settings, MockTeamService):
+        """POST /teams with an unknown seed address raises 400 when ALLOW_TEAM_INVITATIONS=false.
+
+        The service raises TeamMemberSeedError (subclass of TeamManagementError),
+        which the router converts to HTTP 400.
+        """
+        mock_settings.allow_team_creation = True
+        mock_perm_service = AsyncMock()
+        mock_perm_service.check_platform_admin_permission = AsyncMock(return_value=False)
+        MockPermissionService.return_value = mock_perm_service
+
+        from mcpgateway.services.team_management_service import TeamMemberSeedError
+
+        mock_service = AsyncMock()
+        mock_service.create_team_with_members = AsyncMock(
+            side_effect=TeamMemberSeedError(0, "external@partner.com", "invitations are currently disabled")
+        )
+        MockTeamService.return_value = mock_service
+
+        from mcpgateway.routers.teams import create_team
+        from mcpgateway.schemas import TeamCreateRequest, TeamMemberSeed
+
+        request = TeamCreateRequest(
+            name="Engineering",
+            visibility="private",
+            members=[TeamMemberSeed(email="external@partner.com", role="member")],
+        )
+        db = MagicMock(spec=Session)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await create_team(request=request, current_user_ctx={"email": "user@example.com", "token_teams": None}, db=db)
+        assert exc_info.value.status_code == 400
+        assert "invitations are currently disabled" in exc_info.value.detail

--- a/tests/unit/mcpgateway/test_team_governance_flags.py
+++ b/tests/unit/mcpgateway/test_team_governance_flags.py
@@ -77,8 +77,11 @@ class TestAllowTeamCreationFlag:
         mock_team.updated_at = datetime.now(timezone.utc)
         mock_team.is_active = True
 
+        # First-Party
+        from mcpgateway.services.team_management_service import TeamSeedResult
+
         mock_service = MagicMock()
-        mock_service.create_team = AsyncMock(return_value=mock_team)
+        mock_service.create_team_with_members = AsyncMock(return_value=TeamSeedResult(team=mock_team))
         mock_service_cls.return_value = mock_service
 
         # First-Party


### PR DESCRIPTION
## Summary

`POST /teams` now accepts an optional `members` list, so a team and its people can be set up from a single form submission. The server decides how each entry is applied rather than making the client work it out: an address belonging to an active user becomes a membership directly, anything else (unknown address, deactivated account) is sent an invitation.

Everything is written in one transaction. A row that can't be applied fails the whole request and leaves nothing behind — no team, no half-populated membership list, no stray invitations. That removes the partial-failure problem the issue describes, and the frontend no longer has to pre-check which addresses are already platform users.

Closes #5238

## Response shape

The issue proposed nesting the team under a `team` key. This uses a **flat superset** instead: every existing `TeamResponse` field stays exactly where it was, with `members_added` and `invitations_sent` added alongside. Existing callers of `POST /teams` — including the HTMX admin form — keep working unchanged, which the issue lists as a goal but which the nested shape would have broken. Both arrays are empty when no members are seeded.

## Behaviour

- **The creator's own row is skipped**, not rejected. They're already made owner by team creation, and the form shouldn't have to know to filter itself out — that's the same kind of leaked API rule the issue is removing.
- **Errors name the offending row.** `TeamMemberSeedError` carries `index`, `email` and `reason`, and the index is the one the caller sent, not the position after the creator's row is dropped: `members[2] (ALICE@example.com): duplicate address, already listed at members[1]`.
- **Validated before anything is written:** duplicate addresses (case-insensitive), capacity (creator + seeds against the team limit), per-user team limits, and whether invitations are enabled.
- **Bounded:** `members` is capped at 500 entries (`MAX_TEAM_MEMBER_SEEDS`) at the request boundary, so an unlimited `MAX_MEMBERS_PER_TEAM` can't be turned into an unbounded request. The real per-team limit still applies underneath.
- **`role` on both response arrays is `Literal["owner", "member"]`**, so the OpenAPI spec exposes it as an enum and generated clients get a typed union rather than a bare string.

## Example

```bash
curl -X POST http://localhost:4444/teams/ \
  -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "name": "Platform Team",
    "description": "Ships things",
    "visibility": "private",
    "members": [
      {"email": "alice@example.com", "role": "member"},
      {"email": "bob@example.com",   "role": "owner"},
      {"email": "external@partner.com", "role": "member"}
    ]
  }'
```

`alice` and `bob` are known users and are added directly; the partner address is invited:

```json
{
  "id": "d46f3a69e7cc4a3ab9e3b1847a7dce7b",
  "name": "Platform Team",
  "slug": "platform-team",
  "description": "Ships things",
  "created_by": "admin@example.com",
  "is_personal": false,
  "visibility": "private",
  "max_members": null,
  "member_count": 3,
  "created_at": "2026-07-14T15:15:31.345835Z",
  "updated_at": "2026-07-14T15:15:31.345837Z",
  "is_active": true,
  "members_added": [
    {"email": "alice@example.com", "role": "member"},
    {"email": "bob@example.com", "role": "owner"}
  ],
  "invitations_sent": [
    {"email": "external@partner.com", "role": "member",
     "invitation_id": "2c81db3f003e41a0bcb5212a11c8a60e"}
  ]
}
```

A rejected row returns `400` and creates nothing:

```json
// alice listed twice
{"detail": "members[2] (ALICE@example.com): duplicate address, already listed at members[1]"}

// creator + 2 members against max_members=2
{"detail": "Team would start with 3 members, exceeding the maximum of 2"}
```

Omitting `members` returns the same flat team object it always did, with both arrays empty.

## Incidental fix: invitations outliving a deleted team

`delete_team` deactivated memberships but left **invitations** active. Because creating a team whose slug matches a deleted one reactivates that row, this had two consequences:

1. Deleting a team and recreating it with the same name and people failed outright (`An active invitation already exists for …`) — the most ordinary recovery path for the new create-team form.
2. More seriously, an invitation to the *old* team stayed live and became a valid invitation to the *new* team once the slug was reused, letting someone join a team they were never invited to. `accept_invitation` checks the team is active, so it was inert while deleted — but it woke up on reactivation. This is reachable on `main` today, independent of this feature.

`delete_team` now deactivates pending invitations alongside memberships.

## Changes

In `mcpgateway/schemas.py`: adds `TeamMemberSeed`, the `members` field on `TeamCreateRequest`, `TeamCreateResponse` extending `TeamResponse`, and the `MAX_TEAM_MEMBER_SEEDS` ceiling.

In `mcpgateway/services/team_management_service.py`: adds `create_team_with_members()`, which does the transactional seeding, with `create_team()` delegating to it and keeping its existing signature; adds `TeamMemberSeedError`; and deactivates pending invitations in `delete_team()`.

In `mcpgateway/services/team_invitation_service.py`: `create_invitation()` gains `commit=False` so invitations can join an outer transaction, and no longer rolls back a transaction it doesn't own.

In `mcpgateway/routers/teams.py`: passes `members` through and returns the seeding outcome.

`tests/unit/mcpgateway/services/test_team_member_seeding.py` is new, covering routing, the creator-skip, row-identifying errors, capacity, rollback, transaction ownership, the reactivation lifecycle, and backwards compatibility. Existing router tests were retargeted from `create_team` to `create_team_with_members`, which is the method the router now calls.

## Notes for review

- **`invitations_sent` is a slight misnomer, inherited from the issue.** Nothing in the codebase sends email — `create_invitation` writes a row and a token, and invitees discover invitations by calling `GET /teams/invitations`. Behaviour matches the existing single-invite endpoint exactly, but the issue's "trigger the existing invite delivery" describes a mechanism that doesn't exist. Happy to rename the field if you'd prefer something truthful.
- **Out of scope:** creating a team whose name collides with an *active* team still returns `500` (`UNIQUE constraint failed: email_teams.slug`) rather than `409`. Pre-existing on `main`; the new form will hit it, so it likely deserves its own issue.
- The React create-team form on `epic/ui-rewrite` doesn't consume this yet