### PR TITLE
chore: eliminate .secrets.baseline merge-queue conflicts

### DIFF
--- a/.github/workflows/secrets-baseline-sync.yml
+++ b/.github/workflows/secrets-baseline-sync.yml
@@ -1,0 +1,95 @@
+# ======================================================================
+# Sync .secrets.baseline on open PRs after main advances
+# ======================================================================
+#
+# .secrets.baseline stores a line_number per finding. That number is not
+# part of detect-secrets' audit identity (filename + secret_hash + type),
+# so it's safe to regenerate — but any PR branch that falls behind main
+# accumulates line-number drift in the file, which turns into merge
+# conflicts (or, worse, a stale baseline that fails
+# `make detect-secrets-hook --fail-on-unaudited`) once several such PRs
+# land back-to-back through the merge queue.
+#
+# This workflow keeps open, same-repo PRs that touch .secrets.baseline
+# continuously synced with main: merge main in, regenerate the baseline,
+# and push back — but only when regeneration doesn't introduce a new,
+# unaudited finding (i.e. only drift, never a silent secret allowlist).
+# PRs from forks are skipped (no push access) and left for a human/manual
+# rebase instead.
+#
+# ======================================================================
+
+name: Sync secrets baseline on open PRs
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: secrets-baseline-sync
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    if: github.repository == 'IBM/mcp-context-forge'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Sync .secrets.baseline on affected open PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          prs=$(gh pr list --state open --json number,headRefName,headRepositoryOwner,isDraft,files \
+            --jq '.[] | select(.isDraft == false) | select(.headRepositoryOwner.login == "IBM") | select([.files[].path] | index(".secrets.baseline")) | .number')
+
+          for pr in $prs; do
+            echo "::group::PR #$pr"
+            head_ref=$(gh pr view "$pr" --json headRefName --jq .headRefName)
+
+            git fetch origin "$head_ref"
+            git checkout -B "sync-$pr" "origin/$head_ref"
+
+            if git merge --no-edit origin/main; then
+              make detect-secrets-scan
+
+              if git diff --quiet -- .secrets.baseline; then
+                echo "Baseline already up to date, nothing to push."
+                git checkout main
+                git branch -D "sync-$pr"
+                echo "::endgroup::"
+                continue
+              fi
+
+              if make detect-secrets-hook; then
+                git add .secrets.baseline
+                git commit -s -m "chore: sync .secrets.baseline with main"
+                git push origin "sync-$pr:$head_ref"
+                echo "Pushed refreshed baseline to $head_ref"
+              else
+                echo "::warning::PR #$pr introduces an unaudited finding after merging main — skipping auto-push, needs human review."
+              fi
+            else
+              echo "::warning::PR #$pr has a real merge conflict with main beyond .secrets.baseline drift — skipping auto-push, needs manual rebase."
+              git merge --abort || true
+            fi
+
+            git checkout main
+            git branch -D "sync-$pr" 2>/dev/null || true
+            echo "::endgroup::"
+          done

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-22T10:32:02Z",
+  "generated_at": "1970-01-01T00:00:00Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5963,
+        "line_number": 5966,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6460,
+        "line_number": 6463,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6472,
+        "line_number": 6475,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6544,
+        "line_number": 6547,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7613,
+        "line_number": 7616,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -580,7 +580,7 @@
         "hashed_secret": "c58a69e6abb14e59f5e5761ac85a933c671bda09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 286,
+        "line_number": 306,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -590,7 +590,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 56,
+        "line_number": 61,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -642,7 +642,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1103,
+        "line_number": 1104,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1106,
+        "line_number": 1107,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1272,
+        "line_number": 1274,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1311,
+        "line_number": 1313,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1365,
+        "line_number": 1367,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1460,
+        "line_number": 1463,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -690,7 +690,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1831,
+        "line_number": 1834,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -414,7 +414,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7611,
+        "line_number": 7613,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/Makefile
+++ b/Makefile
@@ -7469,6 +7469,8 @@ detect-secrets-scan: uv                      ## 🔍  detect-secrets scan for se
 		--update .secrets.baseline \
 		--use-all-plugins \
 		--exclude-files $(DETECT_SECRETS_FILES_EXCLUDE)
+	@echo "📌 Pinning generated_at to avoid spurious merge conflicts..."
+	@python3 -c "import json; p='.secrets.baseline'; d=json.load(open(p)); d['generated_at']='1970-01-01T00:00:00Z'; json.dump(d, open(p, 'w'), indent=2); open(p, 'a').write('\n')"
 	@echo "📊 detect-secrets findings report:"
 	@$(UV_BIN) tool run --from '$(DETECT_SECRETS_SPEC)' detect-secrets audit --report .secrets.baseline
 


### PR DESCRIPTION
## Summary

- Pin `generated_at` in `.secrets.baseline` to a fixed sentinel value after `make detect-secrets-scan`, so regenerating the baseline no longer collides on that line whenever two or more PRs touch it.
- Add `secrets-baseline-sync.yml`: on push to `main`, finds open, same-repo PRs that touch `.secrets.baseline`, merges `main` in, reruns the scan, and pushes the refreshed baseline back — but only if `detect-secrets-hook --fail-on-unaudited` still passes (i.e. only drift, never a silent new-secret allowlist). PRs with real conflicts or new unaudited findings are left alone for manual handling.

## Why

Investigated a batch of 5 PRs headed for the merge queue; 3 touched `.secrets.baseline` and their diffs were entirely mechanical: the `generated_at` timestamp plus `line_number` drift on already-audited findings. `detect-secrets`' own audit identity is `filename + secret_hash + type` — line numbers aren't part of it (`PotentialSecret.fields_to_compare` in `detect_secrets/core/potential_secret.py`), so this drift is always safe to regenerate away. Left unaddressed, any concurrent batch of PRs editing scanned files (`.env.example`, `config.py`, docs) risks getting ejected from the merge queue on baseline conflicts, requiring manual serialized rebase+rescan per PR.

Closes #5758

## Test plan
- [ ] `make detect-secrets-scan` produces a baseline with `generated_at` pinned to `1970-01-01T00:00:00Z`, verified against a copy of the current file (single-line diff)
- [ ] `secrets-baseline-sync.yml` YAML validated
- [ ] Manually trigger the workflow (`workflow_dispatch`) once merged and confirm it correctly skips PRs with no baseline drift and pushes only clean drift-only updates