### PR TITLE
[UI-REWRITE] Show source onboarding on empty dashboard

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -38,8 +38,8 @@ describe("App", () => {
     await user.type(passwordInput, "password123");
     await user.click(submitButton);
 
-    // Wait for dashboard to load after successful login
-    await screen.findByRole("heading", { name: /dashboard/i });
+    // Empty dashboard shows source onboarding after successful login
+    await screen.findByRole("heading", { name: /connect a source/i });
 
     // Click on Virtual Servers in the sidebar
     const gatewaysLink = screen.getByRole("button", { name: /virtual servers/i });

--- a/client/src/i18n/locales/en-US/dashboard.json
+++ b/client/src/i18n/locales/en-US/dashboard.json
@@ -3,5 +3,6 @@
   "dashboard.welcome": "Welcome to ContextForge",
   "dashboard.overview": "Overview",
   "dashboard.stats": "Statistics",
-  "dashboard.recentActivity": "Recent Activity"
+  "dashboard.recentActivity": "Recent Activity",
+  "dashboard.errorLoadingSources": "Error loading dashboard sources"
 }

--- a/client/src/i18n/locales/es-ES/dashboard.json
+++ b/client/src/i18n/locales/es-ES/dashboard.json
@@ -3,5 +3,6 @@
   "dashboard.welcome": "Bienvenido a ContextForge",
   "dashboard.overview": "Resumen",
   "dashboard.stats": "Estadísticas",
-  "dashboard.recentActivity": "Actividad Reciente"
+  "dashboard.recentActivity": "Actividad Reciente",
+  "dashboard.errorLoadingSources": "Error al cargar las fuentes del panel"
 }

--- a/client/src/i18n/locales/pt-BR/dashboard.json
+++ b/client/src/i18n/locales/pt-BR/dashboard.json
@@ -3,5 +3,6 @@
   "dashboard.welcome": "Bem-vindo ao ContextForge",
   "dashboard.overview": "Visão Geral",
   "dashboard.stats": "Estatísticas",
-  "dashboard.recentActivity": "Atividade Recente"
+  "dashboard.recentActivity": "Atividade Recente",
+  "dashboard.errorLoadingSources": "Erro ao carregar as fontes do painel"
 }

