### PR TITLE
[UI-rewrite] Dialog component height adjustment

### DIFF
--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed inset-0 z-50 m-auto grid h-fit w-full max-w-lg gap-4 border bg-popover p-6 shadow-lg duration-150 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 sm:rounded-lg",
+        "fixed inset-x-0 top-1/2 z-50 mx-auto grid w-full max-w-lg -translate-y-1/2 gap-5 border bg-popover p-7 shadow-lg duration-150 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 sm:rounded-lg",
         className,
       )}
       {...props}
@@ -52,7 +52,7 @@ const DialogContent = React.forwardRef<
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+  <div className={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...props} />
 );
 DialogHeader.displayName = "DialogHeader";
 


### PR DESCRIPTION
**Summary**
Fix for dialog height issue introduced in commit d19b4dcf0 ("modified dialog motion").

 What happened: that commit switched `DialogContent` centering from translate-based to `fixed inset-0 m-auto h-fit …`. `inset-0` pins both `top:0` and `bottom:0`; combined with `display: grid` and the default `align-content: stretch`, the container stretches to viewport height and the header/footer tracks expand. That's why the delete-prompt confirmation renders viewport-tall with the buttons floating in the middle.   

Bug:
https://github.com/user-attachments/assets/c2a9cdbb-e884-4c6f-830d-0ad85faead75

**Fix**                                                                                                                                                  
 Center vertically with `top-1/2 -translate-y-1/2 mx-auto` and drop `bottom:0`, so height stays `auto` and shrinks to content. Motion classes (`duration-150`, `fade-in-0` / `fade-out-0`) are unchanged: this touches positioning only.                                                                                   
                                                                                                                                                                  
  Also a small spacing tune so the modal doesn't feel flush once it collapses to its real content size:
  - `DialogHeader`: `space-y-1.5` → `space-y-2`                                                                                                                   
  - `DialogContent`: `gap-4` → `gap-5`, `p-6` → `p-7`    

https://github.com/user-attachments/assets/54645fd7-d942-40f6-95a4-5fd00f0dcfcd
