### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ContextForge
 
+[![MCP Toplist](https://mcptoplist.com/badge/glama%2FIBM%2Fmcp-context-forge.svg)](https://mcptoplist.com/server/glama%2FIBM%2Fmcp-context-forge)
+
 > An open source registry and proxy that federates MCP, A2A, and REST/gRPC APIs with centralized governance, discovery, and observability. Optimizes Agent & Tool calling, and supports plugins.
 
 ![ContextForge Banner](docs/docs/images/contextforge-logo_horizontal_black.png)


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,432 MCP servers across the major
registries, and **ContextForge MCP Gateway** is currently ranked **#173**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/glama%2FIBM%2Fmcp-context-forge.svg)](https://mcptoplist.com/server/glama%2FIBM%2Fmcp-context-forge)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building ContextForge MCP Gateway!
