### PR TITLE
fix(llmchat): allow any worker to resume LLM Chat sessions from Redis

### DIFF
--- a/docs/docs/using/clients/llm-chat.md
+++ b/docs/docs/using/clients/llm-chat.md
@@ -443,8 +443,9 @@ The LLM Chat system follows a **three-tier architecture** with clear separation 
 
 - `active_sessions`: Dict storing active MCPChatService instances per user
 - `user_configs`: Dict storing user configurations
-- **Redis Integration** (optional): Distributed session storage with TTL and worker affinity
-- **Sticky Sessions**: Workers use locks to prevent race conditions during session initialization
+- **Redis Integration** (optional): Distributed storage for user config and session ownership, with TTLs
+- **Cross-Worker Takeover**: Any worker may materialize a user's session locally from the Redis-backed config, rather than requiring the request to stay pinned to the worker that created it. Locks coordinate initialization so concurrent requests don't build duplicate sessions, and an idle reaper shuts down a session once its previous worker's copy is no longer in use
+- Without `CACHE_TYPE=redis` + `REDIS_URL`, session and config state is per-process only, so LLM Chat only works reliably with a single worker
 
 ![LLM Chat Session Management](llm-chat-session-management.png)
 
@@ -607,11 +608,12 @@ MCPClientConfig
 - TTL-based expiration reduces memory footprint
 - Redis caching for distributed deployments
 
-**Sticky Sessions** (Multi-worker):
+**Session Takeover** (Multi-worker):
 
-- Worker affinity via Redis ownership keys
-- Reduces session recreation overhead
-- Lock-based coordination prevents race conditions
+- Any worker can resume a user's session by rebuilding it locally from the Redis-backed config -- requests are not required to stay pinned to the worker that created the session
+- Lock-based coordination prevents concurrent requests from building duplicate sessions for the same user
+- An idle reaper shuts down a worker's local copy once it is no longer the session's owner and has been unused past the session TTL
+- Requires `CACHE_TYPE=redis` + `REDIS_URL`; without Redis, session and config state is per-process only, so LLM Chat only works reliably with a single worker
 
 
 ### 🧪 Error Handling

