### PR TITLE
feat(ui-rewrite): add a new tags inline component to each details panel

### DIFF
--- a/client/src/api/prompts.test.ts
+++ b/client/src/api/prompts.test.ts
@@ -94,4 +94,33 @@ describe("promptsApi", () => {
       );
     });
   });
+
+  describe("updateTags", () => {
+    it("PUTs /prompts/:id with a tags-only body and returns the updated prompt", async () => {
+      const updated = { id: "prompt-1", tags: [{ id: "draft", label: "draft" }] };
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify(updated), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await promptsApi.updateTags("prompt-1", ["draft"]);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/prompts/prompt-1"),
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ tags: ["draft"] }),
+        }),
+      );
+      expect(result).toEqual(updated);
+    });
+
+    it("throws synchronously for an invalid prompt ID", () => {
+      expect(() => promptsApi.updateTags("../etc/passwd", ["x"])).toThrow(
+        "Invalid prompt ID format",
+      );
+    });
+  });
 });

--- a/client/src/api/prompts.ts
+++ b/client/src/api/prompts.ts
@@ -3,6 +3,7 @@
  */
 
 import { api } from "./client";
+import type { PromptRead } from "@/generated/types";
 
 /**
  * Shape of a rendered MCP `prompts/get` response — the gateway substitutes
@@ -45,6 +46,22 @@ function validatePromptName(value: string): string {
   return value;
 }
 
+/**
+ * Validates a prompt ID (the primary-key identifier used by `PUT /prompts/{id}`,
+ * distinct from the name used by {@link promptsApi.render}). Guards against path
+ * traversal and injection by allowing only alphanumerics, hyphens, and
+ * underscores.
+ */
+function validatePromptId(id: string): string {
+  if (!id || typeof id !== "string") {
+    throw new Error("Invalid prompt ID");
+  }
+  if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
+    throw new Error("Invalid prompt ID format");
+  }
+  return id;
+}
+
 export const promptsApi = {
   /**
    * Render a prompt without invoking an LLM. Runs plugin hooks; returns the
@@ -85,5 +102,18 @@ export const promptsApi = {
         signal: options.signal,
       })
       .then(({ data, status }) => ({ rendered: data, status }));
+  },
+
+  /**
+   * Replace a prompt's tags.
+   *
+   * Sends a partial `PUT /prompts/{id}` (keyed by the prompt's primary-key ID,
+   * not its name) carrying only `tags`; the update service preserves every other
+   * field when it is omitted. Returns the updated prompt so callers can patch
+   * their cache with the normalized tags.
+   */
+  updateTags: (id: string, tags: string[]): Promise<PromptRead> => {
+    const validId = validatePromptId(id);
+    return api.put<PromptRead>(`/prompts/${encodeURIComponent(validId)}`, { tags });
   },
 };

--- a/client/src/api/resources.test.ts
+++ b/client/src/api/resources.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { resourcesApi } from "./resources";
+
+describe("resourcesApi", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    global.fetch = mockFetch;
+    vi.clearAllMocks();
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      value: "mcpgateway_csrf_token=test-csrf-token",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("updateTags", () => {
+    it("PUTs /resources/:id with a tags-only body and returns the updated resource", async () => {
+      const updated = { id: "42", tags: ["alerts"] };
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify(updated), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await resourcesApi.updateTags("42", ["alerts"]);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/resources/42"),
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ tags: ["alerts"] }),
+        }),
+      );
+      expect(result).toEqual(updated);
+    });
+
+    it("throws synchronously for an invalid ID", () => {
+      expect(() => resourcesApi.updateTags("../etc/passwd", ["x"])).toThrow(
+        "Invalid resource ID format",
+      );
+    });
+
+    it("throws ApiError on a non-2xx response", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ detail: "Forbidden" }), {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      await expect(resourcesApi.updateTags("42", ["x"])).rejects.toThrow("HTTP 403");
+    });
+  });
+});

--- a/client/src/api/resources.ts
+++ b/client/src/api/resources.ts
@@ -3,7 +3,7 @@
  */
 
 import { api } from "./client";
-import type { ResourceCreate, ResourceUpdate } from "@/generated/types";
+import type { ResourceCreate, ResourceRead, ResourceUpdate } from "@/generated/types";
 
 /**
  * Validates resource ID to prevent path traversal and injection attacks
@@ -43,6 +43,18 @@ export const resourcesApi = {
   update: (id: string, data: ResourceUpdate): Promise<void> => {
     const validId = validateResourceId(id);
     return api.put(`/resources/${validId}`, data);
+  },
+
+  /**
+   * Replace a resource's tags.
+   *
+   * Sends a partial `PUT /resources/{id}` carrying only `tags`; other fields are
+   * preserved because the update service skips omitted values. Returns the
+   * updated resource so callers can patch their cache with the normalized tags.
+   */
+  updateTags: (id: string, tags: string[]): Promise<ResourceRead> => {
+    const validId = validateResourceId(id);
+    return api.put<ResourceRead>(`/resources/${validId}`, { tags });
   },
 
   /**

--- a/client/src/api/servers.test.ts
+++ b/client/src/api/servers.test.ts
@@ -270,4 +270,33 @@ describe("serversApi", () => {
       vi.useRealTimers();
     });
   });
+
+  describe("updateTags", () => {
+    it("PUTs /gateways/:id with a tags-only body and returns the updated server", async () => {
+      const updated = { id: "server-123", tags: [{ id: "prod", label: "prod" }] };
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify(updated), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await serversApi.updateTags("server-123", ["prod"]);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/gateways/server-123"),
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ tags: ["prod"] }),
+        }),
+      );
+      expect(result).toEqual(updated);
+    });
+
+    it("throws synchronously for an invalid server ID", () => {
+      expect(() => serversApi.updateTags("../etc/passwd", ["prod"])).toThrow(
+        "Invalid server ID format",
+      );
+    });
+  });
 });

--- a/client/src/api/servers.ts
+++ b/client/src/api/servers.ts
@@ -96,6 +96,18 @@ export const serversApi = {
   },
 
   /**
+   * Replace an MCP server's (gateway's) tags.
+   *
+   * Sends a partial `PUT /gateways/{id}` carrying only `tags`; the gateway
+   * update service preserves every other field when it is omitted. Returns the
+   * updated server so callers can patch their cache with the normalized tags.
+   */
+  updateTags: (id: string, tags: string[]): Promise<MCPServer> => {
+    const validId = validateServerId(id);
+    return api.put<MCPServer>(`/gateways/${validId}`, { tags });
+  },
+
+  /**
    * Test connection to an MCP server
    */
   testConnection: (id: string): Promise<{ success: boolean; message: string }> => {

--- a/client/src/api/tools.test.ts
+++ b/client/src/api/tools.test.ts
@@ -234,4 +234,31 @@ describe("toolsApi", () => {
       ).rejects.toThrow("HTTP 400");
     });
   });
+
+  describe("updateTags", () => {
+    it("PUTs /tools/:id with a tags-only body and returns the updated tool", async () => {
+      const updated = { id: "tool-abc-123", tags: [{ id: "ml", label: "ml" }] };
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify(updated), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await toolsApi.updateTags("tool-abc-123", ["ml"]);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/tools/tool-abc-123"),
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ tags: ["ml"] }),
+        }),
+      );
+      expect(result).toEqual(updated);
+    });
+
+    it("throws synchronously for an invalid ID", () => {
+      expect(() => toolsApi.updateTags("../etc/passwd", ["ml"])).toThrow("Invalid tool ID format");
+    });
+  });
 });

--- a/client/src/api/tools.ts
+++ b/client/src/api/tools.ts
@@ -69,6 +69,19 @@ export const toolsApi = {
     return api.delete(`/tools/${validId}`);
   },
 
+  /**
+   * Replace a tool's tags.
+   *
+   * Sends a partial `PUT /tools/{id}` carrying only `tags`; the update service
+   * leaves every other field untouched when it is omitted. Returns the updated
+   * tool (with backend-normalized tag objects) so callers can patch their cache
+   * with the canonical values.
+   */
+  updateTags: (id: string, tags: string[]): Promise<Tool> => {
+    const validId = validateToolId(id);
+    return api.put<Tool>(`/tools/${validId}`, { tags });
+  },
+
   // Activation uses the canonical `POST /tools/{tool_id}/state?activate=true|false`
   // endpoint (requires `tools.update` permission). The deprecated `/toggle` endpoint
   // is intentionally not used.

--- a/client/src/api/virtualServers.test.ts
+++ b/client/src/api/virtualServers.test.ts
@@ -4,17 +4,20 @@ import {
   buildCreateVirtualServerPayload,
   buildUpdateVirtualServerPayload,
   deleteVirtualServer,
+  updateVirtualServerTags,
 } from "./virtualServers";
 
 vi.mock("./client", () => ({
   api: {
     delete: vi.fn(),
+    put: vi.fn(),
   },
 }));
 
 describe("virtualServers API", () => {
   beforeEach(() => {
     vi.mocked(api.delete).mockReset();
+    vi.mocked(api.put).mockReset();
   });
 
   it("builds the create payload expected by POST /servers", () => {
@@ -279,5 +282,23 @@ describe("virtualServers API", () => {
       team_id: "team-abc-123",
     });
     expect(payload).not.toHaveProperty("oauth_config");
+  });
+
+  it("PUTs /servers/:id with a tags-only body via updateVirtualServerTags", async () => {
+    const updated = { id: "server-1", tags: [{ id: "prod", label: "prod" }] };
+    vi.mocked(api.put).mockResolvedValue(updated);
+
+    const result = await updateVirtualServerTags("server-1", ["prod"]);
+
+    expect(api.put).toHaveBeenCalledWith("/servers/server-1", { tags: ["prod"] });
+    expect(result).toBe(updated);
+  });
+
+  it("URL-encodes the server ID in updateVirtualServerTags", async () => {
+    vi.mocked(api.put).mockResolvedValue({});
+
+    await updateVirtualServerTags("team/1", ["x"]);
+
+    expect(api.put).toHaveBeenCalledWith("/servers/team%2F1", { tags: ["x"] });
   });
 });

