### PR TITLE
feat(mcp-apps): support standard MCP messages over the AppBridge

### DIFF
--- a/docs/docs/architecture/mcp-apps.md
+++ b/docs/docs/architecture/mcp-apps.md
@@ -340,6 +340,13 @@ transport level with `202 Accepted` and an empty body, matching the Streamable
 HTTP rule for notification-only input. The other three methods are requests and
 return a normal JSON-RPC result or error with the request `id` echoed back.
 
+JSON-RPC distinguishes a notification from a request by the *presence* of the
+`id` member, not by its value, so `"id": null` still makes the message a request
+that requires a response. Because `notifications/message` is defined as
+notification-only, an `id`-bearing form is rejected with `-32600 Invalid Request`
+rather than acknowledged with an empty `202` that would leave the caller waiting
+on a response it will never receive.
+
 Being a core MCP method does not make a method reachable over AppBridge: the
 allowlist is explicit, so `tools/list`, `resources/list`, `prompts/list`, and
 `resources/subscribe` remain rejected.

--- a/docs/docs/architecture/mcp-apps.md
+++ b/docs/docs/architecture/mcp-apps.md
@@ -47,7 +47,7 @@ For authenticated MCP initialization requests, the gateway advertises:
           "schemes": ["ui://"]
         },
         "bridge": {
-          "methods": ["tools/call"]
+          "methods": ["tools/call", "resources/read", "notifications/message", "ping"]
         }
       }
     }
@@ -313,6 +313,23 @@ Content-Type: application/json
 The RPC endpoint requires `tools.execute`. The tool must resolve within the
 stored server binding and must be app-visible through
 `audience: ["app"]` or `audience: ["model", "app"]`.
+
+### Supported AppBridge Methods
+
+The RPC endpoint accepts the standard MCP messages an app may send, and rejects
+everything else with `-32601`. Session ownership and the stored server binding
+are validated before any method is dispatched.
+
+| Method | Behaviour |
+| --- | --- |
+| `tools/call` | Invokes an app-visible tool within the bound server. |
+| `resources/read` | Reads a resource within the bound server, using the identity and team scoping stored on the session. |
+| `notifications/message` | Recorded by the gateway for observability and never proxied upstream. |
+| `ping` | Answered by the gateway without an upstream call. |
+
+Being a core MCP method does not make a method reachable over AppBridge: the
+allowlist is explicit, so `tools/list`, `resources/list`, `prompts/list`, and
+`resources/subscribe` remain rejected.
 
 ## Security Invariants
 

--- a/docs/docs/architecture/mcp-apps.md
+++ b/docs/docs/architecture/mcp-apps.md
@@ -30,8 +30,10 @@ When enabled, the gateway can:
   server, and UI resource;
 - allow AppBridge RPC calls only to tools marked for app use.
 
