### PR TITLE
feat: add ICA metering exporter plugin with JWT auth and call-context attribution

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
+    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-04T13:25:06Z",
+  "generated_at": "2026-08-04T11:30:49Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -224,7 +224,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 292,
+        "line_number": 291,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -232,7 +232,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 294,
+        "line_number": 293,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -240,7 +240,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 366,
+        "line_number": 365,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -248,7 +248,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 367,
+        "line_number": 366,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -258,7 +258,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1938,
+        "line_number": 1930,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2026,
+        "line_number": 2018,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2376,
+        "line_number": 2368,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3741,
+        "line_number": 3733,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3832,
+        "line_number": 3824,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3875,
+        "line_number": 3867,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3880,
+        "line_number": 3872,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3885,
+        "line_number": 3877,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -910,7 +910,7 @@
         "hashed_secret": "32cedd1d512c32c41cf5aae15c03a74c806120d2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 16,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2350,7 +2350,7 @@
         "hashed_secret": "1513802ada0ec04c2446206e16baa7256ebff74b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 635,
+        "line_number": 601,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-04T11:30:49Z",
+  "generated_at": "2026-08-05T02:37:45Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -224,7 +224,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 291,
+        "line_number": 292,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -232,7 +232,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 293,
+        "line_number": 294,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -240,7 +240,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 365,
+        "line_number": 366,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -248,7 +248,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 366,
+        "line_number": 367,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -258,7 +258,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1930,
+        "line_number": 1938,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2018,
+        "line_number": 2026,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2368,
+        "line_number": 2376,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3733,
+        "line_number": 3741,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3824,
+        "line_number": 3832,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3867,
+        "line_number": 3875,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3872,
+        "line_number": 3880,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3877,
+        "line_number": 3885,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -910,7 +910,7 @@
         "hashed_secret": "32cedd1d512c32c41cf5aae15c03a74c806120d2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 16,
+        "line_number": 17,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2350,7 +2350,7 @@
         "hashed_secret": "1513802ada0ec04c2446206e16baa7256ebff74b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 601,
+        "line_number": 635,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/plugins/config.yaml
+++ b/plugins/config.yaml
@@ -1234,6 +1234,22 @@ plugins:
       export_full_payload: false # opt in only if you explicitly want result content in telemetry
       max_payload_bytes_size: 10000
 
+  # ICA Metering Exporter - export MCP tool invocation metrics to ICA core-services
+  - name: "IcaMeteringExporter"
+    kind: "plugins.ica_metering_exporter.ica_metering_exporter.IcaMeteringExporterPlugin"
+    description: "Export MCP tool invocation metrics to ICA metering service"
+    version: "0.1.0"
+    author: "ICA Team"
+    hooks: ["tool_pre_invoke", "tool_post_invoke"]
+    tags: ["metering", "ica", "observability"]
+    mode: "disabled"
+    priority: 200
+    conditions: []
+    config:
+      metering_url: ""
+      metering_token: ""
+      enabled: false
+
   # TOON Encoder - Convert JSON to TOON format for token efficiency
   - name: "ToonEncoder"
     kind: "plugins.toon_encoder.toon_encoder.ToonEncoderPlugin"

--- a/plugins/config.yaml
+++ b/plugins/config.yaml
@@ -1249,6 +1249,18 @@ plugins:
       metering_url: ""
       metering_token: ""
       enabled: false
+      # Model name fallback defaults
+      # global_default_model: "gpt-4"  # Fallback when no other source provides model
+      # include_model_source: false     # Set true to emit modelSource field in metering payload
+
+      # Gateway-level default model configuration (optional)
+      # gateways:
+      #   - id: "gw-research"
+      #     name: "Research Team Gateway"
+      #     default_model: "claude-opus-4"
+      #   - id: "gw-support"
+      #     name: "Support Team Gateway"
+      #     default_model: "claude-sonnet-3.5"
 
   # TOON Encoder - Convert JSON to TOON format for token efficiency
   - name: "ToonEncoder"

--- a/plugins/ica_metering_exporter/README.md
+++ b/plugins/ica_metering_exporter/README.md
@@ -1,0 +1,47 @@
+# ICA Metering Exporter Plugin
+
+Exports MCP tool invocation metrics to ICA core-services metering endpoint.
+
+## Configuration
+
+```yaml
+plugins:
+  - name: "IcaMeteringExporter"
+    kind: "plugins.ica_metering_exporter.ica_metering_exporter.IcaMeteringExporterPlugin"
+    version: "0.1.0"
+    description: "Export MCP tool invocation metrics to ICA metering service"
+    author: "ICA Team"
+    hooks: ["tool_pre_invoke", "tool_post_invoke"]
+    tags: ["metering", "ica", "observability"]
+    mode: "disabled"
+    priority: 200
+    conditions: []
+    config:
+      metering_url: "http://service-launchpad:8080/internal/mcp-metering/event"
+      metering_token: "${MCP_METERING_TOKEN}"
+      enabled: true
+```
+
+## Required Settings
+
+- `metering_url`: Internal ICA endpoint URL (required)
+- `metering_token`: Shared secret for endpoint authentication (required)
+- `enabled`: Set to `true` to activate (default: `false`)
+
+## Security
+
+The `metering_token` should be:
+- At least 32 characters
+- Generated with `openssl rand -base64 32`
+- Stored in environment variables or secrets manager
+- Never committed to git
+
+## Data Sent
+
+Sends structured JSON with:
+- User/team identity
+- Tool name, server ID, gateway metadata
+- Execution latency, error status
+- Optional: model name, trace ID, token counts
+
+See `docs/MCP_TOOL_OBSERVABILITY_ARCHITECTURE.md` for full schema.

--- a/plugins/ica_metering_exporter/__init__.py
+++ b/plugins/ica_metering_exporter/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""ICA Metering Exporter Plugin."""
+
+from plugins.ica_metering_exporter.ica_metering_exporter import IcaMeteringExporterPlugin
+
+__all__ = ["IcaMeteringExporterPlugin"]

--- a/plugins/ica_metering_exporter/ica_metering_exporter.py
+++ b/plugins/ica_metering_exporter/ica_metering_exporter.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/ica_metering_exporter/ica_metering_exporter.py
+
+ICA Metering Exporter Plugin.
+Exports MCP tool invocation metrics to ICA core-services.
+"""
+
+# Standard
+import time
+from typing import Any, Optional
+
+# Third-Party
+import httpx
+
+# First-Party
+from cpex.framework import Plugin, PluginConfig, PluginContext
+from cpex.framework.constants import GATEWAY_METADATA
+from cpex.framework.hooks.tools import (
+    ToolPostInvokePayload,
+    ToolPostInvokeResult,
+    ToolPreInvokePayload,
+    ToolPreInvokeResult,
+)
+from mcpgateway.services.logging_service import LoggingService
+
+logging_service = LoggingService()
+logger = logging_service.get_logger(__name__)
+
+
+class IcaMeteringExporterPlugin(Plugin):
+    """Export MCP tool invocation metrics to ICA metering service."""
+
+    def __init__(self, config: PluginConfig) -> None:
+        super().__init__(config)
+        self.telemetry_config = config.config
+        self.http_client: Optional[httpx.AsyncClient] = None
+        if self.telemetry_config.get("enabled", False):
+            self.http_client = httpx.AsyncClient(
+                timeout=httpx.Timeout(5.0, connect=2.0),
+                limits=httpx.Limits(max_keepalive_connections=5),
+            )
+
+    async def shutdown(self) -> None:
+        """Plugin cleanup code - close HTTP client."""
+        if self.http_client:
+            await self.http_client.aclose()
+            self.http_client = None
+
+    async def tool_pre_invoke(
+        self, payload: ToolPreInvokePayload, context: PluginContext
+    ) -> ToolPreInvokeResult:
+        if not self.telemetry_config.get("enabled", False):
+            return ToolPreInvokeResult(continue_processing=True)
+
+        context.state["ica_metering_start_time"] = time.monotonic()
+        # Extract model name from transport headers (set by OpenWebUI)
+        headers = getattr(payload.headers, "root", {})
+        model_name = headers.get("x-openwebui-model-id") or headers.get("X-OpenWebUI-Model-Id")
+        if model_name:
+            context.state["ica_metering_model_name"] = model_name
+        logger.debug("ICA metering: Pre-invoke for tool %s", payload.name)
+        return ToolPreInvokeResult(continue_processing=True)
+
+    async def tool_post_invoke(
+        self, payload: ToolPostInvokePayload, context: PluginContext
+    ) -> ToolPostInvokeResult:
+        if not self.telemetry_config.get("enabled", False):
+            return ToolPostInvokeResult(continue_processing=True)
+
+        pre_invoke_time = context.state.get("ica_metering_start_time")
+        latency_ms: Optional[int] = None
+        if pre_invoke_time is not None:
+            elapsed_ms = (time.monotonic() - pre_invoke_time) * 1000
+            latency_ms = max(0, int(elapsed_ms))
+
+        if not payload.name:
+            logger.warning("ICA metering: Tool name is empty, skipping")
+            return ToolPostInvokeResult(continue_processing=True)
+
+        gateway_meta = context.global_context.metadata.get(GATEWAY_METADATA, {})
+        if not isinstance(gateway_meta, dict):
+            gateway_meta = {}
+
+        ctx_meta = context.global_context.metadata.get("meta_data", {})
+        if not isinstance(ctx_meta, dict):
+            ctx_meta = {}
+
+        # modelName sources in priority order:
+        # 1. Pre-invoke transport headers (OpenWebUI sets X-OpenWebUI-Model-Id)
+        # 2. meta_data.model (set by ContextForge internal API callers)
+        # 3. Fallback to empty string
+        model_name = (
+            context.state.get("ica_metering_model_name")
+            or ctx_meta.get("model")
+        )
+
+        tokens = self._extract_tokens(payload.result)
+
+        metering_payload = {
+            "userEmail": context.global_context.user or "unknown",
+            "teamName": context.global_context.tenant_id or "unknown",
+            "toolDetails": {
+                "toolName": payload.name,
+                "serverId": context.global_context.server_id or "unknown",
+                "serverName": gateway_meta.get("name"),
+                "gatewayId": gateway_meta.get("id"),
+                # TODO: Extract from gateway metadata once available
+                # For MVP, all ContextForge tools are MCP over SSE
+                "integrationType": "MCP",
+                "requestType": "SSE",
+                "latencyMs": latency_ms,
+                "hasError": self._is_error(payload.result),
+                "errorMessage": self._extract_error_message(payload.result),
+                "cached": context.state.get("cache_hit", False),
+                "retryAttempt": context.state.get("retry_count", 0),
+                "modelName": model_name,
+                "traceId": context.global_context.request_id,
+                "tokenInput": tokens.get("input"),
+                "tokenOutput": tokens.get("output"),
+                "source": "ContextForge",
+            },
+        }
+
+        await self._send_to_ica(metering_payload)
+        return ToolPostInvokeResult(continue_processing=True)
+
+    @staticmethod
+    def _is_error(result: Any) -> bool:
+        """Check if result indicates an error."""
+        if result is None:
+            return False
+        if isinstance(result, dict):
+            return bool(result.get("isError", False))
+        return False
+
+    @staticmethod
+    def _extract_error_message(result: Any) -> Optional[str]:
+        """Extract error message from result."""
+        if isinstance(result, dict) and result.get("isError"):
+            return result.get("errorMessage")
+        return None
+
+    @staticmethod
+    def _extract_tokens(result: Any) -> dict:
+        """Safely extract token metadata from result."""
+        if not isinstance(result, dict):
+            return {}
+        meta = result.get("meta", {})
+        if not isinstance(meta, dict):
+            return {}
+        tokens = meta.get("tokens", {})
+        return tokens if isinstance(tokens, dict) else {}
+
+    async def _send_to_ica(self, payload: dict) -> None:
+        """Send metering data to ICA endpoint (fire-and-forget)."""
+        if not self.http_client:
+            return
+
+        metering_url = self.telemetry_config.get("metering_url")
+        metering_token = self.telemetry_config.get("metering_token")
+
+        if not metering_url or not metering_token:
+            logger.warning("ICA metering URL or token not configured")
+            return
+
+        try:
+            response = await self.http_client.post(
+                metering_url,
+                json=payload,
+                headers={"X-MCP-Metering-Token": metering_token},
+            )
+            if response.status_code != 202:
+                logger.warning(
+                    "ICA metering endpoint returned %s: %s",
+                    response.status_code,
+                    response.text,
+                )
+            else:
+                logger.debug("ICA metering: Successfully sent metrics")
+        except httpx.TimeoutException:
+            logger.warning("ICA metering: Timeout sending metrics")
+        except httpx.NetworkError:
+            logger.warning("ICA metering: Network error")
+        except httpx.HTTPStatusError as e:
+            logger.error(
+                "ICA metering: HTTP %s: %s", e.response.status_code, e.response.text
+            )
+        except Exception as e:
+            logger.error("ICA metering: Failed to send metrics: %s", e)

--- a/plugins/ica_metering_exporter/ica_metering_exporter.py
+++ b/plugins/ica_metering_exporter/ica_metering_exporter.py
@@ -32,6 +32,7 @@ class IcaMeteringExporterPlugin(Plugin):
     """Export MCP tool invocation metrics to ICA metering service."""
 
     def __init__(self, config: PluginConfig) -> None:
+        """Initialize plugin: parse config, parse gateway defaults, create HTTP client if enabled."""
         super().__init__(config)
         self.telemetry_config = config.config
         self.http_client: Optional[httpx.AsyncClient] = None
@@ -62,6 +63,7 @@ class IcaMeteringExporterPlugin(Plugin):
     async def tool_pre_invoke(
         self, payload: ToolPreInvokePayload, context: PluginContext
     ) -> ToolPreInvokeResult:
+        """Record tool invocation start time and extract model name from transport headers."""
         if not self.telemetry_config.get("enabled", False):
             return ToolPreInvokeResult(continue_processing=True)
 
@@ -77,6 +79,7 @@ class IcaMeteringExporterPlugin(Plugin):
     async def tool_post_invoke(
         self, payload: ToolPostInvokePayload, context: PluginContext
     ) -> ToolPostInvokeResult:
+        """Compute latency, resolve model name via cascade, build metering payload, fire-and-forget to ICA."""
         if not self.telemetry_config.get("enabled", False):
             return ToolPostInvokeResult(continue_processing=True)
 

--- a/plugins/ica_metering_exporter/ica_metering_exporter.py
+++ b/plugins/ica_metering_exporter/ica_metering_exporter.py
@@ -225,6 +225,9 @@ class IcaMeteringExporterPlugin(Plugin):
         now = int(time.time())
         payload = {
             "sub": "contextforge-metering",
+            "service": "mcp-context-forge",
+            "instance": os.getenv("HOSTNAME", "unknown"),
+            "scope": "metering:write",
             "iat": now,
             "exp": now + 86400,
         }

--- a/plugins/ica_metering_exporter/ica_metering_exporter.py
+++ b/plugins/ica_metering_exporter/ica_metering_exporter.py
@@ -60,9 +60,7 @@ class IcaMeteringExporterPlugin(Plugin):
             await self.http_client.aclose()
             self.http_client = None
 
