### PR TITLE
chore: remove obsolete redis_fallback config references

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-16T00:08:38Z",
+  "generated_at": "2026-07-20T13:38:01Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -266,7 +266,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1746,
+        "line_number": 1747,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1834,
+        "line_number": 1835,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2184,
+        "line_number": 2185,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3549,
+        "line_number": 3550,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3640,
+        "line_number": 3641,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3683,
+        "line_number": 3684,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3688,
+        "line_number": 3689,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +322,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3693,
+        "line_number": 3694,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5953,
+        "line_number": 5963,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6450,
+        "line_number": 6460,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6462,
+        "line_number": 6472,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6534,
+        "line_number": 6544,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7601,
+        "line_number": 7611,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4048,7 +4048,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 750,
+        "line_number": 749,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4058,7 +4058,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 177,
+        "line_number": 176,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4066,7 +4066,7 @@
         "hashed_secret": "1073ab6cda4b991cd29f9e83a307f34004ae9327",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 183,
+        "line_number": 182,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4074,7 +4074,7 @@
         "hashed_secret": "d4fe581561f18ee5006254a7e53f53cbed780bc2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 270,
+        "line_number": 269,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4084,7 +4084,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4577,
+        "line_number": 4576,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4104,7 +4104,7 @@
         "hashed_secret": "6993a3fd94a012ab50fb6b9e97ec238310f0b177",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 110,
+        "line_number": 105,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4112,7 +4112,7 @@
         "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 137,
+        "line_number": 132,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4120,7 +4120,7 @@
         "hashed_secret": "9ec4f370c96047d96f3eb3637ca9fd144ed6e21b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 167,
+        "line_number": 162,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4128,7 +4128,7 @@
         "hashed_secret": "6947818ac409551f11fbaa78f0ea6391960aa5b8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 494,
+        "line_number": 489,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4174,7 +4174,7 @@
         "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 189,
+        "line_number": 188,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4182,7 +4182,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 316,
+        "line_number": 315,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4192,7 +4192,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 118,
+        "line_number": 117,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4200,7 +4200,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 130,
+        "line_number": 129,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -4208,7 +4208,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 136,
+        "line_number": 135,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -4216,7 +4216,7 @@
         "hashed_secret": "b02dff0ec9d24823e77c27c281a852247896b86d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 138,
+        "line_number": 137,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -4832,7 +4832,7 @@
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1397,
+        "line_number": 1396,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4842,7 +4842,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 160,
+        "line_number": 159,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4852,7 +4852,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 461,
+        "line_number": 398,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4862,7 +4862,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17941,
+        "line_number": 17920,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4872,7 +4872,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 129,
+        "line_number": 128,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -4892,7 +4892,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1464,
+        "line_number": 1463,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-22T17:06:12Z",
+  "generated_at": "2026-07-16T00:08:38Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -266,7 +266,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1889,
+        "line_number": 1746,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1977,
+        "line_number": 1834,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2327,
+        "line_number": 2184,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3692,
+        "line_number": 3549,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3783,
+        "line_number": 3640,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3826,
+        "line_number": 3683,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3831,
+        "line_number": 3688,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +322,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3836,
+        "line_number": 3693,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -342,7 +342,7 @@
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 521,
+        "line_number": 531,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +350,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 977,
+        "line_number": 987,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +358,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 979,
+        "line_number": 989,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +366,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1631,
+        "line_number": 1641,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +374,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1850,
+        "line_number": 1860,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5931,
+        "line_number": 5953,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6428,
+        "line_number": 6450,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6440,
+        "line_number": 6462,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6512,
+        "line_number": 6534,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7579,
+        "line_number": 7601,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -562,7 +562,7 @@
         "hashed_secret": "bc1a7c4dc707a3b61e2e9a345eec9e23674efa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1119,
+        "line_number": 1126,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -570,7 +570,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1426,
+        "line_number": 1433,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -580,7 +580,7 @@
         "hashed_secret": "c58a69e6abb14e59f5e5761ac85a933c671bda09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 306,
+        "line_number": 285,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -590,7 +590,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 61,
+        "line_number": 56,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -626,7 +626,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 824,
+        "line_number": 845,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -634,7 +634,7 @@
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 979,
+        "line_number": 1000,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1083,
+        "line_number": 1103,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1086,
+        "line_number": 1106,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1253,
+        "line_number": 1272,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1292,
+        "line_number": 1311,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1346,
+        "line_number": 1365,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1442,
+        "line_number": 1460,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -690,7 +690,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1813,
+        "line_number": 1831,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -756,7 +756,7 @@
         "hashed_secret": "b6f3674b78a02881de33177e6f6fb8b851e0101c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 243,
