### PR TITLE
feat: allow reassigning a gateway's team (and its federated entities) from the edit form

### DIFF
--- a/mcpgateway/admin_ui/formSubmitHandlers.js
+++ b/mcpgateway/admin_ui/formSubmitHandlers.js
@@ -767,6 +767,22 @@ export const handleEditGatewayFormSubmit = async function (e) {
   e.preventDefault();
   const form = e.target;
   const formData = new FormData(form);
+  const teamRadio = form.querySelector("#edit-gateway-visibility-team");
+  const teamSelect = form.querySelector("#edit-gateway-team-id");
+  const teamMessage = form.querySelector("#edit-gateway-team-message");
+
+  if (teamRadio?.checked && !formData.get("team_id")) {
+    if (teamMessage) {
+      teamMessage.textContent = "Please select a team";
+    }
+    teamSelect?.focus();
+    return;
+  }
+
+  if (teamMessage) {
+    teamMessage.textContent = "";
+  }
+
   try {
     // Validate form inputs
     const name = formData.get("name");

--- a/mcpgateway/admin_ui/gateways.js
+++ b/mcpgateway/admin_ui/gateways.js
@@ -239,6 +239,81 @@ export const viewGateway = async function (gatewayId) {
 /**
  * SECURE: Edit Gateway function
  */
+const updateEditGatewayTeamSelectorState = () => {
+  const teamContainer = safeGetElement("edit-gateway-team-container");
+  const teamSelect = safeGetElement("edit-gateway-team-id");
+  const teamRadio = safeGetElement("edit-gateway-visibility-team");
+  const teamMessage = safeGetElement("edit-gateway-team-message");
+
+  if (!teamContainer || !teamSelect) {
+    return;
+  }
+
+  const hasOwnerTeams = teamSelect.dataset.hasOwnerTeams === "true";
+  const isTeamVisibility = Boolean(teamRadio?.checked);
+  teamContainer.classList.toggle("hidden", !isTeamVisibility);
+  teamSelect.disabled = !isTeamVisibility || !hasOwnerTeams;
+
+  if (teamMessage) {
+    teamMessage.textContent = hasOwnerTeams
+      ? ""
+      : "You have no teams you own; team visibility is unavailable.";
+  }
+};
+
+const initializeEditGatewayTeamSelector = (currentTeamId) => {
+  const teamSelect = safeGetElement("edit-gateway-team-id");
+  const teamRadio = safeGetElement("edit-gateway-visibility-team");
+  if (!teamSelect) {
+    return;
+  }
+
+  const ownerTeams = Array.isArray(window.USER_TEAMS_DATA)
+    ? window.USER_TEAMS_DATA.filter((team) => team?.role === "owner")
+    : [];
+  const placeholderOption = document.createElement("option");
+  placeholderOption.value = "";
+  placeholderOption.textContent = "— Select a team —";
+  const teamOptions = ownerTeams.map((team) => {
+    const option = document.createElement("option");
+    option.value = team.id;
+    option.textContent = team.name;
+    return option;
+  });
+
+  teamSelect.replaceChildren(placeholderOption, ...teamOptions);
+  teamSelect.dataset.hasOwnerTeams = String(ownerTeams.length > 0);
+  teamSelect.value = "";
+  if (teamRadio) {
+    teamRadio.disabled = ownerTeams.length === 0;
+  }
+
+  const normalizedTeamId =
+    currentTeamId === null || currentTeamId === undefined
+      ? ""
+      : String(currentTeamId);
+  if (
+    normalizedTeamId &&
+    teamOptions.some((option) => option.value === normalizedTeamId)
+  ) {
+    teamSelect.value = normalizedTeamId;
+  }
+
+  [
+    "edit-gateway-visibility-public",
+    "edit-gateway-visibility-team",
+    "edit-gateway-visibility-private",
+  ].forEach((radioId) => {
+    const radio = safeGetElement(radioId);
+    if (radio) {
+      radio.removeEventListener("change", updateEditGatewayTeamSelectorState);
+      radio.addEventListener("change", updateEditGatewayTeamSelectorState);
+    }
+  });
+
+  updateEditGatewayTeamSelectorState();
+};
+
 export const editGateway = async function (gatewayId) {
   try {
     console.log(`Editing gateway ID: ${gatewayId}`);
@@ -305,16 +380,6 @@ export const editGateway = async function (gatewayId) {
       tagsField.value = rawTags.join(", ");
     }
 
-    const teamId = new URL(window.location.href).searchParams.get("team_id");
-
-    if (teamId) {
-      const hiddenInput = document.createElement("input");
-      hiddenInput.type = "hidden";
-      hiddenInput.name = "team_id";
-      hiddenInput.value = teamId;
-      editForm.appendChild(hiddenInput);
-    }
-
     const visibility = gateway.visibility
       ? gateway.visibility.toLowerCase()
       : null;
@@ -350,6 +415,8 @@ export const editGateway = async function (gatewayId) {
         privateRadio.checked = true;
       }
     }
+
+    initializeEditGatewayTeamSelector(gateway.teamId);
 
     if (transportField) {
       transportField.value = gateway.transport || "SSE"; // falls back to Admin.SSE(default)

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -2610,6 +2610,11 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             if not gateway:
                 raise GatewayNotFoundError(f"Gateway not found: {gateway_id}")
 
+            old_team_id = gateway.team_id
+            effective_team_id = gateway_update.team_id if gateway_update.team_id is not None else old_team_id
+            effective_visibility = gateway_update.visibility if gateway_update.visibility is not None else gateway.visibility
+            team_assignment_changed = gateway_update.team_id is not None and effective_team_id != old_team_id
+
             # Check ownership if user_email provided
             if user_email:
                 # First-Party
@@ -2620,11 +2625,14 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     raise PermissionError("Only the owner can update this gateway")
 
             if gateway.enabled or include_inactive:
+                if team_assignment_changed or gateway_update.visibility == "team":
+                    _validate_gateway_team_assignment(db, user_email, effective_team_id)
+
                 if getattr(settings, "gateway_async_lifecycle_enabled", False) is True and getattr(gateway, "status", None) == "pending":
                     return self.convert_gateway_to_read(gateway)
 
-                # Check for name conflicts if name is being changed
-                if gateway_update.name is not None and gateway_update.name != gateway.name:
+                # Check for name conflicts if the name or team scope is changing
+                if (gateway_update.name is not None and gateway_update.name != gateway.name) or (effective_visibility == "team" and team_assignment_changed):
                     # existing_gateway = db.execute(select(DbGateway).where(DbGateway.name == gateway_update.name).where(DbGateway.id != gateway_id)).scalar_one_or_none()
 
                     # if existing_gateway:
@@ -2634,7 +2642,8 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     #         gateway_id=existing_gateway.id,
                     #     )
                     # Check for existing gateway with the same slug and visibility
-                    new_slug = slugify(gateway_update.name)
+                    target_name = gateway_update.name if gateway_update.name is not None else gateway.name
+                    new_slug = slugify(target_name)
                     if gateway_update.visibility is not None:
                         vis = gateway_update.visibility
                     else:
@@ -2653,12 +2662,12 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                                 gateway_id=existing_gateway.id,
                                 visibility=existing_gateway.visibility,
                             )
-                    elif vis == "team" and gateway.team_id:
+                    elif vis == "team" and effective_team_id:
                         # Check for existing team gateway with the same slug (row-locked)
                         existing_gateway = get_for_update(
                             db,
                             DbGateway,
-                            where=and_(DbGateway.slug == new_slug, DbGateway.visibility == "team", DbGateway.team_id == gateway.team_id, DbGateway.id != gateway_id),
+                            where=and_(DbGateway.slug == new_slug, DbGateway.visibility == "team", DbGateway.team_id == effective_team_id, DbGateway.id != gateway_id),
                         )
                         if existing_gateway:
                             raise GatewayNameConflictError(
@@ -2671,6 +2680,8 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 normalized_url = ""
                 if gateway_update.url is not None:
                     normalized_url = self.normalize_url(str(gateway_update.url))
+                elif team_assignment_changed:
+                    normalized_url = gateway.url
                 else:
                     normalized_url = None
 
@@ -2697,7 +2708,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         url=normalized_url,
                         auth_value=final_auth_value,
                         oauth_config=final_oauth_config,
-                        team_id=gateway.team_id,
+                        team_id=effective_team_id,
                         visibility=final_visibility,
                         gateway_id=gateway_id,  # Exclude current gateway from check
                         owner_email=user_email,
@@ -2771,10 +2782,6 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     gateway.tags = gateway_update.tags
                 if gateway_update.visibility is not None:
                     old_visibility = gateway.visibility
-                    # Validate visibility transitions
-                    if gateway_update.visibility == "team":
-                        target_team_id = gateway_update.team_id if gateway_update.team_id is not None else gateway.team_id
-                        _validate_gateway_team_assignment(db, user_email, target_team_id)
                     gateway.visibility = gateway_update.visibility
                     # Propagate visibility to all linked items immediately so it
                     # takes effect even when the upstream server is unreachable
@@ -2805,9 +2812,17 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
                 # Update team assignment if provided, validating ownership
                 if gateway_update.team_id is not None:
-                    if gateway_update.team_id != gateway.team_id:
-                        _validate_gateway_team_assignment(db, user_email, gateway_update.team_id)
                     gateway.team_id = gateway_update.team_id
+                    if gateway.team_id != old_team_id:
+                        for tool in gateway.tools:
+                            if tool.team_id == old_team_id:
+                                tool.team_id = gateway.team_id
+                        for resource in gateway.resources:
+                            if resource.team_id == old_team_id:
+                                resource.team_id = gateway.team_id
+                        for prompt in gateway.prompts:
+                            if prompt.team_id == old_team_id:
+                                prompt.team_id = gateway.team_id
 
                 # Update CA certificate fields if provided
                 if getattr(gateway_update, "ca_certificate", None) is not None:

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -9851,6 +9851,26 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                         </div>
                       </div>
                     </div>
+                    <div id="edit-gateway-team-container" class="hidden">
+                      <label
+                        for="edit-gateway-team-id"
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                        >Team</label
+                      >
+                      <select
+                        id="edit-gateway-team-id"
+                        name="team_id"
+                        aria-label="Team"
+                        disabled
+                        class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:text-gray-300"
+                      ></select>
+                    </div>
+                    <p
+                      id="edit-gateway-team-message"
+                      class="mt-1 min-h-[1.25rem] text-sm text-red-600 dark:text-red-400"
+                      aria-live="polite"
+                      role="status"
+                    ></p>
 
                     <div>
                       <label class="block text-sm font-medium text-gray-700"

--- a/tests/unit/js/formSubmitHandlers.test.js
+++ b/tests/unit/js/formSubmitHandlers.test.js
@@ -514,6 +514,32 @@ describe("handleEditToolFormSubmit", () => {
 // handleEditGatewayFormSubmit
 // ---------------------------------------------------------------------------
 describe("handleEditGatewayFormSubmit", () => {
+  test("blocks team visibility submission until a team is selected", async () => {
+    const event = createFormEvent(`
+      <form action="/admin/gateways/1/edit">
+        <input name="name" value="GW" />
+        <input name="url" value="http://example.com" />
+        <input id="edit-gateway-visibility-team" type="radio" name="visibility" value="team" checked />
+        <select id="edit-gateway-team-id" name="team_id">
+          <option value="" selected>— Select a team —</option>
+        </select>
+        <p id="edit-gateway-team-message"></p>
+        <input name="auth_type" value="none" />
+      </form>
+    `);
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await handleEditGatewayFormSubmit(event);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(
+      document.getElementById("edit-gateway-team-message").textContent
+    ).toBe("Please select a team");
+    expect(document.activeElement).toBe(
+      document.getElementById("edit-gateway-team-id")
+    );
+  });
+
   test("validates gateway name and URL on edit", async () => {
     const event = createFormEvent(`
       <form action="/admin/gateways/1/edit">

--- a/tests/unit/js/gateway.test.js
+++ b/tests/unit/js/gateway.test.js
@@ -72,6 +72,7 @@ vi.mock("../../../mcpgateway/admin_ui/utils", () => ({
 afterEach(() => {
   document.body.innerHTML = "";
   delete window.ROOT_PATH;
+  delete window.USER_TEAMS_DATA;
   vi.clearAllMocks();
 });
 
@@ -261,6 +262,150 @@ describe("editGateway", () => {
     await editGateway("bad-gw");
 
     expect(showErrorMessage).toHaveBeenCalled();
+  });
+});
+
+describe("editGateway team selector", () => {
+  function createGatewayTeamEditHTML() {
+    return `
+      <form id="edit-gateway-form">
+        <input id="edit-gateway-name" />
+        <input id="edit-gateway-url" />
+        <textarea id="edit-gateway-description"></textarea>
+        <input id="edit-gateway-tags" />
+        <input id="edit-gateway-visibility-public" type="radio" name="visibility" value="public" />
+        <input id="edit-gateway-visibility-team" type="radio" name="visibility" value="team" />
+        <input id="edit-gateway-visibility-private" type="radio" name="visibility" value="private" />
+        <div id="edit-gateway-team-container" class="hidden">
+          <select id="edit-gateway-team-id" name="team_id" disabled></select>
+        </div>
+        <p id="edit-gateway-team-message"></p>
+        <select id="edit-gateway-transport"><option value="SSE">SSE</option></select>
+        <select id="auth-type-gw-edit"><option value="">None</option></select>
+        <input id="edit-gateway-passthrough-headers" />
+      </form>
+      <div id="gateway-edit-modal" class="hidden"></div>
+    `;
+  }
+
+  function mockGatewayEditResponse(overrides = {}) {
+    fetchWithTimeout.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          name: "Team Gateway",
+          url: "http://localhost:8080",
+          visibility: "team",
+          transport: "SSE",
+          authType: "",
+          tags: [],
+          ...overrides,
+        }),
+    });
+  }
+
+  test("lists only owner teams and selects the current owned team", async () => {
+    document.body.innerHTML = createGatewayTeamEditHTML();
+    window.USER_TEAMS_DATA = [
+      { id: "team-owner-1", name: "Owner One", role: "owner" },
+      { id: "team-member", name: "Member Team", role: "member" },
+      { id: "team-owner-2", name: "Owner Two", role: "owner" },
+    ];
+    mockGatewayEditResponse({ teamId: "team-owner-2" });
+
+    await editGateway("gw-team");
+
+    const teamSelect = document.getElementById("edit-gateway-team-id");
+    expect(
+      Array.from(teamSelect.options).map((option) => option.value)
+    ).toEqual(["", "team-owner-1", "team-owner-2"]);
+    expect(teamSelect.value).toBe("team-owner-2");
+    expect(teamSelect.disabled).toBe(false);
+    expect(
+      document
+        .getElementById("edit-gateway-team-container")
+        .classList.contains("hidden")
+    ).toBe(false);
+  });
+
+  test("keeps the placeholder selected when the current team is not owned", async () => {
+    document.body.innerHTML = createGatewayTeamEditHTML();
+    window.USER_TEAMS_DATA = [
+      { id: "team-owner", name: "Owner Team", role: "owner" },
+      { id: "team-member", name: "Member Team", role: "member" },
+    ];
+    mockGatewayEditResponse({ teamId: "team-member" });
+
+    await editGateway("gw-member-team");
+
+    const teamSelect = document.getElementById("edit-gateway-team-id");
+    expect(teamSelect.value).toBe("");
+    expect(teamSelect.options[0].textContent).toBe("— Select a team —");
+  });
+
+  test("disables and omits team_id outside team visibility", async () => {
+    document.body.innerHTML = createGatewayTeamEditHTML();
+    window.USER_TEAMS_DATA = [
+      { id: "team-owner", name: "Owner Team", role: "owner" },
+    ];
+    mockGatewayEditResponse({
+      visibility: "private",
+      teamId: "team-owner",
+    });
+
+    await editGateway("gw-private");
+
+    const form = document.getElementById("edit-gateway-form");
+    const teamSelect = document.getElementById("edit-gateway-team-id");
+    expect(teamSelect.disabled).toBe(true);
+    expect(
+      document
+        .getElementById("edit-gateway-team-container")
+        .classList.contains("hidden")
+    ).toBe(true);
+    expect(new FormData(form).has("team_id")).toBe(false);
+  });
+
+  test("updates selector state when visibility changes", async () => {
+    document.body.innerHTML = createGatewayTeamEditHTML();
+    window.USER_TEAMS_DATA = [
+      { id: "team-owner", name: "Owner Team", role: "owner" },
+    ];
+    mockGatewayEditResponse({ visibility: "private", teamId: "team-owner" });
+    await editGateway("gw-toggle");
+
+    const teamRadio = document.getElementById("edit-gateway-visibility-team");
+    const teamSelect = document.getElementById("edit-gateway-team-id");
+    teamRadio.checked = true;
+    teamRadio.dispatchEvent(new Event("change"));
+
+    expect(teamSelect.disabled).toBe(false);
+    expect(
+      document
+        .getElementById("edit-gateway-team-container")
+        .classList.contains("hidden")
+    ).toBe(false);
+    expect(
+      new FormData(document.getElementById("edit-gateway-form")).get("team_id")
+    ).toBe("team-owner");
+  });
+
+  test("disables team visibility when the user owns no teams", async () => {
+    document.body.innerHTML = createGatewayTeamEditHTML();
+    window.USER_TEAMS_DATA = [
+      { id: "team-member", name: "Member Team", role: "member" },
+    ];
+    mockGatewayEditResponse({ teamId: "team-member" });
+
+    await editGateway("gw-no-owner");
+
+    expect(
+      document.getElementById("edit-gateway-visibility-team").disabled
+    ).toBe(true);
+    expect(document.getElementById("edit-gateway-team-id").disabled).toBe(true);
+    expect(
+      document.getElementById("edit-gateway-team-message").textContent
+    ).toContain("no teams you own");
   });
 });
 

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -1812,20 +1812,24 @@ class TestGatewayService:
     @pytest.mark.asyncio
     async def test_update_gateway_team_id_rejects_non_owner(self, gateway_service, mock_gateway, test_db):
         """Reassigning a gateway to a team where user is not owner must raise GatewayError."""
-        # First-Party
-        from mcpgateway.services.gateway_service import _validate_gateway_team_assignment
-
+        mock_gateway.team_id = "old-team"
+        test_db.execute = Mock(return_value=_make_execute_result(scalar=mock_gateway))
         mock_team = MagicMock()
         mock_query = Mock()
         mock_query.filter.return_value = mock_query
         # Team exists but membership check returns None (not owner)
         mock_query.first.side_effect = [mock_team, None]
+        test_db.query = Mock(return_value=mock_query)
+        test_db.rollback = Mock()
 
-        mock_db = MagicMock()
-        mock_db.query.return_value = mock_query
+        gateway_update = GatewayUpdate(team_id="other-team")
 
-        with pytest.raises(ValueError, match="membership"):
-            _validate_gateway_team_assignment(mock_db, "user@example.com", "other-team")
+        with patch("mcpgateway.services.permission_service.PermissionService.check_resource_ownership", new=AsyncMock(return_value=True)):
+            with pytest.raises(GatewayError, match="membership"):
+                await gateway_service.update_gateway(test_db, 1, gateway_update, user_email="user@example.com")
+
+        assert mock_gateway.team_id == "old-team"
+        test_db.rollback.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_update_gateway_team_id_skips_ownership_check_without_user_email(self, gateway_service, mock_gateway, test_db):
@@ -1835,7 +1839,12 @@ class TestGatewayService:
         mock_gateway.oauth_config = None
         mock_gateway.auth_query_params = None
         mock_gateway.slug = "test_gateway"
-        test_db.execute = Mock(return_value=_make_execute_result(scalar=mock_gateway))
+        test_db.execute = Mock(
+            side_effect=[
+                _make_execute_result(scalar=mock_gateway),
+                _make_execute_result(scalar=None),
+            ]
+        )
         test_db.commit = Mock()
         test_db.refresh = Mock()
         mock_query = Mock()
@@ -1856,6 +1865,152 @@ class TestGatewayService:
             await gateway_service.update_gateway(test_db, 1, gateway_update, user_email=None)
 
         assert mock_gateway.team_id == "new-team"
+
+    @pytest.mark.asyncio
+    async def test_update_gateway_team_id_propagates_inherited_children_and_preserves_overrides(self, gateway_service, mock_gateway, test_db):
+        """Team reassignment propagates only to children that inherited the old team."""
+        inherited_tool = MagicMock(spec=DbTool)
+        inherited_tool.team_id = "team-a"
+        overridden_tool = MagicMock(spec=DbTool)
+        overridden_tool.team_id = "team-override"
+        inherited_resource = MagicMock(spec=DbResource)
+        inherited_resource.team_id = "team-a"
+        overridden_resource = MagicMock(spec=DbResource)
+        overridden_resource.team_id = "team-override"
+        inherited_prompt = MagicMock(spec=DbPrompt)
+        inherited_prompt.team_id = "team-a"
+        overridden_prompt = MagicMock(spec=DbPrompt)
+        overridden_prompt.team_id = "team-override"
+
+        mock_gateway.team_id = "team-a"
+        mock_gateway.visibility = "team"
+        mock_gateway.slug = "test-gateway"
+        mock_gateway.auth_type = None
+        mock_gateway.auth_value = {}
+        mock_gateway.auth_query_params = None
+        mock_gateway.oauth_config = None
+        mock_gateway.ca_certificate = None
+        mock_gateway.ca_certificate_sig = None
+        mock_gateway.signing_algorithm = None
+        mock_gateway.client_cert = None
+        mock_gateway.client_key = None
+        mock_gateway.tools = [inherited_tool, overridden_tool]
+        mock_gateway.resources = [inherited_resource, overridden_resource]
+        mock_gateway.prompts = [inherited_prompt, overridden_prompt]
+
+        test_db.execute = Mock(
+            side_effect=[
+                _make_execute_result(scalar=mock_gateway),
+                _make_execute_result(scalar=None),
+            ]
+        )
+        test_db.commit = Mock()
+        test_db.refresh = Mock()
+        mock_query = Mock()
+        mock_query.filter.return_value = mock_query
+        mock_query.first.side_effect = [MagicMock(), MagicMock()]
+        mock_query.all.return_value = []
+        test_db.query = Mock(return_value=mock_query)
+
+        gateway_service._initialize_gateway = AsyncMock(side_effect=GatewayConnectionError("unreachable"))
+        gateway_service._notify_gateway_updated = AsyncMock()
+
+        with patch("mcpgateway.services.permission_service.PermissionService.check_resource_ownership", new=AsyncMock(return_value=True)):
+            await gateway_service.update_gateway(
+                test_db,
+                1,
+                GatewayUpdate(team_id="team-b"),
+                user_email="owner@example.com",
+            )
+
+        assert mock_gateway.team_id == "team-b"
+        assert inherited_tool.team_id == "team-b"
+        assert inherited_resource.team_id == "team-b"
+        assert inherited_prompt.team_id == "team-b"
+        assert overridden_tool.team_id == "team-override"
+        assert overridden_resource.team_id == "team-override"
+        assert overridden_prompt.team_id == "team-override"
+        test_db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_gateway_team_move_checks_destination_team_for_slug_conflicts(self, gateway_service, mock_gateway, test_db):
+        """A team-only move rejects a slug already present in the destination team."""
+        mock_gateway.team_id = "team-a"
+        mock_gateway.visibility = "team"
+        mock_gateway.slug = "test-gateway"
+
+        conflicting = MagicMock(spec=DbGateway)
+        conflicting.id = 2
+        conflicting.enabled = True
+        conflicting.visibility = "team"
+        test_db.execute = Mock(
+            side_effect=[
+                _make_execute_result(scalar=mock_gateway),
+                _make_execute_result(scalar=conflicting),
+            ]
+        )
+        test_db.rollback = Mock()
+        mock_query = Mock()
+        mock_query.filter.return_value = mock_query
+        mock_query.first.side_effect = [MagicMock(), MagicMock()]
+        test_db.query = Mock(return_value=mock_query)
+
+        with patch("mcpgateway.services.permission_service.PermissionService.check_resource_ownership", new=AsyncMock(return_value=True)):
+            with pytest.raises(GatewayNameConflictError):
+                await gateway_service.update_gateway(
+                    test_db,
+                    1,
+                    GatewayUpdate(team_id="team-b"),
+                    user_email="owner@example.com",
+                )
+
+        assert mock_gateway.team_id == "team-a"
+        test_db.rollback.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_gateway_team_move_checks_destination_team_for_url_conflicts(self, gateway_service, mock_gateway, test_db):
+        """A team-only move checks the current URL in the destination team scope."""
+        mock_gateway.team_id = "team-a"
+        mock_gateway.visibility = "team"
+        mock_gateway.slug = "test-gateway"
+        mock_gateway.auth_value = {}
+        mock_gateway.oauth_config = None
+
+        conflicting = MagicMock(spec=DbGateway)
+        conflicting.id = 2
+        conflicting.url = mock_gateway.url
+        conflicting.enabled = True
+        conflicting.visibility = "team"
+        conflicting.name = "existing-gateway"
+        conflicting.team_id = "team-b"
+        test_db.execute = Mock(
+            side_effect=[
+                _make_execute_result(scalar=mock_gateway),
+                _make_execute_result(scalar=None),
+            ]
+        )
+        test_db.rollback = Mock()
+        mock_query = Mock()
+        mock_query.filter.return_value = mock_query
+        mock_query.first.side_effect = [MagicMock(), MagicMock()]
+        test_db.query = Mock(return_value=mock_query)
+        gateway_service._check_gateway_uniqueness = Mock(return_value=conflicting)
+
+        with patch("mcpgateway.services.permission_service.PermissionService.check_resource_ownership", new=AsyncMock(return_value=True)):
+            with pytest.raises(GatewayError, match="already exists"):
+                await gateway_service.update_gateway(
+                    test_db,
+                    1,
+                    GatewayUpdate(team_id="team-b"),
+                    user_email="owner@example.com",
+                )
+
+        uniqueness_call = gateway_service._check_gateway_uniqueness.call_args.kwargs
+        assert uniqueness_call["url"] == mock_gateway.url
+        assert uniqueness_call["team_id"] == "team-b"
+        assert uniqueness_call["visibility"] == "team"
+        assert mock_gateway.team_id == "team-a"
+        test_db.rollback.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_update_gateway_visibility_preserves_per_resource_overrides(self, gateway_service, mock_gateway, test_db):


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

> **Draft** — opened for feedback on the design question below before finalizing, since this touches team scoping (RBAC visibility).

## 🔗 Epic / Issue

Closes #5792

---

## 🚀 Summary (1-2 sentences)

Adds a team selector to the MCP server (gateway) edit form and makes team reassignment consistent by propagating the new team to the gateway's federated tools/resources/prompts. Mirrors the virtual server selector in #5791, plus the backend propagation gateways need.

---

## ❓ Design question for maintainers (please confirm before merge)

When a gateway's team changes, this PR propagates the new `team_id` to child tools/resources/prompts **that inherited the old team**, preserving per-item overrides (mirroring how visibility already propagates). Is that the desired behavior, or should children be left in place and moved individually? Happy to change the approach based on your preference — that's why this is a draft.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

Notes:
- The UI-only virtual server counterpart is a separate PR (#5791). This PR is the gateway case, which additionally needs backend changes.
- The linked issue was just opened and is not yet maintainer-labeled; opening as a draft to provide concrete code and drive the design discussion.

### What it does
**UI** (mirrors the virtual server selector): owned-teams-only dropdown, empty placeholder to avoid implicit moves, `team_id` sent only for `team` visibility, submission blocked with an accessible message otherwise, disabled with an explanation when the user owns no teams.

**Backend** (`update_gateway`):
- Validates destination-team ownership before the duplicate checks.
- Runs the slug/URL duplicate checks against the **destination** team when the team is changing (previously used the pre-change team).
- On team change, propagates the new `team_id` to child tools/resources/prompts that inherited the old team, preserving per-item overrides. No schema/migration change (columns already exist).

---

## 🧪 Checks

_Targeted checks run locally (not the full `make lint`/`make test` suite):_

- `python -m pytest tests/unit/mcpgateway/services/test_gateway_service.py` → **354 passed, 1 skipped** (includes new deny-path, propagation-with-override, and destination-team conflict tests)
- `npx vitest run tests/unit/js/gateway.test.js tests/unit/js/formSubmitHandlers.test.js` → **116 passed**
- `ruff check mcpgateway/services/gateway_service.py` → clean
- `make build-ui` → success
- Manually verified end-to-end: reassigning a gateway's team on a local instance moved the gateway and its two federated tools to the destination team together; per-item overrides were preserved.

- [ ] `make lint` passes _(ran targeted ruff/eslint on changed files only)_
- [ ] `make test` passes _(ran targeted pytest/vitest above)_
- [ ] CHANGELOG updated (if user-facing) _(can add an entry if preferred)_

---

## 📓 Notes (optional)

Security: destination-team ownership is validated before applying the change and cannot be bypassed via disabled gateways (validation and assignment are under the same enabled/include-inactive guard). Deny-path regression tests are included.
