### PR TITLE
fix(api): use savepoint for personal team cascade delete and reorder FK deletes

### DIFF
--- a/mcpgateway/services/email_auth_service.py
+++ b/mcpgateway/services/email_auth_service.py
@@ -2139,11 +2139,11 @@ class EmailAuthService:
 
         except IntegrityError as e:
             self.db.rollback()
-            logger.error(f"FK constraint violation deleting user {SecurityValidator.sanitize_log_message(email)}: {e}")
+            logger.error("FK constraint violation deleting user %s: %s", SecurityValidator.sanitize_log_message(email), str(e))
             raise ValueError("Cannot delete user due to existing references") from e
         except Exception as e:
             self.db.rollback()
-            logger.error("Error deleting user %s: %s", SecurityValidator.sanitize_log_message(email), e)
+            logger.error("Error deleting user %s: %s", SecurityValidator.sanitize_log_message(email), e, exc_info=True)
             raise
 
     async def count_active_admin_users(self) -> int:

--- a/mcpgateway/services/email_auth_service.py
+++ b/mcpgateway/services/email_auth_service.py
@@ -2076,18 +2076,18 @@ class EmailAuthService:
 
                         if len(all_members) == 1 and all_members[0].user_email == email:
                             # This is a single-user personal team - cascade delete it
-                            logger.info(f"Deleting personal team '{SecurityValidator.sanitize_log_message(team.name)}' (single member: {SecurityValidator.sanitize_log_message(email)})")
-                            # Delete history records first: team_id FK has no ON DELETE CASCADE,
-                            # so history must be removed before the team is deleted.
-                            self.db.execute(delete(EmailTeamMemberHistory).where(EmailTeamMemberHistory.team_id == team.id))
-                            # Delete team members via raw SQL.
-                            self.db.execute(delete(EmailTeamMember).where(EmailTeamMember.team_id == team.id))
-                            # Expire the members collection so the ORM cascade re-queries the DB
-                            # (finding nothing) instead of re-deleting already-gone objects,
-                            # which would raise StaleDataError at commit time.
-                            self.db.expire(team, ["members"])
-                            # Delete the team
-                            self.db.delete(team)
+                            logger.info("Deleting personal team '%s' (single member: %s)", SecurityValidator.sanitize_log_message(team.name), SecurityValidator.sanitize_log_message(email))
+                            with self.db.begin_nested():
+                                # Delete history records first: team_id FK has no ON DELETE CASCADE,
+                                # so history must be removed before the team is deleted.
+                                self.db.execute(delete(EmailTeamMemberHistory).where(EmailTeamMemberHistory.team_id == team.id))
+                                # Delete team members via raw SQL.
+                                self.db.execute(delete(EmailTeamMember).where(EmailTeamMember.team_id == team.id))
+                                # Expire the members collection so the ORM cascade re-queries the DB
+                                # (finding nothing) instead of re-deleting already-gone objects,
+                                # which would raise StaleDataError at commit time.
+                                self.db.expire(team, ["members"])
+                                self.db.delete(team)
                         else:
                             # Multi-member team with no other owners - cannot delete user
                             raise ValueError(f"Cannot delete user {email}: owns team '{team.name}' with {len(all_members)} members but no other owners to transfer ownership to")
@@ -2116,16 +2116,17 @@ class EmailAuthService:
             self.db.query(PendingUserApproval).filter(PendingUserApproval.approved_by == email).update({PendingUserApproval.approved_by: None}, synchronize_session=False)
             self.db.query(SSOAuthSession).filter(SSOAuthSession.user_email == email).update({SSOAuthSession.user_email: None}, synchronize_session=False)
 
+            # Remove user from all team memberships BEFORE deleting teams
+            # This prevents FK constraint issues when teams are deleted
+            team_members_stmt = delete(EmailTeamMember).where(EmailTeamMember.user_email == email)
+            self.db.execute(team_members_stmt)
+
             # Remove rows where this user is the primary subject.
             self.db.query(EmailTeamJoinRequest).filter(EmailTeamJoinRequest.user_email == email).delete(synchronize_session=False)
 
             # Delete related auth events
             auth_events_stmt = delete(EmailAuthEvent).where(EmailAuthEvent.user_email == email)
             self.db.execute(auth_events_stmt)
-
-            # Remove user from all team memberships
-            team_members_stmt = delete(EmailTeamMember).where(EmailTeamMember.user_email == email)
-            self.db.execute(team_members_stmt)
 
             # Delete the user
             self.db.delete(user)
@@ -2136,6 +2137,10 @@ class EmailAuthService:
             logger.info("User %s deleted permanently", SecurityValidator.sanitize_log_message(email))
             return True
 
+        except IntegrityError as e:
+            self.db.rollback()
+            logger.error(f"FK constraint violation deleting user {SecurityValidator.sanitize_log_message(email)}: {e}")
+            raise ValueError("Cannot delete user due to existing references") from e
         except Exception as e:
             self.db.rollback()
             logger.error("Error deleting user %s: %s", SecurityValidator.sanitize_log_message(email), e)

--- a/tests/unit/mcpgateway/services/test_email_auth_basic.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_basic.py
@@ -2717,9 +2717,9 @@ class TestEmailAuthServiceUserDeletion:
             mock_no_owners,  # No other owners
             mock_single_member,  # Just the user as member
             mock_empty,  # Delete team member history records
-            mock_empty,  # Delete team members
+            mock_empty,  # Delete team members (for the team)
+            mock_empty,  # Delete team members (remove user from all teams)
             mock_empty,  # Delete auth events
-            mock_empty,  # Delete user team members
         ]
 
         mock_role_svc = MagicMock()