+        "line_number": 258,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -764,7 +764,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 338,
+        "line_number": 353,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -772,7 +772,7 @@
         "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 388,
+        "line_number": 403,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -780,7 +780,7 @@
         "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 396,
+        "line_number": 411,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -788,7 +788,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 444,
+        "line_number": 459,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -796,7 +796,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 947,
+        "line_number": 998,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -804,7 +804,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1050,
+        "line_number": 1101,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -812,7 +812,7 @@
         "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1056,
+        "line_number": 1107,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -820,7 +820,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1165,
+        "line_number": 1216,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -828,7 +828,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1200,
+        "line_number": 1251,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -836,7 +836,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1736,
+        "line_number": 1787,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -844,7 +844,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1984,
+        "line_number": 2035,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -852,7 +852,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2459,
+        "line_number": 2510,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -860,7 +860,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2459,
+        "line_number": 2510,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -868,7 +868,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2472,
+        "line_number": 2523,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -876,7 +876,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2620,
+        "line_number": 2671,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -884,7 +884,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2641,
+        "line_number": 2692,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -892,7 +892,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2649,
+        "line_number": 2700,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -900,7 +900,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2654,
+        "line_number": 2705,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1191,6 +1191,216 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 184,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "docs/docs/architecture/roadmap.md": [
+      {
+        "hashed_secret": "ff2ccd73154c1c71ef9a2982fe16e3c529e7a1ae",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 106,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "74f82b992f8a92b849c2be77447f98a510338333",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 107,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "64814a3b7fd8444a56ad3641fd3451c6deaf0757",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 115,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "af84d91fde168566c7dc18f3121ea2fbe651af1f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 144,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d1081e351fbebe0deb0c2867d5f731c8f9cc3fd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 397,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 398,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6d244f58364223afcc2322f696137b01ece78d9d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 399,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8bf177a72c93155020ebca9ee7f3c6e0fbdee946",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 417,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c41e6cd4245e404f07635fdbac351aad4d54a213",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 516,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6568a9761e26d16a111247f279b6fcabff1c8c86",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 551,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "314fc7fd580f8c510be196143946bbe5ea753443",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 552,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "afb9d1dcf212fa33d079a070ab90f0bef03c324b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 566,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 573,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7542c8f677ffbbe75a5301a5c76f88401dc42897",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 582,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ca20728d35f00c3a4c21b1fc8b0086b59f89df2d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 587,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5b7dcd14a4faa2cdd54cf6eb8d4bc35da31914a1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 599,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "245dbfa0498aaa6898fe57a191a5b3130466a943",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 620,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 622,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 625,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a603075604516de626cda903868e457fad826533",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 632,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "95ef18f58f32e3821ec7e627af6ee4757f68760e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 633,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b3aca92c793ee0e9b1a9b0a5f5fc044e05140df3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 671,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ae21c64a87f6bb0b8e16e55c48be4cc638d7bd3f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 682,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "58d1bbce297de3c304a9fefc3b483181872a5c6b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 684,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "de93ba2d15f3dbf65f76e6fd21e1e4b002459dd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 716,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "533739bb9d1dad53e71d8c93200cc2510d442226",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 719,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1644,7 +1854,7 @@
         "hashed_secret": "4729dd879b70a5a3ae4fa180ccbb4bea7b1d4ce2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 604,
+        "line_number": 617,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1850,7 +2060,7 @@
         "hashed_secret": "91174c4e6859da80df4e7ce9d45b35501f591210",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1559,
+        "line_number": 1432,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1858,7 +2068,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1600,
+        "line_number": 1473,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1930,7 +2140,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 821,
+        "line_number": 820,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1938,7 +2148,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1328,
+        "line_number": 1327,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -1946,7 +2156,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1332,
+        "line_number": 1331,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2218,7 +2428,7 @@
         "hashed_secret": "c92ae7357b37d02896900f57e76d315173fbf715",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 144,
+        "line_number": 127,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2226,7 +2436,7 @@
         "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 179,
+        "line_number": 162,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2234,7 +2444,7 @@
         "hashed_secret": "9b466094ec991a03cb95c489c19c4d75635f0ae5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 181,
+        "line_number": 164,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2770,7 +2980,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 636,
+        "line_number": 827,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -3838,7 +4048,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 749,
+        "line_number": 750,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -3848,7 +4058,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 176,
+        "line_number": 177,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3856,7 +4066,7 @@
         "hashed_secret": "1073ab6cda4b991cd29f9e83a307f34004ae9327",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 182,
+        "line_number": 183,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3864,7 +4074,7 @@
         "hashed_secret": "d4fe581561f18ee5006254a7e53f53cbed780bc2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 269,
+        "line_number": 270,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3874,7 +4084,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4576,
+        "line_number": 4577,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -3894,7 +4104,7 @@
         "hashed_secret": "6993a3fd94a012ab50fb6b9e97ec238310f0b177",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 105,
+        "line_number": 110,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3902,7 +4112,7 @@
         "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 132,
+        "line_number": 137,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3910,7 +4120,7 @@
         "hashed_secret": "9ec4f370c96047d96f3eb3637ca9fd144ed6e21b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 162,
+        "line_number": 167,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3918,7 +4128,7 @@
         "hashed_secret": "6947818ac409551f11fbaa78f0ea6391960aa5b8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 489,
+        "line_number": 494,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3964,7 +4174,7 @@
         "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 188,
+        "line_number": 189,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3972,7 +4182,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 315,
+        "line_number": 316,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3982,7 +4192,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 117,
+        "line_number": 118,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3990,7 +4200,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 129,
+        "line_number": 130,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -3998,7 +4208,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 135,
+        "line_number": 136,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -4006,7 +4216,7 @@
         "hashed_secret": "b02dff0ec9d24823e77c27c281a852247896b86d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 137,
+        "line_number": 138,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -4217,6 +4427,24 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 28,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "run-granian.sh": [
+      {
+        "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 291,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 406,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4604,7 +4832,7 @@
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1396,
+        "line_number": 1397,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4614,7 +4842,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 159,
+        "line_number": 160,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4624,7 +4852,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 398,
+        "line_number": 461,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4634,7 +4862,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17920,
+        "line_number": 17941,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4644,7 +4872,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 128,
+        "line_number": 129,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -4664,7 +4892,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1470,
+        "line_number": 1464,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-20T13:38:01Z",
+  "generated_at": "2026-07-23T07:19:18Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -266,7 +266,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1747,
+        "line_number": 1889,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1835,
+        "line_number": 1977,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2185,
+        "line_number": 2327,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3550,
+        "line_number": 3692,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3641,
+        "line_number": 3783,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3684,
+        "line_number": 3826,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3689,
+        "line_number": 3831,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +322,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3694,
+        "line_number": 3836,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -342,7 +342,7 @@
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 531,
+        "line_number": 521,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +350,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 987,
+        "line_number": 977,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +358,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 989,
+        "line_number": 979,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +366,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1641,
+        "line_number": 1631,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +374,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1860,
+        "line_number": 1850,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5963,
+        "line_number": 5931,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6460,
+        "line_number": 6428,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6472,
+        "line_number": 6440,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6544,
+        "line_number": 6512,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7611,
+        "line_number": 7579,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -562,7 +562,7 @@
         "hashed_secret": "bc1a7c4dc707a3b61e2e9a345eec9e23674efa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1126,
+        "line_number": 1119,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -570,7 +570,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1433,
+        "line_number": 1426,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -580,7 +580,7 @@
         "hashed_secret": "c58a69e6abb14e59f5e5761ac85a933c671bda09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 285,
+        "line_number": 305,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -590,7 +590,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 56,
+        "line_number": 61,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -626,7 +626,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 845,
+        "line_number": 824,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -634,7 +634,7 @@
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1000,
+        "line_number": 979,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1103,
+        "line_number": 1083,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1106,
+        "line_number": 1086,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1272,
+        "line_number": 1253,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1311,
+        "line_number": 1292,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1365,
+        "line_number": 1346,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1460,
+        "line_number": 1442,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -690,7 +690,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1831,
+        "line_number": 1813,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -756,7 +756,7 @@
         "hashed_secret": "b6f3674b78a02881de33177e6f6fb8b851e0101c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 258,
+        "line_number": 243,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -764,7 +764,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 353,
+        "line_number": 338,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -772,7 +772,7 @@
         "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 403,
+        "line_number": 388,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -780,7 +780,7 @@
         "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 411,
+        "line_number": 396,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -788,7 +788,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 459,
+        "line_number": 444,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -796,7 +796,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 998,
+        "line_number": 947,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -804,7 +804,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1101,
+        "line_number": 1050,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -812,7 +812,7 @@
         "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1107,
+        "line_number": 1056,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -820,7 +820,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1216,
+        "line_number": 1165,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -828,7 +828,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1251,
+        "line_number": 1200,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -836,7 +836,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1787,
+        "line_number": 1736,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -844,7 +844,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2035,
+        "line_number": 1984,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -852,7 +852,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2510,
+        "line_number": 2459,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -860,7 +860,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2510,
+        "line_number": 2459,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -868,7 +868,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2523,
+        "line_number": 2472,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -876,7 +876,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2671,
+        "line_number": 2620,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -884,7 +884,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2692,
+        "line_number": 2641,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -892,7 +892,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2700,
+        "line_number": 2649,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -900,7 +900,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2705,
+        "line_number": 2654,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1191,216 +1191,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 184,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "docs/docs/architecture/roadmap.md": [
-      {
-        "hashed_secret": "ff2ccd73154c1c71ef9a2982fe16e3c529e7a1ae",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 106,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "74f82b992f8a92b849c2be77447f98a510338333",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 107,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "64814a3b7fd8444a56ad3641fd3451c6deaf0757",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 115,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "af84d91fde168566c7dc18f3121ea2fbe651af1f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 144,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d1081e351fbebe0deb0c2867d5f731c8f9cc3fd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 397,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 398,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6d244f58364223afcc2322f696137b01ece78d9d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 399,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8bf177a72c93155020ebca9ee7f3c6e0fbdee946",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 417,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c41e6cd4245e404f07635fdbac351aad4d54a213",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 516,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6568a9761e26d16a111247f279b6fcabff1c8c86",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 551,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "314fc7fd580f8c510be196143946bbe5ea753443",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 552,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "afb9d1dcf212fa33d079a070ab90f0bef03c324b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 566,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 573,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "7542c8f677ffbbe75a5301a5c76f88401dc42897",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 582,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ca20728d35f00c3a4c21b1fc8b0086b59f89df2d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 587,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5b7dcd14a4faa2cdd54cf6eb8d4bc35da31914a1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 599,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "245dbfa0498aaa6898fe57a191a5b3130466a943",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 620,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 622,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 625,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a603075604516de626cda903868e457fad826533",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 632,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "95ef18f58f32e3821ec7e627af6ee4757f68760e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 633,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b3aca92c793ee0e9b1a9b0a5f5fc044e05140df3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 671,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ae21c64a87f6bb0b8e16e55c48be4cc638d7bd3f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 682,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "58d1bbce297de3c304a9fefc3b483181872a5c6b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 684,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "de93ba2d15f3dbf65f76e6fd21e1e4b002459dd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 716,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "533739bb9d1dad53e71d8c93200cc2510d442226",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 719,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1854,7 +1644,7 @@
         "hashed_secret": "4729dd879b70a5a3ae4fa180ccbb4bea7b1d4ce2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 617,
+        "line_number": 604,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2060,7 +1850,7 @@
         "hashed_secret": "91174c4e6859da80df4e7ce9d45b35501f591210",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1432,
+        "line_number": 1559,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2068,7 +1858,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1473,
+        "line_number": 1600,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2140,7 +1930,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 820,
+        "line_number": 821,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2148,7 +1938,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1327,
+        "line_number": 1328,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2156,7 +1946,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1331,
+        "line_number": 1332,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2428,7 +2218,7 @@
         "hashed_secret": "c92ae7357b37d02896900f57e76d315173fbf715",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 127,
+        "line_number": 144,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2436,7 +2226,7 @@
         "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 162,
+        "line_number": 179,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2444,7 +2234,7 @@
         "hashed_secret": "9b466094ec991a03cb95c489c19c4d75635f0ae5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 164,
+        "line_number": 181,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2980,7 +2770,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 827,
+        "line_number": 636,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -4431,24 +4221,6 @@
         "verified_result": null
       }
     ],
-    "run-granian.sh": [
-      {
-        "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 291,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 406,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "run-gunicorn.sh": [
       {
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
@@ -4892,7 +4664,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1463,
+        "line_number": 1470,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/charts/mcp-stack/profiles/ocp/values-pgo.yaml
+++ b/charts/mcp-stack/profiles/ocp/values-pgo.yaml
@@ -107,7 +107,6 @@ mcpContextForge:
             backend: "redis"
             redis_url: "redis://:{{ "{{" }} env.REDIS_PASSWORD {{ "}}" }}@{{ .Release.Name }}-mcp-stack-redis:6379/0"
             redis_key_prefix: "rl"
-            redis_fallback: true
             by_user: "30/m"
             by_tenant: "3000/m"
             by_tool: {}

--- a/docs/docs/api/plugin-bindings-api.md
+++ b/docs/docs/api/plugin-bindings-api.md
@@ -338,7 +338,7 @@ Rate strings use the format `<count>/<period>` where period is `s` (second) or `
 | `by_tool`   | object (string → string) \| null                           | `null`           | values: `<int>/s` or `<int>/m` | Per-tool rate limits as a map of `tool_name → rate`; `null` disables |
 | `algorithm` | `"fixed_window"` \| `"sliding_window"` \| `"token_bucket"` | `"fixed_window"` | —                              | Counting algorithm to use                                            |
 | `backend`   | `"memory"` \| `"redis"`                                    | `"memory"`       | —                              | Storage backend for counters; `"redis"` shares state across replicas, `"memory"` is local to each worker |
-| `fail_mode` | `"open"` \| `"closed"`                                     | `"open"`         | —                              | Behaviour when the `"redis"` backend is unreachable: `"open"` falls back to in-process memory counters (availability-first); `"closed"` blocks requests until Redis recovers (enforcement-first); ignored when `backend` is `"memory"` |
+| `fail_mode` | `"open"` \| `"closed"`                                     | `"open"`         | —                              | Behaviour when the `"redis"` backend is unreachable: `"open"` allows requests through without counting them (availability-first); `"closed"` blocks requests until Redis recovers (enforcement-first); ignored when `backend` is `"memory"` |
 
 > When `backend` is `"redis"`, the Redis connection URL is configured via `redis_url` in `plugins/config.yaml` — it is **not** a binding payload field. Gateway operators set it once at deployment time; binding-API users should not override it per-tenant.
 

--- a/plugins/config.yaml
+++ b/plugins/config.yaml
@@ -310,7 +310,6 @@ plugins:
       # separate container, ensure that host is reachable from within it.
       redis_url: '{{ env.RATELIMITER_REDIS_URL | default(env.REDIS_URL | default("redis://redis:6379/0")) }}'
       redis_key_prefix: "rl"
-      redis_fallback: true
       algorithm: "fixed_window"
       by_user: "30/m"
       by_tenant: "3000/m"

--- a/tests/integration/test_plugins_config_yaml_validation.py
+++ b/tests/integration/test_plugins_config_yaml_validation.py
@@ -17,12 +17,18 @@ The schema-alignment check runs without Redis and stays green everywhere.
 
 # Standard
 import logging
+import pathlib
 
 # Third-Party
 import pytest
 
 # First-Party
-from cpex.framework import ConfigLoader
+from cpex.framework import ConfigLoader, PluginLoader
+
+# Anchor the config path to this file's location so the test works regardless
+# of the directory pytest is invoked from (repo root, tests/, etc.).
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_CONFIG_YAML = str(_REPO_ROOT / "plugins" / "config.yaml")
 
 
 @pytest.mark.asyncio
@@ -39,15 +45,14 @@ async def test_shipped_plugins_config_has_no_unknown_keys(caplog, monkeypatch):
     in the hope a feature exists when it doesn't) all silently pollute
     operators' logs and pull focus during incident response.
 
-    This test is the regression guard against that drift.  It loads the
-    yaml, instantiates each plugin via the plugin-framework loader (which
-    invokes the plugin's ``__init__`` and therefore any unknown-key
-    warnings), and asserts the captured log records contain none of those
-    warnings.
+    This test is the regression guard against that drift.  It loads the yaml
+    and loads each plugin through the framework loader (which invokes the
+    plugin's ``__init__`` and therefore any unknown-key warnings), then asserts
+    the captured log records contain none of those warnings.
 
-    Constructions that raise (e.g. a plugin requiring a Redis it can't
-    reach) are tolerated — that's a *connectivity* concern, not a *schema*
-    concern, and the warning still fires before the connection attempt.
+    Loads that raise (e.g. a plugin whose optional dependency is absent) are
+    tolerated — that's not a *schema* concern, and the unknown-key warning
+    fires during loading regardless.
     """
     # Inject a default REDIS_URL so the rate-limiter's Jinja substitution
     # resolves even when the test runner hasn't set the env var.  The
@@ -56,22 +61,28 @@ async def test_shipped_plugins_config_has_no_unknown_keys(caplog, monkeypatch):
     # validation time, which precedes the network attempt.
     monkeypatch.setenv("REDIS_URL", "redis://127.0.0.1:6379/0")
 
-    # First-Party — local import so test-collection doesn't pay for it
-    # in environments where mcpgateway isn't fully installed.
-    from cpex.framework import PluginLoader  # noqa: PLC0415
-
-    cfg = ConfigLoader.load_config("plugins/config.yaml")
+    cfg = ConfigLoader.load_config(_CONFIG_YAML)
     loader = PluginLoader()
 
+    constructed = 0
     with caplog.at_level(logging.WARNING):
         for plugin_cfg in cfg.plugins:
             try:
+                # Load via the framework loader (build + initialise) — the same
+                # path the gateway uses at startup.  We keep initialise() rather
+                # than only constructing so the guard mirrors real startup and
+                # still catches unknown-key warnings even if a future plugin
+                # surfaces them at initialise() instead of __init__.
                 await loader.load_and_instantiate_plugin(plugin_cfg)
+                constructed += 1
             except Exception:
-                # Plugin construction may fail for connectivity / other
-                # runtime reasons; the unknown-key warning fires earlier
-                # at schema-validation time and is still captured.
+                # A plugin may fail to load (optional dependency absent, etc.);
+                # the unknown-key warning fires during loading and is still captured.
                 pass
+
+    # Fail rather than pass on zero checks: an empty config or an all-failed
+    # load would otherwise verify nothing.
+    assert constructed, "No plugins were loaded from plugins/config.yaml — check the config path."
 
     unknown_warnings = [
         r.getMessage()

--- a/tests/integration/test_plugins_config_yaml_validation.py
+++ b/tests/integration/test_plugins_config_yaml_validation.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/integration/test_plugins_config_yaml_validation.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Pratik Gandhi
+
+Validation test for the gateway's shipped ``plugins/config.yaml``.
+
+Pins one contract about the *yaml as shipped* matching the plugins it
+configures: loading ``plugins/config.yaml`` and constructing each plugin
+produces zero ``unknown config key`` warnings — every key in every plugin's
+``config:`` block must be in that plugin's accepted schema.  Catches
+stale / typo / aspirational keys before they reach operators' logs.
+
+The schema-alignment check runs without Redis and stays green everywhere.
+"""
+
+# Standard
+import logging
+
+# Third-Party
+import pytest
+
+# First-Party
+from cpex.framework import ConfigLoader
+
+
+@pytest.mark.asyncio
+async def test_shipped_plugins_config_has_no_unknown_keys(caplog, monkeypatch):
+    """Loading ``plugins/config.yaml`` and constructing each plugin must
+    produce zero ``unknown config key`` warnings.
+
+    Plugins that emit those warnings (currently the rate-limiter's Rust
+    engine; future plugins may follow the same pattern) accept a fixed
+    schema and warn at WARN-level when an unrecognised key appears in
+    their ``config:`` block.  The shipped yaml should never contain such
+    keys: stale ones (left behind after a rename), typos
+    (``redis_ur`` instead of ``redis_url``), or aspirational ones (added
+    in the hope a feature exists when it doesn't) all silently pollute
+    operators' logs and pull focus during incident response.
+
+    This test is the regression guard against that drift.  It loads the
+    yaml, instantiates each plugin via the plugin-framework loader (which
+    invokes the plugin's ``__init__`` and therefore any unknown-key
+    warnings), and asserts the captured log records contain none of those
+    warnings.
+
+    Constructions that raise (e.g. a plugin requiring a Redis it can't
+    reach) are tolerated — that's a *connectivity* concern, not a *schema*
+    concern, and the warning still fires before the connection attempt.
+    """
+    # Inject a default REDIS_URL so the rate-limiter's Jinja substitution
+    # resolves even when the test runner hasn't set the env var.  The
+    # plugin's connection attempt may still fail (no Redis required for
+    # this test); we only care about warnings emitted at config-key
+    # validation time, which precedes the network attempt.
+    monkeypatch.setenv("REDIS_URL", "redis://127.0.0.1:6379/0")
+
+    # First-Party — local import so test-collection doesn't pay for it
+    # in environments where mcpgateway isn't fully installed.
+    from cpex.framework import PluginLoader  # noqa: PLC0415
+
+    cfg = ConfigLoader.load_config("plugins/config.yaml")
+    loader = PluginLoader()
+
+    with caplog.at_level(logging.WARNING):
+        for plugin_cfg in cfg.plugins:
+            try:
+                await loader.load_and_instantiate_plugin(plugin_cfg)
+            except Exception:
+                # Plugin construction may fail for connectivity / other
+                # runtime reasons; the unknown-key warning fires earlier
+                # at schema-validation time and is still captured.
+                pass
+
+    unknown_warnings = [
+        r.getMessage()
+        for r in caplog.records
+        if "unknown config key" in r.getMessage().lower()
+    ]
+    assert not unknown_warnings, (
+        f"plugins/config.yaml contains config keys the corresponding plugins "
+        f"do not recognise.  Drop them from the yaml or fix typos.  "
+        f"Captured warnings: {unknown_warnings}"
+    )

--- a/tests/integration/test_plugins_config_yaml_validation.py
+++ b/tests/integration/test_plugins_config_yaml_validation.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """Location: ./tests/integration/test_plugins_config_yaml_validation.py
-Copyright 2026
+Copyright contributors to the MCP-CONTEXT-FORGE project
 SPDX-License-Identifier: Apache-2.0
-Authors: Pratik Gandhi
 
 Validation test for the gateway's shipped ``plugins/config.yaml``.
 

--- a/tests/integration/test_rate_limiter.py
+++ b/tests/integration/test_rate_limiter.py
@@ -1206,15 +1206,20 @@ class TestRedisBackendIntegration:
         assert result.violation is None, "After the rate window expires, Redis TTL must reset counters and allow fresh requests"
 
     @pytest.mark.asyncio
-    async def test_redis_fallback_to_memory_on_unavailable_redis(self):
-        """Plugin with an unreachable Redis URL falls back to memory backend without crashing."""
+    async def test_unavailable_redis_fails_open_by_default(self):
+        """An unavailable Redis URL fails open by default: the request is allowed, not blocked, and nothing crashes.
+
+        There is no memory fallback. When Redis is unavailable, the plugin is governed by fail_mode
+        it decides what happens, and it defaults to "open" (allow the request).
+        This test pins that default; fail_mode "closed" would block instead.
+        """
         plugin = _make_redis_plugin("redis://127.0.0.1:19999/0", limit="3/s")
         ctx = PluginContext(global_context=GlobalContext(request_id="r1", user="alice"))
         payload = ToolPreInvokePayload(name="tool", arguments={})
 
-        # Must not raise — fallback to memory backend should handle the request
+        # Default fail_mode is "open", so an unavailable Redis allows the request rather than raising.
         result = await plugin.tool_pre_invoke(payload, ctx)
-        assert result.violation is None, "Plugin must fall back to memory backend when Redis is unavailable — must not crash"
+        assert result.violation is None, "With the default fail_mode 'open', an unavailable Redis backend must allow the request, not crash"
 
     # ------------------------------------------------------------------
     # sliding_window on real Redis

--- a/tests/integration/test_rate_limiter.py
+++ b/tests/integration/test_rate_limiter.py
@@ -1209,9 +1209,9 @@ class TestRedisBackendIntegration:
     async def test_unavailable_redis_fails_open_by_default(self):
         """An unavailable Redis URL fails open by default: the request is allowed, not blocked, and nothing crashes.
 
-        There is no memory fallback. When Redis is unavailable, the plugin is governed by fail_mode
-        it decides what happens, and it defaults to "open" (allow the request).
-        This test pins that default; fail_mode "closed" would block instead.
+        There is no memory fallback. When Redis is unavailable, the plugin's
+        behaviour is governed by fail_mode, which defaults to "open" (allow the
+        request). This test pins that default; fail_mode "closed" would block instead.
         """
         plugin = _make_redis_plugin("redis://127.0.0.1:19999/0", limit="3/s")
         ctx = PluginContext(global_context=GlobalContext(request_id="r1", user="alice"))

--- a/tests/integration/test_rate_limiter_dynamic_behavior.py
+++ b/tests/integration/test_rate_limiter_dynamic_behavior.py
@@ -11,7 +11,7 @@ actually affect rate limiting behavior on tool calls.
 The rate limiter is configured in plugins/config.yaml with:
     mode: "disabled"
     by_user: "30/m"
-    backend: "redis" (with redis_fallback: true)
+    backend: "redis"
 
 Tests toggle the mode at runtime and verify tool calls are rate-limited
 (or not) accordingly.

--- a/tests/performance/plugins/config.yaml
+++ b/tests/performance/plugins/config.yaml
@@ -309,7 +309,6 @@ plugins:
       algorithm: fixed_window
       backend: redis
       redis_url: redis://localhost:6379/0
-      redis_fallback: true
 
   # Rate limiter (sliding_window algorithm, Redis backend)
   - name: RateLimiterPlugin_redis_sliding_window
@@ -330,7 +329,6 @@ plugins:
       algorithm: sliding_window
       backend: redis
       redis_url: redis://localhost:6379/0
-      redis_fallback: true
 
   # Rate limiter (token_bucket algorithm, Redis backend)
   - name: RateLimiterPlugin_redis_token_bucket
@@ -351,7 +349,6 @@ plugins:
       algorithm: token_bucket
       backend: redis
       redis_url: redis://localhost:6379/0
-      redis_fallback: true
 
   # Schema guard for tool args/results (subset JSONSchema)
   - name: SchemaGuardPlugin

--- a/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
+++ b/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
@@ -74,7 +74,6 @@ _RL: dict = {
     "backend": "memory",
     "redis_url": None,
     "redis_key_prefix": "rl",
-    "redis_fallback": True,
 }
 
 

--- a/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
+++ b/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
@@ -109,7 +109,6 @@ _RL: dict = {
     "backend": "memory",
     "redis_url": None,
     "redis_key_prefix": "rl",
-    "redis_fallback": True,
 }
 
 

--- a/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
@@ -71,7 +71,6 @@ _RL: dict = {
     "backend": "memory",
     "redis_url": None,
     "redis_key_prefix": "rl",
-    "redis_fallback": True,
 }
 
 _SD: dict = {


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #4603

---

## 📝 Summary

The rate limiter used to be Python code that lived inside this repo, and it had a `redis_fallback` option: if Redis went down, keep counting requests in local memory instead of failing.

That in-repo rate limiter was later replaced by an installed package, `cpex-rate-limiter` (a Rust rewrite). The new one has no `redis_fallback` option at all. What happens when Redis is unreachable is now decided by a different setting, `fail_mode`, which defaults to `"open"` (let requests through).

`redis_fallback` was not removed from the shipped config files, the OCP Helm chart, the docs, or the test fixtures. So on every gateway boot the new rate limiter hits a key it doesn't recognise and logs `unknown config key(s): redis_fallback`, then ignores it. This leaves a confusing warning in operators' logs and docs that describe a feature that no longer exists.

This PR removes the dead key everywhere it survived, fixes the docs that still describe the old behaviour, renames a test whose name described the removed mechanism, and adds a guard test so an unrecognised config key can't slip back in unnoticed.
### Changes

- Removed `redis_fallback` from `plugins/config.yaml`, `tests/performance/plugins/config.yaml` (×3), `charts/mcp-stack/profiles/ocp/values-pgo.yaml`, and three unit-test mock fixtures.
- Renamed `test_redis_fallback_to_memory_on_unavailable_redis` → `test_unavailable_redis_fails_open_by_default`; the assertion passed only by virtue of the `fail_mode: "open"` default, so the name/docstring now describe what is actually verified.
- Added `tests/integration/test_plugins_config_yaml_validation.py::test_shipped_plugins_config_has_no_unknown_keys`. Loads `plugins/config.yaml`, constructs each plugin via the framework loader, and asserts zero `unknown config key` warnings.

### Two same-root-cause fixes bundled in

Both surfaced while removing the key:

- Dropped a stale `(with redis_fallback: true)` note from the `test_rate_limiter_dynamic_behavior.py` docstring.
- Corrected the `fail_mode: "open"` row in `docs/docs/api/plugin-bindings-api.md`, which incorrectly claimed it "falls back to in-process memory counters" — the current engine allows the request through without counting.
---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| New regression test | `pytest tests/integration/test_plugins_config_yaml_validation.py --with-integration` | ✅ 1 passed |
| Renamed test | `pytest tests/integration/test_rate_limiter.py -k unavailable_redis_fails_open --with-integration` | ✅ 1 passed |
| Edited unit fixtures | `pytest tests/unit/.../test_tool_plugin_bindings.py tests/unit/.../test_gateway_plugin_manager.py tests/unit/.../test_tool_plugin_binding_service.py` | ✅ 142 passed |

**Guard proven, not just green:** Re-injecting `redis_fallback: true` into `plugins/config.yaml` makes the new test fail with exactly one captured `unknown config key(s): redis_fallback` warning; removing it returns the suite to zero. Guard fails correctly.

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

The regression test is credited to **Pratik Gandhi** (`Authors:` header). It was drafted *during* #4582 but pulled out before that PR merged (per #4603), then parked on branch `chore/rate-limiter-redis-fallback-cleanup-wip` ([commit `5caa753a`](https://github.com/IBM/mcp-context-forge/commit/5caa753a0)). This PR adapts it from that branch. changes from the draft:

- Loader imports repointed from `mcpgateway.plugins.framework.loader.*` to `cpex.framework` (the framework moved into the `cpex` package after the draft was written). This is the only change to the test's logic.