-    async def tool_pre_invoke(
-        self, payload: ToolPreInvokePayload, context: PluginContext
-    ) -> ToolPreInvokeResult:
+    async def tool_pre_invoke(self, payload: ToolPreInvokePayload, context: PluginContext) -> ToolPreInvokeResult:
         """Record tool invocation start time and extract model name from transport headers."""
         if not self.telemetry_config.get("enabled", False):
             return ToolPreInvokeResult(continue_processing=True)
@@ -76,9 +74,7 @@ class IcaMeteringExporterPlugin(Plugin):
         logger.debug("ICA metering: Pre-invoke for tool %s", payload.name)
         return ToolPreInvokeResult(continue_processing=True)
 
-    async def tool_post_invoke(
-        self, payload: ToolPostInvokePayload, context: PluginContext
-    ) -> ToolPostInvokeResult:
+    async def tool_post_invoke(self, payload: ToolPostInvokePayload, context: PluginContext) -> ToolPostInvokeResult:
         """Compute latency, resolve model name via cascade, build metering payload, fire-and-forget to ICA."""
         if not self.telemetry_config.get("enabled", False):
             return ToolPostInvokeResult(continue_processing=True)
@@ -257,8 +253,6 @@ class IcaMeteringExporterPlugin(Plugin):
         except httpx.NetworkError:
             logger.warning("ICA metering: Network error")
         except httpx.HTTPStatusError as e:
-            logger.error(
-                "ICA metering: HTTP %s: %s", e.response.status_code, e.response.text
-            )
+            logger.error("ICA metering: HTTP %s: %s", e.response.status_code, e.response.text)
         except Exception as e:
             logger.error("ICA metering: Failed to send metrics: %s", e)

--- a/plugins/ica_metering_exporter/ica_metering_exporter.py
+++ b/plugins/ica_metering_exporter/ica_metering_exporter.py
@@ -24,6 +24,7 @@ import jwt
 
 # First-Party
 from mcpgateway.services.logging_service import LoggingService
+from mcpgateway.transports.context import request_headers_var
 
 logging_service = LoggingService()
 logger = logging_service.get_logger(__name__)
@@ -83,17 +84,57 @@ class IcaMeteringExporterPlugin(Plugin):  # type: ignore[misc, no-any-unimported
             return ToolPreInvokeResult(continue_processing=True)
 
         context.state["ica_metering_start_time"] = time.monotonic()
+
+        # Read raw inbound request headers (unfiltered by passthrough logic).
+        # payload.headers only contains outbound/filtered headers (e.g. just Authorization),
+        # but we need the full inbound set for metering attribution headers.
+        raw_headers = request_headers_var.get() or {}
+        # payload.headers (outbound) as fallback for model-id which OI puts in passthrough
+        outbound_headers = getattr(payload.headers, "root", {})
+
         # Extract model name from transport headers (set by OpenWebUI)
-        headers = getattr(payload.headers, "root", {})
-        model_name = headers.get("x-openwebui-model-id") or headers.get("X-OpenWebUI-Model-Id")
+        model_name = (
+            raw_headers.get("x-openwebui-model-id")
+            or outbound_headers.get("x-openwebui-model-id")
+            or outbound_headers.get("X-OpenWebUI-Model-Id")
+        )
         if model_name:
             context.state["ica_metering_model_name"] = model_name
-        app_id = headers.get("x-app-id") or headers.get("X-App-Id")
+
+        app_id = raw_headers.get("x-app-id") or raw_headers.get("X-App-Id")
         if app_id:
             context.state["ica_app_id"] = app_id
-        user_agent = headers.get("x-forwarded-user-agent") or headers.get("X-Forwarded-User-Agent") or headers.get("user-agent") or headers.get("User-Agent")
+
+        # MCP client identity headers (sent by MCP clients with each request)
+        client_name = raw_headers.get("x-mcp-client-name") or raw_headers.get("X-MCP-Client-Name")
+        client_version = raw_headers.get("x-mcp-client-version") or raw_headers.get("X-MCP-Client-Version")
+        if client_name:
+            context.state["ica_mcp_client_name"] = client_name
+            context.state["ica_mcp_client_version"] = client_version
+
+        # User-agent resolution: prefer X-Forwarded-User-Agent (browser path),
+        # fall back to MCP client identity headers, then raw user-agent.
+        user_agent = (
+            raw_headers.get("x-forwarded-user-agent")
+            or raw_headers.get("X-Forwarded-User-Agent")
+        )
+        if not user_agent and client_name:
+            user_agent = f"{client_name}/{client_version}" if client_version else client_name
+        if not user_agent:
+            user_agent = raw_headers.get("user-agent") or raw_headers.get("User-Agent")
         if user_agent:
             context.state["ica_user_agent"] = user_agent
+
+        # Derive appId for API clients when X-App-Id is not provided
+        if not app_id and client_name:
+            context.state["ica_app_id"] = f"api:{client_name}"
+        elif not app_id and user_agent:
+            # Fall back to user-agent prefix (e.g. "opencode/1.18.13" -> "api:opencode")
+            ua_name = user_agent.split("/")[0].strip() if "/" in user_agent else user_agent.split(" ")[0].strip()
+            if ua_name and not ua_name.startswith("Mozilla"):
+                context.state["ica_app_id"] = f"api:{ua_name}"
+
+        # Call-context attribution headers (persona headers from OI)
         for state_key, header_name in self.CALL_CONTEXT_HEADERS.items():
             value = self._get_header(headers, header_name)
             if value:
@@ -116,8 +157,13 @@ class IcaMeteringExporterPlugin(Plugin):  # type: ignore[misc, no-any-unimported
             logger.warning("ICA metering: Tool name is empty, skipping")
             return ToolPostInvokeResult(continue_processing=True)
 
-        gateway_meta = context.global_context.metadata.get(GATEWAY_METADATA, {})
-        if not isinstance(gateway_meta, dict):
+        gateway_meta_raw = context.global_context.metadata.get(GATEWAY_METADATA, {})
+        # GATEWAY_METADATA can be a Pydantic model (PydanticGateway) or a dict
+        if hasattr(gateway_meta_raw, "model_dump"):
+            gateway_meta = gateway_meta_raw.model_dump()
+        elif isinstance(gateway_meta_raw, dict):
+            gateway_meta = gateway_meta_raw
+        else:
             gateway_meta = {}
 
         ctx_meta = context.global_context.metadata.get("meta_data", {})
@@ -132,13 +178,22 @@ class IcaMeteringExporterPlugin(Plugin):  # type: ignore[misc, no-any-unimported
 
         tokens = self._extract_tokens(payload.result)
 
