### PR TITLE
feat(vault): resolve per-user creds from Vault for all auth types

### DIFF
--- a/mcpgateway/services/token_backends/vault_backend.py
+++ b/mcpgateway/services/token_backends/vault_backend.py
@@ -418,6 +418,39 @@ class VaultTokenBackend(AbstractTokenBackend):
 
         return access_token
 
+    async def get_user_auth_headers(
+        self,
+        gateway_id: str,
+        team_id: str,
+        app_user_email: str,
+    ) -> dict | None:
+        """Get per-user non-OAuth auth headers from Vault.
+
+        For non-OAuth credential types (bearer / basic / authheaders) ICA writes the
+        credential as a plain ``{header: value}`` dict under a ``headers`` field at the
+        SAME per-user Vault path used for OAuth tokens. This returns that dict so the
+        caller can merge it into the upstream request headers, exactly like the
+        gateway-wide static auth path does.
+
+        Args:
+            gateway_id: Gateway ID (resolved to mcp_url)
+            team_id: Team identifier
+            app_user_email: ContextForge user email
+
+        Returns:
+            The ``{header: value}`` dict, or None if no per-user record / no headers field.
+        """
+        mcp_url = self._resolve_mcp_url(gateway_id)
+        path = self._construct_vault_path(team_id, mcp_url, app_user_email)
+        result = await self._vault_request("GET", path)
+        if not result or "data" not in result:
+            return None
+        data = result["data"]["data"]
+        headers = data.get("headers")
+        if isinstance(headers, dict) and headers:
+            return {str(k): str(v) for k, v in headers.items() if k and v}
+        return None
+
     async def get_token_info(
         self,
         gateway_id: str,

--- a/mcpgateway/services/token_storage_service.py
+++ b/mcpgateway/services/token_storage_service.py
@@ -283,6 +283,33 @@ class TokenStorageService:
             threshold_seconds=threshold_seconds,
         )
 
+    async def get_user_auth_headers(
+        self,
+        gateway_id: str,
+        app_user_email: str,
+    ) -> Optional[Dict[str, str]]:
+        """Get per-user non-OAuth auth headers (bearer/basic/authheaders) for a user.
+
+        Only the Vault backend stores these (written by ICA as a ``headers`` dict at the
+        per-user path). Returns None for backends that don't support it.
+
+        Args:
+            gateway_id: ID of the gateway
+            app_user_email: ContextForge user email (required)
+
+        Returns:
+            The ``{header: value}`` dict, or None.
+        """
+        backend_getter = getattr(self._backend, "get_user_auth_headers", None)
+        if backend_getter is None:
+            return None
+        team_id = self._get_team_id(gateway_id, app_user_email)
+        return await backend_getter(
+            gateway_id=gateway_id,
+            team_id=team_id,
+            app_user_email=app_user_email,
+        )
+
     async def get_token_info(
         self,
         gateway_id: str,

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -4409,7 +4409,31 @@ class ToolService(BaseService):
                     logger.error("Failed to obtain OAuth access token for gateway %s: %s", gateway_name, e)
                     raise ToolInvocationError(f"OAuth authentication failed for gateway: {str(e)}")
         else:
-            headers = decode_auth(gateway_auth_value) if gateway_auth_value else {}
+            # Non-OAuth auth types (bearer / basic / authheaders / none): resolve PER-USER creds
+            # from Vault FIRST, then fall back to the gateway-wide (admin-set) static auth. ICA
+            # writes the per-user credential as a plain {header: value} dict under a `headers` field
+            # at the same per-user Vault path used for OAuth tokens.
+            headers = {}
+            if app_user_email:
+                try:
+                    # First-Party
+                    from mcpgateway.services.token_storage_service import TokenStorageService, build_token_user_context  # pylint: disable=import-outside-toplevel
+
+                    with fresh_db_session() as token_db:
+                        token_storage_context = build_token_user_context(token_db, app_user_email, token_teams)
+                        token_storage = TokenStorageService(token_db, user_context=token_storage_context)
+                        user_headers = await token_storage.get_user_auth_headers(gateway_id_str, app_user_email)
+                    if user_headers:
+                        headers = user_headers
+                        logger.info(
+                            "Using per-user Vault auth headers for gateway '%s' (user=%s)",
+                            gateway_name,
+                            app_user_email,
+                        )
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.warning("Per-user Vault auth-header lookup failed for gateway %s: %s; falling back to gateway auth", gateway_name, e)
+            if not headers:
+                headers = decode_auth(gateway_auth_value) if gateway_auth_value else {}
 
         if request_headers:
             # B3: when the gateway uses token-exchange, the exchanged Authorization header
@@ -5682,7 +5706,24 @@ class ToolService(BaseService):
                                 logger.error("Failed to obtain OAuth access token for gateway %s: %s", gateway_name, e)
                                 raise ToolInvocationError(f"OAuth authentication failed for gateway: {str(e)}")
                     else:
-                        headers = decode_auth(gateway_auth_value) if gateway_auth_value else {}
+                        # Non-OAuth: per-user Vault creds FIRST, then gateway-wide static auth.
+                        headers = {}
+                        if app_user_email:
+                            try:
+                                # First-Party
+                                from mcpgateway.services.token_storage_service import TokenStorageService, build_token_user_context  # pylint: disable=import-outside-toplevel
+
+                                with fresh_db_session() as token_db:
+                                    token_storage_context = build_token_user_context(token_db, app_user_email, token_teams)
+                                    token_storage = TokenStorageService(token_db, user_context=token_storage_context)
+                                    user_headers = await token_storage.get_user_auth_headers(gateway_id_str, app_user_email)
+                                if user_headers:
+                                    headers = user_headers
+                                    logger.info("Using per-user Vault auth headers for gateway '%s' (user=%s)", gateway_name, app_user_email)
+                            except Exception as e:  # pylint: disable=broad-except
+                                logger.warning("Per-user Vault auth-header lookup failed for gateway %s: %s; falling back to gateway auth", gateway_name, e)
+                        if not headers:
+                            headers = decode_auth(gateway_auth_value) if gateway_auth_value else {}
 
                     # Use cached passthrough headers (no DB query needed)
                     if request_headers:


### PR DESCRIPTION
## Summary

Extends the Vault OAuth token backend (added in #5599) so per-user credentials are read from Vault for non-OAuth auth types too, not just OAuth `authorization_code`.

- `VaultTokenBackend.get_user_auth_headers` + `TokenStorageService` facade: read a per-user `{header: value}` dict stored under a `headers` field at the same per-user Vault path used for OAuth tokens.
- `tool_service` invoke paths: for non-OAuth gateways, resolve per-user Vault headers FIRST, then fall back to the gateway-wide (admin-set) static auth.

This lets ICA write per-user bearer/basic/authheaders creds to Vault which ContextForge injects at invocation, consistent with the OAuth flow.

## Notes

Targets the #5599 branch (`feat_contextforge-pluggable-token-storage`) since it builds directly on the pluggable token storage work.