### PR TITLE
Update python call in fix file headers pre-commit to use uv run

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -381,7 +381,7 @@ repos:
         description: Ensures mcpgateway/ and tests/ .py files have the correct license header.
         entry: >-
           bash -c '
-          python3 .github/tools/fix_file_headers.py --fix-all "$@";
+          uv run .github/tools/fix_file_headers.py --fix-all "$@";
           ' --
         language: system
         types: [python]


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes # N/A

---

## 📝 Summary
Small issue running pre-commit following the resolution to #5506 and PR #5637 in claling python from pre-commit, changing it to use `uv run` instead.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [ ] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

_List exact commands, screenshots, videos, logs, reproduction steps, or manual validation. If evidence is not feasible, explain why._

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] No secrets or credentials committed

---

## 📓 Notes (optional)

_Screenshots, design decisions, or additional context._
