### PR TITLE
ci: add compose production smoke check

### DIFF
--- a/.github/workflows/compose-prod-smoke-required.yml
+++ b/.github/workflows/compose-prod-smoke-required.yml
@@ -1,0 +1,34 @@
+# ===============================================================
+# Compose Production Smoke — Skip Reporter
+# ===============================================================
+#
+# This workflow is the complement of compose-prod-smoke.yml.
+# It runs on every PR and immediately reports success for the
+# "Compose Production Smoke Complete" required status check so
+# that PRs are not blocked waiting for a check that only runs
+# in the merge queue.
+#
+# Together with the compose-prod-smoke-complete gate job in
+# compose-prod-smoke.yml, the required check always has a result:
+#   - Pull request  → this workflow reports success (skipped)
+#   - Merge queue   → compose-prod-smoke.yml runs the real check
+#
+# ===============================================================
+
+name: Compose Production Smoke Skip Reporter
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  compose-prod-smoke-complete:
+    name: Compose Production Smoke Complete
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compose production smoke skipped on PR — runs in merge queue
+        run: echo "Compose production smoke skipped — the real check runs in the merge queue via compose-prod-smoke.yml"

--- a/.github/workflows/compose-prod-smoke.yml
+++ b/.github/workflows/compose-prod-smoke.yml
@@ -41,6 +41,14 @@ jobs:
       GATEWAY_CPU_LIMIT: "4"
       GATEWAY_CPU_RESERVATION: "1"
       TESTING_LOCUST_WORKERS: "1"
+      # Union of every profile started across both stacks: the default
+      # stack enables with-fast-time (auto on linux/amd64), and testing-up
+      # adds testing/inspector/sso. Diagnostics and teardown must span all
+      # of them or profile-only containers (fast test, A2A, Locust,
+      # Inspector, Keycloak) are silently dropped from logs and left
+      # running. Applied only to ps/logs/down — NOT to `up`, which must
+      # keep starting one stack at a time.
+      SMOKE_COMPOSE_PROFILES: "with-fast-time,testing,inspector,sso"
 
     steps:
       - name: Checkout source
@@ -144,10 +152,14 @@ jobs:
       # ── Always-run diagnostics ─────────────────────────────────
       - name: Show compose status
         if: always()
+        env:
+          COMPOSE_PROFILES: ${{ env.SMOKE_COMPOSE_PROFILES }}
         run: docker compose -f docker-compose.yml ps -a || true
 
       - name: Collect compose logs on failure
         if: failure()
+        env:
+          COMPOSE_PROFILES: ${{ env.SMOKE_COMPOSE_PROFILES }}
         run: docker compose -f docker-compose.yml logs --no-color > /tmp/compose-prod-smoke.log || true
 
       - name: Upload compose logs on failure
@@ -171,6 +183,8 @@ jobs:
 
       - name: Stop compose stack
         if: always()
+        env:
+          COMPOSE_PROFILES: ${{ env.SMOKE_COMPOSE_PROFILES }}
         run: make compose-down || true
 
   # ── Required status check gate ─────────────────────────────────

