### PR TITLE
fix: forward stored user OAuth tokens to REST tools

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -5306,6 +5306,10 @@ class ToolService(BaseService):
                     gateway_grant_type = gateway_oauth_config.get("grant_type", "client_credentials")
 
                 if tool_integration_type == "REST":
+                    # Track missing stored OAuth credentials until after pre-invoke
+                    # hooks have had a chance to inject an Authorization header.
+                    oauth_authcode_no_db_token = False
+
                     # Handle OAuth authentication for REST tools
                     if tool_auth_type == "oauth" and isinstance(tool_oauth_config, dict) and tool_oauth_config:
                         try:
@@ -5321,6 +5325,28 @@ class ToolService(BaseService):
                         except Exception as e:
                             logger.error("Failed to obtain OAuth access token for tool %s: %s", tool_name_computed, e)
                             raise ToolInvocationError(f"OAuth authentication failed: {str(e)}")
+                    elif has_gateway and gateway_auth_type == "oauth" and gateway_grant_type == "authorization_code":
+                        try:
+                            with fresh_db_session() as token_db:
+                                token_storage = TokenStorageService(token_db)
+
+                                if not app_user_email:
+                                    raise ToolInvocationError(f"User authentication required for OAuth-protected gateway '{gateway_name}'. Please ensure you are authenticated.")
+
+                                access_token = await token_storage.get_user_token(gateway_id_str, app_user_email)
+
+                            if access_token:
+                                headers["Authorization"] = f"Bearer {access_token}"
+                            else:
+                                oauth_authcode_no_db_token = True
+                                logger.info(
+                                    "OAuth authorization_code gateway '%s' invoked without DB-stored token; deferring auth check to allow plugin injection",
+                                    gateway_name,
+                                    extra={"gateway_id": gateway_id_str, "user": app_user_email or "<unknown>"},
+                                )
+                        except Exception as e:
+                            logger.error("Failed to obtain stored OAuth token for gateway %s: %s", gateway_name, e)
+                            raise ToolInvocationError(f"OAuth token retrieval failed for gateway: {str(e)}")
                     else:
                         credentials = decode_auth(tool_auth_value) if tool_auth_value else {}
                         # Filter out empty header names/values to avoid "Illegal header name" errors
@@ -5334,7 +5360,7 @@ class ToolService(BaseService):
                             headers,
                             passthrough_allowed,
                             gateway_auth_type=None,
-                            gateway_passthrough_headers=None,  # REST tools don't use gateway auth here
+                            gateway_passthrough_headers=None,  # Preserve REST's global passthrough configuration
                         )
                         # Read MCP-Session-Id from downstream client (MCP protocol header)
                         # and normalize to x-mcp-session-id for our internal session affinity logic
@@ -5374,6 +5400,9 @@ class ToolService(BaseService):
                             arguments = payload.args
                             if payload.headers is not None:
                                 headers = payload.headers.model_dump()
+
+                    if oauth_authcode_no_db_token and not any(hk.lower() == "authorization" for hk in headers):
+                        raise ToolInvocationError(f"Please authorize {gateway_name} first. Visit /oauth/authorize/{gateway_id_str} to complete OAuth flow.")
 
                     # Build the payload based on integration type
                     payload = arguments.copy()

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -4365,6 +4365,154 @@ class TestToolService:
         # Verify result
         assert result.content[0].text == '{\n  "result": "OAuth success"\n}'
 
