### PR TITLE
feat(ui-rewrite): add local search to Users, Teams, and MCP Servers tables

### DIFF
--- a/client/src/components/ui/list-search.test.tsx
+++ b/client/src/components/ui/list-search.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { ListSearch } from "./list-search";
+
+function Harness({ initial = "" }: { initial?: string }) {
+  const [value, setValue] = useState(initial);
+  return (
+    <ListSearch value={value} onChange={setValue} ariaLabel="Search users" placeholder="Search" />
+  );
+}
+
+describe("ListSearch", () => {
+  it("renders an accessible search trigger and input", () => {
+    render(<Harness />);
+    expect(screen.getByRole("button", { name: "Search users" })).toBeInTheDocument();
+    expect(screen.getByRole("searchbox", { name: "Search users" })).toBeInTheDocument();
+  });
+
+  it("updates the value as the user types", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const input = screen.getByRole("searchbox", { name: "Search users" });
+    await user.type(input, "alice");
+    expect(input).toHaveValue("alice");
+  });
+
+  it("focuses the input when the trigger is clicked", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole("button", { name: "Search users" }));
+    expect(screen.getByRole("searchbox", { name: "Search users" })).toHaveFocus();
+  });
+});

--- a/client/src/components/ui/list-search.tsx
+++ b/client/src/components/ui/list-search.tsx
@@ -1,0 +1,64 @@
+import { useRef, useState } from "react";
+import { Search } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+interface ListSearchProps {
+  value: string;
+  onChange: (value: string) => void;
+  ariaLabel: string;
+  placeholder?: string;
+  className?: string;
+}
+
+/**
+ * Expandable search box for entity list tables. Collapses to an icon until
+ * focused or non-empty, mirroring the search affordance used in the details
+ * drawers. Filtering is owned by the caller; this component only manages the
+ * expand/collapse presentation.
+ */
+export function ListSearch({
+  value,
+  onChange,
+  ariaLabel,
+  placeholder,
+  className,
+}: ListSearchProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const open = isExpanded || value.length > 0;
+
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        onClick={() => inputRef.current?.focus()}
+        className="size-8 rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        aria-label={ariaLabel}
+      >
+        <Search className="size-4" />
+      </Button>
+      <Input
+        ref={inputRef}
+        type="search"
+        aria-label={ariaLabel}
+        tabIndex={open ? 0 : -1}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onFocus={() => setIsExpanded(true)}
+        onBlur={() => setIsExpanded(value.length > 0)}
+        placeholder={open ? placeholder : ""}
+        className={cn(
+          "h-8 rounded-md border-border bg-muted/50 text-sm shadow-none transition-[width,padding,color,background-color,border-color] duration-200 ease-out placeholder:text-muted-foreground focus-visible:bg-background",
+          open
+            ? "w-48 px-3 text-foreground"
+            : "w-0 px-0 text-transparent caret-foreground border-transparent",
+        )}
+      />
+    </div>
+  );
+}

--- a/client/src/components/ui/list-search.tsx
+++ b/client/src/components/ui/list-search.tsx
@@ -13,12 +13,7 @@ interface ListSearchProps {
   className?: string;
 }
 
-/**
- * Expandable search box for entity list tables. Collapses to an icon until
- * focused or non-empty, mirroring the search affordance used in the details
- * drawers. Filtering is owned by the caller; this component only manages the
- * expand/collapse presentation.
- */
+/** Expandable list-table search box; collapses to an icon, filtering owned by the caller. */
 export function ListSearch({
   value,
   onChange,

--- a/client/src/hooks/useDebouncedValue.ts
+++ b/client/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,10 @@
+import { useEffect, useState } from "react";
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = window.setTimeout(() => setDebounced(value), delayMs);
+    return () => window.clearTimeout(id);
+  }, [value, delayMs]);
+  return debounced;
+}

--- a/client/src/hooks/useLocalSearch.test.ts
+++ b/client/src/hooks/useLocalSearch.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useLocalSearch } from "./useLocalSearch";
+
+interface Row {
+  id: string;
+  name: string;
+}
+
+const items: Row[] = [
+  { id: "1", name: "Alpha" },
+  { id: "2", name: "Beta" },
+];
+
+const getText = (row: Row) => `${row.name} ${row.id}`;
+
+describe("useLocalSearch", () => {
+  it("returns all items when the query is empty", () => {
+    const { result } = renderHook(() => useLocalSearch(items, getText));
+    expect(result.current.results).toEqual(items);
+  });
+
+  it("filters by text once the debounce elapses", async () => {
+    const { result } = renderHook(() => useLocalSearch(items, getText, 50));
+
+    act(() => result.current.setQuery("alpha"));
+
+    await waitFor(() => {
+      expect(result.current.results).toEqual([items[0]]);
+    });
+  });
+
+  it("matches on the id field", async () => {
+    const { result } = renderHook(() => useLocalSearch(items, getText, 50));
+
+    act(() => result.current.setQuery("2"));
+
+    await waitFor(() => {
+      expect(result.current.results).toEqual([items[1]]);
+    });
+  });
+});