@@ -2774,6 +2774,97 @@ class TestEmailAuthServiceUserDeletion:
         mock_db.commit.side_effect = Exception("Database error")
 
         with pytest.raises(Exception, match="Database error"):
+            await service.delete_user("test@example.com")
+
+        mock_db.rollback.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_user_integrity_error_raises_value_error(self, service, mock_db, mock_user):
+        """FK constraint violation on commit raises ValueError with user-friendly message."""
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_user
+        mock_result.scalars.return_value.all.return_value = []
+        mock_db.execute.return_value = mock_result
+        mock_db.commit.side_effect = IntegrityError("fk violation", None, None)
+
+        with pytest.raises(ValueError, match="Cannot delete user due to existing references"):
+            await service.delete_user("test@example.com")
+
+        mock_db.rollback.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_user_cascade_uses_savepoint(self, service, mock_db, mock_user, mock_team):
+        """Personal team cascade deletion uses begin_nested() savepoint."""
+        single_member = MagicMock(spec=EmailTeamMember)
+        single_member.user_email = "test@example.com"
+        single_member.team_id = 1
+
+        mock_user_result = MagicMock()
+        mock_user_result.scalar_one_or_none.return_value = mock_user
+
+        mock_teams_result = MagicMock()
+        mock_teams_result.scalars.return_value.all.return_value = [mock_team]
+
+        mock_no_owners = MagicMock()
+        mock_no_owners.scalars.return_value.all.return_value = []
+
+        mock_single_member = MagicMock()
+        mock_single_member.scalars.return_value.all.return_value = [single_member]
+
+        mock_empty = MagicMock()
+        mock_db.execute.side_effect = [
+            mock_user_result,
+            mock_teams_result,
+            mock_no_owners,
+            mock_single_member,
+            mock_empty,  # delete history
+            mock_empty,  # delete team members
+            mock_empty,  # delete user memberships
+            mock_empty,  # delete auth events
+        ]
+
+        # begin_nested() must return a context manager
+        mock_savepoint = MagicMock()
+        mock_savepoint.__enter__ = MagicMock(return_value=mock_savepoint)
+        mock_savepoint.__exit__ = MagicMock(return_value=False)
+        mock_db.begin_nested.return_value = mock_savepoint
+
+        mock_role_svc = MagicMock()
+        mock_role_svc.delete_all_user_roles = AsyncMock(return_value=0)
+
+        with patch.object(type(service), "role_service", new_callable=lambda: property(lambda self: mock_role_svc)):
+            result = await service.delete_user("test@example.com")
+
+        assert result is True
+        mock_db.begin_nested.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_user_cascade_savepoint_failure_rolls_back(self, service, mock_db, mock_user, mock_team):
+        """If cascade savepoint raises, the whole transaction rolls back."""
+        single_member = MagicMock(spec=EmailTeamMember)
+        single_member.user_email = "test@example.com"
+        single_member.team_id = 1
+
+        mock_user_result = MagicMock()
+        mock_user_result.scalar_one_or_none.return_value = mock_user
+
+        mock_teams_result = MagicMock()
+        mock_teams_result.scalars.return_value.all.return_value = [mock_team]
+
+        mock_no_owners = MagicMock()
+        mock_no_owners.scalars.return_value.all.return_value = []
+
+        mock_single_member = MagicMock()
+        mock_single_member.scalars.return_value.all.return_value = [single_member]
+
+        mock_db.execute.side_effect = [mock_user_result, mock_teams_result, mock_no_owners, mock_single_member]
+
+        mock_savepoint = MagicMock()
+        mock_savepoint.__enter__ = MagicMock(return_value=mock_savepoint)
+        mock_savepoint.__exit__ = MagicMock(side_effect=Exception("savepoint failed"))
+        mock_db.begin_nested.return_value = mock_savepoint
+
+        with pytest.raises(Exception):
             await service.delete_user("test@example.com")
 
         mock_db.rollback.assert_called()

--- a/tests/unit/mcpgateway/services/test_email_auth_basic.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_basic.py
@@ -2709,17 +2709,20 @@ class TestEmailAuthServiceUserDeletion:
         mock_single_member = MagicMock()
         mock_single_member.scalars.return_value.all.return_value = [single_member]
 
-        mock_empty = MagicMock()
+        mock_delete_history = MagicMock()
+        mock_delete_team_members_for_team = MagicMock()
+        mock_delete_team_members_all = MagicMock()
+        mock_delete_auth_events = MagicMock()
 
         mock_db.execute.side_effect = [
             mock_user_result,
             mock_teams_result,
             mock_no_owners,  # No other owners
             mock_single_member,  # Just the user as member
-            mock_empty,  # Delete team member history records
-            mock_empty,  # Delete team members (for the team)
-            mock_empty,  # Delete team members (remove user from all teams)
-            mock_empty,  # Delete auth events
+            mock_delete_history,  # Delete team member history records
+            mock_delete_team_members_for_team,  # Delete team members (for the team)
+            mock_delete_team_members_all,  # Delete team members (remove user from all teams)
+            mock_delete_auth_events,  # Delete auth events
         ]
 
         mock_role_svc = MagicMock()


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 🔗 Epic / Issue

Closes #5658

---

## 🚀 Summary (1-2 sentences)

Wrapped personal-team cascade delete in db.begin_nested() savepoint (fixes StaleDataError from ORM re-deleting already-removed member rows) and moved user's team-membership cleanup before other FK-dependent deletes, catching IntegrityError into a clean ValueError instead of leaking raw DB errors.

---

## 📏 Reviewability

- [X] This PR has one clear purpose
- [X] The linked issue is not labeled `triage`
- [X] Unrelated bugs or improvements are tracked in separate issues/PRs
- [X] Tests are included with the code they validate
- [X] If AI-assisted, I understand and can explain the generated changes