### PR TITLE
fix(retry): guard request() Retry-After against RFC 9110 HTTP-date

### DIFF
--- a/mcpgateway/utils/retry_manager.py
+++ b/mcpgateway/utils/retry_manager.py
@@ -435,11 +435,17 @@ class ResilientHttpClient:
                 if response.status_code == 429:
                     retry_after = response.headers.get("Retry-After")
                     if retry_after:
-                        retry_after_sec = float(retry_after)
-                        logger.info(f"Rate-limited. Retrying after {retry_after_sec}s.")
-                        await asyncio.sleep(retry_after_sec)
-                        attempt += 1
-                        continue
+                        try:
+                            retry_after_sec = float(retry_after)
+                        except ValueError:
+                            # RFC 9110 §10.2.3 also allows an HTTP-date, which is not a float.
+                            # Mirror stream(): fall through to normal exponential backoff.
+                            retry_after_sec = None
+                        if retry_after_sec:
+                            logger.info(f"Rate-limited. Retrying after {retry_after_sec}s.")
+                            await asyncio.sleep(retry_after_sec)
+                            attempt += 1
+                            continue
 
                 if not self._should_retry(Exception(), response):
                     return response

--- a/mcpgateway/utils/retry_manager.py
+++ b/mcpgateway/utils/retry_manager.py
@@ -441,7 +441,7 @@ class ResilientHttpClient:
                             # RFC 9110 §10.2.3 also allows an HTTP-date, which is not a float.
                             # Mirror stream(): fall through to normal exponential backoff.
                             retry_after_sec = None
-                        if retry_after_sec:
+                        if retry_after_sec is not None:
                             logger.info(f"Rate-limited. Retrying after {retry_after_sec}s.")
                             await asyncio.sleep(retry_after_sec)
                             attempt += 1

--- a/tests/unit/mcpgateway/utils/test_retry_manager.py
+++ b/tests/unit/mcpgateway/utils/test_retry_manager.py
@@ -77,6 +77,24 @@ async def test_retry_after_header_respected(client):
 
 
 @pytest.mark.asyncio
+async def test_request_retry_after_http_date_does_not_crash(client):
+    """RFC 9110 §10.2.3 allows Retry-After as an HTTP-date, not only delay-seconds.
+
+    request() must not raise ValueError on the date form. The sibling stream()
+    path already guards this (test_stream_429_retry_after_invalid_value); request()
+    should behave the same, falling through to normal backoff and returning the 429.
+    """
+    mock_resp = httpx.Response(429, headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"})
+
+    with patch.object(client.client, "request", new=AsyncMock(return_value=mock_resp)) as mock_req:
+        with patch("asyncio.sleep", new=AsyncMock()):
+            resp = await client.get("http://retry-after-http-date.com")
+
+    assert resp.status_code == 429
+    assert mock_req.call_count == client.max_retries
+
+
+@pytest.mark.asyncio
 async def test_max_retry_reached_raises_exception(client):
     failing_func = AsyncMock(side_effect=httpx.ConnectTimeout("Connection failed"))
 

--- a/tests/unit/mcpgateway/utils/test_retry_manager.py
+++ b/tests/unit/mcpgateway/utils/test_retry_manager.py
@@ -95,6 +95,25 @@ async def test_request_retry_after_http_date_does_not_crash(client):
 
 
 @pytest.mark.asyncio
+async def test_request_retry_after_zero_retries_immediately(client):
+    """Retry-After: 0 is a valid delay-seconds value meaning retry immediately.
+
+    Guards the truthiness check: `if retry_after_sec:` would treat 0.0 as falsy and
+    skip the retry path, so the header must be tested with `is not None`. The client
+    should sleep(0) and keep retrying up to max_retries.
+    """
+    mock_resp = httpx.Response(429, headers={"Retry-After": "0"})
+
+    with patch.object(client.client, "request", new=AsyncMock(return_value=mock_resp)) as mock_req:
+        with patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            resp = await client.get("http://retry-after-zero.com")
+
+    assert resp.status_code == 429
+    assert mock_sleep.call_args_list[0][0][0] == 0.0
+    assert mock_req.call_count == client.max_retries
+
+
+@pytest.mark.asyncio
 async def test_max_retry_reached_raises_exception(client):
     failing_func = AsyncMock(side_effect=httpx.ConnectTimeout("Connection failed"))
 


### PR DESCRIPTION
## 📌 Summary

On a 429 response, `ResilientHttpClient.request()` reads `Retry-After` with a bare `float()` (`mcpgateway/utils/retry_manager.py:438`). RFC 9110 §10.2.3 allows `Retry-After` to be either `delay-seconds` **or** an `HTTP-date`, and both are valid. When an upstream sends the date form, `float()` raises `ValueError`, `_should_retry(ValueError, None)` matches neither a retryable exception nor a response, and the bare `raise` propagates the error out of `request()`. A retryable rate-limit becomes an unhandled crash.

## 🔁 Reproduction Steps

Closes #5674. Verified in a clean `python:3.12-slim` container (`pip install -e .`), no mocking of the parse path:

```python
mock_resp = httpx.Response(429, headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"})
await client.get("http://x")   # ValueError: could not convert string to float: 'Wed, 21 Oct 2026 07:28:00 GMT'
```

## 🐞 Root Cause

`request()` and the sibling `stream()` are the two `Retry-After` consumers in this class, and they disagree. `stream()` (`:585`) already wraps `float(ra)` in `except ValueError: wait = None` and falls through to normal backoff; `request()` never got the same guard. That asymmetry is what makes this an oversight rather than a deliberate design choice.

## 💡 Fix Description

Mirror `stream()` in `request()`: wrap the `float()` in `try/except ValueError`, and on a non-numeric value fall through to the existing exponential-backoff path instead of raising. Parsing the HTTP-date into a precise delay is intentionally left out of scope so the two paths behave identically.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

All run in a clean `python:3.12-slim` container at `main`, `pip install -e .`:

| Check | Command | Status |
|-------|---------|--------|
| Regression (fails before fix, `ValueError` at `retry_manager.py:438`) | `pytest ...::test_request_retry_after_http_date_does_not_crash` | fails on main, passes on branch |
| Full module suite | `pytest tests/unit/mcpgateway/utils/test_retry_manager.py` | green |
| Coverage of `retry_manager.py` | `pytest --cov=mcpgateway.utils.retry_manager` | 100% |
| Lint | `ruff check` | clean |
| Hooks | `pre-commit run --files <changed>` | ruff, format, headers, interrogate, detect-secrets pass |

The new test asserts the final state: a 429 with an HTTP-date `Retry-After` no longer raises, falls through to backoff, and returns the 429 after `max_retries` attempts. It patches the transport (returning the 429), matching the existing `test_retry_after_header_respected` convention in this file; it does not exercise a live socket.

## ✅ Checklist

- [x] Code formatted (`ruff format`, pre-commit)
- [x] No secrets/credentials committed