+    async def test_invoke_tool_rest_gateway_oauth_authorization_code_uses_stored_user_token(self, tool_service, mock_tool, mock_gateway, mock_global_config_obj, test_db):
+        """REST tools should forward a stored user token from an OAuth gateway."""
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.auth_type = None
+        mock_tool.oauth_config = None
+        mock_gateway.auth_type = "oauth"
+        mock_gateway.oauth_config = {"grant_type": "authorization_code"}
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+        tool_service.oauth_manager.get_access_token = AsyncMock()
+
+        token_storage = MagicMock()
+        token_storage.get_user_token = AsyncMock(return_value="stored-token")
+        fresh_session = MagicMock()
+
+        @contextmanager
+        def _fresh_db_session():
+            yield fresh_session
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value={"result": "OAuth success"})
+        tool_service._http_client.request.return_value = mock_response
+        tool_service._record_tool_metric_sync = Mock()
+
+        with (
+            patch("mcpgateway.services.tool_service.TokenStorageService", return_value=token_storage),
+            patch("mcpgateway.services.tool_service.fresh_db_session", _fresh_db_session),
+            patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"result": "OAuth success"}),
+        ):
+            await tool_service.invoke_tool(
+                test_db,
+                "test_tool",
+                {"param": "value"},
+                request_headers=None,
+                app_user_email="user@example.com",
+            )
+
+        token_storage.get_user_token.assert_awaited_once_with("1", "user@example.com")
+        tool_service.oauth_manager.get_access_token.assert_not_awaited()
+        headers = tool_service._http_client.request.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer stored-token"
+
+    async def test_invoke_tool_rest_gateway_oauth_authorization_code_requires_prior_authorization(self, tool_service, mock_tool, mock_gateway, mock_global_config_obj, test_db):
+        """REST gateway OAuth should fail locally when no user token is available."""
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.auth_type = None
+        mock_tool.oauth_config = None
+        mock_gateway.auth_type = "oauth"
+        mock_gateway.oauth_config = {"grant_type": "authorization_code"}
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        token_storage = MagicMock()
+        token_storage.get_user_token = AsyncMock(return_value=None)
+        fresh_session = MagicMock()
+
+        @contextmanager
+        def _fresh_db_session():
+            yield fresh_session
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value={"result": "unexpected"})
+        tool_service._http_client.request.return_value = mock_response
+        tool_service._record_tool_metric_sync = Mock()
+
+        with (
+            patch("mcpgateway.services.tool_service.TokenStorageService", return_value=token_storage),
+            patch("mcpgateway.services.tool_service.fresh_db_session", _fresh_db_session),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
+        ):
+            with pytest.raises(ToolInvocationError, match="Please authorize test_gateway first"):
+                await tool_service.invoke_tool(
+                    test_db,
+                    "test_tool",
+                    {"param": "value"},
+                    request_headers=None,
+                    app_user_email="user@example.com",
+                )
+
+        token_storage.get_user_token.assert_awaited_once_with("1", "user@example.com")
+        tool_service._http_client.request.assert_not_awaited()
+
+    async def test_invoke_tool_rest_gateway_oauth_authorization_code_allows_plugin_auth(self, tool_service, mock_tool, mock_gateway, mock_global_config_obj, test_db):
+        """REST gateway OAuth should allow pre-invoke plugins to supply auth."""
+        # Third-Party
+        from cpex.framework import HttpHeaderPayload, ToolPreInvokePayload
+
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.auth_type = None
+        mock_tool.oauth_config = None
+        mock_gateway.auth_type = "oauth"
+        mock_gateway.oauth_config = {"grant_type": "authorization_code"}
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        token_storage = MagicMock()
+        token_storage.get_user_token = AsyncMock(return_value=None)
+        fresh_session = MagicMock()
+
+        @contextmanager
+        def _fresh_db_session():
+            yield fresh_session
+
+        mock_pm = MagicMock()
+        mock_pm.has_hooks_for = MagicMock(side_effect=lambda hook_type: hook_type == ToolHookType.TOOL_PRE_INVOKE)
+        mock_pm.invoke_hook = AsyncMock(
+            return_value=(
+                PluginResult(
+                    modified_payload=ToolPreInvokePayload(
+                        name="test_tool",
+                        args={"param": "value"},
+                        headers=HttpHeaderPayload(root={"Authorization": "Bearer plugin-token"}),
+                    ),
+                    continue_processing=True,
+                ),
+                {},
+            )
+        )
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value={"result": "OAuth success"})
+        tool_service._http_client.request.return_value = mock_response
+        tool_service._record_tool_metric_sync = Mock()
+
+        with (
+            patch("mcpgateway.services.tool_service.TokenStorageService", return_value=token_storage),
+            patch("mcpgateway.services.tool_service.fresh_db_session", _fresh_db_session),
+            patch("mcpgateway.services.tool_service.extract_using_jq", return_value={"result": "OAuth success"}),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=mock_pm)),
+        ):
+            await tool_service.invoke_tool(
+                test_db,
+                "test_tool",
+                {"param": "value"},
+                request_headers=None,
+                app_user_email="user@example.com",
+            )
+
+        token_storage.get_user_token.assert_awaited_once_with("1", "user@example.com")
+        headers = tool_service._http_client.request.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer plugin-token"
+
     async def test_invoke_tool_rest_oauth_failure(self, tool_service, mock_tool, mock_global_config_obj, test_db):
         """Test invoking REST tool with failed OAuth authentication."""
         # Configure tool with OAuth


