### PR TITLE
fix(docker-compose): restore gateway HOST binding and fast-time-server startup

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-23T13:22:36Z",
+  "generated_at": "2026-07-24T07:39:14Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -756,7 +756,7 @@
         "hashed_secret": "b6f3674b78a02881de33177e6f6fb8b851e0101c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 243,
+        "line_number": 245,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -764,7 +764,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 338,
+        "line_number": 340,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -772,7 +772,7 @@
         "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 388,
+        "line_number": 390,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -780,7 +780,7 @@
         "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 396,
+        "line_number": 398,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -788,7 +788,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 443,
+        "line_number": 445,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -796,7 +796,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 946,
+        "line_number": 948,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -804,7 +804,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1049,
+        "line_number": 1051,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -812,7 +812,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1164,
+        "line_number": 1166,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -820,7 +820,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1199,
+        "line_number": 1201,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -828,7 +828,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1737,
+        "line_number": 1741,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -836,7 +836,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1985,
+        "line_number": 1990,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -844,7 +844,7 @@
         "hashed_secret": "afba9d98073dfb79fba7b21516c4d4d676c72935",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2362,
+        "line_number": 2368,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -852,7 +852,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2462,
+        "line_number": 2468,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -860,7 +860,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2462,
+        "line_number": 2468,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -868,7 +868,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2475,
+        "line_number": 2481,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -876,7 +876,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2623,
+        "line_number": 2629,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -884,7 +884,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2644,
+        "line_number": 2650,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -892,7 +892,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2652,
+        "line_number": 2658,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -900,7 +900,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2657,
+        "line_number": 2663,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/Containerfile
+++ b/Containerfile
@@ -45,8 +45,8 @@ ARG ENABLE_PROFILING=false
 #     --build-arg NODEJS_IMAGE=<internal-registry>/ubi9/nodejs-20:latest \
 #     --build-arg UBI_MINIMAL=<internal-registry>/ubi9/ubi-minimal:latest \
 #     .
-ARG UBI_BASE=registry.access.redhat.com/ubi10:10.2-1784581466
-ARG NODEJS_IMAGE=registry.access.redhat.com/ubi10/nodejs-24:10.2-1784624696
+ARG UBI_BASE=registry.access.redhat.com/ubi10:10.2-1784668814
+ARG NODEJS_IMAGE=registry.access.redhat.com/ubi10/nodejs-24:10.2-1784784528
 ARG UBI_MINIMAL=registry.access.redhat.com/ubi10/ubi-minimal:10.2-1784669047
 # Wheel closure stage — used only for s390x and ppc64le where PyPI manylinux
 # binary wheels are unavailable (tiktoken/psycopg/cryptography require native

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,6 +141,8 @@ services:
     environment:
       # Domain for CORS/cookies (nginx default at http://localhost:8080)
       - APP_DOMAIN=${APP_DOMAIN:-http://localhost:8080}
+      # Bind address - must be 0.0.0.0 inside Docker or other containers cannot connect
+      - HOST=${GATEWAY_HOST:-0.0.0.0}
       # Transport: sse, streamablehttp, http, or all (default: all)
       - TRANSPORT_TYPE=streamablehttp
       # High-level Rust MCP UX:
@@ -1477,9 +1479,11 @@ services:
     restart: unless-stopped
     networks: [mcpnet]
     ports:
-      - "8888:9080"    # Map host port 8888 to container port 9080 (server's default port)
-    # Use dual mode for both SSE (/sse) and Streamable HTTP (/http) endpoints
-    command: ["-transport=dual", "-listen=0.0.0.0:9080", "-log-level=info"]
+      - "8888:9080"    # Map host port 8888 to container port 9080
+    # Configured via environment variables (Streamable HTTP at /mcp)
+    environment:
+      - BIND_ADDRESS=0.0.0.0:9080
+      - RUST_LOG=info
 
   ###############################################################################
   # Auto-registration service - registers fast_time_server with gateway
@@ -1910,6 +1914,7 @@ services:
         condition: service_healthy
     environment:
       - "JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY is not set. Run: make setup (first time) or make init-secrets-patch-env (if .env exists)}"
+      - "AUTH_ENCRYPTION_SECRET=${AUTH_ENCRYPTION_SECRET:?AUTH_ENCRYPTION_SECRET is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
     restart: "no"
     entrypoint: ["/bin/sh", "-c"]
     command:
@@ -2117,6 +2122,7 @@ services:
         condition: service_healthy
     environment:
       - "JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY is not set. Run: make setup (first time) or make init-secrets-patch-env (if .env exists)}"
+      - "AUTH_ENCRYPTION_SECRET=${AUTH_ENCRYPTION_SECRET:?AUTH_ENCRYPTION_SECRET is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
     restart: "no"
     entrypoint: ["/bin/sh", "-c"]
     command:

--- a/infra/wheels/Containerfile
+++ b/infra/wheels/Containerfile
@@ -17,7 +17,7 @@
 #   docker buildx build --platform linux/ppc64le -t wheels:ppc64le -f infra/wheels/Containerfile .
 ###############################################################################
 
-ARG UBI_MINIMAL=registry.access.redhat.com/ubi10/ubi-minimal:10.2-1784581369
+ARG UBI_MINIMAL=registry.access.redhat.com/ubi10/ubi-minimal:10.2-1784669047
 FROM ${UBI_MINIMAL}
 
 ARG PYTHON_VERSION=3.12


### PR DESCRIPTION
## Summary

Three hotfixes to `docker-compose.yml` that restore a working `make compose-up` / `make testing-up` stack:

- **gateway**: add `HOST=${GATEWAY_HOST:-0.0.0.0}`. The entry was lost in the Granian-removal PR (#5607); without it the gateway binds loopback inside the container and other containers (nginx, registration jobs) cannot reach it.
- **fast_time_server**: remove the obsolete Go CLI flags (`-transport=dual -listen -log-level`) that the current `cfex-mcp-fast-time-server` image no longer accepts, and configure it via `BIND_ADDRESS`/`RUST_LOG` environment variables instead — matching `fast_test_server`, which uses the same image. Registration continues to use Streamable HTTP at `/mcp`; no dual transport.
- **register_fast_test**: add `AUTH_ENCRYPTION_SECRET` to the environment. `python -m mcpgateway.utils.create_jwt_token` imports `mcpgateway.config.settings`, which requires both secrets; without it token generation crashed silently (stderr was piped to /dev/null), the registration container sent an empty bearer token, got 401 on all 60 readiness retries, and the `fast-test-*` tools were never registered.

## Root cause of the fast-test registration failure

`register_fast_time` succeeded while `register_fast_test` failed because the two services differed only in their environment: `register_fast_time` sets both `JWT_SECRET_KEY` and `AUTH_ENCRYPTION_SECRET`, `register_fast_test` set only the former.

## Verification

- `docker compose config` renders cleanly; `HOST: 0.0.0.0` and the new `fast_time_server` environment interpolate as expected.
- Full testing stack brought up with `make testing-up`; `register_fast_test` now exits 0 and the `fast-test-*` tools are registered.
- `tests/live_gateway/mcp/test_mcp_protocol_e2e.py` (previously failing with `Tool not found: fast-test-echo` etc.) passes.