### PR TITLE
chore: fix pip-audit

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-24T13:48:49Z",
+  "generated_at": "2026-07-24T15:22:57Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7750,
+        "line_number": 7759,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-24T12:36:31Z",
+  "generated_at": "2026-07-24T13:48:49Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -258,7 +258,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1922,
+        "line_number": 1920,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2010,
+        "line_number": 2008,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2360,
+        "line_number": 2358,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3725,
+        "line_number": 3723,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3816,
+        "line_number": 3814,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3859,
+        "line_number": 3857,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3864,
+        "line_number": 3862,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3869,
+        "line_number": 3867,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,6 @@
 ### Fixed
 
 - Fixed RBAC seeder race condition that produced HTTP 500 under concurrent bootstrap: added partial unique indexes on `roles(name, scope) WHERE is_active` and `user_roles` equivalent columns, plus savepoint/retry in `RoleService.create_role()` and `assign_role_to_user()`. The migration (`d21698ae4a19`) now also remaps `user_roles.role_id` from duplicate roles to the kept role before deactivating the duplicates (so `list_user_roles()` joins remain intact), and prefers unexpired / most-recently-granted assignments when deduplicating user-role rows (#4636)
-### Security
-
-- **[CRITICAL] Unconditional weak-secret rejection** (GHSA-8pcq-mx48-hjvj) - `JWT_SECRET_KEY` and `AUTH_ENCRYPTION_SECRET` placeholder and known-weak values now cause `SecurityConfigurationError` at startup in **every** environment, including development. The previous `env != "development"` carve-out and `changeme` → `__REPLACE_ME__` default are both closed. `BASIC_AUTH_PASSWORD` is also patched to a strong value by `make setup` / `make init-secrets-patch-env`. Run `make setup` (fresh checkout) or `make init-secrets-patch-env` (existing `.env`) to provision real secrets.
-
-### Fixed
-
 - **Startup secret validation** - `JWT_SECRET_KEY`, `AUTH_ENCRYPTION_SECRET`, and `BASIC_AUTH_PASSWORD` are validated at startup with a minimum 32-byte length requirement and a comprehensive blocklist of known-weak values. Weak secrets previously only rejected in non-development environments now fail unconditionally across all environments.
 - **Hardened Helm chart defaults** - `JWT_SECRET_KEY` in `charts/mcp-stack/values.yaml` now defaults to an empty string with deployment guidance, rather than shipping a sample weak key.
 - **Docker Compose and entrypoint hardening** - Compose `:?` variable guards and entrypoint secret checks updated to match the new enforcement policy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **Unconditional weak-secret rejection** - `JWT_SECRET_KEY` and `AUTH_ENCRYPTION_SECRET` placeholder and known-weak values now cause `SecurityConfigurationError` at startup in **every** environment, including development. The previous `env != "development"` carve-out and `changeme` → `__REPLACE_ME__` default are both closed. `BASIC_AUTH_PASSWORD` is also patched to a strong value by `make setup` / `make init-secrets-patch-env`. Run `make setup` (fresh checkout) or `make init-secrets-patch-env` (existing `.env`) to provision real secrets.
+
 ### Fixed
 
 - Fixed RBAC seeder race condition that produced HTTP 500 under concurrent bootstrap: added partial unique indexes on `roles(name, scope) WHERE is_active` and `user_roles` equivalent columns, plus savepoint/retry in `RoleService.create_role()` and `assign_role_to_user()`. The migration (`d21698ae4a19`) now also remaps `user_roles.role_id` from duplicate roles to the kept role before deactivating the duplicates (so `list_user_roles()` joins remain intact), and prefers unexpired / most-recently-granted assignments when deduplicating user-role rows (#4636)

--- a/Makefile
+++ b/Makefile
@@ -7447,6 +7447,15 @@ prospector:                         ## 🔬 Comprehensive code analysis
 
 pip-audit:                          ## 🔒 Audit Python dependencies for CVEs
 	@echo "🔒  pip-audit vulnerability scan..."
+	@echo ""
+	@echo "  ⚠️  NOTE: --skip-editable is active. Two editable installs are expected to be skipped:"
+	@echo "       • compliance-reference-server   (mcp-servers/ dev install)"
+	@echo "       • mcp-contextforge-gateway      (main gateway dev install)"
+	@echo ""
+	@echo "  🚨 If ANY OTHER package appears in the skip table → STOP and investigate."
+	@echo "     It may have active CVEs that are being silently suppressed."
+	@echo "     To audit it manually: pip-audit --path <pkg-path> --no-deps"
+	@echo ""
 	@test -d "$(VENV_DIR)" || $(MAKE) venv
 	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
 		$(UV_BIN) pip install -q pip-audit && \

--- a/Makefile
+++ b/Makefile
@@ -7450,7 +7450,7 @@ pip-audit:                          ## 🔒 Audit Python dependencies for CVEs
 	@test -d "$(VENV_DIR)" || $(MAKE) venv
 	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
 		$(UV_BIN) pip install -q pip-audit && \
-		pip-audit --strict || true"
+		pip-audit --skip-editable || true"
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,14 +219,14 @@ dev = [
     "url-normalize>=3.0.0",
     "uv>=0.11.6",
     "websockets>=16.0",
-    "pyasn1>=0.6.3", # a2a-sdk; https://github.com/IBM/mcp-context-forge/security/dependabot/73
+    "pyasn1>=0.6.4", # a2a-sdk; https://github.com/IBM/mcp-context-forge/security/dependabot/73
     "tornado>=6.5.7",  # transitive via jupyter; CVE-2026-31958
     # gRPC plugin framework testing (optional at runtime, required for test coverage)
     "grpcio>=1.81.1",
     "grpcio-reflection>=1.81.1",
     "grpcio-tools>=1.81.1",
     "pipdeptree>=3.1.0",
-    "setuptools>=82.0.1",
+    "setuptools>=83.0.0",
     "debugpy>=1.8.21",
     "maturin>=1.14.1",
     "Pygments>=2.20.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3307,7 +3307,7 @@ dev = [
     { name = "playwright", specifier = ">=1.61.0" },
     { name = "pre-commit", specifier = ">=4.6.0" },
     { name = "prospector", extras = ["with-everything"], specifier = ">=1.19.0" },
-    { name = "pyasn1", specifier = ">=0.6.3" },
+    { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "pydocstyle", specifier = ">=6.3.0" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyrefly", specifier = ">=1.1.1" },
@@ -3336,7 +3336,7 @@ dev = [
     { name = "rich", specifier = ">=15.0.0" },
     { name = "schemathesis", specifier = ">=4.15.2" },
     { name = "settings-doc", specifier = ">=4.3.2" },
-    { name = "setuptools", specifier = ">=82.0.1" },
+    { name = "setuptools", specifier = ">=83.0.0" },
     { name = "snakeviz", specifier = ">=2.2.2" },
     { name = "tomlkit", specifier = ">=0.15.0" },
     { name = "tornado", specifier = ">=6.5.7" },
@@ -4466,11 +4466,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]
@@ -5811,11 +5811,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #5709 
https://github.ibm.com/contextforge-org/internal_issues/issues/467

---

## 📝 Summary

Hardens Python dependency minimums and fixes the `make pip-audit` invocation so the scan completes cleanly.

- `Makefile`: replaced `pip-audit --strict` with `pip-audit --skip-editable` — `--strict` was aborting the entire scan when encountering local editable packages (e.g. `compliance-reference-server`) that are not published to PyPI
- `pyproject.toml`: bumped minimum versions for two dependencies to pick up upstream hardening releases
- `uv.lock`: regenerated to pin the updated versions
- Fix Changelog - remove duplicated `Fixed` section and added `Breaking Change` Header

Before fix : - False Positive

```pip-audit vulnerability scan...

ERROR:pip_audit._cli:compliance-reference-server: Dependency not found on PyPI and could not be audited: compliance-reference-server (0.2.0)
```


After fix : 
```

Name                        Skip Reason
--------------------------- -------------------------------
compliance-reference-server distribution marked as editable
mcp-contextforge-gateway    distribution marked as editable


```
---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Chore (deps, CI, tooling)

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| pip-audit scan | `make pip-audit` | ✅ No known vulnerabilities found |
| Lint suite | `make lint` | |
| Unit tests | `make test` | |
| Coverage ≥ 80% | `make coverage` | |

**`make pip-audit` output after fix:**