### PR DESCRIPTION
## Related Issue

Closes #5614

## Summary

REST tools attached to an OAuth gateway did not inherit the stored per-user access token for `authorization_code` flows. The upstream REST API therefore received no `Authorization` header even after the user had completed consent.

This change restores the gateway-level stored-token path for REST tools and prevents unauthenticated calls when neither token storage nor a pre-invoke plugin provides credentials.

## Reproduction Steps

1. Configure a gateway with `auth_type: oauth` and `grant_type: authorization_code`.
2. Complete the consent flow so a token is stored for the application user.
3. Attach a REST tool to that gateway and invoke it.

On current `main`, the REST branch does not call `TokenStorageService.get_user_token`, and the upstream request is sent without the stored bearer token.

## Root Cause

`ToolService.invoke_tool` handled tool-level OAuth in the REST branch, but tool registration requires OAuth to be configured on the gateway. Gateway authorization-code token lookup existed in the MCP and Rust execution-plan paths but was absent from REST invocation.

## Changes

- Retrieve the stored gateway token by gateway ID and authenticated application-user email for REST `authorization_code` flows.
- Add the stored token as `Authorization: Bearer ...` while preserving existing tool headers.
- Allow pre-invoke plugins to provide Authorization when token storage has no token, matching the existing MCP behavior.
- Fail locally with the existing authorization guidance if no token or plugin-provided Authorization header is available.

OAuth scope validation, issuer validation, token exchange, client credentials, and MCP invocation behavior are unchanged.

## Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are kept out of this PR
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## Verification

| Check | Command | Result |
|---|---|---|
| REST gateway authorization-code regressions | `uv run pytest tests/unit/mcpgateway/services/test_tool_service.py -q -k 'rest_gateway_oauth_authorization_code'` | 3 passed |
| Adjacent REST/MCP OAuth behavior | `uv run pytest tests/unit/mcpgateway/services/test_tool_service.py -q -k 'invoke_tool_rest_oauth or rest_gateway_oauth_authorization_code or invoke_tool_mcp_oauth_client_credentials or prepare_rust_mcp_tool_execution_oauth'` | 11 passed |
| Complete tool-service unit module | `uv run pytest tests/unit/mcpgateway/services/test_tool_service.py -q` | 395 passed |
| Production-file lint and formatting | `make lint-quick mcpgateway/services/tool_service.py` | passed |
| Test-file lint and formatting | `make lint-quick tests/unit/mcpgateway/services/test_tool_service.py` | passed |

```bash
uv run pytest tests/unit/mcpgateway/services/test_tool_service.py -q -k 'rest_gateway_oauth_authorization_code'
uv run pytest tests/unit/mcpgateway/services/test_tool_service.py -q -k 'invoke_tool_rest_oauth or rest_gateway_oauth_authorization_code or invoke_tool_mcp_oauth_client_credentials or prepare_rust_mcp_tool_execution_oauth'
uv run pytest tests/unit/mcpgateway/services/test_tool_service.py -q
make lint-quick mcpgateway/services/tool_service.py
make lint-quick tests/unit/mcpgateway/services/test_tool_service.py
```

The full repository test and coverage suites were not run locally. The focused service module and all adjacent OAuth tests pass; CI remains the broader repository-level verification.

## Checklist

- [x] Code formatted and changed files pass Ruff, Black, and isort
- [x] Tests added for stored-token, missing-token, and plugin-injected-auth paths
- [x] No secrets or credentials committed

## MCP Compliance

No protocol message or client-facing MCP contract changes.
