### PR TITLE
feat(api): support popup-based authorization flow for React UI

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -258,7 +258,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1925,
+        "line_number": 1926,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2013,
+        "line_number": 2014,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2363,
+        "line_number": 2364,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3728,
+        "line_number": 3729,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3819,
+        "line_number": 3820,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3862,
+        "line_number": 3863,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3867,
+        "line_number": 3868,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3872,
+        "line_number": 3873,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2234,7 +2234,7 @@
         "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 179,
+        "line_number": 254,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2242,7 +2242,7 @@
         "hashed_secret": "9b466094ec991a03cb95c489c19c4d75635f0ae5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 181,
+        "line_number": 256,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - **`make setup`** - For fresh checkouts: copies `.env.example` → `.env` and runs `init-secrets-patch-env` to provision real secrets before first use.
 - **`mcpgateway/scripts/init_secrets.py`** - Script backing both Makefile targets; generates secrets using `secrets.token_hex(32)` and rewrites the relevant lines in `.env` without touching unrelated configuration.
 - **`mcpgateway/scripts/validate_env.py`** - Startup validation script invoked by the container entrypoint and `make check-env` that enforces the secret strength policy and surfaces clear remediation guidance.
+- **Popup-Based OAuth Authorization Flow** ([#5660](https://github.com/IBM/mcp-context-forge/issues/5660)) - `GET /oauth/authorize/{gateway_id}` accepts an optional `popup` query parameter that prefixes the generated state token with `popup.`. `GET /oauth/callback` detects the prefix and, for both success and every error path (provider error, missing code, invalid state, `OAuthError`, unexpected exception), responds with a minimal CSP-nonce'd `postMessage` script instead of the full HTML admin page, so a React UI can drive the flow in a popup window without a parent-page navigation. Non-popup flows keep the existing full HTML response unchanged.
 
 ### Removed
 

--- a/docs/docs/architecture/oauth-authorization-code-ui-design.md
+++ b/docs/docs/architecture/oauth-authorization-code-ui-design.md
@@ -176,6 +176,71 @@ sequenceDiagram
     Gateway-->>Admin: Success page
 ```
 
+### Popup OAuth Flow (React UI)
+
+The React UI supports initiating OAuth in a popup window for better UX:
+
+**Endpoint**: `GET /oauth/authorize/{gateway_id}?popup=true`
+
+**Flow Differences**:
+1. **State Token**: When `popup=true`, the OAuth Manager prefixes the state token with `popup.` (e.g., `popup.abc123...`)
+2. **Callback Response**: The callback endpoint detects the `popup.` prefix and responds with `postMessage` instead of HTML
+3. **Window Closure**: The popup closes automatically after posting the result to the parent window
+
+**postMessage Contract**:
+
+Success payload:
+```javascript
+{
+  type: "oauth_callback",
+  status: "success",
+  gatewayId: "gateway-uuid",
+  gatewayName: "Gateway Name"
+}
+```
+
+Error payload:
+```javascript
+{
+  type: "oauth_callback",
+  status: "error",
+  error: "error_code",        // One of: access_denied, missing_code, invalid_state, oauth_error, server_error
+  errorDescription: "Human-readable error message"
+}
+```
+
+**Security Model**:
+- Callback uses `postMessage(..., '*')` for cross-origin compatibility (API and React app may be on different origins)
+- Parent window MUST validate `event.source === authWindow` (exact popup reference) before processing
+- State token signature (HMAC-SHA256) prevents tampering
+- CSP nonce is embedded in the inline script for strict CSP compliance
+
+**Implementation Notes**:
+- State prefix detection: `oauth_router.py:605` checks `state.startswith("popup.")`
+- State generation: `oauth_manager.py:1033` adds prefix when `popup=True`
+- Callback script: `oauth_router.py:189-221` (`_popup_notification_script`)
+- CSP nonce extraction: `oauth_router.py:605` (`get_csp_nonce_from_request`)
+
+```mermaid
+sequenceDiagram
+    participant React as React UI
+    participant Popup as OAuth Popup
+    participant Gateway as OAuth Router
+    participant Provider as OAuth Provider
+
+    React->>Popup: window.open(/oauth/authorize/{id}?popup=true)
+    Popup->>Gateway: GET with popup=true
+    Gateway->>Gateway: Generate state with "popup." prefix
+    Gateway-->>Popup: Redirect to provider
+    Popup->>Provider: User authenticates
+    Provider-->>Gateway: Callback with code & popup-prefixed state
+    Gateway->>Gateway: Detect popup prefix, prepare postMessage
+    Gateway-->>Popup: HTML with postMessage script
+    Popup->>React: postMessage({type: "oauth_callback", status: "success", ...}, '*')
+    React->>React: Validate event.source === Popup
+    Popup->>Popup: window.close()
+```
+
 ### Tool invocation using stored tokens
 
 ```mermaid

--- a/docs/docs/architecture/oauth-authorization-code-ui-design.md
+++ b/docs/docs/architecture/oauth-authorization-code-ui-design.md
@@ -22,7 +22,7 @@ This document describes how the Admin UI initiates OAuth 2.0 Authorization Code 
 ### Implemented today
 
 - Admin UI exposes OAuth configuration fields for gateways and an "Authorize" action.
-- Authorization Code flow uses PKCE (S256) and an HMAC-signed state value with a 300-second TTL.
+- Authorization Code flow uses PKCE (S256) and an opaque random state token with server-side 300-second TTL and single-use enforcement.
 - OAuth state is stored in Redis when `CACHE_TYPE=redis`, in the database when `CACHE_TYPE=database`, and in memory otherwise.
 - Tokens are stored per gateway and app user (email) in `oauth_tokens`, encrypted with `AUTH_ENCRYPTION_SECRET`.
 - Refresh tokens are used when access tokens are near expiry; invalid refresh tokens are cleared.
@@ -212,7 +212,7 @@ Error payload:
 **Security Model**:
 - Callback uses `postMessage(..., '*')` for cross-origin compatibility (API and React app may be on different origins)
 - Parent window MUST validate `event.source === authWindow` (exact popup reference) before processing
-- State token signature (HMAC-SHA256) prevents tampering
+- State token is opaque random value with server-side 300-second TTL and single-use enforcement to prevent replay attacks
 - CSP nonce is embedded in the inline script for strict CSP compliance
 
 **Implementation Notes**:

--- a/docs/docs/manage/oauth-troubleshooting.md
+++ b/docs/docs/manage/oauth-troubleshooting.md
@@ -655,6 +655,169 @@ This section covers requests that present an access token issued by an external 
 
 ---
 
+---
+
+## Popup OAuth Flow Issues (React UI)
+
+### Popup Blocked by Browser
+
+**Symptom**: OAuth popup doesn't open, or opens then immediately closes.
+
+**Cause**: Browser popup blocker or user gesture requirement not met.
+
+**Fix**:
+- Ensure OAuth is triggered by direct user action (click handler)
+- Check browser console for popup blocker warnings
+- Add site to browser's popup allowlist
+- Use `window.open()` synchronously in click handler (not in async callback)
+
+### postMessage Not Received
+
+**Symptom**: Popup completes OAuth but parent window doesn't receive result.
+
+**Causes**:
+1. Parent window closed before callback
+2. Event listener not registered before popup opens
+3. `event.source` validation rejecting message
+4. Cross-origin policy blocking message
+
+**Diagnosis**:
+```javascript
+// Add debug logging to message handler
+window.addEventListener('message', (event) => {
+  console.log('Received message:', event.data);
+  console.log('Event source matches popup:', event.source === authWindow);
+  console.log('Event origin:', event.origin);
+});
+```
+
+**Fix**:
+- Register message listener BEFORE opening popup
+- Verify `event.source === authWindow` check is correct
+- Check browser console for CORS/CSP errors
+- Ensure parent window stays open during OAuth flow
+
+### Popup State Mismatch
+
+**Symptom**: Callback fails with "Invalid state" even though popup flow worked.
+
+**Cause**: State token doesn't have `popup.` prefix.
+
+**Diagnosis**:
+```bash
+# Check state generation logs
+grep "popup\." logs/mcpgateway.log
+grep "Stored OAuth state" logs/mcpgateway.log
+```
+
+**Fix**:
+- Verify `popup=true` query parameter is included in authorize URL
+- Check `oauth_manager.py:1033` generates prefixed state
+- Ensure state prefix isn't stripped during storage/retrieval
+
+### CSP Blocks Inline Script
+
+**Symptom**: Popup shows blank page or "Content Security Policy" error.
+
+**Cause**: Strict CSP without nonce support for inline scripts.
+
+**Diagnosis**:
+```bash
+# Check browser console for CSP errors
+# Look for: "Refused to execute inline script because it violates CSP"
+```
+
+**Fix**:
+- Verify CSP middleware generates nonces (`mcpgateway/middleware/csp_middleware.py`)
+- Check `get_csp_nonce_from_request()` returns valid nonce
+- Ensure callback script includes nonce attribute: `<script nonce="...">`
+- Review CSP header: should include `script-src 'self' 'nonce-...'`
+
+### Popup Closes Before User Sees Result
+
+**Symptom**: Popup closes immediately, user doesn't see success/error message.
+
+**Cause**: `window.close()` executes before user can read the message.
+
+**Expected Behavior**:
+- Popup posts message to parent and closes automatically
+- Parent window should display success/error notification
+- Popup fallback HTML is only shown if `window.opener` is missing
+
+**Fix**: Handle notifications in parent window, not popup:
+```javascript
+window.addEventListener('message', (event) => {
+  if (event.source !== authWindow) return;
+
+  const { type, status, error, errorDescription } = event.data;
+
+  if (type === 'oauth_callback') {
+    if (status === 'success') {
+      showNotification('OAuth authorization successful', 'success');
+    } else {
+      showNotification(`OAuth failed: ${errorDescription}`, 'error');
+    }
+  }
+});
+```
+
+### Multiple Popups or Duplicate Messages
+
+**Symptom**: Multiple OAuth popups open or parent receives duplicate messages.
+
+**Cause**:
+- User clicks "Authorize" multiple times
+- Event listener registered multiple times
+- Popup reference not tracked
+
+**Fix**:
+```javascript
+let authWindow = null;
+
+function startOAuth(gatewayId) {
+  // Close existing popup if any
+  if (authWindow && !authWindow.closed) {
+    authWindow.close();
+  }
+
+  authWindow = window.open(
+    `/oauth/authorize/${gatewayId}?popup=true`,
+    'oauth-popup',
+    'width=600,height=700'
+  );
+}
+
+// Use once() to prevent duplicate listeners
+window.addEventListener('message', handleOAuthMessage, { once: true });
+```
+
+### Popup Opens But Shows Error Page
+
+**Symptom**: Popup opens but immediately shows OAuth error page.
+
+**Causes**:
+1. Gateway not configured for OAuth
+2. Missing OAuth configuration fields
+3. Invalid redirect URI
+4. Provider rejected authorization request
+
+**Diagnosis**:
+```bash
+# Check gateway OAuth config
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/oauth/status/{gateway_id}
+
+# Check logs for authorization errors
+grep "OAuth provider returned error" logs/mcpgateway.log
+```
+
+**Fix**:
+- Verify gateway has `auth_type: oauth` and complete `oauth_config`
+- Check redirect URI matches provider configuration
+- Review provider's authorization requirements (scopes, audience, etc.)
+
+---
+
 ## Related Documentation
 
 - [OAuth Integration](oauth.md) - Main OAuth setup guide

--- a/docs/docs/manage/oauth.md
+++ b/docs/docs/manage/oauth.md
@@ -164,6 +164,81 @@ The `audience` parameter:
 - Your provider must whitelist the full redirect URI, e.g. `https://gateway.example.com/oauth/callback`
 - The gateway handles exchanging the authorization code for an access token and applies it as `Authorization: Bearer <token>` when contacting the MCP server
 
+### Popup OAuth Flow (React UI)
+
+The React UI can initiate OAuth in a popup window instead of a full-page redirect:
+
+**Endpoint**: `GET /oauth/authorize/{gateway_id}?popup=true`
+
+**Behavior**:
+- Opens OAuth provider in a popup window
+- Callback responds with `postMessage` instead of HTML page
+- Parent window receives result and closes popup automatically
+
+**postMessage Payload Structure**:
+
+Success:
+```javascript
+{
+  type: "oauth_callback",
+  status: "success",
+  gatewayId: "gateway-uuid",
+  gatewayName: "Gateway Name"
+}
+```
+
+Error:
+```javascript
+{
+  type: "oauth_callback",
+  status: "error",
+  error: "error_code",
+  errorDescription: "Human-readable description"
+}
+```
+
+**Error Codes**:
+- `access_denied` - User denied authorization at provider
+- `missing_code` - Authorization code missing from callback
+- `invalid_state` - State parameter invalid or expired
+- `oauth_error` - OAuth protocol error (see errorDescription)
+- `server_error` - Unexpected server error
+
+**React Integration Pattern**:
+
+```javascript
+// Open popup
+const authWindow = window.open(
+  `/oauth/authorize/${gatewayId}?popup=true`,
+  'oauth-popup',
+  'width=600,height=700'
+);
+
+// Listen for result
+window.addEventListener('message', (event) => {
+  // Security: Validate event.source matches popup
+  if (event.source !== authWindow) return;
+
+  const { type, status, error, errorDescription } = event.data;
+
+  if (type === 'oauth_callback') {
+    if (status === 'success') {
+      // Handle success
+      console.log('OAuth successful');
+    } else {
+      // Handle error
+      console.error(`OAuth failed: ${error} - ${errorDescription}`);
+    }
+  }
+});
+```
+
+**Security Notes**:
+- Callback uses `postMessage(..., '*')` for cross-origin compatibility
+- Receiver MUST validate `event.source === authWindow` (exact popup reference)
+- State token includes `popup.` prefix for callback mode detection
+- CSP nonce is embedded in callback script for strict CSP compliance
+
 Sequence (Authorization Code):
 
 ```mermaid

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -186,6 +186,41 @@ async def _persist_learned_audience(gateway: Gateway, oauth_result: Dict[str, An
     logger.info("Learned OAuth audience from IdP token for gateway %s; persisted as resource", gateway.name)
 
 
+def _popup_notification_script(nonce: str, payload: dict) -> str:
+    """Build an inline script that posts the OAuth result to window.opener and closes the popup.
+
+    When the callback page is opened inside a React UI popup, this script communicates
+    the OAuth result to the parent window via postMessage and then closes the popup.
+    When opened via direct navigation (no opener), the script is a no-op and the
+    surrounding HTML page is shown as a fallback.
+
+    Args:
+        nonce: CSP nonce for the inline script tag.
+        payload: Dict to send as the postMessage data.  Values are JSON-encoded
+            with ``<``, ``>``, and ``&`` Unicode-escaped to prevent script injection.
+
+    Returns:
+        HTML ``<script>`` tag string safe for embedding in an HTML body.
+    """
+    safe_payload = (
+        json.dumps(payload)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .replace("\u2028", "\\u2028")  # U+2028 LINE SEPARATOR
+        .replace("\u2029", "\\u2029")  # U+2029 PARAGRAPH SEPARATOR
+    )
+    safe_nonce = escape(nonce, quote=True)
+    # targetOrigin is "*" rather than window.location.origin because in production
+    # the API server and the React app may run on different origins (e.g.
+    # api.company.com vs app.company.com).  Using window.location.origin would
+    # cause the browser to silently drop the message.  The receiver mitigates the
+    # reduced targetOrigin restriction by validating event.source === authWindow
+    # (the exact popup reference), so only the window that initiated the flow can
+    # act on the result.
+    return f"<script nonce=\"{safe_nonce}\">(function(){{if(window.opener&&!window.opener.closed){{window.opener.postMessage({safe_payload},'*');window.close();}}}})()</script>"
+
+
 oauth_router = APIRouter(prefix="/oauth", tags=["oauth"])
 
 
@@ -347,7 +382,16 @@ async def _enforce_gateway_access(
 
 
 @oauth_router.get("/authorize/{gateway_id}")
-async def initiate_oauth_flow(gateway_id: str, request: Request, current_user: EmailUserResponse = Depends(get_current_user_with_permissions), db: Session = Depends(get_db)) -> RedirectResponse:  # noqa: ARG001
+async def initiate_oauth_flow(
+    gateway_id: str,
+    request: Request,
+    current_user: EmailUserResponse = Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+    popup: bool = Query(
+        default=False,
+        description="Set by the React UI when opening OAuth in a popup window; encodes a popup. prefix in the state token so the callback responds with postMessage instead of a full HTML page",
+    ),
+) -> RedirectResponse:  # noqa: ARG001
     """Initiates the OAuth 2.0 Authorization Code flow for a specified gateway.
 
     This endpoint retrieves the OAuth configuration for the given gateway, validates that
@@ -485,7 +529,7 @@ async def initiate_oauth_flow(gateway_id: str, request: Request, current_user: E
         if requester_email == "unknown":
             requester_email = None
         oauth_manager = OAuthManager(token_storage=TokenStorageService(db))
-        auth_data = await oauth_manager.initiate_authorization_code_flow(gateway_id, oauth_config, app_user_email=requester_email)
+        auth_data = await oauth_manager.initiate_authorization_code_flow(gateway_id, oauth_config, app_user_email=requester_email, popup=popup)
 
         logger.info(f"Initiated OAuth flow for gateway {SecurityValidator.sanitize_log_message(gateway_id)} by user {SecurityValidator.sanitize_log_message(requester_email)}")
 
@@ -543,6 +587,12 @@ async def oauth_callback(
         True
     """
 
+    # Determine early whether this callback was initiated from the React UI popup.
+    # The authorize endpoint prefixes the state token with "popup." when popup=True,
+    # so we can detect it here without any additional storage lookups.
+    is_popup = bool(state and isinstance(state, str) and state.startswith("popup."))
+    csp_nonce = get_csp_nonce_from_request(request)
+
     try:
         # Get root path for URL construction
         root_path = resolve_root_path(request) if request else ""
@@ -554,6 +604,17 @@ async def oauth_callback(
             description_text = escape(error_description or "OAuth provider returned an authorization error.")
             # Sanitize untrusted query parameters before logging to prevent log injection
             logger.warning(f"OAuth provider returned error callback: error={sanitize_for_log(error)}, description={sanitize_for_log(error_description)}")
+            if is_popup:
+                return HTMLResponse(
+                    content=(
+                        "<!DOCTYPE html><html><head><title>OAuth Authorization Failed</title></head><body>"
+                        + _popup_notification_script(
+                            csp_nonce, {"type": "oauth_callback", "status": "error", "error": error, "errorDescription": error_description or "OAuth provider returned an authorization error."}
+                        )
+                        + "</body></html>"
+                    ),
+                    status_code=400,
+                )
             return HTMLResponse(
                 content=f"""
                 <!DOCTYPE html>
@@ -572,6 +633,17 @@ async def oauth_callback(
 
         if not code:
             logger.warning("OAuth callback missing authorization code")
+            if is_popup:
+                return HTMLResponse(
+                    content=(
+                        "<!DOCTYPE html><html><head><title>OAuth Authorization Failed</title></head><body>"
+                        + _popup_notification_script(
+                            csp_nonce, {"type": "oauth_callback", "status": "error", "error": "missing_code", "errorDescription": "Missing authorization code in callback response."}
+                        )
+                        + "</body></html>"
+                    ),
+                    status_code=400,
+                )
             return HTMLResponse(
                 content=f"""
                 <!DOCTYPE html>
@@ -593,6 +665,15 @@ async def oauth_callback(
             Returns:
                 HTMLResponse: A 400 error page describing the invalid state.
             """
+            if is_popup:
+                return HTMLResponse(
+                    content=(
+                        "<!DOCTYPE html><html><head><title>OAuth Authorization Failed</title></head><body>"
+                        + _popup_notification_script(csp_nonce, {"type": "oauth_callback", "status": "error", "error": "invalid_state", "errorDescription": "Invalid OAuth state parameter."})
+                        + "</body></html>"
+                    ),
+                    status_code=400,
+                )
             return HTMLResponse(
                 content=f"""
                 <!DOCTYPE html>
@@ -651,10 +732,18 @@ async def oauth_callback(
 
         logger.info(f"Completed OAuth flow for gateway {SecurityValidator.sanitize_log_message(gateway_id)}, user {SecurityValidator.sanitize_log_message(str(result.get('user_id')))}")
 
-        # Return success page with option to return to admin
-        # Get CSP nonce for inline script
-        csp_nonce = get_csp_nonce_from_request(request)
+        # React UI popup: post result to parent window and close.
+        if is_popup:
+            return HTMLResponse(
+                content=(
+                    "<!DOCTYPE html><html><head><title>OAuth Authorization Successful</title></head><body>"
+                    + _popup_notification_script(csp_nonce, {"type": "oauth_callback", "status": "success", "gatewayId": str(gateway_id), "gatewayName": str(gateway.name)})
+                    + "<p>Authorization successful. This window will close automatically.</p>"
+                    + "</body></html>"
+                )
+            )
 
+        # Legacy admin UI: return full page with fetch-tools button.
         # Generate CSRF token early so it can be embedded in the JS literal
         csrf_token = request.cookies.get(ADMIN_CSRF_COOKIE_NAME, "")
         if not isinstance(csrf_token, str) or not re.match(r"^[A-Za-z0-9_=-]{32,}$", csrf_token):
@@ -782,6 +871,15 @@ async def oauth_callback(
 
     except OAuthError as e:
         logger.error(f"OAuth callback failed: {str(e)}")
+        if is_popup:
+            return HTMLResponse(
+                content=(
+                    "<!DOCTYPE html><html><head><title>OAuth Authorization Failed</title></head><body>"
+                    + _popup_notification_script(csp_nonce, {"type": "oauth_callback", "status": "error", "error": "oauth_error", "errorDescription": str(e)})
+                    + "</body></html>"
+                ),
+                status_code=400,
+            )
         return HTMLResponse(
             content=f"""
         <!DOCTYPE html>
@@ -816,6 +914,17 @@ async def oauth_callback(
 
     except Exception as e:
         logger.error(f"Unexpected error in OAuth callback: {str(e)}")
+        if is_popup:
+            return HTMLResponse(
+                content=(
+                    "<!DOCTYPE html><html><head><title>OAuth Authorization Failed</title></head><body>"
+                    + _popup_notification_script(
+                        csp_nonce, {"type": "oauth_callback", "status": "error", "error": "server_error", "errorDescription": "An unexpected error occurred during authorization."}
+                    )
+                    + "</body></html>"
+                ),
+                status_code=500,
+            )
         return HTMLResponse(
             content=f"""
         <!DOCTYPE html>

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -207,8 +207,8 @@ def _popup_notification_script(nonce: str, payload: dict) -> str:
         .replace("<", "\\u003c")
         .replace(">", "\\u003e")
         .replace("&", "\\u0026")
-        .replace("\u2028", "\\u2028")  # U+2028 LINE SEPARATOR
-        .replace("\u2029", "\\u2029")  # U+2029 PARAGRAPH SEPARATOR
+        .replace("\u2028", "\\\\u2028")  # U+2028 LINE SEPARATOR
+        .replace("\u2029", "\\\\u2029")  # U+2029 PARAGRAPH SEPARATOR
     )
     safe_nonce = escape(nonce, quote=True)
     # targetOrigin is "*" rather than window.location.origin because in production

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -221,6 +221,25 @@ def _popup_notification_script(nonce: str, payload: dict) -> str:
     return f"<script nonce=\"{safe_nonce}\">(function(){{if(window.opener&&!window.opener.closed){{window.opener.postMessage({safe_payload},'*');window.close();}}}})()</script>"
 
 
+def _popup_callback_response(nonce: str, payload: dict, status_code: int = 200, extra_body: str = "") -> HTMLResponse:
+    """Build the full HTML page wrapping the popup postMessage script for an OAuth callback result.
+
+    Args:
+        nonce: CSP nonce for the inline script tag.
+        payload: Dict to send as the postMessage data (see ``_popup_notification_script``).
+        status_code: HTTP status code for the response.
+        extra_body: Optional extra HTML appended after the script tag (e.g. a visible message).
+
+    Returns:
+        HTMLResponse containing the postMessage script for the popup window.
+    """
+    title = "OAuth Authorization Successful" if payload.get("status") == "success" else "OAuth Authorization Failed"
+    return HTMLResponse(
+        content=(f"<!DOCTYPE html><html><head><title>{title}</title></head><body>" + _popup_notification_script(nonce, payload) + extra_body + "</body></html>"),
+        status_code=status_code,
+    )
+
+
 oauth_router = APIRouter(prefix="/oauth", tags=["oauth"])
 
 
@@ -605,14 +624,9 @@ async def oauth_callback(
             # Sanitize untrusted query parameters before logging to prevent log injection
             logger.warning(f"OAuth provider returned error callback: error={sanitize_for_log(error)}, description={sanitize_for_log(error_description)}")
             if is_popup:
-                return HTMLResponse(
-                    content=(
-                        "<!DOCTYPE html><html><head><title>OAuth Authorization Failed</title></head><body>"
-                        + _popup_notification_script(
-                            csp_nonce, {"type": "oauth_callback", "status": "error", "error": error, "errorDescription": error_description or "OAuth provider returned an authorization error."}
-                        )
-                        + "</body></html>"
-                    ),
+                return _popup_callback_response(
+                    csp_nonce,
+                    {"type": "oauth_callback", "status": "error", "error": error, "errorDescription": error_description or "OAuth provider returned an authorization error."},
                     status_code=400,
                 )
             return HTMLResponse(
@@ -634,15 +648,8 @@ async def oauth_callback(
         if not code:
             logger.warning("OAuth callback missing authorization code")
             if is_popup:
-                return HTMLResponse(
-                    content=(
-                        "<!DOCTYPE html><html><head><title>OAuth Authorization Failed</title></head><body>"
-                        + _popup_notification_script(
-                            csp_nonce, {"type": "oauth_callback", "status": "error", "error": "missing_code", "errorDescription": "Missing authorization code in callback response."}
-                        )
-                        + "</body></html>"
-                    ),
-                    status_code=400,
+                return _popup_callback_response(
+                    csp_nonce, {"type": "oauth_callback", "status": "error", "error": "missing_code", "errorDescription": "Missing authorization code in callback response."}, status_code=400
                 )
             return HTMLResponse(
                 content=f"""
@@ -666,13 +673,8 @@ async def oauth_callback(
                 HTMLResponse: A 400 error page describing the invalid state.
             """
             if is_popup:
-                return HTMLResponse(
-                    content=(
-                        "<!DOCTYPE html><html><head><title>OAuth Authorization Failed</title></head><body>"
-                        + _popup_notification_script(csp_nonce, {"type": "oauth_callback", "status": "error", "error": "invalid_state", "errorDescription": "Invalid OAuth state parameter."})
-                        + "</body></html>"
-                    ),
-                    status_code=400,
+                return _popup_callback_response(
+                    csp_nonce, {"type": "oauth_callback", "status": "error", "error": "invalid_state", "errorDescription": "Invalid OAuth state parameter."}, status_code=400
                 )
             return HTMLResponse(
                 content=f"""
@@ -734,13 +736,10 @@ async def oauth_callback(
 
         # React UI popup: post result to parent window and close.
         if is_popup:
-            return HTMLResponse(
-                content=(
-                    "<!DOCTYPE html><html><head><title>OAuth Authorization Successful</title></head><body>"
-                    + _popup_notification_script(csp_nonce, {"type": "oauth_callback", "status": "success", "gatewayId": str(gateway_id), "gatewayName": str(gateway.name)})
-                    + "<p>Authorization successful. This window will close automatically.</p>"
-                    + "</body></html>"
-                )
+            return _popup_callback_response(
+                csp_nonce,
+                {"type": "oauth_callback", "status": "success", "gatewayId": str(gateway_id), "gatewayName": str(gateway.name)},
+                extra_body="<p>Authorization successful. This window will close automatically.</p>",
             )
 
         # Legacy admin UI: return full page with fetch-tools button.
@@ -872,14 +871,7 @@ async def oauth_callback(
     except OAuthError as e:
         logger.error(f"OAuth callback failed: {str(e)}")
         if is_popup:
-            return HTMLResponse(
-                content=(
-                    "<!DOCTYPE html><html><head><title>OAuth Authorization Failed</title></head><body>"
-                    + _popup_notification_script(csp_nonce, {"type": "oauth_callback", "status": "error", "error": "oauth_error", "errorDescription": str(e)})
-                    + "</body></html>"
-                ),
-                status_code=400,
-            )
+            return _popup_callback_response(csp_nonce, {"type": "oauth_callback", "status": "error", "error": "oauth_error", "errorDescription": str(e)}, status_code=400)
         return HTMLResponse(
             content=f"""
         <!DOCTYPE html>
@@ -915,15 +907,8 @@ async def oauth_callback(
     except Exception as e:
         logger.error(f"Unexpected error in OAuth callback: {str(e)}")
         if is_popup:
-            return HTMLResponse(
-                content=(
-                    "<!DOCTYPE html><html><head><title>OAuth Authorization Failed</title></head><body>"
-                    + _popup_notification_script(
-                        csp_nonce, {"type": "oauth_callback", "status": "error", "error": "server_error", "errorDescription": "An unexpected error occurred during authorization."}
-                    )
-                    + "</body></html>"
-                ),
-                status_code=500,
+            return _popup_callback_response(
+                csp_nonce, {"type": "oauth_callback", "status": "error", "error": "server_error", "errorDescription": "An unexpected error occurred during authorization."}, status_code=500
             )
         return HTMLResponse(
             content=f"""

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -884,13 +884,15 @@ class OAuthManager:
 
         raise OAuthError("Token exchange failed after all retry attempts")
 
-    async def initiate_authorization_code_flow(self, gateway_id: str, credentials: Dict[str, Any], app_user_email: str = None) -> Dict[str, str]:
+    async def initiate_authorization_code_flow(self, gateway_id: str, credentials: Dict[str, Any], app_user_email: str = None, popup: bool = False) -> Dict[str, str]:
         """Initiate Authorization Code flow with PKCE and return authorization URL.
 
         Args:
             gateway_id: ID of the gateway being configured
             credentials: OAuth configuration with client_id, authorization_url, etc.
             app_user_email: ContextForge user email to associate with tokens
+            popup: When True, the state token is prefixed with ``popup.`` so the
+                callback endpoint knows to respond with postMessage instead of HTML.
 
         Returns:
             Dict containing authorization_url and state
@@ -900,7 +902,7 @@ class OAuthManager:
         pkce_params = self._generate_pkce_params()
 
         # Generate state parameter with user context for CSRF protection
-        state = self._generate_state(gateway_id, app_user_email)
+        state = self._generate_state(gateway_id, app_user_email, popup=popup)
 
         # Store state with code_verifier in session/cache for validation
         if self.token_storage:
@@ -1012,7 +1014,7 @@ class OAuthManager:
             return await self.token_storage.get_user_token(gateway_id, app_user_email)
         return None
 
-    def _generate_state(self, _gateway_id: str, _app_user_email: str = None) -> str:
+    def _generate_state(self, _gateway_id: str, _app_user_email: str = None, popup: bool = False) -> str:
         """Generate an opaque state token for CSRF protection.
 
         Args:
@@ -1020,11 +1022,15 @@ class OAuthManager:
                 prior embedded-state call sites).
             _app_user_email: ContextForge user email (reserved for
                 compatibility with prior embedded-state call sites).
+            popup: When True, prefixes the token with ``popup.`` so the
+                callback can detect that it was opened from the React UI
+                popup and should respond with postMessage instead of HTML.
 
         Returns:
-            Opaque random state token
+            Opaque random state token, optionally prefixed with ``popup.``
         """
-        return secrets.token_urlsafe(48)
+        state = secrets.token_urlsafe(48)
+        return f"popup.{state}" if popup else state
 
     @staticmethod
     def _extract_legacy_state_payload(state: str) -> Optional[Dict[str, Any]]:

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -2515,4 +2515,428 @@ class TestOAuthCallbackCSPCompliance:
             nonces_seen.add(nonce)
 
         # Verify we collected 3 unique nonces
-        assert len(nonces_seen) == 3, "Each request should have a unique CSP nonce"
+
+
+class TestOAuthRouterPopupMode:
+    """Test cases for OAuth router popup mode functionality."""
+
+    @pytest.mark.asyncio
+    async def test_initiate_oauth_flow_with_popup_parameter(self, mock_db, mock_request, mock_gateway, mock_current_user):
+        """Test that popup=True parameter is passed to OAuth manager."""
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        auth_data = {
+            "authorization_url": "https://oauth.example.com/authorize?state=popup.abc123",
+            "state": "popup.abc123"
+        }
+
+        with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_manager_class:
+            mock_oauth_manager = Mock()
+            mock_oauth_manager.initiate_authorization_code_flow = AsyncMock(return_value=auth_data)
+            mock_oauth_manager_class.return_value = mock_oauth_manager
+
+            with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                with patch("mcpgateway.routers.oauth_router._enforce_gateway_access", new_callable=AsyncMock):
+                    from mcpgateway.routers.oauth_router import initiate_oauth_flow
+
+                    # Execute with popup=True
+                    result = await initiate_oauth_flow(
+                        gateway_id="gateway123",
+                        request=mock_request,
+                        popup=True,
+                        current_user=mock_current_user,
+                        db=mock_db
+                    )
+
+                    # Assert redirect response
+                    assert isinstance(result, RedirectResponse)
+                    assert result.status_code == 307
+
+                    # Verify popup=True was passed to OAuth manager
+                    call_args = mock_oauth_manager.initiate_authorization_code_flow.call_args
+                    assert call_args[1]["popup"] is True
+
+    @pytest.mark.asyncio
+    async def test_initiate_oauth_flow_without_popup_parameter(self, mock_db, mock_request, mock_gateway, mock_current_user):
+        """Test that popup defaults to False when not provided."""
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        auth_data = {
+            "authorization_url": "https://oauth.example.com/authorize?state=abc123",
+            "state": "abc123"
+        }
+
+        with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_manager_class:
+            mock_oauth_manager = Mock()
+            mock_oauth_manager.initiate_authorization_code_flow = AsyncMock(return_value=auth_data)
+            mock_oauth_manager_class.return_value = mock_oauth_manager
+
+            with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                with patch("mcpgateway.routers.oauth_router._enforce_gateway_access", new_callable=AsyncMock):
+                    from mcpgateway.routers.oauth_router import initiate_oauth_flow
+
+                    # Execute without popup parameter (defaults to False)
+                    result = await initiate_oauth_flow(
+                        gateway_id="gateway123",
+                        request=mock_request,
+                        current_user=mock_current_user,
+                        db=mock_db
+                    )
+
+                    # Assert redirect response
+                    assert isinstance(result, RedirectResponse)
+
+                    # Verify popup=False was passed to OAuth manager
+                    call_args = mock_oauth_manager.initiate_authorization_code_flow.call_args
+                    # popup is a Query object with default False, check its value
+                    popup_arg = call_args[1]["popup"]
+                    assert popup_arg == False or (hasattr(popup_arg, 'default') and popup_arg.default == False)
+
+    @pytest.mark.asyncio
+    async def test_popup_notification_script_helper(self):
+        """Test _popup_notification_script generates safe HTML."""
+        from mcpgateway.routers.oauth_router import _popup_notification_script
+
+        payload = {
+            "type": "oauth_callback",
+            "status": "success",
+            "gatewayId": "test-gateway",
+            "gatewayName": "Test Gateway"
+        }
+        nonce = "test-nonce-123"
+
+        result = _popup_notification_script(nonce, payload)
+
+        # Verify it's a script tag with nonce
+        assert '<script nonce="test-nonce-123">' in result
+        assert '</script>' in result
+
+        # Verify payload is present (JSON.stringify formats with spaces)
+        assert '"type": "oauth_callback"' in result or '"type":"oauth_callback"' in result
+        assert '"status": "success"' in result or '"status":"success"' in result
+
+        # Verify dangerous characters are escaped in the payload (not in the script tags themselves)
+        # Extract just the payload part between postMessage( and )
+        import re
+        payload_match = re.search(r'postMessage\(({[^}]+})', result)
+        if payload_match:
+            payload_str = payload_match.group(1)
+            # The payload should not contain unescaped < or > characters
+            assert '<script' not in payload_str
+            assert '</script' not in payload_str
+
+    @pytest.mark.asyncio
+    async def test_popup_notification_script_escapes_dangerous_characters(self):
+        """Test that _popup_notification_script escapes <, >, and & in payload."""
+        from mcpgateway.routers.oauth_router import _popup_notification_script
+
+        payload = {
+            "message": "<script>alert('xss')</script>",
+            "data": "value&with&ampersands",
+            "html": "<div>content</div>"
+        }
+        nonce = "safe-nonce"
+
+        result = _popup_notification_script(nonce, payload)
+
+        # Verify dangerous characters are Unicode-escaped (JSON.stringify does this)
+        assert '\\u003c' in result or '\\u003C' in result  # < escaped
+        assert '\\u003e' in result or '\\u003E' in result  # > escaped
+        assert '\\u0026' in result  # & escaped
+
+        # Verify the actual dangerous strings are not present
+        assert "<script>alert" not in result
+        assert "<div>" not in result
+
+    @pytest.mark.asyncio
+    async def test_popup_notification_script_escapes_line_terminators(self):
+        """Test that U+2028 and U+2029 in payload are escaped.
+
+        json.dumps emits these characters literally, but JavaScript treats
+        them as line terminators inside string literals, which causes a
+        SyntaxError and hangs the popup.
+        """
+        from mcpgateway.routers.oauth_router import _popup_notification_script
+
+        payload = {
+            "errorDescription": "line1\u2028line2\u2029end",
+        }
+        nonce = "safe-nonce"
+
+        result = _popup_notification_script(nonce, payload)
+
+        assert "\\u2028" in result
+        assert "\\u2029" in result
+        assert "\u2028" not in result
+        assert "\u2029" not in result
+
+    @pytest.mark.asyncio
+    async def test_popup_notification_script_escapes_nonce(self):
+        """Test that nonce is HTML-escaped to prevent attribute injection."""
+        from mcpgateway.routers.oauth_router import _popup_notification_script
+
+        dangerous_nonce = 'nonce"><script>alert("xss")</script><div class="'
+        payload = {"status": "success"}
+
+        result = _popup_notification_script(dangerous_nonce, payload)
+
+        # Verify nonce is HTML-escaped
+        assert 'nonce&quot;&gt;&lt;script&gt;' in result or "nonce&#x27;&#x3E;&#x3C;script&#x3E;" in result
+        # Verify the dangerous script is not executable
+        assert '"><script>alert' not in result
+
+    @pytest.mark.asyncio
+    async def test_oauth_callback_with_popup_state_success(self, mock_db):
+        """Test oauth_callback returns postMessage response when state starts with 'popup.'"""
+        from mcpgateway.routers.oauth_router import oauth_callback
+
+        # Mock gateway
+        mock_gateway = Mock()
+        mock_gateway.id = "test-gateway"
+        mock_gateway.name = "Test Gateway"
+        mock_gateway.url = "https://mcp.example.com"
+        mock_gateway.oauth_config = {
+            "client_id": "test-client",
+            "authorization_url": "https://oauth.example.com/authorize",
+            "token_url": "https://oauth.example.com/token"
+        }
+        mock_gateway.ca_certificate = None
+        mock_gateway.client_cert = None
+        mock_gateway.client_key = None
+
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        # Mock OAuth manager
+        with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_manager_class:
+            mock_oauth_manager = Mock()
+            mock_oauth_manager.resolve_gateway_id_from_state = AsyncMock(return_value="test-gateway")
+            mock_oauth_manager.complete_authorization_code_flow = AsyncMock(return_value={
+                "user_id": "user@example.com",
+                "expires_at": "2026-12-31T23:59:59Z"
+            })
+            mock_oauth_manager_class.return_value = mock_oauth_manager
+
+            with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                with patch("mcpgateway.routers.oauth_router._persist_learned_audience", new_callable=AsyncMock):
+                    # Mock request with CSP nonce
+                    mock_request = Mock()
+                    mock_request.state = Mock()
+                    mock_request.state.csp_nonce = "test-nonce-456"
+
+                    # Execute with popup state
+                    result = await oauth_callback(
+                        code="auth-code-123",
+                        state="popup.abc123def456",
+                        request=mock_request,
+                        db=mock_db
+                    )
+
+                    # Assert HTMLResponse with postMessage script
+                    assert isinstance(result, HTMLResponse)
+                    body = result.body.decode()
+
+                    # Verify postMessage script is present
+                    assert '<script nonce="test-nonce-456">' in body
+                    assert 'window.opener.postMessage' in body
+                    assert '"type": "oauth_callback"' in body or '"type":"oauth_callback"' in body
+                    assert '"status": "success"' in body or '"status":"success"' in body
+                    assert '"gatewayId": "test-gateway"' in body or '"gatewayId":"test-gateway"' in body
+                    assert '"gatewayName": "Test Gateway"' in body or '"gatewayName":"Test Gateway"' in body
+
+                    # Verify no legacy admin UI elements
+                    assert 'Fetch Tools from MCP Server' not in body
+
+    @pytest.mark.asyncio
+    async def test_oauth_callback_with_popup_state_provider_error(self, mock_db):
+        """Test oauth_callback returns postMessage error when provider returns error with popup state."""
+        from mcpgateway.routers.oauth_router import oauth_callback
+
+        # Mock request with CSP nonce
+        mock_request = Mock()
+        mock_request.state = Mock()
+        mock_request.state.csp_nonce = "test-nonce-789"
+
+        # Execute with popup state and provider error
+        result = await oauth_callback(
+            code=None,
+            state="popup.xyz789",
+            error="access_denied",
+            error_description="User denied authorization",
+            request=mock_request,
+            db=mock_db
+        )
+
+        # Assert HTMLResponse with postMessage error script
+        assert isinstance(result, HTMLResponse)
+        assert result.status_code == 400
+        body = result.body.decode()
+
+        # Verify postMessage error script
+        assert '<script nonce="test-nonce-789">' in body
+        assert 'window.opener.postMessage' in body
+        assert '"type": "oauth_callback"' in body or '"type":"oauth_callback"' in body
+        assert '"status": "error"' in body or '"status":"error"' in body
+        assert '"error": "access_denied"' in body or '"error":"access_denied"' in body
+        assert '"errorDescription": "User denied authorization"' in body or '"errorDescription":"User denied authorization"' in body
+
+        # Verify no legacy admin UI elements
+        assert 'Return to Admin Panel' not in body
+
+    @pytest.mark.asyncio
+    async def test_oauth_callback_with_popup_state_missing_code(self, mock_db):
+        """Test oauth_callback returns postMessage error when code is missing with popup state."""
+        from mcpgateway.routers.oauth_router import oauth_callback
+
+        # Mock request with CSP nonce
+        mock_request = Mock()
+        mock_request.state = Mock()
+        mock_request.state.csp_nonce = "test-nonce-missing"
+
+        # Execute with popup state but no code
+        result = await oauth_callback(
+            code=None,
+            state="popup.state123",
+            request=mock_request,
+            db=mock_db
+        )
+
+        # Assert HTMLResponse with postMessage error
+        assert isinstance(result, HTMLResponse)
+        assert result.status_code == 400
+        body = result.body.decode()
+
+        # Verify postMessage error script
+        assert '<script nonce="test-nonce-missing">' in body
+        assert '"type": "oauth_callback"' in body or '"type":"oauth_callback"' in body
+        assert '"status": "error"' in body or '"status":"error"' in body
+        assert '"error": "missing_code"' in body or '"error":"missing_code"' in body
+        assert '"errorDescription": "Missing authorization code in callback response."' in body or '"errorDescription":"Missing authorization code in callback response."' in body
+
+    @pytest.mark.asyncio
+    async def test_oauth_callback_with_popup_state_invalid_state(self, mock_db):
+        """Test oauth_callback returns postMessage error when state is invalid with popup prefix."""
+        from mcpgateway.routers.oauth_router import oauth_callback
+
+        # Mock OAuth manager to return None for invalid state
+        with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_manager_class:
+            mock_oauth_manager = Mock()
+            mock_oauth_manager.resolve_gateway_id_from_state = AsyncMock(return_value=None)
+            mock_oauth_manager_class.return_value = mock_oauth_manager
+
+            with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                # Mock request with CSP nonce
+                mock_request = Mock()
+                mock_request.state = Mock()
+                mock_request.state.csp_nonce = "test-nonce-invalid"
+
+                # Execute with popup state that doesn't resolve
+                result = await oauth_callback(
+                    code="auth-code-123",
+                    state="popup.invalid-state",
+                    request=mock_request,
+                    db=mock_db
+                )
+
+                # Assert HTMLResponse with postMessage error
+                assert isinstance(result, HTMLResponse)
+                assert result.status_code == 400
+                body = result.body.decode()
+
+                # Verify postMessage error script
+                assert '<script nonce="test-nonce-invalid">' in body
+                assert '"type": "oauth_callback"' in body or '"type":"oauth_callback"' in body
+                assert '"status": "error"' in body or '"status":"error"' in body
+                assert '"error": "invalid_state"' in body or '"error":"invalid_state"' in body
+                assert '"errorDescription": "Invalid OAuth state parameter."' in body or '"errorDescription":"Invalid OAuth state parameter."' in body
+
+    @pytest.mark.asyncio
+    async def test_oauth_callback_without_popup_state_returns_html_page(self, mock_db):
+        """Test oauth_callback returns full HTML page when state does not start with 'popup.'"""
+        from mcpgateway.routers.oauth_router import oauth_callback
+
+        # Mock gateway
+        mock_gateway = Mock()
+        mock_gateway.id = "test-gateway"
+        mock_gateway.name = "Test Gateway"
+        mock_gateway.url = "https://mcp.example.com"
+        mock_gateway.oauth_config = {
+            "client_id": "test-client",
+            "authorization_url": "https://oauth.example.com/authorize",
+            "token_url": "https://oauth.example.com/token"
+        }
+        mock_gateway.ca_certificate = None
+        mock_gateway.client_cert = None
+        mock_gateway.client_key = None
+
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        # Mock OAuth manager
+        with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_manager_class:
+            mock_oauth_manager = Mock()
+            mock_oauth_manager.resolve_gateway_id_from_state = AsyncMock(return_value="test-gateway")
+            mock_oauth_manager.complete_authorization_code_flow = AsyncMock(return_value={
+                "user_id": "user@example.com",
+                "expires_at": "2026-12-31T23:59:59Z"
+            })
+            mock_oauth_manager_class.return_value = mock_oauth_manager
+
+            with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                with patch("mcpgateway.routers.oauth_router._persist_learned_audience", new_callable=AsyncMock):
+                    # Mock request with CSP nonce
+                    mock_request = Mock()
+                    mock_request.state = Mock()
+                    mock_request.state.csp_nonce = "test-nonce-legacy"
+
+                    # Execute with non-popup state
+                    result = await oauth_callback(
+                        code="auth-code-123",
+                        state="regular-state-abc123",
+                        request=mock_request,
+                        db=mock_db
+                    )
+
+                    # Assert HTMLResponse with legacy admin UI
+                    assert isinstance(result, HTMLResponse)
+                    body = result.body.decode()
+
+                    # Verify legacy admin UI elements are present
+                    assert 'OAuth Authorization Successful' in body
+                    assert 'Fetch Tools from MCP Server' in body
+                    assert 'Return to Admin Panel' in body
+
+                    # Verify NO postMessage script (should use inline fetch script instead)
+                    assert 'window.opener.postMessage' not in body
+
+    @pytest.mark.asyncio
+    async def test_oauth_callback_without_popup_state_provider_error_returns_html(self, mock_db):
+        """Test oauth_callback returns full HTML error page when provider returns error without popup state."""
+        from mcpgateway.routers.oauth_router import oauth_callback
+
+        # Mock request
+        mock_request = Mock()
+        mock_request.state = Mock()
+        mock_request.state.csp_nonce = "test-nonce-error"
+
+        # Execute with non-popup state and provider error
+        result = await oauth_callback(
+            code=None,
+            state="regular-state-xyz",
+            error="access_denied",
+            error_description="User denied authorization",
+            request=mock_request,
+            db=mock_db
+        )
+
+        # Assert HTMLResponse with legacy error page
+        assert isinstance(result, HTMLResponse)
+        assert result.status_code == 400
+        body = result.body.decode()
+
+        # Verify legacy admin UI error elements
+        assert 'OAuth Authorization Failed' in body
+        assert 'access_denied' in body
+        assert 'User denied authorization' in body
+        assert 'Return to Admin Panel' in body
+
+        # Verify NO postMessage script
+        assert 'window.opener.postMessage' not in body

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -3027,3 +3027,82 @@ class TestOAuthRouterPopupMode:
                 assert b"<!DOCTYPE html>" in result.body
                 assert b"oauth_callback" in result.body
                 assert b"server_error" in result.body
+
+
+class TestOAuthRouterPopupQueryResolution:
+    """HTTP-level tests exercising FastAPI's real `Query` dependency-injection layer for `popup`.
+
+    The tests above call `initiate_oauth_flow` directly as a plain coroutine, so the
+    `popup` parameter never goes through FastAPI's `Query` resolution -- it's whatever
+    the test passes in (or the raw `Query(default=False)` sentinel when omitted). These
+    tests instead route a real HTTP request through a `TestClient`, so `popup` is parsed
+    from the query string exactly as it would be in production.
+    """
+
+    @staticmethod
+    def _build_app(mock_db, mock_current_user):
+        from fastapi import FastAPI
+
+        from mcpgateway.db import get_db
+        from mcpgateway.middleware.rbac import get_current_user_with_permissions
+        from mcpgateway.routers.oauth_router import oauth_router
+
+        app = FastAPI()
+        app.include_router(oauth_router)
+
+        async def _get_db_override():
+            return mock_db
+
+        async def _get_user_override():
+            return mock_current_user
+
+        app.dependency_overrides[get_db] = _get_db_override
+        app.dependency_overrides[get_current_user_with_permissions] = _get_user_override
+        return app
+
+    def test_authorize_popup_true_resolved_from_query_string(self, mock_db, mock_gateway, mock_current_user):
+        """`?popup=true` on the real route must resolve to `popup=True` in the handler."""
+        from fastapi.testclient import TestClient
+
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+        auth_data = {"authorization_url": "https://oauth.example.com/authorize?state=popup.abc123", "state": "popup.abc123"}
+
+        app = self._build_app(mock_db, mock_current_user)
+
+        with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_manager_class:
+            mock_oauth_manager = Mock()
+            mock_oauth_manager.initiate_authorization_code_flow = AsyncMock(return_value=auth_data)
+            mock_oauth_manager_class.return_value = mock_oauth_manager
+
+            with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                with patch("mcpgateway.routers.oauth_router._enforce_gateway_access", new_callable=AsyncMock):
+                    client = TestClient(app)
+                    response = client.get("/oauth/authorize/gateway123?popup=true", follow_redirects=False)
+
+        assert response.status_code == 307
+        assert response.headers["location"] == auth_data["authorization_url"]
+        call_kwargs = mock_oauth_manager.initiate_authorization_code_flow.call_args.kwargs
+        assert call_kwargs["popup"] is True
+
+    def test_authorize_popup_omitted_resolves_to_false_from_query_string(self, mock_db, mock_gateway, mock_current_user):
+        """Omitting `popup` on the real route must resolve to `popup=False`, not the `Query` default object."""
+        from fastapi.testclient import TestClient
+
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+        auth_data = {"authorization_url": "https://oauth.example.com/authorize?state=abc123", "state": "abc123"}
+
+        app = self._build_app(mock_db, mock_current_user)
+
+        with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_manager_class:
+            mock_oauth_manager = Mock()
+            mock_oauth_manager.initiate_authorization_code_flow = AsyncMock(return_value=auth_data)
+            mock_oauth_manager_class.return_value = mock_oauth_manager
+
+            with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                with patch("mcpgateway.routers.oauth_router._enforce_gateway_access", new_callable=AsyncMock):
+                    client = TestClient(app)
+                    response = client.get("/oauth/authorize/gateway123", follow_redirects=False)
+
+        assert response.status_code == 307
+        call_kwargs = mock_oauth_manager.initiate_authorization_code_flow.call_args.kwargs
+        assert call_kwargs["popup"] is False

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -8,6 +8,8 @@ This module tests OAuth endpoints including authorization flow, callbacks, and s
 """
 
 # Standard
+import base64
+import json
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
@@ -44,6 +46,17 @@ def mock_request():
     request.state = SimpleNamespace(token_teams=["team-1"])
     return request
 
+
+@pytest.fixture
+def mock_request_popup():
+    """Create mock FastAPI request for popup mode."""
+    request = Mock(spec=Request)
+    request.url = Mock()
+    request.url.scheme = "https"
+    request.url.netloc = "gateway.example.com"
+    request.scope = {"root_path": ""}
+    request.state = SimpleNamespace(token_teams=["team-1"], csp_nonce="test-nonce-popup", is_popup=True)
+    return request
 
 @pytest.fixture
 def mock_gateway():
@@ -2515,6 +2528,8 @@ class TestOAuthCallbackCSPCompliance:
             nonces_seen.add(nonce)
 
         # Verify we collected 3 unique nonces
+        assert len(nonces_seen) == 3, "Each request should have a unique CSP nonce"
+
 
 
 class TestOAuthRouterPopupMode:
@@ -2940,3 +2955,75 @@ class TestOAuthRouterPopupMode:
 
         # Verify NO postMessage script
         assert 'window.opener.postMessage' not in body
+
+    @pytest.mark.asyncio
+    async def test_oauth_callback_oauth_error_popup_mode(self, mock_db, mock_request_popup, mock_gateway):
+        """Test OAuth callback OAuthError in popup mode (line 887 coverage)."""
+        # Setup state with popup prefix
+        state_data = {"gateway_id": "gateway123", "app_user_email": "test@example.com"}
+        payload = json.dumps(state_data).encode()
+        signature = b"x" * 32
+        state = "popup." + base64.urlsafe_b64encode(payload + signature).decode()
+
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_manager_class:
+            mock_oauth_manager = Mock()
+            mock_oauth_manager.resolve_gateway_id_from_state = AsyncMock(return_value="gateway123")
+            mock_oauth_manager.complete_authorization_code_flow = AsyncMock(
+                side_effect=OAuthError("Invalid authorization code")
+            )
+            mock_oauth_manager_class.return_value = mock_oauth_manager
+
+            with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                from mcpgateway.routers.oauth_router import oauth_callback
+
+                # Execute
+                result = await oauth_callback(
+                    code="invalid_code",
+                    state=state,
+                    request=mock_request_popup,
+                    db=mock_db
+                )
+
+                # Assert popup response
+                assert result.status_code == 400
+                assert b"<!DOCTYPE html>" in result.body
+                assert b"oauth_callback" in result.body
+                assert b"oauth_error" in result.body
+
+    @pytest.mark.asyncio
+    async def test_oauth_callback_unexpected_error_popup_mode(self, mock_db, mock_request_popup, mock_gateway):
+        """Test OAuth callback unexpected error in popup mode (line 930 coverage)."""
+        # Setup state with popup prefix
+        state_data = {"gateway_id": "gateway123", "app_user_email": "test@example.com"}
+        payload = json.dumps(state_data).encode()
+        signature = b"x" * 32
+        state = "popup." + base64.urlsafe_b64encode(payload + signature).decode()
+
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_manager_class:
+            mock_oauth_manager = Mock()
+            mock_oauth_manager.resolve_gateway_id_from_state = AsyncMock(return_value="gateway123")
+            mock_oauth_manager.complete_authorization_code_flow = AsyncMock(
+                side_effect=RuntimeError("Unexpected server error")
+            )
+            mock_oauth_manager_class.return_value = mock_oauth_manager
+
+            with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                from mcpgateway.routers.oauth_router import oauth_callback
+
+                # Execute
+                result = await oauth_callback(
+                    code="auth_code_123",
+                    state=state,
+                    request=mock_request_popup,
+                    db=mock_db
+                )
+
+                # Assert popup response
+                assert result.status_code == 500
+                assert b"<!DOCTYPE html>" in result.body
+                assert b"oauth_callback" in result.body
+                assert b"server_error" in result.body

--- a/tests/unit/mcpgateway/services/test_oauth_manager.py
+++ b/tests/unit/mcpgateway/services/test_oauth_manager.py
@@ -1571,6 +1571,66 @@ def test_generate_state_is_opaque_and_no_email_leak(oauth_manager):
     assert "gw-1" not in state
 
 
+def test_generate_state_with_popup_false(oauth_manager):
+    """Test that popup=False generates state without popup prefix."""
+    state = oauth_manager._generate_state("gw-1", "user@test.com", popup=False)
+    assert isinstance(state, str)
+    assert not state.startswith("popup.")
+    assert len(state) > 20
+
+
+def test_generate_state_with_popup_true(oauth_manager):
+    """Test that popup=True generates state with popup. prefix."""
+    state = oauth_manager._generate_state("gw-1", "user@test.com", popup=True)
+    assert isinstance(state, str)
+    assert state.startswith("popup.")
+    # Remove prefix and verify the rest is a valid token
+    token_part = state[6:]  # Remove "popup." prefix
+    assert len(token_part) > 20
+
+
+@pytest.mark.asyncio
+async def test_initiate_authorization_code_flow_with_popup_false(oauth_manager):
+    """Test that initiate_authorization_code_flow with popup=False generates non-prefixed state."""
+    credentials = {
+        "client_id": "test-client",
+        "authorization_url": "https://auth.example.com/authorize",
+        "redirect_uri": "https://app.example.com/callback",
+    }
+
+    result = await oauth_manager.initiate_authorization_code_flow(
+        "test-gateway",
+        credentials,
+        app_user_email="user@test.com",
+        popup=False
+    )
+
+    assert "authorization_url" in result
+    assert "state" in result
+    assert not result["state"].startswith("popup.")
+
+
+@pytest.mark.asyncio
+async def test_initiate_authorization_code_flow_with_popup_true(oauth_manager):
+    """Test that initiate_authorization_code_flow with popup=True generates popup-prefixed state."""
+    credentials = {
+        "client_id": "test-client",
+        "authorization_url": "https://auth.example.com/authorize",
+        "redirect_uri": "https://app.example.com/callback",
+    }
+
+    result = await oauth_manager.initiate_authorization_code_flow(
+        "test-gateway",
+        credentials,
+        app_user_email="user@test.com",
+        popup=True
+    )
+
+    assert "authorization_url" in result
+    assert "state" in result
+    assert result["state"].startswith("popup.")
+
+
 # ---------- _create_authorization_url_with_pkce ----------
 
 


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue

Closes #5660

---

## 🚀 Summary (1-2 sentences)

Add popup query param to OAuth authorize endpoint, prefixing state token with `popup.`. Callback detects it and responds with a postMessage + window.close() script instead of a full HTML page, for React UI popup-window connects.

---

## 📏 Reviewability

- [X] This PR has one clear purpose
- [X] The linked issue is not labeled `triage`
- [X] Unrelated bugs or improvements are tracked in separate issues/PRs
- [X] Tests are included with the code they validate
- [X] If AI-assisted, I understand and can explain the generated changes
