### PR TITLE
feat: add container image version bumper (make container-bump-image-versions)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-24T13:07:36Z",
+  "generated_at": "2026-07-24T13:07:40Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -342,7 +342,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1054,
+        "line_number": 1064,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +350,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1056,
+        "line_number": 1066,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +358,7 @@
         "hashed_secret": "db69d9215c29ae2f2e4ead587890a9f8455059dd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1130,
+        "line_number": 1140,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +366,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1710,
+        "line_number": 1720,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +374,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1929,
+        "line_number": 1939,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6063,
+        "line_number": 6078,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6560,
+        "line_number": 6575,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6572,
+        "line_number": 6587,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6644,
+        "line_number": 6659,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7060,
+        "line_number": 7075,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7750,
+        "line_number": 7765,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
+    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-24T12:36:31Z",
+  "generated_at": "2026-07-24T13:07:36Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/Makefile
+++ b/Makefile
@@ -879,6 +879,16 @@ smoketest:
 	@$(VENV_DIR)/bin/python ./smoketest.py --verbose || { echo "❌ Smoketest failed!"; exit 1; }
 	@echo "✅ Smoketest passed!"
 
+.PHONY: bats
+bats: ## Run all bats shell tests (tests/**/*.bats; requires bats-core)
+	@command -v bats >/dev/null 2>&1 || { echo "❌ bats not found - install with 'brew install bats-core' or see https://bats-core.readthedocs.io"; exit 1; }
+	@echo "🦇 Running bats shell tests..."
+	@files=$$(find tests -type f -name '*.bats' | sort); \
+	if [ -z "$$files" ]; then echo "ℹ️  No .bats files found under tests/"; exit 0; fi; \
+	echo "$$files" | sed 's/^/   /'; \
+	bats $$files || { echo "❌ bats tests failed!"; exit 1; }
+	@echo "✅ bats tests passed!"
+
 test-mcp-protocol-e2e: uv  ## MCP protocol E2E via FastMCP client (K=<filter> to pick one)
 	@echo "🔌 Running MCP protocol E2E tests against $${MCP_CLI_BASE_URL:-http://localhost:8080}..."
 	@echo "   Env: MCP_CLI_BASE_URL (gateway URL)  JWT_SECRET_KEY  PLATFORM_ADMIN_EMAIL"
@@ -4996,6 +5006,11 @@ container-build-rust-lite:
 container-rust: container-build-rust
 	@echo "🦀 Building and running container with Rust plugins..."
 	$(MAKE) container-run
+
+.PHONY: container-bump-image-versions
+container-bump-image-versions: ## Bump pinned UBI image tags in Containerfiles to latest within their minor line
+	@echo "🔄 Checking Red Hat Catalog for newer UBI image tags..."
+	@bash scripts/container-bump-image-versions.sh
 
 container-build-fips: ## Build FedRAMP-compliant image (ENABLE_FIPS=true) for Dreadnought/FedRAMP deployments
 	@$(MAKE) container-build ENABLE_FIPS_BUILD=true

