### PR TITLE
fix(auth): enforce safe admin demotion rules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1210,9 +1210,9 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # SECURITY: Keep this false in production unless you explicitly need public sign-up
 # PUBLIC_REGISTRATION_ENABLED=false
 
-# Admin protection mode
-# When true (default), no admin can be demoted, deactivated, or locked out via API/UI
-# When false, only the last remaining active admin is protected
+# Admin login-lockout protection
+# When true (default), active admin accounts can bypass login lockout
+# Admin self-demotion and last-active-admin protection are always enforced independently
 # PROTECT_ALL_ADMINS=true
 
 # Platform admin user (bootstrap from environment)

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1922,7 +1922,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 454,
+        "line_number": 456,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1930,7 +1930,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 821,
+        "line_number": 823,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1938,7 +1938,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1328,
+        "line_number": 1330,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -1946,7 +1946,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1332,
+        "line_number": 1334,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2290,7 +2290,7 @@
         "hashed_secret": "f18eecadfbe015aaa19e4efb26ea35e4b22c4716",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 67,
+        "line_number": 84,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2298,7 +2298,7 @@
         "hashed_secret": "65ccbbc69885ff7d13099428b96bc5a0db135e90",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 87,
+        "line_number": 104,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4650,7 +4650,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17920,
+        "line_number": 7151,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -828,7 +828,7 @@ mcpContextForge:
 
     # ─ Email-Based Authentication ─
     EMAIL_AUTH_ENABLED: "true"             # enable email-based authentication system
-    PROTECT_ALL_ADMINS: "true"             # prevent any admin from being demoted or deactivated via API/UI
+    PROTECT_ALL_ADMINS: "true"             # allow active admin accounts to bypass login lockout
     PLATFORM_ADMIN_EMAIL: admin@example.com # email for bootstrap platform admin user
     PLATFORM_ADMIN_PASSWORD: changeme     # password for bootstrap platform admin user
     PLATFORM_ADMIN_FULL_NAME: Platform Administrator # full name for bootstrap platform admin

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -415,6 +415,8 @@ curl -X POST -H "Authorization: Bearer $TOKEN" \
 | `SMTP_USE_SSL`                | Use implicit SSL/TLS                              | `false`               | bool    |
 | `SMTP_TIMEOUT_SECONDS`        | SMTP timeout in seconds                           | `15`                  | int > 0 |
 
+Changing `PROTECT_ALL_ADMINS` does not control peer-administrator removal. An administrator with `admin.user_management` can demote or deactivate another administrator while at least one active administrator remains. Protect administrator credentials accordingly; deployments requiring dual control should enforce that process outside this endpoint.
+
 When `PASSWORD_RESET_ENABLED=false`, self-service forgot/reset endpoints are disabled (`403` on API and disabled/redirected UI flows).
 When `SMTP_ENABLED=false`, reset requests are accepted but no email is delivered.
 

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -32,7 +32,7 @@ These settings are enabled by default for security—only disable for backward c
 | `REQUIRE_JTI` | Require JTI claim in tokens for revocation support | `true` |
 | `REQUIRE_TOKEN_EXPIRATION` | Require exp claim in tokens | `true` |
 | `PUBLIC_REGISTRATION_ENABLED` | Allow public user self-registration | `false` |
-| `PROTECT_ALL_ADMINS` | Prevent any admin from being demoted or deactivated via API/UI | `true` |
+| `PROTECT_ALL_ADMINS` | Allow active admin accounts to bypass login lockout | `true` |
 |`REQUIRE_STRONG_SECRETS`|Enforces strong secret validation. Automatically defaults to true in production to ensure fail-safe deployments.|`true` (prod) / `false` (dev)|
 
 ### ⚙️ Project Defaults (Dev Setup)
@@ -403,7 +403,7 @@ curl -X POST -H "Authorization: Bearer $TOKEN" \
 | `PASSWORD_RESET_RATE_WINDOW_MINUTES` | Password reset rate-limit window        | `15`                  | int > 0 |
 | `PASSWORD_RESET_INVALIDATE_SESSIONS` | Invalidate active sessions on reset     | `true`                | bool    |
 | `PASSWORD_RESET_MIN_RESPONSE_MS` | Minimum forgot-password response duration    | `250`                 | int >= 0 |
-| `PROTECT_ALL_ADMINS`         | Prevent any admin from being demoted or deactivated via API/UI. When false, only the last active admin is protected. | `true` | bool |
+| `PROTECT_ALL_ADMINS`         | Allow active admin accounts to bypass login lockout. Admin self-demotion and last-active-admin protection are always enforced independently. | `true` | bool |
 | `SMTP_ENABLED`                | Enable SMTP notifications for auth emails        | `false`               | bool    |
 | `SMTP_HOST`                   | SMTP host                                         | (none)                | string  |
 | `SMTP_PORT`                   | SMTP port                                         | `587`                 | int     |

--- a/docs/docs/manage/password-management.md
+++ b/docs/docs/manage/password-management.md
@@ -57,6 +57,23 @@ Navigate to `Admin -> Users` (`/admin/#users`):
 
 ## API-Based Admin Reset & Unlock
 