+        # Resolve transport type from gateway metadata (populated by CF tool service)
+        raw_transport = gateway_meta.get("transport", "").lower() if gateway_meta else ""
+        if raw_transport in ("streamablehttp", "streamable_http"):
+            request_type = "STREAMABLE_HTTP"
+        elif raw_transport == "sse":
+            request_type = "SSE"
+        else:
+            request_type = raw_transport.upper() if raw_transport else "UNKNOWN"
+
         tool_details: dict[str, Any] = {
             "toolName": payload.name,
             "serverId": context.global_context.server_id or "unknown",
             "serverName": gateway_meta.get("name"),
             "gatewayId": gateway_meta.get("id"),
             "integrationType": "MCP",
-            "requestType": "SSE",
+            "requestType": request_type,
             "latencyMs": latency_ms,
             "hasError": self._is_error(payload.result),
             "errorMessage": self._extract_error_message(payload.result),

--- a/plugins/ica_metering_exporter/ica_metering_exporter.py
+++ b/plugins/ica_metering_exporter/ica_metering_exporter.py
@@ -11,28 +11,43 @@ import time
 from typing import Any, Optional
 
 # Third-Party
-import jwt
-import httpx
-
-# First-Party
-from cpex.framework import Plugin, PluginConfig, PluginContext
-from cpex.framework.constants import GATEWAY_METADATA
-from cpex.framework.hooks.tools import (
+from cpex.framework import Plugin, PluginConfig, PluginContext  # type: ignore[import-untyped]
+from cpex.framework.constants import GATEWAY_METADATA  # type: ignore[import-untyped]
+from cpex.framework.hooks.tools import (  # type: ignore[import-untyped]
     ToolPostInvokePayload,
     ToolPostInvokeResult,
     ToolPreInvokePayload,
     ToolPreInvokeResult,
 )
+import httpx
+import jwt
+
+# First-Party
 from mcpgateway.services.logging_service import LoggingService
 
 logging_service = LoggingService()
 logger = logging_service.get_logger(__name__)
 
 
-class IcaMeteringExporterPlugin(Plugin):
+class IcaMeteringExporterPlugin(Plugin):  # type: ignore[misc, no-any-unimported]  # noqa: E501
     """Export MCP tool invocation metrics to ICA metering service."""
 
-    def __init__(self, config: PluginConfig) -> None:
+    # Call-context headers set by the invoking application (Open WebUI), mirroring
+    # ica-litellm-extensions/ica_metering_callbacks.py. Header names are identical
+    # so the MCP and LLM metering pipelines stay symmetric.
+    CALL_CONTEXT_HEADERS: dict[str, str] = {
+        "ica_llm_call_type": "llm_call_type",
+        "ica_assistant_name": "assistant_name",
+        "ica_assistant_uuid": "assistant_uuid",
+        "ica_agent_name": "agent_name",
+        "ica_agent_uuid": "agent_uuid",
+        "ica_agent_tool_ids": "agent_tool_ids",
+        "ica_digital_ibmer_name": "digital-ibmer_name",
+        "ica_digital_ibmer_uuid": "digital-ibmer_uuid",
+        "ica_digital_ibmer_tool_ids": "digital-ibmer_tool_ids",
+    }
+
+    def __init__(self, config: PluginConfig) -> None:  # type: ignore[no-any-unimported]  # noqa: E501
         """Initialize plugin: parse config, parse gateway defaults, create HTTP client if enabled."""
         super().__init__(config)
         self.telemetry_config = config.config
@@ -41,7 +56,7 @@ class IcaMeteringExporterPlugin(Plugin):
         self._jwt_secret: Optional[str] = config.config.get("jwt_secret")
 
         # Parse gateway-level defaults from plugin config
-        self._gateway_configs: dict[str, dict] = {}
+        self._gateway_configs: dict[str, dict[str, Any]] = {}
         raw_gateways = self.telemetry_config.get("gateways", [])
         if isinstance(raw_gateways, list):
             for gw in raw_gateways:
@@ -62,7 +77,7 @@ class IcaMeteringExporterPlugin(Plugin):
             await self.http_client.aclose()
             self.http_client = None
 
-    async def tool_pre_invoke(self, payload: ToolPreInvokePayload, context: PluginContext) -> ToolPreInvokeResult:
+    async def tool_pre_invoke(self, payload: ToolPreInvokePayload, context: PluginContext) -> ToolPreInvokeResult:  # type: ignore[no-any-unimported]  # noqa: E501
         """Record tool invocation start time and extract model name from transport headers."""
         if not self.telemetry_config.get("enabled", False):
             return ToolPreInvokeResult(continue_processing=True)
@@ -76,18 +91,17 @@ class IcaMeteringExporterPlugin(Plugin):
         app_id = headers.get("x-app-id") or headers.get("X-App-Id")
         if app_id:
             context.state["ica_app_id"] = app_id
-        user_agent = (
-            headers.get("x-forwarded-user-agent")
-            or headers.get("X-Forwarded-User-Agent")
-            or headers.get("user-agent")
-            or headers.get("User-Agent")
-        )
+        user_agent = headers.get("x-forwarded-user-agent") or headers.get("X-Forwarded-User-Agent") or headers.get("user-agent") or headers.get("User-Agent")
         if user_agent:
             context.state["ica_user_agent"] = user_agent
+        for state_key, header_name in self.CALL_CONTEXT_HEADERS.items():
+            value = self._get_header(headers, header_name)
+            if value:
+                context.state[state_key] = value
         logger.debug("ICA metering: Pre-invoke for tool %s", payload.name)
         return ToolPreInvokeResult(continue_processing=True)
 
-    async def tool_post_invoke(self, payload: ToolPostInvokePayload, context: PluginContext) -> ToolPostInvokeResult:
+    async def tool_post_invoke(self, payload: ToolPostInvokePayload, context: PluginContext) -> ToolPostInvokeResult:  # type: ignore[no-any-unimported]  # noqa: E501
         """Compute latency, resolve model name via cascade, build metering payload, fire-and-forget to ICA."""
         if not self.telemetry_config.get("enabled", False):
             return ToolPostInvokeResult(continue_processing=True)
@@ -142,6 +156,15 @@ class IcaMeteringExporterPlugin(Plugin):
             "teamName": context.global_context.tenant_id or "unknown",
             "appId": context.state.get("ica_app_id"),
             "userAgent": context.state.get("ica_user_agent"),
+            "llmCallType": context.state.get("ica_llm_call_type"),
+            "assistantName": context.state.get("ica_assistant_name"),
+            "assistantUuid": context.state.get("ica_assistant_uuid"),
+            "agentName": context.state.get("ica_agent_name"),
+            "agentUuid": context.state.get("ica_agent_uuid"),
+            "agentToolIds": context.state.get("ica_agent_tool_ids"),
+            "digitalIbmerName": context.state.get("ica_digital_ibmer_name"),
+            "digitalIbmerUuid": context.state.get("ica_digital_ibmer_uuid"),
+            "digitalIbmerToolIds": context.state.get("ica_digital_ibmer_tool_ids"),
             "toolDetails": tool_details,
         }
 
@@ -152,11 +175,11 @@ class IcaMeteringExporterPlugin(Plugin):
         await self._send_to_ica(metering_payload)
         return ToolPostInvokeResult(continue_processing=True)
 
-    def _resolve_model_name(
+    def _resolve_model_name(  # type: ignore[no-any-unimported]  # noqa: E501
         self,
         context: PluginContext,
-        headers: dict,
-        ctx_meta: dict,
+        headers: dict[str, Any],
+        ctx_meta: dict[str, Any],
     ) -> tuple[Optional[str], Optional[str]]:
         """
         Resolve model name from multiple sources in priority order.
@@ -211,6 +234,14 @@ class IcaMeteringExporterPlugin(Plugin):
         return None, "unknown"
 
     @staticmethod
+    def _get_header(headers: dict[str, Any], name: str) -> Optional[str]:
+        """Case-insensitive lookup of a header value in a dict."""
+        for key, val in headers.items():
+            if isinstance(key, str) and key.lower() == name.lower() and val is not None:
+                return str(val)
+        return None
+
+    @staticmethod
     def _coerce_int(value: Any) -> int | None:
         """Coerce a value to int or return None if not possible."""
         if value is None:
@@ -250,7 +281,7 @@ class IcaMeteringExporterPlugin(Plugin):
         return None
 
     @staticmethod
-    def _extract_tokens(result: Any) -> dict:
+    def _extract_tokens(result: Any) -> dict[str, Any]:
         """Safely extract token metadata from result."""
         if not isinstance(result, dict):
             return {}
@@ -260,7 +291,7 @@ class IcaMeteringExporterPlugin(Plugin):
         tokens = meta.get("tokens", {})
         return tokens if isinstance(tokens, dict) else {}
 
-    async def _send_to_ica(self, payload: dict) -> None:
+    async def _send_to_ica(self, payload: dict[str, Any]) -> None:
         """Send metering data to ICA endpoint (fire-and-forget)."""
         if not self.http_client:
             return

--- a/plugins/ica_metering_exporter/ica_metering_exporter.py
+++ b/plugins/ica_metering_exporter/ica_metering_exporter.py
@@ -6,6 +6,7 @@ Exports MCP tool invocation metrics to ICA core-services.
 """
 
 # Standard
+import os
 import time
 from typing import Any, Optional
 
@@ -34,11 +35,23 @@ class IcaMeteringExporterPlugin(Plugin):
         super().__init__(config)
         self.telemetry_config = config.config
         self.http_client: Optional[httpx.AsyncClient] = None
+        self.env_model_name: Optional[str] = None
+
+        # Parse gateway-level defaults from plugin config
+        self._gateway_configs: dict[str, dict] = {}
+        raw_gateways = self.telemetry_config.get("gateways", [])
+        if isinstance(raw_gateways, list):
+            for gw in raw_gateways:
+                gw_id = gw.get("id")
+                if gw_id:
+                    self._gateway_configs[gw_id] = gw
+
         if self.telemetry_config.get("enabled", False):
             self.http_client = httpx.AsyncClient(
                 timeout=httpx.Timeout(5.0, connect=2.0),
                 limits=httpx.Limits(max_keepalive_connections=5),
             )
+            self.env_model_name = os.getenv("MCP_DEFAULT_MODEL")
 
     async def shutdown(self) -> None:
         """Plugin cleanup code - close HTTP client."""
@@ -85,44 +98,103 @@ class IcaMeteringExporterPlugin(Plugin):
         if not isinstance(ctx_meta, dict):
             ctx_meta = {}
 
-        # modelName sources in priority order:
-        # 1. Pre-invoke transport headers (OpenWebUI sets X-OpenWebUI-Model-Id)
-        # 2. meta_data.model (set by ContextForge internal API callers)
-        # 3. Fallback to empty string
-        model_name = (
-            context.state.get("ica_metering_model_name")
-            or ctx_meta.get("model")
-        )
+        # Resolve model name using priority cascade
+        headers = getattr(getattr(payload, "headers", None), "root", {})
+        if not isinstance(headers, dict):
+            headers = {}
+        model_name, model_source = self._resolve_model_name(context, headers, ctx_meta)
 
         tokens = self._extract_tokens(payload.result)
 
-        metering_payload = {
+        tool_details: dict[str, Any] = {
+            "toolName": payload.name,
+            "serverId": context.global_context.server_id or "unknown",
+            "serverName": gateway_meta.get("name"),
+            "gatewayId": gateway_meta.get("id"),
+            "integrationType": "MCP",
+            "requestType": "SSE",
+            "latencyMs": latency_ms,
+            "hasError": self._is_error(payload.result),
+            "errorMessage": self._extract_error_message(payload.result),
+            "cached": context.state.get("cache_hit", False),
+            "retryAttempt": context.state.get("retry_count", 0),
+            "modelName": model_name,
+            "traceId": context.global_context.request_id,
+            "tokenInput": tokens.get("input"),
+            "tokenOutput": tokens.get("output"),
+            "source": "ContextForge",
+        }
+
+        metering_payload: dict[str, Any] = {
             "userEmail": context.global_context.user or "unknown",
             "teamName": context.global_context.tenant_id or "unknown",
-            "toolDetails": {
-                "toolName": payload.name,
-                "serverId": context.global_context.server_id or "unknown",
-                "serverName": gateway_meta.get("name"),
-                "gatewayId": gateway_meta.get("id"),
-                # TODO: Extract from gateway metadata once available
-                # For MVP, all ContextForge tools are MCP over SSE
-                "integrationType": "MCP",
-                "requestType": "SSE",
-                "latencyMs": latency_ms,
-                "hasError": self._is_error(payload.result),
-                "errorMessage": self._extract_error_message(payload.result),
-                "cached": context.state.get("cache_hit", False),
-                "retryAttempt": context.state.get("retry_count", 0),
-                "modelName": model_name,
-                "traceId": context.global_context.request_id,
-                "tokenInput": tokens.get("input"),
-                "tokenOutput": tokens.get("output"),
-                "source": "ContextForge",
-            },
+            "toolDetails": tool_details,
         }
+
+        # Optional model source tracking for debugging
+        if self.telemetry_config.get("include_model_source", False):
+            metering_payload.setdefault("_metadata", {})["modelSource"] = model_source
 
         await self._send_to_ica(metering_payload)
         return ToolPostInvokeResult(continue_processing=True)
+
+    def _resolve_model_name(
+        self,
+        context: PluginContext,
+        headers: dict,
+        ctx_meta: dict,
+    ) -> tuple[Optional[str], Optional[str]]:
+        """
+        Resolve model name from multiple sources in priority order.
+
+        Priority:
+          1. Transport header (X-OpenWebUI-Model-Id) — set by OpenWebUI tools.py,
+             stored in context.state by tool_pre_invoke
+          2. Session metadata (global_context.metadata["model_name"]) — CLI client session init
+          3. Environment variable (MCP_DEFAULT_MODEL) — container/env config
+          4. Tool call meta_data.model — API callers
+          5. Gateway-level default from config — per-gateway fallback
+          6. Global default from config — system-wide fallback
+          7. None — truly unknown
+
+        Returns:
+            Tuple of (model_name, source_label)
+        """
+        # Priority 1: Transport headers (extracted by tool_pre_invoke from payload headers)
+        model = context.state.get("ica_metering_model_name")
+        if model:
+            return str(model), "transport_header"
+
+        # Priority 2: Session metadata (set by CLI client during session init)
+        model = context.global_context.metadata.get("model_name")
+        if model:
+            return str(model), "session_init"
+
+        # Priority 3: Environment variable
+        if self.env_model_name:
+            return self.env_model_name, "environment"
+
+        # Priority 4: Tool call meta_data (API callers)
+        model = ctx_meta.get("model")
+        if model:
+            return str(model), "tool_metadata"
+
+        # Priority 5: Gateway-level default
+        gw_meta = context.global_context.metadata.get(GATEWAY_METADATA)
+        if isinstance(gw_meta, dict):
+            gateway_id = gw_meta.get("id")
+            if gateway_id and gateway_id in self._gateway_configs:
+                model = self._gateway_configs[gateway_id].get("default_model")
+                if model:
+                    return str(model), "gateway_default"
+
+        # Priority 6: Global default from config
+        model = self.telemetry_config.get("global_default_model")
+        if model:
+            return str(model), "global_default"
+
+        # Priority 7: Truly unknown
+        return None, "unknown"
 
     @staticmethod
     def _is_error(result: Any) -> bool:

--- a/plugins/ica_metering_exporter/ica_metering_exporter.py
+++ b/plugins/ica_metering_exporter/ica_metering_exporter.py
@@ -11,6 +11,7 @@ import time
 from typing import Any, Optional
 
 # Third-Party
+import jwt
 import httpx
 
 # First-Party
@@ -37,6 +38,7 @@ class IcaMeteringExporterPlugin(Plugin):
         self.telemetry_config = config.config
         self.http_client: Optional[httpx.AsyncClient] = None
         self.env_model_name: Optional[str] = None
+        self._jwt_secret: Optional[str] = config.config.get("jwt_secret")
 
         # Parse gateway-level defaults from plugin config
         self._gateway_configs: dict[str, dict] = {}
@@ -71,6 +73,17 @@ class IcaMeteringExporterPlugin(Plugin):
         model_name = headers.get("x-openwebui-model-id") or headers.get("X-OpenWebUI-Model-Id")
         if model_name:
             context.state["ica_metering_model_name"] = model_name
+        app_id = headers.get("x-app-id") or headers.get("X-App-Id")
+        if app_id:
+            context.state["ica_app_id"] = app_id
+        user_agent = (
+            headers.get("x-forwarded-user-agent")
+            or headers.get("X-Forwarded-User-Agent")
+            or headers.get("user-agent")
+            or headers.get("User-Agent")
+        )
+        if user_agent:
+            context.state["ica_user_agent"] = user_agent
         logger.debug("ICA metering: Pre-invoke for tool %s", payload.name)
         return ToolPreInvokeResult(continue_processing=True)
 
@@ -119,14 +132,16 @@ class IcaMeteringExporterPlugin(Plugin):
             "retryAttempt": context.state.get("retry_count", 0),
             "modelName": model_name,
             "traceId": context.global_context.request_id,
-            "tokenInput": tokens.get("input"),
-            "tokenOutput": tokens.get("output"),
+            "tokenInput": self._coerce_int(tokens.get("input")),
+            "tokenOutput": self._coerce_int(tokens.get("output")),
             "source": "ContextForge",
         }
 
         metering_payload: dict[str, Any] = {
             "userEmail": context.global_context.user or "unknown",
             "teamName": context.global_context.tenant_id or "unknown",
+            "appId": context.state.get("ica_app_id"),
+            "userAgent": context.state.get("ica_user_agent"),
             "toolDetails": tool_details,
         }
 
@@ -196,6 +211,26 @@ class IcaMeteringExporterPlugin(Plugin):
         return None, "unknown"
 
     @staticmethod
+    def _coerce_int(value: Any) -> int | None:
+        """Coerce a value to int or return None if not possible."""
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _get_service_jwt(secret: str) -> str:
+        now = int(time.time())
+        payload = {
+            "sub": "contextforge-metering",
+            "iat": now,
+            "exp": now + 86400,
+        }
+        return jwt.encode(payload, secret, algorithm="HS256")
+
+    @staticmethod
     def _is_error(result: Any) -> bool:
         """Check if result indicates an error."""
         if result is None:
@@ -230,15 +265,23 @@ class IcaMeteringExporterPlugin(Plugin):
         metering_url = self.telemetry_config.get("metering_url")
         metering_token = self.telemetry_config.get("metering_token")
 
-        if not metering_url or not metering_token:
-            logger.warning("ICA metering URL or token not configured")
+        if not metering_url:
+            logger.warning("ICA metering URL not configured")
+            return
+
+        if self._jwt_secret:
+            headers = {"Authorization": f"Bearer {self._get_service_jwt(self._jwt_secret)}"}
+        elif metering_token:
+            headers = {"X-MCP-Metering-Token": metering_token}
+        else:
+            logger.warning("ICA metering: neither jwt_secret nor metering_token configured")
             return
 
         try:
             response = await self.http_client.post(
                 metering_url,
                 json=payload,
-                headers={"X-MCP-Metering-Token": metering_token},
+                headers=headers,
             )
             if response.status_code != 202:
                 logger.warning(

--- a/plugins/ica_metering_exporter/plugin-manifest.yaml
+++ b/plugins/ica_metering_exporter/plugin-manifest.yaml
@@ -1,0 +1,10 @@
+description: "Export MCP tool invocation metrics to ICA metering service"
+author: "ICA Team"
+version: "0.1.0"
+available_hooks:
+  - "tool_pre_invoke"
+  - "tool_post_invoke"
+default_configs:
+  metering_url: ""
+  metering_token: ""
+  enabled: false

--- a/tests/unit/mcpgateway/plugins/plugins/ica_metering_exporter/test_ica_metering_exporter.py
+++ b/tests/unit/mcpgateway/plugins/plugins/ica_metering_exporter/test_ica_metering_exporter.py
@@ -1,0 +1,580 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/plugins/plugins/ica_metering_exporter/test_ica_metering_exporter.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for IcaMeteringExporterPlugin.
+"""
+
+# Standard
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
+
+# Third-Party
+import httpx
+import pytest
+
+# First-Party
+from cpex.framework import (
+    GlobalContext,
+    PluginConfig,
+    PluginContext,
+    ToolHookType,
+    ToolPostInvokePayload,
+    ToolPreInvokePayload,
+)
+from cpex.framework.constants import GATEWAY_METADATA
+from plugins.ica_metering_exporter.ica_metering_exporter import IcaMeteringExporterPlugin
+
+
+def _create_plugin(config_dict: dict | None = None, mock_send: bool = True) -> IcaMeteringExporterPlugin:
+    """Create an ICA metering exporter plugin with optional config."""
+    config = config_dict or {
+        "enabled": True,
+        "metering_url": "http://localhost:8080/event",
+        "metering_token": "test-token",
+    }
+    plugin = IcaMeteringExporterPlugin(
+        PluginConfig(
+            name="ica_metering_test",
+            kind="plugins.ica_metering_exporter.ica_metering_exporter.IcaMeteringExporterPlugin",
+            hooks=[ToolHookType.TOOL_PRE_INVOKE, ToolHookType.TOOL_POST_INVOKE],
+            config=config,
+        )
+    )
+    if mock_send:
+        plugin._send_to_ica = AsyncMock()  # type: ignore[method-assign]
+    return plugin
+
+
+def _create_context(
+    metadata: dict | None = None,
+    user: str = "user@ibm.com",
+    tenant_id: str = "team-1",
+    server_id: str = "srv-1",
+) -> PluginContext:
+    """Create a standard plugin context for tests."""
+    return PluginContext(
+        global_context=GlobalContext(
+            request_id="req-123",
+            user=user,
+            tenant_id=tenant_id,
+            server_id=server_id,
+            metadata=metadata or {},
+        ),
+    )
+
+
+class TestIcaMeteringExporterPlugin:
+    """Unit tests for ICA metering exporter plugin."""
+
+    # ── Pre-invoke tests ─────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_records_timestamp(self):
+        """Pre-invoke should store start time in context state."""
+        plugin = _create_plugin()
+        context = _create_context()
+        payload = ToolPreInvokePayload(name="test_tool", args={}, headers=None)
+
+        await plugin.tool_pre_invoke(payload, context)
+
+        assert "ica_metering_start_time" in context.state
+        assert isinstance(context.state["ica_metering_start_time"], float)
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_is_noop_when_disabled(self):
+        """Pre-invoke should be a no-op when plugin is disabled."""
+        plugin = _create_plugin({"enabled": False})
+        context = _create_context()
+        payload = ToolPreInvokePayload(name="test_tool", args={}, headers=None)
+
+        await plugin.tool_pre_invoke(payload, context)
+
+        assert "ica_metering_start_time" not in context.state
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_always_returns_continue(self):
+        """Pre-invoke should never block execution."""
+        plugin = _create_plugin()
+        result = await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="test_tool", args={}, headers=None),
+            _create_context(),
+        )
+        assert result.continue_processing is True
+
+    # ── Post-invoke latency tests ────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_post_invoke_calculates_latency(self):
+        """Post-invoke should calculate latency from stored timestamp."""
+        plugin = _create_plugin()
+        context = _create_context()
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="test_tool", args={}, headers=None),
+            context,
+        )
+        payload = ToolPostInvokePayload(
+            name="test_tool",
+            result={"content": [{"type": "text", "text": "result"}], "isError": False},
+        )
+
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["toolDetails"]["latencyMs"] is not None
+        assert sent_payload["toolDetails"]["latencyMs"] >= 0
+
+    @pytest.mark.asyncio
+    async def test_post_invoke_latency_is_none_when_no_pre_invoke(self):
+        """Latency should be None if pre-invoke was not called."""
+        plugin = _create_plugin()
+        context = _create_context()
+        payload = ToolPostInvokePayload(
+            name="test_tool",
+            result={"content": [], "isError": False},
+        )
+
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["toolDetails"]["latencyMs"] is None
+
+    # ── Post-invoke structured JSON tests ────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_post_invoke_sends_structured_json(self):
+        """Post-invoke should send structured JSON matching ToolCallDetails."""
+        plugin = _create_plugin()
+        context = _create_context(
+            metadata={
+                "gateway": {"name": "gw-name", "id": "gw-1"},
+                "meta_data": {"model": "gpt-4"},
+            },
+        )
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="get_weather", args={}, headers=None),
+            context,
+        )
+        payload = ToolPostInvokePayload(
+            name="get_weather",
+            result={
+                "content": [{"type": "text", "text": "sunny"}],
+                "isError": False,
+                "meta": {"tokens": {"input": 10, "output": 20}},
+            },
+        )
+
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        td = sent_payload["toolDetails"]
+
+        assert sent_payload["userEmail"] == "user@ibm.com"
+        assert sent_payload["teamName"] == "team-1"
+        assert td["toolName"] == "get_weather"
+        assert td["serverId"] == "srv-1"
+        assert td["serverName"] == "gw-name"
+        assert td["gatewayId"] == "gw-1"
+        assert td["integrationType"] == "MCP"
+        assert td["requestType"] == "SSE"
+        assert td["hasError"] is False
+        assert td["errorMessage"] is None
+        assert td["cached"] is False
+        assert td["retryAttempt"] == 0
+        assert td["modelName"] == "gpt-4"
+        assert td["traceId"] == "req-123"
+        assert td["tokenInput"] == 10
+        assert td["tokenOutput"] == 20
+        assert td["source"] == "ContextForge"
+
+    @pytest.mark.asyncio
+    async def test_post_invoke_noop_when_disabled(self):
+        """Post-invoke should be a no-op when plugin is disabled."""
+        plugin = _create_plugin({"enabled": False})
+        payload = ToolPostInvokePayload(
+            name="test_tool",
+            result={"content": [], "isError": False},
+        )
+
+        await plugin.tool_post_invoke(payload, _create_context())
+
+        plugin._send_to_ica.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_post_invoke_noop_when_empty_tool_name(self):
+        """Post-invoke should skip metering when tool name is empty."""
+        plugin = _create_plugin()
+        payload = ToolPostInvokePayload(name="", result={"content": [], "isError": False})
+
+        await plugin.tool_post_invoke(payload, _create_context())
+
+        plugin._send_to_ica.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_post_invoke_always_returns_continue(self):
+        """Post-invoke should never block execution."""
+        plugin = _create_plugin()
+        result = await plugin.tool_post_invoke(
+            ToolPostInvokePayload(name="test_tool", result={"content": [], "isError": False}),
+            _create_context(),
+        )
+        assert result.continue_processing is True
+
+    # ── Default / fallback field tests ───────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_post_invoke_defaults_unknown_for_missing_fields(self):
+        """Missing global context fields should default to 'unknown'."""
+        plugin = _create_plugin()
+        context = _create_context(user="", tenant_id="", server_id="")
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers=None),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["userEmail"] == "unknown"
+        assert sent_payload["teamName"] == "unknown"
+        assert sent_payload["toolDetails"]["serverId"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_post_invoke_optional_fields_absent_when_not_provided(self):
+        """Optional fields (model, trace, tokens) should be None when not provided."""
+        plugin = _create_plugin()
+        context = _create_context(metadata={})
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers=None),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        td = sent_payload["toolDetails"]
+        assert td["modelName"] is None
+        assert td["modelName"] is None  # None from empty ctx_meta
+        assert td["tokenInput"] is None
+        assert td["tokenOutput"] is None
+
+    # ── Model name from headers tests ──────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_extracts_model_from_headers(self):
+        """Pre-invoke should extract model name from transport headers."""
+        plugin = _create_plugin()
+        context = _create_context(metadata={})
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(
+                name="tool",
+                args={},
+                headers={"X-OpenWebUI-Model-Id": "gpt-4"},
+            ),
+            context,
+        )
+
+        assert context.state.get("ica_metering_model_name") == "gpt-4"
+
+    @pytest.mark.asyncio
+    async def test_model_name_from_headers_takes_priority(self):
+        """Header-extracted model should take priority over meta_data.model."""
+        plugin = _create_plugin()
+        context = _create_context(
+            metadata={"meta_data": {"model": "claude-3"}},
+        )
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(
+                name="tool",
+                args={},
+                headers={"X-OpenWebUI-Model-Id": "gpt-4"},
+            ),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["toolDetails"]["modelName"] == "gpt-4"
+
+    # ── Error handling tests ─────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "result,expected_error,expected_message",
+        [
+            ({"isError": True, "errorMessage": "timeout"}, True, "timeout"),
+            ({"isError": True}, True, None),
+            ({"isError": False}, False, None),
+            ({}, False, None),
+            (None, False, None),
+            ("string result", False, None),
+            (42, False, None),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_post_invoke_error_detection(self, result, expected_error, expected_message):
+        """Error detection should handle various result types."""
+        plugin = _create_plugin()
+        context = _create_context()
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers=None),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result=result)
+
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        td = sent_payload["toolDetails"]
+        assert td["hasError"] == expected_error
+        assert td["errorMessage"] == expected_message
+
+    # ── Token extraction tests ───────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "result,expected_input,expected_output",
+        [
+            ({"meta": {"tokens": {"input": 10, "output": 20}}}, 10, 20),
+            ({"meta": {"tokens": {"input": 10}}}, 10, None),
+            ({"meta": {}}, None, None),
+            ({}, None, None),
+            (None, None, None),
+            ("string", None, None),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_post_invoke_token_extraction(self, result, expected_input, expected_output):
+        """Token extraction should handle various meta structures."""
+        plugin = _create_plugin()
+        context = _create_context()
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers=None),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result=result)
+
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        td = sent_payload["toolDetails"]
+        assert td["tokenInput"] == expected_input
+        assert td["tokenOutput"] == expected_output
+
+    @pytest.mark.asyncio
+    async def test_post_invoke_tokens_missing_when_no_meta_dict(self):
+        """Token fields should be None when meta is not a dict."""
+        plugin = _create_plugin()
+        context = _create_context()
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers=None),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"meta": "not-a-dict"})
+
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        td = sent_payload["toolDetails"]
+        assert td["tokenInput"] is None
+        assert td["tokenOutput"] is None
+
+    # ── cache_hit and retry_count tests ──────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_post_invoke_cached_flag_from_context_state(self):
+        """cached flag should be read from context.state."""
+        plugin = _create_plugin()
+        context = _create_context()
+        context.state["cache_hit"] = True
+        context.state["retry_count"] = 3
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers=None),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        td = sent_payload["toolDetails"]
+        assert td["cached"] is True
+        assert td["retryAttempt"] == 3
+
+    # ── HTTP client lifecycle tests ──────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_http_client_not_created_when_disabled(self):
+        """HTTP client should not be created when plugin is disabled."""
+        plugin = _create_plugin({"enabled": False})
+        assert plugin.http_client is None
+
+    @pytest.mark.asyncio
+    async def test_http_client_created_when_enabled(self):
+        """HTTP client should be created when plugin is enabled."""
+        plugin = _create_plugin()
+        assert plugin.http_client is not None
+        assert isinstance(plugin.http_client, httpx.AsyncClient)
+
+    @pytest.mark.asyncio
+    async def test_shutdown_closes_http_client(self):
+        """shutdown() should close the HTTP client."""
+        plugin = _create_plugin()
+        assert plugin.http_client is not None
+        aclose_mock = AsyncMock()
+        plugin.http_client.aclose = aclose_mock
+
+        await plugin.shutdown()
+
+        aclose_mock.assert_awaited_once()
+        assert plugin.http_client is None
+
+    @pytest.mark.asyncio
+    async def test_shutdown_safe_when_no_client(self):
+        """shutdown() should not fail when there is no HTTP client."""
+        plugin = _create_plugin({"enabled": False})
+        assert plugin.http_client is None
+
+        await plugin.shutdown()  # should not raise
+
+    # ── _send_to_ica error handling tests ────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_send_to_ica_noop_without_client(self):
+        """_send_to_ica should be a no-op when http_client is None."""
+        plugin = _create_plugin({"enabled": False}, mock_send=False)
+        plugin.http_client = None
+
+        await plugin._send_to_ica({"key": "value"})
+
+    @pytest.mark.asyncio
+    async def test_send_to_ica_noop_without_url(self):
+        """_send_to_ica should skip when URL or token is missing."""
+        plugin = _create_plugin(
+            {"enabled": True, "metering_url": "", "metering_token": ""},
+            mock_send=False,
+        )
+        assert plugin.http_client is not None
+        plugin.http_client.post = AsyncMock()
+
+        await plugin._send_to_ica({"key": "value"})
+
+        plugin.http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_to_ica_sends_correct_headers(self):
+        """_send_to_ica should send the correct auth header."""
+        plugin = _create_plugin(mock_send=False)
+        assert plugin.http_client is not None
+        plugin.http_client.post = AsyncMock(return_value=MagicMock(status_code=202))
+
+        payload = {"key": "value"}
+        await plugin._send_to_ica(payload)
+
+        plugin.http_client.post.assert_awaited_once_with(
+            "http://localhost:8080/event",
+            json=payload,
+            headers={"X-MCP-Metering-Token": "test-token"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_to_ica_logs_non_202(self):
+        """_send_to_ica should warn when response is not 202."""
+        plugin = _create_plugin(mock_send=False)
+        assert plugin.http_client is not None
+        plugin.http_client.post = AsyncMock(return_value=MagicMock(status_code=500, text="error"))
+
+        await plugin._send_to_ica({"key": "value"})
+
+    @pytest.mark.asyncio
+    async def test_send_to_ica_handles_httpx_errors(self):
+        """_send_to_ica should handle httpx exceptions gracefully."""
+        plugin = _create_plugin(mock_send=False)
+        assert plugin.http_client is not None
+        plugin.http_client.post = AsyncMock(side_effect=httpx.NetworkError("connection refused"))
+
+        await plugin._send_to_ica({"key": "value"})
+
+    @pytest.mark.asyncio
+    async def test_send_to_ica_handles_unexpected_errors(self):
+        """_send_to_ica should handle unexpected exceptions gracefully."""
+        plugin = _create_plugin(mock_send=False)
+        assert plugin.http_client is not None
+        plugin.http_client.post = AsyncMock(side_effect=RuntimeError("unexpected"))
+
+        await plugin._send_to_ica({"key": "value"})
+
+    @pytest.mark.asyncio
+    async def test_send_to_ica_handles_http_status_error(self):
+        """_send_to_ica should handle httpx HTTPStatusError gracefully."""
+        plugin = _create_plugin(mock_send=False)
+        assert plugin.http_client is not None
+        response = MagicMock(status_code=403, text="forbidden")
+        plugin.http_client.post = AsyncMock(
+            side_effect=httpx.HTTPStatusError("403 error", request=MagicMock(), response=response)
+        )
+
+        await plugin._send_to_ica({"key": "value"})
+
+    @pytest.mark.asyncio
+    async def test_send_to_ica_handles_timeout(self):
+        """_send_to_ica should handle httpx TimeoutException gracefully."""
+        plugin = _create_plugin(mock_send=False)
+        assert plugin.http_client is not None
+        plugin.http_client.post = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
+
+        await plugin._send_to_ica({"key": "value"})
+
+    @pytest.mark.asyncio
+    async def test_send_to_ica_with_non_dict_metadata(self):
+        """_send_to_ica should handle non-dict gateway_meta and ctx_meta gracefully."""
+        plugin = _create_plugin()
+        context = _create_context()
+        context.global_context.metadata[GATEWAY_METADATA] = "string_not_dict"
+        context.global_context.metadata["meta_data"] = "also_not_dict"
+
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="test_tool", args={}, headers=None),
+            context,
+        )
+        payload = ToolPostInvokePayload(
+            name="test_tool",
+            result={"content": [{"type": "text", "text": "result"}], "isError": False},
+        )
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["userEmail"] == context.global_context.user or "unknown"
+
+    # ── Static helper tests ──────────────────────────────────────
+
+    def test_is_error_various_types(self):
+        """_is_error should handle various input types."""
+        assert IcaMeteringExporterPlugin._is_error({"isError": True}) is True
+        assert IcaMeteringExporterPlugin._is_error({"isError": False}) is False
+        assert IcaMeteringExporterPlugin._is_error({}) is False
+        assert IcaMeteringExporterPlugin._is_error(None) is False
+        assert IcaMeteringExporterPlugin._is_error("string") is False
+        assert IcaMeteringExporterPlugin._is_error(42) is False
+
+    def test_extract_error_message(self):
+        """_extract_error_message should return message when present."""
+        assert IcaMeteringExporterPlugin._extract_error_message({"isError": True, "errorMessage": "fail"}) == "fail"
+        assert IcaMeteringExporterPlugin._extract_error_message({"isError": True}) is None
+        assert IcaMeteringExporterPlugin._extract_error_message({"isError": False}) is None
+        assert IcaMeteringExporterPlugin._extract_error_message({}) is None
+        assert IcaMeteringExporterPlugin._extract_error_message(None) is None
+        assert IcaMeteringExporterPlugin._extract_error_message("string") is None
+
+    def test_extract_tokens(self):
+        """_extract_tokens should extract tokens from result."""
+        result = {"meta": {"tokens": {"input": 10, "output": 20}}}
+        assert IcaMeteringExporterPlugin._extract_tokens(result) == {"input": 10, "output": 20}
+
+        assert IcaMeteringExporterPlugin._extract_tokens({"meta": {}}) == {}
+        assert IcaMeteringExporterPlugin._extract_tokens({}) == {}
+        assert IcaMeteringExporterPlugin._extract_tokens(None) == {}
+        assert IcaMeteringExporterPlugin._extract_tokens("string") == {}
+        assert IcaMeteringExporterPlugin._extract_tokens({"meta": "not-dict"}) == {}

--- a/tests/unit/mcpgateway/plugins/plugins/ica_metering_exporter/test_ica_metering_exporter.py
+++ b/tests/unit/mcpgateway/plugins/plugins/ica_metering_exporter/test_ica_metering_exporter.py
@@ -102,6 +102,87 @@ class TestIcaMeteringExporterPlugin:
         )
         assert result.continue_processing is True
 
+    # ── App ID and User Agent extraction tests ───────────────────
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_extracts_app_id_from_headers(self):
+        """Pre-invoke should extract appId from X-App-Id header."""
+        plugin = _create_plugin()
+        context = _create_context()
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(
+                name="tool", args={},
+                headers={"X-App-Id": "coding-agent:research"},
+            ),
+            context,
+        )
+        assert context.state.get("ica_app_id") == "coding-agent:research"
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_extracts_user_agent_from_headers(self):
+        """Pre-invoke should extract user agent from User-Agent header."""
+        plugin = _create_plugin()
+        context = _create_context()
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(
+                name="tool", args={},
+                headers={"User-Agent": "ClaudeCode/1.2.3"},
+            ),
+            context,
+        )
+        assert context.state.get("ica_user_agent") == "ClaudeCode/1.2.3"
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_forwarded_user_agent_takes_priority(self):
+        """X-Forwarded-User-Agent should take priority over User-Agent."""
+        plugin = _create_plugin()
+        context = _create_context()
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(
+                name="tool", args={},
+                headers={
+                    "User-Agent": "JavaHttpClient/4.0",
+                    "X-Forwarded-User-Agent": "ClaudeCode/1.2.3",
+                },
+            ),
+            context,
+        )
+        assert context.state.get("ica_user_agent") == "ClaudeCode/1.2.3"
+
+    @pytest.mark.asyncio
+    async def test_post_invoke_includes_app_id_and_user_agent(self):
+        """Post-invoke payload should include appId and userAgent from state."""
+        plugin = _create_plugin()
+        context = _create_context()
+        context.state["ica_app_id"] = "coding-agent:research"
+        context.state["ica_user_agent"] = "ClaudeCode/1.2.3"
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers=None),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["appId"] == "coding-agent:research"
+        assert sent_payload["userAgent"] == "ClaudeCode/1.2.3"
+
+    @pytest.mark.asyncio
+    async def test_post_invoke_app_id_is_none_when_not_set(self):
+        """appId should be None in payload when no X-App-Id header was present."""
+        plugin = _create_plugin()
+        context = _create_context()
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers={}),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["appId"] is None
+        assert sent_payload["userAgent"] is None
+
     # ── Post-invoke latency tests ────────────────────────────────
 
     @pytest.mark.asyncio
@@ -779,3 +860,175 @@ class TestIcaMeteringExporterPlugin:
         assert IcaMeteringExporterPlugin._extract_tokens(None) == {}
         assert IcaMeteringExporterPlugin._extract_tokens("string") == {}
         assert IcaMeteringExporterPlugin._extract_tokens({"meta": "not-dict"}) == {}
+
+    # ── _coerce_int tests ─────────────────────────────────────────
+
+    @pytest.mark.parametrize("value,expected", [
+        (None, None),
+        (42, 42),
+        (42.0, 42),
+        (42.7, 42),
+        ("42", 42),
+        ("abc", None),
+        ([], None),
+        ({}, None),
+    ])
+    def test_coerce_int(self, value, expected):
+        """_coerce_int should safely convert values or return None."""
+        assert IcaMeteringExporterPlugin._coerce_int(value) == expected
+
+    # ── JWT service token tests ───────────────────────────────────
+
+    def test_get_service_jwt_returns_token(self):
+        """_get_service_jwt should return a valid JWT string."""
+        token = IcaMeteringExporterPlugin._get_service_jwt("test-secret-key-for-jwt-generation-test")
+        assert isinstance(token, str)
+        assert len(token) > 20
+        assert token.count(".") == 2
+
+    def test_get_service_jwt_uses_contextforge_metering_subject(self):
+        """JWT should contain 'contextforge-metering' as subject."""
+        import jwt as pyjwt
+        token = IcaMeteringExporterPlugin._get_service_jwt("test-secret-key-for-jwt-generation-test")
+        decoded = pyjwt.decode(token, "test-secret-key-for-jwt-generation-test", algorithms=["HS256"])
+        assert decoded["sub"] == "contextforge-metering"
+
+    def test_get_service_jwt_expires_in_future(self):
+        """JWT exp should be ~24h from now."""
+        import jwt as pyjwt
+        import time
+        token = IcaMeteringExporterPlugin._get_service_jwt("test-secret-key-for-jwt-generation-test")
+        decoded = pyjwt.decode(token, "test-secret-key-for-jwt-generation-test", algorithms=["HS256"])
+        assert decoded["exp"] > time.time() + 86000  # ~23.9h
+        assert decoded["exp"] < time.time() + 86500  # ~24.0h
+
+    @pytest.mark.asyncio
+    async def test_send_to_ica_uses_jwt_when_configured(self):
+        """_send_to_ica should send Authorization: Bearer when jwt_secret is set."""
+        plugin = _create_plugin({
+            "enabled": True,
+            "metering_url": "http://localhost:8080/event",
+            "jwt_secret": "test-secret-key-for-jwt-generation-test",
+        }, mock_send=False)
+        assert plugin.http_client is not None
+        plugin.http_client.post = AsyncMock(return_value=MagicMock(status_code=202))
+
+        await plugin._send_to_ica({"key": "value"})
+
+        call_kwargs = plugin.http_client.post.await_args.kwargs
+        headers = call_kwargs["headers"]
+        assert "Authorization" in headers
+        assert headers["Authorization"].startswith("Bearer ")
+
+    @pytest.mark.asyncio
+    async def test_send_to_ica_uses_shared_secret_when_no_jwt(self):
+        """_send_to_ica should fall back to X-MCP-Metering-Token when jwt_secret is absent."""
+        plugin = _create_plugin(mock_send=False)
+        assert plugin.http_client is not None
+        plugin.http_client.post = AsyncMock(return_value=MagicMock(status_code=202))
+
+        await plugin._send_to_ica({"key": "value"})
+
+        call_kwargs = plugin.http_client.post.await_args.kwargs
+        headers = call_kwargs["headers"]
+        assert "X-MCP-Metering-Token" in headers
+        assert headers["X-MCP-Metering-Token"] == "test-token"
+
+    @pytest.mark.asyncio
+    async def test_send_to_ica_skips_when_no_auth_configured(self):
+        """_send_to_ica should warn and skip when neither jwt_secret nor metering_token is set."""
+        plugin = _create_plugin({
+            "enabled": True,
+            "metering_url": "http://localhost:8080/event",
+        }, mock_send=False)
+        assert plugin.http_client is not None
+        plugin.http_client.post = AsyncMock()
+
+        await plugin._send_to_ica({"key": "value"})
+
+        plugin.http_client.post.assert_not_called()
+
+    # ── End-to-end integration test ───────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_e2e_metering_payload_via_http(self):
+        """Plugin sends correct JSON payload through real HTTP to metering endpoint."""
+        from httpx import MockTransport
+
+        captured_body = None
+
+        def transport_handler(request):
+            nonlocal captured_body
+            captured_body = request
+            return httpx.Response(202)
+
+        plugin = _create_plugin(mock_send=False)
+        plugin.http_client = httpx.AsyncClient(transport=MockTransport(transport_handler))
+
+        context = _create_context()
+        context.state["ica_app_id"] = "coding-agent:research"
+        context.state["ica_user_agent"] = "ClaudeCode/1.2.3"
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="echo", args={"msg": "hello"}, headers=None),
+            context,
+        )
+        payload = ToolPostInvokePayload(
+            name="echo",
+            result={
+                "content": [{"type": "text", "text": "hello world"}],
+                "isError": False,
+                "meta": {"tokens": {"input": 10, "output": 20}},
+            },
+        )
+        await plugin.tool_post_invoke(payload, context)
+
+        import json
+        body = json.loads(captured_body.content)
+        assert body["userEmail"] == "user@ibm.com"
+        assert body["teamName"] == "team-1"
+        assert body["appId"] == "coding-agent:research"
+        assert body["userAgent"] == "ClaudeCode/1.2.3"
+        assert body["toolDetails"]["toolName"] == "echo"
+        assert body["toolDetails"]["tokenInput"] == 10
+        assert body["toolDetails"]["tokenOutput"] == 20
+        assert body["toolDetails"]["source"] == "ContextForge"
+        assert body["toolDetails"]["latencyMs"] >= 0
+        assert body["toolDetails"]["hasError"] is False
+        assert captured_body.headers["x-mcp-metering-token"] == "test-token"
+
+    @pytest.mark.asyncio
+    async def test_e2e_metering_payload_coerces_token_types(self):
+        """Token values as float/string are coerced to int in HTTP payload."""
+        from httpx import MockTransport
+
+        captured_body = None
+
+        def transport_handler(request):
+            nonlocal captured_body
+            captured_body = request
+            return httpx.Response(202)
+
+        plugin = _create_plugin(mock_send=False)
+        plugin.http_client = httpx.AsyncClient(transport=MockTransport(transport_handler))
+
+        context = _create_context()
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="echo", args={}, headers=None),
+            context,
+        )
+        payload = ToolPostInvokePayload(
+            name="echo",
+            result={
+                "content": [{"type": "text", "text": "hello"}],
+                "isError": False,
+                "meta": {"tokens": {"input": 10.0, "output": "20"}},
+            },
+        )
+        await plugin.tool_post_invoke(payload, context)
+
+        import json
+        body = json.loads(captured_body.content)
+        assert body["toolDetails"]["tokenInput"] == 10
+        assert body["toolDetails"]["tokenOutput"] == 20
+        assert isinstance(body["toolDetails"]["tokenInput"], int)
+        assert isinstance(body["toolDetails"]["tokenOutput"], int)

--- a/tests/unit/mcpgateway/plugins/plugins/ica_metering_exporter/test_ica_metering_exporter.py
+++ b/tests/unit/mcpgateway/plugins/plugins/ica_metering_exporter/test_ica_metering_exporter.py
@@ -139,6 +139,207 @@ class TestIcaMeteringExporterPlugin:
         sent_payload = plugin._send_to_ica.await_args.args[0]
         assert sent_payload["toolDetails"]["latencyMs"] is None
 
+    # ── Model resolution priority cascade tests ──────────────────
+
+    @pytest.mark.asyncio
+    async def test_model_resolution_priority_1_headers(self):
+        """Priority 1: Transport headers should take highest priority."""
+        plugin = _create_plugin()
+        plugin.env_model_name = "env-model"
+        context = _create_context(
+            metadata={"model_name": "session-model", GATEWAY_METADATA: {"id": "gw-1"}},
+        )
+        plugin._gateway_configs = {"gw-1": {"default_model": "gateway-model"}}
+        plugin.telemetry_config["global_default_model"] = "global-model"
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(
+                name="tool", args={},
+                headers={"X-OpenWebUI-Model-Id": "header-model"},
+            ),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["toolDetails"]["modelName"] == "header-model"
+
+    @pytest.mark.asyncio
+    async def test_model_resolution_priority_2_session_init(self):
+        """Priority 2: Session metadata should resolve when headers absent."""
+        plugin = _create_plugin()
+        context = _create_context(
+            metadata={"model_name": "session-model"},
+        )
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers={}),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["toolDetails"]["modelName"] == "session-model"
+
+    @pytest.mark.asyncio
+    async def test_model_resolution_priority_3_environment(self):
+        """Priority 3: Environment variable should resolve when headers and session absent."""
+        plugin = _create_plugin()
+        plugin.env_model_name = "env-gpt-4"
+        context = _create_context(metadata={})
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers={}),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["toolDetails"]["modelName"] == "env-gpt-4"
+
+    @pytest.mark.asyncio
+    async def test_model_resolution_priority_4_tool_metadata(self):
+        """Priority 4: meta_data.model should resolve when higher priorities absent."""
+        plugin = _create_plugin()
+        context = _create_context(
+            metadata={"meta_data": {"model": "tool-meta-model"}},
+        )
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers={}),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["toolDetails"]["modelName"] == "tool-meta-model"
+
+    @pytest.mark.asyncio
+    async def test_model_resolution_priority_5_gateway_default(self):
+        """Priority 5: Gateway-level default should resolve when higher priorities absent."""
+        plugin = _create_plugin()
+        plugin._gateway_configs = {"gw-research": {"default_model": "gateway-model"}}
+        context = _create_context(
+            metadata={GATEWAY_METADATA: {"id": "gw-research"}},
+        )
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers={}),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["toolDetails"]["modelName"] == "gateway-model"
+
+    @pytest.mark.asyncio
+    async def test_model_resolution_priority_6_global_default(self):
+        """Priority 6: Global default should resolve when all higher priorities absent."""
+        plugin = _create_plugin()
+        plugin.telemetry_config["global_default_model"] = "global-default-model"
+        context = _create_context(metadata={})
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers={}),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["toolDetails"]["modelName"] == "global-default-model"
+
+    @pytest.mark.asyncio
+    async def test_model_resolution_priority_7_unknown(self):
+        """Priority 7: None when all sources exhausted."""
+        plugin = _create_plugin()
+        context = _create_context(metadata={})
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers={}),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["toolDetails"]["modelName"] is None
+
+    @pytest.mark.asyncio
+    async def test_model_source_tracking_when_enabled(self):
+        """modelSource field should be emitted when include_model_source is true."""
+        plugin = _create_plugin({"enabled": True, "include_model_source": True,
+                                "metering_url": "http://localhost:8080/event",
+                                "metering_token": "test-token"})
+        context = _create_context(metadata={"model_name": "session-model"})
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers={}),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["_metadata"]["modelSource"] == "session_init"
+        assert sent_payload["toolDetails"]["modelName"] == "session-model"
+
+    @pytest.mark.asyncio
+    async def test_model_source_tracking_not_emitted_when_disabled(self):
+        """modelSource field should not be emitted when include_model_source is false."""
+        plugin = _create_plugin()
+        context = _create_context(metadata={"model_name": "session-model"})
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers={}),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert "_metadata" not in sent_payload
+
+    @pytest.mark.asyncio
+    async def test_model_resolution_full_cascade_header_wins(self):
+        """All 6 sources present - Priority 1 (transport header) wins."""
+        plugin = _create_plugin()
+        plugin.env_model_name = "env-model"
+        plugin._gateway_configs = {"gw-1": {"default_model": "gateway-model"}}
+        plugin.telemetry_config["global_default_model"] = "global-model"
+        context = _create_context(
+            metadata={
+                "model_name": "session-model",
+                "meta_data": {"model": "meta-model"},
+                GATEWAY_METADATA: {"id": "gw-1"},
+            },
+        )
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(
+                name="tool", args={},
+                headers={"X-OpenWebUI-Model-Id": "header-model"},
+            ),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["toolDetails"]["modelName"] == "header-model"
+
+    @pytest.mark.asyncio
+    async def test_model_resolution_picks_highest_available(self):
+        """Only Priority 2 (session) available — should use that."""
+        plugin = _create_plugin()
+        context = _create_context(
+            metadata={"model_name": "session-only"},
+        )
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers={}),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["toolDetails"]["modelName"] == "session-only"
+
     # ── Post-invoke structured JSON tests ────────────────────────
 
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/plugins/plugins/ica_metering_exporter/test_ica_metering_exporter.py
+++ b/tests/unit/mcpgateway/plugins/plugins/ica_metering_exporter/test_ica_metering_exporter.py
@@ -1113,7 +1113,7 @@ class TestIcaMeteringExporterPlugin:
             {
                 "enabled": True,
                 "metering_url": "http://localhost:8080/event",
-                "jwt_secret": "test-secret-key-for-jwt-generation-test",
+                "jwt_secret": "test-secret-key-for-jwt-generation-test",  # pragma: allowlist secret
             },
             mock_send=False,
         )

--- a/tests/unit/mcpgateway/plugins/plugins/ica_metering_exporter/test_ica_metering_exporter.py
+++ b/tests/unit/mcpgateway/plugins/plugins/ica_metering_exporter/test_ica_metering_exporter.py
@@ -893,6 +893,16 @@ class TestIcaMeteringExporterPlugin:
         decoded = pyjwt.decode(token, "test-secret-key-for-jwt-generation-test", algorithms=["HS256"])
         assert decoded["sub"] == "contextforge-metering"
 
+    def test_get_service_jwt_has_service_attribution(self):
+        """JWT should contain service, instance, and scope claims."""
+        import jwt as pyjwt
+        token = IcaMeteringExporterPlugin._get_service_jwt("test-secret-key-for-jwt-generation-test")
+        decoded = pyjwt.decode(token, "test-secret-key-for-jwt-generation-test", algorithms=["HS256"])
+        assert decoded["service"] == "mcp-context-forge"
+        assert isinstance(decoded["instance"], str)
+        assert len(decoded["instance"]) > 0
+        assert decoded["scope"] == "metering:write"
+
     def test_get_service_jwt_expires_in_future(self):
         """JWT exp should be ~24h from now."""
         import jwt as pyjwt

--- a/tests/unit/mcpgateway/plugins/plugins/ica_metering_exporter/test_ica_metering_exporter.py
+++ b/tests/unit/mcpgateway/plugins/plugins/ica_metering_exporter/test_ica_metering_exporter.py
@@ -7,9 +7,14 @@ Unit tests for IcaMeteringExporterPlugin.
 """
 
 # Standard
-from unittest.mock import AsyncMock, MagicMock
+from contextlib import contextmanager
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 # Third-Party
+import httpx
+import pytest
+
+# First-Party
 from cpex.framework import (
     GlobalContext,
     PluginConfig,
@@ -19,11 +24,18 @@ from cpex.framework import (
     ToolPreInvokePayload,
 )
 from cpex.framework.constants import GATEWAY_METADATA
-import httpx
-import pytest
-
-# First-Party
+from mcpgateway.transports.context import request_headers_var
 from plugins.ica_metering_exporter.ica_metering_exporter import IcaMeteringExporterPlugin
+
+
+@contextmanager
+def _set_request_headers(headers: dict):
+    """Context manager to set request_headers_var for testing."""
+    token = request_headers_var.set(headers)
+    try:
+        yield
+    finally:
+        request_headers_var.reset(token)
 
 
 def _create_plugin(config_dict: dict | None = None, mock_send: bool = True) -> IcaMeteringExporterPlugin:
@@ -106,32 +118,26 @@ class TestIcaMeteringExporterPlugin:
 
     @pytest.mark.asyncio
     async def test_pre_invoke_extracts_app_id_from_headers(self):
-        """Pre-invoke should extract appId from X-App-Id header."""
+        """Pre-invoke should extract appId from request_headers_var."""
         plugin = _create_plugin()
         context = _create_context()
-        await plugin.tool_pre_invoke(
-            ToolPreInvokePayload(
-                name="tool",
-                args={},
-                headers={"X-App-Id": "coding-agent:research"},
-            ),
-            context,
-        )
+        with _set_request_headers({"x-app-id": "coding-agent:research"}):
+            await plugin.tool_pre_invoke(
+                ToolPreInvokePayload(name="tool", args={}, headers=None),
+                context,
+            )
         assert context.state.get("ica_app_id") == "coding-agent:research"
 
     @pytest.mark.asyncio
     async def test_pre_invoke_extracts_user_agent_from_headers(self):
-        """Pre-invoke should extract user agent from User-Agent header."""
+        """Pre-invoke should extract user agent from user-agent header."""
         plugin = _create_plugin()
         context = _create_context()
-        await plugin.tool_pre_invoke(
-            ToolPreInvokePayload(
-                name="tool",
-                args={},
-                headers={"User-Agent": "ClaudeCode/1.2.3"},
-            ),
-            context,
-        )
+        with _set_request_headers({"user-agent": "ClaudeCode/1.2.3"}):
+            await plugin.tool_pre_invoke(
+                ToolPreInvokePayload(name="tool", args={}, headers=None),
+                context,
+            )
         assert context.state.get("ica_user_agent") == "ClaudeCode/1.2.3"
 
     @pytest.mark.asyncio
@@ -139,17 +145,14 @@ class TestIcaMeteringExporterPlugin:
         """X-Forwarded-User-Agent should take priority over User-Agent."""
         plugin = _create_plugin()
         context = _create_context()
-        await plugin.tool_pre_invoke(
-            ToolPreInvokePayload(
-                name="tool",
-                args={},
-                headers={
-                    "User-Agent": "JavaHttpClient/4.0",
-                    "X-Forwarded-User-Agent": "ClaudeCode/1.2.3",
-                },
-            ),
-            context,
-        )
+        with _set_request_headers({
+            "user-agent": "JavaHttpClient/4.0",
+            "x-forwarded-user-agent": "ClaudeCode/1.2.3",
+        }):
+            await plugin.tool_pre_invoke(
+                ToolPreInvokePayload(name="tool", args={}, headers=None),
+                context,
+            )
         assert context.state.get("ica_user_agent") == "ClaudeCode/1.2.3"
 
     @pytest.mark.asyncio
@@ -186,117 +189,121 @@ class TestIcaMeteringExporterPlugin:
         assert sent_payload["appId"] is None
         assert sent_payload["userAgent"] is None
 
-    # ── Call-context (persona) header tests ─────────────────────
+    # ── MCP Client Identity Header Tests ─────────────────────────
 
     @pytest.mark.asyncio
-    async def test_pre_invoke_extracts_assistant_headers(self):
-        """Pre-invoke should extract llm_call_type and assistant headers."""
+    async def test_pre_invoke_extracts_mcp_client_name(self):
+        """Pre-invoke should extract X-MCP-Client-Name and X-MCP-Client-Version."""
         plugin = _create_plugin()
         context = _create_context()
-        await plugin.tool_pre_invoke(
-            ToolPreInvokePayload(
-                name="tool",
-                args={},
-                headers={
-                    "llm_call_type": "assistant",
-                    "assistant_uuid": "assistant-123",
-                    "assistant_name": "Austin Weather",
-                },
-            ),
-            context,
+        with _set_request_headers({"x-mcp-client-name": "opencode", "x-mcp-client-version": "1.5.0"}):
+            await plugin.tool_pre_invoke(
+                ToolPreInvokePayload(name="tool", args={}, headers=None),
+                context,
+            )
+        assert context.state.get("ica_mcp_client_name") == "opencode"
+        assert context.state.get("ica_mcp_client_version") == "1.5.0"
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_mcp_client_name_used_as_user_agent_fallback(self):
+        """MCP client name/version should be used as userAgent when X-Forwarded-User-Agent absent."""
+        plugin = _create_plugin()
+        context = _create_context()
+        with _set_request_headers({"x-mcp-client-name": "opencode", "x-mcp-client-version": "1.5.0"}):
+            await plugin.tool_pre_invoke(
+                ToolPreInvokePayload(name="tool", args={}, headers=None),
+                context,
+            )
+        assert context.state.get("ica_user_agent") == "opencode/1.5.0"
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_mcp_client_name_without_version(self):
+        """MCP client name alone (no version) should still populate userAgent."""
+        plugin = _create_plugin()
+        context = _create_context()
+        with _set_request_headers({"x-mcp-client-name": "vscode-copilot"}):
+            await plugin.tool_pre_invoke(
+                ToolPreInvokePayload(name="tool", args={}, headers=None),
+                context,
+            )
+        assert context.state.get("ica_user_agent") == "vscode-copilot"
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_forwarded_user_agent_takes_priority_over_mcp_client(self):
+        """X-Forwarded-User-Agent should take priority over X-MCP-Client-Name."""
+        plugin = _create_plugin()
+        context = _create_context()
+        with _set_request_headers({
+            "x-forwarded-user-agent": "Mozilla/5.0 Safari",
+            "x-mcp-client-name": "opencode",
+            "x-mcp-client-version": "1.0",
+        }):
+            await plugin.tool_pre_invoke(
+                ToolPreInvokePayload(name="tool", args={}, headers=None),
+                context,
+            )
+        assert context.state.get("ica_user_agent") == "Mozilla/5.0 Safari"
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_derives_app_id_from_mcp_client_name(self):
+        """appId should be derived as 'api:{client_name}' when X-App-Id absent."""
+        plugin = _create_plugin()
+        context = _create_context()
+        with _set_request_headers({"x-mcp-client-name": "opencode", "x-mcp-client-version": "1.0"}):
+            await plugin.tool_pre_invoke(
+                ToolPreInvokePayload(name="tool", args={}, headers=None),
+                context,
+            )
+        assert context.state.get("ica_app_id") == "api:opencode"
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_explicit_app_id_not_overridden_by_mcp_client(self):
+        """Explicit X-App-Id should NOT be overridden by X-MCP-Client-Name."""
+        plugin = _create_plugin()
+        context = _create_context()
+        with _set_request_headers({
+            "x-app-id": "agent:MyAgent:agent-123",
+            "x-mcp-client-name": "opencode",
+        }):
+            await plugin.tool_pre_invoke(
+                ToolPreInvokePayload(name="tool", args={}, headers=None),
+                context,
+            )
+        assert context.state.get("ica_app_id") == "agent:MyAgent:agent-123"
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_derives_app_id_from_user_agent(self):
+        """appId should be derived from user-agent when no X-App-Id or X-MCP-Client-Name."""
+        plugin = _create_plugin()
+        context = _create_context()
+        with _set_request_headers({"user-agent": "opencode/1.18.13"}):
+            await plugin.tool_pre_invoke(
+                ToolPreInvokePayload(name="tool", args={}, headers=None),
+                context,
+            )
+        assert context.state.get("ica_app_id") == "api:opencode"
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_does_not_derive_app_id_from_mozilla_user_agent(self):
+        """appId should NOT be derived from browser-like user-agent."""
+        plugin = _create_plugin()
+        context = _create_context()
+        with _set_request_headers({"user-agent": "Mozilla/5.0 (Macintosh) Safari/537.36"}):
+            await plugin.tool_pre_invoke(
+                ToolPreInvokePayload(name="tool", args={}, headers=None),
+                context,
+            )
+        assert context.state.get("ica_app_id") is None
+
+    # ── requestType from gateway transport tests ─────────────────
+
+    @pytest.mark.asyncio
+    async def test_request_type_from_gateway_streamablehttp(self):
+        """requestType should be STREAMABLE_HTTP when gateway transport is streamablehttp."""
+        plugin = _create_plugin()
+        context = _create_context(
+            metadata={GATEWAY_METADATA: {"id": "gw-1", "name": "gw", "transport": "streamablehttp"}},
         )
-        assert context.state.get("ica_llm_call_type") == "assistant"
-        assert context.state.get("ica_assistant_uuid") == "assistant-123"
-        assert context.state.get("ica_assistant_name") == "Austin Weather"
-
-    @pytest.mark.asyncio
-    async def test_pre_invoke_extracts_agent_headers(self):
-        """Pre-invoke should extract llm_call_type and agent headers including tool ids."""
-        plugin = _create_plugin()
-        context = _create_context()
-        await plugin.tool_pre_invoke(
-            ToolPreInvokePayload(
-                name="tool",
-                args={},
-                headers={
-                    "llm_call_type": "agent",
-                    "agent_uuid": "agent-456",
-                    "agent_name": "Research Agent",
-                    "agent_tool_ids": "server:mcp:abc123,server:mcp:def456",
-                },
-            ),
-            context,
-        )
-        assert context.state.get("ica_llm_call_type") == "agent"
-        assert context.state.get("ica_agent_uuid") == "agent-456"
-        assert context.state.get("ica_agent_name") == "Research Agent"
-        assert context.state.get("ica_agent_tool_ids") == "server:mcp:abc123,server:mcp:def456"
-
-    @pytest.mark.asyncio
-    async def test_pre_invoke_extracts_digital_ibmer_headers(self):
-        """Pre-invoke should extract llm_call_type and digital-ibmer headers."""
-        plugin = _create_plugin()
-        context = _create_context()
-        await plugin.tool_pre_invoke(
-            ToolPreInvokePayload(
-                name="tool",
-                args={},
-                headers={
-                    "llm_call_type": "digital-ibmer",
-                    "digital-ibmer_uuid": "ibmer-789",
-                    "digital-ibmer_name": "Digital Coworker",
-                    "digital-ibmer_tool_ids": "server:mcp:xyz1",
-                },
-            ),
-            context,
-        )
-        assert context.state.get("ica_llm_call_type") == "digital-ibmer"
-        assert context.state.get("ica_digital_ibmer_uuid") == "ibmer-789"
-        assert context.state.get("ica_digital_ibmer_name") == "Digital Coworker"
-        assert context.state.get("ica_digital_ibmer_tool_ids") == "server:mcp:xyz1"
-
-    @pytest.mark.asyncio
-    async def test_pre_invoke_persona_headers_case_insensitive(self):
-        """Pre-invoke should extract persona headers regardless of casing."""
-        plugin = _create_plugin()
-        context = _create_context()
-        await plugin.tool_pre_invoke(
-            ToolPreInvokePayload(
-                name="tool",
-                args={},
-                headers={
-                    "LLM_CALL_TYPE": "assistant",
-                    "Assistant_Uuid": "assistant-111",
-                    "AGENT_TOOL_IDS": "server:mcp:abc",
-                },
-            ),
-            context,
-        )
-        assert context.state.get("ica_llm_call_type") == "assistant"
-        assert context.state.get("ica_assistant_uuid") == "assistant-111"
-        assert context.state.get("ica_agent_tool_ids") == "server:mcp:abc"
-
-    @pytest.mark.asyncio
-    async def test_pre_invoke_no_persona_headers_leave_state_empty(self):
-        """Pre-invoke should not store persona state when headers are absent."""
-        plugin = _create_plugin()
-        context = _create_context()
-        await plugin.tool_pre_invoke(
-            ToolPreInvokePayload(name="tool", args={}, headers={"x-app-id": "ica-api-dev"}),
-            context,
-        )
-        for state_key in IcaMeteringExporterPlugin.CALL_CONTEXT_HEADERS:
-            assert state_key not in context.state
-
-    @pytest.mark.asyncio
-    async def test_post_invoke_emits_persona_fields(self):
-        """Post-invoke payload should include persona fields from state."""
-        plugin = _create_plugin()
-        context = _create_context()
-        context.state["ica_llm_call_type"] = "agent"
-        context.state["ica_agent_uuid"] = "agent-456"
-        context.state["ica_agent_name"] = "Research Agent"
-        context.state["ica_agent_tool_ids"] = "server:mcp:abc123"
         await plugin.tool_pre_invoke(
             ToolPreInvokePayload(name="tool", args={}, headers=None),
             context,
@@ -305,68 +312,56 @@ class TestIcaMeteringExporterPlugin:
         await plugin.tool_post_invoke(payload, context)
 
         sent_payload = plugin._send_to_ica.await_args.args[0]
-        assert sent_payload["llmCallType"] == "agent"
-        assert sent_payload["agentUuid"] == "agent-456"
-        assert sent_payload["agentName"] == "Research Agent"
-        assert sent_payload["agentToolIds"] == "server:mcp:abc123"
-        assert sent_payload["appId"] is None
+        assert sent_payload["toolDetails"]["requestType"] == "STREAMABLE_HTTP"
 
     @pytest.mark.asyncio
-    async def test_post_invoke_persona_fields_none_when_not_set(self):
-        """Persona fields should be None in payload when no persona headers were present."""
+    async def test_request_type_from_gateway_streamable_http_underscore(self):
+        """requestType should be STREAMABLE_HTTP when gateway transport is streamable_http."""
         plugin = _create_plugin()
-        context = _create_context()
+        context = _create_context(
+            metadata={GATEWAY_METADATA: {"id": "gw-1", "name": "gw", "transport": "streamable_http"}},
+        )
         await plugin.tool_pre_invoke(
-            ToolPreInvokePayload(name="tool", args={}, headers={}),
+            ToolPreInvokePayload(name="tool", args={}, headers=None),
             context,
         )
         payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
         await plugin.tool_post_invoke(payload, context)
 
         sent_payload = plugin._send_to_ica.await_args.args[0]
-        assert sent_payload["llmCallType"] is None
-        assert sent_payload["assistantUuid"] is None
-        assert sent_payload["agentUuid"] is None
-        assert sent_payload["agentToolIds"] is None
-        assert sent_payload["digitalIbmerUuid"] is None
-        assert sent_payload["digitalIbmerToolIds"] is None
+        assert sent_payload["toolDetails"]["requestType"] == "STREAMABLE_HTTP"
 
     @pytest.mark.asyncio
-    async def test_post_invoke_emits_persona_fields_via_http(self):
-        """Persona fields propagate through real HTTP payload."""
-        # Third-Party
-        from httpx import MockTransport
-
-        captured_body = None
-
-        def transport_handler(request):
-            nonlocal captured_body
-            captured_body = request
-            return httpx.Response(202)
-
-        plugin = _create_plugin(mock_send=False)
-        plugin.http_client = httpx.AsyncClient(transport=MockTransport(transport_handler))
-
-        context = _create_context()
-        context.state["ica_llm_call_type"] = "assistant"
-        context.state["ica_assistant_uuid"] = "assistant-123"
+    async def test_request_type_from_gateway_sse(self):
+        """requestType should be SSE when gateway transport is sse."""
+        plugin = _create_plugin()
+        context = _create_context(
+            metadata={GATEWAY_METADATA: {"id": "gw-1", "name": "gw", "transport": "sse"}},
+        )
         await plugin.tool_pre_invoke(
-            ToolPreInvokePayload(name="echo", args={}, headers=None),
+            ToolPreInvokePayload(name="tool", args={}, headers=None),
             context,
         )
-        payload = ToolPostInvokePayload(
-            name="echo",
-            result={"content": [{"type": "text", "text": "hello"}], "isError": False},
-        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
         await plugin.tool_post_invoke(payload, context)
 
-        # Standard
-        import json
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["toolDetails"]["requestType"] == "SSE"
 
-        body = json.loads(captured_body.content)
-        assert body["llmCallType"] == "assistant"
-        assert body["assistantUuid"] == "assistant-123"
-        assert body["assistantName"] is None  # only populated when header present
+    @pytest.mark.asyncio
+    async def test_request_type_unknown_when_no_gateway_metadata(self):
+        """requestType should be UNKNOWN when no gateway metadata present."""
+        plugin = _create_plugin()
+        context = _create_context(metadata={})
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers=None),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["toolDetails"]["requestType"] == "UNKNOWN"
 
     # ── Post-invoke latency tests ────────────────────────────────
 
@@ -419,8 +414,7 @@ class TestIcaMeteringExporterPlugin:
         plugin.telemetry_config["global_default_model"] = "global-model"
         await plugin.tool_pre_invoke(
             ToolPreInvokePayload(
-                name="tool",
-                args={},
+                name="tool", args={},
                 headers={"X-OpenWebUI-Model-Id": "header-model"},
             ),
             context,
@@ -533,7 +527,9 @@ class TestIcaMeteringExporterPlugin:
     @pytest.mark.asyncio
     async def test_model_source_tracking_when_enabled(self):
         """modelSource field should be emitted when include_model_source is true."""
-        plugin = _create_plugin({"enabled": True, "include_model_source": True, "metering_url": "http://localhost:8080/event", "metering_token": "test-token"})
+        plugin = _create_plugin({"enabled": True, "include_model_source": True,
+                                "metering_url": "http://localhost:8080/event",
+                                "metering_token": "test-token"})
         context = _create_context(metadata={"model_name": "session-model"})
         await plugin.tool_pre_invoke(
             ToolPreInvokePayload(name="tool", args={}, headers={}),
@@ -577,8 +573,7 @@ class TestIcaMeteringExporterPlugin:
         )
         await plugin.tool_pre_invoke(
             ToolPreInvokePayload(
-                name="tool",
-                args={},
+                name="tool", args={},
                 headers={"X-OpenWebUI-Model-Id": "header-model"},
             ),
             context,
@@ -616,6 +611,7 @@ class TestIcaMeteringExporterPlugin:
             metadata={
                 "gateway": {"name": "gw-name", "id": "gw-1"},
                 "meta_data": {"model": "gpt-4"},
+                GATEWAY_METADATA: {"name": "gw-name", "id": "gw-1", "transport": "streamablehttp"},
             },
         )
         await plugin.tool_pre_invoke(
@@ -643,7 +639,7 @@ class TestIcaMeteringExporterPlugin:
         assert td["serverName"] == "gw-name"
         assert td["gatewayId"] == "gw-1"
         assert td["integrationType"] == "MCP"
-        assert td["requestType"] == "SSE"
+        assert td["requestType"] == "STREAMABLE_HTTP"
         assert td["hasError"] is False
         assert td["errorMessage"] is None
         assert td["cached"] is False
@@ -979,7 +975,9 @@ class TestIcaMeteringExporterPlugin:
         plugin = _create_plugin(mock_send=False)
         assert plugin.http_client is not None
         response = MagicMock(status_code=403, text="forbidden")
-        plugin.http_client.post = AsyncMock(side_effect=httpx.HTTPStatusError("403 error", request=MagicMock(), response=response))
+        plugin.http_client.post = AsyncMock(
+            side_effect=httpx.HTTPStatusError("403 error", request=MagicMock(), response=response)
+        )
 
         await plugin._send_to_ica({"key": "value"})
 
@@ -1046,19 +1044,16 @@ class TestIcaMeteringExporterPlugin:
 
     # ── _coerce_int tests ─────────────────────────────────────────
 
-    @pytest.mark.parametrize(
-        "value,expected",
-        [
-            (None, None),
-            (42, 42),
-            (42.0, 42),
-            (42.7, 42),
-            ("42", 42),
-            ("abc", None),
-            ([], None),
-            ({}, None),
-        ],
-    )
+    @pytest.mark.parametrize("value,expected", [
+        (None, None),
+        (42, 42),
+        (42.0, 42),
+        (42.7, 42),
+        ("42", 42),
+        ("abc", None),
+        ([], None),
+        ({}, None),
+    ])
     def test_coerce_int(self, value, expected):
         """_coerce_int should safely convert values or return None."""
         assert IcaMeteringExporterPlugin._coerce_int(value) == expected
@@ -1074,18 +1069,14 @@ class TestIcaMeteringExporterPlugin:
 
     def test_get_service_jwt_uses_contextforge_metering_subject(self):
         """JWT should contain 'contextforge-metering' as subject."""
-        # Third-Party
         import jwt as pyjwt
-
         token = IcaMeteringExporterPlugin._get_service_jwt("test-secret-key-for-jwt-generation-test")
         decoded = pyjwt.decode(token, "test-secret-key-for-jwt-generation-test", algorithms=["HS256"])
         assert decoded["sub"] == "contextforge-metering"
 
     def test_get_service_jwt_has_service_attribution(self):
         """JWT should contain service, instance, and scope claims."""
-        # Third-Party
         import jwt as pyjwt
-
         token = IcaMeteringExporterPlugin._get_service_jwt("test-secret-key-for-jwt-generation-test")
         decoded = pyjwt.decode(token, "test-secret-key-for-jwt-generation-test", algorithms=["HS256"])
         assert decoded["service"] == "mcp-context-forge"
@@ -1095,12 +1086,8 @@ class TestIcaMeteringExporterPlugin:
 
     def test_get_service_jwt_expires_in_future(self):
         """JWT exp should be ~24h from now."""
-        # Standard
-        import time
-
-        # Third-Party
         import jwt as pyjwt
-
+        import time
         token = IcaMeteringExporterPlugin._get_service_jwt("test-secret-key-for-jwt-generation-test")
         decoded = pyjwt.decode(token, "test-secret-key-for-jwt-generation-test", algorithms=["HS256"])
         assert decoded["exp"] > time.time() + 86000  # ~23.9h
@@ -1109,14 +1096,11 @@ class TestIcaMeteringExporterPlugin:
     @pytest.mark.asyncio
     async def test_send_to_ica_uses_jwt_when_configured(self):
         """_send_to_ica should send Authorization: Bearer when jwt_secret is set."""
-        plugin = _create_plugin(
-            {
-                "enabled": True,
-                "metering_url": "http://localhost:8080/event",
-                "jwt_secret": "test-secret-key-for-jwt-generation-test",  # pragma: allowlist secret
-            },
-            mock_send=False,
-        )
+        plugin = _create_plugin({
+            "enabled": True,
+            "metering_url": "http://localhost:8080/event",
+            "jwt_secret": "test-secret-key-for-jwt-generation-test",
+        }, mock_send=False)
         assert plugin.http_client is not None
         plugin.http_client.post = AsyncMock(return_value=MagicMock(status_code=202))
 
@@ -1144,13 +1128,10 @@ class TestIcaMeteringExporterPlugin:
     @pytest.mark.asyncio
     async def test_send_to_ica_skips_when_no_auth_configured(self):
         """_send_to_ica should warn and skip when neither jwt_secret nor metering_token is set."""
-        plugin = _create_plugin(
-            {
-                "enabled": True,
-                "metering_url": "http://localhost:8080/event",
-            },
-            mock_send=False,
-        )
+        plugin = _create_plugin({
+            "enabled": True,
+            "metering_url": "http://localhost:8080/event",
+        }, mock_send=False)
         assert plugin.http_client is not None
         plugin.http_client.post = AsyncMock()
 
@@ -1163,7 +1144,6 @@ class TestIcaMeteringExporterPlugin:
     @pytest.mark.asyncio
     async def test_e2e_metering_payload_via_http(self):
         """Plugin sends correct JSON payload through real HTTP to metering endpoint."""
-        # Third-Party
         from httpx import MockTransport
 
         captured_body = None
@@ -1193,9 +1173,7 @@ class TestIcaMeteringExporterPlugin:
         )
         await plugin.tool_post_invoke(payload, context)
 
-        # Standard
         import json
-
         body = json.loads(captured_body.content)
         assert body["userEmail"] == "user@ibm.com"
         assert body["teamName"] == "team-1"
@@ -1212,7 +1190,6 @@ class TestIcaMeteringExporterPlugin:
     @pytest.mark.asyncio
     async def test_e2e_metering_payload_coerces_token_types(self):
         """Token values as float/string are coerced to int in HTTP payload."""
-        # Third-Party
         from httpx import MockTransport
 
         captured_body = None
@@ -1240,9 +1217,7 @@ class TestIcaMeteringExporterPlugin:
         )
         await plugin.tool_post_invoke(payload, context)
 
-        # Standard
         import json
-
         body = json.loads(captured_body.content)
         assert body["toolDetails"]["tokenInput"] == 10
         assert body["toolDetails"]["tokenOutput"] == 20

--- a/tests/unit/mcpgateway/plugins/plugins/ica_metering_exporter/test_ica_metering_exporter.py
+++ b/tests/unit/mcpgateway/plugins/plugins/ica_metering_exporter/test_ica_metering_exporter.py
@@ -7,13 +7,9 @@ Unit tests for IcaMeteringExporterPlugin.
 """
 
 # Standard
-from unittest.mock import ANY, AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 # Third-Party
-import httpx
-import pytest
-
-# First-Party
 from cpex.framework import (
     GlobalContext,
     PluginConfig,
@@ -23,6 +19,10 @@ from cpex.framework import (
     ToolPreInvokePayload,
 )
 from cpex.framework.constants import GATEWAY_METADATA
+import httpx
+import pytest
+
+# First-Party
 from plugins.ica_metering_exporter.ica_metering_exporter import IcaMeteringExporterPlugin
 
 
@@ -111,7 +111,8 @@ class TestIcaMeteringExporterPlugin:
         context = _create_context()
         await plugin.tool_pre_invoke(
             ToolPreInvokePayload(
-                name="tool", args={},
+                name="tool",
+                args={},
                 headers={"X-App-Id": "coding-agent:research"},
             ),
             context,
@@ -125,7 +126,8 @@ class TestIcaMeteringExporterPlugin:
         context = _create_context()
         await plugin.tool_pre_invoke(
             ToolPreInvokePayload(
-                name="tool", args={},
+                name="tool",
+                args={},
                 headers={"User-Agent": "ClaudeCode/1.2.3"},
             ),
             context,
@@ -139,7 +141,8 @@ class TestIcaMeteringExporterPlugin:
         context = _create_context()
         await plugin.tool_pre_invoke(
             ToolPreInvokePayload(
-                name="tool", args={},
+                name="tool",
+                args={},
                 headers={
                     "User-Agent": "JavaHttpClient/4.0",
                     "X-Forwarded-User-Agent": "ClaudeCode/1.2.3",
@@ -182,6 +185,188 @@ class TestIcaMeteringExporterPlugin:
         sent_payload = plugin._send_to_ica.await_args.args[0]
         assert sent_payload["appId"] is None
         assert sent_payload["userAgent"] is None
+
+    # ── Call-context (persona) header tests ─────────────────────
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_extracts_assistant_headers(self):
+        """Pre-invoke should extract llm_call_type and assistant headers."""
+        plugin = _create_plugin()
+        context = _create_context()
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(
+                name="tool",
+                args={},
+                headers={
+                    "llm_call_type": "assistant",
+                    "assistant_uuid": "assistant-123",
+                    "assistant_name": "Austin Weather",
+                },
+            ),
+            context,
+        )
+        assert context.state.get("ica_llm_call_type") == "assistant"
+        assert context.state.get("ica_assistant_uuid") == "assistant-123"
+        assert context.state.get("ica_assistant_name") == "Austin Weather"
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_extracts_agent_headers(self):
+        """Pre-invoke should extract llm_call_type and agent headers including tool ids."""
+        plugin = _create_plugin()
+        context = _create_context()
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(
+                name="tool",
+                args={},
+                headers={
+                    "llm_call_type": "agent",
+                    "agent_uuid": "agent-456",
+                    "agent_name": "Research Agent",
+                    "agent_tool_ids": "server:mcp:abc123,server:mcp:def456",
+                },
+            ),
+            context,
+        )
+        assert context.state.get("ica_llm_call_type") == "agent"
+        assert context.state.get("ica_agent_uuid") == "agent-456"
+        assert context.state.get("ica_agent_name") == "Research Agent"
+        assert context.state.get("ica_agent_tool_ids") == "server:mcp:abc123,server:mcp:def456"
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_extracts_digital_ibmer_headers(self):
+        """Pre-invoke should extract llm_call_type and digital-ibmer headers."""
+        plugin = _create_plugin()
+        context = _create_context()
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(
+                name="tool",
+                args={},
+                headers={
+                    "llm_call_type": "digital-ibmer",
+                    "digital-ibmer_uuid": "ibmer-789",
+                    "digital-ibmer_name": "Digital Coworker",
+                    "digital-ibmer_tool_ids": "server:mcp:xyz1",
+                },
+            ),
+            context,
+        )
+        assert context.state.get("ica_llm_call_type") == "digital-ibmer"
+        assert context.state.get("ica_digital_ibmer_uuid") == "ibmer-789"
+        assert context.state.get("ica_digital_ibmer_name") == "Digital Coworker"
+        assert context.state.get("ica_digital_ibmer_tool_ids") == "server:mcp:xyz1"
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_persona_headers_case_insensitive(self):
+        """Pre-invoke should extract persona headers regardless of casing."""
+        plugin = _create_plugin()
+        context = _create_context()
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(
+                name="tool",
+                args={},
+                headers={
+                    "LLM_CALL_TYPE": "assistant",
+                    "Assistant_Uuid": "assistant-111",
+                    "AGENT_TOOL_IDS": "server:mcp:abc",
+                },
+            ),
+            context,
+        )
+        assert context.state.get("ica_llm_call_type") == "assistant"
+        assert context.state.get("ica_assistant_uuid") == "assistant-111"
+        assert context.state.get("ica_agent_tool_ids") == "server:mcp:abc"
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_no_persona_headers_leave_state_empty(self):
+        """Pre-invoke should not store persona state when headers are absent."""
+        plugin = _create_plugin()
+        context = _create_context()
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers={"x-app-id": "ica-api-dev"}),
+            context,
+        )
+        for state_key in IcaMeteringExporterPlugin.CALL_CONTEXT_HEADERS:
+            assert state_key not in context.state
+
+    @pytest.mark.asyncio
+    async def test_post_invoke_emits_persona_fields(self):
+        """Post-invoke payload should include persona fields from state."""
+        plugin = _create_plugin()
+        context = _create_context()
+        context.state["ica_llm_call_type"] = "agent"
+        context.state["ica_agent_uuid"] = "agent-456"
+        context.state["ica_agent_name"] = "Research Agent"
+        context.state["ica_agent_tool_ids"] = "server:mcp:abc123"
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers=None),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["llmCallType"] == "agent"
+        assert sent_payload["agentUuid"] == "agent-456"
+        assert sent_payload["agentName"] == "Research Agent"
+        assert sent_payload["agentToolIds"] == "server:mcp:abc123"
+        assert sent_payload["appId"] is None
+
+    @pytest.mark.asyncio
+    async def test_post_invoke_persona_fields_none_when_not_set(self):
+        """Persona fields should be None in payload when no persona headers were present."""
+        plugin = _create_plugin()
+        context = _create_context()
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="tool", args={}, headers={}),
+            context,
+        )
+        payload = ToolPostInvokePayload(name="tool", result={"content": [], "isError": False})
+        await plugin.tool_post_invoke(payload, context)
+
+        sent_payload = plugin._send_to_ica.await_args.args[0]
+        assert sent_payload["llmCallType"] is None
+        assert sent_payload["assistantUuid"] is None
+        assert sent_payload["agentUuid"] is None
+        assert sent_payload["agentToolIds"] is None
+        assert sent_payload["digitalIbmerUuid"] is None
+        assert sent_payload["digitalIbmerToolIds"] is None
+
+    @pytest.mark.asyncio
+    async def test_post_invoke_emits_persona_fields_via_http(self):
+        """Persona fields propagate through real HTTP payload."""
+        # Third-Party
+        from httpx import MockTransport
+
+        captured_body = None
+
+        def transport_handler(request):
+            nonlocal captured_body
+            captured_body = request
+            return httpx.Response(202)
+
+        plugin = _create_plugin(mock_send=False)
+        plugin.http_client = httpx.AsyncClient(transport=MockTransport(transport_handler))
+
+        context = _create_context()
+        context.state["ica_llm_call_type"] = "assistant"
+        context.state["ica_assistant_uuid"] = "assistant-123"
+        await plugin.tool_pre_invoke(
+            ToolPreInvokePayload(name="echo", args={}, headers=None),
+            context,
+        )
+        payload = ToolPostInvokePayload(
+            name="echo",
+            result={"content": [{"type": "text", "text": "hello"}], "isError": False},
+        )
+        await plugin.tool_post_invoke(payload, context)
+
+        # Standard
+        import json
+
+        body = json.loads(captured_body.content)
+        assert body["llmCallType"] == "assistant"
+        assert body["assistantUuid"] == "assistant-123"
+        assert body["assistantName"] is None  # only populated when header present
 
     # ── Post-invoke latency tests ────────────────────────────────
 
@@ -234,7 +419,8 @@ class TestIcaMeteringExporterPlugin:
         plugin.telemetry_config["global_default_model"] = "global-model"
         await plugin.tool_pre_invoke(
             ToolPreInvokePayload(
-                name="tool", args={},
+                name="tool",
+                args={},
                 headers={"X-OpenWebUI-Model-Id": "header-model"},
             ),
             context,
@@ -347,9 +533,7 @@ class TestIcaMeteringExporterPlugin:
     @pytest.mark.asyncio
     async def test_model_source_tracking_when_enabled(self):
         """modelSource field should be emitted when include_model_source is true."""
-        plugin = _create_plugin({"enabled": True, "include_model_source": True,
-                                "metering_url": "http://localhost:8080/event",
-                                "metering_token": "test-token"})
+        plugin = _create_plugin({"enabled": True, "include_model_source": True, "metering_url": "http://localhost:8080/event", "metering_token": "test-token"})
         context = _create_context(metadata={"model_name": "session-model"})
         await plugin.tool_pre_invoke(
             ToolPreInvokePayload(name="tool", args={}, headers={}),
@@ -393,7 +577,8 @@ class TestIcaMeteringExporterPlugin:
         )
         await plugin.tool_pre_invoke(
             ToolPreInvokePayload(
-                name="tool", args={},
+                name="tool",
+                args={},
                 headers={"X-OpenWebUI-Model-Id": "header-model"},
             ),
             context,
@@ -794,9 +979,7 @@ class TestIcaMeteringExporterPlugin:
         plugin = _create_plugin(mock_send=False)
         assert plugin.http_client is not None
         response = MagicMock(status_code=403, text="forbidden")
-        plugin.http_client.post = AsyncMock(
-            side_effect=httpx.HTTPStatusError("403 error", request=MagicMock(), response=response)
-        )
+        plugin.http_client.post = AsyncMock(side_effect=httpx.HTTPStatusError("403 error", request=MagicMock(), response=response))
 
         await plugin._send_to_ica({"key": "value"})
 
@@ -863,16 +1046,19 @@ class TestIcaMeteringExporterPlugin:
 
     # ── _coerce_int tests ─────────────────────────────────────────
 
-    @pytest.mark.parametrize("value,expected", [
-        (None, None),
-        (42, 42),
-        (42.0, 42),
-        (42.7, 42),
-        ("42", 42),
-        ("abc", None),
-        ([], None),
-        ({}, None),
-    ])
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (None, None),
+            (42, 42),
+            (42.0, 42),
+            (42.7, 42),
+            ("42", 42),
+            ("abc", None),
+            ([], None),
+            ({}, None),
+        ],
+    )
     def test_coerce_int(self, value, expected):
         """_coerce_int should safely convert values or return None."""
         assert IcaMeteringExporterPlugin._coerce_int(value) == expected
@@ -888,14 +1074,18 @@ class TestIcaMeteringExporterPlugin:
 
     def test_get_service_jwt_uses_contextforge_metering_subject(self):
         """JWT should contain 'contextforge-metering' as subject."""
+        # Third-Party
         import jwt as pyjwt
+
         token = IcaMeteringExporterPlugin._get_service_jwt("test-secret-key-for-jwt-generation-test")
         decoded = pyjwt.decode(token, "test-secret-key-for-jwt-generation-test", algorithms=["HS256"])
         assert decoded["sub"] == "contextforge-metering"
 
     def test_get_service_jwt_has_service_attribution(self):
         """JWT should contain service, instance, and scope claims."""
+        # Third-Party
         import jwt as pyjwt
+
         token = IcaMeteringExporterPlugin._get_service_jwt("test-secret-key-for-jwt-generation-test")
         decoded = pyjwt.decode(token, "test-secret-key-for-jwt-generation-test", algorithms=["HS256"])
         assert decoded["service"] == "mcp-context-forge"
@@ -905,8 +1095,12 @@ class TestIcaMeteringExporterPlugin:
 
     def test_get_service_jwt_expires_in_future(self):
         """JWT exp should be ~24h from now."""
-        import jwt as pyjwt
+        # Standard
         import time
+
+        # Third-Party
+        import jwt as pyjwt
+
         token = IcaMeteringExporterPlugin._get_service_jwt("test-secret-key-for-jwt-generation-test")
         decoded = pyjwt.decode(token, "test-secret-key-for-jwt-generation-test", algorithms=["HS256"])
         assert decoded["exp"] > time.time() + 86000  # ~23.9h
@@ -915,11 +1109,14 @@ class TestIcaMeteringExporterPlugin:
     @pytest.mark.asyncio
     async def test_send_to_ica_uses_jwt_when_configured(self):
         """_send_to_ica should send Authorization: Bearer when jwt_secret is set."""
-        plugin = _create_plugin({
-            "enabled": True,
-            "metering_url": "http://localhost:8080/event",
-            "jwt_secret": "test-secret-key-for-jwt-generation-test",
-        }, mock_send=False)
+        plugin = _create_plugin(
+            {
+                "enabled": True,
+                "metering_url": "http://localhost:8080/event",
+                "jwt_secret": "test-secret-key-for-jwt-generation-test",
+            },
+            mock_send=False,
+        )
         assert plugin.http_client is not None
         plugin.http_client.post = AsyncMock(return_value=MagicMock(status_code=202))
 
@@ -947,10 +1144,13 @@ class TestIcaMeteringExporterPlugin:
     @pytest.mark.asyncio
     async def test_send_to_ica_skips_when_no_auth_configured(self):
         """_send_to_ica should warn and skip when neither jwt_secret nor metering_token is set."""
-        plugin = _create_plugin({
-            "enabled": True,
-            "metering_url": "http://localhost:8080/event",
-        }, mock_send=False)
+        plugin = _create_plugin(
+            {
+                "enabled": True,
+                "metering_url": "http://localhost:8080/event",
+            },
+            mock_send=False,
+        )
         assert plugin.http_client is not None
         plugin.http_client.post = AsyncMock()
 
@@ -963,6 +1163,7 @@ class TestIcaMeteringExporterPlugin:
     @pytest.mark.asyncio
     async def test_e2e_metering_payload_via_http(self):
         """Plugin sends correct JSON payload through real HTTP to metering endpoint."""
+        # Third-Party
         from httpx import MockTransport
 
         captured_body = None
@@ -992,7 +1193,9 @@ class TestIcaMeteringExporterPlugin:
         )
         await plugin.tool_post_invoke(payload, context)
 
+        # Standard
         import json
+
         body = json.loads(captured_body.content)
         assert body["userEmail"] == "user@ibm.com"
         assert body["teamName"] == "team-1"
@@ -1009,6 +1212,7 @@ class TestIcaMeteringExporterPlugin:
     @pytest.mark.asyncio
     async def test_e2e_metering_payload_coerces_token_types(self):
         """Token values as float/string are coerced to int in HTTP payload."""
+        # Third-Party
         from httpx import MockTransport
 
         captured_body = None
@@ -1036,7 +1240,9 @@ class TestIcaMeteringExporterPlugin:
         )
         await plugin.tool_post_invoke(payload, context)
 
+        # Standard
         import json
+
         body = json.loads(captured_body.content)
         assert body["toolDetails"]["tokenInput"] == 10
         assert body["toolDetails"]["tokenOutput"] == 20


### PR DESCRIPTION
## Problem

There is no visibility into MCP tool invocations flowing through the gateway from ICA Open WebUI: which team/user invoked a tool, against which virtual server, with what latency, and — critically — **which assistant, agent, or Digital IBMer context triggered the call**. Without this, ICA-wide usage analytics (per-app, per-assistant, per-tenant) cannot be built.

Closes #5694

## Related

- Companion PR: ICA20/ica-core-services #265 (MCP tool metering endpoint)
- Companion PR: ICA20/ica-open-webui #445 (model/trace metadata)

## Solution

Add a native **ICA Metering Exporter** plugin that captures MCP tool invocation metrics and exports them to the ICA core-services metering endpoint as structured JSON, mirroring the trust model of `ica-litellm-extensions/ica_metering_callbacks.py`:

- `appId` is authoritative (developer-key bound, read from the `X-App-Id` transport header) — key-minted per-developer identity
- Assistant/agent/Digital IBMer context is **client-declared** via transport headers with the *same header names* the LLM metering callbacks use, keeping the MCP and LLM metering pipelines symmetric (`llm_call_type`, `assistant_name/uuid`, `agent_name/uuid`, `agent_tool_ids`, `digital-ibmer_name/uuid`, `digital-ibmer_tool_ids`)

The plugin hooks `tool_pre_invoke`/`tool_post_invoke` (registered in `plugins/config.yaml`), so no changes to core proxy routing are required.

## Implementation Details

- **Plugin scaffolding** — `plugins/ica_metering_exporter/` with `plugin-manifest.yaml`, `README.md`, and registration in `plugins/config.yaml`
- **Capture** — `IcaMeteringExporterPlugin.tool_pre_invoke` (`plugin.py`) records invocation start, model id, and persona context; `tool_post_invoke` builds the payload and fire-and-forgets to `metering_url`
- **Call-context attribution** — `CALL_CONTEXT_HEADERS` mapping + case-insensitive `_get_header`; persona fields are emitted only when declared by the caller, never fabricated
- **Model name cascade** — layered fallback (transport header, plugin env, per-gateway config, global default, context metadata) rather than a single source
- **Auth** — metering export authenticates to the ICA endpoint with a **JWT service token** (HMAC-signed with the shared `jwt_secret`), including `service`/`instance`/`scope` claims for multi-instance deployments
- **Payload** — user/team identity (derived server-side), `appId`, `toolDetails` (name, server id, gateway metadata), latency, error state, token counts, and the persona fields

## Testing

- `tests/unit/mcpgateway/plugins/plugins/ica_metering_exporter/test_ica_metering_exporter.py` — 78 tests covering payload emission (unit + real HTTP), JWT signature/claims, appId + persona header extraction (incl. case variants and absent-header fail-safe), model cascade resolution, token coercion, latency, and error handling
- Full plugin suite green; `ruff`, `black`, `isort` clean; `mypy` reports zero errors on the plugin file

## Breaking Changes

None — the plugin is **disabled by default** (`enabled: false`; `mode: disabled` in README sample). No changes to existing routes, schemas, or transports.

## Checklist

- [x] Tests pass locally
- [x] Lint clean (ruff, black, isort, mypy on changed files)
- [x] Plugin disabled by default
- [x] No secrets committed (shared token sourced from `${MCP_METERING_TOKEN}`)
