### PR TITLE
fix(ui): preselect scroll-paginated tools in virtual-server edit modal

### DIFF
--- a/mcpgateway/admin_ui/servers.js
+++ b/mcpgateway/admin_ui/servers.js
@@ -1216,6 +1216,83 @@ export function resetEditSelections() {
   });
 }
 
+// Maps a selector container id to the data-* attribute that holds its server's
+// currently-associated items, and to how each checkbox in that container is
+// matched against that attribute.  For tools the attribute holds tool *names*
+// (matched against the checkbox's data-tool-name); for resources and prompts it
+// holds ids (matched against the checkbox value).  This is the authoritative,
+// churn-proof source of association: unlike the selection store, it is only
+// mutated by an explicit user check/uncheck, never by the paginated re-render.
+const SERVER_ITEMS_ATTR = {
+  "edit-server-tools": { attr: "data-server-tools", by: "data-tool-name" },
+  "edit-server-resources": { attr: "data-server-resources", by: "value" },
+  "edit-server-prompts": { attr: "data-server-prompts", by: "value" },
+};
+
+/**
+ * Re-apply checked state to all checkboxes currently in the given selector
+ * container.  Called after any DOM change (search result render or HTMX
+ * scroll-paginated append) that may have added new, unchecked checkboxes.
+ *
+ * A checkbox is (re-)checked when its id is in the persistent selection store
+ * OR its identity is in the container's data-server-* association attribute.
+ *
+ * The dual match is what fixes #3358.  As the infinite-scroll pages stream in,
+ * tools.js's pill-count update() syncs DOM->store and *deletes* the id of every
+ * checkbox that is currently rendered unchecked.  A server's associated items
+ * on page 2+ always render unchecked, so their seeded ids are stripped from the
+ * store before any re-check runs — a store-only match then restores nothing and
+ * the associated items appear unchecked despite being associated.  The
+ * data-server-* attribute survives that churn (it is only edited on a real user
+ * toggle), so it is the reliable signal for "was this associated when the modal
+ * opened" and lets the item be re-checked even after its store id was dropped.
+ *
+ * When a box is (re-)checked we dispatch a bubbling change event so the store
+ * listener re-adds the id, repairing the store that update() depleted and
+ * keeping the pill count and the save payload correct.
+ *
+ * @param {string} containerId - The id of the selector container.
+ */
+export function restoreCheckedStateFromStore(containerId) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+
+  const sel = getEditSelections(containerId);
+
+  // Association identities from the data-server-* attribute (names for tools,
+  // ids for resources/prompts).  Kept as strings for comparison.
+  const mapping = SERVER_ITEMS_ATTR[containerId];
+  let serverItems = null;
+  if (mapping) {
+    const raw = container.getAttribute(mapping.attr);
+    if (raw) {
+      try {
+        serverItems = new Set(JSON.parse(raw).map(String));
+      } catch (e) {
+        console.error(`Failed to parse ${mapping.attr}:`, e);
+      }
+    }
+  }
+
+  if (sel.size === 0 && !(serverItems && serverItems.size > 0)) return;
+
+  container.querySelectorAll('input[type="checkbox"]').forEach((cb) => {
+    if (cb.checked) return;
+    const id = String(cb.value);
+    let shouldCheck = sel.has(id);
+    if (!shouldCheck && serverItems) {
+      const key =
+        mapping.by === "value" ? id : String(cb.getAttribute(mapping.by));
+      shouldCheck = serverItems.has(key);
+    }
+    if (shouldCheck) {
+      cb.checked = true;
+      // Re-seed the store (update() may have deleted this id) and refresh pills.
+      cb.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+  });
+}
+
 export function ensureEditStoreListeners() {
   if (window._editStoreListenersAttached) return;
   window._editStoreListenersAttached = true;
@@ -1224,6 +1301,8 @@ export function ensureEditStoreListeners() {
     (containerId) => {
       const container = document.getElementById(containerId);
       if (!container) return;
+
+      // Track checkbox check/uncheck into the persistent selection store.
       container.addEventListener("change", function (e) {
         const target = e.target;
         if (
@@ -1241,6 +1320,23 @@ export function ensureEditStoreListeners() {
           }
         }
       });
+
+      // Re-apply checked state after HTMX scroll-paginates new items into this
+      // container.  The infinite-scroll sentinel uses hx-swap="outerHTML" and is
+      // a child of the container, so both events bubble up here.
+      //
+      // We listen on afterSettle (not just afterSwap): tools.js's pill-count
+      // update() runs on the settle phase and syncs DOM->store, deleting the
+      // ids of any checkbox rendered unchecked.  Restoring on afterSwap alone
+      // would be undone by that later update().  afterSettle runs after it, so
+      // the re-check (and its change-driven store repair) is the final word.
+      // afterSwap is kept for search-result re-renders, which do not always
+      // settle identically.
+      const reapply = function () {
+        restoreCheckedStateFromStore(containerId);
+      };
+      container.addEventListener("htmx:afterSwap", reapply);
+      container.addEventListener("htmx:afterSettle", reapply);
     }
   );
 }

