### PR TITLE
fix(mcp-apps): honour deprecated flat ui/resourceUri metadata key

### DIFF
--- a/docs/docs/architecture/mcp-apps.md
+++ b/docs/docs/architecture/mcp-apps.md
@@ -77,6 +77,38 @@ and resources. MCP Apps metadata is keyed by the MCP UI capability identifier:
 The gateway also accepts the internal snake_case form, `extension_metadata`, in
 Python service paths. Public API payloads should use `extensionMetadata`.
 
+### Deprecated Flat `ui/resourceUri` Key
+
+Upstream servers advertise Apps metadata on the wire as `_meta`, which the
+gateway folds into `extensionMetadata` during ingest. Alongside the nested
+`_meta.ui` object, the gateway still honours the deprecated flat
+`_meta["ui/resourceUri"]` key so that servers emitting only the older shape keep
+their tool/UI association:
+
+```json
+{
+  "name": "customer_search",
+  "_meta": { "ui/resourceUri": "ui://widgets/customer-search" }
+}
+```
+
+Precedence and handling:
+
+- **The nested object wins.** If `_meta.ui` contains `resourceUri` (or
+  `resource_uri`), the flat key is ignored. Precedence is decided by key
+  *presence*, not truthiness, so a nested value that is empty or malformed stays
+  authoritative and is rejected by validation rather than being silently
+  replaced by the deprecated value.
+- **Only well-formed `ui://` values are folded in.** An unusable flat value is
+  ignored and logged. Folding it in would fail extension metadata validation and
+  drop the whole tool from gateway sync, which is worse than ingesting the tool
+  without a UI association.
+- **Ingest only.** ContextForge always projects the nested shape outbound; it
+  does not re-emit the deprecated key.
+
+The flat key is scheduled for removal from the spec before GA, so treat it as a
+compatibility path rather than a supported input format.
+
 ### Tool Metadata
 
 Tool metadata controls who sees or can invoke the tool:

--- a/mcpgateway/services/mcp_apps.py
+++ b/mcpgateway/services/mcp_apps.py
@@ -33,6 +33,9 @@ logger = logging.getLogger(__name__)
 MCP_UI_EXTENSION = "io.modelcontextprotocol/ui"
 MCP_UI_DEFAULT_VERSION = "2026-01-26"
 MCP_APP_MIME_TYPE = "text/html;profile=mcp-app"