--- a/scripts/container-bump-image-versions.sh
+++ b/scripts/container-bump-image-versions.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# container-bump-image-versions.sh — bump pinned Red Hat UBI image tags in the
+# repo's Containerfiles to the latest build tag within their CURRENT minor line.
+#
+# Managed pins (full build tags only, e.g. 10.2-1784669047):
+#   Containerfile:               ARG UBI_BASE / NODEJS_IMAGE / UBI_MINIMAL
+#   infra/wheels/Containerfile:  ARG UBI_MINIMAL (must stay identical to root)
+#
+# Tags are discovered via the Red Hat Catalog (Pyxis) API, which allows
+# anonymous access:
+#   GET https://catalog.redhat.com/api/containers/v1/repositories/registry/
+#       registry.access.redhat.com/repository/<repo>/images
+#       ?page_size=100&sort_by=last_update_date[desc]
+#
+# Policy:
+#   - Stay within each pin's current minor line (10.2); minor bumps are a
+#     deliberate, reviewed change — not something a script should do.
+#   - The ENABLE_FIPS build path overrides these ARGs with UBI 9 images at
+#     build time (see Makefile container-build); those are not file-pinned
+#     and are intentionally not managed here.
+#
+# Safety:
+#   - All lookups and validation complete before any file is written; a
+#     failed or malformed API response means zero files modified.
+#   - Both UBI_MINIMAL pins are always updated together.
+#
+# Requires: curl, jq.
+# Test hooks: CONTAINERFILE_PATH / WHEELS_CONTAINERFILE_PATH override the
+# file locations (used by tests/scripts/container-bump-image-versions.bats).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+CONTAINERFILE_PATH="${CONTAINERFILE_PATH:-$REPO_ROOT/Containerfile}"
+WHEELS_CONTAINERFILE_PATH="${WHEELS_CONTAINERFILE_PATH:-$REPO_ROOT/infra/wheels/Containerfile}"
+
+PYXIS_BASE="https://catalog.redhat.com/api/containers/v1/repositories/registry/registry.access.redhat.com/repository"
+
+# ARG name -> Pyxis repository path
+MANAGED_ARGS=(UBI_BASE NODEJS_IMAGE UBI_MINIMAL)
+repo_for_arg() {
+    case "$1" in
+        UBI_BASE)     echo "ubi10" ;;
+        NODEJS_IMAGE) echo "ubi10/nodejs-24" ;;
+        UBI_MINIMAL)  echo "ubi10/ubi-minimal" ;;
+        *) return 1 ;;
+    esac
+}
+
+# latest_tag_in_minor <minor> — read candidate tags (one per line) on stdin,
+# print the tag matching ^<minor>-<epoch>$ with the numerically highest epoch.
+# Exit 1 when no such tag exists.
+latest_tag_in_minor() {
+    local minor="$1" esc best
+    esc="${minor//./\\.}"
+    best=$(grep -E "^${esc}-[0-9]+$" | sort -t- -k2,2 -n | tail -n1) || return 1
+    [ -n "$best" ] || return 1
+    printf '%s\n' "$best"
+}
+
+# fetch_tags <repo> — print all tag names reported by the Pyxis API.
+fetch_tags() {
+    local repo="$1"
+    curl -fsSL -g --retry 3 --retry-delay 2 \
+        "${PYXIS_BASE}/${repo}/images?page_size=100&sort_by=last_update_date[desc]" \
+        | jq -r '[.data[]?.repositories[]?.tags[]?.name] | unique | .[]'
+}
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+main() {
+    command -v curl >/dev/null || die "curl is required"
+    command -v jq   >/dev/null || die "jq is required"
+    [ -f "$CONTAINERFILE_PATH" ]        || die "not found: $CONTAINERFILE_PATH"
+    [ -f "$WHEELS_CONTAINERFILE_PATH" ] || die "not found: $WHEELS_CONTAINERFILE_PATH"
+
+    # ---- Plan phase: validate pins and resolve latest tags; no writes ----
+    local arg line value tag minor tags latest
+    declare -A new_tag=()
+    declare -A cur_tag=()
+    declare -A image_of=()
+
+    for arg in "${MANAGED_ARGS[@]}"; do
+        line=$(grep -E "^ARG ${arg}=" "$CONTAINERFILE_PATH") \
+            || die "no '^ARG ${arg}=' line in $CONTAINERFILE_PATH"
+        value="${line#ARG "${arg}"=}"
+        tag="${value##*:}"
+        [[ "$tag" =~ ^[0-9]+\.[0-9]+-[0-9]+$ ]] \
+            || die "${arg} pin '${value}' is not a full build tag (<minor>-<epoch>); refusing to manage it"
+        minor="${tag%-*}"
+
+        tags=$(fetch_tags "$(repo_for_arg "$arg")") \
+            || die "tag lookup failed for ${arg} ($(repo_for_arg "$arg")); no files modified"
+        latest=$(printf '%s\n' "$tags" | latest_tag_in_minor "$minor") \
+            || die "no pinned tag in minor line ${minor} found for ${arg}; no files modified"
+
+        cur_tag[$arg]="$tag"
+        image_of[$arg]="${value%:*}"
+        if [ "$latest" != "$tag" ]; then
+            new_tag[$arg]="$latest"
+        fi
+    done
+
+    # ---- Report ----
+    for arg in "${MANAGED_ARGS[@]}"; do
+        if [ -n "${new_tag[$arg]:-}" ]; then
+            echo "${arg}: ${cur_tag[$arg]} -> ${new_tag[$arg]}"
+        else
+            echo "${arg}: ${cur_tag[$arg]} (up to date)"
+        fi
+    done
+
+    if [ "${#new_tag[@]}" -eq 0 ]; then
+        echo "All image pins are up to date."
+        return 0
+    fi
+
+    # ---- Apply phase ----
+    for arg in "${!new_tag[@]}"; do
+        local files=("$CONTAINERFILE_PATH")
+        # UBI_MINIMAL is pinned in both Containerfiles; keep them identical.
+        if [ "$arg" = "UBI_MINIMAL" ]; then
+            files+=("$WHEELS_CONTAINERFILE_PATH")
+        fi
+        local f
+        for f in "${files[@]}"; do
+            if sed -i.bak "s|^ARG ${arg}=.*|ARG ${arg}=${image_of[$arg]}:${new_tag[$arg]}|" "$f"; then
+                rm -f "${f}.bak"
+            else
+                die "failed to update ${arg} in $f"
+            fi
+            echo "  updated $f"
+        done
+    done
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/container-bump-image-versions.sh
+++ b/scripts/container-bump-image-versions.sh
@@ -116,7 +116,11 @@ main() {
     fi
 
     # ---- Apply phase ----
-    for arg in "${!new_tag[@]}"; do
+    # sed -i.bak leaves the backup behind if it fails mid-write; remove any
+    # stray backups on exit, including the die path, so nothing leaks.
+    trap 'rm -f "${CONTAINERFILE_PATH}.bak" "${WHEELS_CONTAINERFILE_PATH}.bak"' EXIT
+    for arg in "${MANAGED_ARGS[@]}"; do
+        [ -n "${new_tag[$arg]:-}" ] || continue
         local files=("$CONTAINERFILE_PATH")
         # UBI_MINIMAL is pinned in both Containerfiles; keep them identical.
         if [ "$arg" = "UBI_MINIMAL" ]; then
@@ -124,11 +128,8 @@ main() {
         fi
         local f
         for f in "${files[@]}"; do
-            if sed -i.bak "s|^ARG ${arg}=.*|ARG ${arg}=${image_of[$arg]}:${new_tag[$arg]}|" "$f"; then
-                rm -f "${f}.bak"
-            else
-                die "failed to update ${arg} in $f"
-            fi
+            sed -i.bak "s|^ARG ${arg}=.*|ARG ${arg}=${image_of[$arg]}:${new_tag[$arg]}|" "$f" \
+                || die "failed to update ${arg} in $f"
             echo "  updated $f"
         done
     done

--- a/scripts/container-bump-image-versions.sh
+++ b/scripts/container-bump-image-versions.sh
@@ -37,16 +37,10 @@ WHEELS_CONTAINERFILE_PATH="${WHEELS_CONTAINERFILE_PATH:-$REPO_ROOT/infra/wheels/
 
 PYXIS_BASE="https://catalog.redhat.com/api/containers/v1/repositories/registry/registry.access.redhat.com/repository"
 
-# ARG name -> Pyxis repository path
+# The Pyxis repository path is derived from each pin's image reference
+# (${value%:*} minus the registry prefix), so a deliberate image-path change
+# in a Containerfile cannot drift from the queried endpoint.
 MANAGED_ARGS=(UBI_BASE NODEJS_IMAGE UBI_MINIMAL)
-repo_for_arg() {
-    case "$1" in
-        UBI_BASE)     echo "ubi10" ;;
-        NODEJS_IMAGE) echo "ubi10/nodejs-24" ;;
-        UBI_MINIMAL)  echo "ubi10/ubi-minimal" ;;
-        *) return 1 ;;
-    esac
-}
 
 # latest_tag_in_minor <minor> — read candidate tags (one per line) on stdin,
 # print the tag matching ^<minor>-<epoch>$ with the numerically highest epoch.