+The user-management endpoints require the `admin.user_management` permission.
+
+### Demote or deactivate an administrator
+
+Use `PATCH /auth/email/admin/users/{email}` for administrator status changes. The service applies the same rules to API and Admin UI requests:
+
+- An administrator can demote or deactivate another administrator while at least one other active administrator remains.
+- Administrators cannot demote or deactivate their own account; the request returns `400 Bad Request`.
+- A request that would remove the last active administrator returns `400 Bad Request`.
+
+```bash
+curl -X PATCH "http://localhost:4444/auth/email/admin/users/admin-b%40example.com" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"is_admin": false}'
+```
+
 ### Reset user password
 
 ```bash

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -8274,6 +8274,7 @@ async def admin_get_user_edit(
                     </label>
                 </div>'''
         }
+                {'<input type="hidden" name="is_admin" value="on">' if is_editing_self and user_obj.is_admin else ""}
                 <div>
                     <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
                         <input type="checkbox" name="email_verified" {"checked" if user_obj.is_email_verified() else ""}
@@ -8366,20 +8367,6 @@ async def admin_update_user(
 
         # Get current user's email to prevent self-demotion
         current_user_email = get_user_email(_user)
-
-        # Check if trying to remove admin privileges from last admin
-        user_obj = await auth_service.get_user_by_email(decoded_email)
-
-        # When editing self, preserve current admin status (checkbox is hidden in UI)
-        if user_obj and current_user_email.lower() == decoded_email.lower():
-            is_admin = user_obj.is_admin
-
-        if user_obj and user_obj.is_admin and not is_admin:
-            # This user is currently an admin and we're trying to remove admin privileges
-            if await auth_service.is_last_active_admin(decoded_email):
-                return HTMLResponse(
-                    content='<div class="text-red-500">Cannot remove administrator privileges from the last remaining admin user</div>', status_code=400, headers={"HX-Retarget": "#edit-user-error"}
-                )
 
         # Update user
         fn_val = form.get("full_name")
@@ -8502,15 +8489,7 @@ async def admin_deactivate_user(
         # Get current user email from JWT
         current_user_email = get_user_email(user)
 
-        # Prevent self-deactivation
-        if decoded_email == current_user_email:
-            return HTMLResponse(content='<div class="text-red-500">Cannot deactivate your own account</div>', status_code=400)
-
-        # Prevent deactivating the last active admin user
-        if await auth_service.is_last_active_admin(decoded_email):
-            return HTMLResponse(content='<div class="text-red-500">Cannot deactivate the last remaining admin user</div>', status_code=400)
-
-        user_obj = await auth_service.deactivate_user(decoded_email)
+        user_obj = await auth_service.update_user(email=decoded_email, is_active=False, requesting_user_email=current_user_email, admin_origin_source="ui")
         admin_count = await auth_service.count_active_admin_users()
         return HTMLResponse(content=_render_user_card_html(user_obj, current_user_email, admin_count, root_path))
 

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -8393,7 +8393,15 @@ async def admin_update_user(
             if not is_valid:
                 return HTMLResponse(content=f'<div class="text-red-500">Password validation failed: {error_msg}</div>', status_code=400, headers={"HX-Retarget": "#edit-user-error"})
 
-        await auth_service.update_user(email=decoded_email, full_name=full_name, is_admin=is_admin, email_verified=email_verified, password=password, admin_origin_source="ui")
+        await auth_service.update_user(
+            email=decoded_email,
+            full_name=full_name,
+            is_admin=is_admin,
+            email_verified=email_verified,
+            password=password,
+            admin_origin_source="ui",
+            requesting_user_email=current_user_email,
+        )
 
         # Return success message with auto-close and refresh
         success_html = """

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -104,6 +104,7 @@ from mcpgateway.db import utc_now
 from mcpgateway.middleware.rbac import _ACCESS_DENIED_MSG, get_current_user_with_permissions, require_any_permission, require_permission
 from mcpgateway.routers.email_auth import create_access_token
 from mcpgateway.schemas import (
+    _encode_auth_headers_list,
     A2AAgentCreate,
     A2AAgentRead,
     A2AAgentUpdate,
@@ -145,7 +146,6 @@ from mcpgateway.schemas import (
     ToolMetrics,
     ToolRead,
     ToolUpdate,
-    _encode_auth_headers_list,
 )
 from mcpgateway.services.a2a_agent_plugin_binding_service import A2AAgentPluginBindingForbiddenError, A2AAgentPluginBindingNotFoundError, A2AAgentPluginBindingService
 from mcpgateway.services.a2a_service import A2AAgentError, A2AAgentNameConflictError, A2AAgentNotFoundError, A2AAgentService

--- a/mcpgateway/alembic/versions/d21698ae4a19_add_rbac_unique_constraints_race_fix.py
+++ b/mcpgateway/alembic/versions/d21698ae4a19_add_rbac_unique_constraints_race_fix.py
@@ -32,15 +32,15 @@ Revises: b6c7d8e9f0a1
 Create Date: 2026-05-06 12:35:58.142694
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
 from sqlalchemy import text, inspect
 
-
 # revision identifiers, used by Alembic.
-revision: str = 'd21698ae4a19'  # pragma: allowlist secret
-down_revision: Union[str, Sequence[str], None] = 'b6c7d8e9f0a1'  # pragma: allowlist secret
+revision: str = "d21698ae4a19"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "b6c7d8e9f0a1"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -69,7 +69,7 @@ def upgrade() -> None:
 
     # Use row_number() for deterministic deduplication (handles timestamp ties via id ordering)
     # Keep the row with row_number = 1 (oldest created_at, lowest id on ties)
-    if dialect == 'postgresql':
+    if dialect == "postgresql":
         # Step 1a: Remap user_roles.role_id from duplicate roles to the kept role
         remap_user_roles_sql = text("""
             UPDATE user_roles
@@ -174,7 +174,7 @@ def upgrade() -> None:
     # an already-expired assignment while discarding a still-valid duplicate.
 
     # Handle scope_id IS NULL case
-    if dialect == 'postgresql':
+    if dialect == "postgresql":
         dedupe_user_roles_null_scope_sql = text("""
             UPDATE user_roles
             SET is_active = false
@@ -221,7 +221,7 @@ def upgrade() -> None:
     deduped_user_roles_null = result.rowcount
 
     # Handle scope_id IS NOT NULL case
-    if dialect == 'postgresql':
+    if dialect == "postgresql":
         dedupe_user_roles_with_scope_sql = text("""
             UPDATE user_roles
             SET is_active = false
@@ -276,80 +276,49 @@ def upgrade() -> None:
     # =============================================================================
 
     # Check if indexes already exist (idempotency)
-    existing_indexes = [idx['name'] for idx in inspector.get_indexes('roles')]
+    existing_indexes = [idx["name"] for idx in inspector.get_indexes("roles")]
 
     # Partial unique index on roles(name, scope) WHERE is_active = true
     # This prevents duplicate active roles with same name+scope
-    if 'uq_roles_name_scope_active' not in existing_indexes:
-        if dialect == 'postgresql':
-            bind.execute(text(
-                "CREATE UNIQUE INDEX uq_roles_name_scope_active "
-                "ON roles (name, scope) "
-                "WHERE is_active = true"
-            ))
-        elif dialect == 'sqlite':
-            bind.execute(text(
-                "CREATE UNIQUE INDEX uq_roles_name_scope_active "
-                "ON roles (name, scope) "
-                "WHERE is_active = 1"
-            ))
+    if "uq_roles_name_scope_active" not in existing_indexes:
+        if dialect == "postgresql":
+            bind.execute(text("CREATE UNIQUE INDEX uq_roles_name_scope_active " "ON roles (name, scope) " "WHERE is_active = true"))
+        elif dialect == "sqlite":
+            bind.execute(text("CREATE UNIQUE INDEX uq_roles_name_scope_active " "ON roles (name, scope) " "WHERE is_active = 1"))
         else:
             # For other databases, create without WHERE clause (less optimal but works)
             # Note: This will only allow one row per (name, scope) total, not just active ones
             print(f"WARNING: Dialect '{dialect}' may not support partial indexes. Creating full unique index.")
-            bind.execute(text(
-                "CREATE UNIQUE INDEX uq_roles_name_scope_active "
-                "ON roles (name, scope)"
-            ))
+            bind.execute(text("CREATE UNIQUE INDEX uq_roles_name_scope_active " "ON roles (name, scope)"))
         print("Created unique index: uq_roles_name_scope_active")
 
     # Check user_roles indexes
-    existing_user_roles_indexes = [idx['name'] for idx in inspector.get_indexes('user_roles')]
+    existing_user_roles_indexes = [idx["name"] for idx in inspector.get_indexes("user_roles")]
 
     # Partial unique index on user_roles(user_email, role_id, scope) WHERE scope_id IS NULL AND is_active = true
-    if 'uq_user_roles_email_role_scope_null_active' not in existing_user_roles_indexes:
-        if dialect == 'postgresql':
-            bind.execute(text(
-                "CREATE UNIQUE INDEX uq_user_roles_email_role_scope_null_active "
-                "ON user_roles (user_email, role_id, scope) "
-                "WHERE scope_id IS NULL AND is_active = true"
-            ))
-        elif dialect == 'sqlite':
-            bind.execute(text(
-                "CREATE UNIQUE INDEX uq_user_roles_email_role_scope_null_active "
-                "ON user_roles (user_email, role_id, scope) "
-                "WHERE scope_id IS NULL AND is_active = 1"
-            ))
+    if "uq_user_roles_email_role_scope_null_active" not in existing_user_roles_indexes:
+        if dialect == "postgresql":
+            bind.execute(text("CREATE UNIQUE INDEX uq_user_roles_email_role_scope_null_active " "ON user_roles (user_email, role_id, scope) " "WHERE scope_id IS NULL AND is_active = true"))
+        elif dialect == "sqlite":
+            bind.execute(text("CREATE UNIQUE INDEX uq_user_roles_email_role_scope_null_active " "ON user_roles (user_email, role_id, scope) " "WHERE scope_id IS NULL AND is_active = 1"))
         else:
             # Fallback: unique on (user_email, role_id, scope) without WHERE
             print(f"WARNING: Dialect '{dialect}' may not support partial indexes. Creating full unique index.")
-            bind.execute(text(
-                "CREATE UNIQUE INDEX uq_user_roles_email_role_scope_null_active "
-                "ON user_roles (user_email, role_id, scope)"
-            ))
+            bind.execute(text("CREATE UNIQUE INDEX uq_user_roles_email_role_scope_null_active " "ON user_roles (user_email, role_id, scope)"))
         print("Created unique index: uq_user_roles_email_role_scope_null_active")
 
     # Partial unique index on user_roles(user_email, role_id, scope, scope_id) WHERE scope_id IS NOT NULL AND is_active = true
-    if 'uq_user_roles_email_role_scope_id_active' not in existing_user_roles_indexes:
-        if dialect == 'postgresql':
-            bind.execute(text(
-                "CREATE UNIQUE INDEX uq_user_roles_email_role_scope_id_active "
-                "ON user_roles (user_email, role_id, scope, scope_id) "
-                "WHERE scope_id IS NOT NULL AND is_active = true"
-            ))
-        elif dialect == 'sqlite':
-            bind.execute(text(
-                "CREATE UNIQUE INDEX uq_user_roles_email_role_scope_id_active "
-                "ON user_roles (user_email, role_id, scope, scope_id) "
-                "WHERE scope_id IS NOT NULL AND is_active = 1"
-            ))
+    if "uq_user_roles_email_role_scope_id_active" not in existing_user_roles_indexes:
+        if dialect == "postgresql":
+            bind.execute(
+                text("CREATE UNIQUE INDEX uq_user_roles_email_role_scope_id_active " "ON user_roles (user_email, role_id, scope, scope_id) " "WHERE scope_id IS NOT NULL AND is_active = true")
+            )
+        elif dialect == "sqlite":
+            bind.execute(text("CREATE UNIQUE INDEX uq_user_roles_email_role_scope_id_active " "ON user_roles (user_email, role_id, scope, scope_id) " "WHERE scope_id IS NOT NULL AND is_active = 1"))
         else:
             # Fallback: unique on all four columns without WHERE
             print(f"WARNING: Dialect '{dialect}' may not support partial indexes. Creating full unique index.")
-            bind.execute(text(
-                "CREATE UNIQUE INDEX uq_user_roles_email_role_scope_id_active "
-                "ON user_roles (user_email, role_id, scope, scope_id)"
-            ))
+            bind.execute(text("CREATE UNIQUE INDEX uq_user_roles_email_role_scope_id_active " "ON user_roles (user_email, role_id, scope, scope_id)"))
         print("Created unique index: uq_user_roles_email_role_scope_id_active")
 
 
@@ -364,18 +333,18 @@ def downgrade() -> None:
         return
 
     # Drop the unique indexes if they exist
-    existing_indexes = [idx['name'] for idx in inspector.get_indexes('roles')]
-    if 'uq_roles_name_scope_active' in existing_indexes:
-        op.drop_index('uq_roles_name_scope_active', table_name='roles')
+    existing_indexes = [idx["name"] for idx in inspector.get_indexes("roles")]
+    if "uq_roles_name_scope_active" in existing_indexes:
+        op.drop_index("uq_roles_name_scope_active", table_name="roles")
         print("Dropped unique index: uq_roles_name_scope_active")
 
-    existing_user_roles_indexes = [idx['name'] for idx in inspector.get_indexes('user_roles')]
-    if 'uq_user_roles_email_role_scope_null_active' in existing_user_roles_indexes:
-        op.drop_index('uq_user_roles_email_role_scope_null_active', table_name='user_roles')
+    existing_user_roles_indexes = [idx["name"] for idx in inspector.get_indexes("user_roles")]
+    if "uq_user_roles_email_role_scope_null_active" in existing_user_roles_indexes:
+        op.drop_index("uq_user_roles_email_role_scope_null_active", table_name="user_roles")
         print("Dropped unique index: uq_user_roles_email_role_scope_null_active")
 
-    if 'uq_user_roles_email_role_scope_id_active' in existing_user_roles_indexes:
-        op.drop_index('uq_user_roles_email_role_scope_id_active', table_name='user_roles')
+    if "uq_user_roles_email_role_scope_id_active" in existing_user_roles_indexes:
+        op.drop_index("uq_user_roles_email_role_scope_id_active", table_name="user_roles")
         print("Dropped unique index: uq_user_roles_email_role_scope_id_active")
 
     # Note: We do NOT reactivate the deduped rows on downgrade

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -979,7 +979,7 @@ class Settings(BaseSettings):
     )
     protect_all_admins: bool = Field(
         default=True,
-        description="When true (default), prevent any admin from being demoted, deactivated, or locked out via API/UI. When false, only the last active admin is protected.",
+        description="When true (default), allow active admin accounts to bypass login lockout. Admin self-demotion and last-active-admin protection are always enforced independently.",
     )
     platform_admin_email: str = Field(default="admin@example.com", description="Platform administrator email address")
     platform_admin_password: SecretStr = Field(default=SecretStr("changeme"), description="Platform administrator password")

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -11,7 +11,7 @@ and time-based restrictions.
 
 # Standard
 from datetime import datetime, timedelta, timezone
-from enum import Enum, auto
+from enum import auto, Enum
 from functools import lru_cache
 import ipaddress
 import re
@@ -884,7 +884,9 @@ class TokenScopingMiddleware:
         normalized_path = self._normalize_path_for_matching(request_path)
         return method == "DELETE" and bool(_TARGETED_MISSING_DELETE_PATTERN.fullmatch(normalized_path))
 
-    def _check_resource_team_ownership(self, request_path: str, token_teams: list, db=None, _user_email: str = None) -> ResourceOwnershipResult:  # noqa: PLR0911  # pylint: disable=too-many-return-statements
+    def _check_resource_team_ownership(  # noqa: PLR0911  # pylint: disable=too-many-return-statements
+        self, request_path: str, token_teams: list, db=None, _user_email: str = None
+    ) -> ResourceOwnershipResult:
         """
         Check if the requested resource is accessible by the token.
 

--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -27,6 +27,7 @@ from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.auth import get_current_user
+from mcpgateway.auth_context import get_user_email
 from mcpgateway.common.query_params import QueryPaginationCursorResults
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
@@ -848,6 +849,7 @@ async def update_user_delegate(user_email: str, user_request: AdminUserUpdateReq
             password_change_required=user_request.password_change_required,
             password=user_request.password,
             admin_origin_source="api",
+            requesting_user_email=get_user_email(current_user_ctx),
         )
 
         logger.info(f"Admin {SecurityValidator.sanitize_log_message(current_user_ctx['email'])} updated user: {SecurityValidator.sanitize_log_message(user.email)}")

--- a/mcpgateway/routers/search.py
+++ b/mcpgateway/routers/search.py
@@ -79,7 +79,10 @@ async def unified_search(
     # (and its module-level service instances) at startup. The search router is
     # always mounted, but the admin core is only needed once a search runs.
     # First-Party
-    from mcpgateway.admin import _validated_team_id_param, perform_unified_search  # noqa: PLC2701 — reuse admin core, deferred to keep admin off the startup import path  # pylint: disable=import-outside-toplevel
+    from mcpgateway.admin import (
+        _validated_team_id_param,
+        perform_unified_search,
+    )  # noqa: PLC2701 — reuse admin core, deferred to keep admin off the startup import path  # pylint: disable=import-outside-toplevel
 
     team_id = _validated_team_id_param(team_id)
     return await perform_unified_search(

--- a/mcpgateway/services/email_auth_service.py
+++ b/mcpgateway/services/email_auth_service.py
@@ -1884,31 +1884,38 @@ class EmailAuthService:
                             if admin_role:
                                 existing = await self.role_service.get_user_role_assignment(user_email=email, role_id=admin_role.id, scope="global", scope_id=None)
                                 if not existing or not existing.is_active:
-                                    await self.role_service.assign_role_to_user(user_email=email, role_id=admin_role.id, scope="global", scope_id=None, granted_by=role_granter)
+                                    await self.role_service.assign_role_to_user(user_email=email, role_id=admin_role.id, scope="global", scope_id=None, granted_by=role_granter, commit=False)
                                     logger.info("Assigned %s role to %s", admin_role_name, SecurityValidator.sanitize_log_message(email))
                             else:
                                 logger.warning("%s role not found, cannot assign to %s", admin_role_name, SecurityValidator.sanitize_log_message(email))
 
                             if user_role:
-                                revoked = await self.role_service.revoke_role_from_user(user_email=email, role_id=user_role.id, scope="global", scope_id=None)
+                                revoked = await self.role_service.revoke_role_from_user(user_email=email, role_id=user_role.id, scope="global", scope_id=None, commit=False)
                                 if revoked:
                                     logger.info("Revoked %s role from %s", SecurityValidator.sanitize_log_message(user_role_name), SecurityValidator.sanitize_log_message(email))
                         else:
                             # Demotion: revoke admin role, assign user role
-                            if admin_role:
-                                revoked = await self.role_service.revoke_role_from_user(user_email=email, role_id=admin_role.id, scope="global", scope_id=None)
-                                if revoked:
-                                    logger.info("Revoked %s role from %s", admin_role_name, SecurityValidator.sanitize_log_message(email))
+                            if not admin_role:
+                                raise ValueError(f"{admin_role_name} role not found; refusing unsafe administrator demotion")
 
-                            if user_role:
-                                existing = await self.role_service.get_user_role_assignment(user_email=email, role_id=user_role.id, scope="global", scope_id=None)
-                                if not existing or not existing.is_active:
-                                    await self.role_service.assign_role_to_user(user_email=email, role_id=user_role.id, scope="global", scope_id=None, granted_by=role_granter)
-                                    logger.info("Assigned %s role to %s", SecurityValidator.sanitize_log_message(user_role_name), SecurityValidator.sanitize_log_message(email))
-                            else:
-                                logger.warning("%s role not found, cannot assign to %s", SecurityValidator.sanitize_log_message(user_role_name), SecurityValidator.sanitize_log_message(email))
+                            existing_admin_assignment = await self.role_service.get_user_role_assignment(user_email=email, role_id=admin_role.id, scope="global", scope_id=None)
+                            if existing_admin_assignment:
+                                revoked = await self.role_service.revoke_role_from_user(user_email=email, role_id=admin_role.id, scope="global", scope_id=None, commit=False)
+                                if not revoked:
+                                    raise ValueError(f"Failed to revoke {admin_role_name} role; refusing unsafe administrator demotion")
+                                logger.info("Revoked %s role from %s", admin_role_name, SecurityValidator.sanitize_log_message(email))
+
+                            if not user_role:
+                                raise ValueError(f"{user_role_name} role not found; refusing unsafe administrator demotion")
+
+                            existing = await self.role_service.get_user_role_assignment(user_email=email, role_id=user_role.id, scope="global", scope_id=None)
+                            if not existing or not existing.is_active:
+                                await self.role_service.assign_role_to_user(user_email=email, role_id=user_role.id, scope="global", scope_id=None, granted_by=role_granter, commit=False)
+                                logger.info("Assigned %s role to %s", SecurityValidator.sanitize_log_message(user_role_name), SecurityValidator.sanitize_log_message(email))
 
                     except Exception as e:
+                        if not is_admin:
+                            raise ValueError("Administrator demotion failed because role synchronization did not complete") from e
                         logger.warning("Failed to sync global roles for %s: %s", SecurityValidator.sanitize_log_message(email), e)
                         # Don't fail user update if role sync fails
 
@@ -2174,14 +2181,10 @@ class EmailAuthService:
         Returns:
             bool: True if this user is the last active admin
         """
-        # First check if the user is an active admin
-        stmt = select(EmailUser).where(EmailUser.email == email)
+        # Lock every active admin row so concurrent demotion/deactivation requests
+        # serialize before checking the last-admin invariant.
+        normalized_email = email.lower().strip()
+        stmt = select(EmailUser).where(EmailUser.is_admin.is_(True), EmailUser.is_active.is_(True)).with_for_update()
         result = self.db.execute(stmt)
-        user = result.scalar_one_or_none()
-
-        if not user or not user.is_admin or not user.is_active:
-            return False
-
-        # Count total active admins
-        admin_count = await self.count_active_admin_users()
-        return admin_count == 1
+        active_admins = result.scalars().all()
+        return len(active_admins) == 1 and active_admins[0].email.lower().strip() == normalized_email

--- a/mcpgateway/services/email_auth_service.py
+++ b/mcpgateway/services/email_auth_service.py
@@ -2009,39 +2009,20 @@ class EmailAuthService:
             logger.error("Error activating user %s: %s", SecurityValidator.sanitize_log_message(email), e)
             raise
 
-    async def deactivate_user(self, email: str) -> EmailUser:
+    async def deactivate_user(self, email: str, requesting_user_email: Optional[str] = None) -> EmailUser:
         """Deactivate a user account.
 
         Args:
             email: User's email address
+            requesting_user_email: Email of the authenticated user making the change. Required when deactivating an active admin.
 
         Returns:
             EmailUser: Updated user object
 
         Raises:
-            ValueError: If user doesn't exist
+            ValueError: If user doesn't exist or the admin-removal policy rejects the change
         """
-        try:
-            stmt = select(EmailUser).where(EmailUser.email == email)
-            result = self.db.execute(stmt)
-            user = result.scalar_one_or_none()
-
-            if not user:
-                raise ValueError(f"User {email} not found")
-
-            user.is_active = False
-            user.updated_at = datetime.now(timezone.utc)
-
-            self.db.commit()
-            await self._invalidate_user_auth_cache(email)
-
-            logger.info("User %s deactivated", SecurityValidator.sanitize_log_message(email))
-            return user
-
-        except Exception as e:
-            self.db.rollback()
-            logger.error("Error deactivating user %s: %s", SecurityValidator.sanitize_log_message(email), e)
-            raise
+        return await self.update_user(email=email, is_active=False, requesting_user_email=requesting_user_email)
 
     async def delete_user(self, email: str) -> bool:
         """Delete a user account permanently.

--- a/mcpgateway/services/email_auth_service.py
+++ b/mcpgateway/services/email_auth_service.py
@@ -1820,7 +1820,7 @@ class EmailAuthService:
             password_change_required: Whether user must change password on next login (optional)
             password: New password (optional, will be hashed)
             admin_origin_source: Source of admin change for tracking (e.g. "api", "ui"). Callers should pass explicitly.
-            requesting_user_email: Email of the authenticated user making the change. Required when demoting or deactivating an active admin.
+            requesting_user_email: Email of the authenticated user making the change. Required when changing admin status or deactivating an active admin.
 
         Returns:
             EmailUser: Updated user object
@@ -1843,6 +1843,10 @@ class EmailAuthService:
 
             normalized_requester_email = requesting_user_email.lower().strip() if requesting_user_email else None
 
+            admin_status_changes = is_admin is not None and is_admin != user.is_admin
+            if admin_status_changes and not normalized_requester_email:
+                raise ValueError("Requesting user email is required to change administrator privileges")
+
             # Admin protection guard. Peer-admin changes are allowed; self-removal and
             # removal of the last active admin are always denied.
             if user.is_admin and user.is_active:
@@ -1855,8 +1859,6 @@ class EmailAuthService:
                     if await self.is_last_active_admin(email):
                         raise ValueError("Cannot demote or deactivate the last remaining active admin user")
 
-            role_granter = normalized_requester_email or email
-
             # Update fields if provided
             if full_name is not None:
                 user.full_name = full_name
@@ -1867,6 +1869,10 @@ class EmailAuthService:
             if is_admin is not None:
                 # Track admin_origin when status actually changes
                 if is_admin != user.is_admin:
+                    # Validated before mutation. Keep grant attribution tied to authenticated actor.
+                    role_granter = normalized_requester_email
+                    if role_granter is None:  # Defensive guard for future refactors.
+                        raise ValueError("Requesting user email is required to change administrator privileges")
                     user.is_admin = is_admin
                     user.admin_origin = admin_origin_source if is_admin else None
 

--- a/mcpgateway/services/email_auth_service.py
+++ b/mcpgateway/services/email_auth_service.py
@@ -1807,6 +1807,7 @@ class EmailAuthService:
         password_change_required: Optional[bool] = None,
         password: Optional[str] = None,
         admin_origin_source: Optional[str] = None,
+        requesting_user_email: Optional[str] = None,
     ) -> EmailUser:
         """Update user information.
 
@@ -1819,12 +1820,13 @@ class EmailAuthService:
             password_change_required: Whether user must change password on next login (optional)
             password: New password (optional, will be hashed)
             admin_origin_source: Source of admin change for tracking (e.g. "api", "ui"). Callers should pass explicitly.
+            requesting_user_email: Email of the authenticated user making the change. Required when demoting or deactivating an active admin.
 
         Returns:
             EmailUser: Updated user object
 
         Raises:
-            ValueError: If user doesn't exist, if protect_all_admins blocks the change, or if it would remove the last active admin
+            ValueError: If user doesn't exist, an admin targets their own account, requester identity is missing, or the change would remove the last active admin
             PasswordValidationError: If password doesn't meet policy
         """
         try:
@@ -1839,14 +1841,21 @@ class EmailAuthService:
             if not user:
                 raise ValueError(f"User {email} not found")
 
-            # Admin protection guard
+            normalized_requester_email = requesting_user_email.lower().strip() if requesting_user_email else None
+
+            # Admin protection guard. Peer-admin changes are allowed; self-removal and
+            # removal of the last active admin are always denied.
             if user.is_admin and user.is_active:
                 would_lose_admin = (is_admin is not None and not is_admin) or (is_active is not None and not is_active)
                 if would_lose_admin:
-                    if settings.protect_all_admins:
-                        raise ValueError("Admin protection is enabled — cannot demote or deactivate any admin user")
+                    if not normalized_requester_email:
+                        raise ValueError("Requesting user email is required to demote or deactivate an admin user")
+                    if normalized_requester_email == email:
+                        raise ValueError("Administrators cannot demote or deactivate their own account")
                     if await self.is_last_active_admin(email):
                         raise ValueError("Cannot demote or deactivate the last remaining active admin user")
+
+            role_granter = normalized_requester_email or email
 
             # Update fields if provided
             if full_name is not None:
@@ -1875,7 +1884,7 @@ class EmailAuthService:
                             if admin_role:
                                 existing = await self.role_service.get_user_role_assignment(user_email=email, role_id=admin_role.id, scope="global", scope_id=None)
                                 if not existing or not existing.is_active:
-                                    await self.role_service.assign_role_to_user(user_email=email, role_id=admin_role.id, scope="global", scope_id=None, granted_by=email)
+                                    await self.role_service.assign_role_to_user(user_email=email, role_id=admin_role.id, scope="global", scope_id=None, granted_by=role_granter)
                                     logger.info("Assigned %s role to %s", admin_role_name, SecurityValidator.sanitize_log_message(email))
                             else:
                                 logger.warning("%s role not found, cannot assign to %s", admin_role_name, SecurityValidator.sanitize_log_message(email))
@@ -1894,7 +1903,7 @@ class EmailAuthService:
                             if user_role:
                                 existing = await self.role_service.get_user_role_assignment(user_email=email, role_id=user_role.id, scope="global", scope_id=None)
                                 if not existing or not existing.is_active:
-                                    await self.role_service.assign_role_to_user(user_email=email, role_id=user_role.id, scope="global", scope_id=None, granted_by=email)
+                                    await self.role_service.assign_role_to_user(user_email=email, role_id=user_role.id, scope="global", scope_id=None, granted_by=role_granter)
                                     logger.info("Assigned %s role to %s", SecurityValidator.sanitize_log_message(user_role_name), SecurityValidator.sanitize_log_message(email))
                             else:
                                 logger.warning("%s role not found, cannot assign to %s", SecurityValidator.sanitize_log_message(user_role_name), SecurityValidator.sanitize_log_message(email))

--- a/mcpgateway/services/leader_election.py
+++ b/mcpgateway/services/leader_election.py
@@ -18,8 +18,8 @@ the cached flag for the redis backend.
 import asyncio
 import logging
 import os
-import uuid
 from typing import Any, Optional
+import uuid
 
 # Third-Party
 from filelock import FileLock, Timeout

--- a/mcpgateway/services/role_service.py
+++ b/mcpgateway/services/role_service.py
@@ -553,7 +553,15 @@ class RoleService:
         return True
 
     async def assign_role_to_user(
-        self, user_email: str, role_id: str, scope: str, scope_id: Optional[str], granted_by: str, expires_at: Optional[datetime] = None, grant_source: Optional[str] = None
+        self,
+        user_email: str,
+        role_id: str,
+        scope: str,
+        scope_id: Optional[str],
+        granted_by: str,
+        expires_at: Optional[datetime] = None,
+        grant_source: Optional[str] = None,
+        commit: bool = True,
     ) -> UserRole:
         """Assign a role to a user.
 
@@ -565,6 +573,7 @@ class RoleService:
             granted_by: Email of user granting the role
             expires_at: Optional expiration datetime
             grant_source: Origin of the grant (e.g., 'sso', 'manual', 'bootstrap', 'auto')
+            commit: Commit immediately. Set false when caller owns transaction.
 
         Returns:
             UserRole: The role assignment
@@ -680,11 +689,14 @@ class RoleService:
             try:
                 with self.db.begin_nested():
                     self.db.add(user_role)
+                    self.db.flush()
             except (AttributeError, TypeError):
                 # Mock object or DB doesn't support savepoints - use regular add
                 self.db.add(user_role)
+                self.db.flush()
 
-            self.db.commit()
+            if commit:
+                self.db.commit()
             self.db.refresh(user_role)
 
             logger.info(
@@ -719,7 +731,7 @@ class RoleService:
             logger.error("IntegrityError but user_role assignment not found after refetch: %s", e)
             raise ValueError(f"Failed to create or fetch role assignment for {user_email} to role {role_id}: {e}") from e
 
-    async def revoke_role_from_user(self, user_email: str, role_id: str, scope: str, scope_id: Optional[str]) -> bool:
+    async def revoke_role_from_user(self, user_email: str, role_id: str, scope: str, scope_id: Optional[str], commit: bool = True) -> bool:
         """Revoke a role from a user.
 
         Args:
@@ -727,6 +739,7 @@ class RoleService:
             role_id: ID of role to revoke
             scope: Scope of assignment
             scope_id: Team ID if team-scoped
+            commit: Commit immediately. Set false when caller owns transaction.
 
         Returns:
             bool: True if role was revoked, False if not found
@@ -757,7 +770,10 @@ class RoleService:
             return False
 
         user_role.is_active = False
-        self.db.commit()
+        if commit:
+            self.db.commit()
+        else:
+            self.db.flush()
 
         logger.info(
             "Revoked role %s from %s (scope: %s, scope_id: %s)",

--- a/tests/integration/test_concurrency_row_locking.py
+++ b/tests/integration/test_concurrency_row_locking.py
@@ -26,15 +26,18 @@ This test suite validates:
 # Standard
 import asyncio
 import os
+import threading
 import uuid
 
 # Third-Party
 from httpx import AsyncClient
 import pytest
 import pytest_asyncio
+from sqlalchemy.orm import sessionmaker
 
 # First-Party
-from mcpgateway.db import get_db
+from mcpgateway.db import EmailUser, get_db
+from mcpgateway.services.email_auth_service import EmailAuthService
 from tests.helpers.auth import make_auth_header_for_email, make_test_jwt
 
 # Set environment variables for testing
@@ -136,6 +139,69 @@ async def client(app_with_temp_db):
     app_with_temp_db.dependency_overrides.pop(get_current_user, None)
     app_with_temp_db.dependency_overrides.pop(get_current_user_with_permissions, None)
     app_with_temp_db.dependency_overrides.pop(require_admin_auth, None)
+
+
+@pytest.mark.asyncio
+@SKIP_IF_NOT_POSTGRES
+async def test_last_admin_check_serializes_concurrent_demotions(test_engine):
+    """A second demotion check observes first transaction's committed result."""
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=test_engine)
+    suffix = uuid.uuid4().hex[:8]
+    first_email = f"concurrent-admin-a-{suffix}@example.com"
+    second_email = f"concurrent-admin-b-{suffix}@example.com"
+    locked = threading.Event()
+    release_first = threading.Event()
+
+    with TestingSessionLocal() as setup_db:
+        previously_active_admins = [user.email for user in setup_db.query(EmailUser).filter(EmailUser.is_admin.is_(True), EmailUser.is_active.is_(True)).all()]
+        setup_db.query(EmailUser).filter(EmailUser.email.in_(previously_active_admins)).update({EmailUser.is_active: False}, synchronize_session=False)
+        setup_db.add_all(
+            [
+                EmailUser(email=first_email, password_hash="dummy_hash", is_admin=True, is_active=True),
+                EmailUser(email=second_email, password_hash="dummy_hash", is_admin=True, is_active=True),
+            ]
+        )
+        setup_db.commit()
+
+    def demote_first_admin() -> bool:
+        with TestingSessionLocal() as db:
+            service = EmailAuthService(db)
+            result = asyncio.run(service.is_last_active_admin(first_email))
+            locked.set()
+            if not release_first.wait(timeout=5):
+                raise TimeoutError("Timed out waiting to release first demotion transaction")
+            user = db.query(EmailUser).filter(EmailUser.email == first_email).one()
+            user.is_admin = False
+            db.commit()
+            return result
+
+    def check_second_admin() -> bool:
+        with TestingSessionLocal() as db:
+            service = EmailAuthService(db)
+            return asyncio.run(service.is_last_active_admin(second_email))
+
+    first_task = asyncio.create_task(asyncio.to_thread(demote_first_admin))
+    second_task = None
+    try:
+        assert await asyncio.to_thread(locked.wait, 5), "First transaction did not acquire admin row locks"
+        second_task = asyncio.create_task(asyncio.to_thread(check_second_admin))
+        await asyncio.sleep(0.2)
+        assert not second_task.done(), "Second last-admin check did not wait for locked admin rows"
+
+        release_first.set()
+        first_result, second_result = await asyncio.gather(first_task, second_task)
+        assert first_result is False
+        assert second_result is True
+    finally:
+        release_first.set()
+        if not first_task.done():
+            await first_task
+        if second_task is not None and not second_task.done():
+            await second_task
+        with TestingSessionLocal() as cleanup_db:
+            cleanup_db.query(EmailUser).filter(EmailUser.email.in_([first_email, second_email])).delete(synchronize_session=False)
+            cleanup_db.query(EmailUser).filter(EmailUser.email.in_(previously_active_admins)).update({EmailUser.is_active: True}, synchronize_session=False)
+            cleanup_db.commit()
 
 
 # -------------------------

--- a/tests/integration/test_role_service_duplicate_handling.py
+++ b/tests/integration/test_role_service_duplicate_handling.py
@@ -9,13 +9,18 @@ Tests the full revoke → re-assign flow that triggers the bug in #3505.
 Uses real database sessions, not mocks.
 """
 
-import pytest
 from datetime import datetime, timezone
 import uuid
-from sqlalchemy.orm import Session
+from unittest.mock import AsyncMock
+
+# Third-Party
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
 
 # First-Party
+from mcpgateway.config import settings
 from mcpgateway.db import EmailUser, Role, UserRole
+from mcpgateway.services.email_auth_service import EmailAuthService
 from mcpgateway.services.role_service import RoleService
 
 
@@ -100,6 +105,65 @@ async def test_revoke_and_reassign_no_duplicate_error(test_db: Session, test_rol
     inactive_count = sum(1 for a in all_assignments if not a.is_active)
     assert active_count == 1
     assert inactive_count == 1
+
+
+@pytest.mark.asyncio
+async def test_admin_demotion_rolls_back_role_changes_on_failure(test_db: Session):
+    """Demotion rollback restores both admin flag and role assignment."""
+    suffix = uuid.uuid4().hex[:8]
+    target_email = f"demotion-target-{suffix}@example.com"
+    requester_email = f"demotion-requester-{suffix}@example.com"
+    target = EmailUser(email=target_email, password_hash="dummy_hash", is_admin=True, is_active=True)
+    requester = EmailUser(email=requester_email, password_hash="dummy_hash", is_admin=True, is_active=True)
+    test_db.add_all([target, requester])
+    test_db.flush()
+
+    admin_role = test_db.query(Role).filter(Role.name == settings.default_admin_role, Role.scope == "global").first()
+    if admin_role is None:
+        admin_role = Role(
+            name=settings.default_admin_role,
+            description="Default administrator role",
+            scope="global",
+            permissions=["*"],
+            created_by=requester_email,
+            is_system_role=True,
+            is_active=True,
+        )
+        test_db.add(admin_role)
+
+    user_role = test_db.query(Role).filter(Role.name == settings.default_user_role, Role.scope == "global").first()
+    if user_role is None:
+        user_role = Role(
+            name=settings.default_user_role,
+            description="Default user role",
+            scope="global",
+            permissions=["tools.read"],
+            created_by=requester_email,
+            is_system_role=True,
+            is_active=True,
+        )
+        test_db.add(user_role)
+
+    test_db.flush()
+    assignment = UserRole(user_email=target_email, role_id=admin_role.id, scope="global", scope_id=None, granted_by=requester_email, is_active=True)
+    test_db.add(assignment)
+    test_db.commit()
+    assignment_id = assignment.id
+
+    role_service = RoleService(test_db)
+    role_service.assign_role_to_user = AsyncMock(side_effect=RuntimeError("simulated viewer-role assignment failure"))
+    auth_service = EmailAuthService(test_db)
+    auth_service._role_service = role_service
+
+    with pytest.raises(ValueError, match="role synchronization did not complete"):
+        await auth_service.update_user(email=target_email, is_admin=False, requesting_user_email=requester_email)
+
+    VerificationSession = sessionmaker(bind=test_db.get_bind())
+    with VerificationSession() as verification_db:
+        persisted_user = verification_db.query(EmailUser).filter(EmailUser.email == target_email).one()
+        persisted_assignment = verification_db.query(UserRole).filter(UserRole.id == assignment_id).one()
+        assert persisted_user.is_admin is True
+        assert persisted_assignment.is_active is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/routers/test_email_auth_router.py
+++ b/tests/unit/mcpgateway/routers/test_email_auth_router.py
@@ -647,10 +647,10 @@ async def test_admin_get_update_delete_user():
             is_active=None,
             email_verified=None,
             password_change_required=None,
-                password="newPassword123!",  # pragma: allowlist secret
-                admin_origin_source="api",
-                requesting_user_email="admin@example.com",
-            )
+            password="newPassword123!",  # pragma: allowlist secret
+            admin_origin_source="api",
+            requesting_user_email="admin@example.com",
+        )
         assert response_input.headers["deprecation"] == "@1775001599"
         assert response_input.headers["sunset"] == "Sun, 16 Aug 2026 23:59:59 GMT"
         # ----------->

--- a/tests/unit/mcpgateway/routers/test_email_auth_router.py
+++ b/tests/unit/mcpgateway/routers/test_email_auth_router.py
@@ -632,6 +632,7 @@ async def test_admin_get_update_delete_user():
             password_change_required=None,
             password="newPassword123!",  # pragma: allowlist secret
             admin_origin_source="api",
+            requesting_user_email="admin@example.com",
         )
 
         # ----------> [#2754] Code to be removed after Sun, 16 Aug 2026 23:59:59 UTC
@@ -646,9 +647,10 @@ async def test_admin_get_update_delete_user():
             is_active=None,
             email_verified=None,
             password_change_required=None,
-            password="newPassword123!",  # pragma: allowlist secret
-            admin_origin_source="api",
-        )
+                password="newPassword123!",  # pragma: allowlist secret
+                admin_origin_source="api",
+                requesting_user_email="admin@example.com",
+            )
         assert response_input.headers["deprecation"] == "@1775001599"
         assert response_input.headers["sunset"] == "Sun, 16 Aug 2026 23:59:59 GMT"
         # ----------->
@@ -705,6 +707,7 @@ async def test_admin_update_user_without_full_name_and_is_admin():
             password_change_required=None,
             password=None,
             admin_origin_source="api",
+            requesting_user_email="admin@example.com",
         )
 
 
@@ -869,8 +872,8 @@ async def test_admin_update_last_admin_deactivate_blocked():
 
 
 @pytest.mark.asyncio
-async def test_admin_update_protect_all_admins_blocked():
-    """Test that demoting any admin is blocked when protect_all_admins is enabled."""
+async def test_admin_update_self_demotion_blocked():
+    """Test that API self-demotion returns 400."""
     # First-Party
     from mcpgateway.routers import email_auth
 
@@ -878,7 +881,7 @@ async def test_admin_update_protect_all_admins_blocked():
 
     with patch("mcpgateway.routers.email_auth.EmailAuthService") as MockAuthService:
         auth_service = MockAuthService.return_value
-        auth_service.update_user = AsyncMock(side_effect=ValueError("Admin protection is enabled — cannot demote or deactivate any admin user"))
+        auth_service.update_user = AsyncMock(side_effect=ValueError("Administrators cannot demote or deactivate their own account"))
 
         update_request = AdminUserUpdateRequest(is_admin=False)
 
@@ -886,12 +889,12 @@ async def test_admin_update_protect_all_admins_blocked():
             await email_auth.update_user(
                 "admin@example.com",
                 update_request,
-                current_user_ctx={"db": mock_db, "email": "other-admin@example.com"},
+                current_user_ctx={"db": mock_db, "email": "admin@example.com"},
                 db=mock_db,
             )
 
         assert excinfo.value.status_code == status.HTTP_400_BAD_REQUEST
-        assert "Admin protection is enabled" in str(excinfo.value.detail)
+        assert "cannot demote or deactivate their own account" in str(excinfo.value.detail)
 
 
 # ============================================================================

--- a/tests/unit/mcpgateway/services/test_email_auth_basic.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_basic.py
@@ -587,7 +587,12 @@ class TestEmailAuthServiceUserManagement:
 
             with patch("mcpgateway.services.email_auth_service.settings", mock_settings):
                 result = await service.create_user(
-                    email="active@example.com", password="SecurePass4$x", full_name="Active User", is_admin=False, is_active=True, auth_provider="local"  # pragma: allowlist secret
+                    email="active@example.com",
+                    password="SecurePass4$x",  # pragma: allowlist secret
+                    full_name="Active User",
+                    is_admin=False,
+                    is_active=True,
+                    auth_provider="local",  # pragma: allowlist secret
                 )
 
                 # Verify user was added with is_active=True
@@ -613,8 +618,13 @@ class TestEmailAuthServiceUserManagement:
 
             with patch("mcpgateway.services.email_auth_service.settings", mock_settings):
                 result = await service.create_user(
-                    email="inactive@example.com", password="SecurePass4$x", full_name="Inactive User", is_admin=False, is_active=False, auth_provider="local"  # pragma: allowlist secret
-                )  # pragma: allowlist secret
+                    email="inactive@example.com",
+                    password="SecurePass4$x",  # pragma: allowlist secret
+                    full_name="Inactive User",
+                    is_admin=False,
+                    is_active=False,
+                    auth_provider="local",
+                )
 
                 # Verify user was added with is_active=False
                 mock_db.add.assert_called()
@@ -2332,6 +2342,15 @@ class TestEmailAuthServiceUserUpdates:
         mock_result.scalar_one_or_none.return_value = admin_user
         mock_db.execute.return_value = mock_result
 
+        admin_role = MagicMock(id="admin-role-123")
+        viewer_role = MagicMock(id="viewer-role-456")
+        role_service = MagicMock()
+        role_service.get_role_by_name = AsyncMock(side_effect=[admin_role, viewer_role])
+        role_service.get_user_role_assignment = AsyncMock(side_effect=[MagicMock(is_active=True), None])
+        role_service.revoke_role_from_user = AsyncMock(return_value=True)
+        role_service.assign_role_to_user = AsyncMock()
+        service._role_service = role_service
+
         with patch.object(service, "is_last_active_admin", new=AsyncMock(return_value=False)):
             result = await service.update_user(email="admin@example.com", is_admin=False, requesting_user_email="other-admin@example.com")
 
@@ -2927,37 +2946,33 @@ class TestEmailAuthServiceAdminCounting:
     async def test_is_last_active_admin_true(self, service, mock_db):
         """Test checking if user is last active admin - true case."""
         mock_user = MagicMock(spec=EmailUser)
+        mock_user.email = "admin@example.com"
         mock_user.is_admin = True
         mock_user.is_active = True
 
-        # First call: get user
-        mock_user_result = MagicMock()
-        mock_user_result.scalar_one_or_none.return_value = mock_user
-
-        # Second call: count admins
-        mock_count_result = MagicMock()
-        mock_count_result.scalar.return_value = 1
-
-        mock_db.execute.side_effect = [mock_user_result, mock_count_result]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [mock_user]
+        mock_db.execute.return_value = mock_result
 
         result = await service.is_last_active_admin("admin@example.com")
 
         assert result is True
+        stmt = mock_db.execute.call_args.args[0]
+        assert stmt._for_update_arg is not None
 
     @pytest.mark.asyncio
     async def test_is_last_active_admin_false_multiple_admins(self, service, mock_db):
         """Test checking if user is last active admin - false due to multiple admins."""
         mock_user = MagicMock(spec=EmailUser)
+        mock_user.email = "admin@example.com"
         mock_user.is_admin = True
         mock_user.is_active = True
+        other_admin = MagicMock(spec=EmailUser)
+        other_admin.email = "other@example.com"
 
-        mock_user_result = MagicMock()
-        mock_user_result.scalar_one_or_none.return_value = mock_user
-
-        mock_count_result = MagicMock()
-        mock_count_result.scalar.return_value = 3  # Multiple admins
-
-        mock_db.execute.side_effect = [mock_user_result, mock_count_result]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [mock_user, other_admin]
+        mock_db.execute.return_value = mock_result
 
         result = await service.is_last_active_admin("admin@example.com")
 
@@ -2966,12 +2981,8 @@ class TestEmailAuthServiceAdminCounting:
     @pytest.mark.asyncio
     async def test_is_last_active_admin_false_not_admin(self, service, mock_db):
         """Test checking if non-admin user is last active admin."""
-        mock_user = MagicMock(spec=EmailUser)
-        mock_user.is_admin = False
-        mock_user.is_active = True
-
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = mock_user
+        mock_result.scalars.return_value.all.return_value = []
         mock_db.execute.return_value = mock_result
 
         result = await service.is_last_active_admin("user@example.com")
@@ -2981,12 +2992,8 @@ class TestEmailAuthServiceAdminCounting:
     @pytest.mark.asyncio
     async def test_is_last_active_admin_false_inactive(self, service, mock_db):
         """Test checking if inactive admin is last active admin."""
-        mock_user = MagicMock(spec=EmailUser)
-        mock_user.is_admin = True
-        mock_user.is_active = False
-
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = mock_user
+        mock_result.scalars.return_value.all.return_value = []
         mock_db.execute.return_value = mock_result
 
         result = await service.is_last_active_admin("admin@example.com")
@@ -2997,7 +3004,7 @@ class TestEmailAuthServiceAdminCounting:
     async def test_is_last_active_admin_user_not_found(self, service, mock_db):
         """Test checking if non-existent user is last active admin."""
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
+        mock_result.scalars.return_value.all.return_value = []
         mock_db.execute.return_value = mock_result
 
         result = await service.is_last_active_admin("nonexistent@example.com")
@@ -3111,16 +3118,15 @@ class TestEmailAuthServiceAdminCounting:
     async def test_is_last_active_admin_true_additional_case(self, service, mock_db):
         """is_last_active_admin returns True when only 1 active admin."""
         mock_user = MagicMock()
+        mock_user.email = "admin@test.com"
         mock_user.is_admin = True
         mock_user.is_active = True
-        # First call: find user; Second call: count admins
-        user_result = MagicMock()
-        user_result.scalar_one_or_none.return_value = mock_user
-        count_result = MagicMock()
-        count_result.scalar.return_value = 1
-        mock_db.execute.side_effect = [user_result, count_result]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [mock_user]
+        mock_db.execute.return_value = mock_result
 
         result = await service.is_last_active_admin("admin@test.com")
+        assert result is True
 
     # =========================================================================
     # Password Policy Fallback Tests (Coverage for lines 294-320, 1145-1146, 1152-1154)
@@ -3205,7 +3211,9 @@ class TestEmailAuthServiceAdminCounting:
                 mock_settings.password_require_special = False
 
                 result = await service.change_password(
-                    email="test@example.com", old_password="OldSecurePass4$x!", new_password="NewSecurePass4$x!"  # pragma: allowlist secret  # pragma: allowlist secret
+                    email="test@example.com",
+                    old_password="OldSecurePass4$x!",  # pragma: allowlist secret
+                    new_password="NewSecurePass4$x!",  # pragma: allowlist secret
                 )
 
                 assert result is True
@@ -3242,7 +3250,9 @@ class TestEmailAuthServiceAdminCounting:
 
                 with pytest.raises(PasswordValidationError, match="must be different from current password"):
                     await service.change_password(
-                        email="test@example.com", old_password="SameSecurePass4$x!", new_password="SameSecurePass4$x!"  # pragma: allowlist secret  # pragma: allowlist secret
+                        email="test@example.com",
+                        old_password="SameSecurePass4$x!",  # pragma: allowlist secret
+                        new_password="SameSecurePass4$x!",  # pragma: allowlist secret
                     )
 
     @pytest.mark.asyncio
@@ -3337,5 +3347,7 @@ class TestEmailAuthServiceAdminCounting:
 
                 with pytest.raises(PasswordValidationError, match="Unable to verify password history"):
                     await service.change_password(
-                        email="test@example.com", old_password="SameSecurePass4$x!", new_password="SameSecurePass4$x!"  # pragma: allowlist secret  # pragma: allowlist secret
+                        email="test@example.com",
+                        old_password="SameSecurePass4$x!",  # pragma: allowlist secret
+                        new_password="SameSecurePass4$x!",  # pragma: allowlist secret
                     )

--- a/tests/unit/mcpgateway/services/test_email_auth_basic.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_basic.py
@@ -2373,7 +2373,8 @@ class TestEmailAuthServiceUserUpdates:
             await service.update_user(email="Admin@Example.COM", requesting_user_email=" ADMIN@example.com ", **{field: False})
 
     @pytest.mark.asyncio
-    async def test_update_user_admin_removal_requires_requester_identity(self, service, mock_db):
+    @pytest.mark.parametrize("requesting_user_email", [None, "", "   "])
+    async def test_update_user_admin_removal_requires_requester_identity(self, service, mock_db, requesting_user_email):
         """Admin removal fails closed when authenticated requester identity is absent."""
         admin_user = MagicMock(spec=EmailUser)
         admin_user.email = "admin@example.com"
@@ -2385,7 +2386,7 @@ class TestEmailAuthServiceUserUpdates:
         mock_db.execute.return_value = mock_result
 
         with pytest.raises(ValueError, match="Requesting user email is required"):
-            await service.update_user(email="admin@example.com", is_admin=False)
+            await service.update_user(email="admin@example.com", is_admin=False, requesting_user_email=requesting_user_email)
 
     @pytest.mark.asyncio
     async def test_update_user_protect_all_admins_allows_other_updates(self, service, mock_db, monkeypatch):

--- a/tests/unit/mcpgateway/services/test_email_auth_basic.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_basic.py
@@ -2315,12 +2315,13 @@ class TestEmailAuthServiceUserUpdates:
         mock_db.commit.assert_called()
 
     @pytest.mark.asyncio
-    async def test_update_user_protect_all_admins_blocks_demote(self, service, mock_db, monkeypatch):
-        """Test that protect_all_admins blocks demoting any admin (not just last)."""
+    @pytest.mark.parametrize("protect_all_admins", [True, False])
+    async def test_update_user_allows_peer_admin_demotion(self, service, mock_db, monkeypatch, protect_all_admins):
+        """Peer-admin demotion is independent of login lockout protection."""
         # First-Party
         from mcpgateway.config import settings
 
-        monkeypatch.setattr(settings, "protect_all_admins", True)
+        monkeypatch.setattr(settings, "protect_all_admins", protect_all_admins)
 
         admin_user = MagicMock(spec=EmailUser)
         admin_user.email = "admin@example.com"
@@ -2331,17 +2332,15 @@ class TestEmailAuthServiceUserUpdates:
         mock_result.scalar_one_or_none.return_value = admin_user
         mock_db.execute.return_value = mock_result
 
-        with pytest.raises(ValueError, match="Admin protection is enabled"):
-            await service.update_user(email="admin@example.com", is_admin=False)
+        with patch.object(service, "is_last_active_admin", new=AsyncMock(return_value=False)):
+            result = await service.update_user(email="admin@example.com", is_admin=False, requesting_user_email="other-admin@example.com")
+
+        assert result.is_admin is False
 
     @pytest.mark.asyncio
-    async def test_update_user_protect_all_admins_blocks_deactivate(self, service, mock_db, monkeypatch):
-        """Test that protect_all_admins blocks deactivating any admin."""
-        # First-Party
-        from mcpgateway.config import settings
-
-        monkeypatch.setattr(settings, "protect_all_admins", True)
-
+    @pytest.mark.parametrize("field", ["is_admin", "is_active"])
+    async def test_update_user_blocks_admin_self_removal_case_insensitive(self, service, mock_db, field):
+        """Admins cannot demote or deactivate themselves, regardless of email case."""
         admin_user = MagicMock(spec=EmailUser)
         admin_user.email = "admin@example.com"
         admin_user.is_admin = True
@@ -2351,8 +2350,23 @@ class TestEmailAuthServiceUserUpdates:
         mock_result.scalar_one_or_none.return_value = admin_user
         mock_db.execute.return_value = mock_result
 
-        with pytest.raises(ValueError, match="Admin protection is enabled"):
-            await service.update_user(email="admin@example.com", is_active=False)
+        with pytest.raises(ValueError, match="cannot demote or deactivate their own account"):
+            await service.update_user(email="Admin@Example.COM", requesting_user_email=" ADMIN@example.com ", **{field: False})
+
+    @pytest.mark.asyncio
+    async def test_update_user_admin_removal_requires_requester_identity(self, service, mock_db):
+        """Admin removal fails closed when authenticated requester identity is absent."""
+        admin_user = MagicMock(spec=EmailUser)
+        admin_user.email = "admin@example.com"
+        admin_user.is_admin = True
+        admin_user.is_active = True
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = admin_user
+        mock_db.execute.return_value = mock_result
+
+        with pytest.raises(ValueError, match="Requesting user email is required"):
+            await service.update_user(email="admin@example.com", is_admin=False)
 
     @pytest.mark.asyncio
     async def test_update_user_protect_all_admins_allows_other_updates(self, service, mock_db, monkeypatch):
@@ -2395,7 +2409,7 @@ class TestEmailAuthServiceUserUpdates:
 
         with patch.object(service, "is_last_active_admin", new=AsyncMock(return_value=True)):
             with pytest.raises(ValueError, match="last remaining active admin"):
-                await service.update_user(email="admin@example.com", is_admin=False)
+                await service.update_user(email="admin@example.com", is_admin=False, requesting_user_email="other-admin@example.com")
 
     @pytest.mark.asyncio
     async def test_update_user_password_history_fail_closed_on_exception(self, service, mock_db, mock_user, mock_password_service):

--- a/tests/unit/mcpgateway/services/test_email_auth_basic.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_basic.py
@@ -2501,6 +2501,55 @@ class TestEmailAuthServiceUserUpdates:
         mock_db.commit.assert_called()
 
     @pytest.mark.asyncio
+    async def test_deactivate_user_active_admin_requires_requester_identity(self, service, mock_db, mock_user):
+        """Direct service calls cannot bypass requester validation for admins."""
+        mock_user.email = "admin@example.com"
+        mock_user.is_admin = True
+        mock_user.is_active = True
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_user
+
+        with pytest.raises(ValueError, match="Requesting user email is required"):
+            await service.deactivate_user("admin@example.com")
+
+    @pytest.mark.asyncio
+    async def test_deactivate_user_blocks_admin_self_deactivation(self, service, mock_db, mock_user):
+        """Direct service calls enforce case-insensitive self-deactivation protection."""
+        mock_user.email = "admin@example.com"
+        mock_user.is_admin = True
+        mock_user.is_active = True
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_user
+
+        with pytest.raises(ValueError, match="cannot demote or deactivate their own account"):
+            await service.deactivate_user("Admin@Example.com", requesting_user_email=" ADMIN@example.com ")
+
+    @pytest.mark.asyncio
+    async def test_deactivate_user_blocks_last_active_admin(self, service, mock_db, mock_user):
+        """Direct service calls enforce last-active-admin protection."""
+        mock_user.email = "admin@example.com"
+        mock_user.is_admin = True
+        mock_user.is_active = True
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_user
+
+        with patch.object(service, "is_last_active_admin", new=AsyncMock(return_value=True)):
+            with pytest.raises(ValueError, match="last remaining active admin"):
+                await service.deactivate_user("admin@example.com", requesting_user_email="other-admin@example.com")
+
+    @pytest.mark.asyncio
+    async def test_deactivate_user_allows_peer_admin_deactivation(self, service, mock_db, mock_user):
+        """Direct service calls allow peer deactivation when another admin remains."""
+        mock_user.email = "admin@example.com"
+        mock_user.is_admin = True
+        mock_user.is_active = True
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_user
+
+        with patch.object(service, "is_last_active_admin", new=AsyncMock(return_value=False)):
+            result = await service.deactivate_user("admin@example.com", requesting_user_email="other-admin@example.com")
+
+        assert result is mock_user
+        assert mock_user.is_active is False
+        mock_db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_deactivate_user_not_found(self, service, mock_db):
         """Test deactivating non-existent user."""
         mock_result = MagicMock()

--- a/tests/unit/mcpgateway/services/test_email_auth_basic.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_basic.py
@@ -2207,7 +2207,7 @@ class TestEmailAuthServiceUserUpdates:
         mock_result.scalar_one_or_none.return_value = mock_user
         mock_db.execute.return_value = mock_result
 
-        result = await service.update_user(email="test@example.com", is_admin=True)
+        result = await service.update_user(email="test@example.com", is_admin=True, requesting_user_email="admin@example.com")
 
         assert mock_user.is_admin is True
         mock_db.commit.assert_called()
@@ -2315,6 +2315,7 @@ class TestEmailAuthServiceUserUpdates:
             is_active=False,
             password_change_required=True,
             password="NewSecurePass4$xVeryLongForAdmin22!",  # pragma: allowlist secret
+            requesting_user_email="admin@example.com",
         )  # pragma: allowlist secret
 
         assert mock_user.full_name == "Updated Name"

--- a/tests/unit/mcpgateway/services/test_email_auth_service_admin_role_sync.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_service_admin_role_sync.py
@@ -123,7 +123,7 @@ async def test_update_user_revoke_admin_role(mock_db):
 
                 mock_role_service.get_role_by_name = AsyncMock(side_effect=get_role_by_name_side_effect)
                 mock_role_service.revoke_role_from_user = AsyncMock(return_value=True)
-                mock_role_service.get_user_role_assignment = AsyncMock(return_value=None)
+                mock_role_service.get_user_role_assignment = AsyncMock(side_effect=[MagicMock(is_active=True), None])
                 mock_role_service.assign_role_to_user = AsyncMock()
                 mock_role_service_cls.return_value = mock_role_service
 
@@ -134,10 +134,12 @@ async def test_update_user_revoke_admin_role(mock_db):
                 assert updated_user.is_admin is False
 
                 # Verify platform_admin was revoked
-                mock_role_service.revoke_role_from_user.assert_called_once_with(user_email="test@example.com", role_id="admin-role-123", scope="global", scope_id=None)
+                mock_role_service.revoke_role_from_user.assert_called_once_with(user_email="test@example.com", role_id="admin-role-123", scope="global", scope_id=None, commit=False)
 
                 # Verify platform_viewer was assigned
-                mock_role_service.assign_role_to_user.assert_called_once_with(user_email="test@example.com", role_id="viewer-role-456", scope="global", scope_id=None, granted_by="admin@example.com")
+                mock_role_service.assign_role_to_user.assert_called_once_with(
+                    user_email="test@example.com", role_id="viewer-role-456", scope="global", scope_id=None, granted_by="admin@example.com", commit=False
+                )
 
 
 @pytest.mark.asyncio
@@ -208,10 +210,12 @@ async def test_update_user_assign_admin_role_inactive_assignment(mock_db):
         assert updated_user.is_admin is True
 
         # Verify platform_admin was assigned (because existing assignment was inactive)
-        mock_role_service.assign_role_to_user.assert_called_once_with(user_email="test@example.com", role_id="admin-role-123", scope="global", scope_id=None, granted_by="test@example.com")
+        mock_role_service.assign_role_to_user.assert_called_once_with(
+            user_email="test@example.com", role_id="admin-role-123", scope="global", scope_id=None, granted_by="test@example.com", commit=False
+        )
 
         # Verify platform_viewer was revoked
-        mock_role_service.revoke_role_from_user.assert_called_once_with(user_email="test@example.com", role_id="viewer-role-456", scope="global", scope_id=None)
+        mock_role_service.revoke_role_from_user.assert_called_once_with(user_email="test@example.com", role_id="viewer-role-456", scope="global", scope_id=None, commit=False)
 
 
 @pytest.mark.asyncio
@@ -248,19 +252,16 @@ async def test_update_user_demote_admin_user_role_not_found(mock_db):
                     return None
 
                 mock_role_service.get_role_by_name = AsyncMock(side_effect=get_role_by_name_side_effect)
+                mock_role_service.get_user_role_assignment = AsyncMock(return_value=MagicMock(is_active=True))
                 mock_role_service.revoke_role_from_user = AsyncMock(return_value=True)
                 mock_role_service_cls.return_value = mock_role_service
 
-                # Update user to non-admin (demote)
-                updated_user = await service.update_user(email="test@example.com", is_admin=False, requesting_user_email="admin@example.com")
+                with pytest.raises(ValueError, match="role synchronization did not complete"):
+                    await service.update_user(email="test@example.com", is_admin=False, requesting_user_email="admin@example.com")
 
-                # Verify user was demoted
-                assert updated_user.is_admin is False
+                mock_db.commit.assert_not_called()
+                mock_db.rollback.assert_called_once()
 
-                # Verify platform_admin was revoked
-                mock_role_service.revoke_role_from_user.assert_called_once_with(user_email="test@example.com", role_id="admin-role-123", scope="global", scope_id=None)
-
-                # Verify platform_viewer was NOT assigned (because role was not found)
                 mock_role_service.assign_role_to_user.assert_not_called()
 
 
@@ -280,7 +281,12 @@ async def test_create_platform_admin_new_user_assigns_role(mock_db):
 
             # Verify create_user was called with is_admin=True
             mock_create_user.assert_called_once_with(
-                email="newadmin@example.com", password="NewAdminPass4$x!", full_name="New Admin", is_admin=True, auth_provider="local", skip_password_validation=True  # pragma: allowlist secret
+                email="newadmin@example.com",
+                password="NewAdminPass4$x!",  # pragma: allowlist secret
+                full_name="New Admin",
+                is_admin=True,
+                auth_provider="local",
+                skip_password_validation=True,
             )
 
             # Verify the returned user has admin status

--- a/tests/unit/mcpgateway/services/test_email_auth_service_admin_role_sync.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_service_admin_role_sync.py
@@ -57,6 +57,22 @@ async def test_create_user_admin_role_not_found(mock_db):
 
 
 @pytest.mark.asyncio
+async def test_update_user_promotion_requires_requester(mock_db):
+    """Test promotion fails when authenticated requester identity is missing."""
+    service = EmailAuthService(mock_db)
+    existing_user = EmailUser(email="test@example.com", password_hash="hashed", is_admin=False, is_active=True)
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = existing_user
+    mock_db.execute.return_value = mock_result
+
+    with pytest.raises(ValueError, match="Requesting user email is required to change administrator privileges"):
+        await service.update_user(email="test@example.com", is_admin=True)
+
+    assert existing_user.is_admin is False
+    mock_db.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_update_user_admin_role_not_found(mock_db):
     """Test update_user when platform_admin role doesn't exist."""
     service = EmailAuthService(mock_db)
@@ -76,7 +92,7 @@ async def test_update_user_admin_role_not_found(mock_db):
         mock_role_service_cls.return_value = mock_role_service
 
         # Update user to admin
-        updated_user = await service.update_user(email="test@example.com", is_admin=True)
+        updated_user = await service.update_user(email="test@example.com", is_admin=True, requesting_user_email="admin@example.com")
 
         # Verify user was updated despite roles not found
         assert updated_user.is_admin is True
@@ -162,7 +178,7 @@ async def test_update_user_admin_role_sync_exception(mock_db):
         mock_role_service_cls.return_value = mock_role_service
 
         # Update user to admin - should succeed despite role sync failure
-        updated_user = await service.update_user(email="test@example.com", is_admin=True)
+        updated_user = await service.update_user(email="test@example.com", is_admin=True, requesting_user_email="admin@example.com")
 
         # Verify user was updated despite role sync failure
         assert updated_user.is_admin is True
@@ -204,14 +220,14 @@ async def test_update_user_assign_admin_role_inactive_assignment(mock_db):
         mock_role_service_cls.return_value = mock_role_service
 
         # Update user to admin
-        updated_user = await service.update_user(email="test@example.com", is_admin=True)
+        updated_user = await service.update_user(email="test@example.com", is_admin=True, requesting_user_email="admin@example.com")
 
         # Verify user was promoted
         assert updated_user.is_admin is True
 
         # Verify platform_admin was assigned (because existing assignment was inactive)
         mock_role_service.assign_role_to_user.assert_called_once_with(
-            user_email="test@example.com", role_id="admin-role-123", scope="global", scope_id=None, granted_by="test@example.com", commit=False
+            user_email="test@example.com", role_id="admin-role-123", scope="global", scope_id=None, granted_by="admin@example.com", commit=False
         )
 
         # Verify platform_viewer was revoked

--- a/tests/unit/mcpgateway/services/test_email_auth_service_admin_role_sync.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_service_admin_role_sync.py
@@ -128,7 +128,7 @@ async def test_update_user_revoke_admin_role(mock_db):
                 mock_role_service_cls.return_value = mock_role_service
 
                 # Update user to non-admin
-                updated_user = await service.update_user(email="test@example.com", is_admin=False)
+                updated_user = await service.update_user(email="test@example.com", is_admin=False, requesting_user_email="admin@example.com")
 
                 # Verify user was demoted
                 assert updated_user.is_admin is False
@@ -137,7 +137,7 @@ async def test_update_user_revoke_admin_role(mock_db):
                 mock_role_service.revoke_role_from_user.assert_called_once_with(user_email="test@example.com", role_id="admin-role-123", scope="global", scope_id=None)
 
                 # Verify platform_viewer was assigned
-                mock_role_service.assign_role_to_user.assert_called_once_with(user_email="test@example.com", role_id="viewer-role-456", scope="global", scope_id=None, granted_by="test@example.com")
+                mock_role_service.assign_role_to_user.assert_called_once_with(user_email="test@example.com", role_id="viewer-role-456", scope="global", scope_id=None, granted_by="admin@example.com")
 
 
 @pytest.mark.asyncio
@@ -252,7 +252,7 @@ async def test_update_user_demote_admin_user_role_not_found(mock_db):
                 mock_role_service_cls.return_value = mock_role_service
 
                 # Update user to non-admin (demote)
-                updated_user = await service.update_user(email="test@example.com", is_admin=False)
+                updated_user = await service.update_user(email="test@example.com", is_admin=False, requesting_user_email="admin@example.com")
 
                 # Verify user was demoted
                 assert updated_user.is_admin is False

--- a/tests/unit/mcpgateway/services/test_role_service.py
+++ b/tests/unit/mcpgateway/services/test_role_service.py
@@ -511,6 +511,18 @@ class TestAssignRoleToUser:
                     mock_db.commit.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_assign_role_can_defer_commit(self, role_service, mock_db, sample_role, sample_user_role):
+        """Caller-owned transactions flush role assignment without committing."""
+        with patch.object(role_service, "get_role_by_id", new=AsyncMock(return_value=sample_role)):
+            with patch.object(role_service, "get_user_role_assignment", new=AsyncMock(return_value=None)):
+                with patch("mcpgateway.services.role_service.UserRole", return_value=sample_user_role):
+                    result = await role_service.assign_role_to_user(user_email="user@example.com", role_id="role-123", scope="team", scope_id="team-789", granted_by="admin@example.com", commit=False)
+
+        assert result == sample_user_role
+        mock_db.flush.assert_called_once()
+        mock_db.commit.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_assign_role_not_found(self, role_service):
         """Test assigning non-existent role."""
         with patch.object(role_service, "get_role_by_id", new=AsyncMock(return_value=None)):
@@ -608,6 +620,19 @@ class TestRevokeRoleFromUser:
             assert result is True
             assert sample_user_role.is_active is False
             mock_db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_revoke_role_can_defer_commit(self, role_service, mock_db, sample_user_role):
+        """Caller-owned transactions flush role revocation without committing."""
+        sample_user_role.is_active = True
+
+        with patch.object(role_service, "get_user_role_assignment", new=AsyncMock(return_value=sample_user_role)):
+            result = await role_service.revoke_role_from_user(user_email="user@example.com", role_id="role-123", scope="team", scope_id="team-789", commit=False)
+
+        assert result is True
+        assert sample_user_role.is_active is False
+        mock_db.flush.assert_called_once()
+        mock_db.commit.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_revoke_role_not_found(self, role_service):

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -10881,6 +10881,7 @@ async def test_admin_update_user_self_demotion_blocked(monkeypatch, mock_db, all
     auth_service.update_user.assert_called_once()
     call_kwargs = auth_service.update_user.call_args[1]
     assert call_kwargs["is_admin"] is True
+    assert call_kwargs["requesting_user_email"] == "admin@example.com"
 
 
 @pytest.mark.asyncio
@@ -10901,6 +10902,7 @@ async def test_admin_update_user_self_demotion_case_insensitive(monkeypatch, moc
     auth_service.update_user.assert_called_once()
     call_kwargs = auth_service.update_user.call_args[1]
     assert call_kwargs["is_admin"] is True
+    assert call_kwargs["requesting_user_email"] == "ADMIN@EXAMPLE.COM"
 
 
 @pytest.mark.asyncio
@@ -10921,6 +10923,7 @@ async def test_admin_update_user_can_demote_others(monkeypatch, mock_db, allow_p
     response = await admin_update_user("other%40example.com", request=request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
     assert response.status_code == 200
     assert response.headers.get("HX-Trigger") is not None
+    assert auth_service.update_user.call_args.kwargs["requesting_user_email"] == "admin@example.com"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -4704,7 +4704,6 @@ class TestAdminUIRoute:
             patch.object(settings, "gateway_tool_name_separator", "__"),
             patch.object(settings, "jwt_secret_key", "test-secret-key-with-minimum-32-bytes"),
         ):
-
             await admin_ui(
                 request=mock_request,
                 team_id=None,
@@ -10743,12 +10742,12 @@ async def test_admin_update_user_last_admin_block(monkeypatch, mock_db, allow_pe
 
     auth_service = MagicMock()
     auth_service.get_user_by_email = AsyncMock(return_value=SimpleNamespace(email="a@example.com", is_admin=True))
-    auth_service.is_last_active_admin = AsyncMock(return_value=True)
+    auth_service.update_user = AsyncMock(side_effect=ValueError("Cannot demote or deactivate the last remaining active admin user"))
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
     response = await admin_update_user("a%40example.com", request=request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
     assert response.status_code == 400
-    assert "last remaining admin" in response.body.decode()
+    assert "last remaining active admin" in response.body.decode()
 
 
 @pytest.mark.asyncio
@@ -10823,8 +10822,9 @@ async def test_admin_get_user_edit_hides_admin_checkbox_when_editing_self(monkey
     assert isinstance(response, HTMLResponse)
     body = response.body.decode()
     assert "Edit User" in body
-    # Administrator checkbox should NOT be present when editing self
-    assert 'name="is_admin"' not in body
+    # Administrator checkbox is hidden; retained state is submitted as hidden input.
+    assert 'type="checkbox" name="is_admin"' not in body
+    assert 'type="hidden" name="is_admin" value="on"' in body
 
 
 @pytest.mark.asyncio
@@ -10850,20 +10850,21 @@ async def test_admin_get_user_edit_case_insensitive_self_check(monkeypatch, mock
     """Test that self-editing check is case-insensitive."""
     monkeypatch.setattr(settings, "email_auth_enabled", True)
     auth_service = MagicMock()
-    auth_service.get_user_by_email = AsyncMock(return_value=SimpleNamespace(email="Admin@Example.com", full_name="Admin User", is_admin=True))
+    auth_service.get_user_by_email = AsyncMock(return_value=SimpleNamespace(email="Admin@Example.com", full_name="Admin User", is_admin=True, is_email_verified=lambda: True))
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
     # User with different case should still be recognized as self
     response = await admin_get_user_edit("admin%40example.com", mock_request, db=mock_db, _user={"email": "ADMIN@EXAMPLE.COM", "db": mock_db})
     assert isinstance(response, HTMLResponse)
     body = response.body.decode()
-    # Administrator checkbox should NOT be present (case-insensitive match)
-    assert 'name="is_admin"' not in body
+    # Administrator checkbox is hidden and retained state is case-insensitive.
+    assert 'type="checkbox" name="is_admin"' not in body
+    assert 'type="hidden" name="is_admin" value="on"' in body
 
 
 @pytest.mark.asyncio
 async def test_admin_update_user_self_demotion_blocked(monkeypatch, mock_db, allow_permission):
-    """Test that admin status is preserved when user edits themselves (checkbox hidden in UI)."""
+    """Forged self-demotion reaches central service and is rejected."""
     monkeypatch.setattr(settings, "email_auth_enabled", True)
     request = MagicMock(spec=Request)
     # Form without is_admin field (checkbox hidden in UI for self-edit)
@@ -10871,16 +10872,15 @@ async def test_admin_update_user_self_demotion_blocked(monkeypatch, mock_db, all
 
     auth_service = MagicMock()
     auth_service.get_user_by_email = AsyncMock(return_value=SimpleNamespace(email="admin@example.com", is_admin=True))
-    auth_service.update_user = AsyncMock(return_value=None)
+    auth_service.update_user = AsyncMock(side_effect=ValueError("Administrators cannot demote or deactivate their own account"))
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
-    # Self-edit should succeed with admin status preserved
     response = await admin_update_user("admin%40example.com", request=request, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
-    assert response.status_code == 200
-    # Verify update_user was called with is_admin=True (preserved from DB)
+    assert response.status_code == 400
+    assert "cannot demote or deactivate" in response.body.decode()
     auth_service.update_user.assert_called_once()
     call_kwargs = auth_service.update_user.call_args[1]
-    assert call_kwargs["is_admin"] is True
+    assert call_kwargs["is_admin"] is False
     assert call_kwargs["requesting_user_email"] == "admin@example.com"
 
 
@@ -10893,15 +10893,14 @@ async def test_admin_update_user_self_demotion_case_insensitive(monkeypatch, moc
 
     auth_service = MagicMock()
     auth_service.get_user_by_email = AsyncMock(return_value=SimpleNamespace(email="Admin@Example.com", is_admin=True))
-    auth_service.update_user = AsyncMock(return_value=None)
+    auth_service.update_user = AsyncMock(side_effect=ValueError("Administrators cannot demote or deactivate their own account"))
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
-    # Self-edit with different case should still preserve admin status
     response = await admin_update_user("admin%40example.com", request=request, db=mock_db, _user={"email": "ADMIN@EXAMPLE.COM", "db": mock_db})
-    assert response.status_code == 200
+    assert response.status_code == 400
     auth_service.update_user.assert_called_once()
     call_kwargs = auth_service.update_user.call_args[1]
-    assert call_kwargs["is_admin"] is True
+    assert call_kwargs["is_admin"] is False
     assert call_kwargs["requesting_user_email"] == "ADMIN@EXAMPLE.COM"
 
 
@@ -10931,8 +10930,7 @@ async def test_admin_update_user_self_can_update_other_fields(monkeypatch, mock_
     """Test that user can update their own profile fields (name, password) while keeping admin status."""
     monkeypatch.setattr(settings, "email_auth_enabled", True)
     request = MagicMock(spec=Request)
-    # No is_admin field in form (checkbox hidden in UI for self-edit)
-    request.form = AsyncMock(return_value=FakeForm({"full_name": "Updated Name", "password": ""}))
+    request.form = AsyncMock(return_value=FakeForm({"full_name": "Updated Name", "password": "", "is_admin": "on"}))
 
     auth_service = MagicMock()
     auth_service.get_user_by_email = AsyncMock(return_value=SimpleNamespace(email="admin@example.com", is_admin=True))
@@ -10985,9 +10983,13 @@ async def test_admin_activate_user_exception(monkeypatch, mock_request, mock_db,
 @pytest.mark.asyncio
 async def test_admin_deactivate_user_self_block(monkeypatch, mock_request, mock_db, allow_permission):
     monkeypatch.setattr(settings, "email_auth_enabled", True)
-    response = await admin_deactivate_user("admin%40example.com", mock_request, db=mock_db, user={"email": "admin@example.com", "db": mock_db})
+    auth_service = MagicMock()
+    auth_service.update_user = AsyncMock(side_effect=ValueError("Administrators cannot demote or deactivate their own account"))
+    monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
+
+    response = await admin_deactivate_user("admin%40example.com", mock_request, db=mock_db, user={"email": "ADMIN@example.com", "db": mock_db})
     assert response.status_code == 400
-    assert "Cannot deactivate your own account" in response.body.decode()
+    assert "cannot demote or deactivate" in response.body.decode()
 
 
 @pytest.mark.asyncio
@@ -11001,20 +11003,19 @@ async def test_admin_deactivate_user_email_auth_disabled(monkeypatch, mock_reque
 async def test_admin_deactivate_user_last_admin_block(monkeypatch, mock_request, mock_db, allow_permission):
     monkeypatch.setattr(settings, "email_auth_enabled", True)
     auth_service = MagicMock()
-    auth_service.is_last_active_admin = AsyncMock(return_value=True)
+    auth_service.update_user = AsyncMock(side_effect=ValueError("Cannot demote or deactivate the last remaining active admin user"))
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
     response = await admin_deactivate_user("a%40example.com", mock_request, db=mock_db, user={"email": "admin@example.com", "db": mock_db})
     assert response.status_code == 400
-    assert "last remaining admin" in response.body.decode()
+    assert "last remaining active admin" in response.body.decode()
 
 
 @pytest.mark.asyncio
 async def test_admin_deactivate_user_success(monkeypatch, mock_request, mock_db, allow_permission):
     monkeypatch.setattr(settings, "email_auth_enabled", True)
     auth_service = MagicMock()
-    auth_service.is_last_active_admin = AsyncMock(return_value=False)
-    auth_service.deactivate_user = AsyncMock(
+    auth_service.update_user = AsyncMock(
         return_value=SimpleNamespace(
             email="a@example.com", full_name="A", is_active=False, is_admin=False, auth_provider="local", created_at=datetime.now(timezone.utc), password_change_required=False
         )
@@ -11024,14 +11025,14 @@ async def test_admin_deactivate_user_success(monkeypatch, mock_request, mock_db,
 
     response = await admin_deactivate_user("a%40example.com", mock_request, db=mock_db, user={"email": "admin@example.com", "db": mock_db})
     assert isinstance(response, HTMLResponse)
+    auth_service.update_user.assert_awaited_once_with(email="a@example.com", is_active=False, requesting_user_email="admin@example.com", admin_origin_source="ui")
 
 
 @pytest.mark.asyncio
 async def test_admin_deactivate_user_exception(monkeypatch, mock_request, mock_db, allow_permission):
     monkeypatch.setattr(settings, "email_auth_enabled", True)
     auth_service = MagicMock()
-    auth_service.is_last_active_admin = AsyncMock(return_value=False)
-    auth_service.deactivate_user = AsyncMock(side_effect=RuntimeError("boom"))
+    auth_service.update_user = AsyncMock(side_effect=RuntimeError("boom"))
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
 
     response = await admin_deactivate_user("a%40example.com", mock_request, db=mock_db, user={"email": "admin@example.com", "db": mock_db})
@@ -12775,7 +12776,7 @@ async def test_admin_get_all_tool_ids_team_scoped_includes_public(monkeypatch, m
     # OR alternative — not wrapped inside `team_id = '...' AND visibility IN (...)`.
     # This is what makes platform-public tools visible to team-scoped queries.
     assert re.search(r"tools\.visibility\s*=\s*'public'", sql), (
-        "Expected a standalone visibility='public' condition in team-scoped tool IDs query. " "Platform-public tools must be accessible when associating with team-owned virtual servers."
+        "Expected a standalone visibility='public' condition in team-scoped tool IDs query. Platform-public tools must be accessible when associating with team-owned virtual servers."
     )
 
 
@@ -12806,7 +12807,7 @@ async def test_admin_get_all_prompt_ids_team_scoped_includes_public(monkeypatch,
     sql = str(executed_query.compile(dialect=sqlite_dialect.dialect(), compile_kwargs={"literal_binds": True}))
 
     assert re.search(r"prompts\.visibility\s*=\s*'public'", sql), (
-        "Expected a standalone visibility='public' condition in team-scoped prompt IDs query. " "Platform-public prompts must be accessible when associating with team-owned virtual servers."
+        "Expected a standalone visibility='public' condition in team-scoped prompt IDs query. Platform-public prompts must be accessible when associating with team-owned virtual servers."
     )
 
 
@@ -12837,7 +12838,7 @@ async def test_admin_get_all_resource_ids_team_scoped_includes_public(monkeypatc
     sql = str(executed_query.compile(dialect=sqlite_dialect.dialect(), compile_kwargs={"literal_binds": True}))
 
     assert re.search(r"resources\.visibility\s*=\s*'public'", sql), (
-        "Expected a standalone visibility='public' condition in team-scoped resource IDs query. " "Platform-public resources must be accessible when associating with team-owned virtual servers."
+        "Expected a standalone visibility='public' condition in team-scoped resource IDs query. Platform-public resources must be accessible when associating with team-owned virtual servers."
     )
 
 
@@ -13319,13 +13320,16 @@ async def test_admin_unified_search_aggregates_results(monkeypatch, mock_db, all
     monkeypatch.setattr("mcpgateway.admin.admin_search_servers", AsyncMock(return_value={"servers": [{"id": "srv-1", "name": "Server 1"}], "count": 1}))
     monkeypatch.setattr("mcpgateway.admin.admin_search_gateways", AsyncMock(return_value={"gateways": [{"id": "gw-1", "name": "Gateway 1"}], "count": 1}))
     monkeypatch.setattr(
-        "mcpgateway.admin.admin_search_tools", AsyncMock(return_value={"tools": [{"id": "550e8400e29b41d4a7164466554400b1", "name": "Tool 1"}], "count": 1})  # pragma: allowlist secret
+        "mcpgateway.admin.admin_search_tools",
+        AsyncMock(return_value={"tools": [{"id": "550e8400e29b41d4a7164466554400b1", "name": "Tool 1"}], "count": 1}),  # pragma: allowlist secret
     )
     monkeypatch.setattr(
-        "mcpgateway.admin.admin_search_resources", AsyncMock(return_value={"resources": [{"id": "550e8400e29b41d4a7164466554400c1", "name": "Resource 1"}], "count": 1})  # pragma: allowlist secret
+        "mcpgateway.admin.admin_search_resources",
+        AsyncMock(return_value={"resources": [{"id": "550e8400e29b41d4a7164466554400c1", "name": "Resource 1"}], "count": 1}),  # pragma: allowlist secret
     )  # pragma: allowlist secret
     monkeypatch.setattr(
-        "mcpgateway.admin.admin_search_prompts", AsyncMock(return_value={"prompts": [{"id": "550e8400e29b41d4a7164466554400d1", "name": "Prompt 1"}], "count": 1})  # pragma: allowlist secret
+        "mcpgateway.admin.admin_search_prompts",
+        AsyncMock(return_value={"prompts": [{"id": "550e8400e29b41d4a7164466554400d1", "name": "Prompt 1"}], "count": 1}),  # pragma: allowlist secret
     )  # pragma: allowlist secret
     monkeypatch.setattr("mcpgateway.admin.admin_search_a2a_agents", AsyncMock(return_value={"agents": [{"id": "agent-1", "name": "Agent 1"}], "count": 1}))
     monkeypatch.setattr("mcpgateway.admin.admin_search_teams", AsyncMock(return_value={"teams": [{"id": "team-1", "name": "Team 1"}], "count": 1}))
@@ -13427,7 +13431,8 @@ async def test_admin_unified_search_drops_users_when_not_permitted(monkeypatch, 
 @pytest.mark.asyncio
 async def test_admin_unified_search_accepts_legacy_team_search_list_shape(monkeypatch, mock_db, allow_permission):
     monkeypatch.setattr(
-        "mcpgateway.admin.admin_search_tools", AsyncMock(return_value={"tools": [{"id": "550e8400e29b41d4a7164466554400b1", "name": "Tool 1"}], "count": 1})  # pragma: allowlist secret
+        "mcpgateway.admin.admin_search_tools",
+        AsyncMock(return_value={"tools": [{"id": "550e8400e29b41d4a7164466554400b1", "name": "Tool 1"}], "count": 1}),  # pragma: allowlist secret
     )  # pragma: allowlist secret
     monkeypatch.setattr("mcpgateway.admin.admin_search_teams", AsyncMock(return_value=[{"id": "team-1", "name": "Team 1"}]))
 
@@ -13452,7 +13457,8 @@ async def test_admin_unified_search_accepts_legacy_team_search_list_shape(monkey
 @pytest.mark.asyncio
 async def test_admin_unified_search_entity_types_parses_a2a_alias(monkeypatch, mock_db, allow_permission):
     monkeypatch.setattr(
-        "mcpgateway.admin.admin_search_tools", AsyncMock(return_value={"tools": [{"id": "550e8400e29b41d4a7164466554400b1", "name": "Tool 1"}], "count": 1})  # pragma: allowlist secret
+        "mcpgateway.admin.admin_search_tools",
+        AsyncMock(return_value={"tools": [{"id": "550e8400e29b41d4a7164466554400b1", "name": "Tool 1"}], "count": 1}),  # pragma: allowlist secret
     )  # pragma: allowlist secret
     monkeypatch.setattr("mcpgateway.admin.admin_search_a2a_agents", AsyncMock(return_value={"agents": [{"id": "agent-1", "name": "Agent 1"}], "count": 1}))
 
@@ -15487,12 +15493,12 @@ async def test_admin_update_user_errors_include_retarget_header(monkeypatch, moc
     request2.form = AsyncMock(return_value=FakeForm({"full_name": "A"}))
     auth_service2 = MagicMock()
     auth_service2.get_user_by_email = AsyncMock(return_value=SimpleNamespace(email="a@example.com", is_admin=True))
-    auth_service2.is_last_active_admin = AsyncMock(return_value=True)
+    auth_service2.update_user = AsyncMock(side_effect=ValueError("Cannot demote or deactivate the last remaining active admin user"))
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service2)
 
     response2 = await admin_update_user("a%40example.com", request=request2, db=mock_db, _user={"email": "admin@example.com", "db": mock_db})
     assert response2.status_code == 400
-    assert "last remaining admin" in response2.body.decode()
+    assert "last remaining active admin" in response2.body.decode()
     assert response2.headers.get("HX-Retarget") == "#edit-user-error", "Admin protection error should include HX-Retarget header"
 
 
@@ -17920,7 +17926,7 @@ async def test_admin_add_a2a_agent_oauth_with_audience(monkeypatch, mock_db):
             "auth_type": "oauth",
             "oauth_grant_type": "authorization_code",
             "oauth_client_id": "client-id",
-            "oauth_client_secret": "client-secret",
+            "oauth_client_secret": "client-secret",  # pragma: allowlist secret
             "oauth_audience": "api.atlassian.com",
             "oauth_scopes": "read:jira-work write:jira-work",
         }
@@ -25093,7 +25099,6 @@ class TestAdminTeamVisibilitySecurity:
             patch("mcpgateway.admin.get_user_email", return_value="admin@example.com"),
             patch("mcpgateway.admin._resolve_root_path", return_value=""),
         ):
-
             await admin_teams_partial_html(
                 request=mock_request,
                 page=1,
@@ -25132,7 +25137,6 @@ class TestAdminTeamVisibilitySecurity:
             patch("mcpgateway.admin.TeamManagementService", return_value=mock_team_service),
             patch("mcpgateway.admin.get_user_email", return_value="admin@example.com"),
         ):
-
             await admin_get_all_team_ids(include_inactive=False, visibility=None, q=None, db=mock_db, user={"email": "admin@example.com", "db": mock_db})
 
             # Verify get_all_team_ids was called with include_personal=False and personal_owner_email
@@ -25161,7 +25165,6 @@ class TestAdminTeamVisibilitySecurity:
             patch("mcpgateway.admin.get_user_email", return_value="admin@example.com"),
             patch("mcpgateway.admin._normalize_search_query", return_value="test"),
         ):
-
             await admin_search_teams(q="test", include_inactive=False, limit=50, visibility=None, db=mock_db, user={"email": "admin@example.com", "db": mock_db})
 
             # Verify list_teams was called with include_personal=False and personal_owner_email
@@ -25197,7 +25200,6 @@ class TestAdminTeamVisibilitySecurity:
             patch("mcpgateway.admin.get_user_email", return_value="admin@example.com"),
             patch("mcpgateway.admin._resolve_root_path", return_value=""),
         ):
-
             await admin_list_teams(request=mock_request, page=1, per_page=50, q=None, db=mock_db, user={"email": "admin@example.com", "db": mock_db}, unified=False)
 
             # Verify list_teams was called with include_personal=False and personal_owner_email
@@ -25233,7 +25235,6 @@ class TestAdminTeamVisibilitySecurity:
             patch("mcpgateway.admin.get_user_email", return_value="user@example.com"),
             patch("mcpgateway.admin._resolve_root_path", return_value=""),
         ):
-
             await admin_teams_partial_html(
                 request=mock_request,
                 page=1,
@@ -25295,7 +25296,6 @@ class TestAdminTeamVisibilitySecurity:
             patch("mcpgateway.admin.get_user_email", return_value="admin@example.com"),
             patch("mcpgateway.admin._resolve_root_path", return_value=""),
         ):
-
             await admin_teams_partial_html(
                 request=mock_request,
                 page=1,
@@ -25353,7 +25353,6 @@ class TestAdminTeamVisibilitySecurity:
             patch("mcpgateway.admin.get_user_email", return_value="admin@example.com"),
             patch("mcpgateway.admin._resolve_root_path", return_value=""),
         ):
-
             await admin_teams_partial_html(
                 request=mock_request,
                 page=1,
@@ -25425,7 +25424,6 @@ class TestAdminPersonalTeamFiltering:
             patch("mcpgateway.admin.TeamManagementService", return_value=mock_team_service),
             patch("mcpgateway.admin.get_user_email", return_value="admin@example.com"),
         ):
-
             result = await admin_get_all_team_ids(include_inactive=False, visibility=None, q=None, db=mock_db, user={"email": "admin@example.com", "db": mock_db})
 
             # Verify service was called with personal_owner_email
@@ -25452,7 +25450,6 @@ class TestAdminPersonalTeamFiltering:
             patch("mcpgateway.admin.TeamManagementService", return_value=mock_team_service),
             patch("mcpgateway.admin.get_user_email", return_value="admin@example.com"),
         ):
-
             await admin_get_all_team_ids(include_inactive=True, visibility="public", q="search", db=mock_db, user={"email": "admin@example.com", "db": mock_db})
 
             call_kwargs = mock_team_service.get_all_team_ids.call_args[1]
@@ -25479,7 +25476,6 @@ class TestAdminPersonalTeamFiltering:
             patch("mcpgateway.admin.get_user_email", return_value="admin@example.com"),
             patch("mcpgateway.admin._normalize_search_query", return_value="admin"),
         ):
-
             await admin_search_teams(q="admin", include_inactive=False, limit=50, visibility=None, db=mock_db, user={"email": "admin@example.com", "db": mock_db})
 
             call_kwargs = mock_team_service.list_teams.call_args[1]
@@ -25503,7 +25499,6 @@ class TestAdminPersonalTeamFiltering:
             patch("mcpgateway.admin.get_user_email", return_value="admin@example.com"),
             patch("mcpgateway.admin._normalize_search_query", return_value="test"),
         ):
-
             await admin_search_teams(q="test", include_inactive=True, limit=25, visibility="public", db=mock_db, user={"email": "admin@example.com", "db": mock_db})
 
             call_kwargs = mock_team_service.list_teams.call_args[1]
@@ -25539,7 +25534,6 @@ class TestAdminPersonalTeamFiltering:
             patch("mcpgateway.admin.get_user_email", return_value="admin@example.com"),
             patch("mcpgateway.admin._get_user_team_roles", return_value={}),
         ):
-
             result = await admin_teams_partial_html(
                 request=mock_request, page=1, per_page=50, include_inactive=False, visibility=None, relationship=None, q=None, db=mock_db, user={"email": "admin@example.com", "db": mock_db}
             )
@@ -25573,7 +25567,6 @@ class TestAdminPersonalTeamFiltering:
             patch("mcpgateway.admin.get_user_email", return_value="admin@example.com"),
             patch("mcpgateway.admin._get_user_team_roles", return_value={}),
         ):
-
             await admin_teams_partial_html(
                 request=mock_request, page=2, per_page=10, include_inactive=True, visibility="public", relationship=None, q="search", db=mock_db, user={"email": "admin@example.com", "db": mock_db}
             )
@@ -25610,7 +25603,6 @@ class TestAdminPersonalTeamFiltering:
             patch("mcpgateway.admin.get_user_email", return_value="admin@example.com"),
             patch("mcpgateway.admin._resolve_root_path", return_value=""),
         ):
-
             await admin_list_teams(request=mock_request, page=1, per_page=50, q=None, db=mock_db, user={"email": "admin@example.com", "db": mock_db}, unified=False)
 
             call_kwargs = mock_team_service.list_teams.call_args[1]
@@ -25639,7 +25631,6 @@ class TestAdminPersonalTeamFiltering:
             patch("mcpgateway.admin.get_user_email", return_value="admin@example.com"),
             patch("mcpgateway.admin._resolve_root_path", return_value=""),
         ):
-
             result = await admin_list_teams(request=mock_request, page=1, per_page=50, q="nomatch", db=mock_db, user={"email": "admin@example.com", "db": mock_db}, unified=False)
 
             assert isinstance(result, HTMLResponse)
@@ -25711,7 +25702,6 @@ class TestAdminPersonalTeamFiltering:
             patch("mcpgateway.admin._resolve_root_path", return_value=""),
             patch("mcpgateway.admin._get_user_team_roles", return_value={}),
         ):
-
             _ = await admin_teams_partial_html(
                 request=mock_request,
                 page=1,
@@ -25804,7 +25794,6 @@ class TestAdminPersonalTeamFiltering:
             patch("mcpgateway.admin._resolve_root_path", return_value=""),
             patch("mcpgateway.admin._get_user_team_roles", return_value={"public-team-id": "member"}),
         ):
-
             _ = await admin_teams_partial_html(
                 request=mock_request,
                 page=1,
@@ -25894,7 +25883,6 @@ class TestAdminPersonalTeamFiltering:
             patch("mcpgateway.admin._resolve_root_path", return_value=""),
             patch("mcpgateway.admin._get_user_team_roles", return_value={}),
         ):
-
             _ = await admin_teams_partial_html(
                 request=mock_request,
                 page=1,


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #2808

---

## 📝 Summary

Enforces consistent administrator demotion rules across API and Admin UI:

- allows one administrator to demote another administrator;
- always rejects administrator self-demotion and self-deactivation;
- always protects the last active administrator;
- requires authenticated requester identity for active-admin removal operations;
- records the requesting administrator as `granted_by` during role synchronization.

Root cause was overloaded `PROTECT_ALL_ADMINS` behavior. It controlled both login-lockout bypass and admin demotion, causing peer demotion to be blocked when enabled while allowing API self-demotion when disabled. This change limits the setting to login-lockout bypass and enforces demotion safety independently in `EmailAuthService.update_user()`.

Existing deployments using `PROTECT_ALL_ADMINS=true` will now permit peer-admin demotion. Deployments using `false` will no longer permit self-demotion or self-deactivation. Configuration and Helm descriptions now document the narrowed setting semantics.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [x] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Ruff | `make ruff` | Passed |
| Affected unit modules | `pytest -q tests/unit/mcpgateway/services/test_email_auth_basic.py tests/unit/mcpgateway/services/test_email_auth_service_admin_role_sync.py tests/unit/mcpgateway/routers/test_email_auth_router.py tests/unit/mcpgateway/test_admin.py` | Passed; 3 existing skips |
| Patch whitespace | `git diff --check` | Passed |

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

`PROTECT_ALL_ADMINS` remains available and defaults to `true`, but now only controls active-admin login-lockout bypass. Self-removal and last-active-admin protections no longer depend on this toggle.
