### PR TITLE
feat(ui): allow selecting the team when editing a virtual server

### DIFF
--- a/mcpgateway/admin_ui/formSubmitHandlers.js
+++ b/mcpgateway/admin_ui/formSubmitHandlers.js
@@ -968,6 +968,21 @@ export const handleEditServerFormSubmit = async function (e) {
   e.preventDefault();
   const form = e.target;
   const formData = new FormData(form);
+  const teamRadio = form.querySelector("#edit-server-visibility-team");
+  const teamSelect = form.querySelector("#edit-server-team-id");
+  const teamMessage = form.querySelector("#edit-server-team-message");
+
+  if (teamRadio?.checked && !formData.get("team_id")) {
+    if (teamMessage) {
+      teamMessage.textContent = "Please select a team";
+    }
+    teamSelect?.focus();
+    return;
+  }
+
+  if (teamMessage) {
+    teamMessage.textContent = "";
+  }
 
   try {
     // Validate inputs

--- a/mcpgateway/admin_ui/servers.js
+++ b/mcpgateway/admin_ui/servers.js
@@ -660,6 +660,139 @@ export const viewServer = async function (serverId) {
 /**
  * SECURE: Edit Server function
  */
+const EDIT_SERVER_ASSOCIATION_CONTAINER_IDS = [
+  "associatedEditGateways",
+  "edit-server-tools",
+  "edit-server-resources",
+  "edit-server-prompts",
+];
+
+const updateEditServerTeamSelectorState = () => {
+  const teamContainer = safeGetElement("edit-server-team-container");
+  const teamSelect = safeGetElement("edit-server-team-id");
+  const teamRadio = safeGetElement("edit-server-visibility-team");
+  const teamMessage = safeGetElement("edit-server-team-message");
+
+  if (!teamContainer || !teamSelect) {
+    return;
+  }
+
+  const hasOwnerTeams = teamSelect.dataset.hasOwnerTeams === "true";
+  const isTeamVisibility = Boolean(teamRadio?.checked);
+  teamContainer.classList.toggle("hidden", !isTeamVisibility);
+  teamSelect.disabled = !isTeamVisibility || !hasOwnerTeams;
+
+  if (teamMessage) {
+    teamMessage.textContent = hasOwnerTeams
+      ? ""
+      : "You have no teams you own; team visibility is unavailable.";
+  }
+};
+
+const rescopeEditServerAssociations = (teamId) => {
+  if (!teamId) {
+    return;
+  }
+
+  const viewPublicCheckbox = safeGetElement("edit-server-view-public");
+  const includePublic = Boolean(viewPublicCheckbox?.checked);
+
+  EDIT_SERVER_ASSOCIATION_CONTAINER_IDS.forEach((containerId) => {
+    const container = safeGetElement(containerId);
+    const hxGet = container?.getAttribute("hx-get");
+    if (!container || !hxGet) {
+      return;
+    }
+
+    const url = new URL(hxGet, window.location.href);
+    url.searchParams.set("team_id", teamId);
+    if (includePublic) {
+      url.searchParams.set("include_public", "true");
+    } else {
+      url.searchParams.delete("include_public");
+    }
+
+    const updatedHxGet = `${url.pathname}${url.search}${url.hash}`;
+    container.setAttribute("hx-get", updatedHxGet);
+    window.htmx.process(container);
+    window.htmx.trigger(container, "load");
+  });
+
+  toggleViewPublic(
+    "edit-server-view-public",
+    EDIT_SERVER_ASSOCIATION_CONTAINER_IDS,
+    teamId
+  );
+};
+
+const handleEditServerTeamChange = () => {
+  updateEditServerTeamSelectorState();
+
+  const teamSelect = safeGetElement("edit-server-team-id");
+  if (!teamSelect) {
+    return;
+  }
+
+  const selectedTeamId = teamSelect.value || teamSelect.dataset.currentTeamId;
+  rescopeEditServerAssociations(selectedTeamId);
+};
+
+const initializeEditServerTeamSelector = (currentTeamId) => {
+  const teamSelect = safeGetElement("edit-server-team-id");
+  const teamRadio = safeGetElement("edit-server-visibility-team");
+  if (!teamSelect) {
+    return;
+  }
+
+  const ownerTeams = Array.isArray(window.USER_TEAMS_DATA)
+    ? window.USER_TEAMS_DATA.filter((team) => team?.role === "owner")
+    : [];
+  const placeholderOption = document.createElement("option");
+  placeholderOption.value = "";
+  placeholderOption.textContent = "— Select a team —";
+  const teamOptions = ownerTeams.map((team) => {
+    const option = document.createElement("option");
+    option.value = team.id;
+    option.textContent = team.name;
+    return option;
+  });
+
+  teamSelect.replaceChildren(placeholderOption, ...teamOptions);
+  teamSelect.dataset.hasOwnerTeams = String(ownerTeams.length > 0);
+  teamSelect.value = "";
+  if (teamRadio) {
+    teamRadio.disabled = ownerTeams.length === 0;
+  }
+
+  const normalizedTeamId =
+    currentTeamId === null || currentTeamId === undefined
+      ? ""
+      : String(currentTeamId);
+  teamSelect.dataset.currentTeamId = normalizedTeamId;
+  if (
+    normalizedTeamId &&
+    teamOptions.some((option) => option.value === normalizedTeamId)
+  ) {
+    teamSelect.value = normalizedTeamId;
+  }
+
+  [
+    "edit-server-visibility-public",
+    "edit-server-visibility-team",
+    "edit-server-visibility-private",
+  ].forEach((radioId) => {
+    const radio = safeGetElement(radioId);
+    if (radio) {
+      radio.removeEventListener("change", updateEditServerTeamSelectorState);
+      radio.addEventListener("change", updateEditServerTeamSelectorState);
+    }
+  });
+  teamSelect.removeEventListener("change", handleEditServerTeamChange);
+  teamSelect.addEventListener("change", handleEditServerTeamChange);
+
+  updateEditServerTeamSelectorState();
+};
+
 export const editServer = async function (serverId) {
   try {
     console.log(`Editing server ID: ${serverId}`);
@@ -726,15 +859,11 @@ export const editServer = async function (serverId) {
       }
     }
 
-    const teamId = new URL(window.location.href).searchParams.get("team_id");
-
-    if (teamId) {
-      const hiddenInput = document.createElement("input");
-      hiddenInput.type = "hidden";
-      hiddenInput.name = "team_id";
-      hiddenInput.value = teamId;
-      editForm.appendChild(hiddenInput);
-    }
+    const teamId =
+      server.teamId === null || server.teamId === undefined
+        ? ""
+        : String(server.teamId);
+    initializeEditServerTeamSelector(teamId);
 
     // Initialize View Public toggle for Edit Server modal
     if (teamId) {
@@ -746,12 +875,7 @@ export const editServer = async function (serverId) {
       }
       toggleViewPublic(
         "edit-server-view-public",
-        [
-          "associatedEditGateways",
-          "edit-server-tools",
-          "edit-server-resources",
-          "edit-server-prompts",
-        ],
+        EDIT_SERVER_ASSOCIATION_CONTAINER_IDS,
         teamId
       );
     }

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -11125,6 +11125,25 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                         </div>
                       </div>
                     </div>
+                    <div id="edit-server-team-container" class="hidden">
+                      <label
+                        for="edit-server-team-id"
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                        >Team</label
+                      >
+                      <select
+                        id="edit-server-team-id"
+                        name="team_id"
+                        disabled
+                        class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:text-gray-300"
+                      ></select>
+                    </div>
+                    <p
+                      id="edit-server-team-message"
+                      class="mt-1 min-h-[1.25rem] text-sm text-red-600 dark:text-red-400"
+                      aria-live="polite"
+                      role="status"
+                    ></p>
                   </div>
                   {% if selected_team_id %}
                   <!-- View Public toggle for team-scoped server editing -->

--- a/tests/unit/js/servers.test.js
+++ b/tests/unit/js/servers.test.js
@@ -11,10 +11,11 @@ import {
   setEditServerAssociations,
   loadServers,
 } from "../../../mcpgateway/admin_ui/servers.js";
+import { handleEditServerFormSubmit } from "../../../mcpgateway/admin_ui/formSubmitHandlers.js";
+import { getSelectedGatewayIds } from "../../../mcpgateway/admin_ui/gateways.js";
 import { fetchWithTimeout } from "../../../mcpgateway/admin_ui/utils";
 import { openModal } from "../../../mcpgateway/admin_ui/modals";
 import { AppState } from "../../../mcpgateway/admin_ui/appState.js";
-import { fetchWithAuth } from "../../../mcpgateway/admin_ui/tokens.js";
 
 vi.mock("../../../mcpgateway/admin_ui/appState.js", () => ({
   AppState: {
@@ -25,6 +26,7 @@ vi.mock("../../../mcpgateway/admin_ui/configExport.js", () => ({
   getCatalogUrl: vi.fn(() => "http://localhost/catalog"),
 }));
 vi.mock("../../../mcpgateway/admin_ui/gateways.js", () => ({
+  getSelectedGatewayIds: vi.fn(() => []),
   initGatewaySelect: vi.fn(),
 }));
 vi.mock("../../../mcpgateway/admin_ui/modals", () => ({
@@ -38,11 +40,16 @@ vi.mock("../../../mcpgateway/admin_ui/resources", () => ({
 }));
 vi.mock("../../../mcpgateway/admin_ui/security.js", () => ({
   escapeHtml: vi.fn((s) => (s != null ? String(s) : "")),
+  safeParseJsonResponse: vi.fn(() => Promise.resolve({ success: true })),
   validateInputName: vi.fn((s) => ({ valid: true, value: s })),
+  validateJson: vi.fn(() => ({ valid: true })),
   validateUrl: vi.fn(() => ({ valid: true })),
 }));
 vi.mock("../../../mcpgateway/admin_ui/tokens.js", () => ({
   fetchWithAuth: vi.fn(),
+}));
+vi.mock("../../../mcpgateway/admin_ui/navigation.js", () => ({
+  navigateAdmin: vi.fn(),
 }));
 vi.mock("../../../mcpgateway/admin_ui/utils", () => ({
   safeGetElement: vi.fn((id) => document.getElementById(id)),
@@ -69,10 +76,14 @@ afterEach(() => {
   document.body.innerHTML = "";
   delete window.ROOT_PATH;
   delete window.Admin;
+  delete window.USER_TEAMS_DATA;
+  delete window.ALLOW_PUBLIC_VISIBILITY;
   delete window._editStoreListenersAttached;
   delete window._addStoreListenersAttached;
   // Reset AppState.editServerSelections
   AppState.editServerSelections = {};
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
   vi.clearAllMocks();
 });
 
@@ -216,6 +227,107 @@ describe("viewServer", () => {
 // editServer
 // ---------------------------------------------------------------------------
 describe("editServer", () => {
+  const createTeamSelectorForm = () => {
+    const form = document.createElement("form");
+    form.id = "edit-server-form";
+    form.action = "/admin/servers/s1/edit";
+
+    const nameInput = document.createElement("input");
+    nameInput.name = "name";
+    nameInput.value = "test-server";
+    form.appendChild(nameInput);
+
+    const visibilityRadios = ["public", "team", "private"].map((visibility) => {
+      const radio = document.createElement("input");
+      radio.type = "radio";
+      radio.name = "visibility";
+      radio.value = visibility;
+      radio.id = `edit-server-visibility-${visibility}`;
+      form.appendChild(radio);
+      return radio;
+    });
+
+    const teamContainer = document.createElement("div");
+    teamContainer.id = "edit-server-team-container";
+    teamContainer.classList.add("hidden");
+
+    const teamLabel = document.createElement("label");
+    teamLabel.htmlFor = "edit-server-team-id";
+    teamLabel.textContent = "Team";
+    teamContainer.appendChild(teamLabel);
+
+    const teamSelect = document.createElement("select");
+    teamSelect.id = "edit-server-team-id";
+    teamSelect.name = "team_id";
+    teamContainer.appendChild(teamSelect);
+    form.appendChild(teamContainer);
+
+    const teamMessage = document.createElement("p");
+    teamMessage.id = "edit-server-team-message";
+    teamMessage.setAttribute("aria-live", "polite");
+    form.appendChild(teamMessage);
+    document.body.appendChild(form);
+
+    return {
+      form,
+      publicRadio: visibilityRadios[0],
+      teamRadio: visibilityRadios[1],
+      privateRadio: visibilityRadios[2],
+      teamContainer,
+      teamSelect,
+      teamMessage,
+    };
+  };
+
+  const mockServerForTeamSelector = ({
+    visibility = "team",
+    teamId = "team-owner-2",
+  } = {}) => {
+    fetchWithTimeout.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          id: "s1",
+          name: "test-server",
+          visibility,
+          teamId,
+        }),
+    });
+  };
+
+  const createEditAssociationScopeElements = () => {
+    const viewPublicCheckbox = document.createElement("input");
+    viewPublicCheckbox.type = "checkbox";
+    viewPublicCheckbox.id = "edit-server-view-public";
+    document.body.appendChild(viewPublicCheckbox);
+
+    const containerIds = [
+      "associatedEditGateways",
+      "edit-server-tools",
+      "edit-server-resources",
+      "edit-server-prompts",
+    ];
+    const containers = containerIds.map((containerId, index) => {
+      const container = document.createElement("div");
+      container.id = containerId;
+      const gatewayFilter = index === 1 ? "&gateway_id=gateway-1" : "";
+      container.setAttribute(
+        "hx-get",
+        `/admin/items/${index}?page=1&team_id=team-owner-1${gatewayFilter}`
+      );
+      document.body.appendChild(container);
+      return container;
+    });
+
+    const htmx = {
+      process: vi.fn(),
+      trigger: vi.fn(),
+    };
+    window.htmx = htmx;
+
+    return { containers, htmx, viewPublicCheckbox };
+  };
+
   test("fetches server data for editing", async () => {
     window.ROOT_PATH = "";
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -365,6 +477,337 @@ describe("editServer", () => {
     expect(privateRadio.checked).toBe(false);
 
     consoleSpy.mockRestore();
+  });
+
+  test("populates only owner teams and selects the server team", async () => {
+    window.ROOT_PATH = "";
+    window.USER_TEAMS_DATA = [
+      { id: "team-owner-1", name: "Owner Team One", role: "owner" },
+      { id: "team-member", name: "Member Team", role: "member" },
+      { id: "team-owner-2", name: "Owner Team Two", role: "owner" },
+    ];
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { teamContainer, teamSelect } = createTeamSelectorForm();
+    mockServerForTeamSelector();
+
+    await editServer("s1");
+
+    expect(
+      Array.from(teamSelect.options, (option) => ({
+        value: option.value,
+        text: option.textContent,
+      }))
+    ).toEqual([
+      { value: "", text: "— Select a team —" },
+      { value: "team-owner-1", text: "Owner Team One" },
+      { value: "team-owner-2", text: "Owner Team Two" },
+    ]);
+    expect(teamSelect.value).toBe("team-owner-2");
+    expect(teamSelect.disabled).toBe(false);
+    expect(teamContainer.classList.contains("hidden")).toBe(false);
+
+    consoleSpy.mockRestore();
+  });
+
+  test("submits the selected team only for team visibility", async () => {
+    window.ROOT_PATH = "";
+    window.USER_TEAMS_DATA = [
+      { id: "team-owner-1", name: "Owner Team One", role: "owner" },
+      { id: "team-owner-2", name: "Owner Team Two", role: "owner" },
+    ];
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const {
+      form,
+      publicRadio,
+      teamRadio,
+      privateRadio,
+      teamContainer,
+      teamSelect,
+    } = createTeamSelectorForm();
+    mockServerForTeamSelector({ visibility: "private" });
+
+    await editServer("s1");
+
+    expect(privateRadio.checked).toBe(true);
+    expect(teamSelect.disabled).toBe(true);
+    expect(teamContainer.classList.contains("hidden")).toBe(true);
+    expect(new FormData(form).has("team_id")).toBe(false);
+
+    teamRadio.checked = true;
+    teamRadio.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(teamSelect.disabled).toBe(false);
+    expect(teamContainer.classList.contains("hidden")).toBe(false);
+    expect(teamSelect.value).toBe("team-owner-2");
+    expect(new FormData(form).get("team_id")).toBe("team-owner-2");
+
+    publicRadio.checked = true;
+    publicRadio.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(teamSelect.disabled).toBe(true);
+    expect(teamContainer.classList.contains("hidden")).toBe(true);
+    expect(new FormData(form).has("team_id")).toBe(false);
+
+    consoleSpy.mockRestore();
+  });
+
+  test("does not duplicate the team select or options when reopened", async () => {
+    window.ROOT_PATH = "";
+    window.USER_TEAMS_DATA = [
+      { id: "team-owner-1", name: "Owner Team One", role: "owner" },
+      { id: "team-owner-2", name: "Owner Team Two", role: "owner" },
+    ];
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { form, teamSelect } = createTeamSelectorForm();
+    mockServerForTeamSelector();
+
+    await editServer("s1");
+    await editServer("s1");
+
+    expect(form.querySelectorAll("#edit-server-team-id")).toHaveLength(1);
+    expect(teamSelect.options).toHaveLength(3);
+    expect(Array.from(teamSelect.options, (option) => option.value)).toEqual([
+      "",
+      "team-owner-1",
+      "team-owner-2",
+    ]);
+
+    consoleSpy.mockRestore();
+  });
+
+  test("keeps the placeholder selected when the current team is not owned", async () => {
+    window.ROOT_PATH = "";
+    window.USER_TEAMS_DATA = [
+      { id: "team-member", name: "Member Team", role: "member" },
+      { id: "team-owner-1", name: "Owner Team One", role: "owner" },
+    ];
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { teamSelect } = createTeamSelectorForm();
+    mockServerForTeamSelector({ teamId: "team-member" });
+
+    await editServer("s1");
+
+    expect(teamSelect.value).toBe("");
+    expect(teamSelect.selectedIndex).toBe(0);
+    expect(teamSelect.options[1].value).toBe("team-owner-1");
+    expect(teamSelect.options[1].selected).toBe(false);
+
+    consoleSpy.mockRestore();
+  });
+
+  test("re-scopes all association selectors when the owner team changes", async () => {
+    window.ROOT_PATH = "";
+    window.USER_TEAMS_DATA = [
+      { id: "team-owner-1", name: "Owner Team One", role: "owner" },
+      { id: "team-owner-2", name: "Owner Team Two", role: "owner" },
+    ];
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { teamSelect } = createTeamSelectorForm();
+    const { containers, htmx, viewPublicCheckbox } =
+      createEditAssociationScopeElements();
+    mockServerForTeamSelector({ teamId: "team-owner-1" });
+
+    await editServer("s1");
+    teamSelect.value = "team-owner-2";
+    teamSelect.dispatchEvent(new Event("change", { bubbles: true }));
+
+    containers.forEach((container) => {
+      const url = new URL(container.getAttribute("hx-get"), window.location);
+      expect(url.searchParams.get("team_id")).toBe("team-owner-2");
+      expect(url.searchParams.has("include_public")).toBe(false);
+    });
+    expect(
+      new URL(
+        containers[1].getAttribute("hx-get"),
+        window.location
+      ).searchParams.get("gateway_id")
+    ).toBe("gateway-1");
+    expect(htmx.process).toHaveBeenCalledTimes(4);
+    expect(htmx.trigger).toHaveBeenCalledTimes(4);
+    containers.forEach((container) => {
+      expect(htmx.process).toHaveBeenCalledWith(container);
+      expect(htmx.trigger).toHaveBeenCalledWith(container, "load");
+    });
+
+    viewPublicCheckbox.checked = true;
+    getSelectedGatewayIds.mockReturnValueOnce(["gateway-1"]);
+    viewPublicCheckbox.dispatchEvent(new Event("change"));
+    containers.forEach((container) => {
+      const url = new URL(container.getAttribute("hx-get"), window.location);
+      expect(url.searchParams.get("team_id")).toBe("team-owner-2");
+      expect(url.searchParams.get("include_public")).toBe("true");
+    });
+    expect(
+      new URL(
+        containers[1].getAttribute("hx-get"),
+        window.location
+      ).searchParams.get("gateway_id")
+    ).toBe("gateway-1");
+
+    consoleSpy.mockRestore();
+  });
+
+  test("preserves include_public while re-scoping association selectors", async () => {
+    window.ROOT_PATH = "";
+    window.USER_TEAMS_DATA = [
+      { id: "team-owner-1", name: "Owner Team One", role: "owner" },
+      { id: "team-owner-2", name: "Owner Team Two", role: "owner" },
+    ];
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { teamSelect } = createTeamSelectorForm();
+    const { containers, viewPublicCheckbox } =
+      createEditAssociationScopeElements();
+    mockServerForTeamSelector({ teamId: "team-owner-1" });
+
+    await editServer("s1");
+    viewPublicCheckbox.checked = true;
+    teamSelect.value = "team-owner-2";
+    teamSelect.dispatchEvent(new Event("change", { bubbles: true }));
+
+    containers.forEach((container) => {
+      const url = new URL(container.getAttribute("hx-get"), window.location);
+      expect(url.searchParams.get("team_id")).toBe("team-owner-2");
+      expect(url.searchParams.get("include_public")).toBe("true");
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  test("keeps the current server team scope when the placeholder is selected", async () => {
+    window.ROOT_PATH = "";
+    window.USER_TEAMS_DATA = [
+      { id: "team-member", name: "Member Team", role: "member" },
+      { id: "team-owner-1", name: "Owner Team One", role: "owner" },
+    ];
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { teamSelect } = createTeamSelectorForm();
+    const { containers } = createEditAssociationScopeElements();
+    mockServerForTeamSelector({ teamId: "team-member" });
+
+    await editServer("s1");
+    expect(teamSelect.value).toBe("");
+    teamSelect.dispatchEvent(new Event("change", { bubbles: true }));
+
+    containers.forEach((container) => {
+      const url = new URL(container.getAttribute("hx-get"), window.location);
+      expect(url.searchParams.get("team_id")).toBe("team-member");
+      expect(url.searchParams.get("team_id")).not.toBe("");
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  test("submits an empty team only until an owner team is explicitly selected", async () => {
+    window.ROOT_PATH = "";
+    window.USER_TEAMS_DATA = [
+      { id: "team-member", name: "Member Team", role: "member" },
+      { id: "team-owner-1", name: "Owner Team One", role: "owner" },
+    ];
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { form, teamSelect, teamMessage } = createTeamSelectorForm();
+    mockServerForTeamSelector({ teamId: "team-member" });
+    await editServer("s1");
+
+    const NativeFormData = globalThis.FormData;
+    const capturedFormData = [];
+    class CapturingFormData extends NativeFormData {
+      constructor(formElement) {
+        super(formElement);
+        capturedFormData.push(this);
+      }
+    }
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("FormData", CapturingFormData);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await handleEditServerFormSubmit({
+      preventDefault: vi.fn(),
+      target: form,
+    });
+
+    expect(capturedFormData[0].get("team_id")).toBe("");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(teamMessage.textContent).toBe("Please select a team");
+
+    teamSelect.value = "team-owner-1";
+    teamSelect.dispatchEvent(new Event("change", { bubbles: true }));
+    await handleEditServerFormSubmit({
+      preventDefault: vi.fn(),
+      target: form,
+    });
+
+    expect(capturedFormData[1].get("team_id")).toBe("team-owner-1");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1].body).toBe(capturedFormData[1]);
+
+    consoleSpy.mockRestore();
+  });
+
+  test("disables team visibility and explains when no owner teams exist", async () => {
+    window.ROOT_PATH = "";
+    window.USER_TEAMS_DATA = [
+      { id: "team-member", name: "Member Team", role: "member" },
+    ];
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { teamRadio, teamSelect, teamMessage } = createTeamSelectorForm();
+    mockServerForTeamSelector({ teamId: "team-member" });
+
+    await editServer("s1");
+
+    expect(teamRadio.disabled).toBe(true);
+    expect(teamSelect.disabled).toBe(true);
+    expect(teamMessage.getAttribute("aria-live")).toBe("polite");
+    expect(teamMessage.textContent).toBe(
+      "You have no teams you own; team visibility is unavailable."
+    );
+
+    window.USER_TEAMS_DATA = [
+      { id: "team-owner-1", name: "Owner Team One", role: "owner" },
+    ];
+    mockServerForTeamSelector({ teamId: "team-owner-1" });
+    await editServer("s1");
+
+    expect(teamRadio.disabled).toBe(false);
+    expect(teamSelect.disabled).toBe(false);
+    expect(teamMessage.textContent).toBe("");
+
+    consoleSpy.mockRestore();
+  });
+
+  test("preserves the selected team across visibility changes without duplicate listeners", async () => {
+    window.ROOT_PATH = "";
+    window.USER_TEAMS_DATA = [
+      { id: "team-owner-1", name: "Owner Team One", role: "owner" },
+      { id: "team-owner-2", name: "Owner Team Two", role: "owner" },
+    ];
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { teamRadio, privateRadio, teamContainer, teamSelect } =
+      createTeamSelectorForm();
+    mockServerForTeamSelector({ teamId: "team-owner-2" });
+
+    await editServer("s1");
+    await editServer("s1");
+
+    const toggleSpy = vi.spyOn(teamContainer.classList, "toggle");
+    privateRadio.checked = true;
+    privateRadio.dispatchEvent(new Event("change", { bubbles: true }));
+    teamRadio.checked = true;
+    teamRadio.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(teamSelect.value).toBe("team-owner-2");
+    expect(teamSelect.disabled).toBe(false);
+    expect(teamContainer.classList.contains("hidden")).toBe(false);
+    expect(toggleSpy).toHaveBeenCalledTimes(2);
+
+    consoleSpy.mockRestore();
+  });
+
+  test("associates the team select with its label", () => {
+    const { form, teamSelect } = createTeamSelectorForm();
+    const label = form.querySelector('label[for="edit-server-team-id"]');
+
+    expect(label).not.toBeNull();
+    expect(label.control).toBe(teamSelect);
   });
 
   test("handles tags and icon fields", async () => {


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue

Closes #5791

---

## 🚀 Summary (1-2 sentences)

Adds a team selector to the virtual server edit form so an owner can assign the server to a team they own when visibility is set to `team`. This is a UI-only change; the backend already validates and persists team assignment (owner-only) via `_validate_server_team_assignment`.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

Notes on the above:
- The gateway (MCP server) equivalent involves backend team propagation and is tracked separately in #5792 (a draft PR), to keep this one UI-only and low-risk.
- The linked issue was just opened and is not yet labeled by a maintainer; opening this PR to provide concrete, reviewable code. Happy to adjust scope based on triage.

### What it does
- Adds a `team_id` `<select>` to the virtual server edit form, shown only for `team` visibility, populated from teams the caller owns (`role == "owner"`).
- Pre-selects the server's current team from the fetched details; keeps an empty placeholder when the current team is not one the user owns, so a server is never implicitly moved (an empty `team_id` is treated by the backend as "keep current team").
- Sends `team_id` only for `team` visibility (disabled otherwise); blocks submission with an accessible message if `team` visibility is chosen without a team; disables `team` visibility with an `aria-live` note when the user owns no teams.
- Re-scopes the associated tools/resources/prompts/gateways candidate lists to the selected team so associations follow the chosen team.

---

## 🧪 Checks

_Targeted checks run locally (not the full `make lint`/`make test` suite):_

- `npx vitest run tests/unit/js/servers.test.js tests/unit/js/formSubmitHandlers.test.js` → **81 passed**
- `make build-ui` → success
- Manually verified end-to-end against a local instance: editing a `team`-visibility virtual server shows the selector, pre-selected to the current team, and reassigning to another owned team updates the server's team.

- [ ] `make lint` passes _(ran targeted ruff/eslint on changed files only)_
- [ ] `make test` passes _(ran targeted vitest above)_
- [ ] CHANGELOG updated (if user-facing) _(can add an entry if preferred)_

---

## 📓 Notes (optional)

Authorization is unchanged and remains server-side (the client-provided `team_id` is validated against active owner membership of the target team). The owner-only policy is assumed; broadening it to team members would be a separate discussion.