-The current AppBridge RPC surface supports `tools/call`. Other MCP methods are
-rejected with JSON-RPC `Method not found`.
+The current AppBridge RPC surface supports `tools/call`, `resources/read`,
+`notifications/message`, and `ping` — see
+[Supported AppBridge Methods](#supported-appbridge-methods). Every other MCP
+method is rejected with JSON-RPC `Method not found`.
 
 ## MCP Capability
 
@@ -314,6 +316,11 @@ The RPC endpoint requires `tools.execute`. The tool must resolve within the
 stored server binding and must be app-visible through
 `audience: ["app"]` or `audience: ["model", "app"]`.
 
+RBAC is enforced per method rather than inherited from the endpoint, so
+`resources/read` additionally requires `resources.read`. A caller who keeps
+`tools.execute` after `resources.read` is revoked cannot keep reading resources
+through an existing AppBridge session.
+
 ### Supported AppBridge Methods
 
 The RPC endpoint accepts the standard MCP messages an app may send, and rejects
@@ -323,9 +330,15 @@ are validated before any method is dispatched.
 | Method | Behaviour |
 | --- | --- |
 | `tools/call` | Invokes an app-visible tool within the bound server. |
-| `resources/read` | Reads a resource within the bound server, using the identity and team scoping stored on the session. |
+| `resources/read` | Reads a resource within the bound server, using the identity and team scoping stored on the session. Requires `resources.read`. |
 | `notifications/message` | Recorded by the gateway for observability and never proxied upstream. |
 | `ping` | Answered by the gateway without an upstream call. |
+
+`notifications/message` is a JSON-RPC notification: it carries no `id` and must
+not receive a JSON-RPC response. The gateway therefore acknowledges it at the
+transport level with `202 Accepted` and an empty body, matching the Streamable
+HTTP rule for notification-only input. The other three methods are requests and
+return a normal JSON-RPC result or error with the request `id` echoed back.
 
 Being a core MCP method does not make a method reachable over AppBridge: the
 allowlist is explicit, so `tools/list`, `resources/list`, `prompts/list`, and

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -10607,12 +10607,29 @@ async def create_mcp_app_session(request: Request, db: Session = Depends(get_db)
     )
 
 
+def _app_bridge_request_headers(request: Request) -> Dict[str, str]:
+    """Build the header passthrough for an AppBridge call.
+
+    The gateway routing header is stripped so an app cannot redirect its own
+    call to a different gateway than the one its session is bound to.
+
+    Args:
+        request: Incoming AppBridge RPC request.
+
+    Returns:
+        Lowercased request headers without the gateway routing header.
+    """
+    request_headers = {k.lower(): v for k, v in request.headers.items()}
+    request_headers.pop("x-context-forge-gateway-id", None)
+    return request_headers
+
+
 def _record_app_bridge_log(app_session, params: Dict[str, Any]) -> None:
     """Record a log notification sent by an MCP App.
 
     The MCP Apps lifecycle terminates ``notifications/message`` at the host, so
     the payload is recorded for observability and never proxied upstream. The
-    contents are attacker-influenced, so the message is truncated and logged as
+    contents are attacker-influenced, so every field is truncated and logged as
     data rather than interpolated into the format string.
 
     Args:
@@ -10623,7 +10640,7 @@ def _record_app_bridge_log(app_session, params: Dict[str, Any]) -> None:
     origin_logger = params.get("logger")
     data = params.get("data")
     logger.info(
-        "AppBridge log notification session=%s server=%s level=%r logger=%r data=%.500r",
+        "AppBridge log notification session=%s server=%s level=%.100r logger=%.100r data=%.500r",
         app_session.id,
         app_session.server_id,
         level,
@@ -10655,8 +10672,7 @@ async def _handle_app_bridge_resources_read(db: Session, request: Request, app_s
 
     token_teams = app_session.token_teams
     resource_user_email = None if token_teams is None else app_session.user_email
-    request_headers = {k.lower(): v for k, v in request.headers.items()}
-    request_headers.pop("x-context-forge-gateway-id", None)
+    request_headers = _app_bridge_request_headers(request)
 
     try:
         result = await resource_service.read_resource(
@@ -10717,8 +10733,7 @@ async def _handle_app_bridge_tools_call(db: Session, request: Request, app_sessi
     try:
         token_teams = app_session.token_teams
         tool_user_email = None if token_teams is None else app_session.user_email
-        request_headers = {k.lower(): v for k, v in request.headers.items()}
-        request_headers.pop("x-context-forge-gateway-id", None)
+        request_headers = _app_bridge_request_headers(request)
         result = await tool_service.invoke_tool(
             db=db,
             name=name,

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -10693,6 +10693,72 @@ async def _handle_app_bridge_resources_read(db: Session, request: Request, app_s
     return {"jsonrpc": "2.0", "result": {"contents": [serialize_resource_content_for_mcp(result, fallback_uri=uri)]}, "id": req_id}
 
 
+async def _handle_app_bridge_tools_call(db: Session, request: Request, app_session, params: Dict[str, Any], req_id: Any, requester_email: Optional[str]) -> Dict[str, Any]:
+    """Invoke an app-visible tool on behalf of an MCP App through its bound session.
+
+    The call is scoped to the server the AppBridge session is bound to and uses the
+    identity and team scoping captured when the session was created.
+
+    Args:
+        db: Database session.
+        request: Incoming request, used for plugin context and header passthrough.
+        app_session: The validated AppBridge session.
+        params: JSON-RPC params carrying the tool ``name`` and ``arguments``.
+        req_id: JSON-RPC request id echoed back to the caller.
+        requester_email: Email of the authenticated caller driving the app.
+
+    Returns:
+        A JSON-RPC response dictionary with the tool result or an error.
+    """
+    name = params.get("name")
+    if not name:
+        return {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Missing tool name in parameters"}, "id": req_id}
+
+    try:
+        token_teams = app_session.token_teams
+        tool_user_email = None if token_teams is None else app_session.user_email
+        request_headers = {k.lower(): v for k, v in request.headers.items()}
+        request_headers.pop("x-context-forge-gateway-id", None)
+        result = await tool_service.invoke_tool(
+            db=db,
+            name=name,
+            arguments=params.get("arguments", {}),
+            request_headers=request_headers,
+            app_user_email=requester_email,
+            user_email=tool_user_email,
+            token_teams=token_teams,
+            server_id=app_session.server_id,
+            plugin_context_table=getattr(request.state, "plugin_context_table", None),
+            plugin_global_context=getattr(request.state, "plugin_global_context", None),
+            meta_data=params.get("_meta"),
+            require_app_visible=True,
+        )
+        if hasattr(result, "model_dump"):
+            result = result.model_dump(by_alias=True, exclude_none=True)
+        return {"jsonrpc": "2.0", "result": result, "id": req_id}
+    except ToolNotFoundError:
+        return {"jsonrpc": "2.0", "error": {"code": -32601, "message": f"Tool not found: {name}"}, "id": req_id}
+    except ToolError as exc:
+        logger.info("AppBridge tool call failed with tool error for %s: %s", name, exc)
+        return {"jsonrpc": "2.0", "error": {"code": -32000, "message": str(exc)}, "id": req_id}
+    except PluginViolationError as exc:
+        error_code = -32602
+        if exc.violation and hasattr(exc.violation, "mcp_error_code") and isinstance(exc.violation.mcp_error_code, int):
+            error_code = exc.violation.mcp_error_code
+        return {"jsonrpc": "2.0", "error": {"code": error_code, "message": str(exc)}, "id": req_id}
+    except PluginError as exc:
+        error_code = -32603
+        if exc.error and hasattr(exc.error, "mcp_error_code") and isinstance(exc.error.mcp_error_code, int):
+            error_code = exc.error.mcp_error_code
+        return {"jsonrpc": "2.0", "error": {"code": error_code, "message": str(exc)}, "id": req_id}
+    except (ValidationError, ValueError) as exc:
+        logger.info("AppBridge tool call received invalid parameters for %s: %s", name, exc)
+        return {"jsonrpc": "2.0", "error": {"code": -32602, "message": str(exc)}, "id": req_id}
+    except Exception:
+        logger.exception("AppBridge tool call failed for %s", name)
+        return {"jsonrpc": "2.0", "error": {"code": -32603, "message": "Internal error"}, "id": req_id}
+
+
 @utility_router.post("/appbridge/sessions/{app_session_id}/rpc")
 @require_permission("tools.execute")
 async def handle_mcp_app_session_rpc(app_session_id: str, request: Request, db: Session = Depends(get_db), user=Depends(get_current_user_with_permissions)):
@@ -10744,58 +10810,22 @@ async def handle_mcp_app_session_rpc(app_session_id: str, request: Request, db: 
 
     if method == "notifications/message":
         _record_app_bridge_log(app_session, params)
-        return {"jsonrpc": "2.0", "result": {}, "id": req_id}
+        # A JSON-RPC notification carries no id and MUST NOT receive a JSON-RPC response, so
+        # this is acknowledged at the transport level only: 202 Accepted with an empty body,
+        # matching the Streamable HTTP rule for notification-only input.
+        return Response(status_code=status.HTTP_202_ACCEPTED)
 
     if method == "resources/read":
+        # RBAC is a layer of its own, separate from the session's token/team scoping: the
+        # endpoint decorator only proves tools.execute, which a caller can retain after
+        # resources.read has been revoked. Authorize the read per method.
+        try:
+            await _ensure_rpc_permission(user, db, "resources.read", method, request=request)
+        except JSONRPCError as exc:
+            return {"jsonrpc": "2.0", "error": exc.to_dict()["error"], "id": req_id}
         return await _handle_app_bridge_resources_read(db, request, app_session, params, req_id)
 
-    name = params.get("name")
-    if not name:
-        return {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Missing tool name in parameters"}, "id": req_id}
-
-    try:
-        token_teams = app_session.token_teams
-        tool_user_email = None if token_teams is None else app_session.user_email
-        request_headers = {k.lower(): v for k, v in request.headers.items()}
-        request_headers.pop("x-context-forge-gateway-id", None)
-        result = await tool_service.invoke_tool(
-            db=db,
-            name=name,
-            arguments=params.get("arguments", {}),
-            request_headers=request_headers,
-            app_user_email=requester_email,
-            user_email=tool_user_email,
-            token_teams=token_teams,
-            server_id=app_session.server_id,
-            plugin_context_table=getattr(request.state, "plugin_context_table", None),
-            plugin_global_context=getattr(request.state, "plugin_global_context", None),
-            meta_data=params.get("_meta"),
-            require_app_visible=True,
-        )
-        if hasattr(result, "model_dump"):
-            result = result.model_dump(by_alias=True, exclude_none=True)
-        return {"jsonrpc": "2.0", "result": result, "id": req_id}
-    except ToolNotFoundError:
-        return {"jsonrpc": "2.0", "error": {"code": -32601, "message": f"Tool not found: {name}"}, "id": req_id}
-    except ToolError as exc:
-        logger.info("AppBridge tool call failed with tool error for %s: %s", name, exc)
-        return {"jsonrpc": "2.0", "error": {"code": -32000, "message": str(exc)}, "id": req_id}
-    except PluginViolationError as exc:
-        error_code = -32602
-        if exc.violation and hasattr(exc.violation, "mcp_error_code") and isinstance(exc.violation.mcp_error_code, int):
-            error_code = exc.violation.mcp_error_code
-        return {"jsonrpc": "2.0", "error": {"code": error_code, "message": str(exc)}, "id": req_id}
-    except PluginError as exc:
-        error_code = -32603
-        if exc.error and hasattr(exc.error, "mcp_error_code") and isinstance(exc.error.mcp_error_code, int):
-            error_code = exc.error.mcp_error_code
-        return {"jsonrpc": "2.0", "error": {"code": error_code, "message": str(exc)}, "id": req_id}
-    except (ValidationError, ValueError) as exc:
-        logger.info("AppBridge tool call received invalid parameters for %s: %s", name, exc)
-        return {"jsonrpc": "2.0", "error": {"code": -32602, "message": str(exc)}, "id": req_id}
-    except Exception:
-        logger.exception("AppBridge tool call failed for %s", name)
-        return {"jsonrpc": "2.0", "error": {"code": -32603, "message": "Internal error"}, "id": req_id}
+    return await _handle_app_bridge_tools_call(db, request, app_session, params, req_id, requester_email)
 
 
 @utility_router.post("/_internal/mcp/tools/call/")
@@ -11778,9 +11808,6 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             result = {}
         elif method.startswith("extensions/") or method.startswith("io.modelcontextprotocol/"):
             # Check if this is a known MCP Apps method.
-            # First-Party
-            from mcpgateway.services.mcp_method_registry import mcp_method_registry
-
             if not mcp_method_registry.is_known_method(method):
                 raise JSONRPCError(-32601, f"Method not found: {method}", {})
             # Known MCP Apps method but not yet implemented here.

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -196,6 +196,7 @@ from mcpgateway.services.mcp_apps import (
     MCPAppsValidationError,
     serialize_resource_content_for_mcp,
 )
+from mcpgateway.services.mcp_method_registry import mcp_method_registry
 from mcpgateway.services.metrics import setup_metrics
 from mcpgateway.services.permission_service import PermissionService
 from mcpgateway.services.prompt_service import PromptError, PromptLockConflictError, PromptNameConflictError, PromptNotFoundError
@@ -10606,10 +10607,96 @@ async def create_mcp_app_session(request: Request, db: Session = Depends(get_db)
     )
 
 
+def _record_app_bridge_log(app_session, params: Dict[str, Any]) -> None:
+    """Record a log notification sent by an MCP App.
+
+    The MCP Apps lifecycle terminates ``notifications/message`` at the host, so
+    the payload is recorded for observability and never proxied upstream. The
+    contents are attacker-influenced, so the message is truncated and logged as
+    data rather than interpolated into the format string.
+
+    Args:
+        app_session: The validated AppBridge session the notification arrived on.
+        params: JSON-RPC params carrying ``level``, optional ``logger`` and ``data``.
+    """
+    level = params.get("level")
+    origin_logger = params.get("logger")
+    data = params.get("data")
+    logger.info(
+        "AppBridge log notification session=%s server=%s level=%r logger=%r data=%.500r",
+        app_session.id,
+        app_session.server_id,
+        level,
+        origin_logger,
+        data,
+    )
+
+
+async def _handle_app_bridge_resources_read(db: Session, request: Request, app_session, params: Dict[str, Any], req_id: Any) -> Dict[str, Any]:
+    """Read a resource on behalf of an MCP App through its bound session.
+
+    The read is scoped to the server the AppBridge session is bound to and uses
+    the identity and team scoping captured when the session was created, so an
+    app cannot reach resources its originating user could not read.
+
+    Args:
+        db: Database session.
+        request: Incoming request, used for plugin context and header passthrough.
+        app_session: The validated AppBridge session.
+        params: JSON-RPC params carrying the resource ``uri``.
+        req_id: JSON-RPC request id echoed back to the caller.
+
+    Returns:
+        A JSON-RPC response dictionary with the resource contents or an error.
+    """
+    uri = params.get("uri")
+    if not uri or not isinstance(uri, str):
+        return {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Missing resource URI in parameters"}, "id": req_id}
+
+    token_teams = app_session.token_teams
+    resource_user_email = None if token_teams is None else app_session.user_email
+    request_headers = {k.lower(): v for k, v in request.headers.items()}
+    request_headers.pop("x-context-forge-gateway-id", None)
+
+    try:
+        result = await resource_service.read_resource(
+            db,
+            resource_uri=uri,
+            user=resource_user_email,
+            server_id=app_session.server_id,
+            token_teams=token_teams,
+            plugin_context_table=getattr(request.state, "plugin_context_table", None),
+            plugin_global_context=getattr(request.state, "plugin_global_context", None),
+            meta_data=params.get("_meta"),
+            request_headers=request_headers,
+        )
+    except (ValueError, ResourceNotFoundError) as exc:
+        logger.info("AppBridge resource read failed for %s on server %s: %s", uri, app_session.server_id, exc)
+        return {"jsonrpc": "2.0", "error": {"code": -32002, "message": f"Resource not found: {uri}"}, "id": req_id}
+    except PluginViolationError as exc:
+        error_code = -32602
+        if exc.violation and hasattr(exc.violation, "mcp_error_code") and isinstance(exc.violation.mcp_error_code, int):
+            error_code = exc.violation.mcp_error_code
+        return {"jsonrpc": "2.0", "error": {"code": error_code, "message": str(exc)}, "id": req_id}
+    except PluginError as exc:
+        error_code = -32603
+        if exc.error and hasattr(exc.error, "mcp_error_code") and isinstance(exc.error.mcp_error_code, int):
+            error_code = exc.error.mcp_error_code
+        return {"jsonrpc": "2.0", "error": {"code": error_code, "message": str(exc)}, "id": req_id}
+    except ResourceError as exc:
+        logger.info("AppBridge resource read errored for %s: %s", uri, exc)
+        return {"jsonrpc": "2.0", "error": {"code": -32000, "message": f"Resource read failed: {exc}"}, "id": req_id}
+    except Exception:
+        logger.exception("AppBridge resource read failed for %s", uri)
+        return {"jsonrpc": "2.0", "error": {"code": -32603, "message": "Internal error"}, "id": req_id}
+
+    return {"jsonrpc": "2.0", "result": {"contents": [serialize_resource_content_for_mcp(result, fallback_uri=uri)]}, "id": req_id}
+
+
 @utility_router.post("/appbridge/sessions/{app_session_id}/rpc")
 @require_permission("tools.execute")
 async def handle_mcp_app_session_rpc(app_session_id: str, request: Request, db: Session = Depends(get_db), user=Depends(get_current_user_with_permissions)):
-    """Execute an app-visible tool through a validated AppBridge session."""
+    """Execute an app-visible tool or standard MCP message through a validated AppBridge session."""
     if not mcp_apps_enabled():
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="MCP Apps are disabled")
 
@@ -10623,7 +10710,7 @@ async def handle_mcp_app_session_rpc(app_session_id: str, request: Request, db: 
     req_id = body.get("id")
     method = body.get("method")
     params = body.get("params") if isinstance(body.get("params"), dict) else {}
-    if method != "tools/call":
+    if not mcp_method_registry.is_app_bridge_method(method):
         return {"jsonrpc": "2.0", "error": {"code": -32601, "message": f"Method not found: {method}"}, "id": req_id}
 
     mcp_session_id = _extract_mcp_session_id(request, body)
@@ -10649,6 +10736,18 @@ async def handle_mcp_app_session_rpc(app_session_id: str, request: Request, db: 
         return {"jsonrpc": "2.0", "error": {"code": -32003, "message": _ACCESS_DENIED_MSG}, "id": req_id}
     if not app_session.server_id or (server_id is not None and server_id != app_session.server_id):
         return {"jsonrpc": "2.0", "error": {"code": -32003, "message": _ACCESS_DENIED_MSG}, "id": req_id}
+
+    # Session ownership and server binding are enforced above for every bridge
+    # method, so the per-method handlers below inherit the same scoping.
+    if method == "ping":
+        return {"jsonrpc": "2.0", "result": {}, "id": req_id}
+
+    if method == "notifications/message":
+        _record_app_bridge_log(app_session, params)
+        return {"jsonrpc": "2.0", "result": {}, "id": req_id}
+
+    if method == "resources/read":
+        return await _handle_app_bridge_resources_read(db, request, app_session, params, req_id)
 
     name = params.get("name")
     if not name:

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -10809,6 +10809,17 @@ async def handle_mcp_app_session_rpc(app_session_id: str, request: Request, db: 
         return {"jsonrpc": "2.0", "result": {}, "id": req_id}
 
     if method == "notifications/message":
+        if "id" in body:
+            # JSON-RPC decides notification vs request on the *presence* of the id member, not
+            # its value: "id": null still makes this a request, which must not go unanswered.
+            # The MCP Apps lifecycle defines notifications/message as terminating at the host
+            # with no reply, so the request form is rejected rather than silently acknowledged
+            # with an empty body the caller is still waiting on.
+            return {
+                "jsonrpc": "2.0",
+                "error": {"code": -32600, "message": "notifications/message must be sent as a JSON-RPC notification, without an 'id' member"},
+                "id": req_id,
+            }
         _record_app_bridge_log(app_session, params)
         # A JSON-RPC notification carries no id and MUST NOT receive a JSON-RPC response, so
         # this is acknowledged at the transport level only: 202 Accepted with an empty body,

--- a/mcpgateway/services/mcp_apps.py
+++ b/mcpgateway/services/mcp_apps.py
@@ -44,6 +44,9 @@ NESTED_RESOURCE_URI_KEYS = ("resourceUri", "resource_uri")
 MAX_LOGGED_URI_LENGTH = 120
 # Stands in for an authority that cannot be shown to be credential-free.
 REDACTED_AUTHORITY = "***"
+# Standard MCP messages an app may send over the AppBridge. Ordered so the
+# advertised capability payload stays stable; the router matches on membership.
+MCP_APPS_BRIDGE_METHODS = ("tools/call", "resources/read", "notifications/message", "ping")
 
 _ALLOWED_CSP_DIRECTIVES = frozenset(
     {
@@ -81,7 +84,7 @@ def mcp_apps_capability() -> Dict[str, Any]:
     return {
         "version": MCP_UI_DEFAULT_VERSION,
         "resources": {"schemes": ["ui://"]},
-        "bridge": {"methods": ["tools/call"]},
+        "bridge": {"methods": list(MCP_APPS_BRIDGE_METHODS)},
     }
 
 

--- a/mcpgateway/services/mcp_method_registry.py
+++ b/mcpgateway/services/mcp_method_registry.py
@@ -13,7 +13,7 @@ while allowing feature-gated MCP Apps AppBridge methods to pass validation.
 from typing import Dict, FrozenSet
 
 # First-Party
-from mcpgateway.services.mcp_apps import mcp_apps_enabled, MCP_UI_EXTENSION
+from mcpgateway.services.mcp_apps import MCP_APPS_BRIDGE_METHODS, mcp_apps_enabled, MCP_UI_EXTENSION
 
 # Core MCP methods that always take precedence.
 _CORE_MCP_METHODS: FrozenSet[str] = frozenset(
@@ -53,11 +53,17 @@ class MCPMethodRegistry:
 
     def _register_mcp_apps_methods(self) -> None:
         """Register MCP Apps AppBridge methods."""
-        self._mcp_apps_methods[MCP_UI_EXTENSION] = frozenset({"tools/call"})
+        self._mcp_apps_methods[MCP_UI_EXTENSION] = frozenset(MCP_APPS_BRIDGE_METHODS)
 
     def is_core_method(self, method: str) -> bool:
         """Return whether a method is a core MCP method."""
         return method in _CORE_MCP_METHODS
+
+    def is_app_bridge_method(self, method: str) -> bool:
+        """Return whether a method may be sent by an app over the AppBridge."""
+        if not mcp_apps_enabled():
+            return False
+        return method in self._mcp_apps_methods.get(MCP_UI_EXTENSION, frozenset())
 
     def is_known_method(self, method: str) -> bool:
         """Return whether a method is known for core MCP or enabled MCP Apps."""

--- a/tests/unit/mcpgateway/test_mcp_apps_security.py
+++ b/tests/unit/mcpgateway/test_mcp_apps_security.py
@@ -615,9 +615,10 @@ class TestAppBridgeEndpoints:
             await main_mod.handle_mcp_app_session_rpc.__wrapped__("app-session-1", request=FakeRequest([]), db=mock_db, user={"email": "user@example.com"})
         assert excinfo.value.status_code == 400
 
+        # A core MCP method that is not an AppBridge method must still be rejected.
         result = await main_mod.handle_mcp_app_session_rpc.__wrapped__(
             "app-session-1",
-            request=FakeRequest({"jsonrpc": "2.0", "id": "1", "method": "resources/read"}),
+            request=FakeRequest({"jsonrpc": "2.0", "id": "1", "method": "prompts/list"}),
             db=mock_db,
             user={"email": "user@example.com"},
         )
@@ -821,6 +822,142 @@ class TestAppBridgeEndpoints:
         ):
             result = await main_mod.handle_mcp_app_session_rpc.__wrapped__("app-session-1", request=request, db=mock_db, user={"email": "user@example.com"})
         assert result["error"]["code"] == -32603
+
+    @pytest.mark.asyncio
+    async def test_rpc_ping_is_answered_without_touching_services(self, monkeypatch, mock_db, valid_app_session):
+        """AppBridge ping should be answered by the gateway without an upstream call."""
+        # First-Party
+        from mcpgateway import main as main_mod
+
+        monkeypatch.setattr("mcpgateway.services.mcp_apps.settings.mcpgateway_mcp_apps_enabled", True)
+        request = FakeRequest({"jsonrpc": "2.0", "id": "1", "method": "ping"}, headers={"mcp-session-id": "mcp-session-123"})
+
+        with (
+            patch.object(main_mod, "_assert_session_owner_or_admin", new=AsyncMock()),
+            patch.object(main_mod, "get_request_identity", return_value=("user@example.com", False)),
+            patch.object(main_mod.mcp_app_session_service, "get_valid_session", return_value=valid_app_session),
+            patch.object(main_mod.tool_service, "invoke_tool", new=AsyncMock()) as invoke_mock,
+            patch.object(main_mod.resource_service, "read_resource", new=AsyncMock()) as read_mock,
+        ):
+            result = await main_mod.handle_mcp_app_session_rpc.__wrapped__("test-session-id", request=request, db=mock_db, user={"email": "user@example.com"})
+            invoke_mock.assert_not_awaited()
+            read_mock.assert_not_awaited()
+
+        assert result == {"jsonrpc": "2.0", "result": {}, "id": "1"}
+
+    @pytest.mark.asyncio
+    async def test_rpc_log_notification_is_recorded_and_not_proxied(self, monkeypatch, mock_db, valid_app_session):
+        """AppBridge log notifications terminate at the gateway and are not forwarded upstream."""
+        # First-Party
+        from mcpgateway import main as main_mod
+
+        monkeypatch.setattr("mcpgateway.services.mcp_apps.settings.mcpgateway_mcp_apps_enabled", True)
+        request = FakeRequest(
+            {"jsonrpc": "2.0", "id": None, "method": "notifications/message", "params": {"level": "info", "logger": "widget", "data": "hello"}},
+            headers={"mcp-session-id": "mcp-session-123"},
+        )
+
+        with (
+            patch.object(main_mod, "_assert_session_owner_or_admin", new=AsyncMock()),
+            patch.object(main_mod, "get_request_identity", return_value=("user@example.com", False)),
+            patch.object(main_mod.mcp_app_session_service, "get_valid_session", return_value=valid_app_session),
+            patch.object(main_mod.tool_service, "invoke_tool", new=AsyncMock()) as invoke_mock,
+            patch.object(main_mod.resource_service, "read_resource", new=AsyncMock()) as read_mock,
+        ):
+            result = await main_mod.handle_mcp_app_session_rpc.__wrapped__("test-session-id", request=request, db=mock_db, user={"email": "user@example.com"})
+            invoke_mock.assert_not_awaited()
+            read_mock.assert_not_awaited()
+
+        assert result["result"] == {}
+
+    @pytest.mark.asyncio
+    async def test_rpc_resources_read_is_scoped_to_the_bound_session(self, monkeypatch, mock_db, valid_app_session):
+        """AppBridge resources/read must use the session's server binding and stored identity."""
+        # First-Party
+        from mcpgateway import main as main_mod
+        from mcpgateway.common.models import ResourceContent
+
+        monkeypatch.setattr("mcpgateway.services.mcp_apps.settings.mcpgateway_mcp_apps_enabled", True)
+        request = FakeRequest(
+            {"jsonrpc": "2.0", "id": "1", "method": "resources/read", "params": {"uri": "ui://widgets/example"}},
+            headers={"mcp-session-id": "mcp-session-123", "x-context-forge-gateway-id": "spoofed"},
+        )
+        content = ResourceContent(type="resource", id="r1", uri="ui://widgets/example", mimeType="text/plain", text="hi")
+
+        with (
+            patch.object(main_mod, "_assert_session_owner_or_admin", new=AsyncMock()),
+            patch.object(main_mod, "get_request_identity", return_value=("user@example.com", False)),
+            patch.object(main_mod.mcp_app_session_service, "get_valid_session", return_value=valid_app_session),
+            patch.object(main_mod.resource_service, "read_resource", new=AsyncMock(return_value=content)) as read_mock,
+        ):
+            result = await main_mod.handle_mcp_app_session_rpc.__wrapped__("test-session-id", request=request, db=mock_db, user={"email": "user@example.com"})
+            call_kwargs = read_mock.await_args.kwargs
+
+        assert result["result"]["contents"][0]["uri"] == "ui://widgets/example"
+        assert call_kwargs["server_id"] == "server-123"
+        assert call_kwargs["token_teams"] == ["team1"]
+        assert call_kwargs["user"] == "user@example.com"
+        assert "x-context-forge-gateway-id" not in call_kwargs["request_headers"]
+
+    @pytest.mark.asyncio
+    async def test_rpc_resources_read_cannot_switch_server(self, monkeypatch, mock_db, valid_app_session):
+        """AppBridge resources/read cannot read from a server other than the bound one."""
+        # First-Party
+        from mcpgateway import main as main_mod
+
+        monkeypatch.setattr("mcpgateway.services.mcp_apps.settings.mcpgateway_mcp_apps_enabled", True)
+        request = FakeRequest(
+            {"jsonrpc": "2.0", "id": "1", "method": "resources/read", "params": {"uri": "ui://widgets/example", "serverId": "server-2"}},
+            headers={"mcp-session-id": "mcp-session-123"},
+        )
+
+        with (
+            patch.object(main_mod, "_assert_session_owner_or_admin", new=AsyncMock()),
+            patch.object(main_mod, "get_request_identity", return_value=("user@example.com", False)),
+            patch.object(main_mod.mcp_app_session_service, "get_valid_session", return_value=valid_app_session),
+            patch.object(main_mod.resource_service, "read_resource", new=AsyncMock()) as read_mock,
+        ):
+            result = await main_mod.handle_mcp_app_session_rpc.__wrapped__("test-session-id", request=request, db=mock_db, user={"email": "user@example.com"})
+            read_mock.assert_not_awaited()
+
+        assert result["error"]["code"] == -32003
+
+    @pytest.mark.asyncio
+    async def test_rpc_resources_read_maps_missing_uri_and_lookup_failures(self, monkeypatch, mock_db, valid_app_session):
+        """AppBridge resources/read should map missing URIs and resource errors to JSON-RPC codes."""
+        # First-Party
+        from mcpgateway import main as main_mod
+
+        monkeypatch.setattr("mcpgateway.services.mcp_apps.settings.mcpgateway_mcp_apps_enabled", True)
+
+        with (
+            patch.object(main_mod, "_assert_session_owner_or_admin", new=AsyncMock()),
+            patch.object(main_mod, "get_request_identity", return_value=("user@example.com", False)),
+            patch.object(main_mod.mcp_app_session_service, "get_valid_session", return_value=valid_app_session),
+        ):
+            result = await main_mod.handle_mcp_app_session_rpc.__wrapped__(
+                "test-session-id",
+                request=FakeRequest({"jsonrpc": "2.0", "id": "1", "method": "resources/read", "params": {}}, headers={"mcp-session-id": "mcp-session-123"}),
+                db=mock_db,
+                user={"email": "user@example.com"},
+            )
+            assert result["error"]["code"] == -32602
+
+            request = FakeRequest(
+                {"jsonrpc": "2.0", "id": "1", "method": "resources/read", "params": {"uri": "ui://widgets/missing"}},
+                headers={"mcp-session-id": "mcp-session-123"},
+            )
+            with patch.object(main_mod.resource_service, "read_resource", new=AsyncMock(side_effect=ResourceNotFoundError("nope"))):
+                result = await main_mod.handle_mcp_app_session_rpc.__wrapped__("test-session-id", request=request, db=mock_db, user={"email": "user@example.com"})
+            assert result["error"]["code"] == -32002
+
+            with patch.object(main_mod.resource_service, "read_resource", new=AsyncMock(side_effect=ResourceError("boom"))):
+                result = await main_mod.handle_mcp_app_session_rpc.__wrapped__("test-session-id", request=request, db=mock_db, user={"email": "user@example.com"})
+            assert result["error"]["code"] == -32000
+
+            with patch.object(main_mod.resource_service, "read_resource", new=AsyncMock(side_effect=RuntimeError("boom"))):
+                result = await main_mod.handle_mcp_app_session_rpc.__wrapped__("test-session-id", request=request, db=mock_db, user={"email": "user@example.com"})
+            assert result["error"]["code"] == -32603
 
 
 class TestAppBridgeSessionSecurity:

--- a/tests/unit/mcpgateway/test_mcp_apps_security.py
+++ b/tests/unit/mcpgateway/test_mcp_apps_security.py
@@ -852,8 +852,9 @@ class TestAppBridgeEndpoints:
         from mcpgateway import main as main_mod
 
         monkeypatch.setattr("mcpgateway.services.mcp_apps.settings.mcpgateway_mcp_apps_enabled", True)
+        # A JSON-RPC notification omits the id member entirely.
         request = FakeRequest(
-            {"jsonrpc": "2.0", "id": None, "method": "notifications/message", "params": {"level": "info", "logger": "widget", "data": "hello"}},
+            {"jsonrpc": "2.0", "method": "notifications/message", "params": {"level": "info", "logger": "widget", "data": "hello"}},
             headers={"mcp-session-id": "mcp-session-123"},
         )
 
@@ -872,6 +873,41 @@ class TestAppBridgeEndpoints:
         # bare transport-level acknowledgement instead.
         assert result.status_code == 202
         assert result.body == b""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("req_id", [None, "1", 7])
+    async def test_rpc_log_notification_with_an_id_is_rejected_as_a_request(self, monkeypatch, mock_db, valid_app_session, req_id):
+        """An id-bearing notifications/message is a request, so it must not be answered with a bare 202.
+
+        JSON-RPC decides notification vs request on the presence of the id member, not its
+        value, so ``"id": null`` counts as a request too. notifications/message is defined as
+        notification-only, so the request form is rejected instead of silently discarding a
+        response the caller is waiting on.
+        """
+        # First-Party
+        from mcpgateway import main as main_mod
+
+        monkeypatch.setattr("mcpgateway.services.mcp_apps.settings.mcpgateway_mcp_apps_enabled", True)
+        request = FakeRequest(
+            {"jsonrpc": "2.0", "id": req_id, "method": "notifications/message", "params": {"level": "info", "logger": "widget", "data": "hello"}},
+            headers={"mcp-session-id": "mcp-session-123"},
+        )
+
+        with (
+            patch.object(main_mod, "_assert_session_owner_or_admin", new=AsyncMock()),
+            patch.object(main_mod, "get_request_identity", return_value=("user@example.com", False)),
+            patch.object(main_mod.mcp_app_session_service, "get_valid_session", return_value=valid_app_session),
+            patch.object(main_mod.tool_service, "invoke_tool", new=AsyncMock()) as invoke_mock,
+            patch.object(main_mod.resource_service, "read_resource", new=AsyncMock()) as read_mock,
+        ):
+            result = await main_mod.handle_mcp_app_session_rpc.__wrapped__("test-session-id", request=request, db=mock_db, user={"email": "user@example.com"})
+            invoke_mock.assert_not_awaited()
+            read_mock.assert_not_awaited()
+
+        assert result["jsonrpc"] == "2.0"
+        assert result["id"] == req_id
+        assert result["error"]["code"] == -32600
+        assert "without an 'id' member" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_rpc_resources_read_is_scoped_to_the_bound_session(self, monkeypatch, mock_db, valid_app_session):

--- a/tests/unit/mcpgateway/test_mcp_apps_security.py
+++ b/tests/unit/mcpgateway/test_mcp_apps_security.py
@@ -868,7 +868,10 @@ class TestAppBridgeEndpoints:
             invoke_mock.assert_not_awaited()
             read_mock.assert_not_awaited()
 
-        assert result["result"] == {}
+        # A JSON-RPC notification must not receive a JSON-RPC response; the app gets a
+        # bare transport-level acknowledgement instead.
+        assert result.status_code == 202
+        assert result.body == b""
 
     @pytest.mark.asyncio
     async def test_rpc_resources_read_is_scoped_to_the_bound_session(self, monkeypatch, mock_db, valid_app_session):
@@ -888,12 +891,14 @@ class TestAppBridgeEndpoints:
             patch.object(main_mod, "_assert_session_owner_or_admin", new=AsyncMock()),
             patch.object(main_mod, "get_request_identity", return_value=("user@example.com", False)),
             patch.object(main_mod.mcp_app_session_service, "get_valid_session", return_value=valid_app_session),
+            patch.object(main_mod, "_ensure_rpc_permission", new=AsyncMock()) as permission_mock,
             patch.object(main_mod.resource_service, "read_resource", new=AsyncMock(return_value=content)) as read_mock,
         ):
             result = await main_mod.handle_mcp_app_session_rpc.__wrapped__("test-session-id", request=request, db=mock_db, user={"email": "user@example.com"})
             call_kwargs = read_mock.await_args.kwargs
 
         assert result["result"]["contents"][0]["uri"] == "ui://widgets/example"