@@ -76,7 +70,7 @@ main() {
     [ -f "$WHEELS_CONTAINERFILE_PATH" ] || die "not found: $WHEELS_CONTAINERFILE_PATH"
 
     # ---- Plan phase: validate pins and resolve latest tags; no writes ----
-    local arg line value tag minor tags latest
+    local arg line value tag minor image repo tags latest
     declare -A new_tag=()
     declare -A cur_tag=()
     declare -A image_of=()
@@ -90,13 +84,18 @@ main() {
             || die "${arg} pin '${value}' is not a full build tag (<minor>-<epoch>); refusing to manage it"
         minor="${tag%-*}"
 
-        tags=$(fetch_tags "$(repo_for_arg "$arg")") \
-            || die "tag lookup failed for ${arg} ($(repo_for_arg "$arg")); no files modified"
+        image="${value%:*}"
+        [[ "$image" == registry.access.redhat.com/* ]] \
+            || die "${arg} image '${image}' is not on registry.access.redhat.com; Pyxis lookup is only defined for that registry"
+        repo="${image#registry.access.redhat.com/}"
+
+        tags=$(fetch_tags "$repo") \
+            || die "tag lookup failed for ${arg} (${repo}); no files modified"
         latest=$(printf '%s\n' "$tags" | latest_tag_in_minor "$minor") \
             || die "no pinned tag in minor line ${minor} found for ${arg}; no files modified"
 
         cur_tag[$arg]="$tag"
-        image_of[$arg]="${value%:*}"
+        image_of[$arg]="$image"
         if [ "$latest" != "$tag" ]; then
             new_tag[$arg]="$latest"
         fi

--- a/tests/scripts/container-bump-image-versions.bats
+++ b/tests/scripts/container-bump-image-versions.bats
@@ -41,6 +41,7 @@ esac
 case "$*" in
     *repository/ubi10/ubi-minimal/images*) cat "$FIXTURE_DIR/ubi-minimal.json" ;;
     *repository/ubi10/nodejs-24/images*)   cat "$FIXTURE_DIR/nodejs.json" ;;
+    *repository/ubi10/ubi-init/images*)    cat "$FIXTURE_DIR/ubi-init.json" ;;
     *repository/ubi10/images*)             cat "$FIXTURE_DIR/ubi10.json" ;;
     *) echo "stub curl: unstubbed URL: $*" >&2; exit 22 ;;
 esac
@@ -175,7 +176,8 @@ write_tags() {  # write_tags <fixture-name> <tag>...
 }
 
 @test "refuses to manage a pin that is not a full build tag" {
-    sed -i '' 's|^ARG UBI_BASE=.*|ARG UBI_BASE=registry.access.redhat.com/ubi10:latest|' "$CONTAINERFILE_PATH"
+    sed -i.bak 's|^ARG UBI_BASE=.*|ARG UBI_BASE=registry.access.redhat.com/ubi10:latest|' "$CONTAINERFILE_PATH"
+    rm -f "${CONTAINERFILE_PATH}.bak"
     cp "$CONTAINERFILE_PATH" "$TEST_DIR/Containerfile.orig"
     write_tags ubi10.json        "10.2-1784669000"
     write_tags nodejs.json       "10.2-1784624696"
@@ -183,6 +185,37 @@ write_tags() {  # write_tags <fixture-name> <tag>...
 
     run "$SCRIPT"
     [ "$status" -eq 1 ]
+    cmp "$CONTAINERFILE_PATH" "$TEST_DIR/Containerfile.orig"
+    cmp "$WHEELS_CONTAINERFILE_PATH" "$TEST_DIR/wheels.Containerfile.orig"
+}
+
+@test "queries the Pyxis repository derived from the pinned image path" {
+    # Pin UBI_BASE at an image path the old hard-coded map did not know; the
+    # script must query that repository, not a static per-ARG mapping.
+    sed -i.bak 's|^ARG UBI_BASE=.*|ARG UBI_BASE=registry.access.redhat.com/ubi10/ubi-init:10.2-100|' "$CONTAINERFILE_PATH"
+    rm -f "${CONTAINERFILE_PATH}.bak"
+    write_tags ubi-init.json     "10.2-1784669000"
+    write_tags nodejs.json       "10.2-1784624696"
+    write_tags ubi-minimal.json  "10.2-1784581369"
+
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+
+    run grep '^ARG UBI_BASE=' "$CONTAINERFILE_PATH"
+    [ "$output" = "ARG UBI_BASE=registry.access.redhat.com/ubi10/ubi-init:10.2-1784669000" ]
+}
+
+@test "refuses a pin on a registry other than registry.access.redhat.com" {
+    sed -i.bak 's|^ARG UBI_BASE=.*|ARG UBI_BASE=quay.io/ubi10:10.2-1784581466|' "$CONTAINERFILE_PATH"
+    rm -f "${CONTAINERFILE_PATH}.bak"
+    cp "$CONTAINERFILE_PATH" "$TEST_DIR/Containerfile.orig"
+    write_tags ubi10.json        "10.2-1784669000"
+    write_tags nodejs.json       "10.2-1784624696"
+    write_tags ubi-minimal.json  "10.2-1784581369"
+
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not on registry.access.redhat.com"* ]]
     cmp "$CONTAINERFILE_PATH" "$TEST_DIR/Containerfile.orig"
     cmp "$WHEELS_CONTAINERFILE_PATH" "$TEST_DIR/wheels.Containerfile.orig"
 }

--- a/tests/scripts/container-bump-image-versions.bats
+++ b/tests/scripts/container-bump-image-versions.bats
@@ -1,0 +1,188 @@
+#!/usr/bin/env bats
+# Tests for scripts/container-bump-image-versions.sh
+#
+# Strategy: stub `curl` on PATH to serve canned Pyxis API responses, run the
+# script against throwaway Containerfile fixtures, and assert on file contents.
+# The script must never partially write: any fetch/parse failure means zero
+# files modified.
+
+SCRIPT="$BATS_TEST_DIRNAME/../../scripts/container-bump-image-versions.sh"
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    FIXTURE_DIR="$TEST_DIR/api"
+    mkdir -p "$FIXTURE_DIR" "$TEST_DIR/bin"
+
+    # Containerfile fixtures mirroring the real pin lines.
+    cat > "$TEST_DIR/Containerfile" <<'EOF'
+# Base image overrides — defaults to UBI 10; pass UBI 9 values for FedRAMP builds
+ARG UBI_BASE=registry.access.redhat.com/ubi10:10.2-1784581466
+ARG NODEJS_IMAGE=registry.access.redhat.com/ubi10/nodejs-24:10.2-1784624696
+ARG UBI_MINIMAL=registry.access.redhat.com/ubi10/ubi-minimal:10.2-1784581369
+FROM ${UBI_BASE}
+EOF
+    cat > "$TEST_DIR/wheels.Containerfile" <<'EOF'
+ARG UBI_MINIMAL=registry.access.redhat.com/ubi10/ubi-minimal:10.2-1784581369
+FROM ${UBI_MINIMAL}
+EOF
+    cp "$TEST_DIR/Containerfile" "$TEST_DIR/Containerfile.orig"
+    cp "$TEST_DIR/wheels.Containerfile" "$TEST_DIR/wheels.Containerfile.orig"
+
+    # curl stub: dispatch on the repository path embedded in the Pyxis URL.
+    # More specific paths first; unknown URLs fail like a 404 (curl -f style).
+    # Emulates curl's URL-globbing behavior: a literal '[' in the URL fails
+    # with exit 3 unless globbing is disabled (-g / --globoff).
+    cat > "$TEST_DIR/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+case " $* " in
+    *" -g "*|*" --globoff "*) ;;
+    *) case "$*" in *\[*) echo "curl: (3) bad range in URL" >&2; exit 3 ;; esac ;;
+esac
+case "$*" in
+    *repository/ubi10/ubi-minimal/images*) cat "$FIXTURE_DIR/ubi-minimal.json" ;;
+    *repository/ubi10/nodejs-24/images*)   cat "$FIXTURE_DIR/nodejs.json" ;;
+    *repository/ubi10/images*)             cat "$FIXTURE_DIR/ubi10.json" ;;
+    *) echo "stub curl: unstubbed URL: $*" >&2; exit 22 ;;
+esac
+EOF
+    chmod +x "$TEST_DIR/bin/curl"
+    export PATH="$TEST_DIR/bin:$PATH"
+    export FIXTURE_DIR
+    export CONTAINERFILE_PATH="$TEST_DIR/Containerfile"
+    export WHEELS_CONTAINERFILE_PATH="$TEST_DIR/wheels.Containerfile"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+# Helper: write a Pyxis-style response listing the given tag names.
+write_tags() {  # write_tags <fixture-name> <tag>...
+    local file="$FIXTURE_DIR/$1"; shift
+    local tags=""
+    local t
+    for t in "$@"; do
+        tags+="{\"name\": \"$t\"},"
+    done
+    printf '{"data": [{"repositories": [{"tags": [%s]}]}]}' "${tags%,}" > "$file"
+}
+
+# --- Unit: latest_tag_in_minor ------------------------------------------------
+
+@test "latest_tag_in_minor picks highest epoch within the minor line" {
+    run bash -c "source '$SCRIPT'; printf '%s\n' '10.2-100' '10.2-1784669047' '10.2-1784581369' | latest_tag_in_minor 10.2"
+    [ "$status" -eq 0 ]
+    [ "$output" = "10.2-1784669047" ]
+}
+
+@test "latest_tag_in_minor ignores other minor lines and floating tags" {
+    run bash -c "source '$SCRIPT'; printf '%s\n' '10.3-9999999999' '10.2' 'latest' '10.2-1784669047' '10.1-9999999999' | latest_tag_in_minor 10.2"
+    [ "$status" -eq 0 ]
+    [ "$output" = "10.2-1784669047" ]
+}
+
+@test "latest_tag_in_minor fails when no matching pinned tag exists" {
+    run bash -c "source '$SCRIPT'; printf '%s\n' 'latest' '10.2' '10.3-1784669047' | latest_tag_in_minor 10.2"
+    [ "$status" -eq 1 ]
+}
+
+# --- Integration: bump behavior ------------------------------------------------
+
+@test "updates all three ARGs in root Containerfile when newer tags exist" {
+    write_tags ubi10.json        "10.2-1784669000" "10.2-1784581466" "latest"
+    write_tags nodejs.json       "10.2-1784669001" "10.2"
+    write_tags ubi-minimal.json  "10.2-1784669047" "10.2-1784581369"
+
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+
+    run grep '^ARG UBI_BASE=' "$CONTAINERFILE_PATH"
+    [ "$output" = "ARG UBI_BASE=registry.access.redhat.com/ubi10:10.2-1784669000" ]
+    run grep '^ARG NODEJS_IMAGE=' "$CONTAINERFILE_PATH"
+    [ "$output" = "ARG NODEJS_IMAGE=registry.access.redhat.com/ubi10/nodejs-24:10.2-1784669001" ]
+    run grep '^ARG UBI_MINIMAL=' "$CONTAINERFILE_PATH"
+    [ "$output" = "ARG UBI_MINIMAL=registry.access.redhat.com/ubi10/ubi-minimal:10.2-1784669047" ]
+}
+
+@test "updates UBI_MINIMAL pin in the wheels Containerfile too" {
+    write_tags ubi10.json        "10.2-1784581466"
+    write_tags nodejs.json       "10.2-1784624696"
+    write_tags ubi-minimal.json  "10.2-1784669047"
+
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+
+    run grep '^ARG UBI_MINIMAL=' "$WHEELS_CONTAINERFILE_PATH"
+    [ "$output" = "ARG UBI_MINIMAL=registry.access.redhat.com/ubi10/ubi-minimal:10.2-1784669047" ]
+}
+
+@test "keeps both UBI_MINIMAL pins identical after update" {
+    write_tags ubi10.json        "10.2-1784581466"
+    write_tags nodejs.json       "10.2-1784624696"
+    write_tags ubi-minimal.json  "10.2-1784669047"
+
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+
+    root_pin=$(grep '^ARG UBI_MINIMAL=' "$CONTAINERFILE_PATH")
+    wheels_pin=$(grep '^ARG UBI_MINIMAL=' "$WHEELS_CONTAINERFILE_PATH")
+    [ "$root_pin" = "$wheels_pin" ]
+}
+
+@test "no-op when every pin is already the latest in its minor line" {
+    write_tags ubi10.json        "10.2-1784581466" "10.2-1000"
+    write_tags nodejs.json       "10.2-1784624696" "10.2"
+    write_tags ubi-minimal.json  "10.2-1784581369" "latest"
+
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"up to date"* ]]
+    cmp "$CONTAINERFILE_PATH" "$TEST_DIR/Containerfile.orig"
+    cmp "$WHEELS_CONTAINERFILE_PATH" "$TEST_DIR/wheels.Containerfile.orig"
+}
+
+@test "stays within the current minor line even when a newer minor exists" {
+    write_tags ubi10.json        "10.3-9999999999" "10.2-1784581466"
+    write_tags nodejs.json       "10.3-9999999999" "10.2-1784624696"
+    write_tags ubi-minimal.json  "10.3-9999999999" "10.2-1784581369"
+
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    cmp "$CONTAINERFILE_PATH" "$TEST_DIR/Containerfile.orig"
+    cmp "$WHEELS_CONTAINERFILE_PATH" "$TEST_DIR/wheels.Containerfile.orig"
+}
+
+@test "writes nothing when any repository lookup fails" {
+    write_tags ubi10.json        "10.2-1784669000"
+    write_tags nodejs.json       "10.2-1784669001"
+    # ubi-minimal.json deliberately missing -> stub curl exits 22
+
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    cmp "$CONTAINERFILE_PATH" "$TEST_DIR/Containerfile.orig"
+    cmp "$WHEELS_CONTAINERFILE_PATH" "$TEST_DIR/wheels.Containerfile.orig"
+}
+
+@test "writes nothing when the API returns malformed JSON" {
+    write_tags ubi10.json        "10.2-1784669000"
+    write_tags nodejs.json       "10.2-1784669001"
+    echo "not json" > "$FIXTURE_DIR/ubi-minimal.json"
+
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    cmp "$CONTAINERFILE_PATH" "$TEST_DIR/Containerfile.orig"
+    cmp "$WHEELS_CONTAINERFILE_PATH" "$TEST_DIR/wheels.Containerfile.orig"
+}
+
+@test "refuses to manage a pin that is not a full build tag" {
+    sed -i '' 's|^ARG UBI_BASE=.*|ARG UBI_BASE=registry.access.redhat.com/ubi10:latest|' "$CONTAINERFILE_PATH"
+    cp "$CONTAINERFILE_PATH" "$TEST_DIR/Containerfile.orig"
+    write_tags ubi10.json        "10.2-1784669000"
+    write_tags nodejs.json       "10.2-1784624696"
+    write_tags ubi-minimal.json  "10.2-1784581369"
+
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    cmp "$CONTAINERFILE_PATH" "$TEST_DIR/Containerfile.orig"
+    cmp "$WHEELS_CONTAINERFILE_PATH" "$TEST_DIR/wheels.Containerfile.orig"
+}

--- a/tests/scripts/container-bump-image-versions.bats
+++ b/tests/scripts/container-bump-image-versions.bats
@@ -175,6 +175,17 @@ write_tags() {  # write_tags <fixture-name> <tag>...
     cmp "$WHEELS_CONTAINERFILE_PATH" "$TEST_DIR/wheels.Containerfile.orig"
 }
 
+@test "leaves no sed backup files behind after an update" {
+    write_tags ubi10.json        "10.2-1784669000"
+    write_tags nodejs.json       "10.2-1784669001"
+    write_tags ubi-minimal.json  "10.2-1784669047"
+
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ ! -e "${CONTAINERFILE_PATH}.bak" ]
+    [ ! -e "${WHEELS_CONTAINERFILE_PATH}.bak" ]
+}
+
 @test "refuses to manage a pin that is not a full build tag" {
     sed -i.bak 's|^ARG UBI_BASE=.*|ARG UBI_BASE=registry.access.redhat.com/ubi10:latest|' "$CONTAINERFILE_PATH"
     rm -f "${CONTAINERFILE_PATH}.bak"


### PR DESCRIPTION
## What

Adds `scripts/container-bump-image-versions.sh`, exposed as `make container-bump-image-versions`, which bumps the pinned Red Hat UBI image tags in the repo's Containerfiles to the latest build tag **within their current minor line**.

## Why

The base-image pins (`UBI_BASE`, `NODEJS_IMAGE`, `UBI_MINIMAL`) are full build tags (`<minor>-<epoch-buildid>`) chosen for reproducibility, but nothing keeps them current — they drift until someone checks by hand. No Dependabot/Renovate config exists in the repo today, and Renovate would treat the two `UBI_MINIMAL` pin sites as independent updates, whereas they must change atomically.

## How it works

- Discovers tags anonymously via the Red Hat Catalog (Pyxis) API (`catalog.redhat.com/api/containers/v1/...`); `registry.access.redhat.com` allows anonymous access, unlike `registry.redhat.io`.
- Tag semantics are `<minor>-<epoch-buildid>`, so "latest" is the numeric max of the epoch component, restricted to each pin's current minor line. Bumping minors (e.g. 10.2 → 10.3) stays a deliberate, reviewed change.
- All lookups and validation complete before any file is written: a failed or malformed API response means zero files modified.
- `UBI_MINIMAL` is pinned in both `Containerfile` and `infra/wheels/Containerfile`; both are always updated together.
- The `ENABLE_FIPS=true` build path overrides these ARGs with UBI 9 images at build time and is intentionally not managed.

## Testing

- New bats suite `tests/scripts/container-bump-image-versions.bats` (11 tests: tag filtering, atomic two-file update, no-op idempotence, minor-line policy, zero-write failure paths, non-pinned-tag refusal), run via the new `make bats` target, which discovers all `tests/**/*.bats`.
- Verified end-to-end against the live Pyxis API: a run correctly identified and applied the pending 10.2-line updates, and a second run was a clean no-op. This surfaced (and fixed, with a stub regression lock) a real curl URL-globbing failure on the `sort_by=last_update_date[desc]` query parameter.
- The actual pin bump is intentionally not included here; it is being handled independently.

## Notes for reviewers

- bats-core is a new dev-only prerequisite (`brew install bats-core`); `make bats` fails gracefully with an install hint when absent.
- bats is currently not wired into `make test` or CI — worth deciding in review whether it should be.
- `.secrets.baseline` line-number drift in the Makefile commit is the detect-secrets hook's own regeneration.

---

Closes #6282 — container image version bumper.