### PR TITLE
Remove dead external log sink settings (elasticsearch, syslog, webhook)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-24T15:22:57Z",
+  "generated_at": "2026-07-25T07:03:21Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -570,7 +570,7 @@
         "hashed_secret": "bc1a7c4dc707a3b61e2e9a345eec9e23674efa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1119,
+        "line_number": 1111,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -578,7 +578,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1426,
+        "line_number": 1418,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -618,7 +618,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 824,
+        "line_number": 815,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -626,7 +626,7 @@
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 979,
+        "line_number": 970,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -634,7 +634,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1083,
+        "line_number": 1074,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1086,
+        "line_number": 1077,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1253,
+        "line_number": 1244,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1292,
+        "line_number": 1283,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1346,
+        "line_number": 1337,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1442,
+        "line_number": 1433,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1813,
+        "line_number": 1804,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/charts/mcp-stack/README.md
+++ b/charts/mcp-stack/README.md
@@ -734,14 +734,6 @@ For detailed guidance on resource limits and process management, see `docs/docs/
 | mcpContextForge.config.STRUCTURED_LOGGING_ENABLED | string | `"true"` |  |
 | mcpContextForge.config.STRUCTURED_LOGGING_EXTERNAL_ENABLED | string | `"false"` |  |
 | mcpContextForge.config.STRUCTURED_LOGGING_DATABASE_ENABLED | string | `"false"` |  |
-| mcpContextForge.config.SYSLOG_ENABLED | string | `"false"` |  |
-| mcpContextForge.config.SYSLOG_HOST | string | `""` |  |
-| mcpContextForge.config.SYSLOG_PORT | string | `"514"` |  |
-| mcpContextForge.config.ELASTICSEARCH_ENABLED | string | `"false"` |  |
-| mcpContextForge.config.ELASTICSEARCH_URL | string | `""` |  |
-| mcpContextForge.config.ELASTICSEARCH_INDEX_PREFIX | string | `"mcpgateway-logs"` |  |
-| mcpContextForge.config.WEBHOOK_LOGGING_ENABLED | string | `"false"` |  |
-| mcpContextForge.config.WEBHOOK_LOGGING_URLS | string | `"[]"` |  |
 | mcpContextForge.config.LOG_RETENTION_DAYS | string | `"30"` |  |
 | mcpContextForge.config.LOG_SEARCH_MAX_RESULTS | string | `"1000"` |  |
 | mcpContextForge.config.MASKED_AUTH_VALUE | string | `"*****"` |  |

--- a/charts/mcp-stack/values.schema.json
+++ b/charts/mcp-stack/values.schema.json
@@ -457,9 +457,6 @@
                 "false"
               ]
             },
-            "ELASTICSEARCH_ENABLED": {
-              "type": "string"
-            },
             "ENABLE_HEADER_PASSTHROUGH": {
               "type": "string"
             },
@@ -1240,9 +1237,6 @@
             "STRUCTURED_LOGGING_EXTERNAL_ENABLED": {
               "type": "string"
             },
-            "SYSLOG_ENABLED": {
-              "type": "string"
-            },
             "TEAM_MEMBER_COUNT_CACHE_ENABLED": {
               "type": "string"
             },
@@ -1326,9 +1320,6 @@
               "type": "string"
             },
             "VALIDATION_STRICT": {
-              "type": "string"
-            },
-            "WEBHOOK_LOGGING_ENABLED": {
               "type": "string"
             },
             "WELL_KNOWN_CACHE_MAX_AGE": {

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -783,17 +783,8 @@ mcpContextForge:
     STRUCTURED_LOGGING_ENABLED: "true" # enable structured logging
     STRUCTURED_LOGGING_DATABASE_ENABLED: "false" # persist structured logs to DB (impacts performance)
 
-    # External log sinks (all disabled by default)
+    # External log sinks (disabled by default)
     STRUCTURED_LOGGING_EXTERNAL_ENABLED: "false"
-    SYSLOG_ENABLED: "false"
-    ELASTICSEARCH_ENABLED: "false"
-    WEBHOOK_LOGGING_ENABLED: "false"
-    # Uncomment and configure when enabling an external sink:
-    # SYSLOG_HOST: ""
-    # SYSLOG_PORT: "514"
-    # ELASTICSEARCH_URL: ""
-    # ELASTICSEARCH_INDEX_PREFIX: "mcpgateway-logs"
-    # WEBHOOK_LOGGING_URLS: "[]"
 
     # Log search
     LOG_RETENTION_DAYS: "30" # retention in days

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -2154,16 +2154,6 @@ class Settings(BaseSettings):
     log_search_max_results: int = Field(default=1000, description="Maximum results per log search query")
     log_retention_days: int = Field(default=30, description="Number of days to retain logs in database")
 
-    # External Log Integration Configuration
-    elasticsearch_enabled: bool = Field(default=False, description="Send logs to Elasticsearch")
-    elasticsearch_url: Optional[str] = Field(default=None, description="Elasticsearch cluster URL")
-    elasticsearch_index_prefix: str = Field(default="mcpgateway-logs", description="Elasticsearch index prefix")
-    syslog_enabled: bool = Field(default=False, description="Send logs to syslog")
-    syslog_host: Optional[str] = Field(default=None, description="Syslog server host")
-    syslog_port: int = Field(default=514, description="Syslog server port")
-    webhook_logging_enabled: bool = Field(default=False, description="Send logs to webhook endpoints")
-    webhook_logging_urls: List[str] = Field(default_factory=list, description="Webhook URLs for log delivery")
-
     @field_validator("siem_destinations", mode="before")
     @classmethod
     def parse_siem_destinations(cls, value: Any) -> List[Dict[str, Any]]:


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Part of #5848 (the three logging-sink flags; the remaining five flags need wiring up and are left for follow-ups)

---

## 📝 Summary

Removes the dead "External Log Integration" settings block from `mcpgateway/config.py` — `elasticsearch_enabled`, `syslog_enabled`, `webhook_logging_enabled` and their companion fields (`elasticsearch_url`, `elasticsearch_index_prefix`, `syslog_host`, `syslog_port`, `webhook_logging_urls`). No code reads any of them, so setting e.g. `ELASTICSEARCH_ENABLED=true` silently does nothing. Per #5848, removal is the right resolution for these three sinks (they look like never-implemented companions to `structured_logging_external_enabled`).

Also removes the corresponding entries from the Helm chart (`values.yaml`, `values.schema.json`, chart README). They were not present in `.env.example`. `docs/docs/design/images/classes.svg` still mentions them but is a generated diagram.

`.secrets.baseline` was regenerated by the pre-commit hook (line-number shifts only).

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate (no tests referenced these settings; removal only)
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Ruff                      | `ruff check mcpgateway/config.py` | ✅ pass |
| YAML lint                 | `yamllint -c .yamllint charts/mcp-stack/values.yaml` | ✅ pass |
| Pre-commit hooks          | `pre-commit run` (on changed files) | ✅ pass |
| Dead-flag check           | `grep -rn` for each removed name (snake_case and UPPER_CASE) | ✅ no hits outside generated `classes.svg` |

Full `make test` was not run locally (Windows dev box); relying on CI.

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes (n/a — settings removal, no tests referenced them)
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed
