### PR TITLE
refactor(ui): reuse shared button components

### DIFF
--- a/client/src/components/gateways/CreateServerForm.tsx
+++ b/client/src/components/gateways/CreateServerForm.tsx
@@ -203,8 +203,9 @@ export function CreateServerForm({
           </div>
         </div>
 
-        <button
+        <Button
           type="button"
+          variant="ghost"
           onClick={() => setOptionalOpen((current) => !current)}
           className="flex h-12 w-full items-center gap-3 rounded-md border border-border px-4 text-left text-sm font-medium text-muted-foreground transition hover:bg-muted/40 hover:text-foreground dark:border-[#252529]"
           aria-expanded={optionalOpen}
@@ -215,7 +216,7 @@ export function CreateServerForm({
             aria-hidden="true"
           />
           {intl.formatMessage({ id: "gateways.createServer.optionalConfiguration" })}
-        </button>
+        </Button>
 
         {optionalOpen && (
           <div id="optional-server-configuration" className="grid gap-7">

--- a/client/src/components/gateways/SourceSelection.tsx
+++ b/client/src/components/gateways/SourceSelection.tsx
@@ -267,8 +267,9 @@ export function SourceSelection({
 
         {createServerActions && (
           <div className="space-y-7">
-            <button
+            <Button
               type="button"
+              variant="ghost"
               onClick={handleToggleComponentsPanel}
               aria-expanded={isComponentsPanelOpen}
               aria-controls={panelId}
@@ -288,7 +289,7 @@ export function SourceSelection({
                   aria-hidden="true"
                 />
               )}
-            </button>
+            </Button>
 
             {isComponentsPanelOpen && (
               <section

--- a/client/src/components/gateways/VirtualServerDetailsPanel.tsx
+++ b/client/src/components/gateways/VirtualServerDetailsPanel.tsx
@@ -454,10 +454,12 @@ export function VirtualServerDetailsPanel({
                     const isSelected = sourceFilter === source.id;
 
                     return (
-                      <button
+                      <Button
                         key={source.id}
                         id={`source-tab-${index}`}
                         type="button"
+                        variant="ghost"
+                        size="sm"
                         role="tab"
                         aria-selected={isSelected}
                         tabIndex={isSelected ? 0 : -1}
@@ -471,7 +473,7 @@ export function VirtualServerDetailsPanel({
                         onKeyDown={(e) => handleSourceTabKeyDown(e, index, sources.length)}
                       >
                         {source.label}
-                      </button>
+                      </Button>
                     );
                   })}
                 </div>
@@ -484,10 +486,12 @@ export function VirtualServerDetailsPanel({
                   className="flex min-w-0 items-center gap-6"
                 >
                   {COMPONENT_FILTER_OPTIONS.map((option) => (
-                    <button
+                    <Button
                       key={option.value}
                       id={`tab-${option.value}`}
                       type="button"
+                      variant="ghost"
+                      size="sm"
                       role="tab"
                       aria-selected={componentFilter === option.value}
                       tabIndex={componentFilter === option.value ? 0 : -1}
@@ -500,7 +504,7 @@ export function VirtualServerDetailsPanel({
                       onKeyDown={(e) => handleTabKeyDown(e, option.value)}
                     >
                       {intl.formatMessage({ id: option.labelId })}
-                    </button>
+                    </Button>
                   ))}
                 </div>
                 <div className="flex items-center gap-2">

--- a/client/src/components/layout/HeaderQuickNav.tsx
+++ b/client/src/components/layout/HeaderQuickNav.tsx
@@ -366,10 +366,11 @@ export function HeaderQuickNav() {
             const isFocused = resultIndex === focusedResultIndex;
 
             return (
-              <button
+              <Button
                 id={`quick-nav-result-${resultIndex}`}
                 key={`${group.entity_type}-${item.id}`}
                 type="button"
+                variant="ghost"
                 role="option"
                 tabIndex={-1}
                 aria-selected={isFocused}
@@ -384,7 +385,7 @@ export function HeaderQuickNav() {
                 {item.summary && item.summary !== item.name ? (
                   <span className="truncate text-xs text-muted-foreground">{item.summary}</span>
                 ) : null}
-              </button>
+              </Button>
             );
           })}
         </div>

--- a/client/src/components/mcp-servers/MCPServerForm.tsx
+++ b/client/src/components/mcp-servers/MCPServerForm.tsx
@@ -162,8 +162,9 @@ export function MCPServerForm({ isOpen, onToggle, serverId, onSuccess }: MCPServ
               {
                 "Context Forge will discover the server's tools, resources, and prompts. The MCP server should be running and reachable. Or, choose a server from the"
               }{" "}
-              <button
+              <Button
                 type="button"
+                variant="link"
                 onClick={() => {
                   onToggle();
                   navigate("/app/server-catalog");
@@ -171,7 +172,7 @@ export function MCPServerForm({ isOpen, onToggle, serverId, onSuccess }: MCPServ
                 className="font-medium text-cyan-700 underline decoration-cyan-300 underline-offset-4 transition hover:text-cyan-800 dark:text-cyan-400 dark:decoration-cyan-700 dark:hover:text-cyan-300"
               >
                 mcp server catalog
-              </button>
+              </Button>
               .
             </p>
           </div>
@@ -289,15 +290,16 @@ export function MCPServerForm({ isOpen, onToggle, serverId, onSuccess }: MCPServ
             </div>
 
             <div className="flex flex-col gap-5 pt-2">
-              <button
+              <Button
                 type="button"
+                variant="ghost"
                 onClick={() => setAdvancedOpen((current) => !current)}
                 className="inline-flex w-full items-center gap-2 rounded-md border border-neutral-200 px-3 py-2 text-sm font-medium text-neutral-600 transition hover:text-neutral-950 dark:border-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-300"
                 aria-expanded={advancedOpen}
               >
                 <ChevronDown className={`h-4 w-4 transition ${advancedOpen ? "rotate-180" : ""}`} />
                 Advanced settings
-              </button>
+              </Button>
 
               {advancedOpen && (
                 <AdvancedSettings

--- a/client/src/components/servers/MCPServerDetailsPanel.tsx
+++ b/client/src/components/servers/MCPServerDetailsPanel.tsx
@@ -336,10 +336,12 @@ export function MCPServerDetailsPanel({
                   className="flex min-w-0 items-center gap-6"
                 >
                   {TABS.map((tab) => (
-                    <button
+                    <Button
                       key={tab.value}
                       id={`tab-${tab.value}`}
                       type="button"
+                      variant="ghost"
+                      size="sm"
                       role="tab"
                       aria-selected={activeTab === tab.value}
                       tabIndex={activeTab === tab.value ? 0 : -1}
@@ -352,7 +354,7 @@ export function MCPServerDetailsPanel({
                       onKeyDown={(e) => handleTabKeyDown(e, tab.value)}
                     >
                       {tab.label}
-                    </button>
+                    </Button>
                   ))}
                 </div>
 

--- a/client/src/components/servers/ServersTable.tsx
+++ b/client/src/components/servers/ServersTable.tsx
@@ -25,6 +25,7 @@ import { ServerActionsMenu } from "./ServerActionsMenu";
 import type { MCPServer, ServerStatus } from "../../types/server";
 import { Loading } from "../ui/loading";
 import { formatLocalDateTime } from "../../utils/formatDate";
+import { Button } from "@/components/ui/button";
 
 function getLastSeenValue(server: MCPServer): string | undefined {
   return server.lastSeen;
@@ -224,8 +225,10 @@ export function ServersTable({
                   {formatLocalDateTime(lastSeen, intl.formatMessage({ id: "mcpServer.neverUsed" }))}
                 </TableCell>
                 <TableCell className="px-4 py-2.5">
-                  <button
+                  <Button
                     type="button"
+                    variant="ghost"
+                    size="sm"
                     onClick={() => handleCopy(server.id)}
                     className="inline-flex items-center gap-2 text-xs text-neutral-600 dark:text-neutral-400 transition hover:text-neutral-900 dark:hover:text-neutral-200"
                     aria-label={`Copy UUID for ${server.name}`}
@@ -239,7 +242,7 @@ export function ServersTable({
                     ) : (
                       <Copy className="h-3.5 w-3.5" aria-hidden="true" />
                     )}
-                  </button>
+                  </Button>
                 </TableCell>
                 <TableCell className="px-4 py-2.5">
                   <div className="inline-flex items-center gap-1.5 text-xs text-neutral-600 dark:text-neutral-400">

--- a/client/src/components/tools/ToolForm.tsx
+++ b/client/src/components/tools/ToolForm.tsx
@@ -476,8 +476,9 @@ export function ToolForm({ isOpen, onToggle, onSuccess, tool }: ToolFormProps) {
                 )}
               </div>
 
-              <button
+              <Button
                 type="button"
+                variant="ghost"
                 onClick={() => setAdvancedOpen((current) => !current)}
                 className="inline-flex w-full items-center gap-2 rounded-md border border-neutral-200 px-3 py-2 text-sm font-medium text-neutral-600 transition hover:text-neutral-950 dark:border-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-300"
                 aria-expanded={advancedOpen}
@@ -485,7 +486,7 @@ export function ToolForm({ isOpen, onToggle, onSuccess, tool }: ToolFormProps) {
               >
                 <ChevronDown className={`h-4 w-4 transition ${advancedOpen ? "rotate-180" : ""}`} />
                 {intl.formatMessage({ id: "tools.form.advancedSettings" })}
-              </button>
+              </Button>
 
               {advancedOpen && (
                 <div id="advanced-settings-panel">

--- a/client/src/components/ui/inline-notification.tsx
+++ b/client/src/components/ui/inline-notification.tsx
@@ -1,4 +1,5 @@
 import { CircleCheck, CircleAlert, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 interface InlineNotificationProps {
   type: "success" | "error";
@@ -31,14 +32,16 @@ export function InlineNotification({
         </p>
       </div>
       {onDismiss && (
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          size="icon"
           onClick={onDismiss}
           aria-label={dismissLabel}
           className="ml-2 shrink-0 p-1 opacity-60 hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
         >
           <X className="h-4 w-4" aria-hidden="true" />
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/client/src/components/ui/inline-tag-add.tsx
+++ b/client/src/components/ui/inline-tag-add.tsx
@@ -131,8 +131,10 @@ export function InlineTagAdd({
       <dd className="flex min-w-0 flex-wrap items-center gap-2 text-foreground">
         {children}
         {!editing && (
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
             disabled={!onAdd}
             onClick={() => setEditing(true)}
             aria-label={ariaLabel}
@@ -143,7 +145,7 @@ export function InlineTagAdd({
           >
             <Plus className="size-3" aria-hidden="true" />
             {addLabel}
-          </button>
+          </Button>
         )}
       </dd>
 

--- a/client/src/components/users/PasswordInput.tsx
+++ b/client/src/components/users/PasswordInput.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { Eye, EyeOff } from "lucide-react";
 import { useIntl } from "react-intl";
 import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
 
 interface PasswordInputProps {
   id: string;
@@ -33,7 +35,7 @@ export function PasswordInput({
 
   return (
     <div className="space-y-1">
-      <label
+      <Label
         htmlFor={id}
         className="inline-flex items-center gap-0.5 text-sm font-medium text-neutral-900 dark:text-neutral-100"
       >
@@ -46,7 +48,7 @@ export function PasswordInput({
             <span className="sr-only">(required)</span>
           </>
         )}
-      </label>
+      </Label>
       <div className="relative">
         <Input
           id={id}
@@ -59,8 +61,10 @@ export function PasswordInput({
           aria-invalid={!!error}
           aria-describedby={error ? errorId : hint ? hintId : undefined}
         />
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          size="icon"
           onClick={() => setShowPassword((v) => !v)}
           className="absolute inset-y-0 right-0 flex items-center px-3 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"
           aria-label={intl.formatMessage({
@@ -73,7 +77,7 @@ export function PasswordInput({
           ) : (
             <Eye className="h-4 w-4" aria-hidden="true" />
           )}
-        </button>
+        </Button>
       </div>
       {error ? (
         <p id={errorId} className="text-sm text-red-600 dark:text-red-400" role="alert">

--- a/client/src/components/users/UserActionsMenu.tsx
+++ b/client/src/components/users/UserActionsMenu.tsx
@@ -7,6 +7,7 @@ import {
 } from "../ui/dropdown-menu";
 import { useIntl } from "react-intl";
 import type { User } from "../../types/user";
+import { Button } from "@/components/ui/button";
 
 interface UserActionsMenuProps {
   user: User;
@@ -21,8 +22,10 @@ export function UserActionsMenu({ user, displayName, onEdit, onDelete }: UserAct
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          size="icon"
           className="inline-flex h-5 w-5 items-center justify-center rounded-sm transition-colors hover:text-card-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           aria-label={intl.formatMessage(
             { id: "users.table.actions.label" },
@@ -31,7 +34,7 @@ export function UserActionsMenu({ user, displayName, onEdit, onDelete }: UserAct
           aria-haspopup="menu"
         >
           <MoreVertical className="h-5 w-5" strokeWidth={1.25} aria-hidden="true" />
-        </button>
+        </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" role="menu">
         <DropdownMenuItem onClick={() => onEdit(user)} role="menuitem">

--- a/client/src/components/users/UserForm.tsx
+++ b/client/src/components/users/UserForm.tsx
@@ -236,8 +236,9 @@ export function UserForm({
             )}
 
             <div className="flex flex-col gap-5 pt-2">
-              <button
+              <Button
                 type="button"
+                variant="ghost"
                 onClick={() => setAdvancedOpen((current) => !current)}
                 className="inline-flex w-full items-center gap-2 rounded-md border border-neutral-200 px-3 py-2 text-sm font-medium text-neutral-600 transition hover:text-neutral-950 dark:border-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-300"
                 aria-expanded={advancedOpen}
@@ -248,7 +249,7 @@ export function UserForm({
                   aria-hidden="true"
                 />
                 {intl.formatMessage({ id: "users.form.advancedSettings" })}
-              </button>
+              </Button>
 
               {advancedOpen && (
                 <div

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -3,6 +3,9 @@ import { useIntl } from "react-intl";
 import { useAuth } from "../auth/useAuth";
 import { useRouter } from "../router";
 import { ApiError } from "../api/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 
 export function Login() {
   const intl = useIntl();
@@ -49,13 +52,13 @@ export function Login() {
         </h1>
         <form onSubmit={handleSubmit} className="space-y-4" noValidate>
           <div>
-            <label
+            <Label
               htmlFor="email"
               className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1"
             >
               {intl.formatMessage({ id: "auth.login.email" })}
-            </label>
-            <input
+            </Label>
+            <Input
               id="email"
               type="email"
               autoComplete="email"
@@ -66,13 +69,13 @@ export function Login() {
             />
           </div>
           <div>
-            <label
+            <Label
               htmlFor="password"
               className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1"
             >
               {intl.formatMessage({ id: "auth.login.password" })}
-            </label>
-            <input
+            </Label>
+            <Input
               id="password"
               type="password"
               autoComplete="current-password"
@@ -87,7 +90,7 @@ export function Login() {
               {error}
             </p>
           )}
-          <button
+          <Button
             type="submit"
             disabled={loading}
             className="w-full bg-neutral-900 dark:bg-neutral-700 text-white rounded px-3 py-2 text-sm font-medium hover:bg-neutral-700 dark:hover:bg-neutral-600 disabled:opacity-50 transition-colors"
@@ -95,15 +98,17 @@ export function Login() {
             {loading
               ? intl.formatMessage({ id: "auth.login.submitting" })
               : intl.formatMessage({ id: "auth.login.submit" })}
-          </button>
+          </Button>
         </form>
         <div className="mt-4 text-center">
-          <button
+          <Button
+            type="button"
+            variant="ghost"
             onClick={() => navigate("/app/forgot-password")}
             className="text-sm text-neutral-500 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors"
           >
             {intl.formatMessage({ id: "auth.login.forgotPassword" })}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/client/src/pages/NotFound.tsx
+++ b/client/src/pages/NotFound.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from "../router";
+import { Button } from "@/components/ui/button";
 
 export function NotFound() {
   const { navigate } = useRouter();
@@ -6,12 +7,14 @@ export function NotFound() {
     <div className="flex flex-col items-center justify-center h-full gap-4">
       <p className="text-4xl font-bold text-neutral-300 dark:text-neutral-600">404</p>
       <p className="text-neutral-500 dark:text-neutral-400">Page not found.</p>
-      <button
+      <Button
+        type="button"
+        variant="link"
         onClick={() => navigate("/app/")}
         className="text-sm text-neutral-900 dark:text-neutral-100 underline hover:no-underline"
       >
         Go to Dashboard
-      </button>
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #5280

---

## 📝 Summary

Consolidates application-level native buttons onto shared `Button` component. Login fields and labels now use shared `Input` and `Label` components. This standardizes variants, disabled behavior, focus styles, and component composition while preserving existing interaction semantics.

Intentional low-level native controls remain in UI primitive implementations and specialized radio/file inputs.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [x] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|-------|---------|--------|
| Client lint | `cd client && npm run lint -- --quiet` | Passed |
| Client unit tests | `cd client && npm run test:run` | 2,090 passed, 1 skipped |
| Client production build | `cd client && npm run build` | Passed |

---

## ✅ Checklist

- [x] Code formatted (`npm exec prettier`)
- [ ] Tests added/updated for changes
- [x] Documentation updated (not applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

`SidebarRail` keeps its native button because it is itself a low-level shared UI primitive. Native radio and file inputs remain where their specialized behavior is intentional.
