### PR TITLE
fix(admin-ui): fix CSRF failures on LLM Settings writes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,7 +86,7 @@ CSRF_SECRET_KEY=
 CSRF_TOKEN_NAME=X-CSRF-Token
 
 # Cookie name for CSRF token
-CSRF_COOKIE_NAME=csrf_token
+CSRF_COOKIE_NAME=mcpgateway_csrf_token
 
 # CSRF token expiration time in seconds (default: 3600 = 1 hour)
 CSRF_TOKEN_EXPIRY=3600

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -4332,7 +4332,11 @@ async def admin_ui(
 
         # Set HTTP-only cookie using centralized security cookie utility
         set_auth_cookie(response, token, remember_me=False)
-        csrf_user_id = str(payload["sub"])
+        # CSRF tokens are HMAC-bound to the identity CSRFMiddleware derives from
+        # request.state.user, which is EmailUser.email — not EmailUser.id (the PK
+        # used for the JWT `sub` claim). Matches routers/auth.py and
+        # routers/email_auth.py, which already bind to the email.
+        csrf_user_id = admin_email
         csrf_session_id = str(payload["jti"])
         LOGGER.debug(f"Set session JWT token cookie for user: {admin_email}")
     except Exception as e:

--- a/mcpgateway/admin_ui/llmModels.js
+++ b/mcpgateway/admin_ui/llmModels.js
@@ -2,11 +2,34 @@ import { AppState } from "./appState.js";
 import { showCopyableModal } from "./modals.js";
 import { parseErrorResponse } from "./security.js";
 import { getAuthToken } from "./tokens.js";
-import { safeGetElement, showToast } from "./utils.js";
+import { getCookie, safeGetElement, showToast } from "./utils.js";
 
 // ===================================================================
 // LLM SETTINGS FUNCTIONS
 // ===================================================================
+
+/**
+ * Build headers for state-changing LLM settings requests.
+ * - Authorization is only attached when a real bearer token is available
+ *   (session logins use an httponly cookie, so getAuthToken() returns "").
+ * - X-CSRF-Token satisfies both CSRFMiddleware (/llm/*) and
+ *   enforce_admin_csrf (/admin/llm/*), which share the same cookie/header names.
+ */
+async function llmRequestHeaders({ json = true } = {}) {
+  const headers = {};
+  if (json) {
+    headers["Content-Type"] = "application/json";
+  }
+  const token = await getAuthToken();
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  const csrfToken = getCookie("mcpgateway_csrf_token");
+  if (csrfToken) {
+    headers["X-CSRF-Token"] = csrfToken;
+  }
+  return headers;
+}
 
 /**
  * Switch between LLM Settings tabs (providers/models)
@@ -75,9 +98,7 @@ const loadLLMProviderDefaults = async function () {
     const response = await fetch(
       `${window.ROOT_PATH}/admin/llm/provider-defaults`,
       {
-        headers: {
-          Authorization: `Bearer ${await getAuthToken()}`,
-        },
+        headers: await llmRequestHeaders({ json: false }),
       },
     );
     if (response.ok) {
@@ -184,9 +205,7 @@ const renderProviderSpecificFields = async function (
     const response = await fetch(
       `${window.ROOT_PATH}/admin/llm/provider-configs`,
       {
-        headers: {
-          Authorization: `Bearer ${await getAuthToken()}`,
-        },
+        headers: await llmRequestHeaders({ json: false }),
       },
     );
 
@@ -353,9 +372,7 @@ export const fetchLLMProviderModels = async function (providerId) {
       `${window.ROOT_PATH}/admin/llm/providers/${providerId}/fetch-models`,
       {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${await getAuthToken()}`,
-        },
+        headers: await llmRequestHeaders({ json: false }),
       },
     );
 
@@ -397,9 +414,7 @@ export const syncLLMProviderModels = async function (providerId) {
       `${window.ROOT_PATH}/admin/llm/providers/${providerId}/sync-models`,
       {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${await getAuthToken()}`,
-        },
+        headers: await llmRequestHeaders({ json: false }),
       },
     );
 
@@ -437,9 +452,7 @@ export const editLLMProvider = async function (providerId) {
     const response = await fetch(
       `${window.ROOT_PATH}/llm/providers/${providerId}`,
       {
-        headers: {
-          Authorization: `Bearer ${await getAuthToken()}`,
-        },
+        headers: await llmRequestHeaders({ json: false }),
       },
     );
     if (!response.ok) {
@@ -555,10 +568,7 @@ export const saveLLMProvider = async function (event) {
 
     const response = await fetch(url, {
       method,
-      headers: {
-        Authorization: `Bearer ${await getAuthToken()}`,
-        "Content-Type": "application/json",
-      },
+      headers: await llmRequestHeaders(),
       body: JSON.stringify(formData),
     });
 
@@ -601,9 +611,7 @@ export const deleteLLMProvider = async function (providerId, providerName) {
       `${window.ROOT_PATH}/llm/providers/${providerId}`,
       {
         method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${await getAuthToken()}`,
-        },
+        headers: await llmRequestHeaders({ json: false }),
       },
     );
 
@@ -632,9 +640,7 @@ export const toggleLLMProvider = async function (providerId) {
       `${window.ROOT_PATH}/llm/providers/${providerId}/state`,
       {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${await getAuthToken()}`,
-        },
+        headers: await llmRequestHeaders({ json: false }),
       },
     );
 
@@ -658,9 +664,7 @@ export const checkLLMProviderHealth = async function (providerId) {
       `${window.ROOT_PATH}/admin/llm/providers/${providerId}/health`,
       {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${await getAuthToken()}`,
-        },
+        headers: await llmRequestHeaders({ json: false }),
       },
     );
 
@@ -730,9 +734,7 @@ export const showAddModelModal = async function () {
 export const populateProviderDropdown = async function () {
   try {
     const response = await fetch(`${window.ROOT_PATH}/llm/providers`, {
-      headers: {
-        Authorization: `Bearer ${await getAuthToken()}`,
-      },
+      headers: await llmRequestHeaders({ json: false }),
     });
     if (!response.ok) {
       throw new Error("Failed to fetch providers");
@@ -808,9 +810,7 @@ export const fetchModelsForModelModal = async function () {
       `${window.ROOT_PATH}/admin/llm/providers/${providerId}/fetch-models`,
       {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${await getAuthToken()}`,
-        },
+        headers: await llmRequestHeaders({ json: false }),
       },
     );
 
@@ -852,9 +852,7 @@ export const editLLMModel = async function (modelId) {
   llmModelComboboxClose();
   try {
     const response = await fetch(`${window.ROOT_PATH}/llm/models/${modelId}`, {
-      headers: {
-        Authorization: `Bearer ${await getAuthToken()}`,
-      },
+      headers: await llmRequestHeaders({ json: false }),
     });
     if (!response.ok) {
       throw new Error("Failed to fetch model details");
@@ -932,10 +930,7 @@ export const saveLLMModel = async function (event) {
 
     const response = await fetch(url, {
       method,
-      headers: {
-        Authorization: `Bearer ${await getAuthToken()}`,
-        "Content-Type": "application/json",
-      },
+      headers: await llmRequestHeaders(),
       body: JSON.stringify(formData),
     });
 
@@ -970,9 +965,7 @@ export const deleteLLMModel = async function (modelId, modelName) {
   try {
     const response = await fetch(`${window.ROOT_PATH}/llm/models/${modelId}`, {
       method: "DELETE",
-      headers: {
-        Authorization: `Bearer ${await getAuthToken()}`,
-      },
+      headers: await llmRequestHeaders({ json: false }),
     });
 
     if (!response.ok) {
@@ -1000,9 +993,7 @@ export const toggleLLMModel = async function (modelId) {
       `${window.ROOT_PATH}/llm/models/${modelId}/state`,
       {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${await getAuthToken()}`,
-        },
+        headers: await llmRequestHeaders({ json: false }),
       },
     );
 
@@ -1117,10 +1108,7 @@ export const llmApiInfoApp = function () {
 
         const response = await fetch(`${window.ROOT_PATH}/admin/llm/test`, {
           method: "POST",
-          headers: {
-            Authorization: `Bearer ${await getAuthToken()}`,
-            "Content-Type": "application/json",
-          },
+          headers: await llmRequestHeaders(),
           body: requestBodyStr,
         });
 

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3390,6 +3390,21 @@ if settings.correlation_id_enabled:
 # Add PasswordChangeEnforcementMiddleware FIRST so it runs AFTER AuthContextMiddleware
 _siem_auth_source_enabled = settings.siem_export_enabled and "auth" in {str(item).lower() for item in getattr(settings, "siem_export_event_sources", [])}
 
+# Add CSRF protection middleware FIRST (runs LAST/innermost due to reverse order)
+# This validates CSRF tokens on state-changing requests to prevent Cross-Site Request Forgery attacks
+# Must be added before AuthContextMiddleware below so it executes AFTER it and request.state.user
+# is available for token validation (adding it later would make it run BEFORE AuthContextMiddleware,
+# leaving request.state.user unset and silently falling back to resolving identity from the raw JWT
+# `sub` claim (EmailUser.id) instead of the email admin.py binds CSRF tokens to).
+if settings.csrf_enabled:
+    # First-Party
+    from mcpgateway.middleware.csrf_middleware import CSRFMiddleware
+
+    app.add_middleware(CSRFMiddleware)
+    logger.info("🛡️  CSRF protection middleware enabled - validating tokens on state-changing requests")
+else:
+    logger.info("🛡️  CSRF protection middleware disabled")
+
 # Add password change enforcement middleware FIRST (runs SECOND due to reverse order)
 # This middleware enforces mandatory password changes for users with password_change_required flag
 # Note: Runs after AuthContextMiddleware (added below) so request.state.user is available
@@ -3413,18 +3428,6 @@ if _auth_context_required:
     logger.info("🔐 Authentication context middleware enabled - capturing authentication security events")
 else:
     logger.info("🔐 Security event logging disabled")
-
-# Add CSRF protection middleware
-# This validates CSRF tokens on state-changing requests to prevent Cross-Site Request Forgery attacks
-# Note: Runs after AuthContextMiddleware so request.state.user is available for token validation
-if settings.csrf_enabled:
-    # First-Party
-    from mcpgateway.middleware.csrf_middleware import CSRFMiddleware
-
-    app.add_middleware(CSRFMiddleware)
-    logger.info("🛡️  CSRF protection middleware enabled - validating tokens on state-changing requests")
-else:
-    logger.info("🛡️  CSRF protection middleware disabled")
 
 # Add token usage logging middleware
 # This tracks API token usage for analytics and security monitoring

--- a/mcpgateway/middleware/auth_middleware.py
+++ b/mcpgateway/middleware/auth_middleware.py
@@ -179,7 +179,8 @@ class AuthContextMiddleware(BaseHTTPMiddleware):
             credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
             user = await get_current_user(credentials, request=request)
 
-            # Note: EmailUser uses 'email' as primary key, not 'id'
+            # Note: EmailUser.id is the primary key (UUID); .email is used here as the
+            # CSRF/logging identity, matching CSRFMiddleware's binding.
             # User is already detached (created with fresh session that was closed)
             user_email = user.email
             user_id = user_email  # For EmailUser, email IS the ID

--- a/mcpgateway/middleware/auth_middleware.py
+++ b/mcpgateway/middleware/auth_middleware.py
@@ -183,7 +183,7 @@ class AuthContextMiddleware(BaseHTTPMiddleware):
             # CSRF/logging identity, matching CSRFMiddleware's binding.
             # User is already detached (created with fresh session that was closed)
             user_email = user.email
-            user_id = user_email  # For EmailUser, email IS the ID
+            user_id = user_email  # CSRF/logging identity is the email, not EmailUser.id
 
             # Store user in request state for downstream use
             request.state.user = user

--- a/mcpgateway/middleware/csrf_middleware.py
+++ b/mcpgateway/middleware/csrf_middleware.py
@@ -135,8 +135,14 @@ class CSRFMiddleware(BaseHTTPMiddleware):
         # Bind CSRF tokens to the verified JWT session (jti) when available
         session_id = getattr(request.state, "jti", None)
 
-        # Fallback: derive user/session from a verified JWT when request.state
-        # was not populated yet (middleware ordering or disabled auth-context).
+        # Fallback: derive whichever of user_id/session_id request.state didn't
+        # already populate (middleware ordering, disabled auth-context, or a
+        # local/session login for which request.state.jti is never set — see
+        # auth.py's _set_auth_method_from_payload). Only fill in the missing
+        # piece; never clobber a user_id already resolved from
+        # request.state.user.email above, or every session-cookie request
+        # would silently re-resolve identity to the JWT `sub` (EmailUser.id)
+        # instead of the email CSRFMiddleware is supposed to bind to.
         if not user_id or not session_id:
             raw_token = request.cookies.get("jwt_token") or request.cookies.get("access_token")
             if not raw_token:
@@ -146,8 +152,10 @@ class CSRFMiddleware(BaseHTTPMiddleware):
             if raw_token:
                 try:
                     payload = await verify_jwt_token_cached(raw_token, request)
-                    user_id = payload.get("sub") or payload.get("email") or payload.get("user", {}).get("email")
-                    session_id = payload.get("jti")
+                    if not user_id:
+                        user_id = payload.get("email") or payload.get("user", {}).get("email") or payload.get("sub")
+                    if not session_id:
+                        session_id = payload.get("jti")
                 except Exception as exc:
                     logger.warning("CSRF fallback JWT verification failed for %s %s: %s", request.method, request.url.path, exc)
 

--- a/tests/unit/js/admin-llm-csrf.test.js
+++ b/tests/unit/js/admin-llm-csrf.test.js
@@ -1,0 +1,518 @@
+/**
+ * Regression tests for #5739 — LLM Settings write requests failing CSRF
+ * validation because llmModels.js never attached X-CSRF-Token.
+ *
+ * These tests exercise the shared `llmRequestHeaders()` helper (indirectly,
+ * through the exported write functions and the `llmApiInfoApp().runTest`
+ * Alpine method) and assert that:
+ *   - `X-CSRF-Token` is attached from the `mcpgateway_csrf_token` cookie on
+ *     every state-changing request.
+ *   - `Authorization` is OMITTED when `getAuthToken()` resolves to "" (the
+ *     httponly session-cookie case) — regression guard for the empty-Bearer
+ *     bug.
+ *   - `Authorization: Bearer <token>` IS present when a real bearer token is
+ *     available.
+ *
+ * Direct coverage (one representative function per HTTP verb, plus the
+ * Alpine `runTest` method):
+ *   - saveLLMProvider      -> POST /llm/providers   and PATCH /llm/providers/{id}
+ *   - saveLLMModel         -> POST /llm/models
+ *   - deleteLLMProvider    -> DELETE /llm/providers/{id}
+ *   - deleteLLMModel       -> DELETE /llm/models/{id}
+ *   - toggleLLMProvider    -> POST /llm/providers/{id}/state
+ *   - fetchLLMProviderModels -> POST /admin/llm/providers/{id}/fetch-models (no body)
+ *   - checkLLMProviderHealth -> POST /admin/llm/providers/{id}/health (no body)
+ *   - llmApiInfoApp().runTest -> POST /admin/llm/test (Alpine component method)
+ *
+ * Not directly covered here (identical request-building path, same shared
+ * helper): syncLLMProviderModels, fetchModelsForModelModal, toggleLLMModel.
+ * They are exercised for behavior (not CSRF headers) in llmModels.test.js and
+ * go through the exact same `llmRequestHeaders()` call as the functions above.
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  saveLLMProvider,
+  deleteLLMProvider,
+  toggleLLMProvider,
+  fetchLLMProviderModels,
+  checkLLMProviderHealth,
+  saveLLMModel,
+  deleteLLMModel,
+  llmApiInfoApp,
+} from "../../../mcpgateway/admin_ui/llmModels.js";
+
+vi.mock("../../../mcpgateway/admin_ui/modals.js", () => ({
+  showCopyableModal: vi.fn(),
+}));
+
+vi.mock("../../../mcpgateway/admin_ui/security.js", () => ({
+  escapeHtml: vi.fn((s) => (s != null ? String(s) : "")),
+  parseErrorResponse: vi.fn((response, defaultMsg) =>
+    Promise.resolve(defaultMsg)
+  ),
+}));
+
+// getAuthToken defaults to "" (httponly session-cookie login) for most tests;
+// individual tests override this to prove the Authorization-present case.
+const getAuthTokenMock = vi.fn(() => Promise.resolve(""));
+vi.mock("../../../mcpgateway/admin_ui/tokens.js", () => ({
+  getAuthToken: (...args) => getAuthTokenMock(...args),
+}));
+
+// utils.js is intentionally NOT mocked for getCookie/safeGetElement — we want
+// the real cookie-reading implementation exercised against jsdom's
+// document.cookie, since that is the exact mechanism the fix relies on.
+
+const CSRF_COOKIE_VALUE = "test-csrf-value";
+
+function setCsrfCookie(value = CSRF_COOKIE_VALUE) {
+  document.cookie = `mcpgateway_csrf_token=${value}`;
+}
+
+function clearCookies() {
+  // jsdom does not support wildcard cookie clearing; expire the one we set.
+  document.cookie =
+    "mcpgateway_csrf_token=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+}
+
+function setupProviderFormDOM() {
+  const ids = [
+    "llm-provider-id",
+    "llm-provider-name",
+    "llm-provider-description",
+    "llm-provider-api-key",
+    "llm-provider-api-base",
+    "llm-provider-default-model",
+    "llm-provider-temperature",
+    "llm-provider-max-tokens",
+  ];
+  const els = {};
+  for (const id of ids) {
+    const el = document.createElement("input");
+    el.id = id;
+    document.body.appendChild(el);
+    els[id] = el;
+  }
+  els["llm-provider-temperature"].value = "0.7";
+
+  const providerType = document.createElement("select");
+  providerType.id = "llm-provider-type";
+  providerType.value = "openai";
+  document.body.appendChild(providerType);
+
+  const enabled = document.createElement("input");
+  enabled.id = "llm-provider-enabled";
+  enabled.type = "checkbox";
+  document.body.appendChild(enabled);
+
+  const configFields = document.createElement("div");
+  configFields.id = "llm-provider-config-fields";
+  document.body.appendChild(configFields);
+
+  const modal = document.createElement("div");
+  modal.id = "llm-provider-modal";
+  document.body.appendChild(modal);
+
+  const container = document.createElement("div");
+  container.id = "llm-providers-container";
+  document.body.appendChild(container);
+
+  return els;
+}
+
+function setupModelFormDOM() {
+  const ids = [
+    "llm-model-id",
+    "llm-model-model-id",
+    "llm-model-name",
+    "llm-model-alias",
+    "llm-model-description",
+    "llm-model-context-window",
+    "llm-model-max-output",
+  ];
+  const els = {};
+  for (const id of ids) {
+    const el = document.createElement("input");
+    el.id = id;
+    document.body.appendChild(el);
+    els[id] = el;
+  }
+  els["llm-model-name"].value = "GPT-4";
+  els["llm-model-model-id"].value = "gpt-4";
+
+  const providerSelect = document.createElement("select");
+  providerSelect.id = "llm-model-provider";
+  providerSelect.value = "p1";
+  document.body.appendChild(providerSelect);
+
+  for (const id of [
+    "llm-model-supports-chat",
+    "llm-model-supports-streaming",
+    "llm-model-supports-functions",
+    "llm-model-supports-vision",
+    "llm-model-enabled",
+    "llm-model-deprecated",
+  ]) {
+    const cb = document.createElement("input");
+    cb.id = id;
+    cb.type = "checkbox";
+    document.body.appendChild(cb);
+  }
+
+  const modal = document.createElement("div");
+  modal.id = "llm-model-modal";
+  document.body.appendChild(modal);
+
+  const container = document.createElement("div");
+  container.id = "llm-models-container";
+  document.body.appendChild(container);
+
+  return els;
+}
+
+beforeEach(() => {
+  window.ROOT_PATH = "";
+  window.htmx = {
+    trigger: vi.fn(),
+    ajax: vi.fn(),
+    process: vi.fn(),
+  };
+  getAuthTokenMock.mockReset();
+  getAuthTokenMock.mockResolvedValue("");
+  setCsrfCookie();
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  delete window.ROOT_PATH;
+  delete window.htmx;
+  clearCookies();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// saveLLMProvider — POST (create) and PATCH (update)
+// ---------------------------------------------------------------------------
+describe("saveLLMProvider CSRF headers", () => {
+  test("POST /llm/providers includes X-CSRF-Token and omits Authorization", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "new-provider" }),
+    });
+    setupProviderFormDOM();
+
+    await saveLLMProvider({ preventDefault: vi.fn() });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/llm/providers",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "X-CSRF-Token": CSRF_COOKIE_VALUE,
+        }),
+      })
+    );
+    const [, options] = fetchSpy.mock.calls[0];
+    expect(options.headers).not.toHaveProperty("Authorization");
+  });
+
+  test("PATCH /llm/providers/{id} includes X-CSRF-Token", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    const els = setupProviderFormDOM();
+    els["llm-provider-id"].value = "provider-1";
+
+    await saveLLMProvider({ preventDefault: vi.fn() });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/llm/providers/provider-1",
+      expect.objectContaining({
+        method: "PATCH",
+        headers: expect.objectContaining({
+          "X-CSRF-Token": CSRF_COOKIE_VALUE,
+        }),
+      })
+    );
+  });
+
+  test("attaches Authorization when a real bearer token is available", async () => {
+    getAuthTokenMock.mockResolvedValue("real-bearer-token");
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "new-provider" }),
+    });
+    setupProviderFormDOM();
+
+    await saveLLMProvider({ preventDefault: vi.fn() });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/llm/providers",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer real-bearer-token",
+          "X-CSRF-Token": CSRF_COOKIE_VALUE,
+        }),
+      })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteLLMProvider — DELETE
+// ---------------------------------------------------------------------------
+describe("deleteLLMProvider CSRF headers", () => {
+  test("DELETE includes X-CSRF-Token and omits Authorization", async () => {
+    const confirmSpy = vi.spyOn(globalThis, "confirm").mockReturnValue(true);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+    });
+    const container = document.createElement("div");
+    container.id = "llm-providers-container";
+    document.body.appendChild(container);
+
+    await deleteLLMProvider("provider-1", "Test Provider");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/llm/providers/provider-1",
+      expect.objectContaining({
+        method: "DELETE",
+        headers: expect.objectContaining({
+          "X-CSRF-Token": CSRF_COOKIE_VALUE,
+        }),
+      })
+    );
+    const [, options] = fetchSpy.mock.calls[0];
+    expect(options.headers).not.toHaveProperty("Authorization");
+
+    confirmSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toggleLLMProvider — POST state-toggle, no body
+// ---------------------------------------------------------------------------
+describe("toggleLLMProvider CSRF headers", () => {
+  test("POST /state includes X-CSRF-Token and omits Content-Type/Authorization", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+    });
+    const container = document.createElement("div");
+    container.id = "llm-providers-container";
+    document.body.appendChild(container);
+
+    await toggleLLMProvider("provider-1");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/llm/providers/provider-1/state",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "X-CSRF-Token": CSRF_COOKIE_VALUE,
+        }),
+      })
+    );
+    const [, options] = fetchSpy.mock.calls[0];
+    expect(options.headers).not.toHaveProperty("Authorization");
+    expect(options.headers).not.toHaveProperty("Content-Type");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchLLMProviderModels — POST /admin/llm/*, no body (enforce_admin_csrf)
+// ---------------------------------------------------------------------------
+describe("fetchLLMProviderModels CSRF headers", () => {
+  test("POST fetch-models includes X-CSRF-Token", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({ success: true, count: 0, models: [] }),
+    });
+
+    await fetchLLMProviderModels("provider-1");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/admin/llm/providers/provider-1/fetch-models",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "X-CSRF-Token": CSRF_COOKIE_VALUE,
+        }),
+      })
+    );
+    const [, options] = fetchSpy.mock.calls[0];
+    expect(options.headers).not.toHaveProperty("Authorization");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkLLMProviderHealth — POST /admin/llm/*, no body (enforce_admin_csrf)
+// ---------------------------------------------------------------------------
+describe("checkLLMProviderHealth CSRF headers", () => {
+  test("POST health includes X-CSRF-Token", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: "healthy", latency_ms: 5 }),
+    });
+    const container = document.createElement("div");
+    container.id = "llm-providers-container";
+    document.body.appendChild(container);
+
+    await checkLLMProviderHealth("provider-1");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/admin/llm/providers/provider-1/health",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "X-CSRF-Token": CSRF_COOKIE_VALUE,
+        }),
+      })
+    );
+    const [, options] = fetchSpy.mock.calls[0];
+    expect(options.headers).not.toHaveProperty("Authorization");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// saveLLMModel — POST (create)
+// ---------------------------------------------------------------------------
+describe("saveLLMModel CSRF headers", () => {
+  test("POST /llm/models includes X-CSRF-Token and omits Authorization", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "new-model" }),
+    });
+    setupModelFormDOM();
+
+    await saveLLMModel({ preventDefault: vi.fn() });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/llm/models",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "X-CSRF-Token": CSRF_COOKIE_VALUE,
+        }),
+      })
+    );
+    const [, options] = fetchSpy.mock.calls[0];
+    expect(options.headers).not.toHaveProperty("Authorization");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteLLMModel — DELETE
+// ---------------------------------------------------------------------------
+describe("deleteLLMModel CSRF headers", () => {
+  test("DELETE includes X-CSRF-Token and omits Authorization", async () => {
+    const confirmSpy = vi.spyOn(globalThis, "confirm").mockReturnValue(true);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+    });
+    const container = document.createElement("div");
+    container.id = "llm-models-container";
+    document.body.appendChild(container);
+
+    await deleteLLMModel("model-1", "GPT-4");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/llm/models/model-1",
+      expect.objectContaining({
+        method: "DELETE",
+        headers: expect.objectContaining({
+          "X-CSRF-Token": CSRF_COOKIE_VALUE,
+        }),
+      })
+    );
+    const [, options] = fetchSpy.mock.calls[0];
+    expect(options.headers).not.toHaveProperty("Authorization");
+
+    confirmSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// llmApiInfoApp().runTest — Alpine component method, POST /admin/llm/test
+// ---------------------------------------------------------------------------
+describe("llmApiInfoApp().runTest CSRF headers", () => {
+  test("POST /admin/llm/test includes X-CSRF-Token and omits Authorization", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: () =>
+        Promise.resolve({
+          success: true,
+          metrics: { modelCount: 1 },
+          data: { data: [{ id: "gpt-4" }] },
+        }),
+    });
+
+    const app = llmApiInfoApp();
+    app.testType = "models";
+    await app.runTest();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/admin/llm/test",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "X-CSRF-Token": CSRF_COOKIE_VALUE,
+          "Content-Type": "application/json",
+        }),
+      })
+    );
+    const [, options] = fetchSpy.mock.calls[0];
+    expect(options.headers).not.toHaveProperty("Authorization");
+    expect(app.testSuccess).toBe(true);
+  });
+
+  test("attaches Authorization when a real bearer token is available", async () => {
+    getAuthTokenMock.mockResolvedValue("real-bearer-token");
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: () =>
+        Promise.resolve({ success: true, metrics: {}, data: { data: [] } }),
+    });
+
+    const app = llmApiInfoApp();
+    app.testType = "models";
+    await app.runTest();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/admin/llm/test",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer real-bearer-token",
+          "X-CSRF-Token": CSRF_COOKIE_VALUE,
+        }),
+      })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No CSRF cookie present — X-CSRF-Token must be omitted, not sent empty
+// ---------------------------------------------------------------------------
+describe("missing CSRF cookie", () => {
+  test("toggleLLMProvider omits X-CSRF-Token when no cookie is set", async () => {
+    clearCookies();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+    });
+    const container = document.createElement("div");
+    container.id = "llm-providers-container";
+    document.body.appendChild(container);
+
+    await toggleLLMProvider("provider-1");
+
+    const [, options] = fetchSpy.mock.calls[0];
+    expect(options.headers).not.toHaveProperty("X-CSRF-Token");
+  });
+});

--- a/tests/unit/js/llmModels.test.js
+++ b/tests/unit/js/llmModels.test.js
@@ -59,6 +59,7 @@ vi.mock("../../../mcpgateway/admin_ui/tokens.js", () => ({
 vi.mock("../../../mcpgateway/admin_ui/utils.js", () => ({
   safeGetElement: vi.fn((id) => document.getElementById(id)),
   showToast: vi.fn(),
+  getCookie: vi.fn(() => ""),
 }));
 
 beforeEach(() => {

--- a/tests/unit/mcpgateway/middleware/test_admin_csrf_binding.py
+++ b/tests/unit/mcpgateway/middleware/test_admin_csrf_binding.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/middleware/test_admin_csrf_binding.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Regression tests for issue #5739 — the Admin UI login handler bound the
+CSRF token to ``EmailUser.id`` (the JWT ``sub`` claim) while ``CSRFMiddleware``
+validates against ``EmailUser.email`` (``request.state.user.email``). The
+mismatched HMAC binding meant every ``/llm/*`` write 403'd with
+``CSRF_TOKEN_INVALID`` even with a syntactically-correct ``X-CSRF-Token``
+header.
+
+These tests prove the binding mismatch directly against ``CSRFService`` /
+``CSRFMiddleware`` (the same pattern used by
+``test_admin_random_csrf_token_fails_hmac_validation`` /
+``test_admin_bound_csrf_token_from_page_load_passes_hmac_validation`` in
+``test_csrf_middleware.py``), and additionally assert that ``admin.py``'s
+login handler source binds ``csrf_user_id`` to the email, not the id/sub.
+"""
+
+# Standard
+import inspect
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+from starlette.requests import Request
+from starlette.responses import Response
+
+# First-Party
+from mcpgateway.middleware.csrf_middleware import CSRFMiddleware
+from mcpgateway.services.csrf_service import CSRFService
+
+# A UUID primary key that deliberately differs from the user's email — the
+# normal case for EmailUser, and the case that exposes the bug.
+USER_ID = "3f9c9b8e-8a3a-4a4a-9d3c-1b2c3d4e5f60"
+USER_EMAIL = "admin@example.com"
+SESSION_ID = "session-jti-1"
+
+
+@pytest.mark.asyncio
+async def test_csrf_token_bound_to_user_id_fails_middleware_validation():
+    """Reproduces the bug: a token bound to EmailUser.id (the old admin.py
+    behavior) does NOT validate against CSRFMiddleware, which derives its
+    user_id from request.state.user.email.
+    """
+    csrf_service = CSRFService(secret="test-csrf-secret", expiry=3600)  # pragma: allowlist secret
+
+    # Token generation bound to the JWT `sub` claim (EmailUser.id) — the bug.
+    csrf_token = csrf_service.generate_csrf_token(USER_ID, SESSION_ID)
+
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/llm/providers"
+    request.headers = {"X-CSRF-Token": csrf_token, "origin": "http://localhost:4444"}
+    request.state = MagicMock()
+    request.state.user = MagicMock(email=USER_EMAIL)  # CSRFMiddleware uses .email
+    request.state.jti = SESSION_ID
+    request.cookies = {"jwt_token": "admin-session-jwt", "mcpgateway_csrf_token": csrf_token}
+
+    with (
+        patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings,
+        patch("mcpgateway.middleware.csrf_middleware.get_csrf_service", return_value=csrf_service),
+    ):
+        mock_settings.csrf_enabled = True
+        mock_settings.auth_required = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_cookie_name = "mcpgateway_csrf_token"
+        mock_settings.csrf_check_referer = False
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 403
+    assert b"CSRF_TOKEN_INVALID" in response.body
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_csrf_token_bound_to_email_passes_middleware_validation():
+    """Proves the fix: a token bound to EmailUser.email (the corrected
+    admin.py behavior) validates successfully against CSRFMiddleware.
+    """
+    csrf_service = CSRFService(secret="test-csrf-secret", expiry=3600)  # pragma: allowlist secret
+
+    # Token generation bound to the email — matches routers/auth.py,
+    # routers/email_auth.py, and the fixed admin.py.
+    csrf_token = csrf_service.generate_csrf_token(USER_EMAIL, SESSION_ID)
+
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/llm/providers"
+    request.headers = {"X-CSRF-Token": csrf_token, "origin": "http://localhost:4444"}
+    request.state = MagicMock()
+    request.state.user = MagicMock(email=USER_EMAIL)
+    request.state.jti = SESSION_ID
+    request.cookies = {"jwt_token": "admin-session-jwt", "mcpgateway_csrf_token": csrf_token}
+
+    with (
+        patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings,
+        patch("mcpgateway.middleware.csrf_middleware.get_csrf_service", return_value=csrf_service),
+    ):
+        mock_settings.csrf_enabled = True
+        mock_settings.auth_required = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_cookie_name = "mcpgateway_csrf_token"
+        mock_settings.csrf_check_referer = False
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    call_next.assert_awaited_once_with(request)
+
+
+def test_validate_csrf_token_id_vs_email_binding_differ():
+    """Focused unit check on CSRFService: binding to .id and binding to
+    .email produce tokens that validate against different user_id values —
+    the crux of the #5739 mismatch (CSRFMiddleware always validates against
+    .email, never .id).
+    """
+    csrf_service = CSRFService(secret="test-csrf-secret-2", expiry=3600)  # pragma: allowlist secret
+
+    token_bound_to_id = csrf_service.generate_csrf_token(USER_ID, SESSION_ID)
+    token_bound_to_email = csrf_service.generate_csrf_token(USER_EMAIL, SESSION_ID)
+
+    # The id-bound token only validates against the id, never the email that
+    # CSRFMiddleware actually uses.
+    assert csrf_service.validate_csrf_token(token_bound_to_id, USER_ID, SESSION_ID) is True
+    assert csrf_service.validate_csrf_token(token_bound_to_id, USER_EMAIL, SESSION_ID) is False
+
+    # The email-bound token validates against the email CSRFMiddleware uses.
+    assert csrf_service.validate_csrf_token(token_bound_to_email, USER_EMAIL, SESSION_ID) is True
+    assert csrf_service.validate_csrf_token(token_bound_to_email, USER_ID, SESSION_ID) is False
+
+
+def test_admin_login_binds_csrf_to_email_not_sub_claim():
+    """Source-level regression guard: the Admin UI login handler must set
+    csrf_user_id from the user's email, not from the JWT `sub` claim
+    (EmailUser.id). A regression back to `str(payload["sub"])` would
+    reintroduce #5739 even if the CSRFMiddleware tests above still pass
+    against a hand-built token.
+    """
+    # First-Party
+    from mcpgateway import admin
+
+    source = inspect.getsource(admin)
+    assert 'csrf_user_id = admin_email' in source, "csrf_user_id must bind to the admin's email (CSRFMiddleware's identity), not the JWT sub claim"
+    assert 'csrf_user_id = str(payload["sub"])' not in source, "csrf_user_id must not bind to the JWT sub claim (EmailUser.id) — CSRFMiddleware validates against .email"

--- a/tests/unit/mcpgateway/middleware/test_admin_csrf_binding.py
+++ b/tests/unit/mcpgateway/middleware/test_admin_csrf_binding.py
@@ -38,6 +38,7 @@ from starlette.responses import Response
 
 # First-Party
 import mcpgateway.db
+from mcpgateway.config import settings as settings_wrapper
 from mcpgateway.db import Base, EmailUser, get_db
 from mcpgateway.middleware.csrf_middleware import CSRFMiddleware
 from mcpgateway.services.csrf_service import CSRFService
@@ -239,6 +240,19 @@ def e2e_client(_main_app_with_llm_routes, _e2e_db_engine) -> Generator:
     mcpgateway.db.engine = _e2e_db_engine
     app.dependency_overrides[get_db] = override_get_db
 
+    # settings.secure_cookies defaults to True (config.py), so jwt_token/CSRF
+    # cookies are set with the Secure flag unless a local .env overrides it —
+    # which CI's checkout doesn't have. httpx's TestClient models real browser
+    # cookie-jar semantics: a Secure cookie set over this plain-http base_url
+    # is silently dropped on the very next request, breaking the whole session
+    # (dashboard load 302s back to /admin/login instead of rendering) with no
+    # exception raised anywhere to explain why. Pin it False for this
+    # non-TLS test transport, matching what .env.example ships for real
+    # non-TLS deployments.
+    _secure_cookies_was_shadowed = "secure_cookies" in settings_wrapper.__dict__
+    _original_secure_cookies = settings_wrapper.__dict__.get("secure_cookies")
+    settings_wrapper.__dict__["secure_cookies"] = False
+
     argon2 = Argon2PasswordService()
     db = TestSessionLocal()
     db.add(
@@ -264,6 +278,10 @@ def e2e_client(_main_app_with_llm_routes, _e2e_db_engine) -> Generator:
     app.dependency_overrides.clear()
     mcpgateway.db.SessionLocal = original_session_local
     mcpgateway.db.engine = original_engine
+    if _secure_cookies_was_shadowed:
+        settings_wrapper.__dict__["secure_cookies"] = _original_secure_cookies
+    else:
+        settings_wrapper.__dict__.pop("secure_cookies", None)
 
 
 def test_admin_login_csrf_token_validates_llm_provider_write(e2e_client):

--- a/tests/unit/mcpgateway/middleware/test_admin_csrf_binding.py
+++ b/tests/unit/mcpgateway/middleware/test_admin_csrf_binding.py
@@ -19,15 +19,26 @@ login handler source binds ``csrf_user_id`` to the email, not the id/sub.
 """
 
 # Standard
+import datetime
+from datetime import timezone
 import inspect
+import os
+from typing import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 import pytest
+from fastapi import Depends, status
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 from starlette.requests import Request
 from starlette.responses import Response
 
 # First-Party
+import mcpgateway.db
+from mcpgateway.db import Base, EmailUser, get_db
 from mcpgateway.middleware.csrf_middleware import CSRFMiddleware
 from mcpgateway.services.csrf_service import CSRFService
 
@@ -153,3 +164,163 @@ def test_admin_login_binds_csrf_to_email_not_sub_claim():
     source = inspect.getsource(admin)
     assert 'csrf_user_id = admin_email' in source, "csrf_user_id must bind to the admin's email (CSRFMiddleware's identity), not the JWT sub claim"
     assert 'csrf_user_id = str(payload["sub"])' not in source, "csrf_user_id must not bind to the JWT sub claim (EmailUser.id) — CSRFMiddleware validates against .email"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end regression: real /admin/login -> real /llm/providers write
+# ---------------------------------------------------------------------------
+
+ADMIN_PASSWORD = "AdminPass123!"  # pragma: allowlist secret
+
+
+@pytest.fixture
+def _e2e_db_engine():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture(scope="session")
+def _main_app_with_llm_routes(main_app_with_admin_api):
+    """Dynamically mount llm_config_router/llm_admin_router if missing.
+
+    Mirrors ``main_app_with_admin_api`` (tests/conftest.py): the session
+    bootstrap force-disables ``LLMCHAT_ENABLED`` for import speed, so
+    ``/llm/providers`` (llm_config_router) isn't mounted on a plain
+    ``mcpgateway.main.app`` import. Unlike the admin router, no existing
+    fixture re-mounts the LLM routers, so this does it the same way.
+    """
+    app = main_app_with_admin_api
+    existing = [r for r in app.routes if getattr(r, "path", "") == "/llm/providers"]
+    if not existing:
+        # First-Party
+        from mcpgateway.config import get_settings
+        from mcpgateway.config import settings as settings_wrapper
+
+        os.environ["LLMCHAT_ENABLED"] = "true"
+        settings_wrapper.__dict__.pop("llmchat_enabled", None)
+        get_settings.cache_clear()
+
+        from mcpgateway.admin import enforce_admin_csrf
+        from mcpgateway.routers.llm_admin_router import llm_admin_router
+        from mcpgateway.routers.llm_config_router import llm_config_router
+
+        app.include_router(llm_config_router, prefix="/llm", tags=["LLM Configuration"])
+        app.include_router(llm_admin_router, prefix="/admin/llm", tags=["LLM Admin"], dependencies=[Depends(enforce_admin_csrf)])
+
+    yield app
+
+
+@pytest.fixture
+def e2e_client(_main_app_with_llm_routes, _e2e_db_engine) -> Generator:
+    """A TestClient wired to the real app/middleware stack with an isolated in-memory DB.
+
+    Depends on ``main_app_with_admin_api`` (tests/conftest.py) because the session
+    bootstrap force-disables ``MCPGATEWAY_ADMIN_API_ENABLED`` for import speed, which
+    means ``admin_router`` (and therefore ``/admin/login``) isn't mounted on a plain
+    ``mcpgateway.main.app`` import.
+    """
+    # Third-Party
+    from mcpgateway.services.argon2_service import Argon2PasswordService
+
+    app = _main_app_with_llm_routes
+    TestSessionLocal = sessionmaker(bind=_e2e_db_engine)
+
+    def override_get_db():
+        db = TestSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    original_session_local = mcpgateway.db.SessionLocal
+    original_engine = mcpgateway.db.engine
+    mcpgateway.db.SessionLocal = TestSessionLocal
+    mcpgateway.db.engine = _e2e_db_engine
+    app.dependency_overrides[get_db] = override_get_db
+
+    argon2 = Argon2PasswordService()
+    db = TestSessionLocal()
+    db.add(
+        EmailUser(
+            email=USER_EMAIL,
+            password_hash=argon2.hash_password(ADMIN_PASSWORD),
+            full_name="Admin E2E Test",
+            is_admin=True,
+            is_active=True,
+            auth_provider="local",
+            email_verified_at=datetime.datetime.now(timezone.utc),
+        )
+    )
+    db.commit()
+    db.close()
+
+    # base_url must match settings.app_domain (default http://localhost:4444) so
+    # Origin/Referer checks in CSRFMiddleware and the RBAC same-origin-referer
+    # check both see a host they actually allow (TestClient's default
+    # "testserver" host matches neither).
+    yield TestClient(app, base_url="http://localhost:4444")
+
+    app.dependency_overrides.clear()
+    mcpgateway.db.SessionLocal = original_session_local
+    mcpgateway.db.engine = original_engine
+
+
+def test_admin_login_csrf_token_validates_llm_provider_write(e2e_client):
+    """End-to-end regression for #5739: a real /admin/login must produce a CSRF
+    cookie that a subsequent /llm/providers write actually validates against.
+
+    This exercises the full stack (real login handler, real CSRFMiddleware,
+    real RBAC) rather than hand-built Request mocks, so a regression in how the
+    login handler binds `csrf_user_id` (or in how CSRFMiddleware derives its
+    own identity) would be caught here even if the more targeted unit tests
+    above still pass.
+    """
+    login_resp = e2e_client.post(
+        "/admin/login",
+        data={"email": USER_EMAIL, "password": ADMIN_PASSWORD},
+        follow_redirects=False,
+    )
+    assert login_resp.status_code == 303, login_resp.text
+    assert "jwt_token" in e2e_client.cookies
+
+    # A real browser auto-follows the 303 to GET /admin/. That first dashboard
+    # load is what actually rotates the CSRF cookie to the HMAC-bound value
+    # (see admin_ui()'s csrf_user_id/csrf_session_id binding in admin.py) —
+    # the login handler itself only sets an opaque, non-HMAC placeholder.
+    dashboard_resp = e2e_client.get("/admin/", headers={"origin": "http://localhost:4444", "accept": "text/html"})
+    assert dashboard_resp.status_code == 200, dashboard_resp.text
+    csrf_token = e2e_client.cookies.get("mcpgateway_csrf_token")
+    assert csrf_token, "dashboard load must set the mcpgateway_csrf_token cookie"
+
+    create_resp = e2e_client.post(
+        "/llm/providers",
+        json={"name": "e2e-test-provider", "provider_type": "openai"},
+        headers={"X-CSRF-Token": csrf_token, "referer": "http://localhost:4444/admin/"},
+    )
+
+    assert create_resp.status_code != 403, create_resp.text
+    assert "CSRF_TOKEN_INVALID" not in create_resp.text
+    assert create_resp.status_code == status.HTTP_201_CREATED, create_resp.text
+
+
+def test_admin_login_csrf_token_rejected_without_header(e2e_client):
+    """Sanity check for the harness itself: the same write without the CSRF
+    header must still 403, proving the positive-path test above isn't passing
+    because CSRF enforcement is silently disabled in this test setup.
+    """
+    login_resp = e2e_client.post(
+        "/admin/login",
+        data={"email": USER_EMAIL, "password": ADMIN_PASSWORD},
+        follow_redirects=False,
+    )
+    assert login_resp.status_code == 303, login_resp.text
+
+    create_resp = e2e_client.post(
+        "/llm/providers",
+        json={"name": "e2e-test-provider-2", "provider_type": "openai"},
+        headers={"origin": "http://localhost:4444"},
+    )
+
+    assert create_resp.status_code == 403
+    assert "CSRF_TOKEN_INVALID" in create_resp.text

--- a/tests/unit/mcpgateway/middleware/test_admin_csrf_binding.py
+++ b/tests/unit/mcpgateway/middleware/test_admin_csrf_binding.py
@@ -86,7 +86,7 @@ async def test_csrf_token_bound_to_user_id_fails_middleware_validation():
 
         response = await middleware.dispatch(request, call_next)
 
-    assert response.status_code == 403
+    assert response.status_code == 403, response.body
     assert b"CSRF_TOKEN_INVALID" in response.body
     call_next.assert_not_awaited()
 
@@ -127,7 +127,7 @@ async def test_csrf_token_bound_to_email_passes_middleware_validation():
 
         response = await middleware.dispatch(request, call_next)
 
-    assert response.status_code == 200
+    assert response.status_code == 200, response.body
     call_next.assert_awaited_once_with(request)
 
 
@@ -320,6 +320,92 @@ def test_admin_login_csrf_token_validates_llm_provider_write(e2e_client):
     assert create_resp.status_code != 403, create_resp.text
     assert "CSRF_TOKEN_INVALID" not in create_resp.text
     assert create_resp.status_code == status.HTTP_201_CREATED, create_resp.text
+
+
+def test_csrf_middleware_runs_after_auth_context_middleware():
+    """Regression guard for the middleware registration-order bug fixed
+    alongside #5739: ``CSRFMiddleware`` must be registered *before*
+    ``AuthContextMiddleware`` in ``main.py`` so that, per Starlette's
+    reverse-registration-order execution, it actually runs *after*
+    ``AuthContextMiddleware`` has populated ``request.state.user``.
+
+    Getting this backwards makes CSRFMiddleware silently fall back to
+    resolving identity from the raw JWT `sub` claim (EmailUser.id) instead
+    of the email admin.py binds CSRF tokens to — reintroducing #5739 even
+    though the HMAC-binding fix itself is correct.
+    """
+    # First-Party
+    from mcpgateway.main import app
+    from mcpgateway.middleware.auth_middleware import AuthContextMiddleware
+    from mcpgateway.middleware.csrf_middleware import CSRFMiddleware
+
+    middleware_classes = [m.cls for m in app.user_middleware]
+    assert AuthContextMiddleware in middleware_classes, "AuthContextMiddleware must be registered for this regression guard to be meaningful"
+    assert CSRFMiddleware in middleware_classes, "CSRFMiddleware must be registered for this regression guard to be meaningful"
+
+    auth_index = middleware_classes.index(AuthContextMiddleware)
+    csrf_index = middleware_classes.index(CSRFMiddleware)
+
+    # Starlette executes app.user_middleware in list order on the way in, so
+    # a lower index runs FIRST. AuthContextMiddleware must run before
+    # CSRFMiddleware so request.state.user is populated by the time
+    # CSRFMiddleware reads it.
+    assert auth_index < csrf_index, f"AuthContextMiddleware (index {auth_index}) must run before CSRFMiddleware (index {csrf_index}) so request.state.user is populated for CSRF identity resolution"
+
+
+@pytest.mark.asyncio
+async def test_csrf_fallback_preserves_existing_user_id():
+    """Regression guard: when ``request.state.user`` already resolved
+    ``user_id`` from the email but ``request.state.jti`` is unset (e.g. a
+    local/session login where no JWT `jti` is minted), the JWT-decode
+    fallback must fill in ONLY the missing ``session_id`` — it must NOT
+    also re-resolve ``user_id`` from the JWT `sub` claim (EmailUser.id) and
+    clobber the already-correct email.
+
+    Before the fix, the fallback unconditionally overwrote both fields
+    whenever either was missing, so this exact case (user_id present,
+    session_id absent) would have silently rebound the CSRF identity to
+    EmailUser.id and failed validation even with everything else correct.
+    """
+    csrf_service = CSRFService(secret="test-csrf-secret-3", expiry=3600)  # pragma: allowlist secret
+
+    # Token bound to the email + session id that request.state should end up
+    # resolving to.
+    csrf_token = csrf_service.generate_csrf_token(USER_EMAIL, SESSION_ID)
+
+    # A JWT whose `sub` is the (different) user id — if the fallback
+    # incorrectly overwrote user_id, it would pick this up instead of the
+    # already-resolved email and the token would fail validation.
+    jwt_payload = {"sub": USER_ID, "email": USER_EMAIL, "jti": SESSION_ID}
+
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/llm/providers"
+    request.headers = {"X-CSRF-Token": csrf_token, "origin": "http://localhost:4444"}
+    request.state = MagicMock()
+    request.state.user = MagicMock(email=USER_EMAIL)  # user_id already resolvable from here
+    request.state.jti = None  # session_id NOT resolvable from request.state — must fall back
+    request.cookies = {"jwt_token": "admin-session-jwt", "mcpgateway_csrf_token": csrf_token}
+
+    with (
+        patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings,
+        patch("mcpgateway.middleware.csrf_middleware.get_csrf_service", return_value=csrf_service),
+        patch("mcpgateway.middleware.csrf_middleware.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)),
+    ):
+        mock_settings.csrf_enabled = True
+        mock_settings.auth_required = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_cookie_name = "mcpgateway_csrf_token"
+        mock_settings.csrf_check_referer = False
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200, response.body
+    call_next.assert_awaited_once_with(request)
 
 
 def test_admin_login_csrf_token_rejected_without_header(e2e_client):

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -70,6 +70,33 @@ def test_ratelimiter_redis_url_defaults():
     assert s.ratelimiter_redis_url is None
     assert s.ratelimiter_redis_max_connections == 50
     assert s.ratelimiter_redis_socket_timeout == 2.0
+
+
+def test_csrf_cookie_name_default_matches_env_example():
+    """CSRF_COOKIE_NAME in .env.example must equal config.py's csrf_cookie_name default.
+
+    Operators who copy .env.example (documented first step in README) must get
+    the same cookie name CSRFMiddleware and the Admin UI JS already hardcode
+    (`mcpgateway_csrf_token`). A stale .env.example value silently breaks CSRF
+    validation for every real deployment even though code defaults are correct
+    (see #5739).
+    """
+    import re
+
+    repo_root = os.path.join(os.path.dirname(__file__), "..", "..", "..")
+    env_example_path = os.path.normpath(os.path.join(repo_root, ".env.example"))
+
+    assert os.path.exists(env_example_path), f".env.example not found at {env_example_path}"
+
+    with open(env_example_path, encoding="utf-8") as f:
+        content = f.read()
+
+    match = re.search(r"^CSRF_COOKIE_NAME=(.+)$", content, re.MULTILINE)
+    assert match, "CSRF_COOKIE_NAME not found in .env.example"
+    env_example_value = match.group(1).strip()
+
+    s = Settings(_env_file=None)
+    assert env_example_value == s.csrf_cookie_name, f".env.example CSRF_COOKIE_NAME={env_example_value!r} does not match config.py default={s.csrf_cookie_name!r}"
     assert s.ratelimiter_redis_socket_connect_timeout == 2.0
 
 


### PR DESCRIPTION
## Summary

Fixes two independent bugs behind #5739 ("Saving LLM Provider/Model in Admin UI fails with 403 CSRF validation failed"):

- `mcpgateway/admin_ui/llmModels.js` built every write request by hand and never attached `X-CSRF-Token`, so all 11 state-changing calls (Save/Delete/Toggle Provider, Health Check, Fetch/Sync Models, Save/Delete/Toggle Model, and the Test tab) 403'd for cookie-authenticated Admin UI sessions. A shared `llmRequestHeaders()` helper now attaches the CSRF token from the `mcpgateway_csrf_token` cookie and only sets `Authorization` when a real bearer token is available (session logins use an httponly cookie, so the old code was sending a meaningless empty `Bearer ` header).
- Separately, the Admin UI login handler bound the CSRF token's HMAC to `EmailUser.id` (the JWT `sub` claim), while `CSRFMiddleware` validates against `EmailUser.email` (`request.state.user.email`). That mismatch meant `/llm/*` writes (guarded by `CSRFMiddleware`) would still fail CSRF validation even with a correct header. Bound `csrf_user_id` to the email instead, matching `routers/auth.py` and `routers/email_auth.py`, which already do this correctly.

Also corrected an inaccurate comment in `auth_middleware.py` that claimed `EmailUser.email` is the primary key (it's `.id`; `.email` is used as the CSRF/logging identity).

Deliberately out of scope: `selectiveImport.js` / `fileTransfer.js` have the same missing-CSRF-header pattern on `/admin/import/*` — left for a follow-up issue since #5739 is specifically the LLM Settings tab.

## Update: end-to-end regression test surfaced three more stacked bugs

Per review feedback, added a real end-to-end test (`/admin/login` → dashboard load → `/llm/providers` write, no mocks). It still 403'd with `CSRF_TOKEN_INVALID` after the fixes above, tracing to three independent, pre-existing bugs that all had to be fixed together for the flow to actually work:

- **`.env.example`** set `CSRF_COOKIE_NAME=csrf_token`, overriding the code default (`mcpgateway_csrf_token`) that `admin.py` and every Admin UI JS file already hardcode. Since `cp .env.example .env` is step one of setup, real deployments never had the cookie name `CSRFMiddleware` was looking for. Fixed the template value.
- **Middleware registration order in `main.py`**: `CSRFMiddleware` was registered after `AuthContextMiddleware`, but Starlette runs middleware in reverse registration order, so `CSRFMiddleware` actually ran *before* `request.state.user` was populated — the opposite of what the surrounding code comments assumed. Reordered so CSRF registers first (runs last/innermost, after auth).
- **`CSRFMiddleware`'s JWT-decode fallback** (used when `request.state.jti` isn't set) unconditionally overwrote `user_id` too, using the JWT `sub` claim (`EmailUser.id`) even when the email had already been correctly resolved from `request.state.user`. Now only fills in whichever of `user_id`/`session_id` is actually missing.

The regression test (`test_admin_login_csrf_token_validates_llm_provider_write`) plus a negative control (`test_admin_login_csrf_token_rejected_without_header`) are in `tests/unit/mcpgateway/middleware/test_admin_csrf_binding.py`.
