### PR TITLE
fix: return 404 for missing server and gateway deletes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-17T15:09:05Z",
+  "generated_at": "2026-07-20T09:47:57Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -266,7 +266,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1746,
+        "line_number": 1747,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1834,
+        "line_number": 1835,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2184,
+        "line_number": 2185,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3549,
+        "line_number": 3550,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3640,
+        "line_number": 3641,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3683,
+        "line_number": 3684,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3688,
+        "line_number": 3689,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +322,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3693,
+        "line_number": 3694,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-17T13:06:41Z",
+  "generated_at": "2026-07-17T14:55:45Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5963,
+        "line_number": 5953,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6460,
+        "line_number": 6450,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6472,
+        "line_number": 6462,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6544,
+        "line_number": 6534,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7611,
+        "line_number": 7601,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4882,7 +4882,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2804,
+        "line_number": 2805,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-17T14:55:45Z",
+  "generated_at": "2026-07-17T15:09:05Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5953,
+        "line_number": 5963,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6450,
+        "line_number": 6460,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6462,
+        "line_number": 6472,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6534,
+        "line_number": 6544,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7601,
+        "line_number": 7611,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- **Missing Server and Gateway Deletes** - `DELETE /servers/{id}` and `DELETE /gateways/{id}` now return `404 Not Found` when the target no longer exists, instead of incorrectly returning `403 Forbidden`.
 - **Custom Auth Headers on Tools** ([#5314](https://github.com/IBM/mcp-context-forge/pull/5314), [#5201](https://github.com/IBM/mcp-context-forge/issues/5201)) - `POST /tools` and `PUT /tools/{tool_id}` now persist the `auth_headers` array instead of silently storing `auth_value: null`. Invalid header keys/values are rejected with a 422 rather than an unhandled 500.
 
 ### Changed

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -112,7 +112,7 @@ from mcpgateway.middleware.rate_limit_middleware import RateLimitMiddleware
 from mcpgateway.middleware.rbac import _ACCESS_DENIED_MSG, get_current_user_with_permissions, PermissionChecker, require_permission
 from mcpgateway.middleware.request_logging_middleware import RequestLoggingMiddleware
 from mcpgateway.middleware.security_headers import SecurityHeadersMiddleware
-from mcpgateway.middleware.token_scoping import token_scoping_middleware
+from mcpgateway.middleware.token_scoping import ResourceOwnershipResult, token_scoping_middleware
 from mcpgateway.middleware.validation_middleware import ValidationMiddleware
 from mcpgateway.observability import configure_baggage_span_attribute_policy, extract_baggage_span_attribute_policy, init_telemetry, OpenTelemetryRequestMiddleware, otel_tracing_enabled
 from mcpgateway.plugins import (
@@ -959,11 +959,14 @@ def _enforce_scoped_resource_access(request: Request, db: Session, user, resourc
     if scoped_token_teams is None:
         return
 
-    if not token_scoping_middleware._check_resource_team_ownership(  # pylint: disable=protected-access
-        resource_path,
-        scoped_token_teams,
-        db=db,
-        _user_email=scoped_user_email,
+    if (
+        token_scoping_middleware._check_resource_team_ownership(  # pylint: disable=protected-access
+            resource_path,
+            scoped_token_teams,
+            db=db,
+            _user_email=scoped_user_email,
+        )
+        is not ResourceOwnershipResult.ALLOWED
     ):
         logger.warning("Scoped resource access denied: user=%s, resource=%s", scoped_user_email, resource_path)
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=_ACCESS_DENIED_MSG)

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -1343,6 +1343,7 @@ class TokenScopingMiddleware:
                     # Check resource team ownership with shared session
                     ownership_result = self._check_resource_team_ownership(normalized_path, token_teams, db=db, _user_email=user_email)
                     if ownership_result is ResourceOwnershipResult.NOT_FOUND and self._is_targeted_missing_resource_delete(request.url.path, request.method):
+                        logger.info("Scoped DELETE target not found: %s", SecurityValidator.sanitize_log_message(normalized_path))
                         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found")
                     if ownership_result is not ResourceOwnershipResult.ALLOWED:
                         logger.warning(f"Access denied: Resource does not belong to token's teams {SecurityValidator.sanitize_log_message(str(token_teams))}")
@@ -1364,6 +1365,7 @@ class TokenScopingMiddleware:
 
                 ownership_result = self._check_resource_team_ownership(normalized_path, token_teams, _user_email=user_email)
                 if ownership_result is ResourceOwnershipResult.NOT_FOUND and self._is_targeted_missing_resource_delete(request.url.path, request.method):
+                    logger.info("Scoped DELETE target not found: %s", SecurityValidator.sanitize_log_message(normalized_path))
                     raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found")
                 if ownership_result is not ResourceOwnershipResult.ALLOWED:
                     logger.warning(f"Access denied: Resource does not belong to token's teams {SecurityValidator.sanitize_log_message(str(token_teams))}")

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -11,6 +11,7 @@ and time-based restrictions.
 
 # Standard
 from datetime import datetime, timedelta, timezone
+from enum import Enum, auto
 from functools import lru_cache
 import ipaddress
 import re
@@ -61,6 +62,17 @@ _RESOURCE_PATTERNS: List[Tuple[Pattern[str], str]] = [
     (re.compile(r"/gateways/?([a-f0-9\-]+)"), "gateway"),
 ]
 _AUTH_COOKIE_NAMES = ("jwt_token", "access_token")
+
+
+class ResourceOwnershipResult(Enum):
+    """Outcome from a token-scoped resource ownership lookup."""
+
+    ALLOWED = auto()
+    NOT_FOUND = auto()
+    DENIED = auto()
+
+
+_TARGETED_MISSING_DELETE_PATTERN = re.compile(r"^/(?:servers|gateways)/(?:[a-f0-9]{32}|[a-f0-9]{8}-(?:[a-f0-9]{4}-){3}[a-f0-9]{12})/?$")
 
 # Permission map with precompiled patterns
 # Maps (HTTP method, path pattern) to required permission
@@ -858,7 +870,12 @@ class TokenScopingMiddleware:
                 finally:
                     db.close()
 
-    def _check_resource_team_ownership(self, request_path: str, token_teams: list, db=None, _user_email: str = None) -> bool:  # noqa: PLR0911  # pylint: disable=too-many-return-statements
+    def _is_targeted_missing_resource_delete(self, request_path: str, method: str) -> bool:
+        """Return whether request is an exact server or gateway DELETE path."""
+        normalized_path = self._normalize_path_for_matching(request_path)
+        return method == "DELETE" and bool(_TARGETED_MISSING_DELETE_PATTERN.fullmatch(normalized_path))
+
+    def _check_resource_team_ownership(self, request_path: str, token_teams: list, db=None, _user_email: str = None) -> ResourceOwnershipResult:  # noqa: PLR0911  # pylint: disable=too-many-return-statements
         """
         Check if the requested resource is accessible by the token.
 
@@ -887,7 +904,7 @@ class TokenScopingMiddleware:
                 If None, creates and manages its own session.
 
         Returns:
-            bool: True if resource access is allowed, False otherwise
+            ResourceOwnershipResult: Allowed, missing, or denied ownership result.
         """
         request_path = self._normalize_path_for_matching(request_path)
 
@@ -923,7 +940,7 @@ class TokenScopingMiddleware:
         # If no resource ID in path, allow (general endpoints like /health, /tokens, /metrics)
         if not resource_id or not resource_type:
             logger.debug(f"No resource ID found in path {request_path}, allowing access")
-            return True
+            return ResourceOwnershipResult.ALLOWED
 
         # Import database models
         # First-Party
@@ -941,7 +958,7 @@ class TokenScopingMiddleware:
 
                 if not server:
                     logger.warning(f"Server {SecurityValidator.sanitize_log_message(resource_id)} not found in database")
-                    return False
+                    return ResourceOwnershipResult.NOT_FOUND
 
                 # Get server visibility (default to 'team' if field doesn't exist)
                 server_visibility = getattr(server, "visibility", "team")
@@ -949,7 +966,7 @@ class TokenScopingMiddleware:
                 # PUBLIC SERVERS: Accessible by everyone (including public-only tokens)
                 if server_visibility == "public":
                     logger.debug(f"Access granted: Server {SecurityValidator.sanitize_log_message(resource_id)} is PUBLIC")
-                    return True
+                    return ResourceOwnershipResult.ALLOWED
 
                 # PUBLIC-ONLY TOKEN: Can ONLY access public servers (strict public-only policy)
                 # No owner access - if user needs own resources, use a personal team-scoped token
@@ -957,7 +974,7 @@ class TokenScopingMiddleware:
                     logger.warning(
                         f"Access denied: Public-only token cannot access {SecurityValidator.sanitize_log_message(server_visibility)} server {SecurityValidator.sanitize_log_message(resource_id)}"
                     )
-                    return False
+                    return ResourceOwnershipResult.DENIED
 
                 # TEAM-SCOPED SERVERS: Check if server belongs to token's teams
                 if server_visibility == "team":
@@ -965,28 +982,28 @@ class TokenScopingMiddleware:
                         logger.debug(
                             f"Access granted: Team server {SecurityValidator.sanitize_log_message(resource_id)} belongs to token's team {SecurityValidator.sanitize_log_message(str(server.team_id))}"
                         )
-                        return True
+                        return ResourceOwnershipResult.ALLOWED
 
                     logger.warning(
                         f"Access denied: Server {SecurityValidator.sanitize_log_message(resource_id)} is team-scoped to '{SecurityValidator.sanitize_log_message(str(server.team_id))}', token is scoped to teams {SecurityValidator.sanitize_log_message(str(token_team_ids))}"
                     )
-                    return False
+                    return ResourceOwnershipResult.DENIED
 
                 # PRIVATE SERVERS: Owner-only access (per RBAC doc)
                 if server_visibility == "private":
                     server_owner = getattr(server, "owner_email", None)
                     if server_owner and server_owner == _user_email:
                         logger.debug(f"Access granted: Private server {SecurityValidator.sanitize_log_message(resource_id)} owned by {SecurityValidator.sanitize_log_message(_user_email)}")
-                        return True
+                        return ResourceOwnershipResult.ALLOWED
 
                     logger.warning(
                         f"Access denied: Server {SecurityValidator.sanitize_log_message(resource_id)} is private, owner is '{SecurityValidator.sanitize_log_message(str(server_owner))}', requester is '{SecurityValidator.sanitize_log_message(_user_email)}'"
                     )
-                    return False
+                    return ResourceOwnershipResult.DENIED
 
                 # Unknown visibility - deny by default
                 logger.warning(f"Access denied: Server {SecurityValidator.sanitize_log_message(resource_id)} has unknown visibility: {SecurityValidator.sanitize_log_message(server_visibility)}")
-                return False
+                return ResourceOwnershipResult.DENIED
 
             # CHECK TOOLS
             if resource_type == "tool":
@@ -994,7 +1011,7 @@ class TokenScopingMiddleware:
 
                 if not tool:
                     logger.warning(f"Tool {SecurityValidator.sanitize_log_message(resource_id)} not found in database")
-                    return False
+                    return ResourceOwnershipResult.DENIED
 
                 # Get tool visibility (default to 'team' if field doesn't exist)
                 tool_visibility = getattr(tool, "visibility", "team")
@@ -1002,7 +1019,7 @@ class TokenScopingMiddleware:
                 # PUBLIC TOOLS: Accessible by everyone (including public-only tokens)
                 if tool_visibility == "public":
                     logger.debug(f"Access granted: Tool {SecurityValidator.sanitize_log_message(resource_id)} is PUBLIC")
-                    return True
+                    return ResourceOwnershipResult.ALLOWED
 
                 # PUBLIC-ONLY TOKEN: Can ONLY access public tools (strict public-only policy)
                 # No owner access - if user needs own resources, use a personal team-scoped token
@@ -1010,7 +1027,7 @@ class TokenScopingMiddleware:
                     logger.warning(
                         f"Access denied: Public-only token cannot access {SecurityValidator.sanitize_log_message(tool_visibility)} tool {SecurityValidator.sanitize_log_message(resource_id)}"
                     )
-                    return False
+                    return ResourceOwnershipResult.DENIED
 
                 # TEAM TOOLS: Check if tool's team matches token's teams
                 if tool_visibility == "team":
@@ -1019,28 +1036,28 @@ class TokenScopingMiddleware:
                         logger.debug(
                             f"Access granted: Team tool {SecurityValidator.sanitize_log_message(resource_id)} belongs to token's team {SecurityValidator.sanitize_log_message(str(tool_team_id))}"
                         )
-                        return True
+                        return ResourceOwnershipResult.ALLOWED
 
                     logger.warning(
                         f"Access denied: Tool {SecurityValidator.sanitize_log_message(resource_id)} is team-scoped to '{SecurityValidator.sanitize_log_message(str(tool_team_id))}', token is scoped to teams {SecurityValidator.sanitize_log_message(str(token_team_ids))}"
                     )
-                    return False
+                    return ResourceOwnershipResult.DENIED
 
                 # PRIVATE TOOLS: Owner-only access (per RBAC doc)
                 if tool_visibility in ["private", "user"]:
                     tool_owner = getattr(tool, "owner_email", None)
                     if tool_owner and tool_owner == _user_email:
                         logger.debug(f"Access granted: Private tool {SecurityValidator.sanitize_log_message(resource_id)} owned by {SecurityValidator.sanitize_log_message(_user_email)}")
-                        return True
+                        return ResourceOwnershipResult.ALLOWED
 
                     logger.warning(
                         f"Access denied: Tool {SecurityValidator.sanitize_log_message(resource_id)} is {SecurityValidator.sanitize_log_message(tool_visibility)}, owner is '{SecurityValidator.sanitize_log_message(str(tool_owner))}', requester is '{SecurityValidator.sanitize_log_message(_user_email)}'"
                     )
-                    return False
+                    return ResourceOwnershipResult.DENIED
 
                 # Unknown visibility - deny by default
                 logger.warning(f"Access denied: Tool {SecurityValidator.sanitize_log_message(resource_id)} has unknown visibility: {SecurityValidator.sanitize_log_message(tool_visibility)}")
-                return False
+                return ResourceOwnershipResult.DENIED
 
             # CHECK RESOURCES
             if resource_type == "resource":
@@ -1048,7 +1065,7 @@ class TokenScopingMiddleware:
 
                 if not resource:
                     logger.warning(f"Resource {SecurityValidator.sanitize_log_message(resource_id)} not found in database")
-                    return False
+                    return ResourceOwnershipResult.DENIED
 
                 # Get resource visibility (default to 'team' if field doesn't exist)
                 resource_visibility = getattr(resource, "visibility", "team")
@@ -1056,7 +1073,7 @@ class TokenScopingMiddleware:
                 # PUBLIC RESOURCES: Accessible by everyone (including public-only tokens)
                 if resource_visibility == "public":
                     logger.debug(f"Access granted: Resource {SecurityValidator.sanitize_log_message(resource_id)} is PUBLIC")
-                    return True
+                    return ResourceOwnershipResult.ALLOWED
 
                 # PUBLIC-ONLY TOKEN: Can ONLY access public resources (strict public-only policy)
                 # No owner access - if user needs own resources, use a personal team-scoped token
@@ -1064,7 +1081,7 @@ class TokenScopingMiddleware:
                     logger.warning(
                         f"Access denied: Public-only token cannot access {SecurityValidator.sanitize_log_message(resource_visibility)} resource {SecurityValidator.sanitize_log_message(resource_id)}"
                     )
-                    return False
+                    return ResourceOwnershipResult.DENIED
 
                 # TEAM RESOURCES: Check if resource's team matches token's teams
                 if resource_visibility == "team":
@@ -1073,28 +1090,28 @@ class TokenScopingMiddleware:
                         logger.debug(
                             f"Access granted: Team resource {SecurityValidator.sanitize_log_message(resource_id)} belongs to token's team {SecurityValidator.sanitize_log_message(str(resource_team_id))}"
                         )
-                        return True
+                        return ResourceOwnershipResult.ALLOWED
 
                     logger.warning(
                         f"Access denied: Resource {SecurityValidator.sanitize_log_message(resource_id)} is team-scoped to '{SecurityValidator.sanitize_log_message(str(resource_team_id))}', token is scoped to teams {SecurityValidator.sanitize_log_message(str(token_team_ids))}"
                     )
-                    return False
+                    return ResourceOwnershipResult.DENIED
 
                 # PRIVATE RESOURCES: Owner-only access (per RBAC doc)
                 if resource_visibility in ["private", "user"]:
                     resource_owner = getattr(resource, "owner_email", None)
                     if resource_owner and resource_owner == _user_email:
                         logger.debug(f"Access granted: Private resource {SecurityValidator.sanitize_log_message(resource_id)} owned by {SecurityValidator.sanitize_log_message(_user_email)}")
-                        return True
+                        return ResourceOwnershipResult.ALLOWED
 
                     logger.warning(
                         f"Access denied: Resource {SecurityValidator.sanitize_log_message(resource_id)} is {SecurityValidator.sanitize_log_message(resource_visibility)}, owner is '{SecurityValidator.sanitize_log_message(str(resource_owner))}', requester is '{SecurityValidator.sanitize_log_message(_user_email)}'"
                     )
-                    return False
+                    return ResourceOwnershipResult.DENIED
 
                 # Unknown visibility - deny by default
                 logger.warning(f"Access denied: Resource {SecurityValidator.sanitize_log_message(resource_id)} has unknown visibility: {SecurityValidator.sanitize_log_message(resource_visibility)}")
-                return False
+                return ResourceOwnershipResult.DENIED
 
             # CHECK PROMPTS
             if resource_type == "prompt":
@@ -1102,7 +1119,7 @@ class TokenScopingMiddleware:
 
                 if not prompt:
                     logger.warning(f"Prompt {SecurityValidator.sanitize_log_message(resource_id)} not found in database")
-                    return False
+                    return ResourceOwnershipResult.DENIED
 
                 # Get prompt visibility (default to 'team' if field doesn't exist)
                 prompt_visibility = getattr(prompt, "visibility", "team")
@@ -1110,7 +1127,7 @@ class TokenScopingMiddleware:
                 # PUBLIC PROMPTS: Accessible by everyone (including public-only tokens)
                 if prompt_visibility == "public":
                     logger.debug(f"Access granted: Prompt {SecurityValidator.sanitize_log_message(resource_id)} is PUBLIC")
-                    return True
+                    return ResourceOwnershipResult.ALLOWED
 
                 # PUBLIC-ONLY TOKEN: Can ONLY access public prompts (strict public-only policy)
                 # No owner access - if user needs own resources, use a personal team-scoped token
@@ -1118,7 +1135,7 @@ class TokenScopingMiddleware:
                     logger.warning(
                         f"Access denied: Public-only token cannot access {SecurityValidator.sanitize_log_message(prompt_visibility)} prompt {SecurityValidator.sanitize_log_message(resource_id)}"
                     )
-                    return False
+                    return ResourceOwnershipResult.DENIED
 
                 # TEAM PROMPTS: Check if prompt's team matches token's teams
                 if prompt_visibility == "team":
@@ -1127,28 +1144,28 @@ class TokenScopingMiddleware:
                         logger.debug(
                             f"Access granted: Team prompt {SecurityValidator.sanitize_log_message(resource_id)} belongs to token's team {SecurityValidator.sanitize_log_message(str(prompt_team_id))}"
                         )
-                        return True
+                        return ResourceOwnershipResult.ALLOWED
 
                     logger.warning(
                         f"Access denied: Prompt {SecurityValidator.sanitize_log_message(resource_id)} is team-scoped to '{SecurityValidator.sanitize_log_message(str(prompt_team_id))}', token is scoped to teams {SecurityValidator.sanitize_log_message(str(token_team_ids))}"
                     )
-                    return False
+                    return ResourceOwnershipResult.DENIED
 
                 # PRIVATE PROMPTS: Owner-only access (per RBAC doc)
                 if prompt_visibility in ["private", "user"]:
                     prompt_owner = getattr(prompt, "owner_email", None)
                     if prompt_owner and prompt_owner == _user_email:
                         logger.debug(f"Access granted: Private prompt {SecurityValidator.sanitize_log_message(resource_id)} owned by {SecurityValidator.sanitize_log_message(_user_email)}")
-                        return True
+                        return ResourceOwnershipResult.ALLOWED
 
                     logger.warning(
                         f"Access denied: Prompt {SecurityValidator.sanitize_log_message(resource_id)} is {SecurityValidator.sanitize_log_message(prompt_visibility)}, owner is '{SecurityValidator.sanitize_log_message(str(prompt_owner))}', requester is '{SecurityValidator.sanitize_log_message(_user_email)}'"
                     )
-                    return False
+                    return ResourceOwnershipResult.DENIED
 
                 # Unknown visibility - deny by default
                 logger.warning(f"Access denied: Prompt {SecurityValidator.sanitize_log_message(resource_id)} has unknown visibility: {SecurityValidator.sanitize_log_message(prompt_visibility)}")
-                return False
+                return ResourceOwnershipResult.DENIED
 
             # CHECK GATEWAYS
             if resource_type == "gateway":
@@ -1156,7 +1173,7 @@ class TokenScopingMiddleware:
 
                 if not gateway:
                     logger.warning(f"Gateway {SecurityValidator.sanitize_log_message(resource_id)} not found in database")
-                    return False
+                    return ResourceOwnershipResult.NOT_FOUND
 
                 # Get gateway visibility (default to 'team' if field doesn't exist)
                 gateway_visibility = getattr(gateway, "visibility", "team")
@@ -1164,7 +1181,7 @@ class TokenScopingMiddleware:
                 # PUBLIC GATEWAYS: Accessible by everyone (including public-only tokens)
                 if gateway_visibility == "public":
                     logger.debug(f"Access granted: Gateway {SecurityValidator.sanitize_log_message(resource_id)} is PUBLIC")
-                    return True
+                    return ResourceOwnershipResult.ALLOWED
 
                 # PUBLIC-ONLY TOKEN: Can ONLY access public gateways (strict public-only policy)
                 # No owner access - if user needs own resources, use a personal team-scoped token
@@ -1172,7 +1189,7 @@ class TokenScopingMiddleware:
                     logger.warning(
                         f"Access denied: Public-only token cannot access {SecurityValidator.sanitize_log_message(gateway_visibility)} gateway {SecurityValidator.sanitize_log_message(resource_id)}"
                     )
-                    return False
+                    return ResourceOwnershipResult.DENIED
 
                 # TEAM GATEWAYS: Check if gateway's team matches token's teams
                 if gateway_visibility == "team":
@@ -1181,37 +1198,37 @@ class TokenScopingMiddleware:
                         logger.debug(
                             f"Access granted: Team gateway {SecurityValidator.sanitize_log_message(resource_id)} belongs to token's team {SecurityValidator.sanitize_log_message(str(gateway_team_id))}"
                         )
-                        return True
+                        return ResourceOwnershipResult.ALLOWED
 
                     logger.warning(
                         f"Access denied: Gateway {SecurityValidator.sanitize_log_message(resource_id)} is team-scoped to '{SecurityValidator.sanitize_log_message(str(gateway_team_id))}', token is scoped to teams {SecurityValidator.sanitize_log_message(str(token_team_ids))}"
                     )
-                    return False
+                    return ResourceOwnershipResult.DENIED
 
                 # PRIVATE GATEWAYS: Owner-only access (per RBAC doc)
                 if gateway_visibility in ["private", "user"]:
                     gateway_owner = getattr(gateway, "owner_email", None)
                     if gateway_owner and gateway_owner == _user_email:
                         logger.debug(f"Access granted: Private gateway {SecurityValidator.sanitize_log_message(resource_id)} owned by {SecurityValidator.sanitize_log_message(_user_email)}")
-                        return True
+                        return ResourceOwnershipResult.ALLOWED
 
                     logger.warning(
                         f"Access denied: Gateway {SecurityValidator.sanitize_log_message(resource_id)} is {SecurityValidator.sanitize_log_message(gateway_visibility)}, owner is '{SecurityValidator.sanitize_log_message(str(gateway_owner))}', requester is '{SecurityValidator.sanitize_log_message(_user_email)}'"
                     )
-                    return False
+                    return ResourceOwnershipResult.DENIED
 
                 # Unknown visibility - deny by default
                 logger.warning(f"Access denied: Gateway {SecurityValidator.sanitize_log_message(resource_id)} has unknown visibility: {SecurityValidator.sanitize_log_message(gateway_visibility)}")
-                return False
+                return ResourceOwnershipResult.DENIED
 
             # UNKNOWN RESOURCE TYPE
             logger.warning(f"Unknown resource type '{SecurityValidator.sanitize_log_message(str(resource_type))}' for path: {SecurityValidator.sanitize_log_message(request_path)}")
-            return False
+            return ResourceOwnershipResult.DENIED
 
         except Exception as e:
             logger.error(f"Error checking resource team ownership for {request_path}: {e}", exc_info=True)
             # Fail securely - deny access on error
-            return False
+            return ResourceOwnershipResult.DENIED
         finally:
             # Only commit/close if we created the session
             if owns_session:
@@ -1324,7 +1341,10 @@ class TokenScopingMiddleware:
                         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Token is invalid: User is no longer a member of the associated team")
 
                     # Check resource team ownership with shared session
-                    if not self._check_resource_team_ownership(normalized_path, token_teams, db=db, _user_email=user_email):
+                    ownership_result = self._check_resource_team_ownership(normalized_path, token_teams, db=db, _user_email=user_email)
+                    if ownership_result is ResourceOwnershipResult.NOT_FOUND and self._is_targeted_missing_resource_delete(request.url.path, request.method):
+                        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found")
+                    if ownership_result is not ResourceOwnershipResult.ALLOWED:
                         logger.warning(f"Access denied: Resource does not belong to token's teams {SecurityValidator.sanitize_log_message(str(token_teams))}")
                         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=_ACCESS_DENIED_MSG)
                 finally:
@@ -1342,7 +1362,10 @@ class TokenScopingMiddleware:
                     logger.warning("Token rejected: User no longer member of associated team(s)")
                     raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Token is invalid: User is no longer a member of the associated team")
 
-                if not self._check_resource_team_ownership(normalized_path, token_teams, _user_email=user_email):
+                ownership_result = self._check_resource_team_ownership(normalized_path, token_teams, _user_email=user_email)
+                if ownership_result is ResourceOwnershipResult.NOT_FOUND and self._is_targeted_missing_resource_delete(request.url.path, request.method):
+                    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found")
+                if ownership_result is not ResourceOwnershipResult.ALLOWED:
                     logger.warning(f"Access denied: Resource does not belong to token's teams {SecurityValidator.sanitize_log_message(str(token_teams))}")
                     raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=_ACCESS_DENIED_MSG)
 

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -33,7 +33,7 @@ from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.db import Gateway, get_db
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
-from mcpgateway.middleware.token_scoping import token_scoping_middleware
+from mcpgateway.middleware.token_scoping import ResourceOwnershipResult, token_scoping_middleware
 from mcpgateway.schemas import EmailUserResponse
 from mcpgateway.services.dcr_service import DcrError, DcrService
 from mcpgateway.services.encryption_service import protect_oauth_config_for_storage
@@ -311,11 +311,14 @@ async def _enforce_gateway_access(
                 return
             token_teams = []
 
-        if not token_scoping_middleware._check_resource_team_ownership(
-            f"/gateways/{gateway_id}",
-            token_teams,
-            db=db,
-            _user_email=requester_email,
+        if (
+            token_scoping_middleware._check_resource_team_ownership(
+                f"/gateways/{gateway_id}",
+                token_teams,
+                db=db,
+                _user_email=requester_email,
+            )
+            is not ResourceOwnershipResult.ALLOWED
         ):
             raise HTTPException(status_code=403, detail="You don't have access to this gateway")
 

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -1834,6 +1834,8 @@ async def test_team_scoped_resource_denied(monkeypatch):
         ("/gateways/aabbccddeeff00112233445566778899", ["team-1"]),
         ("/servers/aabbccddeeff00112233445566778899", []),
         ("/gateways/aabbccddeeff00112233445566778899", []),
+        ("/servers/aabbccdd-eeff-0011-2233-445566778899", ["team-1"]),
+        ("/gateways/aabbccdd-eeff-0011-2233-445566778899", []),
         ("/v1/servers/aabbccddeeff00112233445566778899", ["team-1"]),
         ("/v1/gateways/aabbccddeeff00112233445566778899", []),
     ],

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -23,7 +23,7 @@ import pytest
 # First-Party
 from mcpgateway.config import settings
 from mcpgateway.db import Permissions
-from mcpgateway.middleware.token_scoping import _get_llm_permission_patterns, TokenScopingMiddleware
+from mcpgateway.middleware.token_scoping import ResourceOwnershipResult, _get_llm_permission_patterns, TokenScopingMiddleware
 
 
 def _trusted_internal_runtime_headers() -> dict[str, str]:
@@ -181,7 +181,7 @@ class TestTokenScopingMiddleware:
         with (
             patch.object(middleware, "_extract_token_scopes", new=AsyncMock(return_value=payload)),
             patch.object(middleware, "_check_team_membership", return_value=True),
-            patch.object(middleware, "_check_resource_team_ownership", return_value=True),
+            patch.object(middleware, "_check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED),
             patch.object(middleware, "_check_server_restriction", return_value=True),
             patch.object(middleware, "_check_permission_restrictions", return_value=False),
         ):
@@ -732,7 +732,7 @@ class TestTokenScopingMiddleware:
                 # Mock _check_team_membership to avoid DB query
                 with patch.object(middleware, "_check_team_membership", return_value=True):
                     # Mock _check_resource_team_ownership to avoid DB query
-                    with patch.object(middleware, "_check_resource_team_ownership", return_value=True):
+                    with patch.object(middleware, "_check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED):
                         call_next = AsyncMock(return_value="success")
 
                         result = await middleware(mock_request, call_next)
@@ -828,7 +828,7 @@ class TestTokenScopingMiddleware:
                     # Mock _check_team_membership to avoid DB query
                     with patch.object(middleware, "_check_team_membership", return_value=True):
                         # Mock _check_resource_team_ownership to avoid DB query
-                        with patch.object(middleware, "_check_resource_team_ownership", return_value=True):
+                        with patch.object(middleware, "_check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED):
                             call_next = AsyncMock(return_value="success")
 
                             result = await middleware(mock_request, call_next)
@@ -863,7 +863,7 @@ class TestTokenScopingMiddleware:
                     # Mock _check_team_membership to avoid DB query
                     with patch.object(middleware, "_check_team_membership", return_value=True):
                         # Mock _check_resource_team_ownership to avoid DB query
-                        with patch.object(middleware, "_check_resource_team_ownership", return_value=True):
+                        with patch.object(middleware, "_check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED):
                             call_next = AsyncMock(return_value="success")
 
                             result = await middleware(mock_request, call_next)
@@ -894,7 +894,7 @@ class TestTokenScopingMiddleware:
 
         with patch.object(middleware, "_extract_token_scopes", return_value=session_payload):
             with patch("mcpgateway.middleware.token_scoping.resolve_session_teams", new=AsyncMock(return_value=["team-1"])) as mock_resolve:
-                with patch.object(middleware, "_check_resource_team_ownership", return_value=True):
+                with patch.object(middleware, "_check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED):
                     call_next = AsyncMock(return_value="success")
 
                     result = await middleware(mock_request, call_next)
@@ -922,7 +922,7 @@ class TestTokenScopingMiddleware:
             # resolve_session_teams returns [] (empty intersection)
             with patch("mcpgateway.auth._resolve_teams_from_db", return_value=["db-team"]) as mock_resolve:
                 with patch.object(middleware, "_check_team_membership", return_value=False) as mock_membership:
-                    with patch.object(middleware, "_check_resource_team_ownership", return_value=True):
+                    with patch.object(middleware, "_check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED):
                         call_next = AsyncMock(return_value="success")
 
                         result = await middleware(mock_request, call_next)
@@ -1008,15 +1008,15 @@ class TestTokenScopingMiddleware:
         tool.team_id = "team-1"
         db.execute.return_value.scalar_one_or_none.return_value = tool
 
-        assert middleware._check_resource_team_ownership("/tools/abc", ["team-1"], db=db, _user_email="user@example.com") is True
-        assert middleware._check_resource_team_ownership("/tools/abc", [], db=db, _user_email="user@example.com") is False
+        assert middleware._check_resource_team_ownership("/tools/abc", ["team-1"], db=db, _user_email="user@example.com") is ResourceOwnershipResult.ALLOWED
+        assert middleware._check_resource_team_ownership("/tools/abc", [], db=db, _user_email="user@example.com") is ResourceOwnershipResult.DENIED
 
         resource = MagicMock()
         resource.visibility = "private"
         resource.owner_email = "user@example.com"
         db.execute.return_value.scalar_one_or_none.return_value = resource
 
-        assert middleware._check_resource_team_ownership("/resources/abc", ["team-1"], db=db, _user_email="user@example.com") is True
+        assert middleware._check_resource_team_ownership("/resources/abc", ["team-1"], db=db, _user_email="user@example.com") is ResourceOwnershipResult.ALLOWED
 
         # Test that GET /tools requires TOOLS_READ permission specifically
         assert middleware._check_permission_restrictions("/tools", "GET", [Permissions.TOOLS_CREATE]) == False
@@ -1358,7 +1358,7 @@ class TestTokenScopingMiddleware:
             db=mock_db,
             _user_email="owner@example.com",
         )
-        assert result is True, "Owner should access their private resource"
+        assert result is ResourceOwnershipResult.ALLOWED, "Owner should access their private resource"
 
         # Test: Non-owner in same team CANNOT access private resource
         result = middleware._check_resource_team_ownership(
@@ -1367,7 +1367,7 @@ class TestTokenScopingMiddleware:
             db=mock_db,
             _user_email="teammate@example.com",
         )
-        assert result is False, "Non-owner teammate should NOT access private resource"
+        assert result is ResourceOwnershipResult.DENIED, "Non-owner teammate should NOT access private resource"
 
         # Test: Non-owner in different team CANNOT access private resource
         result = middleware._check_resource_team_ownership(
@@ -1376,7 +1376,7 @@ class TestTokenScopingMiddleware:
             db=mock_db,
             _user_email="outsider@example.com",
         )
-        assert result is False, "Non-owner outsider should NOT access private resource"
+        assert result is ResourceOwnershipResult.DENIED, "Non-owner outsider should NOT access private resource"
 
     @pytest.mark.asyncio
     async def test_team_visibility_allows_team_members(self, middleware):
@@ -1397,7 +1397,7 @@ class TestTokenScopingMiddleware:
             db=mock_db,
             _user_email="teammate@example.com",
         )
-        assert result is True, "Team member should access team resource"
+        assert result is ResourceOwnershipResult.ALLOWED, "Team member should access team resource"
 
         # Test: Non-team member cannot access team resource
         result = middleware._check_resource_team_ownership(
@@ -1406,7 +1406,7 @@ class TestTokenScopingMiddleware:
             db=mock_db,
             _user_email="outsider@example.com",
         )
-        assert result is False, "Non-team member should NOT access team resource"
+        assert result is ResourceOwnershipResult.DENIED, "Non-team member should NOT access team resource"
 
     @pytest.mark.asyncio
     async def test_public_visibility_allows_all(self, middleware):
@@ -1427,7 +1427,7 @@ class TestTokenScopingMiddleware:
             db=mock_db,
             _user_email="anyone@example.com",
         )
-        assert result is True, "Any user should access public resource"
+        assert result is ResourceOwnershipResult.ALLOWED, "Any user should access public resource"
 
         # Test: Public-only token (empty teams) can access public resource
         result = middleware._check_resource_team_ownership(
@@ -1436,7 +1436,7 @@ class TestTokenScopingMiddleware:
             db=mock_db,
             _user_email="public-user@example.com",
         )
-        assert result is True, "Public-only token should access public resource"
+        assert result is ResourceOwnershipResult.ALLOWED, "Public-only token should access public resource"
 
     @pytest.mark.asyncio
     async def test_admin_bypass_skips_team_validation(self, middleware, mock_request):
@@ -1495,7 +1495,7 @@ class TestTokenScopingMiddleware:
         with (
             patch.object(middleware, "_extract_token_scopes", return_value=payload),
             patch.object(middleware, "_check_team_membership", return_value=True),
-            patch.object(middleware, "_check_resource_team_ownership", return_value=True),
+            patch.object(middleware, "_check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED),
             patch("mcpgateway.auth._resolve_teams_from_db", new=AsyncMock(return_value=["team-1"])),
         ):
             call_next = AsyncMock(return_value="ok")
@@ -1522,7 +1522,7 @@ class TestTokenScopingMiddleware:
         with (
             patch.object(middleware, "_extract_token_scopes", return_value=payload),
             patch.object(middleware, "_check_team_membership", return_value=True),
-            patch.object(middleware, "_check_resource_team_ownership", return_value=True),
+            patch.object(middleware, "_check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED),
             patch.object(middleware, "_check_server_restriction", return_value=True),
             patch.object(middleware, "_check_permission_restrictions", return_value=True),
         ):
@@ -1601,18 +1601,18 @@ def test_check_resource_team_ownership_prompt_and_gateway():
     prompt.visibility = "team"
     prompt.team_id = "team-1"
     db.execute.return_value.scalar_one_or_none.return_value = prompt
-    assert middleware._check_resource_team_ownership("/prompts/a1b2c3d4", ["team-1"], db=db, _user_email="user@example.com") is True
+    assert middleware._check_resource_team_ownership("/prompts/a1b2c3d4", ["team-1"], db=db, _user_email="user@example.com") is ResourceOwnershipResult.ALLOWED
 
     # Gateway: private visibility with owner match should allow
     gateway = MagicMock()
     gateway.visibility = "private"
     gateway.owner_email = "owner@example.com"
     db.execute.return_value.scalar_one_or_none.return_value = gateway
-    assert middleware._check_resource_team_ownership("/gateways/a1b2c3d4", ["team-1"], db=db, _user_email="owner@example.com") is True
+    assert middleware._check_resource_team_ownership("/gateways/a1b2c3d4", ["team-1"], db=db, _user_email="owner@example.com") is ResourceOwnershipResult.ALLOWED
 
     # Missing resources must fail closed
     db.execute.return_value.scalar_one_or_none.return_value = None
-    assert middleware._check_resource_team_ownership("/resources/a1b2c3d4", ["team-1"], db=db, _user_email="user@example.com") is False
+    assert middleware._check_resource_team_ownership("/resources/a1b2c3d4", ["team-1"], db=db, _user_email="user@example.com") is ResourceOwnershipResult.DENIED
 
 
 def test_check_resource_team_ownership_normalizes_team_dict_and_allows_team_resource():
@@ -1625,7 +1625,7 @@ def test_check_resource_team_ownership_normalizes_team_dict_and_allows_team_reso
     resource.team_id = "team-1"
     db.execute.return_value.scalar_one_or_none.return_value = resource
 
-    assert middleware._check_resource_team_ownership("/resources/a1b2c3d4", [{"id": "team-1"}], db=db, _user_email="user@example.com") is True
+    assert middleware._check_resource_team_ownership("/resources/a1b2c3d4", [{"id": "team-1"}], db=db, _user_email="user@example.com") is ResourceOwnershipResult.ALLOWED
 
 
 def test_check_resource_team_ownership_owns_session_commits_and_closes(monkeypatch):
@@ -1642,7 +1642,7 @@ def test_check_resource_team_ownership_owns_session_commits_and_closes(monkeypat
 
     monkeypatch.setattr("mcpgateway.db.get_db", _get_db)
 
-    assert middleware._check_resource_team_ownership("/resources/a1b2c3d4", ["team-1"], _user_email="user@example.com") is True
+    assert middleware._check_resource_team_ownership("/resources/a1b2c3d4", ["team-1"], _user_email="user@example.com") is ResourceOwnershipResult.ALLOWED
     db.commit.assert_called_once()
     db.close.assert_called_once()
 
@@ -1657,7 +1657,7 @@ def test_check_resource_team_ownership_public_only_token_denied_for_team_prompt(
     prompt.team_id = "team-1"
     db.execute.return_value.scalar_one_or_none.return_value = prompt
 
-    assert middleware._check_resource_team_ownership("/prompts/a1b2c3d4", [], db=db, _user_email="user@example.com") is False
+    assert middleware._check_resource_team_ownership("/prompts/a1b2c3d4", [], db=db, _user_email="user@example.com") is ResourceOwnershipResult.DENIED
 
 
 def test_check_resource_team_ownership_prompt_unknown_visibility_denies():
@@ -1670,7 +1670,7 @@ def test_check_resource_team_ownership_prompt_unknown_visibility_denies():
     prompt.team_id = "team-1"
     db.execute.return_value.scalar_one_or_none.return_value = prompt
 
-    assert middleware._check_resource_team_ownership("/prompts/a1b2c3d4", ["team-1"], db=db, _user_email="user@example.com") is False
+    assert middleware._check_resource_team_ownership("/prompts/a1b2c3d4", ["team-1"], db=db, _user_email="user@example.com") is ResourceOwnershipResult.DENIED
 
 
 def test_check_resource_team_ownership_gateway_team_allows_matching_team():
@@ -1683,7 +1683,7 @@ def test_check_resource_team_ownership_gateway_team_allows_matching_team():
     gateway.team_id = "team-1"
     db.execute.return_value.scalar_one_or_none.return_value = gateway
 
-    assert middleware._check_resource_team_ownership("/gateways/a1b2c3d4", ["team-1"], db=db, _user_email="user@example.com") is True
+    assert middleware._check_resource_team_ownership("/gateways/a1b2c3d4", ["team-1"], db=db, _user_email="user@example.com") is ResourceOwnershipResult.ALLOWED
 
 
 def test_check_resource_team_ownership_gateway_private_denies_non_owner():
@@ -1697,7 +1697,7 @@ def test_check_resource_team_ownership_gateway_private_denies_non_owner():
     gateway.team_id = "team-1"
     db.execute.return_value.scalar_one_or_none.return_value = gateway
 
-    assert middleware._check_resource_team_ownership("/gateways/a1b2c3d4", ["team-1"], db=db, _user_email="other@example.com") is False
+    assert middleware._check_resource_team_ownership("/gateways/a1b2c3d4", ["team-1"], db=db, _user_email="other@example.com") is ResourceOwnershipResult.DENIED
 
 
 def test_check_resource_team_ownership_unknown_resource_type_denies(monkeypatch):
@@ -1712,7 +1712,7 @@ def test_check_resource_team_ownership_unknown_resource_type_denies(monkeypatch)
     db = MagicMock()
 
     monkeypatch.setattr(token_scoping_module, "_RESOURCE_PATTERNS", [(re.compile(r"/weird/?([a-f0-9\\-]+)"), "weird")])
-    assert middleware._check_resource_team_ownership("/weird/a1b2c3d4", ["team-1"], db=db, _user_email="user@example.com") is False
+    assert middleware._check_resource_team_ownership("/weird/a1b2c3d4", ["team-1"], db=db, _user_email="user@example.com") is ResourceOwnershipResult.DENIED
 
 
 def test_check_resource_team_ownership_tool_private_and_unknown():
@@ -1724,12 +1724,12 @@ def test_check_resource_team_ownership_tool_private_and_unknown():
     tool.visibility = "private"
     tool.owner_email = "owner@example.com"
     db.execute.return_value.scalar_one_or_none.return_value = tool
-    assert middleware._check_resource_team_ownership("/tools/a1b2c3d4", ["team-1"], db=db, _user_email="owner@example.com") is True
-    assert middleware._check_resource_team_ownership("/tools/a1b2c3d4", ["team-1"], db=db, _user_email="other@example.com") is False
+    assert middleware._check_resource_team_ownership("/tools/a1b2c3d4", ["team-1"], db=db, _user_email="owner@example.com") is ResourceOwnershipResult.ALLOWED
+    assert middleware._check_resource_team_ownership("/tools/a1b2c3d4", ["team-1"], db=db, _user_email="other@example.com") is ResourceOwnershipResult.DENIED
 
     # Unknown visibility denies
     tool.visibility = "mystery"
-    assert middleware._check_resource_team_ownership("/tools/a1b2c3d4", ["team-1"], db=db, _user_email="owner@example.com") is False
+    assert middleware._check_resource_team_ownership("/tools/a1b2c3d4", ["team-1"], db=db, _user_email="owner@example.com") is ResourceOwnershipResult.DENIED
 
 
 def test_check_resource_team_ownership_resource_branches():
@@ -1740,31 +1740,31 @@ def test_check_resource_team_ownership_resource_branches():
     resource = MagicMock()
     resource.visibility = "public"
     db.execute.return_value.scalar_one_or_none.return_value = resource
-    assert middleware._check_resource_team_ownership("/resources/a1b2c3d4", ["team-1"], db=db, _user_email="user@example.com") is True
+    assert middleware._check_resource_team_ownership("/resources/a1b2c3d4", ["team-1"], db=db, _user_email="user@example.com") is ResourceOwnershipResult.ALLOWED
 
     # Public-only token denied for team resource
     resource.visibility = "team"
     resource.team_id = "team-1"
-    assert middleware._check_resource_team_ownership("/resources/a1b2c3d4", [], db=db, _user_email="user@example.com") is False
+    assert middleware._check_resource_team_ownership("/resources/a1b2c3d4", [], db=db, _user_email="user@example.com") is ResourceOwnershipResult.DENIED
 
     # Team mismatch denied
-    assert middleware._check_resource_team_ownership("/resources/a1b2c3d4", ["team-2"], db=db, _user_email="user@example.com") is False
+    assert middleware._check_resource_team_ownership("/resources/a1b2c3d4", ["team-2"], db=db, _user_email="user@example.com") is ResourceOwnershipResult.DENIED
 
     # Private resource denied for non-owner
     resource.visibility = "private"
     resource.owner_email = "owner@example.com"
-    assert middleware._check_resource_team_ownership("/resources/a1b2c3d4", ["team-1"], db=db, _user_email="other@example.com") is False
+    assert middleware._check_resource_team_ownership("/resources/a1b2c3d4", ["team-1"], db=db, _user_email="other@example.com") is ResourceOwnershipResult.DENIED
 
     # Unknown visibility denies
     resource.visibility = "mystery"
-    assert middleware._check_resource_team_ownership("/resources/a1b2c3d4", ["team-1"], db=db, _user_email="user@example.com") is False
+    assert middleware._check_resource_team_ownership("/resources/a1b2c3d4", ["team-1"], db=db, _user_email="user@example.com") is ResourceOwnershipResult.DENIED
 
 
-def test_check_resource_team_ownership_exception_returns_false():
+def test_check_resource_team_ownership_exception_returns_denied():
     middleware = TokenScopingMiddleware()
     db = MagicMock()
     db.execute.side_effect = RuntimeError("boom")
-    assert middleware._check_resource_team_ownership("/tools/a1b2c3d4", ["team-1"], db=db, _user_email="user@example.com") is False
+    assert middleware._check_resource_team_ownership("/tools/a1b2c3d4", ["team-1"], db=db, _user_email="user@example.com") is ResourceOwnershipResult.DENIED
 
 
 def _make_request(path: str = "/servers/server-123") -> MagicMock:
@@ -1818,12 +1818,109 @@ async def test_team_scoped_resource_denied(monkeypatch):
     with (
         patch.object(middleware, "_extract_token_scopes", return_value=payload),
         patch.object(middleware, "_check_team_membership", return_value=True),
-        patch.object(middleware, "_check_resource_team_ownership", return_value=False),
+        patch.object(middleware, "_check_resource_team_ownership", return_value=ResourceOwnershipResult.DENIED),
     ):
         call_next = AsyncMock()
         response = await middleware(mock_request, call_next)
         assert response.status_code == status.HTTP_403_FORBIDDEN
         call_next.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "token_teams"),
+    [
+        ("/servers/aabbccddeeff00112233445566778899", ["team-1"]),
+        ("/gateways/aabbccddeeff00112233445566778899", ["team-1"]),
+        ("/servers/aabbccddeeff00112233445566778899", []),
+        ("/gateways/aabbccddeeff00112233445566778899", []),
+        ("/v1/servers/aabbccddeeff00112233445566778899", ["team-1"]),
+        ("/v1/gateways/aabbccddeeff00112233445566778899", []),
+    ],
+)
+async def test_missing_targeted_delete_returns_404(monkeypatch, path, token_teams):
+    middleware = TokenScopingMiddleware()
+    request = _make_request(path)
+    request.method = "DELETE"
+    db = MagicMock()
+    db.execute.return_value.scalar_one_or_none.return_value = None
+    payload = {"sub": "user@example.com", "teams": token_teams, "scopes": {"permissions": ["*"]}}
+
+    monkeypatch.setattr("mcpgateway.db.get_db", lambda: iter([db]))
+    with (
+        patch.object(middleware, "_extract_token_scopes", return_value=payload),
+        patch.object(middleware, "_check_team_membership", return_value=True),
+    ):
+        response = await middleware(request, AsyncMock())
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_missing_targeted_delete_under_app_root_path_returns_404(monkeypatch):
+    middleware = TokenScopingMiddleware()
+    request = _make_request("/forge/v1/servers/aabbccddeeff00112233445566778899")
+    request.method = "DELETE"
+    db = MagicMock()
+    db.execute.return_value.scalar_one_or_none.return_value = None
+    payload = {"sub": "user@example.com", "teams": ["team-1"], "scopes": {"permissions": ["*"]}}
+
+    monkeypatch.setattr("mcpgateway.middleware.token_scoping.settings.app_root_path", "/forge")
+    monkeypatch.setattr("mcpgateway.db.get_db", lambda: iter([db]))
+    with (
+        patch.object(middleware, "_extract_token_scopes", return_value=payload),
+        patch.object(middleware, "_check_team_membership", return_value=True),
+    ):
+        response = await middleware(request, AsyncMock())
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_targeted_delete_database_error_returns_403(monkeypatch):
+    middleware = TokenScopingMiddleware()
+    request = _make_request("/servers/aabbccddeeff00112233445566778899")
+    request.method = "DELETE"
+    db = MagicMock()
+    db.execute.side_effect = RuntimeError("boom")
+    payload = {"sub": "user@example.com", "teams": ["team-1"], "scopes": {"permissions": ["*"]}}
+
+    monkeypatch.setattr("mcpgateway.db.get_db", lambda: iter([db]))
+    with (
+        patch.object(middleware, "_extract_token_scopes", return_value=payload),
+        patch.object(middleware, "_check_team_membership", return_value=True),
+    ):
+        response = await middleware(request, AsyncMock())
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "path", "ownership_result"),
+    [
+        ("DELETE", "/servers/aabbccddeeff00112233445566778899", ResourceOwnershipResult.DENIED),
+        ("DELETE", "/gateways/aabbccddeeff00112233445566778899", ResourceOwnershipResult.DENIED),
+        ("GET", "/servers/aabbccddeeff00112233445566778899", ResourceOwnershipResult.NOT_FOUND),
+        ("PUT", "/gateways/aabbccddeeff00112233445566778899", ResourceOwnershipResult.NOT_FOUND),
+        ("DELETE", "/servers/aabbccddeeff00112233445566778899/sse", ResourceOwnershipResult.NOT_FOUND),
+        ("DELETE", "/tools/aabbccddeeff00112233445566778899", ResourceOwnershipResult.DENIED),
+    ],
+)
+async def test_non_targeted_or_denied_ownership_returns_403(method, path, ownership_result):
+    middleware = TokenScopingMiddleware()
+    request = _make_request(path)
+    request.method = method
+    payload = {"sub": "user@example.com", "teams": [], "scopes": {"permissions": ["*"]}}
+
+    with (
+        patch.object(middleware, "_extract_token_scopes", return_value=payload),
+        patch.object(middleware, "_check_team_membership", return_value=True),
+        patch.object(middleware, "_check_resource_team_ownership", return_value=ownership_result),
+    ):
+        response = await middleware(request, AsyncMock())
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 class TestRuntimeMcpTransportCompensation:
@@ -2002,7 +2099,7 @@ async def test_public_only_resource_denied():
     with (
         patch.object(middleware, "_extract_token_scopes", return_value=payload),
         patch.object(middleware, "_check_team_membership", return_value=True),
-        patch.object(middleware, "_check_resource_team_ownership", return_value=False),
+        patch.object(middleware, "_check_resource_team_ownership", return_value=ResourceOwnershipResult.DENIED),
     ):
         call_next = AsyncMock()
         response = await middleware(mock_request, call_next)

--- a/tests/unit/mcpgateway/middleware/test_token_scoping_extra.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping_extra.py
@@ -16,7 +16,7 @@ import pytest
 from fastapi import HTTPException
 
 # First-Party
-from mcpgateway.middleware.token_scoping import TokenScopingMiddleware
+from mcpgateway.middleware.token_scoping import ResourceOwnershipResult, TokenScopingMiddleware
 
 # Hex-only IDs that match the regex pattern [a-f0-9\-]+
 _SRV_ID = "aabbccdd-1122-3344-5566-778899aabbcc"
@@ -194,7 +194,7 @@ def test_check_team_membership_public_token():
 
 def test_check_resource_team_ownership_no_resource():
     middleware = TokenScopingMiddleware()
-    assert middleware._check_resource_team_ownership("/health", [], db=None, _user_email=None) is True
+    assert middleware._check_resource_team_ownership("/health", [], db=None, _user_email=None) is ResourceOwnershipResult.ALLOWED
 
 
 # --------------------------------------------------------------------------- #
@@ -248,56 +248,56 @@ class TestResourceTeamOwnershipServers:
         middleware = TokenScopingMiddleware()
         db = self._make_db_with_entity(None)
         result = middleware._check_resource_team_ownership(f"/servers/{_SRV_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is False
+        assert result is ResourceOwnershipResult.NOT_FOUND
 
     def test_server_public_allowed(self):
         middleware = TokenScopingMiddleware()
         server = SimpleNamespace(visibility="public", team_id=None, owner_email=None)
         db = self._make_db_with_entity(server)
         result = middleware._check_resource_team_ownership(f"/servers/{_SRV_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is True
+        assert result is ResourceOwnershipResult.ALLOWED
 
     def test_server_public_token_denied_team_server(self):
         middleware = TokenScopingMiddleware()
         server = SimpleNamespace(visibility="team", team_id="team-2", owner_email=None)
         db = self._make_db_with_entity(server)
         result = middleware._check_resource_team_ownership(f"/servers/{_SRV_ID}", [], db=db, _user_email="u@t.com")
-        assert result is False
+        assert result is ResourceOwnershipResult.DENIED
 
     def test_server_team_access_granted(self):
         middleware = TokenScopingMiddleware()
         server = SimpleNamespace(visibility="team", team_id="team-1", owner_email=None)
         db = self._make_db_with_entity(server)
         result = middleware._check_resource_team_ownership(f"/servers/{_SRV_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is True
+        assert result is ResourceOwnershipResult.ALLOWED
 
     def test_server_team_access_denied(self):
         middleware = TokenScopingMiddleware()
         server = SimpleNamespace(visibility="team", team_id="team-2", owner_email=None)
         db = self._make_db_with_entity(server)
         result = middleware._check_resource_team_ownership(f"/servers/{_SRV_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is False
+        assert result is ResourceOwnershipResult.DENIED
 
     def test_server_private_owner_access(self):
         middleware = TokenScopingMiddleware()
         server = SimpleNamespace(visibility="private", team_id=None, owner_email="u@t.com")
         db = self._make_db_with_entity(server)
         result = middleware._check_resource_team_ownership(f"/servers/{_SRV_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is True
+        assert result is ResourceOwnershipResult.ALLOWED
 
     def test_server_private_non_owner_denied(self):
         middleware = TokenScopingMiddleware()
         server = SimpleNamespace(visibility="private", team_id=None, owner_email="other@t.com")
         db = self._make_db_with_entity(server)
         result = middleware._check_resource_team_ownership(f"/servers/{_SRV_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is False
+        assert result is ResourceOwnershipResult.DENIED
 
     def test_server_unknown_visibility_denied(self):
         middleware = TokenScopingMiddleware()
         server = SimpleNamespace(visibility="unknown_vis", team_id=None, owner_email=None)
         db = self._make_db_with_entity(server)
         result = middleware._check_resource_team_ownership(f"/servers/{_SRV_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is False
+        assert result is ResourceOwnershipResult.DENIED
 
 
 # --------------------------------------------------------------------------- #
@@ -315,28 +315,28 @@ class TestResourceTeamOwnershipTools:
         middleware = TokenScopingMiddleware()
         db = self._make_db_with_entity(None)
         result = middleware._check_resource_team_ownership(f"/tools/{_TOOL_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is False
+        assert result is ResourceOwnershipResult.DENIED
 
     def test_tool_public_allowed(self):
         middleware = TokenScopingMiddleware()
         tool = SimpleNamespace(visibility="public", team_id=None, owner_email=None)
         db = self._make_db_with_entity(tool)
         result = middleware._check_resource_team_ownership(f"/tools/{_TOOL_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is True
+        assert result is ResourceOwnershipResult.ALLOWED
 
     def test_tool_team_access_denied(self):
         middleware = TokenScopingMiddleware()
         tool = SimpleNamespace(visibility="team", team_id="team-2", owner_email=None)
         db = self._make_db_with_entity(tool)
         result = middleware._check_resource_team_ownership(f"/tools/{_TOOL_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is False
+        assert result is ResourceOwnershipResult.DENIED
 
     def test_tool_public_token_denied(self):
         middleware = TokenScopingMiddleware()
         tool = SimpleNamespace(visibility="team", team_id="team-1", owner_email=None)
         db = self._make_db_with_entity(tool)
         result = middleware._check_resource_team_ownership(f"/tools/{_TOOL_ID}", [], db=db, _user_email="u@t.com")
-        assert result is False
+        assert result is ResourceOwnershipResult.DENIED
 
 
 # --------------------------------------------------------------------------- #
@@ -354,14 +354,14 @@ class TestResourceTeamOwnershipResources:
         middleware = TokenScopingMiddleware()
         db = self._make_db_with_entity(None)
         result = middleware._check_resource_team_ownership(f"/resources/{_RES_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is False
+        assert result is ResourceOwnershipResult.DENIED
 
     def test_resource_team_denied(self):
         middleware = TokenScopingMiddleware()
         resource = SimpleNamespace(visibility="team", team_id="team-2", owner_email=None)
         db = self._make_db_with_entity(resource)
         result = middleware._check_resource_team_ownership(f"/resources/{_RES_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is False
+        assert result is ResourceOwnershipResult.DENIED
 
 
 # --------------------------------------------------------------------------- #
@@ -379,35 +379,35 @@ class TestResourceTeamOwnershipPrompts:
         middleware = TokenScopingMiddleware()
         db = self._make_db_with_entity(None)
         result = middleware._check_resource_team_ownership(f"/prompts/{_PROMPT_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is False
+        assert result is ResourceOwnershipResult.DENIED
 
     def test_prompt_public_allowed(self):
         middleware = TokenScopingMiddleware()
         prompt = SimpleNamespace(visibility="public", team_id=None, owner_email=None)
         db = self._make_db_with_entity(prompt)
         result = middleware._check_resource_team_ownership(f"/prompts/{_PROMPT_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is True
+        assert result is ResourceOwnershipResult.ALLOWED
 
     def test_prompt_team_denied(self):
         middleware = TokenScopingMiddleware()
         prompt = SimpleNamespace(visibility="team", team_id="team-2", owner_email=None)
         db = self._make_db_with_entity(prompt)
         result = middleware._check_resource_team_ownership(f"/prompts/{_PROMPT_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is False
+        assert result is ResourceOwnershipResult.DENIED
 
     def test_prompt_private_owner_access(self):
         middleware = TokenScopingMiddleware()
         prompt = SimpleNamespace(visibility="private", team_id=None, owner_email="u@t.com")
         db = self._make_db_with_entity(prompt)
         result = middleware._check_resource_team_ownership(f"/prompts/{_PROMPT_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is True
+        assert result is ResourceOwnershipResult.ALLOWED
 
     def test_prompt_private_non_owner_denied(self):
         middleware = TokenScopingMiddleware()
         prompt = SimpleNamespace(visibility="private", team_id=None, owner_email="other@t.com")
         db = self._make_db_with_entity(prompt)
         result = middleware._check_resource_team_ownership(f"/prompts/{_PROMPT_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is False
+        assert result is ResourceOwnershipResult.DENIED
 
 
 # --------------------------------------------------------------------------- #
@@ -425,42 +425,42 @@ class TestResourceTeamOwnershipGateways:
         middleware = TokenScopingMiddleware()
         db = self._make_db_with_entity(None)
         result = middleware._check_resource_team_ownership(f"/gateways/{_GW_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is False
+        assert result is ResourceOwnershipResult.NOT_FOUND
 
     def test_gateway_public_allowed(self):
         middleware = TokenScopingMiddleware()
         gw = SimpleNamespace(visibility="public", team_id=None, owner_email=None)
         db = self._make_db_with_entity(gw)
         result = middleware._check_resource_team_ownership(f"/gateways/{_GW_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is True
+        assert result is ResourceOwnershipResult.ALLOWED
 
     def test_gateway_public_token_denied(self):
         middleware = TokenScopingMiddleware()
         gw = SimpleNamespace(visibility="team", team_id="team-1", owner_email=None)
         db = self._make_db_with_entity(gw)
         result = middleware._check_resource_team_ownership(f"/gateways/{_GW_ID}", [], db=db, _user_email="u@t.com")
-        assert result is False
+        assert result is ResourceOwnershipResult.DENIED
 
     def test_gateway_team_denied(self):
         middleware = TokenScopingMiddleware()
         gw = SimpleNamespace(visibility="team", team_id="team-2", owner_email=None)
         db = self._make_db_with_entity(gw)
         result = middleware._check_resource_team_ownership(f"/gateways/{_GW_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is False
+        assert result is ResourceOwnershipResult.DENIED
 
     def test_gateway_private_owner(self):
         middleware = TokenScopingMiddleware()
         gw = SimpleNamespace(visibility="private", team_id=None, owner_email="u@t.com")
         db = self._make_db_with_entity(gw)
         result = middleware._check_resource_team_ownership(f"/gateways/{_GW_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is True
+        assert result is ResourceOwnershipResult.ALLOWED
 
     def test_gateway_unknown_visibility(self):
         middleware = TokenScopingMiddleware()
         gw = SimpleNamespace(visibility="weird", team_id=None, owner_email=None)
         db = self._make_db_with_entity(gw)
         result = middleware._check_resource_team_ownership(f"/gateways/{_GW_ID}", ["team-1"], db=db, _user_email="u@t.com")
-        assert result is False
+        assert result is ResourceOwnershipResult.DENIED
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.db import Gateway
+from mcpgateway.middleware.token_scoping import ResourceOwnershipResult
 from mcpgateway.routers.oauth_router import ADMIN_CSRF_COOKIE_NAME, enforce_fetch_tools_csrf
 from mcpgateway.schemas import EmailUserResponse
 from mcpgateway.services.oauth_manager import OAuthError
@@ -1119,7 +1120,7 @@ class TestOAuthRouter:
             from mcpgateway.routers.oauth_router import fetch_tools_after_oauth
 
             # Execute
-            with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=True):
+            with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED):
                 result = await fetch_tools_after_oauth(gateway_id="gateway123", request=request, current_user={"email": "test@example.com", "is_admin": False}, db=mock_db)
 
             # Assert
@@ -1149,7 +1150,7 @@ class TestOAuthRouter:
             from mcpgateway.routers.oauth_router import fetch_tools_after_oauth
 
             # Execute
-            with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=True):
+            with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED):
                 result = await fetch_tools_after_oauth(gateway_id="gateway123", request=request, current_user={"email": "test@example.com", "is_admin": False}, db=mock_db)
 
             # Assert
@@ -1178,7 +1179,7 @@ class TestOAuthRouter:
 
             # Execute & Assert
             with pytest.raises(HTTPException) as exc_info:
-                with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=True):
+                with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED):
                     await fetch_tools_after_oauth(gateway_id="gateway123", request=request, current_user={"email": "test@example.com", "is_admin": False}, db=mock_db)
 
             assert exc_info.value.status_code == 500
@@ -1206,7 +1207,7 @@ class TestOAuthRouter:
             from mcpgateway.routers.oauth_router import fetch_tools_after_oauth
 
             # Execute
-            with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=True):
+            with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED):
                 result = await fetch_tools_after_oauth(gateway_id="gateway123", request=request, current_user={"email": "test@example.com", "is_admin": False}, db=mock_db)
 
             # Assert
@@ -1226,7 +1227,7 @@ class TestOAuthRouter:
         from mcpgateway.routers.oauth_router import fetch_tools_after_oauth
 
         with pytest.raises(HTTPException) as exc_info:
-            with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=False):
+            with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ResourceOwnershipResult.DENIED):
                 await fetch_tools_after_oauth(gateway_id="gateway123", request=request, current_user={"email": "test@example.com", "is_admin": False}, db=mock_db)
 
         assert exc_info.value.status_code == 403
@@ -1249,7 +1250,7 @@ class TestOAuthRouter:
             from mcpgateway.routers.oauth_router import fetch_tools_after_oauth
 
             with pytest.raises(HTTPException) as exc_info:
-                with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=False) as ownership_check:
+                with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ResourceOwnershipResult.DENIED) as ownership_check:
                     await fetch_tools_after_oauth(
                         gateway_id="gateway123",
                         request=request,
@@ -1277,7 +1278,7 @@ class TestOAuthRouter:
 
             from mcpgateway.routers.oauth_router import fetch_tools_after_oauth
 
-            with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=True) as ownership_check:
+            with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED) as ownership_check:
                 result = await fetch_tools_after_oauth(
                     gateway_id="gateway123",
                     request=request,
@@ -1338,7 +1339,7 @@ class TestOAuthRouter:
         from mcpgateway.routers.oauth_router import fetch_tools_after_oauth
 
         with pytest.raises(HTTPException) as exc_info:
-            with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=False):
+            with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ResourceOwnershipResult.DENIED):
                 await fetch_tools_after_oauth(
                     gateway_id="gateway123",
                     request=request,
@@ -1398,12 +1399,38 @@ class TestOAuthAccessHelpers:
         request.state = SimpleNamespace(token_teams=None)
         gateway = SimpleNamespace(visibility="public", owner_email=None, team_id=None)
 
-        with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=False) as ownership_check:
+        with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ResourceOwnershipResult.DENIED) as ownership_check:
             with pytest.raises(HTTPException) as exc_info:
                 await _enforce_gateway_access("gateway123", gateway, {"email": "user@example.com", "is_admin": False}, mock_db, request=request)
 
         assert exc_info.value.status_code == 403
         assert ownership_check.call_args.args[1] == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("ownership_result", [ResourceOwnershipResult.DENIED, ResourceOwnershipResult.NOT_FOUND])
+    async def test_enforce_gateway_access_rejects_non_allowed_ownership_results(self, mock_db, ownership_result):
+        from mcpgateway.routers.oauth_router import _enforce_gateway_access
+
+        request = Mock(spec=Request)
+        request.state = SimpleNamespace(token_teams=[])
+        gateway = SimpleNamespace(visibility="public", owner_email=None, team_id=None)
+
+        with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ownership_result):
+            with pytest.raises(HTTPException) as exc_info:
+                await _enforce_gateway_access("gateway123", gateway, {"email": "user@example.com", "is_admin": False}, mock_db, request=request)
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_enforce_gateway_access_allows_allowed_ownership_result(self, mock_db):
+        from mcpgateway.routers.oauth_router import _enforce_gateway_access
+
+        request = Mock(spec=Request)
+        request.state = SimpleNamespace(token_teams=[])
+        gateway = SimpleNamespace(visibility="public", owner_email=None, team_id=None)
+
+        with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED):
+            await _enforce_gateway_access("gateway123", gateway, {"email": "user@example.com", "is_admin": False}, mock_db, request=request)
 
     @pytest.mark.asyncio
     async def test_enforce_gateway_access_admin_null_token_teams_short_circuit(self, mock_db):
@@ -1923,7 +1950,7 @@ class TestOAuthRouterAdditionalCoverage:
 
         from mcpgateway.routers.oauth_router import initiate_oauth_flow
 
-        with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=True):
+        with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED):
             with pytest.raises(HTTPException) as exc_info:
                 await initiate_oauth_flow("gateway123", mock_request, {"email": "intruder@example.com", "is_admin": False}, mock_db)
 
@@ -1941,7 +1968,7 @@ class TestOAuthRouterAdditionalCoverage:
 
         from mcpgateway.routers.oauth_router import get_oauth_status
 
-        with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=True):
+        with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED):
             result = await get_oauth_status(
                 "gateway123",
                 mock_request,
@@ -1963,7 +1990,7 @@ class TestOAuthRouterAdditionalCoverage:
 
         from mcpgateway.routers.oauth_router import get_oauth_status
 
-        with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=True):
+        with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED):
             with pytest.raises(HTTPException) as exc_info:
                 await get_oauth_status(
                     "gateway123",

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -35,6 +35,7 @@ from starlette.routing import Mount
 # First-Party
 from mcpgateway.common.models import LogLevel
 from mcpgateway.config import settings
+from mcpgateway.middleware.token_scoping import ResourceOwnershipResult
 import mcpgateway.db as db_mod
 from mcpgateway.auth_context import _expected_internal_mcp_runtime_auth_header
 from mcpgateway.auth import TokenValidationError
@@ -13336,12 +13337,40 @@ class TestHardeningHelperCoverage:
 
         with (
             patch.object(main_mod, "get_scoped_resource_access_context", return_value=("user@example.com", ["team-1"])),
-            patch.object(main_mod.token_scoping_middleware, "_check_resource_team_ownership", return_value=False),
+            patch.object(main_mod.token_scoping_middleware, "_check_resource_team_ownership", return_value=ResourceOwnershipResult.DENIED),
         ):
             with pytest.raises(HTTPException) as excinfo:
                 main_mod._enforce_scoped_resource_access(request, db, {"email": "user@example.com"}, "/servers/server-1")
 
         assert excinfo.value.status_code == 403
+
+    @pytest.mark.parametrize("ownership_result", [ResourceOwnershipResult.DENIED, ResourceOwnershipResult.NOT_FOUND])
+    def test_enforce_scoped_resource_access_rejects_non_allowed_results(self, ownership_result):
+        import mcpgateway.main as main_mod
+
+        request = MagicMock(spec=Request)
+        db = MagicMock()
+
+        with (
+            patch.object(main_mod, "get_scoped_resource_access_context", return_value=("user@example.com", ["team-1"])),
+            patch.object(main_mod.token_scoping_middleware, "_check_resource_team_ownership", return_value=ownership_result),
+        ):
+            with pytest.raises(HTTPException) as excinfo:
+                main_mod._enforce_scoped_resource_access(request, db, {"email": "user@example.com"}, "/servers/server-1")
+
+        assert excinfo.value.status_code == 403
+
+    def test_enforce_scoped_resource_access_allows_allowed_result(self):
+        import mcpgateway.main as main_mod
+
+        request = MagicMock(spec=Request)
+        db = MagicMock()
+
+        with (
+            patch.object(main_mod, "get_scoped_resource_access_context", return_value=("user@example.com", ["team-1"])),
+            patch.object(main_mod.token_scoping_middleware, "_check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED),
+        ):
+            main_mod._enforce_scoped_resource_access(request, db, {"email": "user@example.com"}, "/servers/server-1")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Bug-fix PR

## Summary

Fix DELETE requests for missing servers and gateways returning `403 Forbidden`
before route handlers can return `404 Not Found`.

## Reproduction Steps

Internal issue 431:

1. Create server or gateway.
2. Delete it successfully.
3. Repeat `DELETE /servers/{id}` or `DELETE /gateways/{id}` with a hexadecimal UUID.
4. Before fix: `403`. After fix: `404`.

## Root Cause

`TokenScopingMiddleware._check_resource_team_ownership()` returned `False` for
both missing rows and denied access. Middleware mapped both results to `403`.

## Fix Description

Add `ResourceOwnershipResult` with `ALLOWED`, `NOT_FOUND`, and `DENIED`.
Missing server and gateway rows return `NOT_FOUND`. Exact server/gateway DELETE
paths map only `NOT_FOUND` to `404`; denied ownership, unsupported resources,
and lookup errors remain `403`.

Direct callers in `main.py` and OAuth router now explicitly allow only
`ALLOWED`.

## Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

## Verification

| Check | Command | Status |
|---|---|---|
| Focused unit tests | ` .venv/bin/python -m pytest tests/unit/mcpgateway/middleware/test_token_scoping.py tests/unit/mcpgateway/middleware/test_token_scoping_extra.py tests/unit/mcpgateway/middleware/test_token_scoping_normalization.py tests/unit/mcpgateway/test_main.py tests/unit/mcpgateway/test_main_extended.py tests/unit/mcpgateway/routers/test_oauth_router.py -q` | Passed |
| Changed source lint | `TARGET='mcpgateway/main.py mcpgateway/middleware/token_scoping.py mcpgateway/routers/oauth_router.py'` | Passed |
| Full lint suite | `make lint` | Not run |
| Full unit/integration suite | `make test` | Not run |
| Coverage | `make coverage` | Not run |
| Manual regression | Repeated DELETE behavior | Not run; focused middleware tests cover regression |

Note: test-file Ruff is blocked by pre-existing `E712` and unused-variable
findings in legacy test files outside this change.

## MCP Compliance (if relevant)

- [ ] Matches current MCP spec
- [x] No breaking change to MCP clients

## Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