--- a/client/src/api/virtualServers.ts
+++ b/client/src/api/virtualServers.ts
@@ -103,3 +103,15 @@ export function updateVirtualServer(
     buildUpdateVirtualServerPayload(details),
   );
 }
+
+/**
+ * Replace a virtual server's tags.
+ *
+ * Sends a partial `PUT /servers/{id}` carrying only `tags`; the server update
+ * service preserves every other field (name, visibility, associated
+ * tools/resources/prompts, ...) when it is omitted. Returns the updated server
+ * so callers can patch their cache with the backend-normalized tags.
+ */
+export function updateVirtualServerTags(serverId: string, tags: string[]): Promise<VirtualServer> {
+  return api.put<VirtualServer>(`/servers/${encodeURIComponent(serverId)}`, { tags });
+}

--- a/client/src/components/gateways/VirtualServerDetailsPanel.test.tsx
+++ b/client/src/components/gateways/VirtualServerDetailsPanel.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders as render } from "@/test/test-utils";
+import { VirtualServerDetailsPanel } from "./VirtualServerDetailsPanel";
+import type { VirtualServer } from "@/types/server";
+
+function makeServer(overrides: Partial<VirtualServer> = {}): VirtualServer {
+  return {
+    id: "gateway-1",
+    name: "GH repo tasks",
+    description: "Test server",
+    icon: "",
+    createdAt: "2026-04-16T13:23:12Z",
+    updatedAt: "2026-04-16T13:23:12Z",
+    enabled: true,
+    associatedTools: [],
+    associatedToolIds: [],
+    associatedResources: [],
+    associatedPrompts: [],
+    associatedA2aAgents: [],
+    metrics: null,
+    tags: [],
+    createdBy: "admin@example.com",
+    createdFromIp: "127.0.0.1",
+    createdVia: "ui",
+    createdUserAgent: "Mozilla/5.0",
+    modifiedBy: null,
+    modifiedFromIp: null,
+    modifiedVia: null,
+    modifiedUserAgent: null,
+    importBatchId: null,
+    federationSource: null,
+    version: 1,
+    teamId: "team-1",
+    team: "Test Team",
+    ownerEmail: "admin@example.com",
+    visibility: "team",
+    oauthEnabled: false,
+    oauthConfig: null,
+    ...overrides,
+  };
+}
+
+describe("VirtualServerDetailsPanel inline tag add", () => {
+  it("calls onAddTag with the merged, de-duplicated tag list", async () => {
+    const user = userEvent.setup();
+    const onAddTag = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <VirtualServerDetailsPanel
+        server={makeServer({ id: "gw-1", tags: ["prod"] })}
+        error={null}
+        open
+        onClose={vi.fn()}
+        onAddSources={vi.fn()}
+        onAddTag={onAddTag}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add tags" }));
+    await user.type(screen.getByPlaceholderText("Add tags separated with commas"), "staging, prod");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    // "prod" already exists and is dropped; "staging" is appended.
+    expect(onAddTag).toHaveBeenCalledWith("gw-1", ["prod", "staging"]);
+  });
+
+  it("disables the add-tag trigger when onAddTag is omitted", () => {
+    render(
+      <VirtualServerDetailsPanel
+        server={makeServer({ tags: [] })}
+        error={null}
+        open
+        onClose={vi.fn()}
+        onAddSources={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Add tags" })).toBeDisabled();
+  });
+});

--- a/client/src/components/gateways/VirtualServerDetailsPanel.tsx
+++ b/client/src/components/gateways/VirtualServerDetailsPanel.tsx
@@ -17,6 +17,7 @@ import {
 import { MCPIcon } from "@/components/icons/MCPIcon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { InlineTagAdd } from "@/components/ui/inline-tag-add";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import type { MCPServer, VirtualServer } from "@/types/server";
@@ -137,12 +138,19 @@ export function VirtualServerDetailsPanel({
   open,
   onClose,
   onAddSources,
+  onAddTag,
 }: {
   server: VirtualServer | null;
   error: { message: string } | null;
   open: boolean;
   onClose: () => void;
   onAddSources: () => void;
+  /**
+   * Persists the server's full tag list after an inline add. Receives the
+   * virtual server ID and the new complete list of tag labels. When omitted, the
+   * tag row shows a non-interactive "add" affordance.
+   */
+  onAddTag?: (serverId: string, tags: string[]) => Promise<void>;
 }) {
   const intl = useIntl();
   const endpoint = server ? getVirtualServerEndpoint(server.id) : "";
@@ -681,28 +689,30 @@ export function VirtualServerDetailsPanel({
                   <DetailRow label={intl.formatMessage({ id: "gateways.details.url" })}>
                     <CopyValue label="URL" value={endpoint} />
                   </DetailRow>
-                  <DetailRow
-                    label={intl.formatMessage({ id: "gateways.details.tags" })}
-                    className="items-center"
-                  >
-                    <div className="flex min-w-0 flex-wrap items-center gap-2">
-                      {tags.map((tag) => (
-                        <Badge
-                          key={tag.key}
-                          variant="outline"
-                          className="rounded-full px-2 py-0 text-[11px] font-medium text-muted-foreground"
-                        >
-                          {tag.label}
-                        </Badge>
-                      ))}
-                      <button
-                        type="button"
-                        className="text-[12px] text-muted-foreground hover:text-foreground"
+                  {(() => {
+                    const tagLabels = tags.map((tag) => tag.label);
+                    return (
+                      <InlineTagAdd
+                        label={intl.formatMessage({ id: "gateways.details.tags" })}
+                        existingTags={tagLabels}
+                        onAdd={
+                          onAddTag && server
+                            ? (newTags) => onAddTag(server.id, [...tagLabels, ...newTags])
+                            : undefined
+                        }
                       >
-                        {intl.formatMessage({ id: "gateways.details.addTag" })}
-                      </button>
-                    </div>
-                  </DetailRow>
+                        {tags.map((tag) => (
+                          <Badge
+                            key={tag.key}
+                            variant="outline"
+                            className="rounded-full px-2 py-0 text-[11px] font-medium text-muted-foreground"
+                          >
+                            {tag.label}
+                          </Badge>
+                        ))}
+                      </InlineTagAdd>
+                    );
+                  })()}
                 </dl>
               </div>
 

--- a/client/src/components/prompts/PromptDetailsPanel.test.tsx
+++ b/client/src/components/prompts/PromptDetailsPanel.test.tsx
@@ -247,4 +247,27 @@ describe("PromptDetailsPanel", () => {
 
     expect(screen.getByText("Local prompt · private · 1 argument")).toBeInTheDocument();
   });
+
+  it("calls onAddTag with the merged, de-duplicated tag list", async () => {
+    const user = userEvent.setup();
+    const onAddTag = vi.fn().mockResolvedValue(undefined);
+    const prompt = mockPrompt({ id: "p1", tags: [{ id: "dev", label: "dev" }] });
+
+    render(
+      <PromptDetailsPanel
+        prompts={[prompt]}
+        title="hugging-face"
+        open={true}
+        onClose={vi.fn()}
+        onAddTag={onAddTag}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add tags" }));
+    await user.type(screen.getByPlaceholderText("Add tags separated with commas"), "alerts, dev");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    // "dev" already exists and is dropped; "alerts" is appended.
+    expect(onAddTag).toHaveBeenCalledWith("p1", ["dev", "alerts"]);
+  });
 });

--- a/client/src/components/prompts/PromptDetailsPanel.tsx
+++ b/client/src/components/prompts/PromptDetailsPanel.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
-import { Activity, Globe, MessageSquareCode, PanelRightClose, Plus } from "lucide-react";
+import { Activity, Globe, MessageSquareCode, PanelRightClose } from "lucide-react";
 import { useIntl } from "react-intl";
 
 import type { PromptRead } from "@/generated/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { InlineTagAdd } from "@/components/ui/inline-tag-add";
 import { cn } from "@/lib/utils";
 import { getTagDisplay } from "@/components/gateways/utils";
 import { formatDateTime } from "@/utils/format";
@@ -27,6 +28,12 @@ export interface PromptDetailsPanelProps {
   initialPromptId?: string;
   open: boolean;
   onClose: () => void;
+  /**
+   * Persists the prompt's full tag list after an inline add. Receives the prompt
+   * ID and the new complete list of tag labels. When omitted, the tag row shows
+   * a non-interactive "add" affordance.
+   */
+  onAddTag?: (promptId: string, tags: string[]) => Promise<void>;
 }
 
 /**
@@ -45,6 +52,7 @@ export function PromptDetailsPanel({
   initialPromptId,
   open,
   onClose,
+  onAddTag,
 }: PromptDetailsPanelProps) {
   const intl = useIntl();
   const closeButtonRef = useRef<HTMLButtonElement>(null);
@@ -237,36 +245,35 @@ export function PromptDetailsPanel({
                           : "Not available"}
                       </span>
                     </DetailRow>
-                    <DetailRow label="Tags">
-                      <div className="flex min-w-0 flex-wrap items-center gap-2">
-                        {(selected.tags || []).map((tag, index) => {
-                          const { key, label } = getTagDisplay(tag, index);
-                          return (
-                            <Badge
-                              key={key}
-                              variant="outline"
-                              className="rounded-full px-2 py-0 text-[11px] font-medium text-muted-foreground"
-                            >
-                              {label}
-                            </Badge>
-                          );
-                        })}
-                        {/* TODO: wire tag add-flow. Placeholder pending the
-                            per-prompt actions menu design (tracked with the
-                            same #5563 follow-up as the drawer variants). */}
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          tabIndex={-1}
-                          aria-hidden="true"
-                          className="h-auto gap-1 p-0 text-[12px] font-normal text-muted-foreground hover:bg-transparent hover:text-foreground"
+                    {(() => {
+                      const tagLabels = (selected.tags || []).map(
+                        (tag, index) => getTagDisplay(tag, index).label,
+                      );
+                      return (
+                        <InlineTagAdd
+                          label="Tags"
+                          existingTags={tagLabels}
+                          onAdd={
+                            onAddTag
+                              ? (newTags) => onAddTag(selected.id, [...tagLabels, ...newTags])
+                              : undefined
+                          }
                         >
-                          <Plus className="size-3" aria-hidden="true" />
-                          add
-                        </Button>
-                      </div>
-                    </DetailRow>
+                          {(selected.tags || []).map((tag, index) => {
+                            const { key, label } = getTagDisplay(tag, index);
+                            return (
+                              <Badge
+                                key={key}
+                                variant="outline"
+                                className="rounded-full px-2 py-0 text-[11px] font-medium text-muted-foreground"
+                              >
+                                {label}
+                              </Badge>
+                            );
+                          })}
+                        </InlineTagAdd>
+                      );
+                    })()}
                   </dl>
                 </div>
 

--- a/client/src/components/resources/ResourceDetailsPanel.test.tsx
+++ b/client/src/components/resources/ResourceDetailsPanel.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders as render } from "@/test/test-utils";
+import { ResourceDetailsPanel } from "./ResourceDetailsPanel";
+import type { ResourceRead } from "@/generated/types";
+
+function mockResource(overrides?: Partial<NonNullable<ResourceRead>>): NonNullable<ResourceRead> {
+  return {
+    id: "42",
+    uri: "file:///a.txt",
+    name: "a.txt",
+    description: null,
+    mimeType: "text/plain",
+    size: 10,
+    createdAt: "2026-01-01T00:00:00",
+    updatedAt: "2026-01-02T00:00:00",
+    enabled: true,
+    tags: ["alerts"],
+    ...overrides,
+  };
+}
+
+describe("ResourceDetailsPanel inline tag add", () => {
+  it("calls onAddTag with the merged, de-duplicated tag list", async () => {
+    const user = userEvent.setup();
+    const onAddTag = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ResourceDetailsPanel
+        resources={[mockResource()]}
+        gatewaySlug="local"
+        open
+        onClose={vi.fn()}
+        onAddTag={onAddTag}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add tags" }));
+    await user.type(screen.getByPlaceholderText("Add tags separated with commas"), "dev, alerts");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    // "alerts" already exists and is dropped; "dev" is appended.
+    expect(onAddTag).toHaveBeenCalledWith("42", ["alerts", "dev"]);
+  });
+
+  it("disables the add-tag trigger when onAddTag is omitted", () => {
+    render(
+      <ResourceDetailsPanel
+        resources={[mockResource({ tags: [] })]}
+        gatewaySlug="local"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Add tags" })).toBeDisabled();
+  });
+});

--- a/client/src/components/resources/ResourceDetailsPanel.tsx
+++ b/client/src/components/resources/ResourceDetailsPanel.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { useIntl } from "react-intl";
-import { Activity, Copy, FileText, Globe, PanelRightClose, Plus } from "lucide-react";
+import { Activity, Copy, FileText, Globe, PanelRightClose } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { InlineTagAdd } from "@/components/ui/inline-tag-add";
 import { cn } from "@/lib/utils";
 import type { ResourceRead } from "@/generated/types";
 import { copyToClipboard } from "@/lib/clipboard";
@@ -54,6 +55,12 @@ interface ResourceDetailsPanelProps {
   onClose: () => void;
   onEditResource?: (resource: NonNullable<ResourceRead>) => void;
   onDeleteResource?: (resourceId: string) => void;
+  /**
+   * Persists the resource's full tag list after an inline add. Receives the
+   * resource ID and the new complete list of tag labels. When omitted, the tag
+   * row shows a non-interactive "add" affordance.
+   */
+  onAddTag?: (resourceId: string, tags: string[]) => Promise<void>;
 }
 
 export function ResourceDetailsPanel({
@@ -63,6 +70,7 @@ export function ResourceDetailsPanel({
   onClose,
   onEditResource,
   onDeleteResource,
+  onAddTag,
 }: ResourceDetailsPanelProps) {
   const intl = useIntl();
   const [selectedResource, setSelectedResource] = useState<NonNullable<ResourceRead> | null>(null);
@@ -246,45 +254,34 @@ export function ResourceDetailsPanel({
                           </span>
                         </DetailRow>
                       )}
-                      <DetailRow
-                        label={intl.formatMessage({ id: "resources.details.label.tags" })}
-                        className="items-center"
-                      >
-                        <div className="flex min-w-0 flex-wrap items-center gap-2">
-                          {(selectedResource.tags || []).length > 0 ? (
-                            <>
-                              {(selectedResource.tags || []).map((tag, index) => (
-                                <Badge
-                                  key={`${tag}-${index}`}
-                                  variant="outline"
-                                  className="rounded-full px-2 py-0 text-[11px] font-medium text-muted-foreground"
-                                >
-                                  {tag}
-                                </Badge>
-                              ))}
-                              <button
-                                type="button"
-                                tabIndex={-1}
-                                aria-hidden="true"
-                                className="flex items-center gap-1 text-[12px] text-muted-foreground hover:text-foreground"
+                      {(() => {
+                        const tagLabels = selectedResource.tags || [];
+                        return (
+                          <InlineTagAdd
+                            label={intl.formatMessage({ id: "resources.details.label.tags" })}
+                            existingTags={tagLabels}
+                            onAdd={
+                              onAddTag
+                                ? (newTags) =>
+                                    onAddTag(String(selectedResource.id), [
+                                      ...tagLabels,
+                                      ...newTags,
+                                    ])
+                                : undefined
+                            }
+                          >
+                            {tagLabels.map((tag, index) => (
+                              <Badge
+                                key={`${tag}-${index}`}
+                                variant="outline"
+                                className="rounded-full px-2 py-0 text-[11px] font-medium text-muted-foreground"
                               >
-                                <Plus className="size-3" aria-hidden="true" />
-                                {intl.formatMessage({ id: "resources.details.addTag" })}
-                              </button>
-                            </>
-                          ) : (
-                            <button
-                              type="button"
-                              tabIndex={-1}
-                              aria-hidden="true"
-                              className="flex items-center gap-1 text-[12px] text-muted-foreground hover:text-foreground"
-                            >
-                              <Plus className="size-3" aria-hidden="true" />
-                              {intl.formatMessage({ id: "resources.details.addTag" })}
-                            </button>
-                          )}
-                        </div>
-                      </DetailRow>
+                                {tag}
+                              </Badge>
+                            ))}
+                          </InlineTagAdd>
+                        );
+                      })()}
                     </dl>
                   </div>
 

--- a/client/src/components/servers/MCPServerDetailsPanel.test.tsx
+++ b/client/src/components/servers/MCPServerDetailsPanel.test.tsx
@@ -660,4 +660,26 @@ describe("MCPServerDetailsPanel", () => {
     const copyButtons = screen.getAllByRole("button", { name: /copy/i });
     expect(copyButtons.length).toBeGreaterThan(0);
   });
+
+  it("calls onAddTag with the merged, de-duplicated tag list", async () => {
+    const user = userEvent.setup();
+    const onAddTag = vi.fn().mockResolvedValue(undefined);
+
+    renderWithProviders(
+      <MCPServerDetailsPanel
+        server={{ ...mockServer, tags: ["prod"] }}
+        error={null}
+        open
+        onClose={vi.fn()}
+        onAddTag={onAddTag}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add tags" }));
+    await user.type(screen.getByPlaceholderText("Add tags separated with commas"), "staging, prod");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    // "prod" already exists and is dropped; "staging" is appended.
+    expect(onAddTag).toHaveBeenCalledWith("test-server-123", ["prod", "staging"]);
+  });
 });

--- a/client/src/components/servers/MCPServerDetailsPanel.tsx
+++ b/client/src/components/servers/MCPServerDetailsPanel.tsx
@@ -8,7 +8,6 @@ import {
   Loader2,
   MessageSquareCode,
   PanelRightClose,
-  Plus,
   Search,
   Server,
   Users,
@@ -17,6 +16,7 @@ import {
 import { MCPIcon } from "@/components/icons/MCPIcon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { InlineTagAdd } from "@/components/ui/inline-tag-add";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import type { MCPServer as BaseMCPServer, VirtualServerTag } from "@/types/server";
@@ -139,11 +139,18 @@ export function MCPServerDetailsPanel({
   error,
   open,
   onClose,
+  onAddTag,
 }: {
   server: MCPServer | null;
   error: { message: string } | null;
   open: boolean;
   onClose: () => void;
+  /**
+   * Persists the server's full tag list after an inline add. Receives the server
+   * (gateway) ID and the new complete list of tag labels. When omitted, the tag
+   * row shows a non-interactive "add" affordance.
+   */
+  onAddTag?: (serverId: string, tags: string[]) => Promise<void>;
 }) {
   const [activeTab, setActiveTab] = useState<ComponentTab>("all");
   const [searchQuery, setSearchQuery] = useState("");
@@ -543,49 +550,34 @@ export function MCPServerDetailsPanel({
                       <span className="text-foreground">{server.team}</span>
                     </DetailRow>
                   )}
-                  <DetailRow label="Tags" className="items-center">
-                    <div className="flex min-w-0 flex-wrap items-center gap-2">
-                      {(server.tags || []).length > 0 ? (
-                        <>
-                          {(server.tags || []).map((tag, index) => {
-                            const tagLabel =
-                              typeof tag === "string"
-                                ? tag
-                                : tag.label || tag.name || tag.value || tag.id || "Tag";
-                            const tagKey = typeof tag === "string" ? tag : tag.id || tagLabel;
-                            return (
-                              <Badge
-                                key={`${tagKey}-${index}`}
-                                variant="outline"
-                                className="rounded-full px-2 py-0 text-[11px] font-medium text-muted-foreground"
-                              >
-                                {tagLabel}
-                              </Badge>
-                            );
-                          })}
-                          <button
-                            type="button"
-                            tabIndex={-1}
-                            aria-hidden="true"
-                            className="flex items-center gap-1 text-[12px] text-muted-foreground hover:text-foreground"
+                  {(() => {
+                    const tagLabels = (server.tags || []).map((tag) =>
+                      typeof tag === "string"
+                        ? tag
+                        : tag.label || tag.name || tag.value || tag.id || "Tag",
+                    );
+                    return (
+                      <InlineTagAdd
+                        label="Tags"
+                        existingTags={tagLabels}
+                        onAdd={
+                          onAddTag && server.id
+                            ? (newTags) => onAddTag(server.id, [...tagLabels, ...newTags])
+                            : undefined
+                        }
+                      >
+                        {tagLabels.map((tagLabel, index) => (
+                          <Badge
+                            key={`${tagLabel}-${index}`}
+                            variant="outline"
+                            className="rounded-full px-2 py-0 text-[11px] font-medium text-muted-foreground"
                           >
-                            <Plus className="size-3" aria-hidden="true" />
-                            add
-                          </button>
-                        </>
-                      ) : (
-                        <button
-                          type="button"
-                          tabIndex={-1}
-                          aria-hidden="true"
-                          className="flex items-center gap-1 text-[12px] text-muted-foreground hover:text-foreground"
-                        >
-                          <Plus className="size-3" aria-hidden="true" />
-                          add
-                        </button>
-                      )}
-                    </div>
-                  </DetailRow>
+                            {tagLabel}
+                          </Badge>
+                        ))}
+                      </InlineTagAdd>
+                    );
+                  })()}
                   {server.owner_email && (
                     <DetailRow label="Owner">
                       <span className="text-foreground">{server.owner_email}</span>

--- a/client/src/components/tools/ToolDetailsPanel.test.tsx
+++ b/client/src/components/tools/ToolDetailsPanel.test.tsx
@@ -648,7 +648,7 @@ describe("ToolDetailsPanel", () => {
     it("calls onAddTag with the merged, de-duplicated tag list", async () => {
       const user = userEvent.setup();
       const onAddTag = vi.fn().mockResolvedValue(undefined);
-      const tools = [createMockTool(1, { id: "tool-1", tags: ["tag1", "tag2"] })];
+      const tools = [createMockTool(1, { id: "tool-1", tags: [{ label: "tag1" }, { label: "tag2" }] })];
 
       render(
         <ToolDetailsPanel
@@ -673,7 +673,7 @@ describe("ToolDetailsPanel", () => {
     });
 
     it("disables the add-tag trigger when onAddTag is omitted", () => {
-      const tools = [createMockTool(1, { id: "tool-1", tags: ["tag1"] })];
+      const tools = [createMockTool(1, { id: "tool-1", tags: [{ label: "tag1" }] })];
 
       render(
         <ToolDetailsPanel

--- a/client/src/components/tools/ToolDetailsPanel.test.tsx
+++ b/client/src/components/tools/ToolDetailsPanel.test.tsx
@@ -643,4 +643,49 @@ describe("ToolDetailsPanel", () => {
     const heading = container.querySelector("#tool-details-heading-my-custom-gateway");
     expect(heading).toBeInTheDocument();
   });
+
+  describe("inline tag add", () => {
+    it("calls onAddTag with the merged, de-duplicated tag list", async () => {
+      const user = userEvent.setup();
+      const onAddTag = vi.fn().mockResolvedValue(undefined);
+      const tools = [createMockTool(1, { id: "tool-1", tags: ["tag1", "tag2"] })];
+
+      render(
+        <ToolDetailsPanel
+          tools={tools}
+          gatewaySlug="test-gateway"
+          open
+          selectedToolId="tool-1"
+          onClose={mockOnClose}
+          onAddTag={onAddTag}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Add tags" }));
+      await user.type(
+        screen.getByPlaceholderText("Add tags separated with commas"),
+        "alpha, tag1, beta",
+      );
+      await user.click(screen.getByRole("button", { name: "Add" }));
+
+      // "tag1" already exists and is dropped; the new tags are appended.
+      expect(onAddTag).toHaveBeenCalledWith("tool-1", ["tag1", "tag2", "alpha", "beta"]);
+    });
+
+    it("disables the add-tag trigger when onAddTag is omitted", () => {
+      const tools = [createMockTool(1, { id: "tool-1", tags: ["tag1"] })];
+
+      render(
+        <ToolDetailsPanel
+          tools={tools}
+          gatewaySlug="test-gateway"
+          open
+          selectedToolId="tool-1"
+          onClose={mockOnClose}
+        />,
+      );
+
+      expect(screen.getByRole("button", { name: "Add tags" })).toBeDisabled();
+    });
+  });
 });

--- a/client/src/components/tools/ToolDetailsPanel.test.tsx
+++ b/client/src/components/tools/ToolDetailsPanel.test.tsx
@@ -648,7 +648,9 @@ describe("ToolDetailsPanel", () => {
     it("calls onAddTag with the merged, de-duplicated tag list", async () => {
       const user = userEvent.setup();
       const onAddTag = vi.fn().mockResolvedValue(undefined);
-      const tools = [createMockTool(1, { id: "tool-1", tags: [{ label: "tag1" }, { label: "tag2" }] })];
+      const tools = [
+        createMockTool(1, { id: "tool-1", tags: [{ label: "tag1" }, { label: "tag2" }] }),
+      ];
 
       render(
         <ToolDetailsPanel

--- a/client/src/components/tools/ToolDetailsPanel.tsx
+++ b/client/src/components/tools/ToolDetailsPanel.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { useIntl } from "react-intl";
-import { Activity, Copy, Globe, PanelRightClose, Plus, Wrench } from "lucide-react";
+import { Activity, Copy, Globe, PanelRightClose, Wrench } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { InlineTagAdd } from "@/components/ui/inline-tag-add";
 import { cn } from "@/lib/utils";
 import type { Tool } from "@/types/tool";
 import { copyToClipboard } from "@/lib/clipboard";
@@ -56,6 +57,7 @@ export function ToolDetailsPanel({
   onDeleteTool,
   onEditTool,
   onToggleTool,
+  onAddTag,
 }: {
   tools: Tool[];
   gatewaySlug: string;
@@ -65,6 +67,12 @@ export function ToolDetailsPanel({
   onDeleteTool?: (toolId: string) => void;
   onEditTool?: (tool: Tool) => void;
   onToggleTool?: (tool: Tool) => void;
+  /**
+   * Persists the tool's full tag list after an inline add. Receives the tool ID
+   * and the new complete list of tag labels. When omitted, the tag row shows a
+   * non-interactive "add" affordance.
+   */
+  onAddTag?: (toolId: string, tags: string[]) => Promise<void>;
 }) {
   const intl = useIntl();
   const [selectedTool, setSelectedTool] = useState<Tool | null>(null);
@@ -266,48 +274,32 @@ export function ToolDetailsPanel({
                           />
                         </DetailRow>
                       )}
-                      <DetailRow
-                        label={intl.formatMessage({ id: "tools.details.label.tags" })}
-                        className="items-center"
-                      >
-                        <div className="flex min-w-0 flex-wrap items-center gap-2">
-                          {(selectedTool.tags || []).length > 0 ? (
-                            <>
-                              {(selectedTool.tags || []).map((tag, index) => {
-                                const label = typeof tag === "string" ? tag : tag.label;
-                                return (
-                                  <Badge
-                                    key={`${label}-${index}`}
-                                    variant="outline"
-                                    className="rounded-full px-2 py-0 text-[11px] font-medium text-muted-foreground"
-                                  >
-                                    {label}
-                                  </Badge>
-                                );
-                              })}
-                              <button
-                                type="button"
-                                tabIndex={-1}
-                                aria-hidden="true"
-                                className="flex items-center gap-1 text-[12px] text-muted-foreground hover:text-foreground"
+                      {(() => {
+                        const tagLabels = (selectedTool.tags || []).map((tag) =>
+                          typeof tag === "string" ? tag : tag.label,
+                        );
+                        return (
+                          <InlineTagAdd
+                            label={intl.formatMessage({ id: "tools.details.label.tags" })}
+                            existingTags={tagLabels}
+                            onAdd={
+                              onAddTag
+                                ? (newTags) => onAddTag(selectedTool.id, [...tagLabels, ...newTags])
+                                : undefined
+                            }
+                          >
+                            {tagLabels.map((label, index) => (
+                              <Badge
+                                key={`${label}-${index}`}
+                                variant="outline"
+                                className="rounded-full px-2 py-0 text-[11px] font-medium text-muted-foreground"
                               >
-                                <Plus className="size-3" aria-hidden="true" />
-                                {intl.formatMessage({ id: "tools.details.addTag" })}
-                              </button>
-                            </>
-                          ) : (
-                            <button
-                              type="button"
-                              tabIndex={-1}
-                              aria-hidden="true"
-                              className="flex items-center gap-1 text-[12px] text-muted-foreground hover:text-foreground"
-                            >
-                              <Plus className="size-3" aria-hidden="true" />
-                              {intl.formatMessage({ id: "tools.details.addTag" })}
-                            </button>
-                          )}
-                        </div>
-                      </DetailRow>
+                                {label}
+                              </Badge>
+                            ))}
+                          </InlineTagAdd>
+                        );
+                      })()}
                     </dl>
                   </div>
 

--- a/client/src/components/ui/inline-tag-add.test.tsx
+++ b/client/src/components/ui/inline-tag-add.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { InlineTagAdd } from "./inline-tag-add";
+
+const PLACEHOLDER = "Add tags separated with commas";
+
+function renderControl(overrides: Partial<React.ComponentProps<typeof InlineTagAdd>> = {}) {
+  const onAdd = overrides.onAdd ?? vi.fn().mockResolvedValue(undefined);
+  // Labels rely on the component's built-in defaults ("add" trigger, "Add tags"
+  // aria label, comma-separated placeholder, "Add" / "Cancel" buttons).
+  render(
+    <InlineTagAdd
+      label="Tags"
+      existingTags={overrides.existingTags ?? ["existing"]}
+      onAdd={onAdd}
+      {...overrides}
+    />,
+  );
+  return { onAdd };
+}
+
+describe("InlineTagAdd", () => {
+  it("renders only the trigger button initially", () => {
+    renderControl();
+
+    expect(screen.getByRole("button", { name: "Add tags" })).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(PLACEHOLDER)).not.toBeInTheDocument();
+  });
+
+  it("shows the input and Cancel/Add buttons after clicking the trigger", async () => {
+    const user = userEvent.setup();
+    renderControl();
+
+    await user.click(screen.getByRole("button", { name: "Add tags" }));
+
+    expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+    // Trigger is gone while editing.
+    expect(screen.queryByRole("button", { name: "add" })).not.toBeInTheDocument();
+  });
+
+  it("Cancel collapses back to the trigger without calling onAdd", async () => {
+    const user = userEvent.setup();
+    const { onAdd } = renderControl();
+
+    await user.click(screen.getByRole("button", { name: "Add tags" }));
+    await user.type(screen.getByPlaceholderText(PLACEHOLDER), "draft");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onAdd).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Add tags" })).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(PLACEHOLDER)).not.toBeInTheDocument();
+  });
+
+  it("Add persists the trimmed tag and collapses on success", async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn().mockResolvedValue(undefined);
+    renderControl({ onAdd });
+
+    await user.click(screen.getByRole("button", { name: "Add tags" }));
+    await user.type(screen.getByPlaceholderText(PLACEHOLDER), "  analytics  ");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(onAdd).toHaveBeenCalledWith(["analytics"]);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Add tags" })).toBeInTheDocument(),
+    );
+  });
+
+  it("splits a comma-separated list into trimmed, de-duplicated tags", async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn().mockResolvedValue(undefined);
+    renderControl({ onAdd, existingTags: ["existing"] });
+
+    await user.click(screen.getByRole("button", { name: "Add tags" }));
+    // Blanks, an existing tag, and a repeat within the input are all filtered out.
+    await user.type(
+      screen.getByPlaceholderText(PLACEHOLDER),
+      "  alpha , beta,, Existing, alpha ,gamma",
+    );
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(onAdd).toHaveBeenCalledWith(["alpha", "beta", "gamma"]);
+  });
+
+  it("keeps the editor open when onAdd rejects so the user can retry", async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn().mockRejectedValue(new Error("boom"));
+    renderControl({ onAdd });
+
+    await user.click(screen.getByRole("button", { name: "Add tags" }));
+    await user.type(screen.getByPlaceholderText(PLACEHOLDER), "ml");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    await waitFor(() => expect(onAdd).toHaveBeenCalled());
+    // Still editing, value preserved.
+    expect(screen.getByPlaceholderText(PLACEHOLDER)).toHaveValue("ml");
+  });
+
+  it("skips input that only repeats existing tags without calling onAdd", async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn().mockResolvedValue(undefined);
+    renderControl({ onAdd, existingTags: ["Analytics"] });
+
+    await user.click(screen.getByRole("button", { name: "Add tags" }));
+    await user.type(screen.getByPlaceholderText(PLACEHOLDER), "analytics");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(onAdd).not.toHaveBeenCalled();
+    // Nothing new to add collapses the editor.
+    expect(screen.getByRole("button", { name: "Add tags" })).toBeInTheDocument();
+  });
+
+  it("submits on Enter and cancels on Escape", async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn().mockResolvedValue(undefined);
+    renderControl({ onAdd });
+
+    await user.click(screen.getByRole("button", { name: "Add tags" }));
+    const input = screen.getByPlaceholderText(PLACEHOLDER);
+    await user.type(input, "prod{Enter}");
+    expect(onAdd).toHaveBeenCalledWith(["prod"]);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Add tags" })).toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add tags" }));
+    await user.type(screen.getByPlaceholderText(PLACEHOLDER), "temp{Escape}");
+    expect(screen.getByRole("button", { name: "Add tags" })).toBeInTheDocument();
+    expect(onAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the pending label on the Add button while the request is in flight", async () => {
+    const user = userEvent.setup();
+    let resolveAdd: () => void = () => {};
+    const onAdd = vi.fn().mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveAdd = resolve;
+      }),
+    );
+    renderControl({ onAdd });
+
+    await user.click(screen.getByRole("button", { name: "Add tags" }));
+    await user.type(screen.getByPlaceholderText(PLACEHOLDER), "beta");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    // While the promise is unresolved the button reads "Adding..." and is disabled.
+    const pendingButton = await screen.findByRole("button", { name: "Adding..." });
+    expect(pendingButton).toBeDisabled();
+
+    resolveAdd();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Add tags" })).toBeInTheDocument(),
+    );
+  });
+
+  it("disables the Add button when the input is empty", async () => {
+    const user = userEvent.setup();
+    renderControl();
+
+    await user.click(screen.getByRole("button", { name: "Add tags" }));
+    expect(screen.getByRole("button", { name: "Add" })).toBeDisabled();
+  });
+});

--- a/client/src/components/ui/inline-tag-add.tsx
+++ b/client/src/components/ui/inline-tag-add.tsx
@@ -1,0 +1,180 @@
+import { useRef, useState } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
+import { Plus } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export interface InlineTagAddProps {
+  /** The detail-row label rendered in the left column (e.g. "Tags"). */
+  label: string;
+  /**
+   * Existing tag chips, rendered in the value column beside the "+ add" trigger.
+   * The caller owns chip markup so each drawer keeps its own styling.
+   */
+  children?: ReactNode;
+  /**
+   * Tag labels already applied to the entity. Used to skip duplicates
+   * (case-insensitive) so the same tag is never sent twice.
+   */
+  existingTags: string[];
+  /**
+   * Persists one or more new tags (the input accepts a comma-separated list).
+   * Receives the parsed, trimmed, de-duplicated new labels — appending them to
+   * {@link existingTags} is the caller's job. Should resolve once the change is
+   * saved and reject if it fails — on rejection the editor stays open with its
+   * value so the user can retry (the caller surfaces the error, e.g. via toast).
+   * When omitted the "+ add" trigger is rendered but disabled.
+   */
+  onAdd?: (tags: string[]) => Promise<void>;
+  /** Text shown on the collapsed trigger button. Defaults to "add". */
+  addLabel?: string;
+  /** Placeholder for the inline input. Defaults to "Add tags separated with commas". */
+  placeholder?: string;
+  /** Accessible label for the trigger button and input. Defaults to "Add tag". */
+  ariaLabel?: string;
+  /** Label for the confirm button. Defaults to "Add". */
+  submitLabel?: string;
+  /** Label for the confirm button while the add is in flight. Defaults to "Adding...". */
+  submitPendingLabel?: string;
+  /** Label for the cancel button. Defaults to "Cancel". */
+  cancelLabel?: string;
+  /** Optional override for the trigger button classes. */
+  triggerClassName?: string;
+}
+
+/**
+ * "Tags" detail row with an inline add-tag interaction, used across the details
+ * drawers.
+ *
+ * The label and existing chips sit on one row (a 2-column grid matching the
+ * other detail rows). Clicking the compact "+ add" trigger replaces it with a
+ * text input plus a Cancel / Add button row that spans the full width *below*
+ * the label — matching the design. Cancel collapses back to the trigger; Add
+ * persists the trimmed value via {@link InlineTagAddProps.onAdd} and, on
+ * success, collapses back so the new tag shows among the chips. Duplicate labels
+ * (matched case-insensitively against {@link InlineTagAddProps.existingTags})
+ * are ignored rather than sent to the backend. Enter confirms and Escape
+ * cancels as keyboard shortcuts.
+ */
+export function InlineTagAdd({
+  label,
+  children,
+  existingTags,
+  onAdd,
+  addLabel = "add",
+  placeholder = "Add tags separated with commas",
+  ariaLabel = "Add tags",
+  submitLabel = "Add",
+  submitPendingLabel = "Adding...",
+  cancelLabel = "Cancel",
+  triggerClassName,
+}: InlineTagAddProps) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState("");
+  const [pending, setPending] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const close = () => {
+    setEditing(false);
+    setValue("");
+  };
+
+  const submit = async () => {
+    if (!onAdd) return;
+
+    // Parse the comma-separated input into trimmed, unique new labels, skipping
+    // blanks, existing tags, and repeats within the same input (all
+    // case-insensitive).
+    const seen = new Set(existingTags.map((t) => t.toLowerCase()));
+    const newTags: string[] = [];
+    for (const raw of value.split(",")) {
+      const tag = raw.trim();
+      if (!tag) continue;
+      const key = tag.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      newTags.push(tag);
+    }
+
+    if (newTags.length === 0) {
+      close();
+      return;
+    }
+
+    setPending(true);
+    try {
+      await onAdd(newTags);
+      close();
+    } catch {
+      // Leave the editor open with its value so the user can retry; the caller
+      // surfaces the error (e.g. via toast).
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      void submit();
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      close();
+    }
+  };
+
+  return (
+    <div className="grid grid-cols-[96px_minmax(0,1fr)] items-center gap-x-4 gap-y-3">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="flex min-w-0 flex-wrap items-center gap-2 text-foreground">
+        {children}
+        {!editing && (
+          <button
+            type="button"
+            disabled={!onAdd}
+            onClick={() => setEditing(true)}
+            aria-label={ariaLabel}
+            className={cn(
+              "flex items-center gap-1 rounded text-[12px] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+              triggerClassName,
+            )}
+          >
+            <Plus className="size-3" aria-hidden="true" />
+            {addLabel}
+          </button>
+        )}
+      </dd>
+
+      {editing && (
+        <div className="col-span-2 flex w-full min-w-0 flex-col gap-3">
+          <Input
+            ref={inputRef}
+            autoFocus
+            value={value}
+            disabled={pending}
+            aria-label={ariaLabel}
+            placeholder={placeholder}
+            onChange={(event) => setValue(event.target.value)}
+            onKeyDown={handleKeyDown}
+            className="h-8 w-full text-[12px] focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0"
+          />
+          <div className="flex items-center justify-end gap-2">
+            <Button type="button" variant="ghost" size="xs" disabled={pending} onClick={close}>
+              {cancelLabel}
+            </Button>
+            <Button
+              type="button"
+              size="xs"
+              disabled={pending || value.trim().length === 0}
+              onClick={() => void submit()}
+            >
+              {pending ? submitPendingLabel : submitLabel}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/i18n/locales/en-US/gateways.json
+++ b/client/src/i18n/locales/en-US/gateways.json
@@ -115,6 +115,7 @@
   "gateways.details.url": "URL",
   "gateways.details.tags": "Tags",
   "gateways.details.addTag": "+ add",
+  "gateways.tags.addError": "Failed to add tag. Please try again.",
   "gateways.details.activity": "Activity",
   "gateways.details.created": "Created",
   "gateways.details.lastModified": "Last modified",

--- a/client/src/i18n/locales/en-US/prompts.json
+++ b/client/src/i18n/locales/en-US/prompts.json
@@ -52,5 +52,6 @@
   "prompts.add.error.templateRequired": "Template is required",
   "prompts.add.error.teamRequired": "Team selection is required when visibility is set to team",
   "prompts.add.error.argumentsInvalidJson": "Invalid JSON format",
-  "prompts.add.error.argumentsArrayRequired": "Arguments must be a JSON array"
+  "prompts.add.error.argumentsArrayRequired": "Arguments must be a JSON array",
+  "prompts.tags.addError": "Failed to add tag. Please try again."
 }

--- a/client/src/i18n/locales/en-US/resources.json
+++ b/client/src/i18n/locales/en-US/resources.json
@@ -81,5 +81,6 @@
   "resources.details.visibility.team": "Team",
   "resources.details.visibility.public": "Public",
   "resources.details.visibility.private": "Private",
-  "resources.details.addTag": "add"
+  "resources.details.addTag": "add",
+  "resources.tags.addError": "Failed to add tag. Please try again."
 }

--- a/client/src/i18n/locales/en-US/tools.json
+++ b/client/src/i18n/locales/en-US/tools.json
@@ -109,5 +109,6 @@
   "tools.form.error.generateSchema.specAuthRequired": "The OpenAPI spec endpoint requires authentication (returned 401/403). The gateway fetches the spec without credentials — provide a direct URL to a reachable spec, or add the schemas manually.",
   "tools.form.error.generateSchema.generic": "Something went wrong while generating the schema. Please try again.",
   "tools.form.error.updateFailed": "Failed to update tool. Please try again.",
-  "tools.form.error.createFailed": "Failed to create tool. Please try again."
+  "tools.form.error.createFailed": "Failed to create tool. Please try again.",
+  "tools.tags.addError": "Failed to add tag. Please try again."
 }

--- a/client/src/i18n/locales/es-ES/gateways.json
+++ b/client/src/i18n/locales/es-ES/gateways.json
@@ -115,6 +115,7 @@
   "gateways.details.url": "URL",
   "gateways.details.tags": "Etiquetas",
   "gateways.details.addTag": "+ agregar",
+  "gateways.tags.addError": "No se pudo añadir la etiqueta. Inténtelo de nuevo.",
   "gateways.details.activity": "Actividad",
   "gateways.details.created": "Creado",
   "gateways.details.lastModified": "Última modificación",

--- a/client/src/i18n/locales/es-ES/prompts.json
+++ b/client/src/i18n/locales/es-ES/prompts.json
@@ -52,5 +52,6 @@
   "prompts.add.error.templateRequired": "La plantilla es obligatoria",
   "prompts.add.error.teamRequired": "La selección de equipo es obligatoria cuando la visibilidad está configurada como equipo",
   "prompts.add.error.argumentsInvalidJson": "Formato JSON inválido",
-  "prompts.add.error.argumentsArrayRequired": "Los argumentos deben ser un array JSON"
+  "prompts.add.error.argumentsArrayRequired": "Los argumentos deben ser un array JSON",
+  "prompts.tags.addError": "No se pudo añadir la etiqueta. Inténtelo de nuevo."
 }

--- a/client/src/i18n/locales/es-ES/resources.json
+++ b/client/src/i18n/locales/es-ES/resources.json
@@ -81,5 +81,6 @@
   "resources.details.visibility.team": "Equipo",
   "resources.details.visibility.public": "Público",
   "resources.details.visibility.private": "Privado",
-  "resources.details.addTag": "añadir"
+  "resources.details.addTag": "añadir",
+  "resources.tags.addError": "No se pudo añadir la etiqueta. Inténtelo de nuevo."
 }

--- a/client/src/i18n/locales/es-ES/tools.json
+++ b/client/src/i18n/locales/es-ES/tools.json
@@ -109,5 +109,6 @@
   "tools.form.error.generateSchema.specAuthRequired": "El punto de acceso de la especificación OpenAPI requiere autenticación (devolvió 401/403). La puerta de enlace obtiene la especificación sin credenciales: proporcione una URL directa a una especificación accesible o añada los esquemas manualmente.",
   "tools.form.error.generateSchema.generic": "Algo salió mal al generar el esquema. Por favor, inténtelo de nuevo.",
   "tools.form.error.updateFailed": "Error al actualizar la herramienta. Por favor, inténtelo de nuevo.",
-  "tools.form.error.createFailed": "Error al crear la herramienta. Por favor, inténtelo de nuevo."
+  "tools.form.error.createFailed": "Error al crear la herramienta. Por favor, inténtelo de nuevo.",
+  "tools.tags.addError": "No se pudo añadir la etiqueta. Inténtelo de nuevo."
 }

--- a/client/src/i18n/locales/pt-BR/gateways.json
+++ b/client/src/i18n/locales/pt-BR/gateways.json
@@ -115,6 +115,7 @@
   "gateways.details.url": "URL",
   "gateways.details.tags": "Tags",
   "gateways.details.addTag": "+ adicionar",
+  "gateways.tags.addError": "Falha ao adicionar a tag. Tente novamente.",
   "gateways.details.activity": "Atividade",
   "gateways.details.created": "Criado",
   "gateways.details.lastModified": "Última modificação",

--- a/client/src/i18n/locales/pt-BR/prompts.json
+++ b/client/src/i18n/locales/pt-BR/prompts.json
@@ -52,5 +52,6 @@
   "prompts.add.error.templateRequired": "O modelo é obrigatório",
   "prompts.add.error.teamRequired": "A seleção de equipe é obrigatória quando a visibilidade está definida como equipe",
   "prompts.add.error.argumentsInvalidJson": "Formato JSON inválido",
-  "prompts.add.error.argumentsArrayRequired": "Os argumentos devem ser um array JSON"
+  "prompts.add.error.argumentsArrayRequired": "Os argumentos devem ser um array JSON",
+  "prompts.tags.addError": "Falha ao adicionar a tag. Tente novamente."
 }

--- a/client/src/i18n/locales/pt-BR/resources.json
+++ b/client/src/i18n/locales/pt-BR/resources.json
@@ -81,5 +81,6 @@
   "resources.details.visibility.team": "Equipe",
   "resources.details.visibility.public": "Público",
   "resources.details.visibility.private": "Privado",
-  "resources.details.addTag": "adicionar"
+  "resources.details.addTag": "adicionar",
+  "resources.tags.addError": "Falha ao adicionar a tag. Tente novamente."
 }

--- a/client/src/i18n/locales/pt-BR/tools.json
+++ b/client/src/i18n/locales/pt-BR/tools.json
@@ -109,5 +109,6 @@
   "tools.form.error.generateSchema.specAuthRequired": "O endpoint da especificação OpenAPI requer autenticação (retornou 401/403). O gateway obtém a especificação sem credenciais — forneça uma URL direta para uma especificação acessível ou adicione os esquemas manualmente.",
   "tools.form.error.generateSchema.generic": "Algo deu errado ao gerar o esquema. Tente novamente.",
   "tools.form.error.updateFailed": "Falha ao atualizar a ferramenta. Tente novamente.",
-  "tools.form.error.createFailed": "Falha ao criar a ferramenta. Tente novamente."
+  "tools.form.error.createFailed": "Falha ao criar a ferramenta. Tente novamente.",
+  "tools.tags.addError": "Falha ao adicionar a tag. Tente novamente."
 }

--- a/client/src/pages/Gateways.tsx
+++ b/client/src/pages/Gateways.tsx
@@ -7,12 +7,13 @@ import { VirtualServerDetailsPanel } from "@/components/gateways/VirtualServerDe
 import { hasVirtualServerComponents } from "@/components/gateways/utils";
 import { ConfirmDialog } from "@/components/servers/ConfirmDialog";
 import { Loading } from "@/components/ui/loading";
-import { deleteVirtualServer } from "@/api/virtualServers";
+import { deleteVirtualServer, updateVirtualServerTags } from "@/api/virtualServers";
+import { ApiError } from "@/api/client";
 import { useQuery } from "@/hooks/useQuery";
 import { useRouter } from "@/router";
 import type { VirtualServer, VirtualServersResponse } from "@/types/server";
 import { cn } from "@/lib/utils";
-import { sanitizeError } from "@/utils/errors";
+import { extractApiErrorDetail, sanitizeError } from "@/utils/errors";
 
 const DEFAULT_PAGE_SIZE = 12;
 const SERVERS_QUERY_PATH = `/servers?limit=${DEFAULT_PAGE_SIZE}&include_pagination=true`;
@@ -248,10 +249,28 @@ function VirtualServerDetailsPanelContainer({
   onClose: () => void;
   onAddSources: (server: VirtualServer) => void;
 }) {
-  const { data: serverDetails, error } = useQuery<VirtualServer>(
-    `/servers/${encodeURIComponent(serverId)}`,
-  );
+  const intl = useIntl();
+  const {
+    data: serverDetails,
+    error,
+    setData: setServerDetails,
+  } = useQuery<VirtualServer>(`/servers/${encodeURIComponent(serverId)}`);
   const hydratedServer = serverDetails?.id === serverId ? serverDetails : server;
+
+  const handleAddTag = useCallback(
+    async (id: string, tags: string[]) => {
+      try {
+        const updated = await updateVirtualServerTags(id, tags);
+        // Patch the fetched detail in place rather than refetching the server.
+        setServerDetails((prev) => (prev && prev.id === updated.id ? updated : prev));
+      } catch (err) {
+        const detail = err instanceof ApiError ? extractApiErrorDetail(err.body) : null;
+        toast.error(detail || intl.formatMessage({ id: "gateways.tags.addError" }));
+        throw err;
+      }
+    },
+    [setServerDetails, intl],
+  );
 
   if (!hydratedServer) {
     return null;
@@ -265,6 +284,7 @@ function VirtualServerDetailsPanelContainer({
       open={open}
       onClose={onClose}
       onAddSources={() => onAddSources(hydratedServer)}
+      onAddTag={handleAddTag}
     />
   );
 }

--- a/client/src/pages/Prompts.test.tsx
+++ b/client/src/pages/Prompts.test.tsx
@@ -358,4 +358,56 @@ describe("Prompts", () => {
     expect(screen.getByText("Error loading prompts")).toBeInTheDocument();
     expect(screen.getByText("HTTP 500")).toBeInTheDocument();
   });
+
+  it("shows a newly added tag in the details drawer (patches cache, no full refetch)", async () => {
+    const user = userEvent.setup();
+    const prompt = createMockPrompt({
+      id: "prompt-1",
+      gatewaySlug: "gh-repo-tasks",
+      tags: [{ id: "summary", label: "summary" }],
+    });
+
+    let promptsListCalls = 0;
+    server.use(
+      http.get("/prompts", () => {
+        promptsListCalls += 1;
+        return HttpResponse.json([prompt]);
+      }),
+      http.put("/prompts/:id", () =>
+        HttpResponse.json({
+          ...prompt,
+          tags: [
+            { id: "summary", label: "summary" },
+            { id: "alerts", label: "alerts" },
+          ],
+        }),
+      ),
+    );
+
+    renderWithProviders(<Prompts />);
+
+    await waitFor(() => expect(screen.getByText("Summarize document")).toBeInTheDocument());
+    const listCallsAfterLoad = promptsListCalls;
+
+    // Open the details drawer for the group.
+    await user.click(screen.getByRole("button", { name: /More options for/i }));
+    await user.click(await screen.findByRole("menuitem", { name: "View details" }));
+
+    const drawer = await screen.findByRole("region", { name: /prompt details/i });
+    expect(within(drawer).getByText("summary")).toBeInTheDocument();
+    expect(within(drawer).queryByText("alerts")).not.toBeInTheDocument();
+
+    // Add a tag through the inline editor.
+    await user.click(within(drawer).getByRole("button", { name: "Add tags" }));
+    await user.type(
+      within(drawer).getByPlaceholderText("Add tags separated with commas"),
+      "alerts",
+    );
+    await user.click(within(drawer).getByRole("button", { name: "Add" }));
+
+    // The new tag renders in the drawer from the patched cache...
+    expect(await within(drawer).findByText("alerts")).toBeInTheDocument();
+    // ...without re-fetching the whole prompts catalog.
+    expect(promptsListCalls).toBe(listCallsAfterLoad);
+  });
 });

--- a/client/src/pages/Prompts.tsx
+++ b/client/src/pages/Prompts.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type Ref } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type Ref } from "react";
 import { MessageSquareCode, MoreHorizontal, Plus } from "lucide-react";
 import { useIntl } from "react-intl";
 import { PromptForm } from "@/components/prompts/PromptForm";
@@ -14,6 +14,10 @@ import {
 import type { CursorPaginatedPromptsResponse, PromptRead } from "@/generated/types";
 import { PromptDetailsPanel } from "@/components/prompts";
 import { useQuery } from "@/hooks/useQuery";
+import { promptsApi } from "@/api/prompts";
+import { ApiError } from "@/api/client";
+import { extractApiErrorDetail } from "@/utils/errors";
+import { toast } from "sonner";
 import type { PromptGroup } from "@/types/prompts";
 
 const MAX_VISIBLE_PROMPTS = 8;
@@ -203,7 +207,30 @@ export function Prompts() {
     error,
     isLoading,
     refetch,
+    setData: setPromptsData,
   } = useQuery<PromptsListResponse>("/prompts?limit=1000&include_inactive=true");
+
+  const handleAddPromptTag = useCallback(
+    async (promptId: string, tags: string[]) => {
+      try {
+        const updated = await promptsApi.updateTags(promptId, tags);
+        if (!updated) return;
+        // Patch the single prompt in place instead of refetching the whole
+        // catalog, which can be expensive with many prompts on the backend.
+        setPromptsData((prev) => {
+          if (!prev) return prev;
+          const replace = (list: (PromptRead | null)[]) =>
+            list.map((p) => (p && p.id === promptId ? updated : p));
+          return Array.isArray(prev) ? replace(prev) : { ...prev, prompts: replace(prev.prompts) };
+        });
+      } catch (err) {
+        const detail = err instanceof ApiError ? extractApiErrorDetail(err.body) : null;
+        toast.error(detail || intl.formatMessage({ id: "prompts.tags.addError" }));
+        throw err;
+      }
+    },
+    [setPromptsData, intl],
+  );
 
   const restPromptsLabel = intl.formatMessage({ id: "prompts.restPromptsGroup" });
   const groups = useMemo(
@@ -211,9 +238,15 @@ export function Prompts() {
     [promptsData, restPromptsLabel],
   );
 
+  // Keep the drawer's group in sync with the latest data: re-resolve the active
+  // group from `groups` by key so edits (e.g. adding tags) show immediately.
+  // When the drawer closes (`activeGroup` becomes null) we leave `displayGroup`
+  // untouched so its content stays put through the slide-out animation.
   useEffect(() => {
-    if (activeGroup) setDisplayGroup(activeGroup);
-  }, [activeGroup]);
+    if (!activeGroup) return;
+    const fresh = groups.find((g) => g.key === activeGroup.key) ?? activeGroup;
+    setDisplayGroup(fresh);
+  }, [activeGroup, groups]);
 
   useEffect(() => {
     if (!showForm && shouldRestoreFormCloseFocus) {
@@ -288,6 +321,7 @@ export function Prompts() {
         title={displayGroup?.label ?? ""}
         open={activeGroup !== null}
         onClose={() => setActiveGroup(null)}
+        onAddTag={handleAddPromptTag}
       />
     </div>
   );

--- a/client/src/pages/Resources.test.tsx
+++ b/client/src/pages/Resources.test.tsx
@@ -1091,4 +1091,43 @@ describe("Resources", () => {
       consoleErrorSpy.mockRestore();
     });
   });
+
+  describe("inline tag add", () => {
+    it("shows a newly added tag in the details drawer (patches cache, no full refetch)", async () => {
+      const user = userEvent.setup();
+      const resource: Resource = { ...createMockResource(1, "test-gateway"), tags: ["tag1"] };
+
+      let resourcesListCalls = 0;
+      server.use(
+        http.get("/resources", () => {
+          resourcesListCalls += 1;
+          return HttpResponse.json([resource]);
+        }),
+        http.put("/resources/:id", () =>
+          HttpResponse.json({ ...resource, tags: ["tag1", "alerts"] }),
+        ),
+      );
+
+      renderWithRouter(<Resources />);
+
+      await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
+      const listCallsAfterLoad = resourcesListCalls;
+
+      await user.click(screen.getByLabelText("More options for test-gateway"));
+      await user.click(await screen.findByText("View Details"));
+
+      const drawer = await screen.findByRole("region", { name: /Resources for test-gateway/i });
+      expect(within(drawer).queryByText("alerts")).not.toBeInTheDocument();
+
+      await user.click(within(drawer).getByRole("button", { name: "Add tags" }));
+      await user.type(
+        within(drawer).getByPlaceholderText("Add tags separated with commas"),
+        "alerts",
+      );
+      await user.click(within(drawer).getByRole("button", { name: "Add" }));
+
+      expect(await within(drawer).findByText("alerts")).toBeInTheDocument();
+      expect(resourcesListCalls).toBe(listCallsAfterLoad);
+    });
+  });
 });

--- a/client/src/pages/Resources.tsx
+++ b/client/src/pages/Resources.tsx
@@ -355,6 +355,22 @@ export function Resources() {
     setIsDetailsPanelOpen(false);
   };
 
+  const handleAddResourceTag = useCallback(
+    async (resourceId: string, tags: string[]) => {
+      try {
+        const updated = await resourcesApi.updateTags(resourceId, tags);
+        setResourcesData((prev) =>
+          prev?.map((r) => (r?.id === resourceId ? { ...r, tags: updated?.tags } : r)),
+        );
+      } catch (err) {
+        const detail = err instanceof ApiError ? extractApiErrorDetail(err.body) : null;
+        toast.error(detail || intl.formatMessage({ id: "resources.tags.addError" }));
+        throw err;
+      }
+    },
+    [setResourcesData, intl],
+  );
+
   const handleDeleteResource = useCallback(
     (id: string) => {
       if (id === OPTIMISTIC_RESOURCE_ID) return;
@@ -541,6 +557,7 @@ export function Resources() {
               onClose={handleCloseDetails}
               onEditResource={handleEditResource}
               onDeleteResource={handleDeleteResource}
+              onAddTag={handleAddResourceTag}
             />
           )}
 

--- a/client/src/pages/Servers.tsx
+++ b/client/src/pages/Servers.tsx
@@ -9,10 +9,10 @@ import { ConfirmDialog } from "@/components/servers/ConfirmDialog";
 import { TestConnectionDialog } from "@/components/servers/TestConnectionDialog";
 import { MCPServerDetailsPanel } from "@/components/servers/MCPServerDetailsPanel";
 import { useQuery } from "@/hooks/useQuery";
-import { api } from "@/api/client";
+import { ApiError, api } from "@/api/client";
 import { serversApi } from "@/api/servers";
 import { useRouter } from "@/router";
-import { sanitizeError } from "@/utils/errors";
+import { extractApiErrorDetail, sanitizeError } from "@/utils/errors";
 import type { MCPServer, ServersResponse } from "@/types/server";
 import { Loading } from "@/components/ui/loading";
 import { InlineNotification } from "@/components/ui/inline-notification";
@@ -67,7 +67,11 @@ export function Servers() {
     [selectedServerIdForDetails],
   );
 
-  const { data: detailsServer, error: detailsQueryError } = useQuery<MCPServer>(detailsQueryPath, {
+  const {
+    data: detailsServer,
+    error: detailsQueryError,
+    setData: setDetailsServer,
+  } = useQuery<MCPServer>(detailsQueryPath, {
     enabled: Boolean(selectedServerIdForDetails),
   });
 
@@ -188,6 +192,21 @@ export function Servers() {
       setSelectedServerIdForDetails(null);
     }
   }, []);
+
+  const handleAddServerTag = useCallback(
+    async (serverId: string, tags: string[]) => {
+      try {
+        const updated = await serversApi.updateTags(serverId, tags);
+        setDetailsServer((prev) => (prev && prev.id === updated.id ? updated : prev));
+        setAllServers((prev) => prev.map((s) => (s.id === updated.id ? updated : s)));
+      } catch (err) {
+        const detail = err instanceof ApiError ? extractApiErrorDetail(err.body) : null;
+        toast.error(detail || "Failed to add tag. Please try again.");
+        throw err;
+      }
+    },
+    [setDetailsServer],
+  );
 
   useEffect(() => {
     if (!selectedSearchServerId) return;
@@ -395,6 +414,7 @@ export function Servers() {
         error={detailsError}
         open={isDetailsDrawerOpen}
         onClose={() => handleCloseDetails(false)}
+        onAddTag={handleAddServerTag}
       />
     </div>
   );

--- a/client/src/pages/Tools.test.tsx
+++ b/client/src/pages/Tools.test.tsx
@@ -1798,7 +1798,7 @@ describe("Tools", () => {
   describe("inline tag add", () => {
     it("shows a newly added tag in the details drawer (patches cache, no full refetch)", async () => {
       const user = userEvent.setup();
-      const tool: Tool = { ...createMockTool(1, "test-gateway"), tags: ["tag1"] };
+      const tool: Tool = { ...createMockTool(1, "test-gateway"), tags: [{ label: "tag1" }] };
 
       let toolsListCalls = 0;
       server.use(

--- a/client/src/pages/Tools.test.tsx
+++ b/client/src/pages/Tools.test.tsx
@@ -1794,4 +1794,41 @@ describe("Tools", () => {
       });
     });
   });
+
+  describe("inline tag add", () => {
+    it("shows a newly added tag in the details drawer (patches cache, no full refetch)", async () => {
+      const user = userEvent.setup();
+      const tool: Tool = { ...createMockTool(1, "test-gateway"), tags: ["tag1"] };
+
+      let toolsListCalls = 0;
+      server.use(
+        http.get("/tools", () => {
+          toolsListCalls += 1;
+          return HttpResponse.json([tool]);
+        }),
+        http.put("/tools/:id", () => HttpResponse.json({ ...tool, tags: ["tag1", "alerts"] })),
+      );
+
+      renderWithRouter(<Tools />);
+
+      await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
+      const listCallsAfterLoad = toolsListCalls;
+
+      await user.click(screen.getByLabelText("More options for test-gateway"));
+      await user.click(await screen.findByText("View Details"));
+
+      const drawer = await screen.findByRole("region", { name: /Tools for test-gateway/i });
+      expect(within(drawer).queryByText("alerts")).not.toBeInTheDocument();
+
+      await user.click(within(drawer).getByRole("button", { name: "Add tags" }));
+      await user.type(
+        within(drawer).getByPlaceholderText("Add tags separated with commas"),
+        "alerts",
+      );
+      await user.click(within(drawer).getByRole("button", { name: "Add" }));
+
+      expect(await within(drawer).findByText("alerts")).toBeInTheDocument();
+      expect(toolsListCalls).toBe(listCallsAfterLoad);
+    });
+  });
 });

--- a/client/src/pages/Tools.tsx
+++ b/client/src/pages/Tools.tsx
@@ -290,6 +290,20 @@ export function Tools() {
     [setToolsData, intl],
   );
 
+  const handleAddToolTag = useCallback(
+    async (toolId: string, tags: string[]) => {
+      try {
+        const updated = await toolsApi.updateTags(toolId, tags);
+        setToolsData((prev) => prev?.map((t) => (t.id === updated.id ? updated : t)));
+      } catch (err) {
+        const detail = err instanceof ApiError ? extractApiErrorDetail(err.body) : null;
+        toast.error(detail || intl.formatMessage({ id: "tools.tags.addError" }));
+        throw err;
+      }
+    },
+    [setToolsData, intl],
+  );
+
   const handleDelete = useCallback(
     (id: string) => {
       const tool = allTools.find((t) => t.id === id);
@@ -428,6 +442,7 @@ export function Tools() {
               onDeleteTool={handleDelete}
               onEditTool={handleEditTool}
               onToggleTool={handleToggleTool}
+              onAddTag={handleAddToolTag}
             />
           )}
 


### PR DESCRIPTION
 ## Summary

Adds an inline "add tag" interaction to every details drawer — Tools, Resources, Prompts, MCP Servers, and Virtual Servers; so users can tag entities directly from the drawer without opening the edit form. Implements the pattern from #5641.

Closes #5641

https://github.com/user-attachments/assets/a83e53f7-9834-464d-8be5-c4b4b9948cbc

## Behavior

  - The Tags row shows the existing chips plus a compact **+ add** trigger.
  - Clicking it reveals an inline input (placeholder _"Add tags separated with commas"_) with **Cancel** / **Add** buttons rendered full-width **below** the label.
  - Multiple comma-separated tags can be added at once; entries are trimmed and de-duplicated (case-insensitive) against existing tags and against each other before saving.
  - **Add** shows an **Adding…** pending state and is disabled while empty or in flight; **Cancel** / Escape collapse the editor; Enter submits.
  - On success the new chips appear immediately; on failure the editor stays open (so the value can be retried) and an error toast is shown.

## Implementation

  - **New reusable component** `client/src/components/ui/inline-tag-add.tsx` — owns the whole Tags detail row (label + chips-as-children + inline editor) so the editor can span the full width beneath the label. Labels default in-component and are overridable.
  - **API** — a tags-only partial update per entity: `toolsApi.updateTags`, `resourcesApi.updateTags`, `promptsApi.updateTags`, `serversApi.updateTags` (`PUT /gateways/{id}`), and `updateVirtualServerTags` (`PUT /servers/{id}`). Each sends only `{ tags }`; the backend update services preserve all other fields.
  - **Panels/pages** — each of the five details panels gained an `onAddTag` prop wired to a page handler that calls the API and **patches the local cache in place** (no full-catalog refetch), then relies on the existing panel re-sync. Also fixes the Prompts drawer, which rendered from a stale `displayGroup` snapshot — it now re-resolves the active group from the live data so added tags appear immediately.
  - **i18n** — added `*.tags.addError` messages across `en-US`, `es-ES`, and `pt-BR`.

  ## Tests

  - **Component**: comma-split/dedup, Cancel/Add, success, error-retry, keyboard, pending state.
  - **API**: `updateTags` for all five (path, tags-only body, returned entity, ID validation).
  - **Panels**: `onAddTag` wiring for all five drawers.
  - **Pages (end-to-end)**: Prompts (regression for the stale-drawer bug), Tools, and Resources — add a tag, confirm the chip renders and the list is not re-fetched.