+        assert permission_mock.await_args.args[2] == "resources.read"
         assert call_kwargs["server_id"] == "server-123"
         assert call_kwargs["token_teams"] == ["team1"]
         assert call_kwargs["user"] == "user@example.com"
@@ -934,6 +939,7 @@ class TestAppBridgeEndpoints:
             patch.object(main_mod, "_assert_session_owner_or_admin", new=AsyncMock()),
             patch.object(main_mod, "get_request_identity", return_value=("user@example.com", False)),
             patch.object(main_mod.mcp_app_session_service, "get_valid_session", return_value=valid_app_session),
+            patch.object(main_mod, "_ensure_rpc_permission", new=AsyncMock()),
         ):
             result = await main_mod.handle_mcp_app_session_rpc.__wrapped__(
                 "test-session-id",
@@ -958,6 +964,61 @@ class TestAppBridgeEndpoints:
             with patch.object(main_mod.resource_service, "read_resource", new=AsyncMock(side_effect=RuntimeError("boom"))):
                 result = await main_mod.handle_mcp_app_session_rpc.__wrapped__("test-session-id", request=request, db=mock_db, user={"email": "user@example.com"})
             assert result["error"]["code"] == -32603
+
+    def test_rpc_resources_read_denied_without_resources_read_permission(self, monkeypatch, mock_db, valid_app_session):
+        """Holding tools.execute must not be enough to read a resource over the AppBridge."""
+        # First-Party
+        from mcpgateway import main as main_mod
+
+        monkeypatch.setattr("mcpgateway.services.mcp_apps.settings.mcpgateway_mcp_apps_enabled", True)
+
+        class GrantsOnlyToolsExecute:
+            """Permission service double granting tools.execute and nothing else."""
+
+            def __init__(self, _db) -> None:
+                pass
+
+            async def check_permission(self, **kwargs) -> bool:
+                """Grant only the endpoint-level tools.execute permission."""
+                return kwargs.get("permission") == "tools.execute"
+
+        class DeniesResourcesRead:
+            """RPC permission checker double that denies resources.read."""
+
+            def __init__(self, _user) -> None:
+                pass
+
+            async def has_permission(self, permission, **kwargs) -> bool:
+                """Deny resources.read, grant anything else."""
+                return permission != "resources.read"
+
+        route_app = FastAPI()
+        route_app.include_router(main_mod.utility_router)
+        route_app.dependency_overrides[main_mod.get_db] = lambda: mock_db
+        route_app.dependency_overrides[main_mod.get_current_user_with_permissions] = lambda: {"email": "user@example.com", "db": mock_db, "is_admin": False}
+        client = TestClient(route_app, raise_server_exceptions=False)
+
+        with (
+            patch("mcpgateway.middleware.rbac.PermissionService", GrantsOnlyToolsExecute),
+            patch.object(main_mod, "PermissionChecker", DeniesResourcesRead),
+            patch.object(main_mod, "_build_rpc_permission_user", return_value={"email": "user@example.com"}),
+            patch.object(main_mod, "_assert_session_owner_or_admin", new=AsyncMock()),
+            patch.object(main_mod, "get_request_identity", return_value=("user@example.com", False)),
+            patch.object(main_mod.mcp_app_session_service, "get_valid_session", return_value=valid_app_session),
+            patch.object(main_mod.resource_service, "read_resource", new=AsyncMock()) as read_mock,
+        ):
+            response = client.post(
+                "/appbridge/sessions/test-session-id/rpc",
+                json={"jsonrpc": "2.0", "id": "1", "method": "resources/read", "params": {"uri": "ui://widgets/example"}},
+                headers={"mcp-session-id": "mcp-session-123"},
+            )
+        client.close()
+
+        # The route decorator passed on tools.execute, so the denial must come from the
+        # method-specific resources.read check inside the handler.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] == -32003
+        read_mock.assert_not_awaited()
 
 
 class TestAppBridgeSessionSecurity:

--- a/tests/unit/mcpgateway/test_mcp_apps_security.py
+++ b/tests/unit/mcpgateway/test_mcp_apps_security.py
@@ -967,6 +967,10 @@ class TestAppBridgeEndpoints:
     async def test_rpc_resources_read_maps_missing_uri_and_lookup_failures(self, monkeypatch, mock_db, valid_app_session):
         """AppBridge resources/read should map missing URIs and resource errors to JSON-RPC codes."""
         # First-Party
+        from cpex.framework.errors import PluginError, PluginViolationError
+        from cpex.framework.models import PluginErrorModel, PluginViolation
+
+        # First-Party
         from mcpgateway import main as main_mod
 
         monkeypatch.setattr("mcpgateway.services.mcp_apps.settings.mcpgateway_mcp_apps_enabled", True)
@@ -996,6 +1000,16 @@ class TestAppBridgeEndpoints:
             with patch.object(main_mod.resource_service, "read_resource", new=AsyncMock(side_effect=ResourceError("boom"))):
                 result = await main_mod.handle_mcp_app_session_rpc.__wrapped__("test-session-id", request=request, db=mock_db, user={"email": "user@example.com"})
             assert result["error"]["code"] == -32000
+
+            violation = PluginViolation(reason="policy denied", description="blocked", code="DENIED", mcp_error_code=-32042)
+            with patch.object(main_mod.resource_service, "read_resource", new=AsyncMock(side_effect=PluginViolationError("blocked", violation=violation))):
+                result = await main_mod.handle_mcp_app_session_rpc.__wrapped__("test-session-id", request=request, db=mock_db, user={"email": "user@example.com"})
+            assert result["error"]["code"] == -32042
+
+            plugin_error = PluginErrorModel(message="plugin crashed", plugin_name="test-plugin", code="CRASH", mcp_error_code=-32043)
+            with patch.object(main_mod.resource_service, "read_resource", new=AsyncMock(side_effect=PluginError(error=plugin_error))):
+                result = await main_mod.handle_mcp_app_session_rpc.__wrapped__("test-session-id", request=request, db=mock_db, user={"email": "user@example.com"})
+            assert result["error"]["code"] == -32043
 
             with patch.object(main_mod.resource_service, "read_resource", new=AsyncMock(side_effect=RuntimeError("boom"))):
                 result = await main_mod.handle_mcp_app_session_rpc.__wrapped__("test-session-id", request=request, db=mock_db, user={"email": "user@example.com"})

--- a/tests/unit/mcpgateway/test_mcp_method_registry.py
+++ b/tests/unit/mcpgateway/test_mcp_method_registry.py
@@ -54,6 +54,26 @@ class TestMCPMethodRegistry:
         assert not registry.is_core_method("extensions/custom")
         assert not registry.is_known_method("io.example/custom")
 
+    def test_app_bridge_methods_are_gated_on_the_feature_flag(self, monkeypatch):
+        """AppBridge methods are only routable while MCP Apps are enabled."""
+        registry = MCPMethodRegistry()
+
+        monkeypatch.setattr("mcpgateway.services.mcp_apps.settings.mcpgateway_mcp_apps_enabled", False)
+        assert not registry.is_app_bridge_method("tools/call")
+
+        monkeypatch.setattr("mcpgateway.services.mcp_apps.settings.mcpgateway_mcp_apps_enabled", True)
+        for method in ("tools/call", "resources/read", "notifications/message", "ping"):
+            assert registry.is_app_bridge_method(method)
+
+    def test_core_methods_are_not_implicitly_app_bridge_methods(self, monkeypatch):
+        """Being a core MCP method must not grant an app access over the AppBridge."""
+        monkeypatch.setattr("mcpgateway.services.mcp_apps.settings.mcpgateway_mcp_apps_enabled", True)
+        registry = MCPMethodRegistry()
+
+        for method in ("initialize", "tools/list", "prompts/list", "resources/list", "resources/subscribe", "logging/setLevel"):
+            assert registry.is_core_method(method)
+            assert not registry.is_app_bridge_method(method)
+
     def test_non_core_mcp_apps_method_recognition_when_enabled(self, monkeypatch):
         """Enabled MCP Apps can make non-core AppBridge methods known."""
         monkeypatch.setattr("mcpgateway.services.mcp_apps.settings.mcpgateway_mcp_apps_enabled", True)


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue

Closes #5763. Tracked with #4970. Part of #2527.

---

## 🚀 Summary

The AppBridge accepted only `tools/call`. This routes the remaining three standard MCP messages an app may send — `resources/read`, `notifications/message` and `ping` — behind the session binding and server scoping `tools/call` already had.

---

## 📓 Design

Spec §"Standard MCP Messages" (`apps.mdx:489-508`) permits exactly four methods from an app context. The practical gap was `resources/read`: an app could not read any resource, including its own companion data resources.

**Ordering.** The method gate runs first, then MCP session ownership and server-binding validation, then per-method dispatch. Every bridge method therefore inherits the scoping `tools/call` had, rather than each handler re-implementing it.

```mermaid
flowchart TD
    A[App JSON-RPC] --> B{is_app_bridge_method?}
    B -->|no| E[-32601 Method not found]
    B -->|yes| C[MCP session ownership]
    C --> D[Server binding check]
    D --> F{method}
    F -->|tools/call| G[invoke_tool require_app_visible]
    F -->|resources/read| H[read_resource scoped to bound server]
    F -->|notifications/message| I[record only, no upstream call]
    F -->|ping| J[answer locally]
```

**The allowlist needs its own predicate — this is the security-critical part of the change.** `resources/read`, `ping` and `notifications/message` are all already in `_CORE_MCP_METHODS` (`mcp_method_registry.py:22,26,37`), so the existing `is_known_method()` returns `True` for them regardless of the MCP Apps feature flag. Reusing it as the bridge gate would have silently exposed the **entire core MCP surface** to apps. This adds `is_app_bridge_method()`, which consults only the MCP Apps allowlist and the feature flag. `test_core_methods_are_not_implicitly_app_bridge_methods` pins that distinction.

**`resources/read`** runs a method-specific `resources.read` permission check via `_ensure_rpc_permission` before dispatch, so the route effectively requires both the endpoint-level `tools.execute` and the method-level `resources.read`. RBAC and token/team scoping are separate layers: the endpoint decorator alone would let a caller who retains `tools.execute` keep reading after `resources.read` is revoked. It then reuses the identity and team scoping captured on the session (`None if token_teams is None else app_session.user_email`, matching the `tools/call` path) and is confined to `app_session.server_id`. The `x-context-forge-gateway-id` header is stripped exactly as it is for tool calls, so an app cannot force direct-proxy routing. Error mapping matches the existing RPC path: `-32002` not found, `-32000` resource error, `-32602` bad params, plugin codes preserved.

**`notifications/message`** is recorded and never proxied upstream, and is acknowledged at the transport level only — `202 Accepted` with an empty body, not a JSON-RPC result. JSON-RPC decides notification vs request on the *presence* of the `id` member rather than its value, so an `id`-bearing `notifications/message` (including `"id": null`) is a request and is rejected with `-32600` rather than answered with an empty `202` the caller cannot correlate. The lifecycle diagram at `apps.mdx:1353-1355` shows this terminating at the host — `H ->> H: Record log`, a self-arrow, versus `H ->> S` for the resource-read branch two lines below. The payload is view-originated and attacker-influenceable, so it is logged as truncated data (`%.500r`) rather than interpolated into the format string.

**`ping`** is answered locally without an upstream call.

The advertised `bridge.methods` capability and the router now share one constant (`MCP_APPS_BRIDGE_METHODS`) so they cannot drift apart.

Internally, the `tools/call` body lives in `_handle_app_bridge_tools_call`, mirroring `_handle_app_bridge_resources_read`; the endpoint validates session ownership and server binding, then delegates. No behaviour change — it keeps the endpoint's return count under ruff's `PLR0911` limit.

### Deviations worth flagging

**Error codes are a reasoned choice, not a conformance claim.** The spec never defines a code for an unsupported method — its only code is `-32000 // Implementation-defined error`. `-32601` is JSON-RPC 2.0 base semantics and what the endpoint already returned.

**Narrowing is discretionary here, not mandated.** The per-server scoping language at `apps.mdx:399`, `:402` and `:1661` is written *exclusively about tools* — there is no stated MUST confining `resources/read` to the same server, and no `ui://`-scheme restriction on it. The licence to restrict is `apps.mdx:487` (*"it MAY decide to block some messages"*), reinforced by the one-way ratchet at `apps.mdx:286`. So this scoping is a deliberate gateway policy choice; I did not want to overstate it as spec-required.

**Not everything the SDK forwards.** The reference `app-bridge.ts:1797-1800` also proxies `resources/list`, `resources/templates/list` and `prompts/list`, none of which are in the spec's normative list. Those are listing surfaces with real leak potential through a gateway, so they are excluded. Flagging it because an SDK-built app may expect them — happy to follow up separately.

### The main open question for reviewers

`resources/read` is scoped to the **bound server**, not to the session's own `resource_uri`. Rationale: an app legitimately reads companion data resources, and this mirrors how `tools/call` allows any app-visible tool on the bound server rather than one specific tool. The authority granted is the same the originating user already has, via existing RBAC and token scoping. If you'd prefer it tightened to the session's own resource, that's a small change and I'll make it.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

On the `triage` checkbox: #5763 currently carries no labels. Filing it and this PR was explicitly requested by @vishu-bh in https://github.com/IBM/mcp-context-forge/issues/2527#issuecomment-5044901298, which CONTRIBUTING lists as one of the conditions for starting work. If you apply `triage` while scoping it, treat this PR as parked until you're ready.

**One behaviour change to an existing test.** `test_rpc_rejects_disabled_malformed_and_missing_session` asserted `resources/read` → `-32601`, encoding the very limitation this PR removes. It now asserts the same for `prompts/list` — a core MCP method deliberately *not* on the bridge allowlist, which is a stronger check than the original.

---

## 🧪 Checks

Added 13 tests: 9 endpoint tests in `test_mcp_apps_security.py` (ping answered without service calls; log notification recorded and not proxied; the `id`-bearing notification form rejected, parametrized over null/string/numeric ids; `resources/read` scoping incl. header stripping and stored token teams; cross-server read denied; an RBAC deny-path test driving the real route through `TestClient` with `tools.execute` granted and `resources.read` denied; error mapping for missing URI, not-found, resource error, plugin violation, plugin error and unexpected exception) and 2 registry tests in `test_mcp_method_registry.py` (feature-flag gating; core methods not implicitly bridge methods).

- [x] `pytest tests/unit/mcpgateway/services/test_mcp_apps.py tests/unit/mcpgateway/test_mcp_apps_security.py tests/unit/mcpgateway/test_mcp_apps_protocol.py tests/unit/mcpgateway/test_mcp_method_registry.py` — **126 passed** (113 before this change)
- [x] `pytest tests/unit/mcpgateway/test_main.py` — **375 passed**
- [x] `ruff check mcpgateway/` — All checks passed
- [x] `pylint --rcfile=.pylintrc mcpgateway/main.py` — **10.00/10**
- [x] `black --check --line-length 200` — unchanged
- [x] Regression sweep across `test_main_rate_limit.py`, `test_streamablehttp_transport.py`, `test_resource_service.py` — **44 pre-existing failures before and after, zero introduced** (diffed the failure lists against unmodified `main`; they are environment-related in my local venv)
- [x] Docs updated — `docs/docs/architecture/mcp-apps.md` gains a supported-methods table, the corrected capability payload, the `resources.read` requirement, and the notification acknowledgement and `id`-form rules
- [ ] CHANGELOG not updated — happy to add an entry if you'd like one for this

Not run locally: `make docker docker-run-ssl` and the postgres/redis matrix. There is no database, migration, or transport surface in this change, but I can produce that evidence if you want it before merge.

---

## 📐 MCP Compliance

- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

The advertised `bridge.methods` capability grows, so clients that detect support see the new methods rather than having to probe for them.

On the spec checkbox: it was previously ticked while `notifications/message` still returned a JSON-RPC result for the `id`-bearing form. That gap is now closed — notifications are acknowledged at the transport level and the request form is rejected with `-32600` — so the claim matches the implemented behaviour.