--- a/.github/workflows/compose-prod-smoke.yml
+++ b/.github/workflows/compose-prod-smoke.yml
@@ -1,0 +1,194 @@
+# ===============================================================
+# Compose Production Smoke
+# ===============================================================
+#
+# Runs on merge_group only — acts as a hard gate before any PR
+# lands on main. Exercises the full production Docker Compose path
+# that users run locally: make docker-prod → make compose-up →
+# nginx on port 8080 → /health and /admin/login, then restarts
+# with the testing profile and verifies all sidecar endpoints.
+#
+# Triggers:
+#   merge_group  — hard gate on every PR before it reaches main
+#   workflow_dispatch — manual re-run / ad-hoc verification
+#
+# ===============================================================
+
+name: Compose Production Smoke
+
+on:
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compose-prod-smoke:
+    name: compose-prod-smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      DOCKER_BUILDKIT: "1"
+      # CI-sized resource values — lower than defaults to fit
+      # GitHub-hosted runner constraints (2 vCPU, 7 GB RAM)
+      GATEWAY_REPLICAS: "1"
+      GUNICORN_WORKERS: "2"
+      GATEWAY_CPU_LIMIT: "4"
+      GATEWAY_CPU_RESERVATION: "1"
+      TESTING_LOCUST_WORKERS: "1"
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      # Builds the production image exactly as prod does:
+      # DOCKER_CONTENT_TRUST=1 + the same Containerfile + build args.
+      # Intentionally no layer-cache shortcut so the image is
+      # identical to what docker-multiplatform.yml publishes.
+      - name: Build production image
+        run: make docker-prod
+
+      # ── Default compose stack ──────────────────────────────────
+      # Start the stack, wait up to 3 min for nginx to proxy
+      # /health, then verify the admin login page renders and
+      # gateway logs are free of runtime errors.
+      - name: Smoke default compose stack
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          make compose-up
+
+          for i in {1..90}; do
+            if curl -fsS http://localhost:8080/health >/tmp/compose-health.json; then
+              break
+            fi
+            echo "Waiting for gateway health through nginx (${i}/90)"
+            sleep 2
+          done
+
+          curl -fsS http://localhost:8080/health | jq -e '.status == "healthy"'
+          curl -fsS http://localhost:8080/admin/login -o /tmp/admin-login.html
+          grep -q "Sign In - ContextForge" /tmp/admin-login.html
+
+          docker compose -f docker-compose.yml logs --no-color gateway > /tmp/default-gateway.log
+          if grep -E "Control server error|Read-only file system|SIGKILL|Perhaps out of memory" /tmp/default-gateway.log; then
+            echo "Gateway logged startup/runtime errors in default compose stack"
+            exit 1
+          fi
+
+      # ── Testing profile ────────────────────────────────────────
+      # Tear down the default stack, bring up the testing profile,
+      # and verify the gateway plus all sidecar endpoints respond.
+      - name: Restart with testing profile and smoke endpoints
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          make compose-down
+          make testing-up
+
+          for i in {1..90}; do
+            if curl -fsS http://localhost:8080/health >/tmp/testing-health.json; then
+              break
+            fi
+            echo "Waiting for testing gateway health through nginx (${i}/90)"
+            sleep 2
+          done
+
+          curl -fsS http://localhost:8080/health | jq -e '.status == "healthy"'
+          curl -fsS http://localhost:8080/admin/login -o /tmp/testing-admin-login.html
+          grep -q "Sign In - ContextForge" /tmp/testing-admin-login.html
+
+          for i in {1..60}; do
+            if curl -fsS http://localhost:8880/health >/tmp/fast-test-health.json; then
+              break
+            fi
+            echo "Waiting for fast test server (${i}/60)"
+            sleep 2
+          done
+
+          for i in {1..60}; do
+            if curl -fsS http://localhost:9100/health >/tmp/a2a-echo-health.json; then
+              break
+            fi
+            echo "Waiting for A2A echo agent (${i}/60)"
+            sleep 2
+          done
+
+          for i in {1..60}; do
+            if curl -fsS http://localhost:8089/ >/tmp/locust.html; then
+              break
+            fi
+            echo "Waiting for Locust UI (${i}/60)"
+            sleep 2
+          done
+
+          curl -fsS http://localhost:8880/health | jq -e '.status == "healthy"'
+          curl -fsS http://localhost:9100/health | jq -e '.status == "healthy"'
+          curl -fsS http://localhost:8089/ > /tmp/locust.html
+
+          docker compose -f docker-compose.yml logs --no-color gateway > /tmp/testing-gateway.log
+          if grep -E "Control server error|Read-only file system|SIGKILL|Perhaps out of memory" /tmp/testing-gateway.log; then
+            echo "Gateway logged startup/runtime errors in testing compose stack"
+            exit 1
+          fi
+
+      # ── Always-run diagnostics ─────────────────────────────────
+      - name: Show compose status
+        if: always()
+        run: docker compose -f docker-compose.yml ps -a || true
+
+      - name: Collect compose logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.yml logs --no-color > /tmp/compose-prod-smoke.log || true
+
+      - name: Upload compose logs on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: compose-prod-smoke-logs
+          if-no-files-found: ignore
+          retention-days: 7
+          path: |
+            /tmp/compose-health.json
+            /tmp/testing-health.json
+            /tmp/fast-test-health.json
+            /tmp/a2a-echo-health.json
+            /tmp/admin-login.html
+            /tmp/testing-admin-login.html
+            /tmp/locust.html
+            /tmp/default-gateway.log
+            /tmp/testing-gateway.log
+            /tmp/compose-prod-smoke.log
+
+      - name: Stop compose stack
+        if: always()
+        run: make compose-down || true
+
+  # ── Required status check gate ─────────────────────────────────
+  # Single job whose name is registered as the required check so
+  # the merge queue can require it. Succeeds only when the smoke
+  # job above passes. The companion compose-prod-smoke-required.yml
+  # skip reporter reports the same name on every PR so that PRs are
+  # never blocked waiting for a check that only runs in the merge queue.
+  compose-prod-smoke-complete:
+    name: Compose Production Smoke Complete
+    runs-on: ubuntu-latest
+    needs: [compose-prod-smoke]
+    if: always()
+    steps:
+      - name: Verify smoke check passed
+        run: |
+          if [ "${{ needs.compose-prod-smoke.result }}" != "success" ]; then
+            echo "Compose production smoke result: ${{ needs.compose-prod-smoke.result }}"
+            exit 1
+          fi
+          echo "Compose production smoke passed."


