### PR TITLE
fix(docker): bump UBI_MINIMAL to pick up patched libpq (CVE-2026-6477)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -47,7 +47,7 @@ ARG ENABLE_PROFILING=false
 #     .
 ARG UBI_BASE=registry.access.redhat.com/ubi10:10.2-1784581466
 ARG NODEJS_IMAGE=registry.access.redhat.com/ubi10/nodejs-24:10.2-1784624696
-ARG UBI_MINIMAL=registry.access.redhat.com/ubi10/ubi-minimal:10.2-1784581369
+ARG UBI_MINIMAL=registry.access.redhat.com/ubi10/ubi-minimal:10.2-1784669047
 # Wheel closure stage — used only for s390x and ppc64le where PyPI manylinux
 # binary wheels are unavailable (tiktoken/psycopg/cryptography require native
 # compilation, and psycopg-binary has no s390x wheel at all).


### PR DESCRIPTION
## Summary

The `Docker Security Scan` merge-queue gate (Grype, `severity-cutoff: high`) has been failing on `CVE-2026-6477` in `libpq 16.11-3.el10_1`, shipped by the runtime stage's `ubi10/ubi-minimal:10.2-1784581369` base image (confirmed failing on `main` itself via `workflow_dispatch` runs on 2026-06-30 and 2026-07-15, independent of any in-flight PR).

Red Hat has since published `libpq-16.14-1.el10_2` with the fix. The pinned dated tag predates that erratum, and Docker's layer cache keeps serving the vulnerable package on rebuilds even though `microdnf upgrade -y` already runs in that layer — so the CI cache (`cache-from: type=gha`) never picks up the fix on its own.

## Fix

Bump `UBI_MINIMAL` to the 2026-07-21 dated snapshot (`ubi10/ubi-minimal:10.2-1784669047`), which carries the patched `libpq` and busts the stale cache layer.

`UBI_BASE` and `NODEJS_IMAGE` are left untouched — `libpq` is only installed in the `UBI_MINIMAL`-based `runtime` stage (Containerfile:402-408), so bumping just that pin is the minimal fix; touching the other two would trigger unrelated rebuild churn for no benefit to this CVE.

## Verification

Reproduced and fixed locally, matching the CI job's exact steps (`.github/workflows/docker-scan.yml` → `scan` job):

```
docker build -f Containerfile --platform linux/amd64 --tag mcp-context-forge-scan:scan .
docker run --rm mcp-context-forge-scan:scan rpm -q libpq
# before: libpq-16.11-3.el10_1.x86_64

docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$PWD:/work" \
  anchore/syft:v1.42.3 "docker:mcp-context-forge-scan:scan" -o spdx-json=/work/sbom.spdx.json
docker run --rm -v "$PWD:/work" -w /work anchore/grype:v0.110.0 \
  sbom:sbom.spdx.json -c .grype.yaml -o table --only-fixed --fail-on high
# before: 1 High: CVE-2026-6477  libpq  16.11-3.el10_1 -> fixed in 0:16.14-1.el10_2
```

After the `UBI_MINIMAL` bump:

```
# rpm -q libpq -> libpq-16.14-1.el10_2.x86_64
# grype (same command/flags/.grype.yaml) -> No vulnerabilities found (exit 0)
```

No other packages changed between the two builds (same `UBI_BASE`/`NODEJS_IMAGE`, same SBOM package count).

## Blast radius

Single build-arg default in `Containerfile`. No application code, no schema, no `docker-compose.yml` changes. `WHEELS_REF` defaults to `UBI_MINIMAL` but only matters for s390x/ppc64le (amd64/arm64 keep an empty `/wheels`, per the existing comment at Containerfile:51-58), so this doesn't affect the PyPI-wheel install path used on amd64/arm64.