+# Deprecated flat metadata key kept for backward compatibility with servers that
+# predate the nested ``_meta.ui`` shape. Removed from the spec before GA.
+LEGACY_RESOURCE_URI_META_KEY = "ui/resourceUri"
 
 _ALLOWED_CSP_DIRECTIVES = frozenset(
     {
@@ -136,19 +139,51 @@ def mcp_ui_metadata(value: Any) -> Dict[str, Any]:
     return ui if isinstance(ui, dict) else {}
 
 
+def _legacy_ui_resource_uri(meta: Dict[str, Any], ui: Dict[str, Any]) -> Optional[str]:
+    """Return the deprecated flat ``ui/resourceUri`` value when it should be applied."""
+    legacy_uri = meta.get(LEGACY_RESOURCE_URI_META_KEY)
+    if not isinstance(legacy_uri, str) or not legacy_uri:
+        return None
+
+    nested_uri = ui.get("resourceUri") or ui.get("resource_uri")
+    if nested_uri:
+        # The nested key is canonical and wins; upstream servers may legitimately
+        # emit both, so only a genuine disagreement is worth reporting.
+        if nested_uri != legacy_uri:
+            logger.info("Ignoring deprecated _meta[%r]=%r in favour of nested resourceUri %r", LEGACY_RESOURCE_URI_META_KEY, legacy_uri, nested_uri)
+        return None
+
+    if not legacy_uri.startswith("ui://"):
+        # Folding an invalid URI in would fail extension metadata validation and
+        # drop the whole tool, so keep the pre-existing "ignore it" behaviour.
+        logger.warning("Ignoring deprecated _meta[%r]=%r because it does not use the ui:// scheme", LEGACY_RESOURCE_URI_META_KEY, legacy_uri)
+        return None
+
+    return legacy_uri
+
+
 def merge_mcp_protocol_meta(payload: Dict[str, Any]) -> None:
     """Translate MCP protocol ``_meta.ui`` into internal extension metadata.
 
     Upstream MCP servers advertise Apps metadata on protocol objects as
     ``_meta: {"ui": ...}``, while ContextForge stores extension state as
     ``extensionMetadata: {"io.modelcontextprotocol/ui": ...}``.
+
+    The deprecated flat ``_meta["ui/resourceUri"]`` key is also honoured so that
+    servers still emitting only the legacy shape keep their tool/UI association.
     """
     meta = payload.get("_meta")
     if not isinstance(meta, dict):
         return
 
-    ui = meta.get("ui")
-    if not isinstance(ui, dict) or not ui:
+    raw_ui = meta.get("ui")
+    ui = dict(raw_ui) if isinstance(raw_ui, dict) else {}
+
+    legacy_uri = _legacy_ui_resource_uri(meta, ui)
+    if legacy_uri:
+        ui["resourceUri"] = legacy_uri
+
+    if not ui:
         return
 
     extension_metadata = payload.get("extensionMetadata") or payload.get("extension_metadata")

--- a/mcpgateway/services/mcp_apps.py
+++ b/mcpgateway/services/mcp_apps.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta, timezone
 import logging
 import re
 from typing import Any, Dict, Iterable, List, Optional
+from urllib.parse import urlsplit, urlunsplit
 import uuid
 
 # Third-Party
@@ -41,6 +42,8 @@ UI_URI_SCHEME = "ui://"
 NESTED_RESOURCE_URI_KEYS = ("resourceUri", "resource_uri")
 # Upstream-controlled URIs are bounded before they reach the logs.
 MAX_LOGGED_URI_LENGTH = 120
+# Stands in for an authority that cannot be shown to be credential-free.
+REDACTED_AUTHORITY = "***"
 
 _ALLOWED_CSP_DIRECTIVES = frozenset(
     {
@@ -146,10 +149,23 @@ def mcp_ui_metadata(value: Any) -> Dict[str, Any]:
 
 def _loggable_uri(value: str) -> str:
     """Reduce an upstream-controlled URI to a bounded, credential-free form for logging."""
-    safe = value.split("?", 1)[0].split("#", 1)[0]
-    scheme, separator, remainder = safe.partition("://")
-    if separator and "@" in remainder.split("/", 1)[0]:
-        safe = f"{scheme}://{remainder.split('@', 1)[1]}"
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        # Malformed enough that no component can be trusted; the length is the only safe detail.
+        return f"<unparseable {len(value)}-character URI>"
+
+    netloc = parts.netloc.rpartition("@")[2]
+    path = parts.path
+    if "@" in parts.query or "@" in parts.fragment or (not parts.netloc and "@" in path):
+        # The authority ended part-way through what may still be credential material: either an
+        # unencoded delimiter pushed the rest of the userinfo into the query or fragment
+        # (``https://user:pa?ss@host/``), or the URI is not hierarchical so there is no authority
+        # to strip (``mailto:user@host``). Nothing preceding that ``@`` can be shown to be safe.
+        netloc = REDACTED_AUTHORITY if parts.netloc else netloc
+        path = path if parts.netloc else path.rpartition("@")[2]
+
+    safe = urlunsplit((parts.scheme, netloc, path, "", ""))
     if len(safe) > MAX_LOGGED_URI_LENGTH:
         safe = f"{safe[:MAX_LOGGED_URI_LENGTH]}...(truncated)"
     return safe
@@ -172,7 +188,7 @@ def _legacy_ui_resource_uri(meta: Dict[str, Any], ui: Dict[str, Any]) -> Optiona
             logger.info("Ignoring deprecated _meta[%r] in favour of the nested %s already present", LEGACY_RESOURCE_URI_META_KEY, nested_key)
         return None
 
-    if not legacy_uri.startswith(UI_URI_SCHEME) or not legacy_uri[len(UI_URI_SCHEME) :].strip():
+    if not legacy_uri.startswith(UI_URI_SCHEME) or not legacy_uri.removeprefix(UI_URI_SCHEME).strip():
         # Folding an unusable URI in would fail extension metadata validation and
         # drop the whole tool, so keep the pre-existing "ignore it" behaviour.
         logger.warning("Ignoring deprecated _meta[%r]=%r because it is not a usable %s URI", LEGACY_RESOURCE_URI_META_KEY, _loggable_uri(legacy_uri), UI_URI_SCHEME)

--- a/mcpgateway/services/mcp_apps.py
+++ b/mcpgateway/services/mcp_apps.py
@@ -36,6 +36,11 @@ MCP_APP_MIME_TYPE = "text/html;profile=mcp-app"
 # Deprecated flat metadata key kept for backward compatibility with servers that
 # predate the nested ``_meta.ui`` shape. Removed from the spec before GA.
 LEGACY_RESOURCE_URI_META_KEY = "ui/resourceUri"
+UI_URI_SCHEME = "ui://"
+# Canonical nested keys that take precedence over the deprecated flat one.
+NESTED_RESOURCE_URI_KEYS = ("resourceUri", "resource_uri")
+# Upstream-controlled URIs are bounded before they reach the logs.
+MAX_LOGGED_URI_LENGTH = 120
 
 _ALLOWED_CSP_DIRECTIVES = frozenset(
     {
@@ -139,24 +144,38 @@ def mcp_ui_metadata(value: Any) -> Dict[str, Any]:
     return ui if isinstance(ui, dict) else {}
 
 
+def _loggable_uri(value: str) -> str:
+    """Reduce an upstream-controlled URI to a bounded, credential-free form for logging."""
+    safe = value.split("?", 1)[0].split("#", 1)[0]
+    scheme, separator, remainder = safe.partition("://")
+    if separator and "@" in remainder.split("/", 1)[0]:
+        safe = f"{scheme}://{remainder.split('@', 1)[1]}"
+    if len(safe) > MAX_LOGGED_URI_LENGTH:
+        safe = f"{safe[:MAX_LOGGED_URI_LENGTH]}...(truncated)"
+    return safe
+
+
 def _legacy_ui_resource_uri(meta: Dict[str, Any], ui: Dict[str, Any]) -> Optional[str]:
     """Return the deprecated flat ``ui/resourceUri`` value when it should be applied."""
     legacy_uri = meta.get(LEGACY_RESOURCE_URI_META_KEY)
     if not isinstance(legacy_uri, str) or not legacy_uri:
         return None
 
-    nested_uri = ui.get("resourceUri") or ui.get("resource_uri")
-    if nested_uri:
-        # The nested key is canonical and wins; upstream servers may legitimately
-        # emit both, so only a genuine disagreement is worth reporting.
-        if nested_uri != legacy_uri:
-            logger.info("Ignoring deprecated _meta[%r]=%r in favour of nested resourceUri %r", LEGACY_RESOURCE_URI_META_KEY, legacy_uri, nested_uri)
+    for nested_key in NESTED_RESOURCE_URI_KEYS:
+        if nested_key not in ui:
+            continue
+        # Presence, not truthiness: the canonical key stays authoritative even when its
+        # value is empty or malformed, so a bad nested value is rejected downstream by
+        # validate_extension_metadata instead of being silently replaced. Upstream servers
+        # may legitimately emit both shapes, so only a genuine disagreement is reported.
+        if ui[nested_key] != legacy_uri:
+            logger.info("Ignoring deprecated _meta[%r] in favour of the nested %s already present", LEGACY_RESOURCE_URI_META_KEY, nested_key)
         return None
 
-    if not legacy_uri.startswith("ui://"):
-        # Folding an invalid URI in would fail extension metadata validation and
+    if not legacy_uri.startswith(UI_URI_SCHEME) or not legacy_uri[len(UI_URI_SCHEME) :].strip():
+        # Folding an unusable URI in would fail extension metadata validation and
         # drop the whole tool, so keep the pre-existing "ignore it" behaviour.
-        logger.warning("Ignoring deprecated _meta[%r]=%r because it does not use the ui:// scheme", LEGACY_RESOURCE_URI_META_KEY, legacy_uri)
+        logger.warning("Ignoring deprecated _meta[%r]=%r because it is not a usable %s URI", LEGACY_RESOURCE_URI_META_KEY, _loggable_uri(legacy_uri), UI_URI_SCHEME)
         return None
 
     return legacy_uri

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -3492,6 +3492,40 @@ class TestGatewayRefresh:
         assert validation_errors == []
         assert valid_tools[0].extension_metadata == {MCP_UI_EXTENSION: {"resourceUri": "ui://widgets/example", "audience": ["model"]}}
 
+    def test_validate_tools_preserves_deprecated_flat_mcp_apps_meta(self, gateway_service):
+        """A tool carrying only the deprecated flat key must survive ToolCreate validation with its UI association."""
+        tools = [
+            {
+                "name": "customer_search",
+                "description": "Search customers",
+                "inputSchema": {},
+                "_meta": {"ui/resourceUri": "ui://widgets/customer-search"},
+            }
+        ]
+
+        valid_tools, validation_errors = gateway_service._validate_tools(tools)
+
+        assert validation_errors == []
+        assert len(valid_tools) == 1
+        assert valid_tools[0].extension_metadata == {MCP_UI_EXTENSION: {"resourceUri": "ui://widgets/customer-search"}}
+
+    def test_validate_tools_keeps_tool_when_deprecated_flat_meta_is_unusable(self, gateway_service):
+        """An invalid legacy value must be ignored rather than failing validation and dropping the tool."""
+        tools = [
+            {
+                "name": "customer_search",
+                "description": "Search customers",
+                "inputSchema": {},
+                "_meta": {"ui/resourceUri": "https://example.com/widget.html"},
+            }
+        ]
+
+        valid_tools, validation_errors = gateway_service._validate_tools(tools)
+
+        assert validation_errors == []
+        assert len(valid_tools) == 1
+        assert valid_tools[0].extension_metadata is None
+
     def test_validate_tools_error_message(self, gateway_service):
         """Validation errors must be 'toolname: reason' strings, not raw pydantic dicts (issue #136 Bug C).
 
@@ -3569,6 +3603,62 @@ class TestGatewayRefresh:
                 result = await gateway_service.register_gateway(db, gateway_data, created_by="test@example.com")
 
         assert result.skipped_tools == [f"{long_name}: Tool name exceeds MCP spec limit of 128 characters (got 129)"]
+
+    @pytest.mark.asyncio
+    async def test_deprecated_flat_meta_honoured_on_resource_ingest_paths(self, gateway_service):
+        """merge_mcp_protocol_meta is shared with the resource and resource-template ingest paths.
+
+        Mocks only the MCP transport so the real connect_to_sse_server chain runs against a
+        resource and a resource template that each carry only the deprecated flat key.
+        """
+        mock_session = AsyncMock()
+        mock_init = MagicMock()
+        mock_init.capabilities.model_dump.return_value = {"resources": {"subscribe": False}}
+        mock_session.initialize.return_value = mock_init
+
+        tool = MagicMock()
+        tool.model_dump.return_value = {"name": "valid_tool", "description": "ok", "inputSchema": {}}
+        mock_list_tools = MagicMock()
+        mock_list_tools.tools = [tool]
+        mock_session.list_tools.return_value = mock_list_tools
+
+        resource = MagicMock()
+        resource.model_dump.return_value = {
+            "uri": "https://example.com/data",
+            "name": "customer_data",
+            "_meta": {"ui/resourceUri": "ui://widgets/customer-search"},
+        }
+        mock_list_resources = MagicMock()
+        mock_list_resources.resources = [resource]
+        mock_session.list_resources.return_value = mock_list_resources
+
+        template = MagicMock()
+        template.model_dump.return_value = {
+            "uriTemplate": "https://example.com/data/{id}",
+            "name": "customer_record",
+            "_meta": {"ui/resourceUri": "ui://widgets/customer-record"},
+        }
+        mock_list_templates = MagicMock()
+        mock_list_templates.resourceTemplates = [template]
+        mock_session.list_resource_templates.return_value = mock_list_templates
+
+        mock_session.list_prompts.return_value = MagicMock(prompts=[])
+
+        mock_sse_cm = AsyncMock()
+        mock_sse_cm.__aenter__.return_value = (MagicMock(), MagicMock())
+        mock_sse_cm.__aexit__.return_value = None
+
+        mock_client_cm = AsyncMock()
+        mock_client_cm.__aenter__.return_value = mock_session
+        mock_client_cm.__aexit__.return_value = None
+
+        with patch("mcpgateway.services.gateway_service.sse_client", return_value=mock_sse_cm):
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=mock_client_cm):
+                _capabilities, _tools, resources, _prompts, _errors = await gateway_service.connect_to_sse_server("https://test.example.com")
+
+        by_name = {resource.name: resource for resource in resources}
+        assert by_name["customer_data"].extension_metadata == {MCP_UI_EXTENSION: {"resourceUri": "ui://widgets/customer-search"}}
+        assert by_name["customer_record"].extension_metadata == {MCP_UI_EXTENSION: {"resourceUri": "ui://widgets/customer-record"}}
 
     def test_validate_tools_all_invalid(self, gateway_service):
         """Test failure when all tools are invalid."""

--- a/tests/unit/mcpgateway/services/test_mcp_apps.py
+++ b/tests/unit/mcpgateway/services/test_mcp_apps.py
@@ -24,6 +24,7 @@ from mcpgateway.services.mcp_apps import (
     build_mcp_apps_capabilities,
     filter_model_visible_tools,
     is_app_visible_tool,
+    LEGACY_RESOURCE_URI_META_KEY,
     MCPAppSessionCleanupService,
     mcp_app_session_service,
     MCP_UI_EXTENSION,
@@ -154,6 +155,85 @@ def test_merge_mcp_protocol_meta_ignores_missing_ui_and_merges_existing_metadata
         "visibility": ["model"],
         "resourceUri": "ui://widgets/example",
     }
+
+
+def test_merge_mcp_protocol_meta_honours_deprecated_flat_resource_uri() -> None:
+    """A server emitting only the deprecated flat key should keep its tool/UI association."""
+    payload = {"_meta": {LEGACY_RESOURCE_URI_META_KEY: "ui://widgets/legacy"}}
+
+    merge_mcp_protocol_meta(payload)
+
+    assert payload["extensionMetadata"][MCP_UI_EXTENSION]["resourceUri"] == "ui://widgets/legacy"
+
+
+def test_merge_mcp_protocol_meta_flat_resource_uri_preserves_nested_siblings() -> None:
+    """The deprecated flat key should merge alongside other nested MCP Apps metadata."""
+    payload = {"_meta": {"ui": {"visibility": ["model", "app"]}, LEGACY_RESOURCE_URI_META_KEY: "ui://widgets/legacy"}}
+
+    merge_mcp_protocol_meta(payload)
+
+    assert payload["extensionMetadata"][MCP_UI_EXTENSION] == {
+        "visibility": ["model", "app"],
+        "resourceUri": "ui://widgets/legacy",
+    }
+
+
+def test_merge_mcp_protocol_meta_prefers_nested_resource_uri_over_flat() -> None:
+    """When both shapes disagree the canonical nested key wins."""
+    payload = {
+        "_meta": {
+            "ui": {"resourceUri": "ui://widgets/new"},
+            LEGACY_RESOURCE_URI_META_KEY: "ui://widgets/old",
+        }
+    }
+
+    merge_mcp_protocol_meta(payload)
+
+    assert payload["extensionMetadata"][MCP_UI_EXTENSION]["resourceUri"] == "ui://widgets/new"
+
+
+def test_merge_mcp_protocol_meta_accepts_matching_nested_and_flat_resource_uri() -> None:
+    """SDK-built servers emit both shapes with the same value and should merge cleanly."""
+    payload = {
+        "_meta": {
+            "ui": {"resourceUri": "ui://widgets/example"},
+            LEGACY_RESOURCE_URI_META_KEY: "ui://widgets/example",
+        }
+    }
+
+    merge_mcp_protocol_meta(payload)
+
+    assert payload["extensionMetadata"][MCP_UI_EXTENSION] == {"resourceUri": "ui://widgets/example"}
+
+
+@pytest.mark.parametrize(
+    "legacy_value",
+    [
+        "https://example.com/widget.html",
+        "",
+        123,
+        None,
+        ["ui://widgets/example"],
+    ],
+)
+def test_merge_mcp_protocol_meta_ignores_unusable_flat_resource_uri(legacy_value) -> None:
+    """Only well-formed ui:// strings are folded in, so invalid values cannot drop a tool."""
+    payload = {"_meta": {LEGACY_RESOURCE_URI_META_KEY: legacy_value}}
+
+    merge_mcp_protocol_meta(payload)
+
+    assert "extensionMetadata" not in payload
+
+
+def test_merge_mcp_protocol_meta_does_not_mutate_source_meta() -> None:
+    """Normalizing the deprecated key must not rewrite the caller's _meta payload."""
+    meta = {"ui": {"visibility": ["app"]}, LEGACY_RESOURCE_URI_META_KEY: "ui://widgets/legacy"}
+    payload = {"_meta": meta}
+
+    merge_mcp_protocol_meta(payload)
+
+    assert meta["ui"] == {"visibility": ["app"]}
+    assert payload["extensionMetadata"][MCP_UI_EXTENSION]["resourceUri"] == "ui://widgets/legacy"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/mcpgateway/services/test_mcp_apps.py
+++ b/tests/unit/mcpgateway/services/test_mcp_apps.py
@@ -8,6 +8,7 @@ Tests for the minimal MCP Apps helpers.
 
 # Standard
 import asyncio
+import logging
 from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -211,6 +212,8 @@ def test_merge_mcp_protocol_meta_accepts_matching_nested_and_flat_resource_uri()
     [
         "https://example.com/widget.html",
         "",
+        "ui://",
+        "ui://   ",
         123,
         None,
         ["ui://widgets/example"],
@@ -223,6 +226,33 @@ def test_merge_mcp_protocol_meta_ignores_unusable_flat_resource_uri(legacy_value
     merge_mcp_protocol_meta(payload)
 
     assert "extensionMetadata" not in payload
+
+
+@pytest.mark.parametrize("nested_key", ["resourceUri", "resource_uri"])
+@pytest.mark.parametrize("nested_value", ["", None, False, 0, "https://example.com/widget.html"])
+def test_merge_mcp_protocol_meta_keeps_present_but_unusable_nested_resource_uri(nested_key, nested_value) -> None:
+    """A present canonical key stays authoritative even when its value is empty or malformed."""
+    payload = {"_meta": {"ui": {nested_key: nested_value}, LEGACY_RESOURCE_URI_META_KEY: "ui://widgets/legacy"}}
+
+    merge_mcp_protocol_meta(payload)
+
+    assert payload["extensionMetadata"][MCP_UI_EXTENSION] == {nested_key: nested_value}
+
+
+def test_merge_mcp_protocol_meta_does_not_log_full_flat_resource_uri(caplog) -> None:
+    """Rejected upstream URIs must not reach the logs verbatim."""
+    legacy_uri = "https://user:s3cret@example.com/" + "a" * 500 + "?token=abcdef#frag"  # pragma: allowlist secret
+    payload = {"_meta": {LEGACY_RESOURCE_URI_META_KEY: legacy_uri}}
+
+    with caplog.at_level(logging.WARNING, logger="mcpgateway.services.mcp_apps"):
+        merge_mcp_protocol_meta(payload)
+
+    logged = caplog.text
+    assert "extensionMetadata" not in payload
+    assert legacy_uri not in logged
+    assert "s3cret" not in logged
+    assert "token=abcdef" not in logged
+    assert "truncated" in logged
 
 
 def test_merge_mcp_protocol_meta_does_not_mutate_source_meta() -> None:

--- a/tests/unit/mcpgateway/services/test_mcp_apps.py
+++ b/tests/unit/mcpgateway/services/test_mcp_apps.py
@@ -255,6 +255,42 @@ def test_merge_mcp_protocol_meta_does_not_log_full_flat_resource_uri(caplog) -> 
     assert "truncated" in logged
 
 
+@pytest.mark.parametrize(
+    "legacy_uri",
+    [
+        "https://user:pa?ss@example.com/widget.html",  # pragma: allowlist secret
+        "https://user:pa#ss@example.com/widget.html",  # pragma: allowlist secret
+        "mailto:user:pa@example.com",  # pragma: allowlist secret
+    ],
+)
+def test_merge_mcp_protocol_meta_redacts_credentials_split_by_a_stray_delimiter(caplog, legacy_uri) -> None:
+    """An unencoded delimiter inside userinfo must not leave a credential prefix in the logs."""
+    payload = {"_meta": {LEGACY_RESOURCE_URI_META_KEY: legacy_uri}}
+
+    with caplog.at_level(logging.WARNING, logger="mcpgateway.services.mcp_apps"):
+        merge_mcp_protocol_meta(payload)
+
+    logged = caplog.text
+    assert "extensionMetadata" not in payload
+    # "pa" is the part of the credential that survives if the query/fragment is stripped
+    # before the userinfo is, so its absence is what pins the ordering-independence.
+    assert "user" not in logged
+    assert "pa" not in logged
+
+
+def test_merge_mcp_protocol_meta_logs_an_unparseable_uri_without_its_contents(caplog) -> None:
+    """A URI that cannot be parsed at all is reported by length only."""
+    legacy_uri = "http://[::1-s3cret"  # pragma: allowlist secret
+    payload = {"_meta": {LEGACY_RESOURCE_URI_META_KEY: legacy_uri}}
+
+    with caplog.at_level(logging.WARNING, logger="mcpgateway.services.mcp_apps"):
+        merge_mcp_protocol_meta(payload)
+
+    assert "extensionMetadata" not in payload
+    assert "s3cret" not in caplog.text
+    assert "unparseable" in caplog.text
+
+
 def test_merge_mcp_protocol_meta_does_not_mutate_source_meta() -> None:
     """Normalizing the deprecated key must not rewrite the caller's _meta payload."""
     meta = {"ui": {"visibility": ["app"]}, LEGACY_RESOURCE_URI_META_KEY: "ui://widgets/legacy"}


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Servers that emit only the deprecated flat `_meta["ui/resourceUri"]` key lose their tool→UI association when passing through the gateway. This folds the legacy key into the nested MCP Apps metadata during the existing merge step.

Closes #5762. Part of #2527.

## 🔁 Reproduction Steps

Federate an upstream MCP server exposing a tool whose `_meta` carries only the legacy key:

```json
{ "name": "customer_search", "_meta": { "ui/resourceUri": "ui://widgets/customer-search" } }
```

After gateway sync the tool is ingested with no `extensionMetadata`, so it has no UI association and the app never renders. Covered as a regression test in `test_merge_mcp_protocol_meta_honours_deprecated_flat_resource_uri`.

## 🐞 Root Cause

`merge_mcp_protocol_meta` (`mcpgateway/services/mcp_apps.py:139`) reads only the nested object and returns early when it is absent:

```python
ui = meta.get("ui")
if not isinstance(ui, dict) or not ui:
    return
```

The flat key had no occurrences anywhere in the repository, so it was never consulted. The spec keeps it live (`apps.mdx:341`, `:347` — *"The deprecated format will be removed before GA"*).

## 💡 Fix Description

The legacy key is now folded into the `ui` block before the merge, behind a small helper. Three design points:

**Nested wins on disagreement.** This follows the reference SDK's consumer-side rule in `getToolUiResourceUri` ([`app-bridge.ts:125-133`](https://github.com/modelcontextprotocol/ext-apps/blob/main/src/app-bridge.ts)): *"The new nested format takes precedence if both are present."* Worth noting the SDK's producer side deliberately does **not** reconcile — `registerAppTool` emits both conflicting values on the wire ([`server/index.ts:238-262`](https://github.com/modelcontextprotocol/ext-apps/blob/main/src/server/index.ts), test `server/index.test.ts:163`) — so the consumer rule is the only one a gateway can apply. A genuine disagreement is logged.

**Only well-formed `ui://` strings are folded in.** This is the part I'd most like a second opinion on. `validate_extension_metadata` (`mcp_apps.py:239-241`) rejects a non-`ui://` `resourceUri`, and `_validate_tools` (`gateway_service.py:6576`) turns that into a `ValidationError` that drops the tool from the sync. Folding an unvalidated legacy value in would therefore convert "ingested without UI" into "tool disappears entirely" — a worse outcome than the bug. Unusable values keep the existing ignore-it behaviour and are logged instead. The SDK throws here; for a gateway, failing closed on ingest seemed wrong.

**Ingest only, not bidirectional.** The SDK also emits the flat key outbound for older hosts. Not done here: ContextForge's own projection (`apply_tool_meta`, `mcp_apps.py:319`) emits the nested shape only, and propagating a format scheduled for removal before GA seems like the wrong direction for a gateway. Trivial to add if you'd prefer symmetry.

The source `_meta` is copied rather than mutated, so callers passing shared dicts are unaffected.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

On the `triage` checkbox: #5762 currently carries no labels. Filing it and this PR was explicitly requested by @vishu-bh in https://github.com/IBM/mcp-context-forge/issues/2527#issuecomment-5044901298, which CONTRIBUTING lists as one of the conditions for starting work. If you apply `triage` while scoping it, treat this PR as parked until you're ready.

## 🧪 Verification

Added 12 tests to `tests/unit/mcpgateway/services/test_mcp_apps.py`, covering: legacy-only payloads, legacy alongside nested siblings, both shapes agreeing, both disagreeing (nested wins), five classes of unusable legacy value, and non-mutation of the caller's `_meta`.

| Check | Command | Status |
|---|---|---|
| MCP Apps + AppBridge + registry suites | `pytest tests/unit/mcpgateway/services/test_mcp_apps.py tests/unit/mcpgateway/test_mcp_apps_security.py tests/unit/mcpgateway/test_mcp_apps_protocol.py tests/unit/mcpgateway/test_mcp_method_registry.py` | ✅ 98 passed (86 before this change) |
| Ingest-path regression | `pytest tests/unit/mcpgateway/services/test_gateway_service.py tests/unit/mcpgateway/services/test_resource_service.py` | ✅ no new failures |
| Ruff | `ruff check mcpgateway/services/mcp_apps.py tests/...` | ✅ All checks passed |
| Black (line length 200) | `black --check` | ✅ unchanged |
| Doctests | `pytest --doctest-modules mcpgateway/services/mcp_apps.py` | ✅ no doctests in module, none broken |

Two pre-existing errors in `test_resource_service.py` (`test_read_resource_template_proxy_blob_none_response_raises`, `test_invoke_resource_sse_returns_content_when_session_teardown_raises`) reproduce identically on unmodified `main`, so they are unrelated to this change.

Not run locally: `make docker docker-run-ssl` and the postgres/redis matrix. This change is a pure in-memory dict transformation with no database, network, or migration surface, so I don't believe it carries container- or backend-specific risk — but say the word if you want that evidence before merging.

## 📐 MCP Compliance

- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

Strictly additive: payloads without the legacy key take an unchanged path.

## ✅ Checklist

- [x] Code formatted
- [x] No secrets/credentials committed
