### PR TITLE
fix(ui): hide description line in server drawers when empty

### DIFF
--- a/client/src/components/gateways/VirtualServerDetailsPanel.test.tsx
+++ b/client/src/components/gateways/VirtualServerDetailsPanel.test.tsx
@@ -281,19 +281,6 @@ describe("VirtualServerDetailsPanel render variants", () => {
     expect(await screen.findByText("Private")).toBeInTheDocument();
   });
 
-  it("shows a placeholder when the server has no description", async () => {
-    render(
-      <VirtualServerDetailsPanel
-        server={makeServer({ description: "" })}
-        error={null}
-        open
-        onClose={vi.fn()}
-        onAddSources={vi.fn()}
-      />,
-    );
-    expect(await screen.findByText("No description provided.")).toBeInTheDocument();
-  });
-
   it("shows N/A when the server has no version", async () => {
     render(
       <VirtualServerDetailsPanel

--- a/client/src/components/gateways/VirtualServerDetailsPanel.tsx
+++ b/client/src/components/gateways/VirtualServerDetailsPanel.tsx
@@ -432,9 +432,11 @@ export function VirtualServerDetailsPanel({
                 </Button>
               </div>
 
-              <p className="mt-7 max-w-4xl text-[15px] leading-6 text-muted-foreground">
-                {server.description || intl.formatMessage({ id: "gateways.details.noDescription" })}
-              </p>
+              {server.description && (
+                <p className="mt-7 max-w-4xl text-[15px] leading-6 text-muted-foreground">
+                  {server.description}
+                </p>
+              )}
 
               <div className="my-8 h-px bg-border" />
 

--- a/client/src/components/servers/MCPServerDetailsPanel.tsx
+++ b/client/src/components/servers/MCPServerDetailsPanel.tsx
@@ -319,9 +319,11 @@ export function MCPServerDetailsPanel({
                 </div>
               </div>
 
-              <p className="mt-7 max-w-4xl text-[15px] leading-6 text-muted-foreground">
-                {server.description || "No description provided"}
-              </p>
+              {server.description && (
+                <p className="mt-7 max-w-4xl text-[15px] leading-6 text-muted-foreground">
+                  {server.description}
+                </p>
+              )}
 
               <div className="my-8 h-px bg-border" />
 

--- a/client/src/i18n/locales/en-US/gateways.json
+++ b/client/src/i18n/locales/en-US/gateways.json
@@ -87,7 +87,6 @@
   "gateways.details.sheetDescription": "Virtual server details and activity.",
   "gateways.details.addSource": "Add source",
   "gateways.details.addSources": "Add sources",
-  "gateways.details.noDescription": "No description provided.",
   "gateways.details.components": "Components",
   "gateways.details.addComponents": "Add components",
   "gateways.details.filter.all": "All",

--- a/client/src/i18n/locales/es-ES/gateways.json
+++ b/client/src/i18n/locales/es-ES/gateways.json
@@ -87,7 +87,6 @@
   "gateways.details.sheetDescription": "Detalles y actividad del servidor virtual.",
   "gateways.details.addSource": "Agregar fuente",
   "gateways.details.addSources": "Agregar fuentes",
-  "gateways.details.noDescription": "No se proporcionó descripción.",
   "gateways.details.components": "Componentes",
   "gateways.details.addComponents": "Agregar componentes",
   "gateways.details.filter.all": "Todos",

--- a/client/src/i18n/locales/pt-BR/gateways.json
+++ b/client/src/i18n/locales/pt-BR/gateways.json
@@ -87,7 +87,6 @@
   "gateways.details.sheetDescription": "Detalhes e atividade do servidor virtual.",
   "gateways.details.addSource": "Adicionar fonte",
   "gateways.details.addSources": "Adicionar fontes",
-  "gateways.details.noDescription": "Nenhuma descrição fornecida.",
   "gateways.details.components": "Componentes",
   "gateways.details.addComponents": "Adicionar componentes",
   "gateways.details.filter.all": "Todos",


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #5715

---

## 📝 Summary

The MCP server and virtual server detail drawers both rendered a **"No description provided"** fallback line under the heading when the entity had no description. This added visual noise, and the copy was inconsistent across the two drawers — one was a hardcoded English string, the other was i18n'd. The sibling **Prompts** drawer already hides the line when empty; this PR aligns both server drawers with that pattern.

Changes:
- **`MCPServerDetailsPanel.tsx`** — render the description `<p>` only when `server.description` is present; removed the hardcoded `"No description provided"` fallback.
- **`VirtualServerDetailsPanel.tsx`** — same conditional render; removed the `intl.formatMessage({ id: "gateways.details.noDescription" })` fallback.
- **i18n** — deleted the now-orphan `gateways.details.noDescription` key from `en-US`, `es-ES`, and `pt-BR` (grep confirmed no other callers).

Editing a description is unchanged — still available via the drawer's kebab menu → **Edit**, whose form already carries the "Add an optional description…" placeholder. No new inline-edit affordance was added.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

Client-only change (React `client/`), so verification uses the client toolchain plus a manual pass in a running gateway.

| Check                | Command                          | Status                          |
|----------------------|----------------------------------|---------------------------------|
| Lint (ESLint)        | `cd client && npm run lint`      | ✅ clean                        |
| Unit tests           | `cd client && npm run test:run`  | ✅ 2506 passed, 1 skipped       |

**Manual verification** (against a local gateway with a registered MCP server + a virtual server):
1. Open an **MCP server** drawer for a server with **no** description → no description line, no reserved empty space.
2. Open a **virtual server** drawer for a server with **no** description → same.
3. Open drawers for entities that **have** a description → renders unchanged.
4. Kebab → **Edit** → description field still lets you add/change a description.

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes 

- **Test difference:** the virtual-server drawer had a `shows a placeholder when the server has no description` test asserting the old fallback text. Since the fallback is removed, that test was **deleted** rather than rewritten, matching the MCP drawer (which never had such a test) and the Prompts drawer, keeping the two server drawers symmetric.
- **Spacing:** With the description removed, the existing divider spacing still looks intentional, so no additional margin adjustment was needed.