--- a/client/src/hooks/useLocalSearch.ts
+++ b/client/src/hooks/useLocalSearch.ts
@@ -1,0 +1,18 @@
+import { useMemo, useState } from "react";
+
+import { useDebouncedValue } from "./useDebouncedValue";
+
+/** Debounced client-side search over an in-memory list; pass a memoised `getText`. */
+export function useLocalSearch<T>(items: T[], getText: (item: T) => string, delayMs = 300) {
+  const [query, setQuery] = useState("");
+  const debouncedQuery = useDebouncedValue(query.trim().toLowerCase(), delayMs);
+
+  const results = useMemo(() => {
+    if (!debouncedQuery) {
+      return items;
+    }
+    return items.filter((item) => getText(item).toLowerCase().includes(debouncedQuery));
+  }, [items, getText, debouncedQuery]);
+
+  return { query, setQuery, results };
+}

--- a/client/src/i18n/locales/en-US/common.json
+++ b/client/src/i18n/locales/en-US/common.json
@@ -22,6 +22,7 @@
   "common.search.results": "Search results",
   "common.search.searching": "Searching...",
   "common.search.startTyping": "Type at least {count} characters to search.",
+  "common.searchLabel": "Search {entity}",
   "common.filter": "Filter",
   "common.export": "Export",
   "common.import": "Import",

--- a/client/src/i18n/locales/es-ES/common.json
+++ b/client/src/i18n/locales/es-ES/common.json
@@ -22,6 +22,7 @@
   "common.search.results": "Resultados de búsqueda",
   "common.search.searching": "Buscando...",
   "common.search.startTyping": "Escribe al menos {count} caracteres para buscar.",
+  "common.searchLabel": "Buscar {entity}",
   "common.filter": "Filtrar",
   "common.export": "Exportar",
   "common.import": "Importar",

--- a/client/src/i18n/locales/pt-BR/common.json
+++ b/client/src/i18n/locales/pt-BR/common.json
@@ -22,6 +22,7 @@
   "common.search.results": "Resultados da busca",
   "common.search.searching": "Buscando...",
   "common.search.startTyping": "Digite pelo menos {count} caracteres para buscar.",
+  "common.searchLabel": "Buscar {entity}",
   "common.filter": "Filtrar",
   "common.export": "Exportar",
   "common.import": "Importar",

--- a/client/src/pages/Servers.test.tsx
+++ b/client/src/pages/Servers.test.tsx
@@ -156,6 +156,31 @@ describe("Servers", () => {
     expect(screen.getByText("MCP Servers")).toBeInTheDocument();
   });
 
