### PR TITLE
fix: use opaque dataplane subject ids

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-28T12:35:16Z",
+  "generated_at": "2026-07-28T15:15:04Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1208,7 +1208,7 @@
         "hashed_secret": "8d7348c4fe7cb659a9ea4ce55d22de30e3ab2c06",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 59,
+        "line_number": 72,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1216,7 +1216,7 @@
         "hashed_secret": "252d0a1297cb2a9a2e3caaedd9c233612a1fc78f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 60,
+        "line_number": 73,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1224,7 +1224,7 @@
         "hashed_secret": "e689846dfc65621eeab3a906bb8b0ddd52f5c514",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 158,
+        "line_number": 171,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-28T15:15:04Z",
+  "generated_at": "2026-07-28T15:15:48Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1208,7 +1208,7 @@
         "hashed_secret": "8d7348c4fe7cb659a9ea4ce55d22de30e3ab2c06",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 72,
+        "line_number": 73,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1216,7 +1216,7 @@
         "hashed_secret": "252d0a1297cb2a9a2e3caaedd9c233612a1fc78f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 73,
+        "line_number": 74,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1224,7 +1224,7 @@
         "hashed_secret": "e689846dfc65621eeab3a906bb8b0ddd52f5c514",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 171,
+        "line_number": 172,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/architecture/security-features.md
+++ b/docs/docs/architecture/security-features.md
@@ -35,24 +35,37 @@ The `jti` (JWT ID) claim is a unique identifier for each JWT token, defined in [
 
 **Token Generation Examples**:
 
+New service-issued tokens use an opaque user identifier in `sub` (`EmailUser.id` when available). Human-readable email
+identity is retained in signed metadata where needed, such as `user.email` on API tokens. Legacy tokens with
+`sub=<email>` continue to authenticate for backward compatibility.
+
 ```python
-# Email auth tokens (always include JTI)
+# Email-auth session tokens (always include JTI; teams/admin are resolved server-side)
 # Location: mcpgateway/routers/email_auth.py
 payload = {
-    "sub": user.email,
+    "sub": str(user.id),
     "jti": str(uuid.uuid4()),  # Unique per token
+    "token_use": "session",
     ...
 }
 
-# Load test tokens (configurable)
-# Location: tests/loadtest/locustfile.py
+# Token-catalog API tokens
+# Location: mcpgateway/services/token_catalog_service.py
 payload = {
-    "sub": JWT_USERNAME,
-    "jti": str(uuid.uuid4()),  # Added for proper cache keying
-    "exp": datetime.now(timezone.utc) + timedelta(hours=JWT_TOKEN_EXPIRY_HOURS),
+    "sub": str(user.id),
+    "jti": str(uuid.uuid4()),
+    "token_use": "api",
+    "user": {
+        "email": user.email,
+        "auth_provider": "api_token",
+        ...
+    },
     ...
 }
 ```
+
+Hand-minted and legacy tokens may still use `sub=<email>`, but new integrations should treat `sub` as opaque and read
+the human identity from signed email metadata when it is present.
 
 **Cache Behavior**:
 

--- a/docs/docs/architecture/security-features.md
+++ b/docs/docs/architecture/security-features.md
@@ -35,9 +35,10 @@ The `jti` (JWT ID) claim is a unique identifier for each JWT token, defined in [
 
 **Token Generation Examples**:
 
-New service-issued tokens use an opaque user identifier in `sub` (`EmailUser.id` when available). Human-readable email
-identity is retained in signed metadata where needed, such as `user.email` on API tokens. Legacy tokens with
-`sub=<email>` continue to authenticate for backward compatibility.
+New session tokens and token-catalog API tokens issued through normal user-backed flows use an opaque user identifier in
+`sub` (`EmailUser.id`). This applies to API tokens platform-wide, not only tokens used with the Rust dataplane.
+Human-readable email identity is retained in signed metadata where needed, such as `user.email` on API tokens. Legacy
+tokens with `sub=<email>` continue to authenticate for backward compatibility.
 
 ```python
 # Email-auth session tokens (always include JTI; teams/admin are resolved server-side)
@@ -64,8 +65,8 @@ payload = {
 }
 ```
 
-Hand-minted and legacy tokens may still use `sub=<email>`, but new integrations should treat `sub` as opaque and read
-the human identity from signed email metadata when it is present.
+Hand-minted, no-user-record fallback, and legacy tokens may still use `sub=<email>`, but new integrations should treat
+`sub` as opaque and read the human identity from signed email metadata when it is present.
 
 **Cache Behavior**:
 

--- a/docs/docs/using/agents/a2a.md
+++ b/docs/docs/using/agents/a2a.md
@@ -457,8 +457,8 @@ Before running the demo agent, ensure the following configuration:
 
   The script creates a JWT signed with your instance's secret. The token identity must resolve to a user in the
   database. The helper commands below pass your `PLATFORM_ADMIN_EMAIL` as a legacy email subject; service-issued tokens
-  may instead use an opaque UUID subject with signed email metadata. See the "Running the Demo" section below for the
-  actual commands.
+  now use opaque UUID subjects for token-catalog API tokens platform-wide and carry the human email in signed metadata
+  such as `user.email`. See the "Running the Demo" section below for the actual commands.
 
 #### Running the Demo
 

--- a/docs/docs/using/agents/a2a.md
+++ b/docs/docs/using/agents/a2a.md
@@ -453,9 +453,12 @@ Before running the demo agent, ensure the following configuration:
 
   Restart ContextForge after adding this. The default blocks loopback addresses as an SSRF safeguard. This is intentional for production, but must be opted into locally.
 
-2. **Pass your admin email at runtime**
+2. **Pass an admin identity at runtime**
 
-  The script creates a JWT signed with your instance's secret. The token subject must match a user in the database (typically your `PLATFORM_ADMIN_EMAIL`). See the "Running the Demo" section below for the actual commands.
+  The script creates a JWT signed with your instance's secret. The token identity must resolve to a user in the
+  database. The helper commands below pass your `PLATFORM_ADMIN_EMAIL` as a legacy email subject; service-issued tokens
+  may instead use an opaque UUID subject with signed email metadata. See the "Running the Demo" section below for the
+  actual commands.
 
 #### Running the Demo
 
@@ -464,7 +467,7 @@ Before running the demo agent, ensure the following configuration:
 make dev
 
 # Terminal 2: Start the demo agent (auto-registers with ContextForge)
-# Override the token subject if your admin email differs from the default:
+# Override the admin email if it differs from the default:
 #   export PLATFORM_ADMIN_EMAIL=you@example.com
 uv run python scripts/demo_a2a_agent.py
 

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -80,6 +80,7 @@ from sqlalchemy.orm import Session
 from starlette.requests import Request
 
 # First-Party
+from mcpgateway.auth_context import normalize_token_teams
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.db import EmailUser, fresh_db_session, SessionLocal
@@ -565,59 +566,6 @@ async def resolve_session_teams(
         db_teams = await _resolve_teams_from_db(email, user_info)
 
     return _narrow_by_jwt_teams(payload, db_teams)
-
-
-def normalize_token_teams(payload: Dict[str, Any]) -> Optional[List[str]]:
-    """
-    Normalize token teams to a canonical form for consistent security checks.
-
-    SECURITY: This is the single source of truth for token team normalization.
-    All code paths that read token teams should use this function.
-
-    Rules:
-    - "teams" key missing → [] (public-only, secure default)
-    - "teams" is null + is_admin=true → None (admin bypass, sees all)
-    - "teams" is null + is_admin=false → [] (public-only, no bypass for non-admins)
-    - "teams" is [] → [] (explicit public-only)
-    - "teams" is [...] → normalized list of string IDs
-
-    Args:
-        payload: The JWT payload dict
-
-    Returns:
-        None for admin bypass, [] for public-only, or list of normalized team ID strings
-    """
-    # Check if "teams" key exists (distinguishes missing from explicit null)
-    if "teams" not in payload:
-        # Missing teams key → public-only (secure default)
-        return []
-
-    teams = payload.get("teams")
-
-    if teams is None:
-        # Explicit null - only allow admin bypass if is_admin is true
-        # Check BOTH top-level is_admin AND nested user.is_admin
-        is_admin = payload.get("is_admin", False)
-        if not is_admin:
-            user_info = payload.get("user", {})
-            is_admin = user_info.get("is_admin", False) if isinstance(user_info, dict) else False
-        if is_admin:
-            # Admin with explicit null teams → admin bypass (sees all)
-            return None
-        # Non-admin with null teams → public-only (no bypass)
-        return []
-
-    # teams is a list - normalize to string IDs
-    # Handle both dict format [{"id": "team1"}] and string format ["team1"]
-    normalized: List[str] = []
-    for team in teams:
-        if isinstance(team, dict):
-            team_id = team.get("id")
-            if team_id:
-                normalized.append(str(team_id))
-        elif isinstance(team, str):
-            normalized.append(team)
-    return normalized
 
 
 async def get_team_from_token(payload: Dict[str, Any]) -> Optional[str]:

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -635,7 +635,8 @@ async def get_team_from_token(payload: Dict[str, Any]) -> Optional[str]:
     Args:
         payload (Dict[str, Any]):
             The token payload. Expected fields:
-            - "sub" (str): The user's unique identifier (email).
+            - "sub" (str): Opaque user subject. New service-issued tokens use
+              ``EmailUser.id``; legacy tokens may contain the user email.
             - "teams" (List[str], optional): List containing team ID.
 
     Returns:
@@ -645,17 +646,17 @@ async def get_team_from_token(payload: Dict[str, Any]) -> Optional[str]:
     Examples:
         >>> import asyncio
         >>> # --- Case 1: Token has team ---
-        >>> payload = {"sub": "user@example.com", "teams": ["team_456"]}
+        >>> payload = {"sub": "550e8400-e29b-41d4-a716-446655440000", "teams": ["team_456"]}
         >>> asyncio.run(get_team_from_token(payload))
         'team_456'
 
         >>> # --- Case 2: Token has explicit empty teams (public-only) ---
-        >>> payload = {"sub": "user@example.com", "teams": []}
+        >>> payload = {"sub": "550e8400-e29b-41d4-a716-446655440000", "teams": []}
         >>> asyncio.run(get_team_from_token(payload))  # Returns None
         >>> # None
 
         >>> # --- Case 3: Token has no teams key (secure default) ---
-        >>> payload = {"sub": "user@example.com"}
+        >>> payload = {"sub": "550e8400-e29b-41d4-a716-446655440000"}
         >>> asyncio.run(get_team_from_token(payload))  # Returns None
         >>> # None
     """
@@ -1564,11 +1565,16 @@ async def get_current_user(
         payload = await verify_jwt_token_cached(credentials.credentials, request)
 
         logger.debug("JWT token validated successfully")
-        # Extract user identifier (support both new and legacy token formats)
-        email = payload.get("sub")
-        if email is None:
-            # Try legacy format
-            email = payload.get("email")
+
+        # Extract user identifier (support new UUID-sub and legacy email-sub formats).
+        # Signed email metadata wins; only UUID-only tokens need DB resolution.
+        from mcpgateway.auth_context import resolve_jwt_user_email_from_payload  # pylint: disable=import-outside-toplevel
+
+        async def resolve_uuid_subject(user_id: str) -> str | None:
+            """Resolve a UUID subject to the owning user's email."""
+            return await asyncio.to_thread(_get_email_by_id_sync, user_id)
+
+        email = await resolve_jwt_user_email_from_payload(payload, uuid_email_resolver=resolve_uuid_subject)
 
         if email is None:
             logger.debug("No email/sub found in JWT payload")
@@ -1577,16 +1583,6 @@ async def get_current_user(
                 detail="Invalid token",
                 headers={"WWW-Authenticate": "Bearer"},
             )
-
-        # If sub is a UUID (new token format), resolve to email via DB lookup
-        if email is not None:
-            try:
-                uuid.UUID(email)
-                resolved = await asyncio.to_thread(_get_email_by_id_sync, email)
-                if resolved is not None:
-                    email = resolved
-            except ValueError:
-                pass  # sub is an email (legacy format), keep as-is
 
         logger.debug("JWT authentication successful for email: %s", email)
 
@@ -2112,21 +2108,28 @@ def _inject_userinfo_instate(request: Optional[object] = None, user: Optional[Em
 
 
 async def get_user_email_from_token(payload: dict, db: Session) -> Optional[str]:
-    """Resolve user email from JWT payload (supports both UUID and email in sub).
+    """Resolve user email from JWT payload.
 
     This helper enables backward-compatible token migration from email-based
-    to user-ID-based tokens. It checks if the 'sub' claim contains a UUID
-    (new format) or an email address (legacy format).
+    to user-ID-based tokens. Signed email metadata is used first, then UUID
+    subjects are resolved through the database, and legacy email-sub tokens are
+    returned as-is.
 
     Args:
-        payload: JWT payload dictionary containing 'sub' claim
+        payload: JWT payload dictionary.
         db: Database session for user lookup
 
     Returns:
         User email string if found, None otherwise
 
     Examples:
-        >>> # New format: sub contains UUID
+        >>> # New API-token format: sub contains UUID, signed metadata carries email
+        >>> payload = {"sub": "550e8400-e29b-41d4-a716-446655440000", "user": {"email": "user@example.com"}}
+        >>> email = await get_user_email_from_token(payload, db)  # doctest: +SKIP
+        >>> email  # doctest: +SKIP
+        'user@example.com'
+
+        >>> # UUID-only format: resolve sub through the DB
         >>> payload = {"sub": "550e8400-e29b-41d4-a716-446655440000"}
         >>> email = await get_user_email_from_token(payload, db)  # doctest: +SKIP
         >>> email  # doctest: +SKIP
@@ -2144,6 +2147,11 @@ async def get_user_email_from_token(payload: dict, db: Session) -> Optional[str]
         >>> email is None  # doctest: +SKIP
         True
     """
+    from mcpgateway.auth_context import get_jwt_user_email_from_payload  # pylint: disable=import-outside-toplevel
+
+    user_email = get_jwt_user_email_from_payload(payload)
+    if user_email is not None:
+        return user_email
 
     sub = payload.get("sub")
     if not sub:

--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -61,6 +61,7 @@ The names below are the **module's public API**. Callers in ``main.py``,
 
     Identity resolution
         get_user_email(user) -> str
+        jwt_subject_is_uuid(payload) -> bool
         get_jwt_user_email_from_payload(payload) -> str | None
         resolve_jwt_user_email_from_payload(payload, uuid_email_resolver=None) -> str | None
 
@@ -218,6 +219,15 @@ def _is_uuid_string(value: str) -> bool:
     except ValueError:
         return False
     return True
+
+
+def jwt_subject_is_uuid(payload: dict[str, Any]) -> bool:
+    """Return True when the JWT subject claim is a syntactically valid UUID."""
+    subject = payload.get("sub")
+    if not isinstance(subject, str):
+        return False
+    subject = subject.strip()
+    return bool(subject) and _is_uuid_string(subject)
 
 
 def _non_uuid_identity(value: Any) -> str | None:

--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -61,6 +61,8 @@ The names below are the **module's public API**. Callers in ``main.py``,
 
     Identity resolution
         get_user_email(user) -> str
+        get_jwt_user_email_from_payload(payload) -> str | None
+        resolve_jwt_user_email_from_payload(payload, uuid_email_resolver=None) -> str | None
 
     Trust-layer headers forwarded from the Rust MCP runtime
         decode_internal_mcp_auth_context(header_value) -> dict
@@ -112,11 +114,13 @@ policy. The key invariants that this module enforces:
 # Standard
 import asyncio
 import base64
+from collections.abc import Awaitable, Callable
 from functools import lru_cache
 import hashlib
 import hmac
 import logging
 from typing import Any, Dict, List, Optional
+import uuid
 
 # Third-Party
 from fastapi import Request
@@ -205,6 +209,70 @@ def get_user_email(user: Any) -> str:
         return "unknown"
     # Fallback to string conversion for other types
     return str(user) if user else "unknown"
+
+
+def _is_uuid_string(value: str) -> bool:
+    """Return True when *value* is a syntactically valid UUID string."""
+    try:
+        uuid.UUID(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _non_uuid_identity(value: Any) -> str | None:
+    """Return a non-empty string identity unless it is a UUID."""
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value or _is_uuid_string(value):
+        return None
+    return value
+
+
+def get_jwt_user_email_from_payload(payload: dict[str, Any]) -> str | None:
+    """Extract a human email identity from signed JWT claims without DB lookup.
+
+    The dataplane JWT subject may be an opaque UUID. This helper intentionally
+    never returns that UUID as a user email; callers that need UUID fallback can
+    use :func:`resolve_jwt_user_email_from_payload` with an injected resolver.
+    """
+    user_info = payload.get("user")
+    if isinstance(user_info, dict):
+        user_email = _non_uuid_identity(user_info.get("email"))
+        if user_email is not None:
+            return user_email
+
+    user_email = _non_uuid_identity(payload.get("email"))
+    if user_email is not None:
+        return user_email
+
+    return _non_uuid_identity(payload.get("sub"))
+
+
+async def resolve_jwt_user_email_from_payload(
+    payload: dict[str, Any],
+    *,
+    uuid_email_resolver: Callable[[str], Awaitable[str | None]] | None = None,
+) -> str | None:
+    """Resolve the human email identity from verified JWT claims.
+
+    Signed email metadata is used first and does not touch the database. Only
+    UUID-sub tokens without email metadata use the optional resolver callback.
+    """
+    user_email = get_jwt_user_email_from_payload(payload)
+    if user_email is not None:
+        return user_email
+
+    subject = payload.get("sub")
+    if not isinstance(subject, str):
+        return None
+    subject = subject.strip()
+    if not subject or not _is_uuid_string(subject) or uuid_email_resolver is None:
+        return None
+
+    resolved = await uuid_email_resolver(subject)
+    return _non_uuid_identity(resolved)
 
 
 def get_internal_mcp_auth_context(request: Request) -> Optional[Dict[str, Any]]:

--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -97,7 +97,7 @@ See ``AGENTS.md`` section "Authentication & RBAC Overview" for the full
 policy. The key invariants that this module enforces:
 
 1. ``get_token_teams_from_request`` respects the secure-first semantics of
-   ``auth.normalize_token_teams``: missing ``teams`` claim means public-only,
+   ``normalize_token_teams``: missing ``teams`` claim means public-only,
    not admin bypass.
 2. ``get_rpc_filter_context`` derives ``is_admin`` from the verified JWT
    payload or the trusted internal MCP auth context - NOT from the DB user -
@@ -113,7 +113,6 @@ policy. The key invariants that this module enforces:
 """
 
 # Standard
-import asyncio
 import base64
 from collections.abc import Awaitable, Callable
 from functools import lru_cache
@@ -129,8 +128,8 @@ import orjson
 from sqlalchemy.orm import Session
 
 # First-Party
-from mcpgateway.auth import normalize_token_teams
 from mcpgateway.config import settings
+from mcpgateway.db import EmailUser
 
 # Module-level logger
 logger = logging.getLogger(__name__)
@@ -238,6 +237,51 @@ def _non_uuid_identity(value: Any) -> str | None:
     if not value or _is_uuid_string(value):
         return None
     return value
+
+
+def normalize_token_teams(payload: Dict[str, Any]) -> Optional[List[str]]:
+    """
+    Normalize token teams to a canonical form for consistent security checks.
+
+    SECURITY: This is the single source of truth for token team normalization.
+    All code paths that read token teams should use this function.
+
+    Rules:
+    - "teams" key missing -> [] (public-only, secure default)
+    - "teams" is null + is_admin=true -> None (admin bypass, sees all)
+    - "teams" is null + is_admin=false -> [] (public-only, no bypass for non-admins)
+    - "teams" is [] -> [] (explicit public-only)
+    - "teams" is [...] -> normalized list of string IDs
+
+    Args:
+        payload: The JWT payload dict
+
+    Returns:
+        None for admin bypass, [] for public-only, or list of normalized team ID strings
+    """
+    if "teams" not in payload:
+        return []
+
+    teams = payload.get("teams")
+
+    if teams is None:
+        is_admin = payload.get("is_admin", False)
+        if not is_admin:
+            user_info = payload.get("user", {})
+            is_admin = user_info.get("is_admin", False) if isinstance(user_info, dict) else False
+        if is_admin:
+            return None
+        return []
+
+    normalized: List[str] = []
+    for team in teams:
+        if isinstance(team, dict):
+            team_id = team.get("id")
+            if team_id:
+                normalized.append(str(team_id))
+        elif isinstance(team, str):
+            normalized.append(team)
+    return normalized
 
 
 def get_jwt_user_email_from_payload(payload: dict[str, Any]) -> str | None:
@@ -716,7 +760,7 @@ def get_rpc_filter_context(request: Request, user) -> tuple[Optional[str], Optio
         db_user_is_admin = None
         if user_email:
             # First-Party
-            from mcpgateway.db import EmailUser, SessionLocal  # lazy import — avoids cycle
+            from mcpgateway.db import SessionLocal  # pylint: disable=import-outside-toplevel
 
             _db = SessionLocal()
             try:
@@ -943,7 +987,8 @@ async def set_user_context_from_token(request: Request, payload: dict, db: Sessi
 
     Resolves user ID to email and caches on request.state for performance.
     This helper supports the token migration from email-based to user-ID-based
-    tokens by using get_user_email_from_token() which handles both formats.
+    tokens by using signed email metadata first, then resolving UUID subjects
+    through the provided database session.
 
     Args:
         request: FastAPI request object
@@ -974,13 +1019,21 @@ async def set_user_context_from_token(request: Request, payload: dict, db: Sessi
         >>> request.state.user_id  # doctest: +SKIP
         'user@example.com'
     """
-    # First-Party
-    from mcpgateway.auth import _get_user_by_email_sync  # pylint: disable=import-outside-toplevel
-    from mcpgateway.auth import get_user_email_from_token
+    user_email = get_jwt_user_email_from_payload(payload)
+    db_user = None
 
-    user_email = await get_user_email_from_token(payload, db)
+    if user_email is None:
+        subject = payload.get("sub")
+        if isinstance(subject, str):
+            subject = subject.strip()
+            if subject and _is_uuid_string(subject):
+                db_user = db.query(EmailUser).filter(EmailUser.id == subject).first()
+                user_email = db_user.email if db_user else None
+
+    if user_email and db_user is None:
+        db_user = db.query(EmailUser).filter(EmailUser.email == user_email).first()
+
     request.state.user_email = user_email
     request.state.user_id = payload.get("sub")
-    db_user = await asyncio.to_thread(_get_user_by_email_sync, user_email) if user_email else None
     request.state.is_admin = db_user.is_admin if db_user else False
     request.state.auth_provider = payload.get("auth_provider", "local")

--- a/mcpgateway/middleware/csrf_middleware.py
+++ b/mcpgateway/middleware/csrf_middleware.py
@@ -21,6 +21,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
 # First-Party
+from mcpgateway.auth_context import get_jwt_user_email_from_payload
 from mcpgateway.config import settings
 from mcpgateway.services.csrf_service import get_csrf_service
 from mcpgateway.utils.verify_credentials import get_auth_header_value, is_proxy_auth_trust_active, verify_jwt_token_cached
@@ -166,7 +167,7 @@ class CSRFMiddleware(BaseHTTPMiddleware):
                 try:
                     payload = await verify_jwt_token_cached(raw_token, request)
                     if not user_id:
-                        user_id = payload.get("email") or payload.get("user", {}).get("email") or payload.get("sub")
+                        user_id = get_jwt_user_email_from_payload(payload)
                     if not session_id:
                         session_id = payload.get("jti")
                 except Exception as exc:

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -23,6 +23,7 @@ from sqlalchemy import and_, func, select
 
 # First-Party
 from mcpgateway.auth import normalize_token_teams, resolve_session_teams
+from mcpgateway.auth_context import get_user_email
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.db import Permissions
@@ -788,6 +789,18 @@ class TokenScopingMiddleware:
         # Default deny for unmatched paths (requires explicit permission mapping)
         return False
 
+    @staticmethod
+    def _get_user_email_from_payload(payload: dict) -> str | None:
+        """Extract the email identity from a signed JWT payload."""
+        user_info = payload.get("user")
+        if isinstance(user_info, dict):
+            user_email = get_user_email(user_info)
+            if user_email != "unknown":
+                return user_email
+
+        user_email = get_user_email(payload)
+        return user_email if user_email != "unknown" else None
+
     def _check_team_membership(self, payload: dict, db=None) -> bool:
         """
         Check if user still belongs to teams in the token.
@@ -809,7 +822,7 @@ class TokenScopingMiddleware:
             bool: True if team membership is valid, False otherwise
         """
         teams = payload.get("teams", [])
-        user_email = payload.get("sub")
+        user_email = self._get_user_email_from_payload(payload)
 
         # PUBLIC-ONLY TOKEN: No team validation needed
         if not teams or len(teams) == 0:
@@ -1312,7 +1325,7 @@ class TokenScopingMiddleware:
 
             # TEAM VALIDATION: Use single DB session for both team checks
             # This reduces connection pool overhead from 2 sessions to 1 for resource endpoints
-            user_email = payload.get("sub") or payload.get("email")  # Extract user email for ownership check
+            user_email = self._get_user_email_from_payload(payload)
 
             # Resolve teams based on token_use claim
             token_use = payload.get("token_use")

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -10,6 +10,7 @@ and time-based restrictions.
 """
 
 # Standard
+import asyncio
 from datetime import datetime, timedelta, timezone
 from enum import auto, Enum
 from functools import lru_cache
@@ -23,7 +24,7 @@ from sqlalchemy import and_, func, select
 
 # First-Party
 from mcpgateway.auth import normalize_token_teams, resolve_session_teams
-from mcpgateway.auth_context import get_jwt_user_email_from_payload
+from mcpgateway.auth_context import get_jwt_user_email_from_payload, resolve_jwt_user_email_from_payload
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.db import Permissions
@@ -794,6 +795,17 @@ class TokenScopingMiddleware:
         """Extract the email identity from a signed JWT payload."""
         return get_jwt_user_email_from_payload(payload)
 
+    @staticmethod
+    async def _resolve_user_email_from_payload(payload: dict) -> str | None:
+        """Resolve the email identity from a signed JWT payload, including UUID-sub fallback."""
+        # First-Party
+        from mcpgateway.auth import _get_email_by_id_sync  # pylint: disable=import-outside-toplevel
+
+        async def resolve_uuid_subject(user_id: str) -> str | None:
+            return await asyncio.to_thread(_get_email_by_id_sync, user_id)
+
+        return await resolve_jwt_user_email_from_payload(payload, uuid_email_resolver=resolve_uuid_subject)
+
     def _check_team_membership(self, payload: dict, db=None) -> bool:
         """
         Check if user still belongs to teams in the token.
@@ -1316,19 +1328,19 @@ class TokenScopingMiddleware:
             if not payload:
                 return await call_next(request)
 
-            # TEAM VALIDATION: Use single DB session for both team checks
-            # This reduces connection pool overhead from 2 sessions to 1 for resource endpoints
-            user_email = self._get_user_email_from_payload(payload)
-
             # Resolve teams based on token_use claim
             token_use = payload.get("token_use")
             if token_use == "session":  # nosec B105 - Not a password; token_use is a JWT claim type
+                user_email = await self._resolve_user_email_from_payload(payload)
                 # Session token: resolve teams from DB/cache directly
                 # Cannot rely on request.state.token_teams — AuthContextMiddleware
                 # is gated by security_logging_enabled (defaults to False)
                 user_info = {}  # is_admin resolved from DB inside _resolve_teams_from_db
                 token_teams = await resolve_session_teams(payload, user_email, user_info)
             else:
+                # API and legacy tokens carry signed email metadata or legacy
+                # email subjects, so keep this path free of DB lookups.
+                user_email = self._get_user_email_from_payload(payload)
                 # API token or legacy: use embedded teams with normalize_token_teams
                 token_teams = normalize_token_teams(payload)
 

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -802,6 +802,7 @@ class TokenScopingMiddleware:
         from mcpgateway.auth import _get_email_by_id_sync  # pylint: disable=import-outside-toplevel
 
         async def resolve_uuid_subject(user_id: str) -> str | None:
+            """Resolve a UUID subject to the owning user's email."""
             return await asyncio.to_thread(_get_email_by_id_sync, user_id)
 
         return await resolve_jwt_user_email_from_payload(payload, uuid_email_resolver=resolve_uuid_subject)

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -23,7 +23,7 @@ from sqlalchemy import and_, func, select
 
 # First-Party
 from mcpgateway.auth import normalize_token_teams, resolve_session_teams
-from mcpgateway.auth_context import get_user_email
+from mcpgateway.auth_context import get_jwt_user_email_from_payload
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.db import Permissions
@@ -792,14 +792,7 @@ class TokenScopingMiddleware:
     @staticmethod
     def _get_user_email_from_payload(payload: dict) -> str | None:
         """Extract the email identity from a signed JWT payload."""
-        user_info = payload.get("user")
-        if isinstance(user_info, dict):
-            user_email = get_user_email(user_info)
-            if user_email != "unknown":
-                return user_email
-
-        user_email = get_user_email(payload)
-        return user_email if user_email != "unknown" else None
+        return get_jwt_user_email_from_payload(payload)
 
     def _check_team_membership(self, payload: dict, db=None) -> bool:
         """

--- a/mcpgateway/middleware/token_usage_middleware.py
+++ b/mcpgateway/middleware/token_usage_middleware.py
@@ -29,13 +29,26 @@ from starlette.requests import Request
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 # First-Party
-from mcpgateway.auth_context import is_trusted_internal_mcp_request
+from mcpgateway.auth_context import get_jwt_user_email_from_payload, is_trusted_internal_mcp_request
 from mcpgateway.db import fresh_db_session
 from mcpgateway.middleware.path_filter import should_skip_auth_context
 from mcpgateway.services.token_catalog_service import TokenCatalogService
 from mcpgateway.utils.verify_credentials import get_auth_header_value, verify_jwt_token_cached
 
 logger = logging.getLogger(__name__)
+
+
+def _get_api_token_owner_email_by_jti(jti: str) -> str | None:
+    """Return the DB-owned API token email for a JTI."""
+    # Third-Party
+    from sqlalchemy import select  # pylint: disable=import-outside-toplevel
+
+    # First-Party
+    from mcpgateway.db import EmailApiToken  # pylint: disable=import-outside-toplevel
+
+    with fresh_db_session() as verify_db:
+        token_row = verify_db.execute(select(EmailApiToken.id, EmailApiToken.user_email).where(EmailApiToken.jti == jti)).first()
+        return token_row.user_email if token_row is not None else None
 
 
 class TokenUsageMiddleware:
@@ -151,13 +164,19 @@ class TokenUsageMiddleware:
                     try:
                         payload = await verify_jwt_token_cached(token, request)
                         jti = jti or payload.get("jti")
-                        user_email = user_email or payload.get("sub") or payload.get("email")
+                        user_email = user_email or get_jwt_user_email_from_payload(payload)
                     except Exception as decode_error:
                         logger.debug(f"Failed to decode token for usage logging: {decode_error}")
                         return
                 except Exception as e:
                     logger.debug(f"Error extracting token information: {e}")
                     return
+
+            if jti and not user_email:
+                try:
+                    user_email = _get_api_token_owner_email_by_jti(jti)
+                except Exception:
+                    user_email = None  # DB error: skip logging rather than misattribute usage
 
             if not jti or not user_email:
                 logger.debug("Missing JTI or user_email for token usage logging")

--- a/mcpgateway/middleware/token_usage_middleware.py
+++ b/mcpgateway/middleware/token_usage_middleware.py
@@ -175,7 +175,8 @@ class TokenUsageMiddleware:
             if jti and not user_email:
                 try:
                     user_email = _get_api_token_owner_email_by_jti(jti)
-                except Exception:
+                except Exception as exc:
+                    logger.debug("Failed to resolve API token owner by JTI for usage logging: %s", exc)
                     user_email = None  # DB error: skip logging rather than misattribute usage
 
             if not jti or not user_email:
@@ -235,7 +236,8 @@ class TokenUsageMiddleware:
                             return  # JTI not in DB — forged token, skip logging
                         # Use the DB-stored owner, not the unverified JWT claim
                         user_email = token_row.user_email
-                except Exception:
+                except Exception as exc:
+                    logger.debug("Failed to verify API token owner by JTI for rejected usage logging: %s", exc)
                     return  # DB error — skip logging rather than log unverified data
 
                 blocked = True

--- a/mcpgateway/routers/reverse_proxy.py
+++ b/mcpgateway/routers/reverse_proxy.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.auth import get_current_user
+from mcpgateway.auth_context import get_jwt_user_email_from_payload
 from mcpgateway.config import settings
 from mcpgateway.db import get_db
 from mcpgateway.middleware.rbac import _ACCESS_DENIED_MSG, PermissionChecker
@@ -144,7 +145,7 @@ class ReverseProxyManager:
                 "last_activity": session.last_activity.isoformat(),
                 "message_count": session.message_count,
                 "bytes_transferred": session.bytes_transferred,
-                "user": session.user if isinstance(session.user, str) else session.user.get("sub") if isinstance(session.user, dict) else None,
+                "user": _get_session_owner(session.user),
             }
             for session in self.sessions.values()
         ]
@@ -437,7 +438,7 @@ async def send_request_to_session(
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to send request")
 
 
-def _get_user_from_credentials(credentials: str | dict) -> tuple[str | None, bool]:
+def _get_user_from_credentials(credentials: str | dict[str, Any] | None) -> tuple[str | None, bool]:
     """Extract user and admin status from credentials.
 
     Args:
@@ -447,16 +448,27 @@ def _get_user_from_credentials(credentials: str | dict) -> tuple[str | None, boo
         Tuple of (username, is_admin)
     """
     if isinstance(credentials, dict):
-        user = credentials.get("sub") or credentials.get("email")
+        user = get_jwt_user_email_from_payload(credentials)
         # Check both top-level is_admin and nested user.is_admin (JWT tokens may nest it)
-        is_admin = credentials.get("is_admin", False) or credentials.get("user", {}).get("is_admin", False)
+        user_claim = credentials.get("user")
+        nested_is_admin = user_claim.get("is_admin", False) if isinstance(user_claim, dict) else False
+        is_admin = bool(credentials.get("is_admin", False) or nested_is_admin)
         return user, is_admin
     elif credentials and credentials != "anonymous":
         return credentials, False
     return None, False
 
 
-def _validate_session_ownership(session: ReverseProxySession, credentials: str | dict, action: str) -> None:
+def _get_session_owner(session_user: str | dict[str, Any] | None) -> str | None:
+    """Extract a comparable owner email from stored reverse-proxy session user data."""
+    if isinstance(session_user, str):
+        return session_user
+    if isinstance(session_user, dict):
+        return get_jwt_user_email_from_payload(session_user)
+    return None
+
+
+def _validate_session_ownership(session: ReverseProxySession, credentials: str | dict[str, Any] | None, action: str) -> None:
     """Validate that the requesting user owns the session or is admin.
 
     Args:
@@ -478,7 +490,7 @@ def _validate_session_ownership(session: ReverseProxySession, credentials: str |
         return
 
     # Session owner can access their own session
-    session_owner = session.user if isinstance(session.user, str) else session.user.get("sub") if isinstance(session.user, dict) else None
+    session_owner = _get_session_owner(session.user)
     if requesting_user and session_owner and requesting_user == session_owner:
         return
 

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -212,12 +212,12 @@ class DataplanePublisherService:
         data: dict[str, dict[str, Any]],
     ) -> dict[str, UserConfig]:
         """
-        Build dataplane payload from already-filtered per-user data.
+        Build dataplane payload from already-filtered per-user data keyed by dataplane subject.
         """
 
         result: dict[str, UserConfig] = {}
 
-        for user_email, user_data in data.items():
+        for subject_key, user_data in data.items():
             servers = user_data["servers"]
             gateways = user_data["gateways"]
             prompts = user_data["prompts"]
@@ -275,7 +275,7 @@ class DataplanePublisherService:
 
                 virtual_hosts[server["id"]] = {"backends": backends}
 
-            result[user_email] = {"virtual_hosts": virtual_hosts}
+            result[subject_key] = {"virtual_hosts": virtual_hosts}
 
         return result
 
@@ -283,14 +283,16 @@ class DataplanePublisherService:
         """Fetch active users and dataplane data with bulk minimal-column queries."""
         with fresh_db_session() as db:
             try:
-                user_rows = db.execute(select(EmailUser.email, EmailUser.is_admin).where(EmailUser.is_active.is_(True))).all()
+                user_rows = db.execute(select(EmailUser.id, EmailUser.email, EmailUser.is_admin).where(EmailUser.is_active.is_(True))).all()
                 userteam_rows = db.execute(select(EmailTeamMember.user_email, EmailTeamMember.team_id).where(EmailTeamMember.is_active.is_(True))).all()
 
                 user_teams_map: dict[str, set[str]] = defaultdict(set)
                 user_admin_map: dict[str, bool] = {}
-                for user_email, is_admin in user_rows:
+                user_subject_key_by_email: dict[str, str] = {}
+                for user_id, user_email, is_admin in user_rows:
                     user_teams_map.setdefault(user_email, set())
                     user_admin_map[user_email] = is_admin
+                    user_subject_key_by_email[user_email] = str(user_id)
 
                 for user_email, team_id in userteam_rows:
                     if user_email in user_admin_map:
@@ -324,7 +326,7 @@ class DataplanePublisherService:
                 backend_items_by_server = self._get_backend_items_by_server(db)
 
                 return {
-                    user_email: self._build_user_data(
+                    user_subject_key_by_email[user_email]: self._build_user_data(
                         user_email,
                         teams,
                         user_admin_map.get(user_email, False),

--- a/mcpgateway/services/token_catalog_service.py
+++ b/mcpgateway/services/token_catalog_service.py
@@ -228,7 +228,7 @@ class TokenCatalogService:
         and expiration. The token follows ContextForge JWT structure.
 
         Args:
-            user_email: User's email address for the token subject
+            user_email: User's email address for token metadata and DB lookups
             jti: JWT ID for token uniqueness
             team_id: Optional team ID for team-scoped tokens
             expires_at: Optional expiration datetime
@@ -267,6 +267,7 @@ class TokenCatalogService:
             "is_admin": user.is_admin if user else False,
             "auth_provider": "api_token",
         }
+        subject = str(getattr(user, "id", None) or user_email)
 
         # Build teams list — None means "all teams" (admin bypass when is_admin=true),
         # [] means "public-only" (see normalize_token_teams() in auth.py)
@@ -301,7 +302,7 @@ class TokenCatalogService:
         # Generate JWT token using the centralized token creation utility
         # Pass structured data to the enhanced create_jwt_token function
         return await create_jwt_token(
-            data={"sub": user_email, "jti": jti, "token_use": "api"},  # nosec B105 - token type marker, not a password
+            data={"sub": subject, "jti": jti, "token_use": "api"},  # nosec B105 - token type marker, not a password
             expires_in_minutes=expires_in_minutes,
             user_data=user_data,
             teams=teams,

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -5095,11 +5095,12 @@ class _StreamableHttpAuthHandler:
 
             # First-Party
             from mcpgateway.auth import _get_auth_context_batched_sync, resolve_trace_team_name  # pylint: disable=import-outside-toplevel
+            from mcpgateway.auth_context import jwt_subject_is_uuid  # pylint: disable=import-outside-toplevel
             from mcpgateway.cache.auth_cache import CachedAuthContext, get_auth_cache  # pylint: disable=import-outside-toplevel
 
             jti = user_payload.get("jti")
             user_email = await _resolve_jwt_user_email_for_streamable(user_payload)
-            if not user_email and settings.require_user_in_db:
+            if not user_email and settings.require_user_in_db and jwt_subject_is_uuid(user_payload):
                 return await self._send_error(detail="User not found in database", headers={"WWW-Authenticate": "Bearer"})
             nested_user = user_payload.get("user", {})
             nested_is_admin = nested_user.get("is_admin", False) if isinstance(nested_user, dict) else False

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -40,7 +40,7 @@ from enum import Enum
 import re
 from typing import Any, assert_never, AsyncGenerator, ContextManager, Dict, Iterable, List, Optional, Pattern, Tuple, Union
 from urllib.parse import urlsplit, urlunsplit
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 # Third-Party
 import anyio
@@ -2203,61 +2203,16 @@ async def _get_request_context_or_default() -> Tuple[str, dict[str, Any], dict[s
         return s_id, request_headers_var.get(), user_context_var.get()
 
 
-async def _resolve_subject_email(payload: dict[str, Any]) -> Optional[str]:
-    """Resolve a JWT subject claim to the user's email address.
-
-    Session tokens (``token_use: "session"``) carry ``sub`` as the
-    ``EmailUser.id`` UUID; legacy/API tokens carry the email directly.  This
-    mirrors the resolution already performed by
-    ``mcpgateway.auth.get_current_user`` and
-    ``mcpgateway.auth.resolve_session_teams`` so that the MCP transport keys its
-    user lookups, auth-cache entries and RBAC context on the same identity as
-    the REST paths.
-
-    Per the repository's canonical email-over-sub precedence (see
-    ``mcpgateway.auth_context.get_user_email``), a non-empty string ``email``
-    claim always wins over ``sub`` when both are present, so the resolved
-    identity can never be spoofed by a conflicting ``sub`` claim.
-
-    When the subject is a UUID that cannot be resolved (no matching user row),
-    the raw subject is returned unchanged so the caller's existing
-    ``require_user_in_db`` checks reject the request rather than silently
-    downgrading it to anonymous access.
-
-    Args:
-        payload: Decoded JWT payload.
-
-    Returns:
-        The user's email address, or ``None`` when the token carries no subject.
-
-    Examples:
-        >>> import asyncio
-        >>> asyncio.run(_resolve_subject_email({"sub": "user@example.com"}))
-        'user@example.com'
-        >>> asyncio.run(_resolve_subject_email({"email": "fallback@example.com"}))
-        'fallback@example.com'
-        >>> asyncio.run(_resolve_subject_email({"email": "canonical@example.com", "sub": "ignored-sub"}))
-        'canonical@example.com'
-        >>> asyncio.run(_resolve_subject_email({})) is None
-        True
-    """
-    email_claim = payload.get("email")
-    subject: Optional[str] = email_claim if isinstance(email_claim, str) and email_claim else payload.get("sub")
-    if not subject:
-        return None
-
-    try:
-        UUID(subject)
-    except (ValueError, AttributeError, TypeError):
-        # Already an email (legacy/API token, or a session token issued before
-        # the user row existed) — no database round-trip needed.
-        return subject
-
+async def _resolve_jwt_user_email_for_streamable(payload: dict[str, Any]) -> str | None:
+    """Resolve JWT user email for Streamable HTTP auth without treating UUID sub as email."""
     # First-Party
     from mcpgateway.auth import _get_email_by_id_sync  # pylint: disable=import-outside-toplevel
+    from mcpgateway.auth_context import resolve_jwt_user_email_from_payload  # pylint: disable=import-outside-toplevel
 
-    resolved = await asyncio.to_thread(_get_email_by_id_sync, subject)
-    return resolved or subject
+    async def resolve_uuid_subject(user_id: str) -> str | None:
+        return await asyncio.to_thread(_get_email_by_id_sync, user_id)
+
+    return await resolve_jwt_user_email_from_payload(payload, uuid_email_resolver=resolve_uuid_subject)
 
 
 async def _normalize_jwt_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -2275,7 +2230,7 @@ async def _normalize_jwt_payload(payload: dict[str, Any]) -> dict[str, Any]:
     Returns:
         Canonical user context dict with keys email, teams, is_admin, is_authenticated, token_use.
     """
-    email = await _resolve_subject_email(payload)
+    email = await _resolve_jwt_user_email_for_streamable(payload)
     jwt_is_admin = payload.get("is_admin", False)
     if not jwt_is_admin:
         user_info = payload.get("user", {})
@@ -5143,9 +5098,9 @@ class _StreamableHttpAuthHandler:
             from mcpgateway.cache.auth_cache import CachedAuthContext, get_auth_cache  # pylint: disable=import-outside-toplevel
 
             jti = user_payload.get("jti")
-            # Resolve sub (a UUID for session tokens) to the user's email before any
-            # cache lookup or DB query, so MCP keys the same identity as the REST paths.
-            user_email = await _resolve_subject_email(user_payload)
+            user_email = await _resolve_jwt_user_email_for_streamable(user_payload)
+            if not user_email and settings.require_user_in_db:
+                return await self._send_error(detail="User not found in database", headers={"WWW-Authenticate": "Bearer"})
             nested_user = user_payload.get("user", {})
             nested_is_admin = nested_user.get("is_admin", False) if isinstance(nested_user, dict) else False
             is_admin = user_payload.get("is_admin", False) or nested_is_admin

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2210,6 +2210,7 @@ async def _resolve_jwt_user_email_for_streamable(payload: dict[str, Any]) -> str
     from mcpgateway.auth_context import resolve_jwt_user_email_from_payload  # pylint: disable=import-outside-toplevel
 
     async def resolve_uuid_subject(user_id: str) -> str | None:
+        """Resolve a UUID subject to the owning user's email."""
         return await asyncio.to_thread(_get_email_by_id_sync, user_id)
 
     return await resolve_jwt_user_email_from_payload(payload, uuid_email_resolver=resolve_uuid_subject)

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -62,7 +62,6 @@ import time
 from time import monotonic
 from typing import Any, Optional, Union
 from urllib.parse import urlsplit, urlunsplit
-import uuid
 
 # Third-Party
 from fastapi import Cookie, Depends, HTTPException, Request, status
@@ -763,6 +762,7 @@ async def _enforce_revocation_and_active_user(payload: dict) -> None:
     """
     # First-Party
     from mcpgateway.auth import _check_token_revoked_sync, _get_email_by_id_sync, _get_user_by_email_sync
+    from mcpgateway.auth_context import jwt_subject_is_uuid, resolve_jwt_user_email_from_payload
 
     jti = payload.get("jti")
     if jti:
@@ -774,23 +774,26 @@ async def _enforce_revocation_and_active_user(payload: dict) -> None:
         except Exception as exc:
             logger.warning("Token revocation check failed for JTI %s: %s", jti, exc)
 
-    username = payload.get("sub") or payload.get("email") or payload.get("username")
-    if not username:
-        return
-
     try:
-        user = await asyncio.to_thread(_get_user_by_email_sync, username)
-        if user is None and payload.get("token_use") == "session":
-            # Session tokens use UUID as sub; resolve to email first
-            try:
-                uuid.UUID(username)
-                resolved = await asyncio.to_thread(_get_email_by_id_sync, username)
-                if resolved:
-                    user = await asyncio.to_thread(_get_user_by_email_sync, resolved)
-            except ValueError:
-                pass  # Not a UUID, skip resolution
+        async def resolve_uuid_subject(user_id: str) -> str | None:
+            return await asyncio.to_thread(_get_email_by_id_sync, user_id)
+
+        username = await resolve_jwt_user_email_from_payload(payload, uuid_email_resolver=resolve_uuid_subject)
+        if not username:
+            raw_username = payload.get("username")
+            username = raw_username.strip() if isinstance(raw_username, str) and raw_username.strip() else None
+
+        unresolved_uuid_subject = False
+        if not username and jwt_subject_is_uuid(payload):
+            username = payload["sub"].strip()
+            unresolved_uuid_subject = True
+
+        if not username:
+            return
+
+        user = None if unresolved_uuid_subject else await asyncio.to_thread(_get_user_by_email_sync, username)
     except Exception as exc:
-        logger.warning("User status check failed for %s: %s", username, exc)
+        logger.warning("User status check failed for %s: %s", payload.get("sub") or payload.get("email") or payload.get("username"), exc)
         return
 
     if user is None:

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -775,7 +775,9 @@ async def _enforce_revocation_and_active_user(payload: dict) -> None:
             logger.warning("Token revocation check failed for JTI %s: %s", jti, exc)
 
     try:
+
         async def resolve_uuid_subject(user_id: str) -> str | None:
+            """Resolve a UUID subject to the owning user's email."""
             return await asyncio.to_thread(_get_email_by_id_sync, user_id)
 
         username = await resolve_jwt_user_email_from_payload(payload, uuid_email_resolver=resolve_uuid_subject)

--- a/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
@@ -9,7 +9,8 @@ Tests cover request validation, token checking, exempt paths, and referer valida
 """
 
 # Standard
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 import pytest
@@ -693,6 +694,41 @@ async def test_session_id_from_header():
     assert response.status_code == 200
     # Verify session_id from JWT context was used
     mock_csrf_service.validate_csrf_token.assert_called_once_with("valid_token", "user@example.com", "header_session_123")
+
+
+@pytest.mark.asyncio
+async def test_fallback_jwt_uuid_sub_uses_signed_email():
+    """CSRF JWT fallback should bind UUID-sub tokens to signed user.email."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/api/data"
+    request.headers = {"X-CSRF-Token": "valid_token"}
+    request.state = SimpleNamespace()
+    request.cookies = {"csrf_token": "valid_token", "jwt_token": "jwt-token"}
+
+    payload = {"sub": "11111111-1111-1111-1111-111111111111", "user": {"email": "user@example.com"}, "jti": "session123"}
+    mock_csrf_service = MagicMock()
+    mock_csrf_service.validate_csrf_token.return_value = True
+
+    with (
+        patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings,
+        patch("mcpgateway.middleware.csrf_middleware.get_csrf_service", return_value=mock_csrf_service),
+        patch("mcpgateway.middleware.csrf_middleware.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+    ):
+        mock_settings.csrf_enabled = True
+        mock_settings.auth_required = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_check_referer = False
+        mock_settings.csrf_cookie_name = "csrf_token"
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    mock_csrf_service.validate_csrf_token.assert_called_once_with("valid_token", "user@example.com", "session123")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -523,7 +523,7 @@ class TestTokenScopingMiddleware:
 
             expected_response = Response(status_code=200, content="ok")
             call_next = AsyncMock(return_value=expected_response)
-            response = await middleware(mock_request, call_next)
+            await middleware(mock_request, call_next)
 
             call_next.assert_called_once()
 
@@ -565,7 +565,7 @@ class TestTokenScopingMiddleware:
 
             expected_response = Response(status_code=200, content="ok")
             call_next = AsyncMock(return_value=expected_response)
-            response = await middleware(mock_request, call_next)
+            await middleware(mock_request, call_next)
 
             call_next.assert_called_once()
 
@@ -607,7 +607,7 @@ class TestTokenScopingMiddleware:
 
             expected_response = Response(status_code=200, content="ok")
             call_next = AsyncMock(return_value=expected_response)
-            response = await middleware(mock_request, call_next)
+            await middleware(mock_request, call_next)
 
             call_next.assert_called_once()
 
@@ -732,6 +732,15 @@ class TestTokenScopingMiddleware:
         assert result is True
         cache.get_team_membership_valid_sync.assert_called_once_with("user@example.com", ["team-1"])
         cache.set_team_membership_valid_sync.assert_called_once_with("user@example.com", ["team-1"], True)
+
+    def test_check_team_membership_does_not_treat_uuid_sub_as_email(self, middleware):
+        """A UUID subject without signed email metadata is not a user email."""
+        payload = {
+            "sub": "11111111-1111-1111-1111-111111111111",
+            "teams": ["team-1"],
+        }
+
+        assert middleware._check_team_membership(payload) is False
 
     @pytest.mark.asyncio
     async def test_session_token_with_teams_claim_still_resolves_from_db(self, middleware, mock_request):

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -712,6 +712,27 @@ class TestTokenScopingMiddleware:
         result = middleware._check_team_membership(payload, db=MagicMock())
         assert result is False
 
+    def test_check_team_membership_uses_signed_user_email_for_uuid_subject(self, middleware, monkeypatch):
+        """UUID-sub API tokens validate membership with the signed email metadata."""
+        payload = {
+            "sub": "11111111-1111-1111-1111-111111111111",
+            "user": {"email": "user@example.com"},
+            "teams": ["team-1"],
+        }
+
+        cache = MagicMock()
+        cache.get_team_membership_valid_sync.return_value = None
+        monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: cache)
+
+        db = MagicMock()
+        db.execute.return_value.scalars.return_value.all.return_value = ["team-1"]
+
+        result = middleware._check_team_membership(payload, db=db)
+
+        assert result is True
+        cache.get_team_membership_valid_sync.assert_called_once_with("user@example.com", ["team-1"])
+        cache.set_team_membership_valid_sync.assert_called_once_with("user@example.com", ["team-1"], True)
+
     @pytest.mark.asyncio
     async def test_session_token_with_teams_claim_still_resolves_from_db(self, middleware, mock_request):
         """Session tokens always resolve teams from DB even when a teams claim is present."""
@@ -842,6 +863,43 @@ class TestTokenScopingMiddleware:
 
                             # Verify _resolve_teams_from_db was NOT called
                             mock_resolve_teams.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_api_token_uuid_subject_uses_signed_user_email_for_ownership(self, middleware, mock_request, monkeypatch):
+        """API tokens can use opaque subjects without breaking email-keyed ownership checks."""
+        mock_request.url.path = "/servers"
+        mock_request.method = "GET"
+        mock_request.headers = {"Authorization": "Bearer api_token"}
+
+        api_payload = {
+            "sub": "11111111-1111-1111-1111-111111111111",
+            "user": {"email": "user@example.com"},
+            "token_use": "api",
+            "teams": ["team-1"],
+            "scopes": {"permissions": ["*"]},
+        }
+        db = MagicMock()
+
+        def _get_db():
+            yield db
+
+        monkeypatch.setattr("mcpgateway.db.get_db", _get_db)
+
+        with (
+            patch.object(middleware, "_extract_token_scopes", return_value=api_payload),
+            patch("mcpgateway.middleware.token_scoping.normalize_token_teams", return_value=["team-1"]),
+            patch.object(middleware, "_check_team_membership", return_value=True) as mock_membership,
+            patch.object(middleware, "_check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED) as mock_ownership,
+            patch.object(middleware, "_check_server_restriction", return_value=True),
+            patch.object(middleware, "_check_permission_restrictions", return_value=True),
+        ):
+            call_next = AsyncMock(return_value="success")
+
+            result = await middleware(mock_request, call_next)
+
+            assert result == "success"
+            mock_membership.assert_called_once_with(api_payload, db=db)
+            mock_ownership.assert_called_once_with("/servers", ["team-1"], db=db, _user_email="user@example.com")
 
     @pytest.mark.asyncio
     async def test_legacy_token_without_token_use_uses_embedded_teams(self, middleware, mock_request):

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -970,6 +970,48 @@ class TestTokenScopingMiddleware:
                     mock_resolve.assert_awaited_once_with(session_payload, "user@example.com", {})
 
     @pytest.mark.asyncio
+    async def test_uuid_only_session_token_resolves_email_before_session_scope(self, middleware, mock_request, monkeypatch):
+        """Production session tokens use UUID sub without email metadata and must still get DB-backed scope."""
+        mock_request.url.path = "/servers/a1b2c3d4-e5f6-0000-1111-222233334444"
+        mock_request.method = "GET"
+        mock_request.headers = {"Authorization": "Bearer session_token"}
+
+        user_id = "11111111-1111-1111-1111-111111111111"
+        session_payload = {
+            "sub": user_id,
+            "token_use": "session",
+            "teams": ["team-1"],
+            "scopes": {"permissions": ["*"]},
+        }
+        db = MagicMock()
+
+        def _get_db():
+            yield db
+
+        monkeypatch.setattr("mcpgateway.db.get_db", _get_db)
+        monkeypatch.setattr("mcpgateway.auth._get_email_by_id_sync", MagicMock(return_value="user@example.com"))
+
+        with (
+            patch.object(middleware, "_extract_token_scopes", return_value=session_payload),
+            patch("mcpgateway.middleware.token_scoping.resolve_session_teams", new=AsyncMock(return_value=["team-1"])) as mock_resolve,
+            patch.object(middleware, "_check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED) as mock_ownership,
+            patch.object(middleware, "_check_server_restriction", return_value=True),
+            patch.object(middleware, "_check_permission_restrictions", return_value=True),
+        ):
+            call_next = AsyncMock(return_value="success")
+
+            result = await middleware(mock_request, call_next)
+
+            assert result == "success"
+            mock_resolve.assert_awaited_once_with(session_payload, "user@example.com", {})
+            mock_ownership.assert_called_once_with(
+                "/servers/a1b2c3d4-e5f6-0000-1111-222233334444",
+                ["team-1"],
+                db=db,
+                _user_email="user@example.com",
+            )
+
+    @pytest.mark.asyncio
     async def test_session_token_skips_membership_check_on_stale_jwt_teams(self, middleware, mock_request):
         """Session tokens skip _check_team_membership; stale JWT teams produce empty intersection (public-only)."""
         mock_request.url.path = "/servers"

--- a/tests/unit/mcpgateway/middleware/test_token_usage_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_token_usage_middleware.py
@@ -219,6 +219,57 @@ async def test_logs_api_token_usage_fallback_to_token_decode():
 
 
 @pytest.mark.asyncio
+async def test_logs_api_token_usage_fallback_uses_signed_email_for_uuid_sub():
+    """Verified UUID-sub API token usage should be attributed to signed user.email."""
+    app = AsyncMock()
+
+    async def app_impl(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    app.side_effect = app_impl
+    middleware = TokenUsageMiddleware(app=app)
+
+    scope = {
+        "type": "http",
+        "path": "/api/resources",
+        "method": "POST",
+        "state": {
+            "auth_method": "api_token",
+            "jti": None,
+            "user": None,
+        },
+        "client": ("10.0.0.1", 12345),
+        "headers": [(b"authorization", b"Bearer uuid_sub_token"), (b"user-agent", b"TestClient/2.0")],
+    }
+
+    user_id = "11111111-1111-1111-1111-111111111111"
+    mock_payload = {
+        "jti": "jti-uuid-sub-789",
+        "sub": user_id,
+        "user": {"email": "owner@example.com", "auth_provider": "api_token"},
+    }
+    mock_db = MagicMock()
+    mock_token_service = MagicMock()
+    mock_token_service.log_token_usage = AsyncMock()
+
+    with (
+        patch("mcpgateway.middleware.token_usage_middleware.fresh_db_session") as mock_fresh_session,
+        patch("mcpgateway.middleware.token_usage_middleware.TokenCatalogService", return_value=mock_token_service),
+        patch("mcpgateway.middleware.token_usage_middleware.verify_jwt_token_cached", AsyncMock(return_value=mock_payload)),
+    ):
+        mock_fresh_session.return_value.__enter__.return_value = mock_db
+        await _make_asgi_call(middleware, scope)
+
+    mock_token_service.log_token_usage.assert_awaited_once()
+    call_args = mock_token_service.log_token_usage.call_args
+    assert call_args.kwargs["jti"] == "jti-uuid-sub-789"
+    assert call_args.kwargs["user_email"] == "owner@example.com"
+    assert call_args.kwargs["user_email"] != user_id
+    mock_fresh_session.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_handles_missing_authorization_header():
     """Middleware should handle missing Authorization header gracefully."""
     app = AsyncMock()

--- a/tests/unit/mcpgateway/middleware/test_token_usage_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_token_usage_middleware.py
@@ -7,13 +7,14 @@ Unit tests for token usage logging middleware.
 """
 
 # Standard
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 import pytest
 
 # First-Party
-from mcpgateway.middleware.token_usage_middleware import TokenUsageMiddleware
+from mcpgateway.middleware.token_usage_middleware import TokenUsageMiddleware, _get_api_token_owner_email_by_jti
 
 
 async def _make_asgi_call(middleware, scope, receive=None, send=None):
@@ -267,6 +268,81 @@ async def test_logs_api_token_usage_fallback_uses_signed_email_for_uuid_sub():
     assert call_args.kwargs["user_email"] == "owner@example.com"
     assert call_args.kwargs["user_email"] != user_id
     mock_fresh_session.assert_called_once()
+
+
+def test_get_api_token_owner_email_by_jti_returns_owner_email():
+    """JTI fallback reads the API token owner email from the database."""
+    mock_db = MagicMock()
+    mock_db.execute.return_value.first.return_value = SimpleNamespace(user_email="owner@example.com")
+
+    with patch("mcpgateway.middleware.token_usage_middleware.fresh_db_session") as mock_fresh_session:
+        mock_fresh_session.return_value.__enter__.return_value = mock_db
+
+        assert _get_api_token_owner_email_by_jti("jti-owner") == "owner@example.com"
+
+    mock_db.execute.assert_called_once()
+
+
+def test_get_api_token_owner_email_by_jti_returns_none_when_missing():
+    """JTI fallback leaves usage unattributed when the token row is gone."""
+    mock_db = MagicMock()
+    mock_db.execute.return_value.first.return_value = None
+
+    with patch("mcpgateway.middleware.token_usage_middleware.fresh_db_session") as mock_fresh_session:
+        mock_fresh_session.return_value.__enter__.return_value = mock_db
+
+        assert _get_api_token_owner_email_by_jti("jti-missing") is None
+
+    mock_db.execute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_logs_api_token_usage_fallback_uses_jti_owner_for_uuid_only_sub():
+    """UUID-only API token usage falls back to the DB-owned token email."""
+    app = AsyncMock()
+
+    async def app_impl(scope, receive, send):
+        """Send a successful ASGI response for usage logging."""
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    app.side_effect = app_impl
+    middleware = TokenUsageMiddleware(app=app)
+
+    scope = {
+        "type": "http",
+        "path": "/api/resources",
+        "method": "POST",
+        "state": {
+            "auth_method": "api_token",
+            "jti": None,
+            "user": None,
+        },
+        "client": ("10.0.0.1", 12345),
+        "headers": [(b"authorization", b"Bearer uuid_only_sub_token")],
+    }
+
+    user_id = "11111111-1111-1111-1111-111111111111"
+    mock_payload = {"jti": "jti-uuid-only-sub", "sub": user_id}
+    mock_db = MagicMock()
+    mock_token_service = MagicMock()
+    mock_token_service.log_token_usage = AsyncMock()
+
+    with (
+        patch("mcpgateway.middleware.token_usage_middleware.fresh_db_session") as mock_fresh_session,
+        patch("mcpgateway.middleware.token_usage_middleware.TokenCatalogService", return_value=mock_token_service),
+        patch("mcpgateway.middleware.token_usage_middleware.verify_jwt_token_cached", AsyncMock(return_value=mock_payload)),
+        patch("mcpgateway.middleware.token_usage_middleware._get_api_token_owner_email_by_jti", return_value="owner@example.com") as mock_owner_lookup,
+    ):
+        mock_fresh_session.return_value.__enter__.return_value = mock_db
+        await _make_asgi_call(middleware, scope)
+
+    mock_owner_lookup.assert_called_once_with("jti-uuid-only-sub")
+    mock_token_service.log_token_usage.assert_awaited_once()
+    call_args = mock_token_service.log_token_usage.call_args
+    assert call_args.kwargs["jti"] == "jti-uuid-only-sub"
+    assert call_args.kwargs["user_email"] == "owner@example.com"
+    assert call_args.kwargs["user_email"] != user_id
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/middleware/test_token_usage_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_token_usage_middleware.py
@@ -7,6 +7,7 @@ Unit tests for token usage logging middleware.
 """
 
 # Standard
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -343,6 +344,44 @@ async def test_logs_api_token_usage_fallback_uses_jti_owner_for_uuid_only_sub():
     assert call_args.kwargs["jti"] == "jti-uuid-only-sub"
     assert call_args.kwargs["user_email"] == "owner@example.com"
     assert call_args.kwargs["user_email"] != user_id
+
+
+@pytest.mark.asyncio
+async def test_logs_jti_owner_lookup_error(caplog):
+    """JTI owner fallback DB errors should be visible in debug logs."""
+    app = AsyncMock()
+
+    async def app_impl(scope, receive, send):
+        """Send a successful ASGI response for usage logging."""
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    app.side_effect = app_impl
+    middleware = TokenUsageMiddleware(app=app)
+
+    scope = {
+        "type": "http",
+        "path": "/api/resources",
+        "method": "POST",
+        "state": {
+            "auth_method": "api_token",
+            "jti": "jti-db-error",
+            "user": None,
+        },
+        "headers": [(b"authorization", b"Bearer uuid_only_sub_token")],
+    }
+    mock_payload = {"jti": "jti-db-error", "sub": "11111111-1111-1111-1111-111111111111"}
+
+    caplog.set_level(logging.DEBUG, logger="mcpgateway.middleware.token_usage_middleware")
+    with (
+        patch("mcpgateway.middleware.token_usage_middleware.verify_jwt_token_cached", AsyncMock(return_value=mock_payload)),
+        patch("mcpgateway.middleware.token_usage_middleware._get_api_token_owner_email_by_jti", side_effect=RuntimeError("db unavailable")),
+        patch("mcpgateway.middleware.token_usage_middleware.TokenCatalogService") as mock_token_service,
+    ):
+        await _make_asgi_call(middleware, scope)
+
+    assert "Failed to resolve API token owner by JTI for usage logging" in caplog.text
+    mock_token_service.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/routers/test_reverse_proxy.py
+++ b/tests/unit/mcpgateway/routers/test_reverse_proxy.py
@@ -235,6 +235,17 @@ class TestReverseProxyManager:
         assert len(result) == 1
         assert result[0]["user"] == "user123"
 
+    def test_list_sessions_with_uuid_dict_user_uses_signed_email(self, reverse_proxy_manager, mock_websocket):
+        """Dict-shaped session users should expose the signed email, not UUID subject."""
+        user_dict = {"sub": "11111111-1111-1111-1111-111111111111", "user": {"email": "owner@test.com"}}
+        session = ReverseProxySession("test-id", mock_websocket, user_dict)
+        reverse_proxy_manager.sessions["test-id"] = session
+
+        result = reverse_proxy_manager.list_sessions()
+
+        assert len(result) == 1
+        assert result[0]["user"] == "owner@test.com"
+
     def test_list_sessions_with_none_user(self, reverse_proxy_manager, mock_websocket):
         """Test listing sessions with None user."""
         session = ReverseProxySession("test-id", mock_websocket, None)
@@ -661,6 +672,32 @@ class TestHTTPEndpoints:
             # Clean up
             manager.sessions.clear()
 
+    def test_list_sessions_uuid_sub_with_nested_email_sees_email_owned_session(self, mock_websocket):
+        """UUID-sub API-token payloads should match sessions owned by signed email."""
+        # Third-Party
+        from fastapi import FastAPI
+
+        uuid_credentials = {"sub": "11111111-1111-1111-1111-111111111111", "user": {"email": "owner@test.com"}}
+        app = FastAPI()
+        app.dependency_overrides[require_auth] = lambda: uuid_credentials
+        app.include_router(router)
+        client = TestClient(app)
+
+        session = ReverseProxySession("test-session", mock_websocket, "owner@test.com")
+        session.server_info = {"name": "test-server"}
+        manager.sessions["test-session"] = session
+
+        try:
+            response = client.get("/reverse-proxy/sessions")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data["sessions"]) == 1
+            assert data["total"] == 1
+            assert data["sessions"][0]["session_id"] == "test-session"
+        finally:
+            manager.sessions.clear()
+
     def test_disconnect_session_success(self, client, mock_auth, mock_websocket):
         """Test disconnecting an existing session."""
         # Add a test session
@@ -763,10 +800,10 @@ class TestHTTPEndpoints:
             async def _run():
                 response = await sse_endpoint("test-session", dummy_request, credentials="test-user")  # pragma: allowlist secret
                 agen = response.body_iterator
-                first = await agen.__anext__()
-                second = await agen.__anext__()
+                first = await anext(agen)
+                second = await anext(agen)
                 with pytest.raises(StopAsyncIteration):
-                    await agen.__anext__()
+                    await anext(agen)
                 return first, second
 
             with patch("mcpgateway.routers.reverse_proxy.asyncio.sleep", new=AsyncMock()):
@@ -794,9 +831,9 @@ class TestHTTPEndpoints:
             async def _run():
                 response = await sse_endpoint("test-session", DummyRequest(), credentials="test-user")  # pragma: allowlist secret
                 agen = response.body_iterator
-                first = await agen.__anext__()
+                first = await anext(agen)
                 with pytest.raises(asyncio.CancelledError):
-                    await agen.__anext__()
+                    await anext(agen)
                 return first
 
             with patch("mcpgateway.routers.reverse_proxy.asyncio.sleep", new=AsyncMock(side_effect=asyncio.CancelledError())):
@@ -954,6 +991,20 @@ class TestGetUserFromCredentials:
         assert user == "user@test.com"
         assert is_admin is False
 
+    def test_dict_with_uuid_sub_prefers_nested_email(self):
+        from mcpgateway.routers.reverse_proxy import _get_user_from_credentials
+
+        user, is_admin = _get_user_from_credentials({"sub": "11111111-1111-1111-1111-111111111111", "user": {"email": "user@test.com"}})
+        assert user == "user@test.com"
+        assert is_admin is False
+
+    def test_dict_with_uuid_sub_without_email_does_not_return_uuid(self):
+        from mcpgateway.routers.reverse_proxy import _get_user_from_credentials
+
+        user, is_admin = _get_user_from_credentials({"sub": "11111111-1111-1111-1111-111111111111"})
+        assert user is None
+        assert is_admin is False
+
     def test_dict_nested_admin(self):
         from mcpgateway.routers.reverse_proxy import _get_user_from_credentials
 
@@ -1019,6 +1070,13 @@ class TestValidateSessionOwnership:
 
         session = ReverseProxySession("test-id", mock_websocket, "owner@test.com")
         _validate_session_ownership(session, {"sub": "owner@test.com"}, "test")
+
+    def test_owner_match_allows_uuid_sub_with_nested_email_credentials(self, mock_websocket):
+        from mcpgateway.routers.reverse_proxy import _validate_session_ownership
+
+        session = ReverseProxySession("test-id", mock_websocket, "owner@test.com")
+        credentials = {"sub": "11111111-1111-1111-1111-111111111111", "user": {"email": "owner@test.com"}}
+        _validate_session_ownership(session, credentials, "test")
 
     def test_owner_match_dict_user(self, mock_websocket):
         from mcpgateway.routers.reverse_proxy import _validate_session_ownership

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -12,6 +12,11 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 import pytest
 
 
+USER1_ID = "11111111-1111-1111-1111-111111111111"
+USER2_ID = "22222222-2222-2222-2222-222222222222"
+USER3_ID = "33333333-3333-3333-3333-333333333333"
+
+
 async def _wait_forever():
     """Block until cancelled by the test cleanup."""
     await asyncio.Event().wait()
@@ -233,7 +238,7 @@ async def test_full_payload_generation_with_mock_db():
     # Mock active users and user-team memberships
     mock_db.execute.return_value.all.side_effect = [
         # Active users query
-        [("user1@example.com", False), ("user2@example.com", False), ("user3@example.com", False)],
+        [(USER1_ID, "user1@example.com", False), (USER2_ID, "user2@example.com", False), (USER3_ID, "user3@example.com", False)],
         # User-team query
         [("user1@example.com", "team1"), ("user2@example.com", "team2")],
         # Server query
@@ -261,12 +266,10 @@ async def test_full_payload_generation_with_mock_db():
 
         # Verify payload structure
         assert payload is not None
-        assert "user1@example.com" in payload
-        assert "user2@example.com" in payload
-        assert "user3@example.com" in payload
+        assert set(payload) == {USER1_ID, USER2_ID, USER3_ID}
 
         # Verify user1 payload (has access to public server)
-        user1_config = payload["user1@example.com"]
+        user1_config = payload[USER1_ID]
         assert "virtual_hosts" in user1_config
         assert "s1" in user1_config["virtual_hosts"]
 
@@ -287,7 +290,7 @@ async def test_full_payload_generation_with_mock_db():
         assert backend["allowed_prompt_names"] == ["Prompt 1"]
 
         # Verify user2 sees public server but not private server from user1
-        user2_config = payload["user2@example.com"]
+        user2_config = payload[USER2_ID]
         assert "s1" in user2_config["virtual_hosts"]  # public
         # Own private server exists but has no backend associations, so it
         # is omitted from the payload (no publishable backends).
@@ -296,7 +299,7 @@ async def test_full_payload_generation_with_mock_db():
         assert user2_backend["allowed_tool_names"] == ["public_tool", "team2_tool"]
 
         # Verify active users with no team membership still get public-only config.
-        user3_config = payload["user3@example.com"]
+        user3_config = payload[USER3_ID]
         assert "s1" in user3_config["virtual_hosts"]
         assert "s2" not in user3_config["virtual_hosts"]
         user3_backend = user3_config["virtual_hosts"]["s1"]["backends"]["g1"]
@@ -373,7 +376,7 @@ def test_create_payload_filters_empty_backends():
 
     service = DataplanePublisherService()
     data = {
-        "user@example.com": {
+        USER1_ID: {
             "servers": [
                 {
                     "id": "server1",
@@ -392,7 +395,7 @@ def test_create_payload_filters_empty_backends():
 
     # A server with no publishable backends is omitted entirely so the
     # dataplane 404s it instead of serving an empty tool list.
-    assert "server1" not in result["user@example.com"]["virtual_hosts"]
+    assert "server1" not in result[USER1_ID]["virtual_hosts"]
 
 
 def test_create_payload_excludes_non_streamable_gateways():
@@ -401,7 +404,7 @@ def test_create_payload_excludes_non_streamable_gateways():
 
     service = DataplanePublisherService()
     data = {
-        "user@example.com": {
+        USER1_ID: {
             "servers": [
                 {
                     "id": "server1",
@@ -419,7 +422,7 @@ def test_create_payload_excludes_non_streamable_gateways():
     result = service.create_payload(data)
 
     # The SSE backend is excluded and the now-backendless server is omitted.
-    assert result["user@example.com"]["virtual_hosts"] == {}
+    assert result[USER1_ID]["virtual_hosts"] == {}
 
 
 def test_create_payload_normalizes_null_passthrough_headers():
@@ -428,7 +431,7 @@ def test_create_payload_normalizes_null_passthrough_headers():
 
     service = DataplanePublisherService()
     data = {
-        "user@example.com": {
+        USER1_ID: {
             "servers": [
                 {
                     "id": "server1",
@@ -445,7 +448,7 @@ def test_create_payload_normalizes_null_passthrough_headers():
 
     result = service.create_payload(data)
 
-    backend = result["user@example.com"]["virtual_hosts"]["server1"]["backends"]["gateway1"]
+    backend = result[USER1_ID]["virtual_hosts"]["server1"]["backends"]["gateway1"]
     assert backend["passthrough_headers"] == []
     assert backend["capabilities"] == {}
 
@@ -456,7 +459,7 @@ def test_create_payload_handles_missing_references():
 
     service = DataplanePublisherService()
     data = {
-        "user@example.com": {
+        USER1_ID: {
             "servers": [
                 {
                     "id": "server1",
@@ -476,7 +479,7 @@ def test_create_payload_handles_missing_references():
     # Server exists but has no backends (gateway missing)
     # With its only gateway missing, the server has no publishable backends
     # and is omitted from the payload.
-    assert "server1" not in result["user@example.com"]["virtual_hosts"]
+    assert "server1" not in result[USER1_ID]["virtual_hosts"]
 
 
 @pytest.mark.asyncio
@@ -599,7 +602,7 @@ async def test_publish_writes_payload_releases_lock_and_exits_when_shutdown_wait
     from mcpgateway.services.dataplane_publisher import PUBLISHER_LOCK_KEY, USER_CONFIG_KEY, DataplanePublisherService, get_publisher_interval, get_publisher_ttl
 
     service = DataplanePublisherService()
-    payload = {"user@example.com": {"virtual_hosts": {"server1": {"backends": {}}}}}
+    payload = {USER1_ID: {"virtual_hosts": {"server1": {"backends": {}}}}}
 
     pipe = MagicMock()
     pipe.execute = AsyncMock()
@@ -623,8 +626,8 @@ async def test_publish_writes_payload_releases_lock_and_exits_when_shutdown_wait
 
     pipe.set.assert_called_once()
     key_arg, value_arg = pipe.set.call_args.args
-    assert msgpack.unpackb(key_arg, raw=False) == [USER_CONFIG_KEY, "user@example.com"]
-    assert msgpack.unpackb(value_arg, raw=False) == payload["user@example.com"]
+    assert msgpack.unpackb(key_arg, raw=False) == [USER_CONFIG_KEY, USER1_ID]
+    assert msgpack.unpackb(value_arg, raw=False) == payload[USER1_ID]
     assert pipe.set.call_args.kwargs == {"ex": get_publisher_ttl()}
     pipe.execute.assert_awaited_once()
     mock_redis.set.assert_awaited_once_with(PUBLISHER_LOCK_KEY, service.worker_id, nx=True, ex=get_publisher_interval() + 30)
@@ -639,7 +642,7 @@ async def test_publish_uses_configured_interval_for_ttl_lock_and_wait():
     from mcpgateway.services import dataplane_publisher
 
     service = dataplane_publisher.DataplanePublisherService()
-    payload = {"user@example.com": {"virtual_hosts": {}}}
+    payload = {USER1_ID: {"virtual_hosts": {}}}
 
     pipe = MagicMock()
     pipe.execute = AsyncMock()
@@ -686,7 +689,7 @@ async def test_publish_releases_lock_when_pipeline_execute_fails():
     with (
         patch("mcpgateway.services.dataplane_publisher.get_redis_client", new_callable=AsyncMock) as mock_get_redis,
         patch("mcpgateway.services.dataplane_publisher.asyncio.wait_for", new_callable=AsyncMock, side_effect=_finish_cycle),
-        patch.object(service, "fetch_payload", new_callable=AsyncMock, return_value={"user@example.com": {"virtual_hosts": {}}}),
+        patch.object(service, "fetch_payload", new_callable=AsyncMock, return_value={USER1_ID: {"virtual_hosts": {}}}),
     ):
         mock_get_redis.return_value = mock_redis
 
@@ -716,7 +719,7 @@ async def test_publish_logs_lock_release_failure():
     with (
         patch("mcpgateway.services.dataplane_publisher.get_redis_client", new_callable=AsyncMock) as mock_get_redis,
         patch("mcpgateway.services.dataplane_publisher.asyncio.wait_for", new_callable=AsyncMock, side_effect=_finish_cycle),
-        patch.object(service, "fetch_payload", new_callable=AsyncMock, return_value={"user@example.com": {"virtual_hosts": {}}}),
+        patch.object(service, "fetch_payload", new_callable=AsyncMock, return_value={USER1_ID: {"virtual_hosts": {}}}),
     ):
         mock_get_redis.return_value = mock_redis
 
@@ -746,7 +749,7 @@ async def test_publish_continues_after_cycle_timeout():
     with (
         patch("mcpgateway.services.dataplane_publisher.get_redis_client", new_callable=AsyncMock) as mock_get_redis,
         patch("mcpgateway.services.dataplane_publisher.asyncio.wait_for", new_callable=AsyncMock, side_effect=_timeout_and_stop),
-        patch.object(service, "fetch_payload", new_callable=AsyncMock, return_value={"user@example.com": {"virtual_hosts": {}}}),
+        patch.object(service, "fetch_payload", new_callable=AsyncMock, return_value={USER1_ID: {"virtual_hosts": {}}}),
     ):
         mock_get_redis.return_value = mock_redis
 

--- a/tests/unit/mcpgateway/services/test_token_catalog_service.py
+++ b/tests/unit/mcpgateway/services/test_token_catalog_service.py
@@ -55,7 +55,7 @@ def mock_user():
     user = MagicMock(spec=EmailUser)
     user.email = "test@example.com"
     user.is_admin = False
-    user.id = "user-123"
+    user.id = "11111111-1111-1111-1111-111111111111"
     return user
 
 
@@ -255,7 +255,7 @@ class TestTokenCatalogService:
 
     @pytest.mark.asyncio
     async def test_generate_token_basic(self, token_service):
-        """Test _generate_token method with basic parameters."""
+        """Test _generate_token method with basic parameters and no user object."""
         with patch("mcpgateway.services.token_catalog_service.create_jwt_token", new_callable=AsyncMock) as mock_create_jwt:
             mock_create_jwt.return_value = "jwt_token_123"
             jti = str(uuid.uuid4())
@@ -269,6 +269,21 @@ class TestTokenCatalogService:
             assert call_kwargs["data"]["jti"] == jti
             assert call_kwargs["user_data"]["email"] == "user@example.com"
             assert call_kwargs["user_data"]["is_admin"] is False
+
+    @pytest.mark.asyncio
+    async def test_generate_token_uses_user_id_as_subject(self, token_service, mock_user):
+        """API tokens use the opaque user id as JWT subject when the user record is available."""
+        with patch("mcpgateway.services.token_catalog_service.create_jwt_token", new_callable=AsyncMock) as mock_create_jwt:
+            mock_create_jwt.return_value = "jwt_token_123"
+            jti = str(uuid.uuid4())
+
+            await token_service._generate_token("user@example.com", jti, user=mock_user)
+
+            call_kwargs = mock_create_jwt.call_args.kwargs
+            assert call_kwargs["data"]["sub"] == mock_user.id
+            assert call_kwargs["data"]["jti"] == jti
+            assert call_kwargs["data"]["token_use"] == "api"
+            assert call_kwargs["user_data"]["email"] == "user@example.com"
 
     @pytest.mark.asyncio
     async def test_generate_token_with_team(self, token_service):
@@ -354,6 +369,7 @@ class TestTokenCatalogService:
             assert token == "jwt_token_admin"
             call_kwargs = mock_create_jwt.call_args.kwargs
             assert call_kwargs["user_data"]["is_admin"] is True
+            assert call_kwargs["data"]["sub"] == mock_user.id
 
     @pytest.mark.asyncio
     async def test_generate_token_no_team_sets_teams_none(self, token_service):
@@ -380,6 +396,7 @@ class TestTokenCatalogService:
             token, raw_token = await token_service.create_token(user_email="test@example.com", name="New Token", description="Test token", expires_in_days=30, tags=["api", "test"])
 
             assert raw_token == "jwt_token_new"
+            assert mock_gen_token.await_args.kwargs["user"] is mock_user
             mock_db.add.assert_called_once()
             mock_db.commit.assert_called()
             mock_db.refresh.assert_called_once()
@@ -1108,7 +1125,7 @@ class TestTokenCatalogService:
             mock_get.return_value = mock_api_token
 
             # Must provide caller_permissions that include the requested scope permissions
-            updated = await token_service.update_token(
+            await token_service.update_token(
                 token_id="token-123",
                 user_email="test@example.com",
                 scope=token_scope,

--- a/tests/unit/mcpgateway/services/test_token_catalog_service.py
+++ b/tests/unit/mcpgateway/services/test_token_catalog_service.py
@@ -259,15 +259,16 @@ class TestTokenCatalogService:
         with patch("mcpgateway.services.token_catalog_service.create_jwt_token", new_callable=AsyncMock) as mock_create_jwt:
             mock_create_jwt.return_value = "jwt_token_123"
             jti = str(uuid.uuid4())
-            token = await token_service._generate_token("user@example.com", jti)
+            user_email = "user@example.com"
+            token = await token_service._generate_token(user_email, jti)
 
             assert token == "jwt_token_123"
             mock_create_jwt.assert_called_once()
             # Access keyword arguments from the call
             call_kwargs = mock_create_jwt.call_args.kwargs
-            assert call_kwargs["data"]["sub"] == "user@example.com"
+            assert call_kwargs["data"]["sub"] == user_email
             assert call_kwargs["data"]["jti"] == jti
-            assert call_kwargs["user_data"]["email"] == "user@example.com"
+            assert call_kwargs["user_data"]["email"] == user_email
             assert call_kwargs["user_data"]["is_admin"] is False
 
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_auth.py
+++ b/tests/unit/mcpgateway/test_auth.py
@@ -252,17 +252,17 @@ class TestGetCurrentUser:
         assert user.email == "resolved@example.com"
 
     @pytest.mark.asyncio
-    async def test_jwt_uuid_sub_not_found_keeps_uuid_as_email(self, monkeypatch):
-        """UUID sub not found in DB: email stays as UUID (resolved is None path, line 1489)."""
+    async def test_jwt_uuid_sub_with_signed_email_uses_email_metadata(self, monkeypatch):
+        """UUID sub with signed user.email should not need UUID-to-email DB resolution."""
         import uuid as _uuid
 
         user_uuid = str(_uuid.uuid4())
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="uuid_sub_token")  # pragma: allowlist secret
-        jwt_payload = {"sub": user_uuid, "exp": (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp()}
+        jwt_payload = {"sub": user_uuid, "user": {"email": "signed@example.com"}, "exp": (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp()}
         mock_user = EmailUser(
-            email=user_uuid,
+            email="signed@example.com",
             password_hash="hash",
-            full_name="UUID User",
+            full_name="Signed User",
             is_admin=False,
             is_active=True,
             email_verified_at=datetime.now(timezone.utc),
@@ -272,14 +272,43 @@ class TestGetCurrentUser:
         monkeypatch.setattr(settings, "auth_cache_enabled", False)
         monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
-            with patch("mcpgateway.auth._get_email_by_id_sync", return_value=None):
-                with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
-                    with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
-                        with patch("mcpgateway.auth._check_token_revoked_sync", return_value=False):
-                            user = await get_current_user(credentials=credentials)
+        with (
+            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)),
+            patch("mcpgateway.auth._get_email_by_id_sync", return_value=None) as mock_resolve_id,
+            patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user) as mock_resolve_email,
+            patch("mcpgateway.auth._get_personal_team_sync", return_value=None),
+            patch("mcpgateway.auth._check_token_revoked_sync", return_value=False),
+        ):
+            user = await get_current_user(credentials=credentials)
 
-        assert user.email == user_uuid
+        assert user.email == "signed@example.com"
+        mock_resolve_id.assert_not_called()
+        mock_resolve_email.assert_called_with("signed@example.com")
+
+    @pytest.mark.asyncio
+    async def test_jwt_unknown_uuid_sub_rejected(self, monkeypatch):
+        """UUID sub not found in DB should fail closed instead of using UUID as email."""
+        import uuid as _uuid
+
+        user_uuid = str(_uuid.uuid4())
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="uuid_sub_token")  # pragma: allowlist secret
+        jwt_payload = {"sub": user_uuid, "exp": (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp()}
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+
+        with (
+            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)),
+            patch("mcpgateway.auth._get_email_by_id_sync", return_value=None),
+            patch("mcpgateway.auth._get_user_by_email_sync") as mock_resolve_email,
+            patch("mcpgateway.auth._get_personal_team_sync", return_value=None),
+            patch("mcpgateway.auth._check_token_revoked_sync", return_value=False),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(credentials=credentials)
+
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+        assert exc_info.value.detail == "Invalid token"
+        mock_resolve_email.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_jwt_without_email_or_sub_raises_401(self):
@@ -4154,7 +4183,7 @@ class TestTenantIdPropagation:
         auth_module._inject_userinfo_instate(request=request, user=user)
         auth_module._propagate_tenant_id(request)
 
-        assert request.state.plugin_global_context.tenant_id == "team-acme", "_propagate_tenant_id must propagate request.state.team_id into " "global_context.tenant_id for single-team tokens"
+        assert request.state.plugin_global_context.tenant_id == "team-acme", "_propagate_tenant_id must propagate request.state.team_id into global_context.tenant_id for single-team tokens"
 
     def test_no_team_id_leaves_tenant_id_none(self):
         """P1: when request.state.team_id is None (multi-team or no team), tenant_id stays None.
@@ -4173,7 +4202,7 @@ class TestTenantIdPropagation:
         auth_module._inject_userinfo_instate(request=request, user=user)
         auth_module._propagate_tenant_id(request)
 
-        assert request.state.plugin_global_context.tenant_id is None, "When team_id is None (multi-team or no-team token), " "tenant_id must remain None — no fake 'default' tenant should be invented"
+        assert request.state.plugin_global_context.tenant_id is None, "When team_id is None (multi-team or no-team token), tenant_id must remain None — no fake 'default' tenant should be invented"
 
     def test_existing_tenant_id_is_not_overwritten(self):
         """P1: if global_context.tenant_id is already set (e.g. by an auth plugin), do not overwrite it.
@@ -4230,7 +4259,7 @@ class TestTenantIdPropagation:
         call_kwargs = mock_pm.invoke_hook.call_args
         global_context = call_kwargs.kwargs.get("global_context")
         assert global_context is not None
-        assert global_context.tenant_id == "team-acme", "get_current_user() fallback must propagate request.state.team_id " "into GlobalContext.tenant_id for by_tenant rate limiting"
+        assert global_context.tenant_id == "team-acme", "get_current_user() fallback must propagate request.state.team_id into GlobalContext.tenant_id for by_tenant rate limiting"
 
     @pytest.mark.asyncio
     async def test_get_current_user_fallback_tenant_id_none_when_no_team(self):
@@ -4268,7 +4297,7 @@ class TestTenantIdPropagation:
         call_kwargs = mock_pm.invoke_hook.call_args
         global_context = call_kwargs.kwargs.get("global_context")
         assert global_context is not None
-        assert global_context.tenant_id is None, "When team_id is None, GlobalContext.tenant_id must be None — " "no phantom tenant should be invented"
+        assert global_context.tenant_id is None, "When team_id is None, GlobalContext.tenant_id must be None — no phantom tenant should be invented"
 
     def test_propagate_tenant_id_on_middleware_seeded_context(self):
         """_propagate_tenant_id must work when middleware has already created GlobalContext.
@@ -4289,7 +4318,7 @@ class TestTenantIdPropagation:
         auth_module._propagate_tenant_id(request)
 
         assert request.state.plugin_global_context.tenant_id == "team-acme", (
-            "_propagate_tenant_id must fill tenant_id even when middleware " "has already created plugin_global_context with tenant_id=None"
+            "_propagate_tenant_id must fill tenant_id even when middleware has already created plugin_global_context with tenant_id=None"
         )
 
     def test_propagate_tenant_id_no_overwrite(self):

--- a/tests/unit/mcpgateway/test_auth_context_email_precedence.py
+++ b/tests/unit/mcpgateway/test_auth_context_email_precedence.py
@@ -179,6 +179,21 @@ class TestJwtPayloadEmailResolution:
 
         assert auth_context.get_jwt_user_email_from_payload(payload) is None
 
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            ({"sub": USER_ID}, True),
+            ({"sub": f"  {USER_ID}  "}, True),
+            ({"sub": "legacy@example.com"}, False),
+            ({"email": "owner@example.com"}, False),
+            ({"sub": ""}, False),
+            ({"sub": None}, False),
+        ],
+    )
+    def test_jwt_subject_is_uuid(self, payload, expected):
+        """Only UUID subjects are treated as unresolved UUID identity candidates."""
+        assert auth_context.jwt_subject_is_uuid(payload) is expected
+
     @pytest.mark.asyncio
     async def test_uuid_sub_resolves_with_injected_resolver(self):
         """UUID-sub fallback uses the injected resolver only when needed."""

--- a/tests/unit/mcpgateway/test_auth_context_email_precedence.py
+++ b/tests/unit/mcpgateway/test_auth_context_email_precedence.py
@@ -13,6 +13,9 @@ and consistency across visibility checks and audit logs.
 # Standard
 from unittest.mock import MagicMock
 
+# Third-Party
+import pytest
+
 # First-Party
 from mcpgateway import admin
 from mcpgateway import auth_context
@@ -145,3 +148,69 @@ class TestEmailSubPrecedenceConsistency:
 
         assert auth_context.get_user_email(user_obj) == "falsy@example.com"
         assert admin.get_user_email(user_obj) == "falsy@example.com"
+
+
+class TestJwtPayloadEmailResolution:
+    """Test JWT email extraction for UUID-sub tokens."""
+
+    USER_ID = "11111111-1111-1111-1111-111111111111"
+
+    def test_signed_user_email_wins_over_uuid_sub(self):
+        """Signed nested user.email is the common UUID-sub token shape."""
+        payload = {"sub": self.USER_ID, "user": {"email": "owner@example.com"}}
+
+        assert auth_context.get_jwt_user_email_from_payload(payload) == "owner@example.com"
+
+    def test_top_level_email_used_when_nested_email_missing(self):
+        """Top-level email is accepted before legacy sub fallback."""
+        payload = {"sub": self.USER_ID, "email": "top-level@example.com"}
+
+        assert auth_context.get_jwt_user_email_from_payload(payload) == "top-level@example.com"
+
+    def test_legacy_email_sub_is_returned(self):
+        """Legacy email-sub tokens continue to resolve without DB lookup."""
+        payload = {"sub": "legacy@example.com"}
+
+        assert auth_context.get_jwt_user_email_from_payload(payload) == "legacy@example.com"
+
+    def test_uuid_sub_without_metadata_is_not_returned_as_email(self):
+        """A raw UUID subject is never treated as user_email."""
+        payload = {"sub": self.USER_ID}
+
+        assert auth_context.get_jwt_user_email_from_payload(payload) is None
+
+    @pytest.mark.asyncio
+    async def test_uuid_sub_resolves_with_injected_resolver(self):
+        """UUID-sub fallback uses the injected resolver only when needed."""
+        calls = []
+
+        async def resolve_user_id(user_id: str) -> str | None:
+            calls.append(user_id)
+            return "resolved@example.com"
+
+        payload = {"sub": self.USER_ID}
+
+        assert await auth_context.resolve_jwt_user_email_from_payload(payload, uuid_email_resolver=resolve_user_id) == "resolved@example.com"
+        assert calls == [self.USER_ID]
+
+    @pytest.mark.asyncio
+    async def test_unknown_uuid_sub_resolves_to_none(self):
+        """Unknown UUID subjects stay unresolved instead of becoming user_email."""
+
+        async def resolve_user_id(_user_id: str) -> str | None:
+            return None
+
+        payload = {"sub": self.USER_ID}
+
+        assert await auth_context.resolve_jwt_user_email_from_payload(payload, uuid_email_resolver=resolve_user_id) is None
+
+    @pytest.mark.asyncio
+    async def test_signed_user_email_does_not_call_uuid_resolver(self):
+        """Well-formed UUID-sub API tokens avoid a DB lookup."""
+
+        async def resolve_user_id(_user_id: str) -> str | None:
+            raise AssertionError("resolver should not be called")
+
+        payload = {"sub": self.USER_ID, "user": {"email": "owner@example.com"}}
+
+        assert await auth_context.resolve_jwt_user_email_from_payload(payload, uuid_email_resolver=resolve_user_id) == "owner@example.com"

--- a/tests/unit/mcpgateway/test_auth_context_email_precedence.py
+++ b/tests/unit/mcpgateway/test_auth_context_email_precedence.py
@@ -220,6 +220,13 @@ class TestJwtPayloadEmailResolution:
         assert await auth_context.resolve_jwt_user_email_from_payload(payload, uuid_email_resolver=resolve_user_id) is None
 
     @pytest.mark.asyncio
+    async def test_uuid_sub_without_resolver_resolves_to_none(self):
+        """UUID subjects need an explicit resolver to become user_email."""
+        payload = {"sub": self.USER_ID}
+
+        assert await auth_context.resolve_jwt_user_email_from_payload(payload) is None
+
+    @pytest.mark.asyncio
     async def test_signed_user_email_does_not_call_uuid_resolver(self):
         """Well-formed UUID-sub API tokens avoid a DB lookup."""
 

--- a/tests/unit/mcpgateway/test_token_migration.py
+++ b/tests/unit/mcpgateway/test_token_migration.py
@@ -33,6 +33,18 @@ async def test_get_user_email_from_token_with_email():
 
 
 @pytest.mark.asyncio
+async def test_get_user_email_from_token_prefers_signed_user_email():
+    """Test new API token format with UUID sub and signed user.email metadata."""
+    payload = {"sub": TEST_UUID, "user": {"email": "user@example.com"}}
+    db = MagicMock()
+
+    email = await get_user_email_from_token(payload, db)
+
+    assert email == "user@example.com"
+    db.query.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_get_user_email_from_token_with_user_id():
     """Test new token format with UUID in sub claim."""
     payload = {"sub": TEST_UUID}

--- a/tests/unit/mcpgateway/test_token_migration.py
+++ b/tests/unit/mcpgateway/test_token_migration.py
@@ -119,9 +119,9 @@ async def test_set_user_context_from_token_with_email():
 
     mock_db_user = MagicMock()
     mock_db_user.is_admin = True
+    db.query.return_value.filter.return_value.first.return_value = mock_db_user
 
-    with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_db_user):
-        await set_user_context_from_token(request, payload, db)
+    await set_user_context_from_token(request, payload, db)
 
     assert request.state.user_email == "user@example.com"
     assert request.state.user_id == "user@example.com"
@@ -140,13 +140,10 @@ async def test_set_user_context_from_token_with_user_id():
     db = MagicMock()
     mock_user = MagicMock(spec=EmailUser)
     mock_user.email = "user@example.com"
+    mock_user.is_admin = False
     db.query.return_value.filter.return_value.first.return_value = mock_user
 
-    mock_db_user = MagicMock()
-    mock_db_user.is_admin = False
-
-    with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_db_user):
-        await set_user_context_from_token(request, payload, db)
+    await set_user_context_from_token(request, payload, db)
 
     assert request.state.user_email == "user@example.com"
     assert request.state.user_id == TEST_UUID
@@ -161,9 +158,9 @@ async def test_set_user_context_from_token_defaults():
     request.state = MagicMock()
     payload = {"sub": "user@example.com"}
     db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
 
-    with patch("mcpgateway.auth._get_user_by_email_sync", return_value=None):
-        await set_user_context_from_token(request, payload, db)
+    await set_user_context_from_token(request, payload, db)
 
     assert request.state.user_email == "user@example.com"
     assert request.state.user_id == "user@example.com"

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -15604,6 +15604,27 @@ async def test_normalize_jwt_payload_with_scoped_permissions(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_normalize_jwt_payload_uuid_sub_resolves_to_email(monkeypatch):
+    """Stateful-session JWT normalization resolves UUID sub before setting email."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _normalize_jwt_payload
+
+    user_id = "11111111-1111-1111-1111-111111111111"
+    is_user_admin = MagicMock(return_value=False)
+
+    monkeypatch.setattr("mcpgateway.auth._get_email_by_id_sync", MagicMock(return_value="resolved@example.com"))
+    monkeypatch.setattr("mcpgateway.auth.normalize_token_teams", lambda payload: [])
+
+    with patch("mcpgateway.utils.admin_check.is_user_admin", is_user_admin):
+        result = await _normalize_jwt_payload({"sub": user_id, "token_use": "api", "teams": []})
+
+    assert result["email"] == "resolved@example.com"
+    assert result["is_authenticated"] is True
+    is_user_admin.assert_called_once()
+    assert is_user_admin.call_args.args[1] == "resolved@example.com"
+
+
+@pytest.mark.asyncio
 async def test_set_logging_level_denied_by_token_scope(monkeypatch):
     """Token without servers.use should be denied set_logging_level."""
     # First-Party
@@ -15648,6 +15669,98 @@ async def test_auth_jwt_scoped_permissions_in_user_context(monkeypatch):
     assert ctx["scoped_permissions"] == ["tools.read", "tools.execute", "servers.use"]
     assert ctx["email"] == "user@example.com"
     assert ctx["auth_method"] == "jwt"
+
+
+@pytest.mark.asyncio
+async def test_auth_jwt_uuid_sub_uses_signed_user_email_without_uuid_lookup(monkeypatch):
+    """UUID-sub API tokens should use signed user.email and avoid UUID DB fallback."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _StreamableHttpAuthHandler, user_context_var
+
+    user_id = "11111111-1111-1111-1111-111111111111"
+    jwt_payload = {
+        "sub": user_id,
+        "user": {"email": "owner@example.com", "is_admin": False},
+        "is_admin": False,
+        "token_use": "api",
+        "teams": [],
+    }
+    user_record = MagicMock()
+    user_record.is_active = True
+    user_record.is_admin = False
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.verify_credentials", AsyncMock(return_value=jwt_payload))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.auth_cache_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.auth_cache_batch_queries", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.require_user_in_db", True)
+    monkeypatch.setattr("mcpgateway.auth._get_email_by_id_sync", MagicMock(side_effect=AssertionError("UUID resolver should not be called")))
+    get_user_by_email = MagicMock(return_value=user_record)
+    monkeypatch.setattr("mcpgateway.auth._get_user_by_email_sync", get_user_by_email)
+    monkeypatch.setattr("mcpgateway.auth._check_token_revoked_sync", MagicMock(return_value=False))
+    monkeypatch.setattr("mcpgateway.auth.resolve_trace_team_name", AsyncMock(return_value=None))
+
+    handler = _StreamableHttpAuthHandler(scope={"type": "http", "headers": []}, receive=AsyncMock(), send=AsyncMock())
+
+    assert await handler._auth_jwt(token="fake-token") is True
+    ctx = user_context_var.get()
+    assert ctx["email"] == "owner@example.com"
+    get_user_by_email.assert_called_once_with("owner@example.com")
+
+
+@pytest.mark.asyncio
+async def test_auth_jwt_uuid_sub_resolves_to_email_when_metadata_missing(monkeypatch):
+    """UUID-sub API tokens without email metadata resolve UUID to email before DB checks."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _StreamableHttpAuthHandler, user_context_var
+
+    user_id = "11111111-1111-1111-1111-111111111111"
+    jwt_payload = {"sub": user_id, "is_admin": False, "token_use": "api", "teams": []}
+    user_record = MagicMock()
+    user_record.is_active = True
+    user_record.is_admin = False
+
+    get_email_by_id = MagicMock(return_value="resolved@example.com")
+    get_user_by_email = MagicMock(return_value=user_record)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.verify_credentials", AsyncMock(return_value=jwt_payload))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.auth_cache_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.auth_cache_batch_queries", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.require_user_in_db", True)
+    monkeypatch.setattr("mcpgateway.auth._get_email_by_id_sync", get_email_by_id)
+    monkeypatch.setattr("mcpgateway.auth._get_user_by_email_sync", get_user_by_email)
+    monkeypatch.setattr("mcpgateway.auth._check_token_revoked_sync", MagicMock(return_value=False))
+    monkeypatch.setattr("mcpgateway.auth.resolve_trace_team_name", AsyncMock(return_value=None))
+
+    handler = _StreamableHttpAuthHandler(scope={"type": "http", "headers": []}, receive=AsyncMock(), send=AsyncMock())
+
+    assert await handler._auth_jwt(token="fake-token") is True
+    assert user_context_var.get()["email"] == "resolved@example.com"
+    get_email_by_id.assert_called_once_with(user_id)
+    get_user_by_email.assert_called_once_with("resolved@example.com")
+
+
+@pytest.mark.asyncio
+async def test_auth_jwt_unknown_uuid_sub_rejected_when_user_required(monkeypatch):
+    """Unknown UUID subjects are rejected in strict DB mode instead of becoming user_email."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _StreamableHttpAuthHandler
+
+    user_id = "11111111-1111-1111-1111-111111111111"
+    jwt_payload = {"sub": user_id, "is_admin": False, "token_use": "api", "teams": []}
+    send_error = AsyncMock(return_value=False)
+    get_user_by_email = MagicMock()
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.verify_credentials", AsyncMock(return_value=jwt_payload))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.require_user_in_db", True)
+    monkeypatch.setattr("mcpgateway.auth._get_email_by_id_sync", MagicMock(return_value=None))
+    monkeypatch.setattr("mcpgateway.auth._get_user_by_email_sync", get_user_by_email)
+    monkeypatch.setattr(_StreamableHttpAuthHandler, "_send_error", send_error)
+
+    handler = _StreamableHttpAuthHandler(scope={"type": "http", "headers": []}, receive=AsyncMock(), send=AsyncMock())
+
+    assert await handler._auth_jwt(token="fake-token") is False
+    send_error.assert_awaited_once()
+    assert send_error.call_args.kwargs["detail"] == "User not found in database"
+    get_user_by_email.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -13278,7 +13278,7 @@ async def test_normalize_jwt_payload_session_admin_no_email_no_bypass():
 
 
 # ---------------------------------------------------------------------------
-# _resolve_subject_email tests (issue #5215)
+# _resolve_jwt_user_email_for_streamable tests (issue #5215)
 #
 # Session tokens carry sub = EmailUser.id (a UUID); legacy/API tokens carry the
 # email. The MCP transport used to treat sub as an email unconditionally, so
@@ -13294,7 +13294,7 @@ async def test_resolve_subject_email_uuid_sub_resolves_to_email():
     """A session token's UUID sub is resolved to the user's email via the DB."""
     lookup = Mock(return_value="user@example.com")
     with patch("mcpgateway.auth._get_email_by_id_sync", lookup):
-        result = await tr._resolve_subject_email({"sub": SESSION_SUB_UUID, "token_use": "session"})
+        result = await tr._resolve_jwt_user_email_for_streamable({"sub": SESSION_SUB_UUID, "token_use": "session"})
 
     assert result == "user@example.com"
     lookup.assert_called_once_with(SESSION_SUB_UUID)
@@ -13305,7 +13305,7 @@ async def test_resolve_subject_email_legacy_sub_skips_db_lookup():
     """An email sub short-circuits before any DB round-trip (hot-path guard)."""
     lookup = Mock(return_value="should-not-be-used@example.com")
     with patch("mcpgateway.auth._get_email_by_id_sync", lookup):
-        result = await tr._resolve_subject_email({"sub": "legacy@example.com", "token_use": "api"})
+        result = await tr._resolve_jwt_user_email_for_streamable({"sub": "legacy@example.com", "token_use": "api"})
 
     assert result == "legacy@example.com"
     lookup.assert_not_called()
@@ -13316,29 +13316,30 @@ async def test_resolve_subject_email_session_token_with_email_sub():
     """Session tokens issued without a user row carry an email sub (admin.py:4273)."""
     lookup = Mock(return_value="should-not-be-used@example.com")
     with patch("mcpgateway.auth._get_email_by_id_sync", lookup):
-        result = await tr._resolve_subject_email({"sub": "admin@example.com", "token_use": "session"})
+        result = await tr._resolve_jwt_user_email_for_streamable({"sub": "admin@example.com", "token_use": "session"})
 
     assert result == "admin@example.com"
     lookup.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_resolve_subject_email_unresolvable_uuid_returns_raw_subject():
-    """An unresolvable UUID keeps the raw subject so require_user_in_db still denies.
+async def test_resolve_subject_email_unresolvable_uuid_returns_none():
+    """An unresolvable UUID returns None so the caller can reject it explicitly.
 
-    SECURITY: the request must fail closed on the caller's existing
-    "User not found in database" branch, never silently downgrade to anonymous.
+    SECURITY: the request must fail closed on the caller's UUID-subject guard,
+    never by treating the raw UUID as an email and never by silently downgrading
+    it to anonymous.
     """
     with patch("mcpgateway.auth._get_email_by_id_sync", Mock(return_value=None)):
-        result = await tr._resolve_subject_email({"sub": SESSION_SUB_UUID, "token_use": "session"})
+        result = await tr._resolve_jwt_user_email_for_streamable({"sub": SESSION_SUB_UUID, "token_use": "session"})
 
-    assert result == SESSION_SUB_UUID
+    assert result is None
 
 
 @pytest.mark.asyncio
 async def test_resolve_subject_email_falls_back_to_email_claim():
     """Falls back to the 'email' claim when 'sub' is absent."""
-    result = await tr._resolve_subject_email({"email": "fallback@example.com"})
+    result = await tr._resolve_jwt_user_email_for_streamable({"email": "fallback@example.com"})
     assert result == "fallback@example.com"
 
 
@@ -13354,7 +13355,7 @@ async def test_resolve_subject_email_prefers_email_over_conflicting_sub():
     """
     lookup = Mock(return_value="should-not-be-used@example.com")
     with patch("mcpgateway.auth._get_email_by_id_sync", lookup):
-        result = await tr._resolve_subject_email({"email": "canonical@example.com", "sub": SESSION_SUB_UUID, "token_use": "session"})
+        result = await tr._resolve_jwt_user_email_for_streamable({"email": "canonical@example.com", "sub": SESSION_SUB_UUID, "token_use": "session"})
 
     assert result == "canonical@example.com"
     lookup.assert_not_called()
@@ -13363,21 +13364,21 @@ async def test_resolve_subject_email_prefers_email_over_conflicting_sub():
 @pytest.mark.asyncio
 async def test_resolve_subject_email_non_string_email_falls_back_to_sub():
     """A malformed (non-string) 'email' claim is ignored in favor of 'sub'."""
-    result = await tr._resolve_subject_email({"email": ["not", "a", "string"], "sub": "legacy@example.com", "token_use": "api"})
+    result = await tr._resolve_jwt_user_email_for_streamable({"email": ["not", "a", "string"], "sub": "legacy@example.com", "token_use": "api"})
     assert result == "legacy@example.com"
 
 
 @pytest.mark.asyncio
 async def test_resolve_subject_email_empty_email_falls_back_to_sub():
     """An empty-string 'email' claim is treated as absent and falls back to 'sub'."""
-    result = await tr._resolve_subject_email({"email": "", "sub": "legacy@example.com", "token_use": "api"})
+    result = await tr._resolve_jwt_user_email_for_streamable({"email": "", "sub": "legacy@example.com", "token_use": "api"})
     assert result == "legacy@example.com"
 
 
 @pytest.mark.asyncio
 async def test_resolve_subject_email_no_subject_returns_none():
     """A payload with no subject yields None rather than raising."""
-    assert await tr._resolve_subject_email({}) is None
+    assert await tr._resolve_jwt_user_email_for_streamable({}) is None
 
 
 @pytest.mark.asyncio
@@ -13393,7 +13394,7 @@ async def test_resolve_subject_email_db_error_propagates():
 
     with patch("mcpgateway.auth._get_email_by_id_sync", Mock(side_effect=SQLAlchemyError("db down"))):
         with pytest.raises(SQLAlchemyError):
-            await tr._resolve_subject_email({"sub": SESSION_SUB_UUID, "token_use": "session"})
+            await tr._resolve_jwt_user_email_for_streamable({"sub": SESSION_SUB_UUID, "token_use": "session"})
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/utils/test_verify_credentials_uuid.py
+++ b/tests/unit/mcpgateway/utils/test_verify_credentials_uuid.py
@@ -54,6 +54,80 @@ class TestVerifyCredentialsUuidCoverage:
         assert result is not None
 
     @pytest.mark.asyncio
+    async def test_require_auth_uuid_sub_api_token_uses_signed_email_for_active_user(self, monkeypatch):
+        """UUID-sub API tokens should pass shared require_auth active-user checks."""
+        from fastapi import Request
+        from fastapi.security import HTTPAuthorizationCredentials
+        from mcpgateway.utils import verify_credentials as vc
+
+        uuid_sub = "550e8400-e29b-41d4-a716-446655440000"
+        token = make_test_jwt(
+            email=uuid_sub,
+            expires_in_minutes=10,
+            extra_payload={"token_use": "api"},
+            user_data={"email": "api-user@example.com", "is_admin": False, "auth_provider": "api_token"},
+        )
+
+        active_user = MagicMock(spec=EmailUser)
+        active_user.email = "api-user@example.com"
+        active_user.is_active = True
+        get_user_by_email = MagicMock(return_value=active_user)
+        get_email_by_id = MagicMock(return_value="api-user@example.com")
+
+        monkeypatch.setattr(vc.settings, "mcp_client_auth_enabled", True, raising=False)
+        monkeypatch.setattr(vc.settings, "auth_required", True, raising=False)
+        monkeypatch.setattr(vc.settings, "require_user_in_db", True, raising=False)
+        monkeypatch.setattr("mcpgateway.auth._get_user_by_email_sync", get_user_by_email)
+        monkeypatch.setattr("mcpgateway.auth._get_email_by_id_sync", get_email_by_id)
+        monkeypatch.setattr("mcpgateway.auth._check_token_revoked_sync", MagicMock(return_value=False))
+
+        request = MagicMock(spec=Request)
+        request.headers = {}
+        request.cookies = {}
+        request.state = MagicMock()
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+        result = await vc.require_auth(request=request, credentials=credentials, jwt_token=None)
+
+        assert result["sub"] == uuid_sub
+        assert result["user"]["email"] == "api-user@example.com"
+        get_user_by_email.assert_called_once_with("api-user@example.com")
+        get_email_by_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_require_auth_unknown_uuid_sub_api_token_rejected_when_user_required(self, monkeypatch):
+        """Unknown UUID-sub API tokens still fail closed in strict DB mode."""
+        from fastapi import Request, HTTPException
+        from fastapi.security import HTTPAuthorizationCredentials
+        from mcpgateway.utils import verify_credentials as vc
+
+        uuid_sub = "550e8400-e29b-41d4-a716-446655440000"
+        token = make_test_jwt(email=uuid_sub, expires_in_minutes=10, extra_payload={"token_use": "api"})
+        get_user_by_email = MagicMock(return_value=None)
+        get_email_by_id = MagicMock(return_value=None)
+
+        monkeypatch.setattr(vc.settings, "mcp_client_auth_enabled", True, raising=False)
+        monkeypatch.setattr(vc.settings, "auth_required", True, raising=False)
+        monkeypatch.setattr(vc.settings, "require_user_in_db", True, raising=False)
+        monkeypatch.setattr("mcpgateway.auth._get_user_by_email_sync", get_user_by_email)
+        monkeypatch.setattr("mcpgateway.auth._get_email_by_id_sync", get_email_by_id)
+        monkeypatch.setattr("mcpgateway.auth._check_token_revoked_sync", MagicMock(return_value=False))
+
+        request = MagicMock(spec=Request)
+        request.headers = {}
+        request.cookies = {}
+        request.state = MagicMock()
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await vc.require_auth(request=request, credentials=credentials, jwt_token=None)
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "User not found in database"
+        get_email_by_id.assert_called_once_with(uuid_sub)
+        get_user_by_email.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_uuid_resolution_valueerror_lines_526_527(self):
         """Cover lines 526-527: ValueError exception when username is not a valid UUID."""
         # Use a non-UUID username (regular email) with token_use=session
@@ -74,7 +148,7 @@ class TestVerifyCredentialsUuidCoverage:
     @pytest.mark.asyncio
     async def test_uuid_resolution_in_require_admin_auth_lines_1409_1414(self):
         """Cover lines 1409-1414: UUID resolution in require_admin_auth."""
-        from fastapi import Request, HTTPException
+        from fastapi import Request
         from mcpgateway.utils.verify_credentials import require_admin_auth
         from mcpgateway.db import EmailUser
         from unittest.mock import AsyncMock
@@ -149,25 +223,19 @@ async def test_enforce_revocation_uuid_resolution_success(monkeypatch):
     active_user = MagicMock()
     active_user.is_active = True
 
-    # First call returns None (triggers UUID resolution), second call returns user
-    call_count = [0]
+    get_user_by_email = MagicMock(return_value=active_user)
+    get_email_by_id = MagicMock(return_value="user@example.com")
 
-    def mock_get_user(email):
-        call_count[0] += 1
-        if call_count[0] == 1:
-            return None  # First call with UUID
-        return active_user  # Second call with resolved email
-
-    monkeypatch.setattr("mcpgateway.auth._get_user_by_email_sync", mock_get_user)
-    monkeypatch.setattr("mcpgateway.auth._get_email_by_id_sync", lambda _uuid: "user@example.com")
+    monkeypatch.setattr("mcpgateway.auth._get_user_by_email_sync", get_user_by_email)
+    monkeypatch.setattr("mcpgateway.auth._get_email_by_id_sync", get_email_by_id)
     monkeypatch.setattr("mcpgateway.auth._check_token_revoked_sync", lambda _jti: False)
 
     payload = {"sub": uuid_sub, "jti": "test-jti", "token_use": "session"}
 
-    # Should resolve UUID and return None (success)
     result = await vc._enforce_revocation_and_active_user(payload)
     assert result is None
-    assert call_count[0] == 2  # Verify UUID resolution was attempted
+    get_email_by_id.assert_called_once_with(uuid_sub)
+    get_user_by_email.assert_called_once_with("user@example.com")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Publish dataplane user configs under `EmailUser.id` instead of email addresses.
- Mint API-token JWT subjects from `EmailUser.id` while retaining signed `user.email` metadata.
- Resolve signed user email metadata in token scoping middleware so UUID-sub tokens keep existing team and ownership checks working.

## Notes

This is the control-plane portion of the dataplane subject migration. Part of #5462.

Matching Rust dataplane/demo fixture updates are open in contextforge-gateway-rs/contextforge-gateway-rs#61.

## Migration / Compatibility

Redis user configs are now keyed by the opaque user UUID instead of email. Existing email-keyed Redis entries are not migrated; they expire through the normal dataplane publisher TTL.

Session tokens already use UUID subjects, so they continue to match UUID-keyed configs.

Pre-existing API tokens minted before this change may still carry email subjects. Those tokens must be rotated or recreated during rollout. After the old email-keyed Redis entry expires, an email-sub token no longer matches a published config and dataplane requests can fail with HTTP 400: `Problem occurred retrieving the configuration` until the token is replaced.

No Rust dataplane fallback is added because the dataplane treats JWT `sub` as an opaque lookup key and does not own email-to-UUID identity mapping.

## Validation Performed

Python unit coverage:

```bash
uv run pytest tests/unit/mcpgateway/services/test_token_catalog_service.py \
  tests/unit/mcpgateway/middleware/test_token_scoping.py \
  tests/unit/mcpgateway/services/test_dataplane_publisher.py -q

uv run pytest tests/unit/mcpgateway/transports/test_streamablehttp_transport.py -q

uv run pytest tests/unit/mcpgateway/test_auth_context_email_precedence.py \
  tests/unit/mcpgateway/middleware/test_token_usage_middleware.py \
  tests/unit/mcpgateway/middleware/test_token_scoping.py -q

uv run pytest tests/unit/mcpgateway/test_auth.py -k "uuid_sub or api_token" -q

uv run ruff check mcpgateway/services/dataplane_publisher.py \
  mcpgateway/services/token_catalog_service.py \
  mcpgateway/middleware/token_scoping.py \
  mcpgateway/auth_context.py \
  mcpgateway/transports/streamablehttp_transport.py \
  mcpgateway/middleware/token_usage_middleware.py \
  tests/unit/mcpgateway/services/test_dataplane_publisher.py \
  tests/unit/mcpgateway/services/test_token_catalog_service.py \
  tests/unit/mcpgateway/middleware/test_token_scoping.py \
  tests/unit/mcpgateway/test_auth_context_email_precedence.py \
  tests/unit/mcpgateway/transports/test_streamablehttp_transport.py \
  tests/unit/mcpgateway/middleware/test_token_usage_middleware.py

git diff --check
```

Cross-repo dataplane smoke test:

1. Started local Redis and one sample MCP backend from the Rust gateway repo:

```bash
cd ../contextforge-gateway-rs
docker compose -f docker/docker-compose-local.yaml up -d redis gateway-one
```

2. Started one Rust dataplane process locally:

```bash
cargo +1.96 run --bin contextforge-gateway-rs -- \
  --address 0.0.0.0:8001 \
  --redis-port 6379 \
  --redis-address 127.0.0.1 \
  --token-verification-public-key assets/jwt.key.pub \
  --number-of-cpus 4 \
  --redis-mode=plain-text \
  --upstream-connection-mode=plain-text-or-tls
```

3. Used the Python dataplane publisher code path to publish one user config to Redis with:

- subject/user key: `11111111-1111-1111-1111-111111111111`
- virtual server: `c0ffee00f001f00lf00ldeadbeefdead`
- backend URL: `http://127.0.0.1:5555/mcp`

4. Minted an RS256 JWT with:

- `sub`: `11111111-1111-1111-1111-111111111111`
- `user.email`: `admin@example.com`

5. Called the Rust dataplane endpoint:

```bash
POST http://127.0.0.1:8001/contextforge-rs/servers/c0ffee00f001f00lf00ldeadbeefdead/mcp
```

Results and confirmation points:

The smoke script stdout confirmed the Python-side Redis write and MCP responses:

```text
published Redis key (UserConfig, 11111111-1111-1111-1111-111111111111)
email Redis key absent for admin@example.com
uuid Redis key TTL 130
initialize status 200
initialized notification status 202
tools/list status 200
tools/list names ['decrement', 'echo', 'get_session_id', 'get_value', 'increment', 'long_task', 'say_hello', 'sum']
```

The smoke script also asserted that no email-keyed Redis config existed for `admin@example.com`, so the published key was UUID-only.

The Rust dataplane process logs confirmed that the JWT `sub` was used as the Redis lookup key and that the config loaded successfully:

```text
user_config_store_layer - getting user config for request subject = 11111111-1111-1111-1111-111111111111
RedisUserConfigStore::get_config - loaded user config blob from Redis subject = 11111111-1111-1111-1111-111111111111
RedisUserConfigStore::get_config - decoded user config subject = 11111111-1111-1111-1111-111111111111 virtual_hosts = 1
user_config_store_layer - loaded user config subject = 11111111-1111-1111-1111-111111111111 virtual_hosts = 1
list_tools: backend gateway-one completed (8 items)
```

So the result was confirmed in two places:

- Python smoke script output: Redis key written, email key absent, MCP request statuses, returned tool names.
- Rust dataplane logs: UUID subject used for config lookup, Redis config loaded, backend `tools/list` completed.

<details>
<summary>Semi-automated cross-repo smoke script</summary>

This is opt-in/manual validation. It uses one Redis container, one sample backend container (`gateway-one`), and one local Rust dataplane process.

Start the Rust-side services:

```bash
export CONTEXTFORGE_GATEWAY_RS_REPO=/path/to/contextforge-gateway-rs

cd "$CONTEXTFORGE_GATEWAY_RS_REPO"
docker compose -f docker/docker-compose-local.yaml up -d redis gateway-one

cargo +1.96 run --bin contextforge-gateway-rs -- \
  --address 0.0.0.0:8001 \
  --redis-port 6379 \
  --redis-address 127.0.0.1 \
  --token-verification-public-key assets/jwt.key.pub \
  --number-of-cpus 4 \
  --redis-mode=plain-text \
  --upstream-connection-mode=plain-text-or-tls
```

In another terminal, from this Python repo branch:

```bash
cat > /tmp/uuid_dataplane_smoke.py <<'PY'
"""Cross-repo smoke for UUID-keyed dataplane Redis config."""

from __future__ import annotations

import asyncio
import os
from pathlib import Path
import time
import uuid

DB_PATH = Path("/tmp/contextforge_uuid_dataplane_smoke.db")
RS_REPO = Path(os.environ["CONTEXTFORGE_GATEWAY_RS_REPO"])

USER_ID = "11111111-1111-1111-1111-111111111111"
USER_EMAIL = "admin@example.com"
VIRTUAL_HOST_ID = "c0ffee00f001f00lf00ldeadbeefdead"
GATEWAY_ID = "gateway-one"
BACKEND_URL = "http://127.0.0.1:5555/mcp"
DATAPLANE_URL = f"http://127.0.0.1:8001/contextforge-rs/servers/{VIRTUAL_HOST_ID}/mcp"

TOOL_NAMES = [
    "decrement",
    "echo",
    "get_session_id",
    "get_value",
    "increment",
    "long_task",
    "say_hello",
    "sum",
]

os.environ["DATABASE_URL"] = f"sqlite:///{DB_PATH}"
os.environ.setdefault("REDIS_URL", "redis://127.0.0.1:6379/0")
os.environ.setdefault("JWT_SECRET_KEY", "uuid-dataplane-smoke-test-secret")
os.environ.setdefault("AUTH_ENCRYPTION_SECRET", "uuid-dataplane-smoke-test-encryption-secret")

import httpx
import jwt
import msgpack
import redis.asyncio as redis
from sqlalchemy import insert

from mcpgateway.db import Base, EmailUser, Gateway, Server, SessionLocal, Tool, engine, server_tool_association
from mcpgateway.services.dataplane_publisher import DataplanePublisherService, USER_CONFIG_KEY, get_publisher_ttl


def reset_smoke_db() -> None:
    if DB_PATH.exists():
        DB_PATH.unlink()

    Base.metadata.create_all(bind=engine)

    with SessionLocal() as db:
        db.execute(
            insert(EmailUser).values(
                id=USER_ID,
                email=USER_EMAIL,
                password_hash="not-used-in-smoke",
                full_name="Smoke Test User",
                is_admin=True,
                is_active=True,
                auth_provider="local",
                password_hash_type="argon2id",
            )
        )
        db.execute(
            insert(Gateway).values(
                id=GATEWAY_ID,
                name=GATEWAY_ID,
                slug=GATEWAY_ID,
                url=BACKEND_URL,
                transport="STREAMABLEHTTP",
                capabilities={},
                enabled=True,
                reachable=True,
                status="active",
                owner_email=USER_EMAIL,
                visibility="public",
                passthrough_headers=[],
            )
        )
        db.execute(
            insert(Server).values(
                id=VIRTUAL_HOST_ID,
                name="uuid-smoke-server",
                description="UUID dataplane smoke server",
                enabled=True,
                owner_email=USER_EMAIL,
                visibility="public",
            )
        )

        for tool_name in TOOL_NAMES:
            tool_id = f"tool-{tool_name.replace('_', '-')}"
            db.execute(
                insert(Tool).values(
                    id=tool_id,
                    name=f"{GATEWAY_ID}-{tool_name}",
                    original_name=tool_name,
                    url=f"{BACKEND_URL}#{tool_name}",
                    input_schema={"type": "object", "properties": {}},
                    output_schema=None,
                    custom_name=tool_name,
                    custom_name_slug=tool_name.replace("_", "-"),
                    display_name=tool_name,
                    integration_type="MCP",
                    request_type="STREAMABLEHTTP",
                    headers={},
                    enabled=True,
                    reachable=True,
                    gateway_id=GATEWAY_ID,
                    owner_email=USER_EMAIL,
                    visibility="public",
                )
            )
            db.execute(insert(server_tool_association).values(server_id=VIRTUAL_HOST_ID, tool_id=tool_id))

        db.commit()


async def publish_uuid_config() -> None:
    service = DataplanePublisherService()
    payload = await service.fetch_payload()
    if payload is None:
        raise RuntimeError("publisher returned None")
    if USER_ID not in payload:
        raise RuntimeError(f"publisher payload missing UUID key {USER_ID}; keys={list(payload)}")
    if USER_EMAIL in payload:
        raise RuntimeError("publisher payload unexpectedly contains an email key")

    client = redis.Redis(host="127.0.0.1", port=6379, decode_responses=False)
    uuid_key = msgpack.dumps((USER_CONFIG_KEY, USER_ID), use_bin_type=True)
    email_key = msgpack.dumps((USER_CONFIG_KEY, USER_EMAIL), use_bin_type=True)
    await client.delete(uuid_key, email_key)
    await client.set(uuid_key, msgpack.dumps(payload[USER_ID], use_bin_type=True), ex=get_publisher_ttl())

    ttl = await client.ttl(uuid_key)
    email_exists = await client.exists(email_key)
    await client.aclose()

    if email_exists:
        raise RuntimeError("email-keyed Redis config exists after cleanup/publish")

    print(f"published Redis key ({USER_CONFIG_KEY}, {USER_ID})")
    print(f"email Redis key absent for {USER_EMAIL}")
    print(f"uuid Redis key TTL {ttl}")


def mint_uuid_token() -> str:
    now = int(time.time())
    private_key = (RS_REPO / "assets/jwt.key").read_bytes()
    claims = {
        "sub": USER_ID,
        "jti": str(uuid.uuid4()),
        "token_use": "api",
        "iat": now,
        "iss": "mcpgateway",
        "aud": "mcpgateway-api",
        "exp": now + 3600,
        "teams": ["team_awesome"],
        "user": {
            "email": USER_EMAIL,
            "auth_provider": "api_token",
            "full_name": "Smoke Test User",
            "is_admin": True,
        },
    }
    return jwt.encode(claims, private_key, algorithm="RS256", headers={"kid": "test"})


def parse_jsonrpc_response(response: httpx.Response) -> dict:
    text = response.text.strip()
    if text.startswith("event:") or text.startswith("data:"):
        data_lines = [line.removeprefix("data:").strip() for line in text.splitlines() if line.startswith("data:")]
        text = "\n".join(data_lines)
    return response.json() if text == response.text.strip() else __import__("json").loads(text)


async def call_dataplane(token: str) -> None:
    headers = {
        "authorization": f"Bearer {token}",
        "content-type": "application/json",
        "accept": "application/json, text/event-stream",
    }

    async with httpx.AsyncClient(timeout=20.0) as client:
        init_response = await client.post(
            DATAPLANE_URL,
            headers=headers,
            json={
                "jsonrpc": "2.0",
                "id": 0,
                "method": "initialize",
                "params": {
                    "protocolVersion": "2025-11-25",
                    "capabilities": {},
                    "clientInfo": {"name": "uuid-smoke", "version": "0.1.0"},
                },
            },
        )
        print(f"initialize status {init_response.status_code}")
        init_response.raise_for_status()

        session_id = init_response.headers.get("mcp-session-id")
        if not session_id:
            raise RuntimeError("initialize response did not include mcp-session-id")

        session_headers = {**headers, "mcp-session-id": session_id, "mcp-protocol-version": "2025-11-25"}

        initialized_response = await client.post(
            DATAPLANE_URL,
            headers=session_headers,
            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
        )
        print(f"initialized notification status {initialized_response.status_code}")
        initialized_response.raise_for_status()

        tools_response = await client.post(
            DATAPLANE_URL,
            headers=session_headers,
            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
        )
        print(f"tools/list status {tools_response.status_code}")
        tools_response.raise_for_status()

        body = parse_jsonrpc_response(tools_response)
        names = [tool["name"] for tool in body["result"]["tools"]]
        print(f"tools/list names {names}")

        missing = sorted(set(TOOL_NAMES) - set(names))
        if missing:
            raise RuntimeError(f"tools/list missing expected tools: {missing}")


async def main() -> None:
    reset_smoke_db()
    await publish_uuid_config()
    await call_dataplane(mint_uuid_token())


if __name__ == "__main__":
    asyncio.run(main())
PY

uv run python /tmp/uuid_dataplane_smoke.py
```

Expected output:

```text
published Redis key (UserConfig, 11111111-1111-1111-1111-111111111111)
email Redis key absent for admin@example.com
uuid Redis key TTL 130
initialize status 200
initialized notification status 202
tools/list status 200
tools/list names ['decrement', 'echo', 'get_session_id', 'get_value', 'increment', 'long_task', 'say_hello', 'sum']
```

Cleanup:

```bash
cd "$CONTEXTFORGE_GATEWAY_RS_REPO"
docker compose -f docker/docker-compose-local.yaml down
```

</details>

Live ContextForge protocol/RBAC validation:

A fresh clone of this PR branch was built and run on `test-vm-cf`.

Environment:
- Branch: `issue-5462-dataplane-uuid-subjects`
- Gateway URL: `http://127.0.0.1:8080`
- Runtime: Python MCP transport (`x-contextforge-mcp-transport-mounted: python`)
- Gateway: single running gateway container behind nginx
- Image: `mcpgateway/mcpgateway:latest` built from this PR branch

Commands:

```bash
MCP_CLI_BASE_URL=http://127.0.0.1:8080 \
JWT_SECRET_KEY=my-test-key-but-now-longer-than-32-bytes \
PLATFORM_ADMIN_EMAIL=admin@example.com \
MCP_E2E_CLIENT_TIMEOUT=15 \
uv run pytest tests/live_gateway/mcp/test_mcp_protocol_e2e.py -v -s --tb=short
```

Result:

```text
19 passed, 3 skipped in 6.34s
```

```bash
MCP_CLI_BASE_URL=http://127.0.0.1:8080 \
JWT_SECRET_KEY=my-test-key-but-now-longer-than-32-bytes \
PLATFORM_ADMIN_EMAIL=admin@example.com \
uv run pytest -p playwright tests/live_gateway/mcp/test_mcp_rbac_transport.py -v -s --tb=short
```

Result:

```text
40 passed in 19.79s
```

Note: the first protocol run exposed stale/incomplete test-stack setup: `fast-time-*` tools were missing from the live catalog. After rerunning the `register_fast_time` setup job, the catalog contained both `fast-time-*` and `fast-test-*` tools, and the full protocol suite passed.


<details>
<summary>Single-instance Playwright token smoke</summary>

Ran against the rebased PR head `5fc641e791` on `test-vm-cf`, using a single `make dev` ContextForge instance at `http://localhost:8000`.

Setup:

- Installed Node.js `v22.23.1` / npm `10.9.8` on the VM so the admin UI bundle could be built.
- Ran `make js-build`.
- Started ContextForge with `make dev`.
- Verified `GET /health` returned `200`.

Command shape:

```bash
TEST_BASE_URL=http://localhost:8000 \
JWT_SECRET_KEY=<throwaway-test-secret> \
AUTH_ENCRYPTION_SECRET=<throwaway-test-encryption-secret> \
BASIC_AUTH_PASSWORD=<throwaway-test-basic-password> \
PLATFORM_ADMIN_PASSWORD=<throwaway-test-admin-password> \
MCPGATEWAY_UI_ENABLED=true \
MCPGATEWAY_ADMIN_API_ENABLED=true \
AUTH_REQUIRED=true \
uv run pytest -p playwright \
  tests/playwright/security/test_token_lifecycle.py \
  tests/playwright/security/test_token_lifecycle_enforcement.py \
  tests/playwright/security/test_token_scope_matrix.py \
  --browser chromium -q
```

Result:

```text
16 passed, 2 warnings in 10.67s
```

This covers API token create/list/update/revoke, using newly generated API tokens as bearer tokens, scoped-token permission enforcement, revocation enforcement, and the admin UI token revoke flow.

</details>
