### PR TITLE
fix: generate strong per-run JWT secret in plugin integration harness

### DIFF
--- a/tests/live_gateway/plugins/Makefile.plugin-integration
+++ b/tests/live_gateway/plugins/Makefile.plugin-integration
@@ -17,7 +17,7 @@
 #    ENFORCEMENT     static | binding | both.           Default: both
 #    GATEWAY_PORT    Port for the test gateway.         Default: 4444
 #    GATEWAY_HOST    Host for the test gateway.         Default: 127.0.0.1
-#    JWT_SECRET_KEY  Must be >32 bytes.                 Default: dev test key
+#    JWT_SECRET_KEY  Must be >32 bytes, strong.         Default: random per run
 #    REDIS_HOST      Redis host (redis-requiring plugins). Default: 127.0.0.1
 #    REDIS_PORT      Redis port.                        Default: 6379
 #    VENV_DIR        Path to project virtualenv.        Default: .venv
@@ -33,7 +33,9 @@ GATEWAY_PORT ?= 4444
 GATEWAY_HOST ?= 127.0.0.1
 REDIS_HOST   ?= 127.0.0.1
 REDIS_PORT   ?= 6379
-JWT_SECRET_KEY ?= my-test-key-but-now-longer-than-32-bytes
+# No default: when unset/empty the runner generates a strong per-run secret
+# (the config validator rejects known-weak/default values in every environment).
+JWT_SECRET_KEY ?=
 
 _PLUGIN_RUNNER := tests/live_gateway/plugins/run_plugin_tests.sh
 

--- a/tests/live_gateway/plugins/run_plugin_tests.sh
+++ b/tests/live_gateway/plugins/run_plugin_tests.sh
@@ -12,7 +12,7 @@
 #  Environment variables (all optional — defaults shown below):
 #    GATEWAY_PORT        Test gateway port              (default: 4444)
 #    GATEWAY_HOST        Test gateway host              (default: 127.0.0.1)
-#    JWT_SECRET_KEY      Must be >32 bytes              (default: see below)
+#    JWT_SECRET_KEY      Must be >32 bytes, strong      (default: random per run)
 #    REDIS_HOST          Redis host for redis-requiring plugins  (default: 127.0.0.1)
 #    REDIS_PORT          Redis port                     (default: 6379)
 #    VENV_DIR              Path to project virtualenv     (default: .venv)
@@ -35,7 +35,10 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 GATEWAY_PORT="${GATEWAY_PORT:-4444}"
 GATEWAY_HOST="${GATEWAY_HOST:-127.0.0.1}"
 GATEWAY_URL="http://${GATEWAY_HOST}:${GATEWAY_PORT}"
-JWT_SECRET="${JWT_SECRET_KEY:-my-test-key-but-now-longer-than-32-bytes}"
+# A strong random secret is generated per run when none is supplied: the config
+# validator rejects known-weak/default values in every environment, and both the
+# gateway and pytest legs inherit the same value so tokens stay consistent.
+JWT_SECRET="${JWT_SECRET_KEY:-$(openssl rand -base64 48 | tr -d '\n')}"
 REDIS_HOST="${REDIS_HOST:-127.0.0.1}"
 REDIS_PORT="${REDIS_PORT:-6379}"
 VENV_DIR="${VENV_DIR:-${PROJECT_ROOT}/.venv}"
@@ -157,8 +160,10 @@ ensure_redis() {
 # ---------------------------------------------------------------------------
 boot_gateway() {
     local config_file="$1"
-    # Kill any stale gateway
+    # Kill any stale gateway — including uvicorn-launched dev servers, which
+    # otherwise keep the port and fool wait_for_health into a false "up".
     pkill -9 -f "python -m mcpgateway" 2>/dev/null || true
+    pkill -9 -f "uvicorn mcpgateway.main:app" 2>/dev/null || true
     sleep 1
 
     # Stamp the Alembic migration cursor to the current codebase head.


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #

---

## 📝 Summary

The plugin E2E harness defaulted `JWT_SECRET_KEY` to `my-test-key-but-now-longer-than-32-bytes`, which is now on the known-weak blocklist (`mcpgateway/_security_constants.py`) rejected by `Settings` validation in **every** environment. As a result, every local `make test-plugin-*` run failed on both legs:

- the **test gateway** crashed at startup with `SecurityConfigurationError`, and
- the **pytest legs** died at conftest import time (`tests/conftest.py` → `mcpgateway.db` → `Settings()`).

The failure was also masked: a stale uvicorn-launched dev gateway holding port 4444 answered the harness health check, producing a false `[info] gateway is up` while the real test gateway was crash-looping — so the summary showed pytest failures instead of the actual gateway boot failure.

**Changes** (local test harness only — CI does not use these files, see Notes):

- `tests/live_gateway/plugins/run_plugin_tests.sh`: generate a strong random secret per run via `openssl rand -base64 48` when none is supplied; the gateway and pytest legs share the same value, so tokens stay consistent within a run.
- `tests/live_gateway/plugins/Makefile.plugin-integration`: drop the weak default so the runner fallback applies; explicit `JWT_SECRET_KEY=...` overrides still work.
- Stale-gateway cleanup now also kills uvicorn-launched gateways (`uvicorn mcpgateway.main:app`), which previously kept the port and fooled `wait_for_health` into a false "gateway is up".

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

Reproduced the failure, applied the fix, and re-ran the affected target end-to-end:

| Check | Command | Status |
|---|---|---|
| Plugin E2E (before fix) | `make test-plugin-pii-filter` | ❌ 0/2 — `SecurityConfigurationError: jwt_secret_key: known-weak/default value rejected` |
| Plugin E2E (after fix) | `make test-plugin-pii-filter` | ✅ 2/2 passed (static + binding) |
| Generated secret passes validation | `JWT_SECRET_KEY="$(openssl rand -base64 48 \| tr -d '\n')" python -c "from mcpgateway.config import Settings; Settings()"` | ✅ constructs cleanly |
| Lint suite | `make lint` | N/A — bash/Makefile only, no Python touched |
| Unit tests | `make test` | N/A — no runtime code changed |
| Coverage ≥ 80% | `make coverage` | N/A — no runtime code changed |

Masked-failure repro: start a dev server (`python -m uvicorn mcpgateway.main:app --port 4444`), run any `make test-plugin-*` target on main — the harness reports `gateway is up` even though its own gateway never started (visible in `/tmp/gateway-plugin-tests.log`).

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`) — N/A for shell/Make changes
- [x] Tests added/updated for changes — the harness is itself test infrastructure; verified live
- [x] Documentation updated (if applicable) — header comments in both files updated
- [x] No secrets or credentials committed — the weak hardcoded secret was *removed*; secrets are now generated per run and never written to disk

---

## 📓 Notes (optional)