### PR DESCRIPTION
## 🔗 Related Issue

Closes #5419

---

## 📝 Summary

Adds a dedicated production Docker Compose smoke workflow that gates every PR in the merge queue before it reaches `main`.

**The gap this closes:** existing CI checks build images or run `make serve` directly but never combine `make docker-prod` → `make compose-up` → nginx routing on port 8080 → admin login verification. That gap allowed a read-only container filesystem issue in Gunicorn startup to pass CI while the real production compose stack was broken.

**What the workflow does:**
1. Builds the production image via `make docker-prod` — identical to what `docker-multiplatform.yml` publishes (`DOCKER_CONTENT_TRUST=1`, same `Containerfile` and build args, no cache shortcuts)
2. Starts the default compose stack, waits for `http://localhost:8080/health` through nginx, verifies `/admin/login` renders, and scans gateway logs for runtime errors (`Read-only file system`, `SIGKILL`, OOM, control socket failures)
3. Tears down and restarts with the testing profile (`make testing-up`), then verifies the gateway, fast test server (`:8880`), A2A echo agent (`:9100`), and Locust UI (`:8089`) all respond
4. Uploads compose logs as artifacts on failure

**Trigger strategy:** `merge_group` + `workflow_dispatch` only — no PR trigger. Running in the merge queue means every PR is gated without adding build latency to every push. CI-sized resource values (`GATEWAY_REPLICAS=1`, `GUNICORN_WORKERS=2`) are used to fit GitHub-hosted runner constraints.

**Required status check plumbing:** `compose-prod-smoke-required.yml` acts as a skip reporter — it fires on every PR and immediately reports `Compose Production Smoke Complete` as success, so PRs are never blocked by a check that only runs in the merge queue. The gate job `compose-prod-smoke-complete` in the main workflow reports the real result.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Workflow lint | `actionlint .github/workflows/compose-prod-smoke.yml .github/workflows/compose-prod-smoke-required.yml` | Pending |
| Compose testing profile config | `GATEWAY_REPLICAS=1 GUNICORN_WORKERS=2 GATEWAY_CPU_LIMIT=4 GATEWAY_CPU_RESERVATION=1 TESTING_LOCUST_WORKERS=1 docker compose -f docker-compose.yml --profile testing --profile inspector --profile sso config --quiet` | Pending |

> Full end-to-end validation requires a merge queue run. The workflow cannot be meaningfully tested on a PR since it has no `pull_request` trigger — `workflow_dispatch` can be used for ad-hoc verification once the branch is pushed.

---

## ✅ Checklist

- [x] Tests added/updated for changes
- [x] No secrets or credentials committed
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Documentation updated (if applicable)

---

## 📓 Notes (optional)

**Required status check registration:** After this PR merges, `Compose Production Smoke Complete` must be added as a required status check in the repository's branch protection / merge queue settings to actually gate merges.