+  it("filters the loaded servers with the search box", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockResolvedValueOnce({
+      gateways: createMockServers(0, 3),
+      nextCursor: null,
+    });
+
+    renderWithRouter(<Servers />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Test Server 0")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Test Server 1")).toBeInTheDocument();
+
+    const search = screen.getByRole("searchbox", { name: "Search MCP Servers" });
+    await user.type(search, "Server 0");
+
+    expect(screen.getByText("Test Server 0")).toBeInTheDocument();
+    expect(screen.queryByText("Test Server 1")).not.toBeInTheDocument();
+
+    await user.clear(search);
+    await user.type(search, "zzz-none");
+    expect(screen.getByText("No matching results.")).toBeInTheDocument();
+  });
+
   it("renders the empty state Connect MCP server panel when no servers exist", async () => {
     vi.mocked(api.get).mockResolvedValueOnce({
       gateways: [],

--- a/client/src/pages/Servers.test.tsx
+++ b/client/src/pages/Servers.test.tsx
@@ -173,12 +173,16 @@ describe("Servers", () => {
     const search = screen.getByRole("searchbox", { name: "Search MCP Servers" });
     await user.type(search, "Server 0");
 
+    await waitFor(() => {
+      expect(screen.queryByText("Test Server 1")).not.toBeInTheDocument();
+    });
     expect(screen.getByText("Test Server 0")).toBeInTheDocument();
-    expect(screen.queryByText("Test Server 1")).not.toBeInTheDocument();
 
     await user.clear(search);
     await user.type(search, "zzz-none");
-    expect(screen.getByText("No matching results.")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("No matching results.")).toBeInTheDocument();
+    });
   });
 
   it("renders the empty state Connect MCP server panel when no servers exist", async () => {

--- a/client/src/pages/Servers.tsx
+++ b/client/src/pages/Servers.tsx
@@ -10,6 +10,7 @@ import { ConfirmDialog } from "@/components/servers/ConfirmDialog";
 import { TestConnectionDialog } from "@/components/servers/TestConnectionDialog";
 import { MCPServerDetailsPanel } from "@/components/servers/MCPServerDetailsPanel";
 import { useQuery } from "@/hooks/useQuery";
+import { useLocalSearch } from "@/hooks/useLocalSearch";
 import { ApiError, api } from "@/api/client";
 import { serversApi } from "@/api/servers";
 import { useRouter } from "@/router";
@@ -37,7 +38,6 @@ export function Servers() {
   const [loadingMore, setLoadingMore] = useState(false);
   const [selectedServerIdForDetails, setSelectedServerIdForDetails] = useState<string | null>(null);
   const [isDetailsDrawerOpen, setIsDetailsDrawerOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
   const selectedSearchServerId = useMemo(() => {
     const queryString = path.split("?")[1] ?? "";
     return new URLSearchParams(queryString).get("selected")?.trim() || null;
@@ -98,15 +98,11 @@ export function Servers() {
   // Derive servers from accumulated list
   const servers = allServers;
 
-  const filteredServers = useMemo(() => {
-    const query = searchQuery.trim().toLowerCase();
-    if (!query) return servers;
-    return servers.filter(
-      (server) =>
-        server.name.toLowerCase().includes(query) ||
-        (server.description ?? "").toLowerCase().includes(query),
-    );
-  }, [servers, searchQuery]);
+  const getServerText = useCallback(
+    (server: MCPServer) => `${server.name} ${server.description ?? ""} ${server.id}`,
+    [],
+  );
+  const { query, setQuery, results: filteredServers } = useLocalSearch(servers, getServerText);
 
   // Convert query error to string for display
   const error = queryError ? queryError.message : null;
@@ -315,8 +311,8 @@ export function Servers() {
                 </h1>
                 <div className="flex items-center gap-3">
                   <ListSearch
-                    value={searchQuery}
-                    onChange={setSearchQuery}
+                    value={query}
+                    onChange={setQuery}
                     ariaLabel={intl.formatMessage(
                       { id: "common.searchLabel" },
                       { entity: intl.formatMessage({ id: "mcpServer.title" }) },
@@ -343,7 +339,7 @@ export function Servers() {
                 onViewDetails={handleViewDetails}
                 onToggleEnabled={handleToggleEnabled}
               />
-              {searchQuery.trim() && filteredServers.length === 0 && (
+              {query.trim() && filteredServers.length === 0 && (
                 <p className="mt-6 text-sm text-muted-foreground">
                   {intl.formatMessage({ id: "common.search.noResults" })}
                 </p>
@@ -374,7 +370,7 @@ export function Servers() {
                     </select>
                   </div>
                 </div>
-                {!searchQuery.trim() && nextCursor && (
+                {!query.trim() && nextCursor && (
                   <Button
                     variant="outline"
                     size="sm"

--- a/client/src/pages/Servers.tsx
+++ b/client/src/pages/Servers.tsx
@@ -5,6 +5,7 @@ import { MCPIcon } from "@/components/icons/MCPIcon";
 import { Button } from "@/components/ui/button";
 import { MCPServerForm } from "@/components/mcp-servers/MCPServerForm";
 import { ServersTable } from "@/components/servers/ServersTable";
+import { ListSearch } from "@/components/ui/list-search";
 import { ConfirmDialog } from "@/components/servers/ConfirmDialog";
 import { TestConnectionDialog } from "@/components/servers/TestConnectionDialog";
 import { MCPServerDetailsPanel } from "@/components/servers/MCPServerDetailsPanel";
@@ -36,6 +37,7 @@ export function Servers() {
   const [loadingMore, setLoadingMore] = useState(false);
   const [selectedServerIdForDetails, setSelectedServerIdForDetails] = useState<string | null>(null);
   const [isDetailsDrawerOpen, setIsDetailsDrawerOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const selectedSearchServerId = useMemo(() => {
     const queryString = path.split("?")[1] ?? "";
     return new URLSearchParams(queryString).get("selected")?.trim() || null;
@@ -95,6 +97,16 @@ export function Servers() {
 
   // Derive servers from accumulated list
   const servers = allServers;
+
+  const filteredServers = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) return servers;
+    return servers.filter(
+      (server) =>
+        server.name.toLowerCase().includes(query) ||
+        (server.description ?? "").toLowerCase().includes(query),
+    );
+  }, [servers, searchQuery]);
 
   // Convert query error to string for display
   const error = queryError ? queryError.message : null;
@@ -301,18 +313,29 @@ export function Servers() {
                 <h1 className="text-base font-semibold text-foreground">
                   {intl.formatMessage({ id: "mcpServer.title" })}
                 </h1>
-                <Button
-                  variant="default"
-                  className="h-7 rounded-sm px-4"
-                  onClick={() => setIsFormOpen(true)}
-                >
-                  <Plus className="h-4 w-4" />
-                  Connect
-                </Button>
+                <div className="flex items-center gap-3">
+                  <ListSearch
+                    value={searchQuery}
+                    onChange={setSearchQuery}
+                    ariaLabel={intl.formatMessage(
+                      { id: "common.searchLabel" },
+                      { entity: intl.formatMessage({ id: "mcpServer.title" }) },
+                    )}
+                    placeholder={intl.formatMessage({ id: "common.search" })}
+                  />
+                  <Button
+                    variant="default"
+                    className="h-7 rounded-sm px-4"
+                    onClick={() => setIsFormOpen(true)}
+                  >
+                    <Plus className="h-4 w-4" />
+                    Connect
+                  </Button>
+                </div>
               </div>
 
               <ServersTable
-                servers={servers}
+                servers={filteredServers}
                 isLoading={isLoading}
                 onEdit={handleEdit}
                 onDelete={handleDelete}
@@ -320,11 +343,16 @@ export function Servers() {
                 onViewDetails={handleViewDetails}
                 onToggleEnabled={handleToggleEnabled}
               />
+              {searchQuery.trim() && filteredServers.length === 0 && (
+                <p className="mt-6 text-sm text-muted-foreground">
+                  {intl.formatMessage({ id: "common.search.noResults" })}
+                </p>
+              )}
 
               <div className="flex items-center justify-between mt-6">
                 <div className="flex items-center gap-4">
                   <div className="text-sm text-gray-600 dark:text-gray-400">
-                    Showing {servers.length} server{servers.length !== 1 ? "s" : ""}
+                    Showing {filteredServers.length} server{filteredServers.length !== 1 ? "s" : ""}
                   </div>
                   <div className="flex items-center gap-2">
                     <label
@@ -346,7 +374,7 @@ export function Servers() {
                     </select>
                   </div>
                 </div>
-                {nextCursor && (
+                {!searchQuery.trim() && nextCursor && (
                   <Button
                     variant="outline"
                     size="sm"

--- a/client/src/pages/Teams.test.tsx
+++ b/client/src/pages/Teams.test.tsx
@@ -224,6 +224,31 @@ describe("Teams", () => {
     expect(screen.getByText("Team 9")).toBeInTheDocument();
   });
 
+  it("filters the loaded teams with the search box", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockResolvedValueOnce({
+      teams: createMockTeams(0, 3),
+      nextCursor: null,
+    });
+
+    renderWithRouter(<Teams />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Team 0")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Team 1")).toBeInTheDocument();
+
+    const search = screen.getByRole("searchbox", { name: "Search Teams" });
+    await user.type(search, "Team 0");
+
+    expect(screen.getByText("Team 0")).toBeInTheDocument();
+    expect(screen.queryByText("Team 1")).not.toBeInTheDocument();
+
+    await user.clear(search);
+    await user.type(search, "zzz-none");
+    expect(screen.getByText("No matching results.")).toBeInTheDocument();
+  });
+
   it("displays correct team count message", async () => {
     vi.mocked(api.get).mockResolvedValueOnce({
       teams: createMockTeams(0, 5),

--- a/client/src/pages/Teams.test.tsx
+++ b/client/src/pages/Teams.test.tsx
@@ -241,12 +241,16 @@ describe("Teams", () => {
     const search = screen.getByRole("searchbox", { name: "Search Teams" });
     await user.type(search, "Team 0");
 
+    await waitFor(() => {
+      expect(screen.queryByText("Team 1")).not.toBeInTheDocument();
+    });
     expect(screen.getByText("Team 0")).toBeInTheDocument();
-    expect(screen.queryByText("Team 1")).not.toBeInTheDocument();
 
     await user.clear(search);
     await user.type(search, "zzz-none");
-    expect(screen.getByText("No matching results.")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("No matching results.")).toBeInTheDocument();
+    });
   });
 
   it("displays correct team count message", async () => {

--- a/client/src/pages/Teams.tsx
+++ b/client/src/pages/Teams.tsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import { toast } from "sonner";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ListSearch } from "@/components/ui/list-search";
 import { TeamsTable } from "@/components/teams/TeamsTable";
 import { TeamForm } from "@/components/teams/TeamForm";
 import { ConfirmDialog } from "@/components/servers/ConfirmDialog";
@@ -27,6 +28,7 @@ export function Teams() {
   const [membersDialogOpen, setMembersDialogOpen] = useState(false);
   const [teamForMembers, setTeamForMembers] = useState<Team | null>(null);
   const [teamToEdit, setTeamToEdit] = useState<Team | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
 
   const queryPath = useMemo(() => {
     const params = new URLSearchParams();
@@ -47,6 +49,16 @@ export function Teams() {
       setNextCursor(response.nextCursor ?? null);
     }
   }, [response]);
+
+  const filteredTeams = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) return allTeams;
+    return allTeams.filter(
+      (team) =>
+        team.name.toLowerCase().includes(query) ||
+        (team.description ?? "").toLowerCase().includes(query),
+    );
+  }, [allTeams, searchQuery]);
 
   const error = queryError ? queryError.message : null;
 
@@ -207,28 +219,44 @@ export function Teams() {
                 <h1 className="text-base font-semibold text-foreground">
                   {intl.formatMessage({ id: "teams.all.title" })}
                 </h1>
-                <Button
-                  variant="default"
-                  className="h-7 rounded-sm px-4"
-                  onClick={() => setCreateFormOpen(true)}
-                >
-                  <Plus className="h-4 w-4" />
-                  {intl.formatMessage({ id: "teams.createTeam" })}
-                </Button>
+                <div className="flex items-center gap-3">
+                  <ListSearch
+                    value={searchQuery}
+                    onChange={setSearchQuery}
+                    ariaLabel={intl.formatMessage(
+                      { id: "common.searchLabel" },
+                      { entity: intl.formatMessage({ id: "navigation.teams" }) },
+                    )}
+                    placeholder={intl.formatMessage({ id: "common.search" })}
+                  />
+                  <Button
+                    variant="default"
+                    className="h-7 rounded-sm px-4"
+                    onClick={() => setCreateFormOpen(true)}
+                  >
+                    <Plus className="h-4 w-4" />
+                    {intl.formatMessage({ id: "teams.createTeam" })}
+                  </Button>
+                </div>
               </div>
 
               <TeamsTable
-                teams={allTeams}
+                teams={filteredTeams}
                 isLoading={false}
                 onEdit={handleEdit}
                 onManageMembers={handleManageMembers}
                 onDelete={handleDelete}
               />
+              {searchQuery.trim() && filteredTeams.length === 0 && (
+                <p className="mt-6 text-sm text-muted-foreground">
+                  {intl.formatMessage({ id: "common.search.noResults" })}
+                </p>
+              )}
 
               <div className="flex items-center justify-between mt-6">
                 <div className="flex items-center gap-4">
                   <div className="text-sm text-gray-600 dark:text-gray-400">
-                    {intl.formatMessage({ id: "teams.showing" }, { count: allTeams.length })}
+                    {intl.formatMessage({ id: "teams.showing" }, { count: filteredTeams.length })}
                   </div>
                   <div className="flex items-center gap-2">
                     <label
@@ -250,7 +278,7 @@ export function Teams() {
                     </select>
                   </div>
                 </div>
-                {nextCursor && (
+                {!searchQuery.trim() && nextCursor && (
                   <Button
                     variant="outline"
                     size="sm"

--- a/client/src/pages/Teams.tsx
+++ b/client/src/pages/Teams.tsx
@@ -9,6 +9,7 @@ import { TeamForm } from "@/components/teams/TeamForm";
 import { ConfirmDialog } from "@/components/servers/ConfirmDialog";
 import { ManageTeamMembersDialog } from "@/components/teams/ManageTeamMembersDialog";
 import { useQuery } from "@/hooks/useQuery";
+import { useLocalSearch } from "@/hooks/useLocalSearch";
 import { api } from "@/api/client";
 import { deleteTeam } from "@/api/teams";
 import type { Team, TeamsResponse } from "@/types/team";
@@ -28,7 +29,6 @@ export function Teams() {
   const [membersDialogOpen, setMembersDialogOpen] = useState(false);
   const [teamForMembers, setTeamForMembers] = useState<Team | null>(null);
   const [teamToEdit, setTeamToEdit] = useState<Team | null>(null);
-  const [searchQuery, setSearchQuery] = useState("");
 
   const queryPath = useMemo(() => {
     const params = new URLSearchParams();
@@ -50,15 +50,11 @@ export function Teams() {
     }
   }, [response]);
 
-  const filteredTeams = useMemo(() => {
-    const query = searchQuery.trim().toLowerCase();
-    if (!query) return allTeams;
-    return allTeams.filter(
-      (team) =>
-        team.name.toLowerCase().includes(query) ||
-        (team.description ?? "").toLowerCase().includes(query),
-    );
-  }, [allTeams, searchQuery]);
+  const getTeamText = useCallback(
+    (team: Team) => `${team.name} ${team.description ?? ""} ${team.id}`,
+    [],
+  );
+  const { query, setQuery, results } = useLocalSearch(allTeams, getTeamText);
 
   const error = queryError ? queryError.message : null;
 
@@ -221,8 +217,8 @@ export function Teams() {
                 </h1>
                 <div className="flex items-center gap-3">
                   <ListSearch
-                    value={searchQuery}
-                    onChange={setSearchQuery}
+                    value={query}
+                    onChange={setQuery}
                     ariaLabel={intl.formatMessage(
                       { id: "common.searchLabel" },
                       { entity: intl.formatMessage({ id: "navigation.teams" }) },
@@ -241,13 +237,13 @@ export function Teams() {
               </div>
 
               <TeamsTable
-                teams={filteredTeams}
+                teams={results}
                 isLoading={false}
                 onEdit={handleEdit}
                 onManageMembers={handleManageMembers}
                 onDelete={handleDelete}
               />
-              {searchQuery.trim() && filteredTeams.length === 0 && (
+              {query.trim() && results.length === 0 && (
                 <p className="mt-6 text-sm text-muted-foreground">
                   {intl.formatMessage({ id: "common.search.noResults" })}
                 </p>
@@ -256,7 +252,7 @@ export function Teams() {
               <div className="flex items-center justify-between mt-6">
                 <div className="flex items-center gap-4">
                   <div className="text-sm text-gray-600 dark:text-gray-400">
-                    {intl.formatMessage({ id: "teams.showing" }, { count: filteredTeams.length })}
+                    {intl.formatMessage({ id: "teams.showing" }, { count: results.length })}
                   </div>
                   <div className="flex items-center gap-2">
                     <label
@@ -278,7 +274,7 @@ export function Teams() {
                     </select>
                   </div>
                 </div>
-                {!searchQuery.trim() && nextCursor && (
+                {!query.trim() && nextCursor && (
                   <Button
                     variant="outline"
                     size="sm"

--- a/client/src/pages/Users.test.tsx
+++ b/client/src/pages/Users.test.tsx
@@ -192,12 +192,16 @@ describe("Users", () => {
     const search = screen.getByRole("searchbox", { name: "Search Users" });
     await user.type(search, "user0");
 
+    await waitFor(() => {
+      expect(screen.queryByText("user1@example.com")).not.toBeInTheDocument();
+    });
     expect(screen.getByText("user0@example.com")).toBeInTheDocument();
-    expect(screen.queryByText("user1@example.com")).not.toBeInTheDocument();
 
     await user.clear(search);
     await user.type(search, "zzz-none");
-    expect(screen.getByText("No matching results.")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("No matching results.")).toBeInTheDocument();
+    });
   });
 
   it("renders users title/header", async () => {

--- a/client/src/pages/Users.test.tsx
+++ b/client/src/pages/Users.test.tsx
@@ -175,6 +175,31 @@ describe("Users", () => {
     });
   });
 
+  it("filters the loaded users with the search box", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockResolvedValueOnce({
+      users: createMockUsers(0, 2),
+      nextCursor: null,
+    });
+
+    renderWithRouter(<Users />);
+
+    await waitFor(() => {
+      expect(screen.getByText("user0@example.com")).toBeInTheDocument();
+    });
+    expect(screen.getByText("user1@example.com")).toBeInTheDocument();
+
+    const search = screen.getByRole("searchbox", { name: "Search Users" });
+    await user.type(search, "user0");
+
+    expect(screen.getByText("user0@example.com")).toBeInTheDocument();
+    expect(screen.queryByText("user1@example.com")).not.toBeInTheDocument();
+
+    await user.clear(search);
+    await user.type(search, "zzz-none");
+    expect(screen.getByText("No matching results.")).toBeInTheDocument();
+  });
+
   it("renders users title/header", async () => {
     vi.mocked(api.get).mockResolvedValueOnce({ users: createMockUsers(0, 1), nextCursor: null });
 

--- a/client/src/pages/Users.tsx
+++ b/client/src/pages/Users.tsx
@@ -3,6 +3,7 @@ import { Plus } from "lucide-react";
 import { useIntl } from "react-intl";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { ListSearch } from "@/components/ui/list-search";
 import { UserForm } from "@/components/users/UserForm";
 import { UsersTable } from "@/components/users/UsersTable";
 import { DeleteUserDialog } from "@/components/users/DeleteUserDialog";
@@ -35,6 +36,7 @@ export function Users() {
   const [userToEdit, setUserToEdit] = useState<User | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [userToDelete, setUserToDelete] = useState<User | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
   const selectedSearchUserId = useMemo(() => {
     const queryString = path.split("?")[1] ?? "";
     return new URLSearchParams(queryString).get("selected")?.trim() || null;
@@ -169,6 +171,16 @@ export function Users() {
 
   const error = queryError ? queryError.message : null;
 
+  const filteredUsers = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) return allUsers;
+    return allUsers.filter(
+      (user) =>
+        (user.full_name ?? "").toLowerCase().includes(query) ||
+        user.email.toLowerCase().includes(query),
+    );
+  }, [allUsers, searchQuery]);
+
   return (
     <main className="p-6">
       {isFormOpen ? (
@@ -204,14 +216,25 @@ export function Users() {
             <h1 className="text-xl font-semibold text-foreground">
               {intl.formatMessage({ id: "users.title" })}
             </h1>
-            <Button
-              onClick={() => setIsFormOpen(true)}
-              className="gap-2"
-              aria-label={intl.formatMessage({ id: "users.createUser" })}
-            >
-              <Plus className="h-4 w-4" aria-hidden="true" />
-              {intl.formatMessage({ id: "users.createUser" })}
-            </Button>
+            <div className="flex items-center gap-3">
+              <ListSearch
+                value={searchQuery}
+                onChange={setSearchQuery}
+                ariaLabel={intl.formatMessage(
+                  { id: "common.searchLabel" },
+                  { entity: intl.formatMessage({ id: "navigation.users" }) },
+                )}
+                placeholder={intl.formatMessage({ id: "common.search" })}
+              />
+              <Button
+                onClick={() => setIsFormOpen(true)}
+                className="gap-2"
+                aria-label={intl.formatMessage({ id: "users.createUser" })}
+              >
+                <Plus className="h-4 w-4" aria-hidden="true" />
+                {intl.formatMessage({ id: "users.createUser" })}
+              </Button>
+            </div>
           </header>
           {isLoading ? (
             <div
@@ -242,15 +265,23 @@ export function Users() {
               {allUsers.length > 0 ? (
                 <>
                   <UsersTable
-                    users={allUsers}
+                    users={filteredUsers}
                     onDeleteClick={handleDeleteClick}
                     onEditClick={handleEditClick}
                   />
+                  {searchQuery.trim() && filteredUsers.length === 0 && (
+                    <p className="mt-6 text-sm text-muted-foreground">
+                      {intl.formatMessage({ id: "common.search.noResults" })}
+                    </p>
+                  )}
 
                   <div className="mt-6 flex items-center justify-between">
                     <div className="flex items-center gap-4">
                       <div className="text-sm text-muted-foreground">
-                        {intl.formatMessage({ id: "users.showing" }, { count: allUsers.length })}
+                        {intl.formatMessage(
+                          { id: "users.showing" },
+                          { count: filteredUsers.length },
+                        )}
                       </div>
                       <div className="flex items-center gap-2">
                         <label
@@ -272,7 +303,7 @@ export function Users() {
                         </select>
                       </div>
                     </div>
-                    {nextCursor && (
+                    {!searchQuery.trim() && nextCursor && (
                       <Button
                         variant="outline"
                         size="sm"

--- a/client/src/pages/Users.tsx
+++ b/client/src/pages/Users.tsx
@@ -9,6 +9,7 @@ import { UsersTable } from "@/components/users/UsersTable";
 import { DeleteUserDialog } from "@/components/users/DeleteUserDialog";
 import { useUsersList } from "@/hooks/useUsersList";
 import { useQuery } from "@/hooks/useQuery";
+import { useLocalSearch } from "@/hooks/useLocalSearch";
 import { usersApi } from "@/api/users";
 import { ApiError } from "@/api/client";
 import { createOptimisticUser } from "@/hooks/useUserForm";
@@ -36,7 +37,6 @@ export function Users() {
   const [userToEdit, setUserToEdit] = useState<User | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [userToDelete, setUserToDelete] = useState<User | null>(null);
-  const [searchQuery, setSearchQuery] = useState("");
   const selectedSearchUserId = useMemo(() => {
     const queryString = path.split("?")[1] ?? "";
     return new URLSearchParams(queryString).get("selected")?.trim() || null;
@@ -171,15 +171,8 @@ export function Users() {
 
   const error = queryError ? queryError.message : null;
 
-  const filteredUsers = useMemo(() => {
-    const query = searchQuery.trim().toLowerCase();
-    if (!query) return allUsers;
-    return allUsers.filter(
-      (user) =>
-        (user.full_name ?? "").toLowerCase().includes(query) ||
-        user.email.toLowerCase().includes(query),
-    );
-  }, [allUsers, searchQuery]);
+  const getUserText = useCallback((user: User) => `${user.full_name ?? ""} ${user.email}`, []);
+  const { query, setQuery, results } = useLocalSearch(allUsers, getUserText);
 
   return (
     <main className="p-6">
@@ -218,8 +211,8 @@ export function Users() {
             </h1>
             <div className="flex items-center gap-3">
               <ListSearch
-                value={searchQuery}
-                onChange={setSearchQuery}
+                value={query}
+                onChange={setQuery}
                 ariaLabel={intl.formatMessage(
                   { id: "common.searchLabel" },
                   { entity: intl.formatMessage({ id: "navigation.users" }) },
@@ -265,11 +258,11 @@ export function Users() {
               {allUsers.length > 0 ? (
                 <>
                   <UsersTable
-                    users={filteredUsers}
+                    users={results}
                     onDeleteClick={handleDeleteClick}
                     onEditClick={handleEditClick}
                   />
-                  {searchQuery.trim() && filteredUsers.length === 0 && (
+                  {query.trim() && results.length === 0 && (
                     <p className="mt-6 text-sm text-muted-foreground">
                       {intl.formatMessage({ id: "common.search.noResults" })}
                     </p>
@@ -278,10 +271,7 @@ export function Users() {
                   <div className="mt-6 flex items-center justify-between">
                     <div className="flex items-center gap-4">
                       <div className="text-sm text-muted-foreground">
-                        {intl.formatMessage(
-                          { id: "users.showing" },
-                          { count: filteredUsers.length },
-                        )}
+                        {intl.formatMessage({ id: "users.showing" }, { count: results.length })}
                       </div>
                       <div className="flex items-center gap-2">
                         <label
@@ -303,7 +293,7 @@ export function Users() {
                         </select>
                       </div>
                     </div>
-                    {!searchQuery.trim() && nextCursor && (
+                    {!query.trim() && nextCursor && (
                       <Button
                         variant="outline"
                         size="sm"


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Relates to #5109

---

## 📝 Summary

Adds a local (client-side) search box to the entity list tables so users can quickly filter the rows already loaded on the page.

- New shared `ListSearch` component (`components/ui/list-search.tsx`) — an expandable search input mirroring the affordance already used in the details drawers.
- Wired into the three list-table pages that have real tables today: **Users**, **Teams**, and **MCP Servers**. Each filters its loaded rows by the entity's key text fields (name/email, name/description).
- Search is debounced (~300ms) and shared across the three tables via a reusable `useLocalSearch(items, getText)` hook; matches on the entity's `id` in addition to name/description.
- Filtering is applied over the rows already fetched; the "Load more" control is hidden while a query is active, and a "No matching results." message is shown when nothing matches.

_Note: Tools/Resources/Prompts list pages render grouped card grids (their tables live only in the per-source drawers), and Agents/Tokens/LLM pages are still stubs — so this covers the entity pages that actually render a list table today._

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

---

## 🏷️ Type of Change

- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Lint | `cd client && npm run lint` | ✅ |
| Format | `cd client && npm run format:check` | ✅ |
| Unit tests | `cd client && npm run test:run` | ✅ 2513 passed |

Manual: on the Users, Teams and MCP Servers pages, typing in the search box filters the loaded rows live; clearing it restores the full list; a non-matching query shows "No matching results.".

---

## ✅ Checklist

- [x] Code formatted
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 🎥 Demo

<!-- drag pr-c-local-search.mp4 here -->


https://github.com/user-attachments/assets/80c6ff17-7d8b-408d-983a-48d40eb089fc


