### PR TITLE
fix(ui): Add static assets to CSS bundle

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -59,7 +59,7 @@ include .snyk
 
 # Runtime data that lives *inside* the package at import time
 recursive-include mcpgateway/templates *.html
-recursive-include mcpgateway/static *.css *.js *.gif *.png *.svg
+recursive-include mcpgateway/static *.css *.js *.gif *.png *.svg *.ttf *.woff *.woff2
 recursive-include mcpgateway/admin_ui *.js
 exclude mcpgateway/static/iframe-test-harness.html
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -29,6 +29,7 @@ function cleanOldBundles() {
 }
 
 export default defineConfig({
+  base: '/static/',
   build: {
     minify: 'terser',
     // lightningcss ships no linux-ppc64(le)/s390x native binary, so fall back


### PR DESCRIPTION
## 📌 Summary

Fix loading screen/PW update screen icons
Closes: #5704

<img width="511" height="385" alt="Screenshot 2026-07-20 at 10 26 57" src="https://github.com/user-attachments/assets/e0fb407b-1a9e-4c97-af8a-baa779a5f7fc" />

## 🔁 Reproduction Steps

1. Start the app
2. Open the login screen

## 🐞 Root Cause

The fonts were not bundled along with the CSS rules.

## 💡 Fix Description

Add the static assets to the bundle.

## 📏 Reviewability

- [X] This PR has one clear purpose
- [X] The linked issue is not labeled `triage`
- [X] Unrelated bugs or improvements are tracked in separate issues/PRs
- [X] Tests are included with the code they validate
- [X] If AI-assisted, I understand and can explain the generated changes
