### PR TITLE
modified dialog motion

### DIFF
--- a/client/src/components/ui/dialog.test.tsx
+++ b/client/src/components/ui/dialog.test.tsx
@@ -204,8 +204,8 @@ describe("Dialog Components", () => {
 
       const content = screen.getByTestId("content");
       expect(content).toHaveClass("fixed");
-      expect(content).toHaveClass("left-[50%]");
-      expect(content).toHaveClass("top-[50%]");
+      expect(content).toHaveClass("inset-0");
+      expect(content).toHaveClass("m-auto");
       expect(content).toHaveClass("z-50");
     });
 

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-popover p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed inset-0 z-50 m-auto grid h-fit w-full max-w-lg gap-4 border bg-popover p-6 shadow-lg duration-150 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 sm:rounded-lg",
         className,
       )}
       {...props}


### PR DESCRIPTION
Small adjustment: dialog motion/animation component adjustment. Removed slide in effect: 

https://github.com/user-attachments/assets/1b298f05-df03-42db-abc2-51a1cb30ae92

// Center with inset/margin, not translate. Tailwind v4's translate property composes with tw-animate's transform keyframes and looks like a slide.