--- a/client/src/pages/Dashboard.test.tsx
+++ b/client/src/pages/Dashboard.test.tsx
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useQuery } from "@/hooks/useQuery";
+import { renderWithProviders } from "@/test/test-utils";
+import { Dashboard } from "./Dashboard";
+
+const mockNavigate = vi.fn();
+
+vi.mock("@/router", () => ({
+  useRouter: () => ({
+    navigate: mockNavigate,
+    path: "/app/",
+    params: {},
+  }),
+}));
+
+vi.mock("@/hooks/useQuery", () => ({
+  useQuery: vi.fn(),
+}));
+
+const mockUseQuery = vi.mocked(useQuery);
+
+describe("Dashboard", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockUseQuery.mockReturnValue({
+      data: { servers: [], gateways: [] },
+      error: null,
+      isLoading: false,
+      execute: vi.fn(),
+      refetch: vi.fn(),
+      setData: vi.fn(),
+    });
+  });
+
+  it("checks whether virtual and MCP servers exist", () => {
+    renderWithProviders(<Dashboard />);
+
+    expect(mockUseQuery).toHaveBeenCalledWith("/servers?limit=1&include_pagination=true");
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      "/gateways?limit=1&include_inactive=true&include_pagination=true",
+    );
+  });
+
+  it("uses the shared loader while dashboard sources are loading", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      error: null,
+      isLoading: true,
+      execute: vi.fn(),
+      refetch: vi.fn(),
+      setData: vi.fn(),
+    });
+
+    renderWithProviders(<Dashboard />);
+
+    expect(screen.getByRole("status", { name: "Loading..." })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Connect a source" })).not.toBeInTheDocument();
+  });
+
+  it("shows an error without showing onboarding when the request fails", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      error: { message: "Unable to load virtual servers" },
+      isLoading: false,
+      execute: vi.fn(),
+      refetch: vi.fn(),
+      setData: vi.fn(),
+    });
+
+    renderWithProviders(<Dashboard />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Error loading dashboard sources");
+    expect(screen.getByRole("alert")).toHaveTextContent("Unable to load virtual servers");
+    expect(screen.queryByRole("heading", { name: "Connect a source" })).not.toBeInTheDocument();
+  });
+
+  it("shows source selection when no virtual or MCP server exists", () => {
+    renderWithProviders(<Dashboard />);
+
+    expect(screen.getByRole("heading", { name: "Connect a source" })).toBeInTheDocument();
+    expect(screen.getByText("MCP server")).toBeInTheDocument();
+    expect(screen.getByText("AI agent")).toBeInTheDocument();
+    expect(screen.getByText("REST API")).toBeInTheDocument();
+    expect(screen.getByText("gRPC")).toBeInTheDocument();
+  });
+
+  it("hides onboarding when a virtual server exists", () => {
+    mockUseQuery.mockReturnValue({
+      data: { servers: [{ id: "server-1" }], gateways: [] },
+      error: null,
+      isLoading: false,
+      execute: vi.fn(),
+      refetch: vi.fn(),
+      setData: vi.fn(),
+    });
+
+    renderWithProviders(<Dashboard />);
+
+    expect(screen.getByRole("heading", { name: "Dashboard" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Connect a source" })).not.toBeInTheDocument();
+  });
+
+  it("hides source selection when an MCP server exists without a virtual server", () => {
+    mockUseQuery.mockReturnValue({
+      data: { servers: [], gateways: [{ id: "mcp-server-1" }] },
+      error: null,
+      isLoading: false,
+      execute: vi.fn(),
+      refetch: vi.fn(),
+      setData: vi.fn(),
+    });
+
+    renderWithProviders(<Dashboard />);
+
+    expect(screen.getByRole("heading", { name: "Dashboard" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Connect a source" })).not.toBeInTheDocument();
+  });
+
+  it("opens the MCP server form from source selection", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Dashboard />);
+
+    await user.click(screen.getAllByRole("button", { name: "+ Connect" })[0]!);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/app/servers?openForm=true");
+  });
+});

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,11 +1,104 @@
+import { useMemo } from "react";
 import { useIntl } from "react-intl";
+import { Blocks, Bot, Code } from "lucide-react";
+import { SourceSelection } from "@/components/gateways/SourceSelection";
+import type { ActionCard } from "@/components/gateways/types";
+import { MCPIcon } from "@/components/icons/MCPIcon";
+import { Loading } from "@/components/ui/loading";
+import { useQuery } from "@/hooks/useQuery";
+import { useRouter } from "@/router";
+import type { VirtualServersResponse } from "@/types/server";
+
+const SERVERS_QUERY_PATH = "/servers?limit=1&include_pagination=true";
+const MCP_SERVERS_QUERY_PATH = "/gateways?limit=1&include_inactive=true&include_pagination=true";
+const SERVERS_FORM_PATH = "/app/servers?openForm=true";
+
+interface MCPServersResponse {
+  gateways?: unknown[];
+}
 
 export function Dashboard() {
   const intl = useIntl();
+  const { navigate } = useRouter();
+  const {
+    data: virtualServersData,
+    error: virtualServersError,
+    isLoading: virtualServersLoading,
+  } = useQuery<VirtualServersResponse>(SERVERS_QUERY_PATH);
+  const {
+    data: mcpServersData,
+    error: mcpServersError,
+    isLoading: mcpServersLoading,
+  } = useQuery<MCPServersResponse>(MCP_SERVERS_QUERY_PATH);
+  const actionCards: ActionCard[] = useMemo(
+    () => [
+      {
+        icon: MCPIcon,
+        title: intl.formatMessage({ id: "gateways.action.mcpServer.title" }),
+        description: intl.formatMessage({ id: "gateways.action.mcpServer.description" }),
+        buttonText: intl.formatMessage({ id: "gateways.action.connect" }),
+        onAction: () => navigate(SERVERS_FORM_PATH),
+      },
+      {
+        icon: Bot,
+        title: intl.formatMessage({ id: "gateways.action.aiAgent.title" }),
+        description: intl.formatMessage({ id: "gateways.action.aiAgent.description" }),
+        buttonText: intl.formatMessage({ id: "gateways.action.connect" }),
+        onAction: () => navigate("/app/agents"),
+      },
+      {
+        icon: Code,
+        title: intl.formatMessage({ id: "gateways.action.restApi.title" }),
+        description: intl.formatMessage({ id: "gateways.action.restApi.description" }),
+        buttonText: intl.formatMessage({ id: "gateways.action.connect" }),
+        disabled: true,
+        disabledReason: intl.formatMessage({ id: "gateways.action.comingSoon" }),
+        onAction: () => undefined,
+      },
+      {
+        icon: Blocks,
+        title: intl.formatMessage({ id: "gateways.action.grpc.title" }),
+        description: intl.formatMessage({ id: "gateways.action.grpc.description" }),
+        buttonText: intl.formatMessage({ id: "gateways.action.connect" }),
+        disabled: true,
+        disabledReason: intl.formatMessage({ id: "gateways.action.comingSoon" }),
+        onAction: () => undefined,
+      },
+    ],
+    [intl, navigate],
+  );
+
+  if (virtualServersLoading || mcpServersLoading) {
+    return <Loading />;
+  }
+
+  const queryError = virtualServersError ?? mcpServersError;
+
+  if (queryError) {
+    return (
+      <div className="p-6">
+        <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4" role="alert">
+          <h1 className="font-semibold text-destructive">
+            {intl.formatMessage({ id: "dashboard.errorLoadingSources" })}
+          </h1>
+          <p className="text-sm text-destructive">{queryError.message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const hasVirtualServers = (virtualServersData?.servers?.length ?? 0) > 0;
+  const hasMCPServers = (mcpServersData?.gateways?.length ?? 0) > 0;
+
+  if (!hasVirtualServers && !hasMCPServers) {
+    return <SourceSelection actionCards={actionCards} />;
+  }
 
   return (
-    <h1 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100">
-      {intl.formatMessage({ id: "dashboard.title" })}
-    </h1>
+    <div className="space-y-9 p-6">
+      <h1 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100">
+        {intl.formatMessage({ id: "dashboard.title" })}
+      </h1>
+    </div>
   );
 }

--- a/client/src/pages/SimplePages.test.tsx
+++ b/client/src/pages/SimplePages.test.tsx
@@ -33,7 +33,11 @@ describe("Simple Page Components", () => {
   });
 
   it("renders Dashboard page", () => {
-    renderWithProviders(<Dashboard />);
+    renderWithProviders(
+      <RouterProvider>
+        <Dashboard />
+      </RouterProvider>,
+    );
     expect(document.body).toBeTruthy();
   });
 


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #5477

---

## 📝 Summary

Show the existing source-selection onboarding experience on the Dashboard when the current scope has neither virtual servers nor registered MCP servers.

The Dashboard performs lightweight existence checks for both resource types, uses the shared page loader while either request is pending, and shows an inline localized error if either request fails. Existing environments continue to see the standard Dashboard, while new environments get direct actions for connecting an MCP server or AI agent.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

---

## 🏷️ Type of Change

- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Client test suite | `npm run test:run` | 2,514 passed, 1 skipped |
| TypeScript | `npx tsc -b --pretty false` | Passed |
| Focused lint | `npx eslint src/pages/Dashboard.tsx src/pages/Dashboard.test.tsx` | Passed |
| Diff validation | `git diff --check` | Passed |

---

## ✅ Checklist

- [x] Code formatted
- [x] Tests added/updated for changes
- [x] Documentation not required
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

The existing `ConnectSourceCard` remains available on the Virtual Servers page. Dashboard onboarding uses `SourceSelection` and is hidden as soon as either an MCP server or virtual server exists.