--- a/docs/docs/using/clients/llm-chat.md
+++ b/docs/docs/using/clients/llm-chat.md
@@ -41,6 +41,7 @@ All LLM providers are configured via the Admin UI's LLM Settings. Navigate to **
 ```bash
 # ===== Redis Connection =====
 CACHE_TYPE=redis                          # Enable Redis
+# Default: database -- must be set to "redis" for multi-worker LLM Chat
 REDIS_URL=redis://localhost:6379/0       # Redis connection string
 
 # ===== Session Management =====

--- a/mcpgateway/routers/llmchat_router.py
+++ b/mcpgateway/routers/llmchat_router.py
@@ -18,8 +18,10 @@ history management via ChatHistoryManager from mcp_client_chat_service.
 # Standard
 import asyncio
 import os
+import socket
 import time
 from typing import Any, Dict, Optional
+from uuid import uuid4
 
 # Third-Party
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -60,20 +62,45 @@ redis_client = None
 
 
 async def init_redis() -> None:
-    """Initialize Redis client using the shared factory.
+    """Initialize Redis client using the shared factory and rebind WORKER_ID.
 
-    Should be called during application startup from main.py lifespan.
+    Should be called during application startup from main.py lifespan, which
+    runs post-fork under gunicorn/UvicornWorker (and once under plain
+    uvicorn/``make dev``). This is where ``WORKER_ID`` must be (re)computed:
+    the module-level default is captured at *import* time, and because
+    ``run-gunicorn.sh`` enables ``--preload`` by default on Linux, gunicorn
+    imports this module once in the master process before forking — every
+    worker would otherwise inherit the master's PID as its ``WORKER_ID`` and
+    the ownership/lock compare-and-delete Lua scripts would compare a value
+    against itself, letting any worker delete or release another's lock.
+    Rebinding here, after fork, gives each process a distinct, host-qualified
+    identifier that also survives PID reuse across worker recycling.
+
+    Returns:
+        None.
     """
-    global redis_client
+    global redis_client, WORKER_ID  # pylint: disable=global-statement
+    WORKER_ID = f"{socket.gethostname()}:{os.getpid()}:{uuid4().hex[:8]}"
     if getattr(settings, "cache_type", None) == "redis" and getattr(settings, "redis_url", None):
         redis_client = await get_redis_client()
         if redis_client:
             logger.info("LLMChat router connected to shared Redis client")
+    if redis_client is None and getattr(settings, "llmchat_enabled", False):
+        logger.warning(
+            "LLM Chat is enabled but Redis is not configured (CACHE_TYPE=redis + REDIS_URL). "
+            "Chat sessions and config are per-process only; with more than one worker, requests "
+            "routed to a different worker may not find the session."
+        )
 
 
 # Fallback in-memory stores (used when Redis unavailable)
 # Store active chat sessions per user
 active_sessions: Dict[str, MCPChatService] = {}
+
+# Monotonic timestamp of last use per user_id, keyed the same as active_sessions.
+# Used by the idle reaper (see _reap_idle_sessions) to bound local session
+# lifetime once any worker may materialize a session via takeover.
+active_sessions_last_used: Dict[str, float] = {}
 
 # Store configuration per user
 user_configs: Dict[str, tuple[bytes, float]] = {}
@@ -551,6 +578,7 @@ async def delete_active_session(user_id: str):
         user_id: User identifier.
     """
     active_sessions.pop(user_id, None)
+    active_sessions_last_used.pop(user_id, None)
     if redis_client:
         try:
             # Lua script for atomic check-and-delete (only delete if we own the key)
@@ -609,6 +637,16 @@ async def _release_lock_safe(user_id: str):
 async def _create_local_session_from_config(user_id: str) -> Optional[MCPChatService]:
     """Create MCPChatService locally from stored config.
 
+    The build is bounded by ``LOCK_TTL``: this call only ever runs while the
+    caller holds the per-user init lock, and that lock expires after
+    ``LOCK_TTL`` seconds. ``MCPChatService.initialize()`` performs real
+    network I/O (MCP transport connect plus tool discovery) that can exceed
+    the default 30s on a slow or large server; without a bound, the lock
+    could expire mid-build and let a second worker start building a
+    duplicate session for the same user. Timing out is treated the same as
+    any other initialization failure: partial state is cleaned up and the
+    caller sees a clean ``None``.
+
     Args:
         user_id: User identifier.
 
@@ -622,106 +660,239 @@ async def _create_local_session_from_config(user_id: str) -> Optional[MCPChatSer
     # create and initialize with unified history manager
     try:
         chat_service = MCPChatService(config, user_id=user_id, redis_client=redis_client)
-        await chat_service.initialize()
+        await asyncio.wait_for(chat_service.initialize(), timeout=LOCK_TTL)
         await set_active_session(user_id, chat_service)
         return chat_service
     except Exception as e:
-        # If initialization fails, ensure nothing partial remains
+        # If initialization fails (including a LOCK_TTL timeout), ensure nothing partial remains
         logger.error(f"Failed to initialize MCPChatService for {SecurityValidator.sanitize_log_message(user_id)}: {e}", exc_info=True)
         # cleanup local state and redis ownership (if we set it)
         await delete_active_session(user_id)
         return None
 
 
-async def get_active_session(user_id: str) -> Optional[MCPChatService]:
-    """
-    Retrieve or (if possible) create the active session for user_id.
+def _touch_last_used(user_id: str) -> None:
+    """Stamp the idle clock for a user's active session.
 
-    Behavior:
-    - If Redis is disabled: return local session or None.
-    - If Redis enabled:
-      * If owner == WORKER_ID and local session exists -> return it (and refresh TTL)
-      * If owner == WORKER_ID but local missing -> try to acquire lock and recreate
-      * If no owner -> try to acquire lock and create session here
-      * If owner != WORKER_ID -> wait a short time for owner to appear or return None
+    Called whenever a session is served or created so the idle reaper
+    (`_reap_idle_sessions`) does not treat it as eligible for eviction.
+
+    Args:
+        user_id: User identifier whose session was just used.
+
+    Returns:
+        None.
+    """
+    active_sessions_last_used[user_id] = time.monotonic()
+
+
+async def _refresh_session_ttls(user_id: str) -> None:
+    """Refresh both the ownership and config Redis keys' TTLs for a user.
+
+    The ownership key (`_active_key`) has always had its TTL renewed on
+    every `get_active_session` hit; the config key (`_cfg_key`) previously
+    was not, so a long conversation's stored config could silently expire
+    after `USER_CONFIG_TTL` seconds even though the conversation was still
+    active. That gap was masked as long as the owning worker always served
+    from its never-expiring local `active_sessions` dict; takeover makes the
+    gap reachable from any worker, so both keys must be kept alive together
+    (§3b of the multi-worker session fix). No-op when Redis is disabled.
+
+    Args:
+        user_id: User identifier whose Redis-backed keys should be renewed.
+
+    Returns:
+        None.
+    """
+    if not redis_client:
+        return
+    try:
+        await redis_client.expire(_active_key(user_id), SESSION_TTL)
+        await redis_client.expire(_cfg_key(user_id), USER_CONFIG_TTL)
+    except Exception as e:  # nosec B110
+        logger.debug(f"Failed to refresh session TTLs for {SecurityValidator.sanitize_log_message(user_id)}: {e}")
+
+
+async def _reap_idle_sessions() -> None:
+    """Evict and shut down local sessions that are idle and foreign-owned.
+
+    Once any worker may take over a session from Redis-backed config, an
+    old owner's local `MCPChatService` becomes orphaned after takeover and
+    would otherwise never be cleaned up (a connection/fd leak). This scans
+    `active_sessions` for entries whose `active_sessions_last_used` stamp is
+    older than `SESSION_TTL` seconds *and* whose Redis ownership key no
+    longer names this worker, and shuts those down.
+
+    An entry with no recorded `last_used` (never touched via
+    `get_active_session`/`_touch_last_used`) is left alone rather than
+    treated as maximally idle. An entry that is idle but still owned by this
+    worker in Redis is also left alone -- the conversation may simply be
+    paused. Long-running streamed responses re-stamp `last_used` per chunk
+    (see `token_streamer`), so an in-flight stream can never look idle
+    mid-response.
+
+    Only runs when Redis is configured; without Redis there is no concept
+    of cross-worker ownership to reap against.
+
+    Returns:
+        None.
+    """
+    if not redis_client:
+        return
+    now = time.monotonic()
+    for uid in list(active_sessions.keys()):
+        last_used = active_sessions_last_used.get(uid)
+        if last_used is None or (now - last_used) <= SESSION_TTL:
+            continue
+        try:
+            owner = await redis_client.get(_active_key(uid))
+            if isinstance(owner, bytes):
+                owner = owner.decode()
+        except Exception as e:  # nosec B110
+            logger.debug(f"Reaper failed to check ownership for {SecurityValidator.sanitize_log_message(uid)}: {e}")
+            continue
+        if owner == WORKER_ID:
+            continue
+        session = active_sessions.pop(uid, None)
+        active_sessions_last_used.pop(uid, None)
+        if session is not None:
+            try:
+                await session.shutdown()
+            except Exception as e:
+                logger.warning(f"Reaper failed to shut down idle session for {SecurityValidator.sanitize_log_message(uid)}: {e}")
+
+
+async def _acquire_and_create_session(user_id: str) -> Optional[MCPChatService]:
+    """Acquire the per-user init lock and materialize a session from config.
+
+    On failure to acquire the lock, polls for the *lock key itself* to
+    clear (not the local `active_sessions` dict -- another worker's process
+    can never fill this worker's own dict, so waiting on it is a guaranteed
+    timeout) and retries acquisition exactly once before giving up.
 
     Args:
         user_id: User identifier.
 
     Returns:
+        Optional[MCPChatService]: Newly created local session, or None if
+        the lock could not be acquired (even after the retry) or the build
+        itself failed (see `_create_local_session_from_config`).
+    """
+    acquired = await _try_acquire_lock(user_id)
+    if acquired:
+        try:
+            return await _create_local_session_from_config(user_id)
+        finally:
+            await _release_lock_safe(user_id)
+
+    # Someone else (another worker, or a concurrent request on this one) is
+    # already (re)building the session. Wait for the lock to clear.
+    for _ in range(LOCK_RETRIES):
+        await asyncio.sleep(LOCK_WAIT)
+        if redis_client and not await redis_client.get(_lock_key(user_id)):
+            break
+    else:
+        return None
+
+    acquired = await _try_acquire_lock(user_id)
+    if acquired:
+        try:
+            return await _create_local_session_from_config(user_id)
+        finally:
+            await _release_lock_safe(user_id)
+    return None
+
+
+async def get_active_session(user_id: str, recreate: bool = True) -> Optional[MCPChatService]:
+    """Retrieve, and optionally take over or (re)create, the active session for user_id.
+
+    Behavior:
+    - If Redis is disabled, or `recreate` is False: return the locally-held
+      session, or None. `recreate=False` is for callers that are about to
+      replace or tear down the session (`/connect`, `/disconnect`) -- they
+      must not pay the cost of rebuilding a foreign worker's session (a full
+      MCP handshake) just to immediately discard it.
+    - If Redis is enabled and `recreate` is True (the default, used by
+      `/chat`):
+      * If owner == WORKER_ID and a local session exists -> return it,
+        refreshing both the ownership and config key TTLs.
+      * If owner == WORKER_ID but the local session is missing (process
+        restart) -> acquire the lock and recreate it.
+      * If there is no owner -> acquire the lock and create the session here.
+      * If another worker owns it -> take over: return a local session if
+        this worker happens to already have one (reclaiming ownership),
+        otherwise acquire the lock and materialize a new local session from
+        the Redis-backed config. This is a deliberate takeover, not a shared
+        session -- the previous owner's local copy becomes orphaned and is
+        reclaimed by the idle reaper (`_reap_idle_sessions`).
+      In all cases, if the stored config is absent or expired, this
+      returns None (the correct outcome: the user never connected, or the
+      config TTL lapsed).
+
+    Args:
+        user_id: User identifier.
+        recreate: Whether to allow rebuilding the session from Redis-backed
+            config when it is not already held locally. Defaults to True.
+
+    Returns:
         Optional[MCPChatService]: Active session if available, None otherwise.
     """
-    # Fast path: no redis => purely local
-    if not redis_client:
-        return active_sessions.get(user_id)
+    # Local-only fast path: no Redis backing, or the caller explicitly wants
+    # the local session without triggering a cross-worker takeover/rebuild.
+    if not redis_client or not recreate:
+        local = active_sessions.get(user_id)
+        if local:
+            _touch_last_used(user_id)
+        return local
+
+    await _reap_idle_sessions()
 
     active_key = _active_key(user_id)
-    # _lock_key = _lock_key(user_id)
     owner = await redis_client.get(active_key)
+    if isinstance(owner, bytes):
+        owner = owner.decode()
 
     # 1) Owned by this worker
     if owner == WORKER_ID:
         local = active_sessions.get(user_id)
         if local:
-            # refresh TTL so ownership persists while active
+            # refresh both TTLs so ownership and config persist while active
             try:
                 await redis_client.expire(active_key, SESSION_TTL)
+                await redis_client.expire(_cfg_key(user_id), USER_CONFIG_TTL)
             except Exception as e:  # nosec B110
                 # non-fatal if expire fails, just log the error
                 logger.debug(f"Failed to refresh session TTL for {SecurityValidator.sanitize_log_message(user_id)}: {e}")
+            _touch_last_used(user_id)
             return local
 
         # Owner in Redis points to this worker but local session missing (process restart or lost).
-        # Try to recreate it (acquire lock).
-        acquired = await _try_acquire_lock(user_id)
-        if acquired:
-            try:
-                # create new local session
-                session = await _create_local_session_from_config(user_id)
-                return session
-            finally:
-                await _release_lock_safe(user_id)
-        else:
-            # someone else is (re)creating; wait a bit for them to finish
-            for _ in range(LOCK_RETRIES):
-                await asyncio.sleep(LOCK_WAIT)
-                if active_sessions.get(user_id):
-                    return active_sessions.get(user_id)
-            return None
+        session = await _acquire_and_create_session(user_id)
+        if session:
+            _touch_last_used(user_id)
+        return session
 
     # 2) No owner -> try to claim & create session locally
     if owner is None:
-        acquired = await _try_acquire_lock(user_id)
-        if acquired:
-            try:
-                session = await _create_local_session_from_config(user_id)
-                return session
-            finally:
-                await _release_lock_safe(user_id)
+        session = await _acquire_and_create_session(user_id)
+        if session:
+            _touch_last_used(user_id)
+        return session
 
-        # if we couldn't acquire lock, someone else is creating; wait a short time
-        for _ in range(LOCK_RETRIES):
-            await asyncio.sleep(LOCK_WAIT)
-            owner2 = await redis_client.get(active_key)
-            if owner2 == WORKER_ID and active_sessions.get(user_id):
-                return active_sessions.get(user_id)
-            if owner2 is not None and owner2 != WORKER_ID:
-                # some other worker now owns it
-                return None
+    # 3) Owned by another worker -> take over rather than reject.
+    local = active_sessions.get(user_id)
+    if local:
+        # Ownership drifted away from us (e.g. a TTL/reaper race) while we
+        # still hold a live session locally; reclaim ownership instead of
+        # paying to rebuild.
+        await set_active_session(user_id, local)
+        _touch_last_used(user_id)
+        return local
 
-        # final attempt to acquire lock (last resort)
-        acquired = await _try_acquire_lock(user_id)
-        if acquired:
-            try:
-                session = await _create_local_session_from_config(user_id)
-                return session
-            finally:
-                await _release_lock_safe(user_id)
-        return None
-
-    # 3) Owned by another worker -> we don't have it locally
-    # Optionally we could attempt to "steal" if owner is stale, but TTL expiry handles that.
-    return None
+    session = await _acquire_and_create_session(user_id)
+    if session:
+        _touch_last_used(user_id)
+    return session
 
 
 # ---------- ROUTES ----------
@@ -813,8 +984,13 @@ async def connect(input_data: ConnectInput, request: Request, user=Depends(get_c
                 raise HTTPException(status_code=401, detail="Authentication required. Please ensure you are logged in.")
             input_data.server.auth_token = jwt_token
 
-        # Close old session if it exists
-        existing = await get_active_session(user_id)
+        # Close old session if it exists. Local-only lookup (recreate=False):
+        # a session owned by another worker is about to be superseded anyway,
+        # so there is no reason to pay for a full takeover rebuild (network +
+        # tool discovery) just to immediately shut it back down. The Redis
+        # ownership key for a foreign copy is left to expire naturally / be
+        # cleaned up by the idle reaper.
+        existing = await get_active_session(user_id, recreate=False)
         if existing:
             try:
                 logger.debug(f"Disconnecting existing session for {SecurityValidator.sanitize_log_message(user_id)} before reconnecting")
@@ -932,6 +1108,9 @@ async def token_streamer(chat_service: MCPChatService, message: str, user_id: st
     Note:
         SSE format requires 'event: <type>\\ndata: <json>\\n\\n' structure.
         All exceptions are caught and converted to error events for client handling.
+        Each emitted event re-stamps the session's idle clock (see
+        `_touch_last_used`), so a long-running stream can never be reaped as
+        idle mid-response even if the stream as a whole outlives `SESSION_TTL`.
     """
 
     async def sse(event_type: str, data: Dict[str, Any]):
@@ -949,6 +1128,10 @@ async def token_streamer(chat_service: MCPChatService, message: str, user_id: st
 
     try:
         async for ev in chat_service.chat_events(message):
+            # Re-stamp idle clock per chunk so the reaper never evicts a
+            # session that is still actively streaming (§4 of the
+            # multi-worker session fix).
+            _touch_last_used(user_id)
             et = ev.get("type")
             if et == "token":
                 content = ev.get("content", "")
@@ -1061,10 +1244,16 @@ async def chat(input_data: ChatInput, user=Depends(get_current_user_with_permiss
     if not input_data.message or not input_data.message.strip():
         raise HTTPException(status_code=400, detail="Message cannot be empty")
 
-    # Check for active session
+    # Check for active session (recreate=True default: any worker may take
+    # over the session from Redis-backed config)
     chat_service = await get_active_session(user_id)
     if not chat_service:
         raise HTTPException(status_code=400, detail="No active session found. Please connect to a server first.")
+
+    # Successful hit -- refresh the config TTL alongside the ownership TTL
+    # (§3b): a freshly-recreated session's config was just read, not
+    # re-written, so without this it keeps counting down from /connect time.
+    await _refresh_session_ttls(user_id)
 
     # Verify session is initialized
     if not chat_service.is_initialized:
@@ -1163,8 +1352,11 @@ async def disconnect(input_data: DisconnectInput, user=Depends(get_current_user_
     if not user_id:
         raise HTTPException(status_code=400, detail="User ID is required")
 
-    # Remove and shut down chat service
-    chat_service = await get_active_session(user_id)
+    # Remove and shut down chat service. Local-only lookup (recreate=False):
+    # this call is about to tear the session down, so there is no reason to
+    # rebuild a foreign worker's copy first just to immediately shut it back
+    # down; the reaper and Redis key deletion below handle that copy.
+    chat_service = await get_active_session(user_id, recreate=False)
     await delete_active_session(user_id)
 
     # Remove user config
@@ -1186,13 +1378,45 @@ async def disconnect(input_data: DisconnectInput, user=Depends(get_current_user_
         return {"status": "disconnected_with_errors", "user_id": user_id, "message": "Disconnected but cleanup encountered errors", "warning": str(e)}
 
 
+async def _has_active_session_state(user_id: str) -> bool:
+    """Check whether active session state exists for a user without building one.
+
+    A pure existence check -- a local dict lookup, plus a Redis `EXISTS` on
+    the ownership/config keys when Redis is configured -- so a read-only
+    status poll never triggers a cross-worker takeover or the cost of
+    deserializing and decrypting the stored config
+    (`_deserialize_user_config_from_storage`) just to produce a boolean.
+
+    Args:
+        user_id: User identifier to check.
+
+    Returns:
+        bool: True when an active session (local, or Redis-backed on any
+        worker) exists for the user.
+    """
+    if user_id in active_sessions:
+        return True
+    if not redis_client:
+        return False
+    try:
+        exists = await redis_client.exists(_active_key(user_id), _cfg_key(user_id))
+        return bool(exists)
+    except Exception as e:  # nosec B110
+        logger.debug(f"Failed to check active session state for {SecurityValidator.sanitize_log_message(user_id)}: {e}")
+        return False
+
+
 @llmchat_router.get("/status/{user_id}")
 @require_permission("llm.read")
 async def status(user_id: str, user=Depends(get_current_user_with_permissions)):
     """Check if an active chat session exists for the specified user.
 
     Lightweight endpoint for verifying session state without modifying data.
-    Useful for health checks and UI state management.
+    Useful for health checks and UI state management. This performs a pure
+    existence check -- it never calls `get_active_session()` -- so a
+    read-only status poll cannot trigger a cross-worker takeover or pay the
+    network/tool-discovery cost of rebuilding a session as a side effect of
+    a GET (see `_has_active_session_state`).
 
     Args:
         user_id: User identifier to check session status for.
@@ -1224,11 +1448,12 @@ async def status(user_id: str, user=Depends(get_current_user_with_permissions)):
         }
 
     Note:
-        This endpoint does not validate that the session is properly initialized,
-        only that it exists in the active_sessions dictionary.
+        This endpoint does not validate that the session is properly
+        initialized, only that active state (local or Redis-backed) exists
+        for the user.
     """
     resolved_user_id = _resolve_user_id(user_id, user)
-    connected = bool(await get_active_session(resolved_user_id))
+    connected = await _has_active_session_state(resolved_user_id)
     return {"user_id": resolved_user_id, "connected": connected}
 
 

--- a/mcpgateway/routers/llmchat_router.py
+++ b/mcpgateway/routers/llmchat_router.py
@@ -399,6 +399,25 @@ def _active_key(user_id: str) -> str:
     return f"active_session:{user_id}"
 
 
+def _cfg_version_key(user_id: str) -> str:
+    """Generate Redis key for the user config's generation marker.
+
+    A fresh random token is written here on every `/connect`, alongside the
+    config itself. A local `MCPChatService` stamps the token it was built
+    from onto itself (`config_version`); comparing that stamp against the
+    current value of this key is how a takeover/reclaim detects that the
+    user reconnected with a different config while the stale local copy was
+    still cached, instead of silently serving it.
+
+    Args:
+        user_id: User identifier.
+
+    Returns:
+        str: Redis key for the config generation marker.
+    """
+    return f"user_config_version:{user_id}"
+
+
 def _lock_key(user_id: str) -> str:
     """Generate Redis key for session initialization lock.
 
@@ -500,18 +519,45 @@ def _mask_sensitive_config_values(value: Any) -> Any:
 # ---------- CONFIG HELPERS ----------
 
 
-async def set_user_config(user_id: str, config: MCPClientConfig):
+async def set_user_config(user_id: str, config: MCPClientConfig, version: Optional[str] = None):
     """Store user configuration in Redis or memory.
 
     Args:
         user_id: User identifier.
         config: Complete MCP client configuration.
+        version: Optional generation marker for this config (Redis-only). Callers
+            that need takeover/reclaim to detect a config change should pass a
+            fresh unique value (e.g. ``uuid4().hex``) here and stamp the same
+            value onto the resulting `MCPChatService.config_version`.
     """
     serialized = _serialize_user_config_for_storage(config)
     if redis_client:
         await redis_client.set(_cfg_key(user_id), serialized, ex=USER_CONFIG_TTL)
+        if version is not None:
+            await redis_client.set(_cfg_version_key(user_id), version, ex=USER_CONFIG_TTL)
     else:
         user_configs[user_id] = (serialized, time.monotonic())
+
+
+async def get_config_version(user_id: str) -> Optional[str]:
+    """Retrieve the current config generation marker for a user (Redis-only).
+
+    Local in-memory fallback (no Redis) never reaches cross-worker takeover
+    logic, so there is nothing to compare against and this always returns
+    None in that mode.
+
+    Args:
+        user_id: User identifier.
+
+    Returns:
+        Optional[str]: Current version token if present, else None.
+    """
+    if not redis_client:
+        return None
+    data = await redis_client.get(_cfg_version_key(user_id))
+    if isinstance(data, bytes):
+        return data.decode()
+    return data
 
 
 async def get_user_config(user_id: str) -> Optional[MCPClientConfig]:
@@ -547,6 +593,7 @@ async def delete_user_config(user_id: str):
     """
     if redis_client:
         await redis_client.delete(_cfg_key(user_id))
+        await redis_client.delete(_cfg_version_key(user_id))
     else:
         user_configs.pop(user_id, None)
 
@@ -660,6 +707,10 @@ async def _create_local_session_from_config(user_id: str) -> Optional[MCPChatSer
     # create and initialize with unified history manager
     try:
         chat_service = MCPChatService(config, user_id=user_id, redis_client=redis_client)
+        # Stamp the config generation this build came from so a later
+        # takeover/reclaim can detect the user reconnected with a different
+        # config in the meantime (see get_active_session).
+        chat_service.config_version = await get_config_version(user_id)
         await asyncio.wait_for(chat_service.initialize(), timeout=LOCK_TTL)
         await set_active_session(user_id, chat_service)
         return chat_service
@@ -709,6 +760,7 @@ async def _refresh_session_ttls(user_id: str) -> None:
     try:
         await redis_client.expire(_active_key(user_id), SESSION_TTL)
         await redis_client.expire(_cfg_key(user_id), USER_CONFIG_TTL)
+        await redis_client.expire(_cfg_version_key(user_id), USER_CONFIG_TTL)
     except Exception as e:  # nosec B110
         logger.debug(f"Failed to refresh session TTLs for {SecurityValidator.sanitize_log_message(user_id)}: {e}")
 
@@ -803,6 +855,50 @@ async def _acquire_and_create_session(user_id: str) -> Optional[MCPChatService]:
     return None
 
 
+async def _discard_stale_session(user_id: str, session: MCPChatService) -> None:
+    """Shut down and remove a locally-held session that no longer matches the current config.
+
+    Args:
+        user_id: User identifier.
+        session: The stale locally-held session to discard.
+
+    Returns:
+        None.
+    """
+    try:
+        await session.shutdown()
+    except Exception as e:
+        logger.warning(f"Failed to cleanly shut down stale session for {SecurityValidator.sanitize_log_message(user_id)}: {e}")
+    await delete_active_session(user_id)
+
+
+async def _local_session_is_stale(user_id: str, session: MCPChatService) -> bool:
+    """Return True when a locally-held session no longer matches the stored config.
+
+    Compares the version stamped on `session` (from whichever config build
+    produced it) against the current `_cfg_version_key` in Redis. A user who
+    reconnects on a different worker overwrites the Redis-backed config and
+    ownership, but cannot reach into another worker's `active_sessions` dict
+    to evict the now-outdated local copy -- without this check, a later
+    request that lands back on the stale worker within `SESSION_TTL` could
+    silently reclaim/serve a session built from a superseded server/model
+    config instead of rebuilding from the current one.
+
+    Args:
+        user_id: User identifier.
+        session: Locally-held session being considered for reuse.
+
+    Returns:
+        bool: True if the session should be discarded and rebuilt.
+    """
+    current_version = await get_config_version(user_id)
+    if current_version is None:
+        # Nothing to compare against (e.g. version key expired/never set) --
+        # do not force a needless rebuild off missing data.
+        return False
+    return getattr(session, "config_version", None) != current_version
+
+
 async def get_active_session(user_id: str, recreate: bool = True) -> Optional[MCPChatService]:
     """Retrieve, and optionally take over or (re)create, the active session for user_id.
 
@@ -855,18 +951,26 @@ async def get_active_session(user_id: str, recreate: bool = True) -> Optional[MC
     # 1) Owned by this worker
     if owner == WORKER_ID:
         local = active_sessions.get(user_id)
-        if local:
+        if local and not await _local_session_is_stale(user_id, local):
             # refresh both TTLs so ownership and config persist while active
             try:
                 await redis_client.expire(active_key, SESSION_TTL)
                 await redis_client.expire(_cfg_key(user_id), USER_CONFIG_TTL)
+                await redis_client.expire(_cfg_version_key(user_id), USER_CONFIG_TTL)
             except Exception as e:  # nosec B110
                 # non-fatal if expire fails, just log the error
                 logger.debug(f"Failed to refresh session TTL for {SecurityValidator.sanitize_log_message(user_id)}: {e}")
             _touch_last_used(user_id)
             return local
 
-        # Owner in Redis points to this worker but local session missing (process restart or lost).
+        if local:
+            # Config changed since this local session was built (or this
+            # worker regained ownership after losing it) -- discard rather
+            # than serve a session built from a superseded config.
+            await _discard_stale_session(user_id, local)
+
+        # Owner in Redis points to this worker but local session is missing
+        # (discarded as stale above, or process restart/lost).
         session = await _acquire_and_create_session(user_id)
         if session:
             _touch_last_used(user_id)
@@ -881,13 +985,19 @@ async def get_active_session(user_id: str, recreate: bool = True) -> Optional[MC
 
     # 3) Owned by another worker -> take over rather than reject.
     local = active_sessions.get(user_id)
-    if local:
+    if local and not await _local_session_is_stale(user_id, local):
         # Ownership drifted away from us (e.g. a TTL/reaper race) while we
-        # still hold a live session locally; reclaim ownership instead of
-        # paying to rebuild.
+        # still hold a live, current session locally; reclaim ownership
+        # instead of paying to rebuild.
         await set_active_session(user_id, local)
         _touch_last_used(user_id)
         return local
+
+    if local:
+        # Stale local copy (user reconnected elsewhere with a different
+        # config while this worker still cached the old session) -- discard
+        # it instead of reclaiming, then rebuild from the current config.
+        await _discard_stale_session(user_id, local)
 
     session = await _acquire_and_create_session(user_id)
     if session:
@@ -1011,12 +1121,17 @@ async def connect(input_data: ConnectInput, request: Request, user=Depends(get_c
             logger.error("Chat configuration error for user %s", SecurityValidator.sanitize_log_message(user_id), exc_info=True)
             raise HTTPException(status_code=400, detail="Configuration error")
 
-        # Store user configuration
-        await set_user_config(user_id, config)
+        # Store user configuration, stamped with a fresh generation marker so
+        # a stale local session cached on another worker can detect this
+        # reconnect and rebuild instead of being silently reclaimed/served
+        # (see get_active_session / _local_session_is_stale).
+        config_version = uuid4().hex
+        await set_user_config(user_id, config, version=config_version)
 
         # Initialize chat service
         try:
             chat_service = MCPChatService(config, user_id=user_id, redis_client=redis_client)
+            chat_service.config_version = config_version
             await chat_service.initialize()
 
             # Clear chat history on new connection

--- a/tests/unit/mcpgateway/routers/test_llmchat_router.py
+++ b/tests/unit/mcpgateway/routers/test_llmchat_router.py
@@ -7,6 +7,7 @@ Tests for LLM chat router helpers and endpoints.
 """
 
 # Standard
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -65,10 +66,12 @@ class FailingStreamChatService(DummyChatService):
 @pytest.fixture(autouse=True)
 def reset_state(monkeypatch: pytest.MonkeyPatch):
     llmchat_router.active_sessions.clear()
+    llmchat_router.active_sessions_last_used.clear()
     llmchat_router.user_configs.clear()
     monkeypatch.setattr(llmchat_router, "redis_client", None)
     yield
     llmchat_router.active_sessions.clear()
+    llmchat_router.active_sessions_last_used.clear()
     llmchat_router.user_configs.clear()
 
 
@@ -318,23 +321,116 @@ async def test_get_active_session_owner_missing_recreate(monkeypatch: pytest.Mon
 
 @pytest.mark.asyncio
 async def test_get_active_session_no_owner_other_worker(monkeypatch: pytest.MonkeyPatch):
+    """Regression (#5740): a foreign worker appearing to own the session
+    mid-wait must not block this worker from materializing its own local
+    copy once the lock clears. Worker affinity is no longer the intended
+    behaviour -- any worker may take over from Redis-backed config."""
     redis_mock = AsyncMock()
-    redis_mock.get.side_effect = [None, "other-worker"]
+    # First .get() is the owner check (None); the second is the lock-key
+    # poll inside _acquire_and_create_session, which clears.
+    redis_mock.get.side_effect = [None, None]
     monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
-    monkeypatch.setattr(llmchat_router, "_try_acquire_lock", AsyncMock(return_value=False))
+
+    session = DummyChatService(config=None, user_id="u1")
+    monkeypatch.setattr(llmchat_router, "_try_acquire_lock", AsyncMock(side_effect=[False, True]))
+    monkeypatch.setattr(llmchat_router, "_create_local_session_from_config", AsyncMock(return_value=session))
+    monkeypatch.setattr(llmchat_router, "_release_lock_safe", AsyncMock())
     monkeypatch.setattr(llmchat_router, "LOCK_RETRIES", 1)
     monkeypatch.setattr(llmchat_router.asyncio, "sleep", AsyncMock())
 
-    assert await llmchat_router.get_active_session("u1") is None
+    result = await llmchat_router.get_active_session("u1")
+    assert result is session
+
+
+@pytest.mark.asyncio
+async def test_get_active_session_lock_contention_then_clears(monkeypatch: pytest.MonkeyPatch):
+    """Lock is held by another process; the poll checks the lock key itself
+    (never the local active_sessions dict, which another worker's process
+    can never fill) and a single retry after it clears succeeds."""
+    redis_mock = AsyncMock()
+    redis_mock.get.side_effect = [None, "still-held", None]
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+
+    session = DummyChatService(config=None, user_id="u1")
+    monkeypatch.setattr(llmchat_router, "_try_acquire_lock", AsyncMock(side_effect=[False, True]))
+    monkeypatch.setattr(llmchat_router, "_create_local_session_from_config", AsyncMock(return_value=session))
+    monkeypatch.setattr(llmchat_router, "_release_lock_safe", AsyncMock())
+    monkeypatch.setattr(llmchat_router, "LOCK_RETRIES", 2)
+    monkeypatch.setattr(llmchat_router.asyncio, "sleep", AsyncMock())
+
+    result = await llmchat_router.get_active_session("u1")
+    assert result is session
 
 
 @pytest.mark.asyncio
 async def test_get_active_session_owned_by_other_worker(monkeypatch: pytest.MonkeyPatch):
+    """Regression (#5740): a session owned by another worker must be taken
+    over (rebuilt locally from the Redis-backed config), not rejected.
+    Worker affinity is no longer the intended behaviour."""
     redis_mock = AsyncMock()
-    redis_mock.get.return_value = "other-worker"
+    redis_mock.get.return_value = "other-worker-pid"
     monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
 
-    assert await llmchat_router.get_active_session("u1") is None
+    session = DummyChatService(config=None, user_id="u1")
+    monkeypatch.setattr(llmchat_router, "_try_acquire_lock", AsyncMock(return_value=True))
+    monkeypatch.setattr(llmchat_router, "_create_local_session_from_config", AsyncMock(return_value=session))
+    monkeypatch.setattr(llmchat_router, "_release_lock_safe", AsyncMock())
+
+    result = await llmchat_router.get_active_session("u1")
+    assert result is session
+
+
+@pytest.mark.asyncio
+async def test_get_active_session_other_worker_no_config_returns_none(monkeypatch: pytest.MonkeyPatch):
+    """Owner is another worker, but the stored config is absent/expired --
+    takeover correctly returns None (the 400 the caller raises is right:
+    the user never connected, or the config TTL lapsed)."""
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = "other-worker-pid"
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+    monkeypatch.setattr(llmchat_router, "_try_acquire_lock", AsyncMock(return_value=True))
+    monkeypatch.setattr(llmchat_router, "get_user_config", AsyncMock(return_value=None))
+    monkeypatch.setattr(llmchat_router, "_release_lock_safe", AsyncMock())
+
+    result = await llmchat_router.get_active_session("u1")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_active_session_takeover_repoints_owner(monkeypatch: pytest.MonkeyPatch):
+    """Takeover must re-point the Redis owner key to this worker's WORKER_ID
+    so a subsequent request lands here directly instead of re-triggering
+    takeover every time."""
+    config = llmchat_router.build_config(ConnectInput(user_id="u1", llm=LLMInput(model="gpt")))
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = "other-worker-pid"
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+    monkeypatch.setattr(llmchat_router, "MCPChatService", DummyChatService)
+    monkeypatch.setattr(llmchat_router, "get_user_config", AsyncMock(return_value=config))
+    monkeypatch.setattr(llmchat_router, "_try_acquire_lock", AsyncMock(return_value=True))
+    monkeypatch.setattr(llmchat_router, "_release_lock_safe", AsyncMock())
+
+    result = await llmchat_router.get_active_session("u1")
+
+    assert isinstance(result, DummyChatService)
+    redis_mock.set.assert_any_await(llmchat_router._active_key("u1"), llmchat_router.WORKER_ID, ex=llmchat_router.SESSION_TTL)
+
+
+@pytest.mark.asyncio
+async def test_get_active_session_owner_bytes_matches_worker_id(monkeypatch: pytest.MonkeyPatch):
+    """REDIS_DECODE_RESPONSES=false would return owner as bytes; it must
+    still be normalized and compared correctly against WORKER_ID (a str)."""
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = llmchat_router.WORKER_ID.encode()
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+
+    session = DummyChatService(config=None, user_id="u1")
+    llmchat_router.active_sessions["u1"] = session
+
+    result = await llmchat_router.get_active_session("u1")
+
+    assert result is session
+    redis_mock.expire.assert_awaited()
 
 
 @pytest.mark.asyncio
@@ -1150,16 +1246,21 @@ async def test_get_active_session_no_owner_claim_success(monkeypatch: pytest.Mon
 
 @pytest.mark.asyncio
 async def test_get_active_session_no_owner_retry_our_worker(monkeypatch: pytest.MonkeyPatch):
+    """Dead-loop fix: the retry poll must check the lock key clearing, not
+    this worker's own active_sessions dict (which another worker's process
+    can never fill). Lock clears after the poll and the retried acquire
+    succeeds, materializing a session locally."""
     redis_mock = AsyncMock()
-    redis_mock.get.side_effect = [None, llmchat_router.WORKER_ID]
+    redis_mock.get.side_effect = [None, None]
     monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
 
     session = DummyChatService(config=None, user_id="u1")
-    # First lock fails, then gets session during retry
-    monkeypatch.setattr(llmchat_router, "_try_acquire_lock", AsyncMock(return_value=False))
+    # First lock attempt fails; poll observes the lock clear; retry succeeds.
+    monkeypatch.setattr(llmchat_router, "_try_acquire_lock", AsyncMock(side_effect=[False, True]))
+    monkeypatch.setattr(llmchat_router, "_create_local_session_from_config", AsyncMock(return_value=session))
+    monkeypatch.setattr(llmchat_router, "_release_lock_safe", AsyncMock())
     monkeypatch.setattr(llmchat_router, "LOCK_RETRIES", 1)
     monkeypatch.setattr(llmchat_router.asyncio, "sleep", AsyncMock())
-    llmchat_router.active_sessions["u1"] = session
 
     result = await llmchat_router.get_active_session("u1")
     assert result is session
@@ -1236,6 +1337,263 @@ async def test_get_user_config_redis_no_data(monkeypatch: pytest.MonkeyPatch):
 
     result = await llmchat_router.get_user_config("u1")
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# #5740 regression: multi-worker session takeover
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_active_session_refreshes_config_ttl(monkeypatch: pytest.MonkeyPatch):
+    """§3b: a local hit must refresh both the ownership and config key TTLs,
+    not just ownership -- otherwise a long conversation's config silently
+    expires out from under a takeover on another worker."""
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = llmchat_router.WORKER_ID
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+
+    session = DummyChatService(config=None, user_id="u1")
+    llmchat_router.active_sessions["u1"] = session
+
+    await llmchat_router.get_active_session("u1")
+
+    redis_mock.expire.assert_any_await(llmchat_router._active_key("u1"), llmchat_router.SESSION_TTL)
+    redis_mock.expire.assert_any_await(llmchat_router._cfg_key("u1"), llmchat_router.USER_CONFIG_TTL)
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_sessions_evicts_foreign_owned(monkeypatch: pytest.MonkeyPatch):
+    """§4: an idle (last_used older than SESSION_TTL) entry owned by another
+    worker is evicted locally and shut down."""
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = "other-worker-pid"
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+
+    session = DummyChatService(config=None, user_id="u1")
+    llmchat_router.active_sessions["u1"] = session
+    llmchat_router.active_sessions_last_used["u1"] = llmchat_router.time.monotonic() - llmchat_router.SESSION_TTL - 1
+
+    await llmchat_router._reap_idle_sessions()
+
+    assert "u1" not in llmchat_router.active_sessions
+    assert "u1" not in llmchat_router.active_sessions_last_used
+    assert session.shutdown_called is True
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_sessions_keeps_still_owned(monkeypatch: pytest.MonkeyPatch):
+    """An idle entry that is still owned by this worker in Redis is left
+    alone -- the conversation may simply be paused, not orphaned."""
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = llmchat_router.WORKER_ID
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+
+    session = DummyChatService(config=None, user_id="u1")
+    llmchat_router.active_sessions["u1"] = session
+    llmchat_router.active_sessions_last_used["u1"] = llmchat_router.time.monotonic() - llmchat_router.SESSION_TTL - 1
+
+    await llmchat_router._reap_idle_sessions()
+
+    assert "u1" in llmchat_router.active_sessions
+    assert session.shutdown_called is False
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_sessions_skips_untracked_entries(monkeypatch: pytest.MonkeyPatch):
+    """An entry with no recorded last_used (never touched via
+    get_active_session) must not be treated as maximally idle."""
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = "other-worker-pid"
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+
+    session = DummyChatService(config=None, user_id="u1")
+    llmchat_router.active_sessions["u1"] = session
+
+    await llmchat_router._reap_idle_sessions()
+
+    assert "u1" in llmchat_router.active_sessions
+    redis_mock.get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reaper_does_not_evict_in_flight_stream(monkeypatch: pytest.MonkeyPatch):
+    """§4: token_streamer re-stamps last_used per emitted chunk, so a stream
+    that (in wall-clock terms) outlives SESSION_TTL is never reaped
+    mid-response even if the reaper fires concurrently between chunks."""
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = "other-worker-pid"  # foreign owner throughout
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+
+    fake_time = [0.0]
+    monkeypatch.setattr(llmchat_router.time, "monotonic", lambda: fake_time[0])
+
+    class SlowStreamChatService(DummyChatService):
+        async def chat_events(self, message):
+            for i in range(3):
+                fake_time[0] += llmchat_router.SESSION_TTL + 1  # each chunk arrives "late"
+                yield {"type": "token", "content": str(i)}
+            yield {"type": "final", "text": f"done:{message}", "metadata": {}}
+
+    svc = SlowStreamChatService(config=None, user_id="user1")
+    llmchat_router.active_sessions["user1"] = svc
+    llmchat_router.active_sessions_last_used["user1"] = 0.0
+
+    async for _part in llmchat_router.token_streamer(svc, "hi", "user1"):
+        # After each chunk, last_used must already have been re-stamped to
+        # "now" -- the reaper firing concurrently must not evict this entry.
+        assert llmchat_router.active_sessions_last_used["user1"] == fake_time[0]
+        await llmchat_router._reap_idle_sessions()
+        assert "user1" in llmchat_router.active_sessions
+
+    assert svc.shutdown_called is False
+
+
+@pytest.mark.asyncio
+async def test_create_local_session_from_config_times_out(monkeypatch: pytest.MonkeyPatch):
+    """§3c: initialize() exceeding LOCK_TTL must fail cleanly instead of
+    letting two workers end up with duplicate live sessions."""
+    config = llmchat_router.build_config(ConnectInput(user_id="u1", llm=LLMInput(model="gpt")))
+
+    class SlowChatService(DummyChatService):
+        async def initialize(self):
+            await asyncio.sleep(10)
+
+    monkeypatch.setattr(llmchat_router, "get_user_config", AsyncMock(return_value=config))
+    monkeypatch.setattr(llmchat_router, "MCPChatService", SlowChatService)
+    monkeypatch.setattr(llmchat_router, "LOCK_TTL", 0.01)
+    delete_active = AsyncMock()
+    monkeypatch.setattr(llmchat_router, "delete_active_session", delete_active)
+
+    result = await llmchat_router._create_local_session_from_config("u1")
+
+    assert result is None
+    assert delete_active.await_count == 1
+    assert "u1" not in llmchat_router.active_sessions
+
+
+@pytest.mark.asyncio
+async def test_init_redis_warns_when_not_configured(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
+    """§5: llmchat_enabled=True but Redis not configured must log a warning
+    (not silent/info), naming the required settings."""
+    monkeypatch.setattr(llmchat_router.settings, "cache_type", "database")
+    monkeypatch.setattr(llmchat_router.settings, "redis_url", None)
+    monkeypatch.setattr(llmchat_router.settings, "llmchat_enabled", True)
+    caplog.set_level("WARNING")
+
+    await llmchat_router.init_redis()
+
+    assert llmchat_router.redis_client is None
+    assert "Redis is not configured" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_init_redis_assigns_distinct_worker_id(monkeypatch: pytest.MonkeyPatch):
+    """§2a: init_redis() must assign a WORKER_ID distinct from the
+    module-level import-time default, and repeated calls (simulating
+    per-process (re)initialization) must never collide."""
+    monkeypatch.setattr(llmchat_router.settings, "cache_type", "database")
+    monkeypatch.setattr(llmchat_router.settings, "redis_url", None)
+    original_worker_id = f"pid-only-{llmchat_router.os.getpid()}"
+    monkeypatch.setattr(llmchat_router, "WORKER_ID", original_worker_id)
+
+    await llmchat_router.init_redis()
+    first = llmchat_router.WORKER_ID
+    assert first != original_worker_id
+
+    await llmchat_router.init_redis()
+    second = llmchat_router.WORKER_ID
+    assert second != first
+
+
+@pytest.mark.asyncio
+async def test_init_redis_worker_id_has_host_component(monkeypatch: pytest.MonkeyPatch):
+    """§2a: the assigned WORKER_ID must contain a host component, so two
+    processes sharing a PID on different hosts (e.g. separate replicas
+    behind one Redis) do not collide."""
+    monkeypatch.setattr(llmchat_router.settings, "cache_type", "database")
+    monkeypatch.setattr(llmchat_router.settings, "redis_url", None)
+
+    await llmchat_router.init_redis()
+
+    hostname = llmchat_router.socket.gethostname()
+    assert llmchat_router.WORKER_ID.startswith(f"{hostname}:{llmchat_router.os.getpid()}:")
+
+
+@pytest.mark.asyncio
+async def test_connect_non_owning_worker_no_foreign_rebuild(monkeypatch: pytest.MonkeyPatch):
+    """§3a: /connect must look at active_sessions directly (recreate=False)
+    -- it must not rebuild a foreign worker's session over the network just
+    to immediately shut it down. Only the new session's initialize() runs."""
+    init_calls = []
+
+    class TrackedChatService(DummyChatService):
+        async def initialize(self):
+            init_calls.append(1)
+            return await super().initialize()
+
+    monkeypatch.setattr(llmchat_router, "MCPChatService", TrackedChatService)
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = "other-worker-pid"  # foreign owner, no local session
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+
+    request = MagicMock()
+    request.cookies = {"jwt_token": "token"}
+    request.headers = {}
+
+    input_data = ConnectInput(user_id="user1", llm=LLMInput(model="gpt"), server=ServerInput(auth_token=""))
+    result = await llmchat_router.connect(input_data, request, user={"id": "user1", "email": "user1@test.com", "db": MagicMock()})
+
+    assert result["status"] == "connected"
+    assert len(init_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_disconnect_non_owning_worker_no_rebuild(monkeypatch: pytest.MonkeyPatch):
+    """§3a: /disconnect must look at active_sessions directly (recreate=False)
+    and never call initialize() to rebuild a foreign worker's session."""
+    monkeypatch.setattr(llmchat_router, "MCPChatService", DummyChatService)
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = "other-worker-pid"
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+
+    result = await llmchat_router.disconnect(DisconnectInput(user_id="user1"), user={"id": "user1", "email": "user1@test.com"})
+
+    assert result["status"] == "no_active_session"
+    redis_mock.delete.assert_awaited()  # delete_user_config removes the cfg key
+
+
+@pytest.mark.asyncio
+async def test_status_non_owning_worker_no_rebuild(monkeypatch: pytest.MonkeyPatch):
+    """§3a: /status must never call get_active_session() -- a read-only poll
+    must not trigger a cross-worker takeover as a side effect of a GET."""
+    redis_mock = AsyncMock()
+    redis_mock.exists.return_value = 1
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+    get_active_session_spy = AsyncMock()
+    monkeypatch.setattr(llmchat_router, "get_active_session", get_active_session_spy)
+
+    result = await llmchat_router.status("user1", user={"id": "user1", "email": "user1@test.com"})
+
+    assert result["connected"] is True
+    get_active_session_spy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_status_local_session_no_redis():
+    """/status reports connected via the local dict when Redis is disabled."""
+    llmchat_router.active_sessions["user1"] = DummyChatService(config=None, user_id="user1")
+
+    result = await llmchat_router.status("user1", user={"id": "user1", "email": "user1@test.com"})
+
+    assert result["connected"] is True
+
+
+@pytest.mark.asyncio
+async def test_status_not_connected_no_redis():
+    result = await llmchat_router.status("user1", user={"id": "user1", "email": "user1@test.com"})
+
+    assert result["connected"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/routers/test_llmchat_router.py
+++ b/tests/unit/mcpgateway/routers/test_llmchat_router.py
@@ -1719,3 +1719,149 @@ class TestLLMChatRBACDecorators:
                 user=None,
             )
         assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_refresh_session_ttls_refreshes_both_keys(monkeypatch: pytest.MonkeyPatch):
+    """§3b happy path: a successful refresh renews both the ownership and
+    config key TTLs -- exercised directly here since /chat is the only
+    route that calls this helper, and only after a full session build."""
+    redis_mock = AsyncMock()
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+
+    await llmchat_router._refresh_session_ttls("u1")
+
+    redis_mock.expire.assert_any_await(llmchat_router._active_key("u1"), llmchat_router.SESSION_TTL)
+    redis_mock.expire.assert_any_await(llmchat_router._cfg_key("u1"), llmchat_router.USER_CONFIG_TTL)
+
+
+@pytest.mark.asyncio
+async def test_refresh_session_ttls_swallows_redis_error(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
+    """§3b: a transient Redis error while refreshing TTLs must be logged and
+    swallowed, not raised -- a failed TTL refresh is not fatal to the caller
+    (e.g. a successful /chat response)."""
+    redis_mock = AsyncMock()
+    redis_mock.expire.side_effect = ConnectionError("redis unreachable")
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+    caplog.set_level("DEBUG")
+
+    await llmchat_router._refresh_session_ttls("u1")
+
+    assert "Failed to refresh session TTLs" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_sessions_noop_without_redis():
+    """The reaper has no concept of cross-worker ownership without Redis, so
+    it must be a no-op (and must not touch active_sessions) when disabled."""
+    session = DummyChatService(config=None, user_id="u1")
+    llmchat_router.active_sessions["u1"] = session
+    llmchat_router.active_sessions_last_used["u1"] = 0.0
+
+    await llmchat_router._reap_idle_sessions()
+
+    assert "u1" in llmchat_router.active_sessions
+    assert session.shutdown_called is False
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_sessions_decodes_bytes_owner(monkeypatch: pytest.MonkeyPatch):
+    """The reaper must decode a bytes-typed owner value (e.g.
+    REDIS_DECODE_RESPONSES=false) before comparing it to WORKER_ID, exactly
+    like get_active_session does -- an un-decoded bytes owner would never
+    equal WORKER_ID and the entry would be wrongly evicted."""
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = llmchat_router.WORKER_ID.encode()
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+
+    session = DummyChatService(config=None, user_id="u1")
+    llmchat_router.active_sessions["u1"] = session
+    llmchat_router.active_sessions_last_used["u1"] = llmchat_router.time.monotonic() - llmchat_router.SESSION_TTL - 1
+
+    await llmchat_router._reap_idle_sessions()
+
+    assert "u1" in llmchat_router.active_sessions
+    assert session.shutdown_called is False
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_sessions_skips_on_ownership_check_error(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
+    """A transient Redis error while checking ownership must not evict the
+    entry -- an unreachable Redis should fail safe (leave the session alone),
+    not fail open (tear down a possibly still-owned session)."""
+    redis_mock = AsyncMock()
+    redis_mock.get.side_effect = ConnectionError("redis unreachable")
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+    caplog.set_level("DEBUG")
+
+    session = DummyChatService(config=None, user_id="u1")
+    llmchat_router.active_sessions["u1"] = session
+    llmchat_router.active_sessions_last_used["u1"] = llmchat_router.time.monotonic() - llmchat_router.SESSION_TTL - 1
+
+    await llmchat_router._reap_idle_sessions()
+
+    assert "u1" in llmchat_router.active_sessions
+    assert session.shutdown_called is False
+    assert "Reaper failed to check ownership" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_sessions_logs_shutdown_error(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
+    """A session whose shutdown() itself raises must still be removed from
+    active_sessions -- the reaper's job is to stop tracking an orphaned
+    session, and a failed shutdown must not leave it tracked forever."""
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = "other-worker-pid"
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+    caplog.set_level("WARNING")
+
+    class FailingShutdownChatService(DummyChatService):
+        async def shutdown(self):
+            raise RuntimeError("shutdown boom")
+
+    session = FailingShutdownChatService(config=None, user_id="u1")
+    llmchat_router.active_sessions["u1"] = session
+    llmchat_router.active_sessions_last_used["u1"] = llmchat_router.time.monotonic() - llmchat_router.SESSION_TTL - 1
+
+    await llmchat_router._reap_idle_sessions()
+
+    assert "u1" not in llmchat_router.active_sessions
+    assert "Reaper failed to shut down idle session" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_get_active_session_reclaims_drifted_ownership(monkeypatch: pytest.MonkeyPatch):
+    """Branch 3 of get_active_session: ownership drifted to another worker
+    (e.g. a TTL/reaper race) while this worker still holds a live local
+    session. It must reclaim ownership in Redis and return the local
+    session directly, without paying to rebuild via
+    _acquire_and_create_session."""
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = "other-worker-pid"
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+
+    session = DummyChatService(config=None, user_id="u1")
+    llmchat_router.active_sessions["u1"] = session
+    acquire_and_create = AsyncMock()
+    monkeypatch.setattr(llmchat_router, "_acquire_and_create_session", acquire_and_create)
+
+    result = await llmchat_router.get_active_session("u1")
+
+    assert result is session
+    acquire_and_create.assert_not_awaited()
+    redis_mock.set.assert_any_await(llmchat_router._active_key("u1"), llmchat_router.WORKER_ID, ex=llmchat_router.SESSION_TTL)
+
+
+@pytest.mark.asyncio
+async def test_has_active_session_state_swallows_redis_error(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
+    """§3a: /status's pure existence check must fail safe (report
+    not-connected) rather than raise, if Redis is unreachable."""
+    redis_mock = AsyncMock()
+    redis_mock.exists.side_effect = ConnectionError("redis unreachable")
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+    caplog.set_level("DEBUG")
+
+    result = await llmchat_router._has_active_session_state("u1")
+
+    assert result is False
+    assert "Failed to check active session state" in caplog.text

--- a/tests/unit/mcpgateway/routers/test_llmchat_router.py
+++ b/tests/unit/mcpgateway/routers/test_llmchat_router.py
@@ -292,7 +292,7 @@ async def test_get_active_session_no_redis():
 @pytest.mark.asyncio
 async def test_get_active_session_owner_local_refresh(monkeypatch: pytest.MonkeyPatch):
     redis_mock = AsyncMock()
-    redis_mock.get.return_value = llmchat_router.WORKER_ID
+    redis_mock.get.side_effect = lambda key: llmchat_router.WORKER_ID if key == llmchat_router._active_key("u1") else None
     monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
 
     session = DummyChatService(config=None, user_id="u1")
@@ -421,7 +421,7 @@ async def test_get_active_session_owner_bytes_matches_worker_id(monkeypatch: pyt
     """REDIS_DECODE_RESPONSES=false would return owner as bytes; it must
     still be normalized and compared correctly against WORKER_ID (a str)."""
     redis_mock = AsyncMock()
-    redis_mock.get.return_value = llmchat_router.WORKER_ID.encode()
+    redis_mock.get.side_effect = lambda key: llmchat_router.WORKER_ID.encode() if key == llmchat_router._active_key("u1") else None
     monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
 
     session = DummyChatService(config=None, user_id="u1")
@@ -1201,7 +1201,7 @@ async def test_connect_tool_extraction_error(monkeypatch: pytest.MonkeyPatch):
 @pytest.mark.asyncio
 async def test_get_active_session_expire_failure(monkeypatch: pytest.MonkeyPatch):
     redis_mock = AsyncMock()
-    redis_mock.get.return_value = llmchat_router.WORKER_ID
+    redis_mock.get.side_effect = lambda key: llmchat_router.WORKER_ID if key == llmchat_router._active_key("u1") else None
     redis_mock.expire.side_effect = RuntimeError("expire failed")
     monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
 
@@ -1350,7 +1350,7 @@ async def test_get_active_session_refreshes_config_ttl(monkeypatch: pytest.Monke
     not just ownership -- otherwise a long conversation's config silently
     expires out from under a takeover on another worker."""
     redis_mock = AsyncMock()
-    redis_mock.get.return_value = llmchat_router.WORKER_ID
+    redis_mock.get.side_effect = lambda key: llmchat_router.WORKER_ID if key == llmchat_router._active_key("u1") else None
     monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
 
     session = DummyChatService(config=None, user_id="u1")
@@ -1360,6 +1360,7 @@ async def test_get_active_session_refreshes_config_ttl(monkeypatch: pytest.Monke
 
     redis_mock.expire.assert_any_await(llmchat_router._active_key("u1"), llmchat_router.SESSION_TTL)
     redis_mock.expire.assert_any_await(llmchat_router._cfg_key("u1"), llmchat_router.USER_CONFIG_TTL)
+    redis_mock.expire.assert_any_await(llmchat_router._cfg_version_key("u1"), llmchat_router.USER_CONFIG_TTL)
 
 
 @pytest.mark.asyncio
@@ -1837,7 +1838,7 @@ async def test_get_active_session_reclaims_drifted_ownership(monkeypatch: pytest
     session directly, without paying to rebuild via
     _acquire_and_create_session."""
     redis_mock = AsyncMock()
-    redis_mock.get.return_value = "other-worker-pid"
+    redis_mock.get.side_effect = lambda key: "other-worker-pid" if key == llmchat_router._active_key("u1") else None
     monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
 
     session = DummyChatService(config=None, user_id="u1")
@@ -1850,6 +1851,75 @@ async def test_get_active_session_reclaims_drifted_ownership(monkeypatch: pytest
     assert result is session
     acquire_and_create.assert_not_awaited()
     redis_mock.set.assert_any_await(llmchat_router._active_key("u1"), llmchat_router.WORKER_ID, ex=llmchat_router.SESSION_TTL)
+
+
+@pytest.mark.asyncio
+async def test_get_active_session_discards_stale_reclaim_on_config_mismatch(monkeypatch: pytest.MonkeyPatch):
+    """Branch 3 of get_active_session: if the user reconnected on another
+    worker with a different config (Redis config version no longer matches
+    the version stamped on this worker's cached local session), the stale
+    local session must be shut down and discarded -- not reclaimed and
+    served -- and a fresh session rebuilt from the current config."""
+    redis_mock = AsyncMock()
+
+    def get_side_effect(key):
+        if key == llmchat_router._active_key("u1"):
+            return "other-worker-pid"
+        if key == llmchat_router._cfg_version_key("u1"):
+            return "new-version"
+        return None
+
+    redis_mock.get.side_effect = get_side_effect
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+
+    stale_session = DummyChatService(config=None, user_id="u1")
+    stale_session.config_version = "old-version"
+    llmchat_router.active_sessions["u1"] = stale_session
+
+    fresh_session = DummyChatService(config=None, user_id="u1")
+    acquire_and_create = AsyncMock(return_value=fresh_session)
+    monkeypatch.setattr(llmchat_router, "_acquire_and_create_session", acquire_and_create)
+
+    result = await llmchat_router.get_active_session("u1")
+
+    assert result is fresh_session
+    assert stale_session.shutdown_called is True
+    acquire_and_create.assert_awaited_once_with("u1")
+    # Must not reclaim ownership with the stale session's data.
+    for call in redis_mock.set.await_args_list:
+        assert call.args != (llmchat_router._active_key("u1"), llmchat_router.WORKER_ID)
+
+
+@pytest.mark.asyncio
+async def test_get_active_session_owner_local_rebuilds_on_config_mismatch(monkeypatch: pytest.MonkeyPatch):
+    """Branch 1 of get_active_session: even when this worker is the recorded
+    owner, a locally-cached session whose stamped config version no longer
+    matches Redis must be discarded and rebuilt rather than served as-is."""
+    redis_mock = AsyncMock()
+
+    def get_side_effect(key):
+        if key == llmchat_router._active_key("u1"):
+            return llmchat_router.WORKER_ID
+        if key == llmchat_router._cfg_version_key("u1"):
+            return "new-version"
+        return None
+
+    redis_mock.get.side_effect = get_side_effect
+    monkeypatch.setattr(llmchat_router, "redis_client", redis_mock)
+
+    stale_session = DummyChatService(config=None, user_id="u1")
+    stale_session.config_version = "old-version"
+    llmchat_router.active_sessions["u1"] = stale_session
+
+    fresh_session = DummyChatService(config=None, user_id="u1")
+    acquire_and_create = AsyncMock(return_value=fresh_session)
+    monkeypatch.setattr(llmchat_router, "_acquire_and_create_session", acquire_and_create)
+
+    result = await llmchat_router.get_active_session("u1")
+
+    assert result is fresh_session
+    assert stale_session.shutdown_called is True
+    acquire_and_create.assert_awaited_once_with("u1")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #5740. `POST /llmchat/connect` on one gunicorn worker followed by `POST /llmchat/chat` landing on another worker returned `400 {"detail":"No active session found. Please connect to a server first."}`, even with `CACHE_TYPE=redis` + `REDIS_URL` configured correctly.

The issue's own diagnosis (`redis_client` is hardcoded `None`/dead code) doesn't hold up on the current checkout — it's assigned and wired through the lifespan, as an earlier comment on the issue also found. The actual bugs are two independent ones in `get_active_session()`:

1. **No cross-worker takeover.** Redis already stores the user's config, session ownership, and chat history. But when `get_active_session()` saw that another worker owned the session, it unconditionally `return None`'d instead of rebuilding the session locally from the Redis-backed config — even though everything needed to do so was already there. The existing retry loops for this case also polled this worker's own `active_sessions` dict waiting for a foreign worker to fill it, which can never happen.

2. **`WORKER_ID` computed at import time.** `WORKER_ID = str(os.getpid())` is a module-level assignment. `run-gunicorn.sh` enables `--preload` by default on Linux, so gunicorn imports the app once in the master process before forking — every worker inherited the *master's* PID as its `WORKER_ID`. The ownership/lock compare-and-delete Lua scripts then compared a value against itself, letting any worker delete or release another worker's lock/ownership key.

## Changes

- `init_redis()` (runs post-fork in the lifespan) now assigns a per-process, host-qualified `WORKER_ID` (`hostname:pid:uuid`), replacing the import-time module default.
- `get_active_session()` takes over a foreign-owned session by rebuilding it from the Redis-backed config and re-pointing ownership, instead of rejecting the request. Added a `recreate` parameter: `/connect` and `/disconnect` pass `recreate=False` since they're about to replace or tear down the session anyway and shouldn't pay for a full MCP handshake just to immediately discard it. `/status` no longer calls `get_active_session()` at all — it's now a pure Redis/local existence check, since a read-only GET should never trigger a session rebuild as a side effect.
- `_create_local_session_from_config()` now bounds `MCPChatService.initialize()` with the lock's TTL (`asyncio.wait_for`), so a slow MCP handshake can't outlive the lock and let two workers build duplicate sessions for the same user.
- The user config's Redis TTL is now refreshed alongside the ownership key's (previously only the ownership key was refreshed on activity, so a long conversation's config could silently expire out from under a later takeover).
- Added an idle reaper for orphaned local sessions left behind after a takeover, which skips any session with an in-flight streaming response (re-stamped per emitted SSE chunk) so it can't evict mid-stream.
- `init_redis()` now warns (previously silent) when LLM Chat is enabled without Redis configured.
- Updated `docs/docs/using/clients/llm-chat.md` — the previous "worker affinity / sticky sessions" description no longer matches the behavior.

## Related

- #4789 (Redis requirement undocumented) is largely addressed by this PR's docs update and startup warning.
- #5215 and #5214/#5223/#5739 are separate, unrelated blockers on the same feature (loopback auth, CSRF).