### PR TITLE
FIX: OCP SCC UID compatibility and Helm volumeMounts indentation

### DIFF
--- a/charts/mcp-stack/profiles/ocp/values-pgo.yaml
+++ b/charts/mcp-stack/profiles/ocp/values-pgo.yaml
@@ -27,6 +27,21 @@ global:
 mcpContextForge:
   replicaCount: 3                          # 3 replicas × 8 CPU = 24 CPU (matches benchmark)
 
+  # OpenShift SCC compatibility — let OCP assign UIDs from its allowed range
+  # instead of using the image default (10001) which is outside OCP's range
+  podSecurityContext:
+    runAsUser: null
+    runAsGroup: null
+    fsGroup: null
+    runAsNonRoot: true
+  containerSecurityContext:
+    runAsUser: null
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile: null
+
   hpa:
     enabled: false                           # disabled — manual scaling for benchmarking
     minReplicas: 3
@@ -224,6 +239,8 @@ mcpContextForge:
     # For tighter control, use SSRF_ALLOWED_NETWORKS to restrict to the cluster CIDR.
     SSRF_ALLOW_PRIVATE_NETWORKS: "true"
     LOG_LEVEL: INFO
+    # Raise validation rate limit to avoid 429s during load test setup and registration jobs
+    VALIDATION_MAX_REQUESTS_PER_MINUTE: "10000"
     # --- Gunicorn tuning (match VM benchmark) ---
     GUNICORN_WORKERS: "8"                  # 8 workers per pod × 3 pods = 24 total (matches VM)
     GUNICORN_MAX_REQUESTS: "1000000"       # recycle after 1M requests (VM: 1M)
@@ -276,6 +293,9 @@ migration:
   hookPhase: "pre-install,pre-upgrade"
   hostKey: "host"
   portKey: "port"
+  # OpenShift SCC: let OCP assign UID from its allowed range (1000740000-1000749999)
+  podSecurityContext:
+    runAsNonRoot: true
 
 # --- Postgres ---
 # Using CrunchyData PGO operator — internal Postgres and PgBouncer disabled

--- a/charts/mcp-stack/templates/deployment-mcpgateway.yaml
+++ b/charts/mcp-stack/templates/deployment-mcpgateway.yaml
@@ -317,22 +317,22 @@ spec:
           resources:
 {{- toYaml .Values.mcpContextForge.resources | nindent 12 }}
 
-    volumeMounts:
-          - name: tmp
-            mountPath: /tmp
-        {{- if .Values.mcpContextForge.pluginConfig.enabled }}
-          - name: plugin-config-volume
-            mountPath: /app/{{ $pluginsConfigFile }}
-            subPath: config.yaml
-        {{- end }}
-    volumes:
-      - name: tmp
-        emptyDir: {}
-    {{- if .Values.mcpContextForge.pluginConfig.enabled }}
-      - name: plugin-config-volume
-        configMap:
-          name: {{ include "mcp-stack.fullname" . }}-gateway-plugins
-          items:
-          - key: config.yaml
-            path: config.yaml
-    {{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          {{- if .Values.mcpContextForge.pluginConfig.enabled }}
+            - name: plugin-config-volume
+              mountPath: /app/{{ $pluginsConfigFile }}
+              subPath: config.yaml
+          {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- if .Values.mcpContextForge.pluginConfig.enabled }}
+        - name: plugin-config-volume
+          configMap:
+            name: {{ include "mcp-stack.fullname" . }}-gateway-plugins
+            items:
+              - key: config.yaml
+                path: config.yaml
+      {{- end }}

--- a/charts/mcp-stack/templates/job-migration.yaml
+++ b/charts/mcp-stack/templates/job-migration.yaml
@@ -29,12 +29,16 @@ spec:
       {{- end }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       securityContext:
+        {{- if .Values.migration.podSecurityContext }}
+        {{- toYaml .Values.migration.podSecurityContext | nindent 8 }}
+        {{- else }}
         runAsUser: 10001
         runAsGroup: 10001
         fsGroup: 10001
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+        {{- end }}
 
       containers:
         - name: migration


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes https://github.com/IBM/mcp-context-forge/issues/5676 
Related to: https://github.com/IBM/mcp-context-forge/pull/5269  (this PR branches from fix/ensure_helm_chart_in_ci to address issue found there and also related openshift specific deploy failures)

---

## 📝 Summary

Fixes two issues preventing successful make ocp-deploy on OpenShift with the PGO profile:

1. Helm template indentation (deployment-mcpgateway.yaml): volumeMounts and volumes introduced in #5269 were placed at the wrong indentation level, causing helm install to fail with field not declared in schema.

2. OCP SCC UID incompatibility (values-pgo.yaml, job-migration.yaml): Hardcoded UID 10001 is outside OpenShift's allowed UID range. Added podSecurityContext overrides with runAsUser: null so OCP assigns UIDs from its allowed range instead.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix

---

## 🧪 Verification

Check | Command | Status
-- | -- | --
Helm template renders | helm template ... -f values-pgo.yaml -f values-pgo-secrets.yaml | ✅
OCP deploy | make ocp-deploy OCP_NS=cg-cf-testing | ✅
Migration job | oc get jobs -n cg-cf-testing | ✅ Completed
All pods running | oc get pods -n cg-cf-testing | ✅ All 1/1 Running

Successfully loaded running instance of contextforge on browser.

---

## ✅ Checklist

- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

`values-pgo.yaml` changes are scoped to the OCP profile only - chart defaults unchanged
`job-migration.yaml` falls back to original hardcoded values when migration.podSecurityContext is not set, so non-OCP deployments are unaffected


Doc update for openshift-pgo.md will be tracked in a separate issue