### PR TITLE
fix(auth): preserve and refresh direct proxy identity context

### DIFF
--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2103,13 +2103,17 @@ async def _get_request_context_or_default() -> Tuple[str, dict[str, Any], dict[s
     if s_id != "default_server_id":
         headers = request_headers_var.get()
         session_id = headers.get("x-mcp-session-id") if headers else None
+        context_user = user_context_var.get()
 
-        # If we have a server_id but no session ID in headers, the ContextVars were captured
-        # before enrichment. Fall through to ASGI scope which has the enriched headers.
-        if not session_id:
+        # If identity or session enrichment is missing, these ContextVars were
+        # captured before request authentication. Fall through to the trusted
+        # ASGI scope instead of returning an empty or stale principal.
+        if not session_id or not context_user:
             logger.debug(
-                "[CONTEXT_RESOLUTION] Path 1 skipped (no session ID) | server_id=%s | falling through to ASGI scope",
+                "[CONTEXT_RESOLUTION] Path 1 skipped (incomplete request context) | server_id=%s | has_session_id=%s | has_user=%s | falling through to ASGI scope",
                 s_id[:8] if s_id else None,
+                bool(session_id),
+                bool(context_user),
             )
             # Don't return - fall through to Path 2 (ASGI scope)
         else:
@@ -2118,7 +2122,7 @@ async def _get_request_context_or_default() -> Tuple[str, dict[str, Any], dict[s
                 s_id[:8] if s_id else None,
                 bool(session_id),
             )
-            return s_id, headers, user_context_var.get()
+            return s_id, headers, context_user
 
     # 2. Try ASGI scope context injected by handle_streamable_http()
     ctx = None

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -1717,6 +1717,11 @@ async def call_tool(
         <class 'dict'>
     """
     server_id, request_headers, user_context = await _get_request_context_or_default()
+    # The MCP SDK may execute this handler in a task that did not inherit the
+    # auth middleware's ContextVars. Materialize the typed identity in the
+    # current task from the canonical context recovered above.
+    _set_user_identity_from_dict(user_context)
+
     meta_data = None
     # Extract _meta from request context if available
     try:
@@ -1783,7 +1788,7 @@ async def call_tool(
                         meta_data=meta_data,
                         user_email=user_email,
                         token_teams=token_teams,
-                        user_context=user_context,
+                        user_context=user_identity_var.get(),
                     )
         except Exception as e:
             logger.error("Direct proxy mode failed for gateway %s: %s", gateway_id_from_header, e)
@@ -4782,6 +4787,10 @@ def _set_user_identity_from_dict(ctx: dict[str, Any]) -> None:
                 authenticated_at=datetime.now(timezone.utc),
             )
         )
+    else:
+        # Fail closed when the current request is anonymous or malformed.
+        # Without this reset a reused task could retain a previous principal.
+        user_identity_var.set(None)
 
 
 async def _set_proxy_user_context(proxy_user: str) -> dict[str, Any] | None:

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -299,6 +299,7 @@ _REJECT = object()
 
 # ASGI scope key for propagating gateway context from middleware to MCP handlers
 _MCPGATEWAY_CONTEXT_KEY = "_mcpgateway_context"
+_MCPGATEWAY_AUTH_CONTEXT_KEY = "_mcpgateway_auth_context"
 
 # Initialize ToolService, PromptService, ResourceService, CompletionService and MCP Server
 tool_service: ToolService = ToolService()
@@ -4054,7 +4055,9 @@ class SessionManagerWrapper:
 
         # Enforce server access parity for server-scoped Streamable HTTP MCP routes.
         # This mirrors /servers/{id}/sse and /servers/{id}/message guards.
-        user_context = user_context_var.get()
+        user_context = scope.get(_MCPGATEWAY_AUTH_CONTEXT_KEY)
+        if not isinstance(user_context, dict):
+            user_context = user_context_var.get()
         if match and _should_enforce_streamable_rbac(user_context):
             _server_id = match.group("server_id")
             has_server_access = await _check_streamable_permission(
@@ -4917,6 +4920,12 @@ class _StreamableHttpAuthHandler:
         self.receive = receive
         self.send = send
 
+    def _persist_auth_context(self) -> None:
+        """Store verified identity on the ASGI scope across task boundaries."""
+        auth_context = user_context_var.get()
+        if isinstance(auth_context, dict):
+            self.scope[_MCPGATEWAY_AUTH_CONTEXT_KEY] = dict(auth_context)
+
     async def _send_error(self, *, detail: str, status_code: int = HTTP_401_UNAUTHORIZED, headers: dict[str, str] | None = None) -> bool:
         """Send an error response and return False (auth rejected).
 
@@ -4997,6 +5006,7 @@ class _StreamableHttpAuthHandler:
             proxy_error = await _set_proxy_user_context(proxy_user)
             if proxy_error:
                 return await self._send_error(**proxy_error)
+            self._persist_auth_context()
             return True  # Trusted proxy supplied valid, active user
 
         # --- Standard JWT authentication flow (client auth enabled) ---
@@ -5010,9 +5020,18 @@ class _StreamableHttpAuthHandler:
                     token = credentials
 
         if token is None:
-            return await self._auth_no_token(path=path, bearer_header_supplied=bearer_header_supplied)
+            authenticated = await self._auth_no_token(
+                path=path,
+                bearer_header_supplied=bearer_header_supplied,
+            )
+            if authenticated:
+                self._persist_auth_context()
+            return authenticated
 
-        return await self._auth_jwt(token=token)
+        authenticated = await self._auth_jwt(token=token)
+        if authenticated:
+            self._persist_auth_context()
+        return authenticated
 
     async def _auth_no_token(self, *, path: str, bearer_header_supplied: bool) -> bool:
         """Handle unauthenticated MCP requests (no Bearer token present).

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2125,16 +2125,22 @@ async def _get_request_context_or_default() -> Tuple[str, dict[str, Any], dict[s
             if isinstance(gw_ctx, dict):
                 headers = gw_ctx.get("request_headers", {})
                 session_id = headers.get("x-mcp-session-id") if headers else None
+                resolved_server_id = gw_ctx.get("server_id") or s_id
+                recovered_user_context = gw_ctx.get("user_context", {})
                 logger.debug(
                     "[CONTEXT_RESOLUTION] Path 2 (ASGI scope) | server_id=%s | has_session_id=%s",
-                    (gw_ctx.get("server_id") or s_id)[:8] if (gw_ctx.get("server_id") or s_id) else None,
+                    resolved_server_id[:8] if resolved_server_id else None,
                     bool(session_id),
                 )
-                return (
-                    gw_ctx.get("server_id") or s_id,
-                    headers,
-                    gw_ctx.get("user_context", {}),
-                )
+                # The MCP SDK may run handlers in a task created before the
+                # request ContextVars were populated. Rehydrate them from the
+                # trusted ASGI scope so downstream services and proxy helpers
+                # see the same authenticated identity recovered above.
+                server_id_var.set(resolved_server_id)
+                request_headers_var.set(headers)
+                user_context_var.set(recovered_user_context)
+                _set_user_identity_from_dict(recovered_user_context)
+                return resolved_server_id, headers, recovered_user_context
     except LookupError:
         # Not in a request context — fall through to ContextVar defaults
         return s_id, request_headers_var.get(), user_context_var.get()

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2142,20 +2142,34 @@ async def _get_request_context_or_default() -> Tuple[str, dict[str, Any], dict[s
                 session_id = headers.get("x-mcp-session-id") if headers else None
                 resolved_server_id = gw_ctx.get("server_id") or s_id
                 recovered_user_context = gw_ctx.get("user_context", {})
-                logger.debug(
-                    "[CONTEXT_RESOLUTION] Path 2 (ASGI scope) | server_id=%s | has_session_id=%s",
-                    resolved_server_id[:8] if resolved_server_id else None,
-                    bool(session_id),
-                )
-                # The MCP SDK may run handlers in a task created before the
-                # request ContextVars were populated. Rehydrate them from the
-                # trusted ASGI scope so downstream services and proxy helpers
-                # see the same authenticated identity recovered above.
-                server_id_var.set(resolved_server_id)
-                request_headers_var.set(headers)
-                user_context_var.set(recovered_user_context)
-                _set_user_identity_from_dict(recovered_user_context)
-                return resolved_server_id, headers, recovered_user_context
+                current_request_headers = dict(request.headers)
+                has_current_authorization = bool(get_auth_header_value(current_request_headers))
+                if has_current_authorization:
+                    logger.debug(
+                        "[CONTEXT_RESOLUTION] Path 2 skipped (current Authorization present) | server_id=%s | falling through to verified request recovery",
+                        resolved_server_id[:8] if resolved_server_id else None,
+                    )
+                elif not isinstance(recovered_user_context, dict) or not recovered_user_context.get("email"):
+                    logger.debug(
+                        "[CONTEXT_RESOLUTION] Path 2 skipped (incomplete ASGI context) | server_id=%s | has_session_id=%s | falling through to re-authentication",
+                        resolved_server_id[:8] if resolved_server_id else None,
+                        bool(session_id),
+                    )
+                else:
+                    logger.debug(
+                        "[CONTEXT_RESOLUTION] Path 2 (ASGI scope) | server_id=%s | has_session_id=%s",
+                        resolved_server_id[:8] if resolved_server_id else None,
+                        bool(session_id),
+                    )
+                    # The MCP SDK may run handlers in a task created before the
+                    # request ContextVars were populated. Rehydrate them from the
+                    # trusted ASGI scope so downstream services and proxy helpers
+                    # see the same authenticated identity recovered above.
+                    server_id_var.set(resolved_server_id)
+                    request_headers_var.set(headers)
+                    user_context_var.set(recovered_user_context)
+                    _set_user_identity_from_dict(recovered_user_context)
+                    return resolved_server_id, headers, recovered_user_context
     except LookupError:
         # Not in a request context — fall through to ContextVar defaults
         return s_id, request_headers_var.get(), user_context_var.get()

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2131,7 +2131,12 @@ async def _get_request_context_or_default() -> Tuple[str, dict[str, Any], dict[s
         ctx = mcp_app.request_context
         request = ctx.request
         if request:
-            gw_ctx = getattr(request, "scope", {}).get(_MCPGATEWAY_CONTEXT_KEY)
+            request_scope = getattr(request, "scope", {})
+            gw_ctx = request_scope.get(_MCPGATEWAY_CONTEXT_KEY)
+            if not isinstance(gw_ctx, dict):
+                request_state = request_scope.get("state")
+                if isinstance(request_state, dict):
+                    gw_ctx = request_state.get(_MCPGATEWAY_CONTEXT_KEY)
             if isinstance(gw_ctx, dict):
                 headers = gw_ctx.get("request_headers", {})
                 session_id = headers.get("x-mcp-session-id") if headers else None
@@ -4055,7 +4060,14 @@ class SessionManagerWrapper:
 
         # Enforce server access parity for server-scoped Streamable HTTP MCP routes.
         # This mirrors /servers/{id}/sse and /servers/{id}/message guards.
-        user_context = scope.get(_MCPGATEWAY_AUTH_CONTEXT_KEY)
+        scope_state = scope.get("state")
+        user_context = (
+            scope_state.get(_MCPGATEWAY_AUTH_CONTEXT_KEY)
+            if isinstance(scope_state, dict)
+            else None
+        )
+        if not isinstance(user_context, dict):
+            user_context = scope.get(_MCPGATEWAY_AUTH_CONTEXT_KEY)
         if not isinstance(user_context, dict):
             user_context = user_context_var.get()
         if match and _should_enforce_streamable_rbac(user_context):
@@ -4525,11 +4537,15 @@ class SessionManagerWrapper:
         # handlers can retrieve it even when ContextVars are lost (the SDK's
         # task group was created at startup, so spawned handler tasks inherit
         # the startup context rather than the per-request context).
-        scope[_MCPGATEWAY_CONTEXT_KEY] = {
+        downstream_context = {
             "server_id": server_id_var.get(),
             "request_headers": enriched_headers,
             "user_context": user_context,
         }
+        scope[_MCPGATEWAY_CONTEXT_KEY] = downstream_context
+        scope_state = scope.setdefault("state", {})
+        if isinstance(scope_state, dict):
+            scope_state[_MCPGATEWAY_CONTEXT_KEY] = downstream_context
 
         buffered_request_body = bytearray()
         initialize_span_cm: Optional[ContextManager[Any]] = None
@@ -4924,7 +4940,11 @@ class _StreamableHttpAuthHandler:
         """Store verified identity on the ASGI scope across task boundaries."""
         auth_context = user_context_var.get()
         if isinstance(auth_context, dict):
-            self.scope[_MCPGATEWAY_AUTH_CONTEXT_KEY] = dict(auth_context)
+            persisted_context = dict(auth_context)
+            self.scope[_MCPGATEWAY_AUTH_CONTEXT_KEY] = persisted_context
+            scope_state = self.scope.setdefault("state", {})
+            if isinstance(scope_state, dict):
+                scope_state[_MCPGATEWAY_AUTH_CONTEXT_KEY] = persisted_context
 
     async def _send_error(self, *, detail: str, status_code: int = HTTP_401_UNAUTHORIZED, headers: dict[str, str] | None = None) -> bool:
         """Send an error response and return False (auth rejected).

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -1783,7 +1783,7 @@ async def call_tool(
                         meta_data=meta_data,
                         user_email=user_email,
                         token_teams=token_teams,
-                        user_context=user_identity_var.get(),
+                        user_context=user_context,
                     )
         except Exception as e:
             logger.error("Direct proxy mode failed for gateway %s: %s", gateway_id_from_header, e)

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -12245,7 +12245,9 @@ class TestCallToolDirectProxy:
             result = await tr.call_tool("my_tool", {"arg": "value"})
 
         assert result is expected_result
-        assert mock_invoke_direct.await_args.kwargs["user_context"] == recovered_identity
+        forwarded_identity = mock_invoke_direct.await_args.kwargs["user_context"]
+        assert forwarded_identity.email == recovered_identity["email"]
+        assert forwarded_identity.teams == recovered_identity["teams"]
 
     @pytest.mark.asyncio
     async def test_call_tool_direct_proxy_access_denied(self):

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -12176,6 +12176,76 @@ class TestCallToolDirectProxy:
         assert call_kwargs.kwargs["gateway_id"] == "gw-direct"
         assert call_kwargs.kwargs["name"] == "my_tool"
         assert call_kwargs.kwargs["arguments"] == {"arg": "value"}
+        assert call_kwargs.kwargs["user_context"] == {
+            "email": "user@test.com",
+            "teams": ["team1"],
+            "is_admin": False,
+            "is_authenticated": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_call_tool_direct_proxy_uses_scope_recovered_identity(self):
+        """Forward identity recovered from ASGI scope when the SDK task lost its ContextVar."""
+        # Third-Party
+        from mcp import types as mcp_types
+
+        recovered_identity = {
+            "email": "user@test.com",
+            "teams": ["team1"],
+            "is_admin": False,
+            "is_authenticated": True,
+        }
+        mock_gateway = MagicMock(id="gw-direct", gateway_mode="direct_proxy")
+        mock_db = MagicMock()
+        mock_db.execute = MagicMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=mock_gateway)))
+
+        @asynccontextmanager
+        async def mock_get_db():
+            yield mock_db
+
+        expected_result = mcp_types.CallToolResult(
+            content=[mcp_types.TextContent(type="text", text="direct proxy result")],
+            isError=False,
+        )
+        mock_invoke_direct = AsyncMock(return_value=expected_result)
+        tr.user_identity_var.set(None)
+
+        with (
+            patch(
+                "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default",
+                AsyncMock(
+                    return_value=(
+                        "server-123",
+                        {"x-context-forge-gateway-id": "gw-direct"},
+                        recovered_identity,
+                    )
+                ),
+            ),
+            patch("mcpgateway.transports.streamablehttp_transport.get_db", mock_get_db),
+            patch(
+                "mcpgateway.transports.streamablehttp_transport.extract_gateway_id_from_headers",
+                return_value="gw-direct",
+            ),
+            patch(
+                "mcpgateway.transports.streamablehttp_transport._check_scoped_permission",
+                return_value=True,
+            ),
+            patch(
+                "mcpgateway.transports.streamablehttp_transport._check_streamable_permission",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "mcpgateway.transports.streamablehttp_transport.check_gateway_access",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(tr.tool_service, "invoke_tool_direct", mock_invoke_direct),
+        ):
+            result = await tr.call_tool("my_tool", {"arg": "value"})
+
+        assert result is expected_result
+        assert mock_invoke_direct.await_args.kwargs["user_context"] == recovered_identity
 
     @pytest.mark.asyncio
     async def test_call_tool_direct_proxy_access_denied(self):

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -12576,7 +12576,11 @@ async def test_get_request_context_no_request_object(monkeypatch, caplog):
     from unittest.mock import PropertyMock
 
     # First-Party
-    from mcpgateway.transports.streamablehttp_transport import _get_request_context_or_default, mcp_app, server_id_var
+    from mcpgateway.transports.streamablehttp_transport import (
+        _get_request_context_or_default,
+        mcp_app,
+        server_id_var,
+    )
 
     token = server_id_var.set("default_server_id")
 
@@ -12601,7 +12605,11 @@ async def test_get_request_context_stateful_success(monkeypatch):
     from unittest.mock import PropertyMock
 
     # First-Party
-    from mcpgateway.transports.streamablehttp_transport import _get_request_context_or_default, mcp_app, server_id_var
+    from mcpgateway.transports.streamablehttp_transport import (
+        _get_request_context_or_default,
+        mcp_app,
+        server_id_var,
+    )
 
     token = server_id_var.set("default_server_id")
 
@@ -14990,10 +14998,20 @@ async def test_get_request_context_reads_scope_context(monkeypatch):
     from unittest.mock import PropertyMock
 
     # First-Party
-    from mcpgateway.transports.streamablehttp_transport import _get_request_context_or_default, mcp_app, server_id_var
+    from mcpgateway.transports.streamablehttp_transport import (
+        _get_request_context_or_default,
+        mcp_app,
+        request_headers_var,
+        server_id_var,
+        user_context_var,
+        user_identity_var,
+    )
 
     # Ensure ContextVars are at defaults (simulating SDK task context)
     token = server_id_var.set("default_server_id")
+    original_headers = request_headers_var.get()
+    original_user_context = user_context_var.get()
+    original_user_identity = user_identity_var.get()
 
     injected_user_context = {"email": "pub@example.com", "teams": [], "is_authenticated": True, "is_admin": False}
     injected_headers = {"authorization": "Bearer tok123"}
@@ -15020,8 +15038,15 @@ async def test_get_request_context_reads_scope_context(monkeypatch):
             assert sid == injected_server_id
             assert headers == injected_headers
             assert user == injected_user_context
+            assert server_id_var.get() == injected_server_id
+            assert request_headers_var.get() == injected_headers
+            assert user_context_var.get() == injected_user_context
+            assert user_identity_var.get().email == "pub@example.com"
     finally:
         server_id_var.reset(token)
+        request_headers_var.set(original_headers)
+        user_context_var.set(original_user_context)
+        user_identity_var.set(original_user_identity)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -5149,6 +5149,7 @@ async def test_streamable_http_auth_proxy_user_when_client_auth_disabled(monkeyp
     user_ctx = tr.user_context_var.get()
     assert user_ctx["email"] == "proxy_user@example.com"
     assert scope[tr._MCPGATEWAY_AUTH_CONTEXT_KEY] == user_ctx
+    assert scope["state"][tr._MCPGATEWAY_AUTH_CONTEXT_KEY] == user_ctx
     assert user_ctx["teams"] == []
     assert user_ctx["is_authenticated"] is True
     assert user_ctx["is_admin"] is False
@@ -10382,6 +10383,7 @@ async def test_auth_session_token_admin_bypass(monkeypatch):
     assert user_ctx["teams"] is None  # Admin bypass
     assert user_ctx["is_admin"] is True
     assert scope[tr._MCPGATEWAY_AUTH_CONTEXT_KEY] == user_ctx
+    assert scope["state"][tr._MCPGATEWAY_AUTH_CONTEXT_KEY] == user_ctx
 
 
 @pytest.mark.asyncio
@@ -15070,10 +15072,12 @@ async def test_get_request_context_reads_scope_context(monkeypatch):
     injected_server_id = "abc123def456"  # pragma: allowlist secret
 
     mock_scope = {
-        _MCPGATEWAY_CONTEXT_KEY: {
-            "server_id": injected_server_id,
-            "request_headers": injected_headers,
-            "user_context": injected_user_context,
+        "state": {
+            _MCPGATEWAY_CONTEXT_KEY: {
+                "server_id": injected_server_id,
+                "request_headers": injected_headers,
+                "user_context": injected_user_context,
+            }
         }
     }
 

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -13021,7 +13021,63 @@ async def test_get_request_context_fast_path_no_session_id_falls_through(monkeyp
                 assert user["email"] == "fallback@test.com"
 
                 # Verify debug log for fallthrough
-                assert any("[CONTEXT_RESOLUTION] Path 1 skipped (no session ID)" in record.message for record in caplog.records)
+                assert any("[CONTEXT_RESOLUTION] Path 1 skipped (incomplete request context)" in record.message for record in caplog.records)
+    finally:
+        server_id_var.reset(s_tok)
+        request_headers_var.reset(h_tok)
+        user_context_var.reset(u_tok)
+
+
+@pytest.mark.asyncio
+async def test_get_request_context_fast_path_empty_identity_falls_through_to_scope():
+    """A session id must not make an empty startup identity authoritative."""
+    # Standard
+    from unittest.mock import PropertyMock
+
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import (
+        _get_request_context_or_default,
+        mcp_app,
+        request_headers_var,
+        server_id_var,
+        user_context_var,
+    )
+
+    scope_identity = {
+        "email": "user@test.com",
+        "teams": [],
+        "is_authenticated": True,
+        "is_admin": False,
+    }
+    scope_headers = {
+        "x-mcp-session-id": "session-123",
+        "x-context-forge-gateway-id": "gateway-123",
+    }
+    mock_request = MagicMock()
+    mock_request.scope = {
+        _MCPGATEWAY_CONTEXT_KEY: {
+            "server_id": "scope-server",
+            "request_headers": scope_headers,
+            "user_context": scope_identity,
+        }
+    }
+    mock_ctx = MagicMock()
+    mock_ctx.request = mock_request
+
+    s_tok = server_id_var.set("stale-server")
+    h_tok = request_headers_var.set({"x-mcp-session-id": "session-123"})
+    u_tok = user_context_var.set({})
+    try:
+        with patch.object(
+            type(mcp_app),
+            "request_context",
+            new_callable=PropertyMock,
+            return_value=mock_ctx,
+        ):
+            sid, headers, user = await _get_request_context_or_default()
+        assert sid == "scope-server"
+        assert headers == scope_headers
+        assert user == scope_identity
     finally:
         server_id_var.reset(s_tok)
         request_headers_var.reset(h_tok)

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -5148,6 +5148,7 @@ async def test_streamable_http_auth_proxy_user_when_client_auth_disabled(monkeyp
 
     user_ctx = tr.user_context_var.get()
     assert user_ctx["email"] == "proxy_user@example.com"
+    assert scope[tr._MCPGATEWAY_AUTH_CONTEXT_KEY] == user_ctx
     assert user_ctx["teams"] == []
     assert user_ctx["is_authenticated"] is True
     assert user_ctx["is_admin"] is False
@@ -10380,6 +10381,7 @@ async def test_auth_session_token_admin_bypass(monkeypatch):
     user_ctx = tr.user_context_var.get()
     assert user_ctx["teams"] is None  # Admin bypass
     assert user_ctx["is_admin"] is True
+    assert scope[tr._MCPGATEWAY_AUTH_CONTEXT_KEY] == user_ctx
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -12576,11 +12576,7 @@ async def test_get_request_context_no_request_object(monkeypatch, caplog):
     from unittest.mock import PropertyMock
 
     # First-Party
-    from mcpgateway.transports.streamablehttp_transport import (
-        _get_request_context_or_default,
-        mcp_app,
-        server_id_var,
-    )
+    from mcpgateway.transports.streamablehttp_transport import _get_request_context_or_default, mcp_app, server_id_var
 
     token = server_id_var.set("default_server_id")
 
@@ -12605,11 +12601,7 @@ async def test_get_request_context_stateful_success(monkeypatch):
     from unittest.mock import PropertyMock
 
     # First-Party
-    from mcpgateway.transports.streamablehttp_transport import (
-        _get_request_context_or_default,
-        mcp_app,
-        server_id_var,
-    )
+    from mcpgateway.transports.streamablehttp_transport import _get_request_context_or_default, mcp_app, server_id_var
 
     token = server_id_var.set("default_server_id")
 

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -15068,7 +15068,7 @@ async def test_get_request_context_reads_scope_context(monkeypatch):
     original_user_identity = user_identity_var.get()
 
     injected_user_context = {"email": "pub@example.com", "teams": [], "is_authenticated": True, "is_admin": False}
-    injected_headers = {"authorization": "Bearer tok123"}
+    injected_headers = {"x-mcp-session-id": "session-123"}
     injected_server_id = "abc123def456"  # pragma: allowlist secret
 
     mock_scope = {
@@ -15139,6 +15139,137 @@ async def test_get_request_context_scope_fallback_to_reauth(monkeypatch):
 
             assert sid == valid_hex_id
             assert user == normalized
+    finally:
+        server_id_var.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_get_request_context_incomplete_scope_falls_back_to_reauth(monkeypatch):
+    """An ASGI context without a principal must not suppress verified request recovery."""
+    # Standard
+    from unittest.mock import PropertyMock
+
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import (
+        _get_request_context_or_default,
+        mcp_app,
+        server_id_var,
+    )
+
+    token = server_id_var.set("default_server_id")
+    gateway_id = "abc123def456"  # pragma: allowlist secret
+    current_headers = {
+        "authorization": "Bearer current-request-token",  # pragma: allowlist secret
+        "x-context-forge-gateway-id": gateway_id,
+    }
+    mock_request = MagicMock()
+    mock_request.scope = {
+        "state": {
+            _MCPGATEWAY_CONTEXT_KEY: {
+                "server_id": "default_server_id",
+                "request_headers": {"x-mcp-session-id": "stale-session"},
+                "user_context": {},
+            }
+        }
+    }
+    mock_request.url.path = "/mcp"
+    mock_request.headers = current_headers
+    mock_request.cookies = {}
+    mock_ctx = MagicMock()
+    mock_ctx.request = mock_request
+
+    raw_jwt = {"sub": "agent@example.com", "token_use": "api", "teams": ["team-1"]}
+    normalized = {
+        "email": "agent@example.com",
+        "teams": ["team-1"],
+        "is_admin": False,
+        "is_authenticated": True,
+    }
+    auth = AsyncMock(return_value=raw_jwt)
+    normalize = AsyncMock(return_value=normalized)
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport.require_auth_header_first",
+        auth,
+    )
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._normalize_jwt_payload",
+        normalize,
+    )
+
+    try:
+        with patch.object(type(mcp_app), "request_context", new_callable=PropertyMock, return_value=mock_ctx):
+            sid, headers, user = await _get_request_context_or_default()
+
+            assert sid == "default_server_id"
+            assert headers == current_headers
+            assert user == normalized
+            auth.assert_awaited_once()
+            normalize.assert_awaited_once_with(raw_jwt)
+    finally:
+        server_id_var.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_get_request_context_authorization_replaces_stale_scope_identity(monkeypatch):
+    """A current bearer token must win over a populated but stale SDK scope."""
+    # Standard
+    from unittest.mock import PropertyMock
+
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import (
+        _get_request_context_or_default,
+        mcp_app,
+        server_id_var,
+    )
+
+    token = server_id_var.set("default_server_id")
+    current_headers = {
+        "authorization": "Bearer current-request-token",  # pragma: allowlist secret
+        "x-context-forge-gateway-id": "abc123def456",  # pragma: allowlist secret
+    }
+    mock_request = MagicMock()
+    mock_request.scope = {
+        "state": {
+            _MCPGATEWAY_CONTEXT_KEY: {
+                "server_id": "default_server_id",
+                "request_headers": {"x-mcp-session-id": "stale-session"},
+                "user_context": {
+                    "email": "stale@example.com",
+                    "is_authenticated": True,
+                },
+            }
+        }
+    }
+    mock_request.url.path = "/mcp"
+    mock_request.headers = current_headers
+    mock_request.cookies = {}
+    mock_ctx = MagicMock()
+    mock_ctx.request = mock_request
+
+    raw_jwt = {"sub": "current@example.com", "token_use": "api", "teams": []}
+    normalized = {
+        "email": "current@example.com",
+        "teams": [],
+        "is_admin": False,
+        "is_authenticated": True,
+    }
+    auth = AsyncMock(return_value=raw_jwt)
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport.require_auth_header_first",
+        auth,
+    )
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._normalize_jwt_payload",
+        AsyncMock(return_value=normalized),
+    )
+
+    try:
+        with patch.object(type(mcp_app), "request_context", new_callable=PropertyMock, return_value=mock_ctx):
+            _sid, headers, user = await _get_request_context_or_default()
+
+            assert headers == current_headers
+            assert user == normalized
+            auth.assert_awaited_once()
     finally:
         server_id_var.reset(token)
 


### PR DESCRIPTION
## Problem

The streamable HTTP transport already recovers authenticated user context from the ASGI scope when the MCP SDK task loses request ContextVars. Two gaps remained:

1. The direct-proxy tool path discarded that recovered value and read `user_identity_var` again, so `invoke_tool_direct()` could omit configured identity headers and metadata.
2. A populated but stale ASGI-scope principal could win over the current request bearer token; an incomplete scope could also suppress verified request recovery.

This complements #5426, which fixes the cached virtual-server invocation path.

## Fix

- Pass the `user_context` returned by `_get_request_context_or_default()` into `invoke_tool_direct()`.
- Re-authenticate when the current MCP request carries Authorization, so that current verified identity wins over stale SDK scope state.
- Fall through to verified recovery when the scope has no principal.
- Keep the ASGI-scope fast path for complete contexts without a current Authorization header.

The deployment issue that initially exposed this also required a separate least-privilege `tools.read`/`tools.execute` role. This PR does not bypass or weaken RBAC.

## Tests

- Direct proxy forwards recovered user context.
- Empty typed ContextVar still forwards ASGI-recovered identity.
- Incomplete ASGI scope falls back to verified authentication.
- Current bearer identity replaces a populated stale scope identity.
- `python3 -m py_compile` passes for both changed files.
- Ruff checks pass for the changed logic; repository-wide pre-existing findings remain delegated to CI.