### PR TITLE
fix: configure secrets for client workflows

### DIFF
--- a/.github/workflows/client-e2e.yml
+++ b/.github/workflows/client-e2e.yml
@@ -39,6 +39,8 @@ jobs:
     env:
       CI: "true"
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
+      JWT_SECRET_KEY: "ci-client-e2e-jwt-secret-not-for-production-use" # pragma: allowlist secret
+      AUTH_ENCRYPTION_SECRET: "ci-client-e2e-auth-enc-secret-not-for-production" # pragma: allowlist secret
 
     steps:
       - name: ⬇️ Checkout source

--- a/.github/workflows/client-generate.yml
+++ b/.github/workflows/client-generate.yml
@@ -21,6 +21,10 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
 
+        env:
+            JWT_SECRET_KEY: "ci-client-generate-jwt-secret-not-for-production-use" # pragma: allowlist secret
+            AUTH_ENCRYPTION_SECRET: "ci-client-generate-auth-enc-secret-not-for-production" # pragma: allowlist secret
+
         steps:
             - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
               with:

--- a/.github/workflows/client-lint-test.yml
+++ b/.github/workflows/client-lint-test.yml
@@ -36,6 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
+    env:
+      JWT_SECRET_KEY: "ci-client-lint-test-jwt-secret-not-for-production-use" # pragma: allowlist secret
+      AUTH_ENCRYPTION_SECRET: "ci-client-lint-test-auth-enc-secret-not-for-production" # pragma: allowlist secret
+
     steps:
       # -----------------------------------------------------------
       # 0️⃣  Checkout


### PR DESCRIPTION
## Summary

Configure explicit CI-only JWT and encryption secrets for client E2E, type generation, and lint/test workflows.

## Root cause

These workflows copied placeholder values from .env.example. Strict secret validation introduced on main rejects those placeholders before OpenAPI export, preventing client checks from starting.

## Validation

Workflow YAML parses successfully, OpenAPI schema generation completes with the configured values, and changed workflow values pass inline secret-scanner allowlisting.