--- a/tests/unit/js/edit-server-scroll-pagination.test.js
+++ b/tests/unit/js/edit-server-scroll-pagination.test.js
@@ -1,0 +1,455 @@
+/**
+ * Tests for #3358 — edit-server selector checked state is re-applied after
+ * HTMX scroll-paginated appends.
+ *
+ * The infinite-scroll sentinel uses hx-swap="outerHTML", which replaces itself
+ * with the next page of tool/resource/prompt items.  htmx:afterSwap /
+ * htmx:afterSettle bubble up to the container div.  The edit modal seeds the
+ * persistent selection store with the associated item ids on open, but as the
+ * pages stream in, tools.js's pill-count update() syncs DOM->store and DELETES
+ * the id of every checkbox that is currently rendered unchecked.  Associated
+ * items on page 2+ always render unchecked, so their seeded ids are stripped
+ * from the store before any re-check runs — a store-only restore then restores
+ * nothing, and the associated tools render unchecked despite being associated.
+ *
+ * These tests confirm:
+ *   1. The bug exists on current main (the "real path" tests FAIL before the
+ *      fix, because the store has been depleted and only the data-server-*
+ *      attribute still carries the association).
+ *   2. After the fix, checkboxes on scroll-appended pages are checked when
+ *      their id is in getEditSelections(containerId) OR their identity is in the
+ *      container's data-server-* attribute, and re-checking repairs the store.
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  getEditSelections,
+  ensureEditStoreListeners,
+} from "../../../mcpgateway/admin_ui/servers.js";
+import { AppState } from "../../../mcpgateway/admin_ui/appState.js";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks required by servers.js transitive imports
+// ---------------------------------------------------------------------------
+vi.mock("../../../mcpgateway/admin_ui/appState.js", () => ({
+  AppState: {
+    editServerSelections: {},
+    setModalActive: vi.fn(),
+    setModalInactive: vi.fn(),
+    isModalActive: vi.fn(() => false),
+  },
+}));
+vi.mock("../../../mcpgateway/admin_ui/configExport.js", () => ({
+  getCatalogUrl: vi.fn(() => ""),
+}));
+vi.mock("../../../mcpgateway/admin_ui/gateways.js", () => ({
+  initGatewaySelect: vi.fn(),
+}));
+vi.mock("../../../mcpgateway/admin_ui/modals.js", () => ({
+  openModal: vi.fn(),
+  closeModal: vi.fn(),
+}));
+vi.mock("../../../mcpgateway/admin_ui/prompts.js", () => ({
+  initPromptSelect: vi.fn(),
+}));
+vi.mock("../../../mcpgateway/admin_ui/resources.js", () => ({
+  initResourceSelect: vi.fn(),
+}));
+vi.mock("../../../mcpgateway/admin_ui/security.js", () => ({
+  escapeHtml: vi.fn((s) => (s != null ? String(s) : "")),
+  validateInputName: vi.fn((s) => ({ valid: true, value: s })),
+  validateUrl: vi.fn(() => ({ valid: true })),
+}));
+vi.mock("../../../mcpgateway/admin_ui/tokens.js", () => ({
+  fetchWithAuth: vi.fn(),
+}));
+vi.mock("../../../mcpgateway/admin_ui/utils.js", () => ({
+  safeGetElement: vi.fn((id) => document.getElementById(id)),
+  fetchWithTimeout: vi.fn(),
+  isInactiveChecked: vi.fn(() => false),
+  handleFetchError: vi.fn((e) => e.message),
+  showErrorMessage: vi.fn(),
+  decodeHtml: vi.fn((s) => s || ""),
+  makeCopyIdButton: vi.fn(() => document.createElement("button")),
+}));
+vi.mock("../../../mcpgateway/admin_ui/filters.js", () => ({
+  toggleViewPublic: vi.fn(),
+}));
+vi.mock("../../../mcpgateway/admin_ui/teams.js", () => ({
+  applyVisibilityRestrictions: vi.fn(),
+  isTeamScopedView: vi.fn(() => false),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an edit-server-tools container with an initial page of checkboxes.
+ * Each checkbox carries a data-tool-name so the name-based association match
+ * (the real save/render path for tools) can be exercised.
+ */
+function buildEditToolsContainer(initialTools = []) {
+  const container = document.createElement("div");
+  container.id = "edit-server-tools";
+  document.body.appendChild(container);
+  for (const t of initialTools) {
+    container.appendChild(makeToolCheckbox(t));
+  }
+  return container;
+}
+
+function makeToolCheckbox({ id, name }) {
+  const cb = document.createElement("input");
+  cb.type = "checkbox";
+  cb.name = "associatedTools";
+  cb.value = id;
+  cb.checked = false;
+  if (name != null) {
+    cb.setAttribute("data-tool-name", name);
+  }
+  return cb;
+}
+
+/**
+ * Build an edit-server-resources container with an initial page of checkboxes.
+ */
+function buildEditResourcesContainer(initialResourceIds = []) {
+  const container = document.createElement("div");
+  container.id = "edit-server-resources";
+  document.body.appendChild(container);
+
+  for (const id of initialResourceIds) {
+    const cb = document.createElement("input");
+    cb.type = "checkbox";
+    cb.name = "associatedResources";
+    cb.value = id;
+    cb.checked = false;
+    container.appendChild(cb);
+  }
+  return container;
+}
+
+/**
+ * Build an edit-server-prompts container with an initial page of checkboxes.
+ */
+function buildEditPromptsContainer(initialPromptIds = []) {
+  const container = document.createElement("div");
+  container.id = "edit-server-prompts";
+  document.body.appendChild(container);
+
+  for (const id of initialPromptIds) {
+    const cb = document.createElement("input");
+    cb.type = "checkbox";
+    cb.name = "associatedPrompts";
+    cb.value = id;
+    cb.checked = false;
+    container.appendChild(cb);
+  }
+  return container;
+}
+
+/**
+ * Simulate the pill-count update() DOM->store sync from tools.js (lines ~1030):
+ * for every checkbox currently in the container, add its id to the store when
+ * checked and DELETE it when unchecked.  This is the churn that erases the
+ * seeded association ids as unchecked page-2+ items render — the crux of the
+ * bug.  Firing this before the restore is what makes these tests exercise the
+ * REAL path rather than a store that conveniently still holds the seed.
+ */
+function simulatePillUpdateStoreSync(container, containerId) {
+  const sel = getEditSelections(containerId);
+  container.querySelectorAll('input[type="checkbox"]').forEach((cb) => {
+    if (cb.checked) {
+      sel.add(String(cb.value));
+    } else {
+      sel.delete(String(cb.value));
+    }
+  });
+}
+
+/**
+ * Simulate an HTMX scroll-paginated append of a new page, mirroring the real
+ * event/mutation ordering:
+ *   1. append the new-page checkboxes to the container (outerHTML swap of the
+ *      sentinel with page content),
+ *   2. run the pill-count store sync (tools.js update()), which deletes the
+ *      unchecked associated ids from the store,
+ *   3. dispatch htmx:afterSettle bubbling through the container — this is the
+ *      phase the fix's listener acts on, after update() has run.
+ *
+ * @param {HTMLElement} container
+ * @param {string} containerId
+ * @param {Array<{name:string, value:string, toolName?:string}>} newCheckboxDefs
+ */
+function simulateScrollAppend(container, containerId, newCheckboxDefs) {
+  for (const { name, value, toolName } of newCheckboxDefs) {
+    const cb = document.createElement("input");
+    cb.type = "checkbox";
+    cb.name = name;
+    cb.value = value;
+    cb.checked = false;
+    if (toolName != null) {
+      cb.setAttribute("data-tool-name", toolName);
+    }
+    container.appendChild(cb);
+  }
+
+  // The pill-count update() runs on settle and depletes the store first...
+  simulatePillUpdateStoreSync(container, containerId);
+
+  // ...then afterSettle bubbles up to the container, where the fix re-applies.
+  const swap = new Event("htmx:afterSwap", { bubbles: true });
+  swap.detail = { target: container };
+  container.dispatchEvent(swap);
+  const settle = new Event("htmx:afterSettle", { bubbles: true });
+  settle.detail = { target: container };
+  container.dispatchEvent(settle);
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  AppState.editServerSelections = {};
+  window._editStoreListenersAttached = false;
+  document.body.innerHTML = "";
+  window.ROOT_PATH = "";
+  window.Admin = window.Admin || {};
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  AppState.editServerSelections = {};
+  delete window._editStoreListenersAttached;
+  delete window.ROOT_PATH;
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests — REAL PATH: store is depleted by update(), only data-server-* survives
+// ---------------------------------------------------------------------------
+
+describe("edit-server scroll-pagination: real path with store depletion (#3358)", () => {
+  test("tools: associated tool on page 2+ stays checked even after the pill-count sync deletes it from the store", () => {
+    // Page 1 renders tools that are NOT associated with this server.
+    const container = buildEditToolsContainer([
+      { id: "id-p1-x", name: "tool-p1-x" },
+      { id: "id-p1-y", name: "tool-p1-y" },
+    ]);
+
+    // The server's association is carried by the data-server-tools attribute as
+    // tool NAMES (exactly as servers.js seeds it from server.associatedTools).
+    container.setAttribute(
+      "data-server-tools",
+      JSON.stringify(["tool-assoc-a", "tool-assoc-b"]),
+    );
+
+    // Store seeded on open with the associated tool IDS (as editServer does).
+    const toolSel = getEditSelections("edit-server-tools");
+    toolSel.add("id-assoc-a");
+    toolSel.add("id-assoc-b");
+
+    ensureEditStoreListeners();
+
+    // Page 1 settles first: update() would delete seeded ids for any of them
+    // rendered unchecked.  Here the assoc checkboxes are not on page 1, so
+    // nothing is deleted yet — but the store is now the only carrier.
+    simulateScrollAppend(container, "edit-server-tools", []);
+    expect(getEditSelections("edit-server-tools").has("id-assoc-a")).toBe(true);
+
+    // Page 2 brings in the two associated tools (unchecked) + a free one.
+    simulateScrollAppend(container, "edit-server-tools", [
+      { name: "associatedTools", value: "id-assoc-a", toolName: "tool-assoc-a" },
+      { name: "associatedTools", value: "id-assoc-b", toolName: "tool-assoc-b" },
+      { name: "associatedTools", value: "id-p2-free", toolName: "tool-p2-free" },
+    ]);
+
+    // Associated tools must be checked (restored via the name attribute even
+    // though update() stripped their ids from the store as they rendered).
+    expect(container.querySelector('input[value="id-assoc-a"]').checked).toBe(true);
+    expect(container.querySelector('input[value="id-assoc-b"]').checked).toBe(true);
+    // The non-associated tool must stay unchecked.
+    expect(container.querySelector('input[value="id-p2-free"]').checked).toBe(false);
+
+    // And the re-check must have repaired the store (change event re-adds ids),
+    // so the save payload and pill count are correct.
+    const sel = getEditSelections("edit-server-tools");
+    expect(sel.has("id-assoc-a")).toBe(true);
+    expect(sel.has("id-assoc-b")).toBe(true);
+    expect(sel.has("id-p2-free")).toBe(false);
+  });
+
+  test("resources: associated resource on page 2 stays checked despite store depletion (id match via data-server-resources)", () => {
+    const container = buildEditResourcesContainer(["res-p1"]);
+    container.setAttribute(
+      "data-server-resources",
+      JSON.stringify(["res-assoc"]),
+    );
+
+    const resSel = getEditSelections("edit-server-resources");
+    resSel.add("res-assoc"); // seeded on open, then stripped by update()
+
+    ensureEditStoreListeners();
+
+    simulateScrollAppend(container, "edit-server-resources", [
+      { name: "associatedResources", value: "res-assoc" },
+      { name: "associatedResources", value: "res-free" },
+    ]);
+
+    expect(container.querySelector('input[value="res-assoc"]').checked).toBe(true);
+    expect(container.querySelector('input[value="res-free"]').checked).toBe(false);
+    expect(getEditSelections("edit-server-resources").has("res-assoc")).toBe(true);
+  });
+
+  test("prompts: associated prompt on page 2 stays checked despite store depletion", () => {
+    const container = buildEditPromptsContainer(["prompt-p1"]);
+    container.setAttribute(
+      "data-server-prompts",
+      JSON.stringify(["prompt-assoc"]),
+    );
+
+    const promptSel = getEditSelections("edit-server-prompts");
+    promptSel.add("prompt-assoc");
+
+    ensureEditStoreListeners();
+
+    simulateScrollAppend(container, "edit-server-prompts", [
+      { name: "associatedPrompts", value: "prompt-assoc" },
+      { name: "associatedPrompts", value: "prompt-free" },
+    ]);
+
+    expect(container.querySelector('input[value="prompt-assoc"]').checked).toBe(true);
+    expect(container.querySelector('input[value="prompt-free"]').checked).toBe(false);
+    expect(getEditSelections("edit-server-prompts").has("prompt-assoc")).toBe(true);
+  });
+
+  test("tools: all associated tools across many pages stay checked while store is depleted page by page", () => {
+    const container = buildEditToolsContainer([]);
+    container.setAttribute(
+      "data-server-tools",
+      JSON.stringify(["a1", "a2", "a3"]),
+    );
+    // Seed the store with the ids; update() will erase them as pages render.
+    ["ida1", "ida2", "ida3"].forEach((id) =>
+      getEditSelections("edit-server-tools").add(id),
+    );
+
+    ensureEditStoreListeners();
+
+    // page 1 — no associated items
+    simulateScrollAppend(container, "edit-server-tools", [
+      { name: "associatedTools", value: "idp1", toolName: "p1" },
+    ]);
+    // page 2 — one associated
+    simulateScrollAppend(container, "edit-server-tools", [
+      { name: "associatedTools", value: "ida1", toolName: "a1" },
+      { name: "associatedTools", value: "idp2", toolName: "p2" },
+    ]);
+    // page 3 — two associated
+    simulateScrollAppend(container, "edit-server-tools", [
+      { name: "associatedTools", value: "ida2", toolName: "a2" },
+      { name: "associatedTools", value: "ida3", toolName: "a3" },
+    ]);
+
+    expect(container.querySelector('input[value="ida1"]').checked).toBe(true);
+    expect(container.querySelector('input[value="ida2"]').checked).toBe(true);
+    expect(container.querySelector('input[value="ida3"]').checked).toBe(true);
+    expect(container.querySelector('input[value="idp1"]').checked).toBe(false);
+    expect(container.querySelector('input[value="idp2"]').checked).toBe(false);
+
+    const sel = getEditSelections("edit-server-tools");
+    expect(sel.has("ida1")).toBe(true);
+    expect(sel.has("ida2")).toBe(true);
+    expect(sel.has("ida3")).toBe(true);
+  });
+
+  test("tools: a user-unchecked associated tool is NOT re-checked (data-server-tools tracks intent)", () => {
+    const container = buildEditToolsContainer([]);
+    container.setAttribute("data-server-tools", JSON.stringify(["a1", "a2"]));
+    ["ida1", "ida2"].forEach((id) =>
+      getEditSelections("edit-server-tools").add(id),
+    );
+
+    ensureEditStoreListeners();
+
+    simulateScrollAppend(container, "edit-server-tools", [
+      { name: "associatedTools", value: "ida1", toolName: "a1" },
+      { name: "associatedTools", value: "ida2", toolName: "a2" },
+    ]);
+    expect(container.querySelector('input[value="ida1"]').checked).toBe(true);
+    expect(container.querySelector('input[value="ida2"]').checked).toBe(true);
+
+    // User unchecks ida1.  The real tools.js change handler removes its name
+    // from data-server-tools; mirror that, then fire a fresh settle.
+    const victim = container.querySelector('input[value="ida1"]');
+    victim.checked = false;
+    victim.dispatchEvent(new Event("change", { bubbles: true }));
+    container.setAttribute("data-server-tools", JSON.stringify(["a2"]));
+
+    const settle = new Event("htmx:afterSettle", { bubbles: true });
+    settle.detail = { target: container };
+    container.dispatchEvent(settle);
+
+    // The re-apply must respect the user's uncheck, not force it back on.
+    expect(container.querySelector('input[value="ida1"]').checked).toBe(false);
+    expect(container.querySelector('input[value="ida2"]').checked).toBe(true);
+    expect(getEditSelections("edit-server-tools").has("ida1")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — store-match path (no data attribute): a user's fresh selection that
+// scrolls out of and back into view must remain checked.
+// ---------------------------------------------------------------------------
+
+describe("edit-server scroll-pagination: store-match preserved without data attribute (#3358)", () => {
+  test("tools: an id present only in the store (no data-server-tools) is restored", () => {
+    const container = buildEditToolsContainer([]);
+    // No data-server-tools attribute at all (e.g. a brand-new user selection).
+    const toolSel = getEditSelections("edit-server-tools");
+    toolSel.add("user-picked");
+
+    ensureEditStoreListeners();
+
+    // Because there is no data attribute, the store must survive for this to
+    // work — so DO NOT run the depleting sync here; append + settle only.
+    const cb = makeToolCheckbox({ id: "user-picked", name: "up" });
+    container.appendChild(cb);
+    const settle = new Event("htmx:afterSettle", { bubbles: true });
+    settle.detail = { target: container };
+    container.dispatchEvent(settle);
+
+    expect(container.querySelector('input[value="user-picked"]').checked).toBe(true);
+  });
+
+  test("containers are independent: tools afterSettle does not affect resources", () => {
+    const toolsContainer = buildEditToolsContainer([]);
+    toolsContainer.setAttribute("data-server-tools", JSON.stringify(["tx"]));
+    const resourcesContainer = buildEditResourcesContainer([]);
+    resourcesContainer.setAttribute(
+      "data-server-resources",
+      JSON.stringify(["resource-y"]),
+    );
+
+    ensureEditStoreListeners();
+
+    // only tools container gets the afterSettle
+    simulateScrollAppend(toolsContainer, "edit-server-tools", [
+      { name: "associatedTools", value: "id-tx", toolName: "tx" },
+    ]);
+    // manually append to resources container without event
+    const resCb = document.createElement("input");
+    resCb.type = "checkbox";
+    resCb.name = "associatedResources";
+    resCb.value = "resource-y";
+    resCb.checked = false;
+    resourcesContainer.appendChild(resCb);
+
+    expect(toolsContainer.querySelector('input[value="id-tx"]').checked).toBe(true);
+    // resources: resource-y was not given an event, so still unchecked
+    expect(resourcesContainer.querySelector('input[value="resource-y"]').checked).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
In the virtual-server **Edit** modal, the associated-tools picker loads its items in pages via HTMX infinite scroll (`per_page=20`; each sentinel uses `hx-swap="outerHTML"`, `hx-trigger="intersect once"`). A server's associated tools that live on page 2+ render **unchecked** even though they are associated, which makes it look like the associations are missing. Page 1 is fine, and Save preserves the real selection (the persistent store is seeded on open and read on submit), so this is a checkbox-rendering correctness issue, not data loss.

## Reproduce
1. Associate more than ~20 tools with a virtual server (so the associations span multiple selector pages).
2. Open the server's Edit modal.
3. Scroll the tools picker down to load later pages — associated tools on page 2+ appear unchecked.

## Root cause
The edit modal seeds the persistent selection store with the associated item ids on open. But `tools.js`'s pill-count `update()` — which runs as each scroll page settles, syncing DOM→store — **deletes** the id of every checkbox currently rendered unchecked. Associated items on page 2+ always render unchecked, so their seeded ids are stripped from the store as they stream in. Restoring checked state from the store alone then finds an empty store and checks nothing. (The store is repaired for Save via other paths, which is why Save itself was unaffected — but the visible checkboxes were wrong.)

## Fix
Restore checked state from a source that survives that churn. `restoreCheckedStateFromStore(containerId)` now (re-)checks a box when its id is in the selection store **or** its identity is in the container's `data-server-*` association attribute (tool *names* for tools, via `data-tool-name`; ids for resources/prompts, via the checkbox value). That attribute is only mutated on an explicit user check/uncheck, never by the paginated re-render, so it is the reliable "was this associated when the modal opened" signal.

- The re-apply is wired on `htmx:afterSettle` (plus `htmx:afterSwap` for search re-renders). Because it also matches the churn-proof `data-server-*` attribute, it restores correctly regardless of its ordering relative to `update()`.
- It only acts on **unchecked** boxes, so a user's explicit uncheck (which removes the item from `data-server-*`) is respected and never forced back on.
- Re-checking dispatches a bubbling `change`, so the store listener re-adds the id — repairing the store that `update()` depleted and keeping the pill count and the save payload correct.

A pre-existing global `htmx:afterSettle` handler in `app.js` already attempts a similar re-check, but it is unreliable in this flow — it gates on a one-shot `data-auto-check` marker that it then consumes, and races the synchronous store sync — so associated tools on later pages still render unchecked. This change adds a dedicated, container-scoped re-apply rather than relying on that path.

Save behavior, selection ordering, and the create-server form are untouched.

## Verification
- New tests in `tests/unit/js/edit-server-scroll-pagination.test.js` simulate the real path (the pill-count store sync that depletes the store before each settle). They cover tools (name match), resources and prompts (id match), multi-page depletion, the user-uncheck regression, and store-only restore — failing without the fix and passing with it.
- Full JS suite: 2294 passed / 3 skipped, no regressions.
- Verified manually against a server with 23 associated tools across 5 scroll pages: before, 23 associated rendered / 0 checked; after, 23/23 checked under both programmatic intersect and real scrolling, with no change to the persisted association count.

Closes #3358
