### PR TITLE
feat(servers): enable/disable via update and race-safe name-conflict handling

### DIFF
--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -4587,6 +4587,7 @@ class ServerUpdate(BaseModelWithConfigDict):
     associated_resources: Optional[List[str]] = Field(None, description="Comma-separated resource IDs")
     associated_prompts: Optional[List[str]] = Field(None, description="Comma-separated prompt IDs")
     associated_a2a_agents: Optional[List[str]] = Field(None, description="Comma-separated A2A agent IDs")
+    enabled: Optional[bool] = Field(None, description="Whether the server is enabled")
 
     @field_validator("name")
     @classmethod

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -313,6 +313,7 @@ class GatewayNameConflictError(GatewayError):
         self.name = name
         self.enabled = enabled
         self.gateway_id = gateway_id
+        self.visibility = visibility
         if visibility == "team":
             vis_label = "Team-level"
         else:

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -1307,6 +1307,9 @@ class ServerService(BaseService):
             if server_update.tags is not None:
                 server.tags = server_update.tags
 
+            if getattr(server_update, "enabled", None) is not None:
+                server.enabled = server_update.enabled
+
             # Update OAuth 2.0 configuration if provided
             # Track if OAuth is being explicitly disabled to prevent config re-assignment
             oauth_being_disabled = server_update.oauth_enabled is not None and not server_update.oauth_enabled

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -200,6 +200,7 @@ class ServerNameConflictError(ServerError):
         self.name = name
         self.enabled = enabled
         self.server_id = server_id
+        self.visibility = visibility
         message = f"{visibility.capitalize()} Server already exists with name: {name}"
         if not enabled:
             message += f" (currently inactive, ID: {server_id})"

--- a/tests/unit/mcpgateway/services/test_row_level_locking.py
+++ b/tests/unit/mcpgateway/services/test_row_level_locking.py
@@ -242,6 +242,44 @@ class TestServerServiceLocking:
             # cover the actual locking behavior.
             assert mock_get.called or not mock_get.called  # Test runs successfully
 
+    @pytest.mark.asyncio
+    async def test_register_server_concurrent_conflict_raises_enriched_error(self):
+        """Loser of a concurrent same-name create gets ServerNameConflictError with server_id and visibility."""
+        # First-Party
+        from mcpgateway.services.server_service import ServerNameConflictError
+
+        service = ServerService()
+        db = MagicMock(spec=Session)
+
+        server_in = MagicMock(spec=ServerCreate)
+        server_in.name = "duplicate-server"
+        server_in.description = "Test"
+        server_in.icon = None
+        server_in.tags = []
+        server_in.id = None
+        server_in.team_id = None
+        server_in.owner_email = None
+        server_in.visibility = None
+        server_in.oauth_enabled = False
+        server_in.oauth_config = None
+
+        # Simulates the row locked by the winning concurrent create
+        existing = MagicMock(spec=Server)
+        existing.id = "existing-server-id"
+        existing.name = "duplicate-server"
+        existing.enabled = True
+        existing.visibility = "public"
+
+        with patch("mcpgateway.services.server_service.get_for_update", return_value=existing):
+            with pytest.raises(ServerNameConflictError) as exc_info:
+                await service.register_server(db, server_in, visibility="public")
+
+        assert exc_info.value.server_id == "existing-server-id"
+        assert exc_info.value.visibility == "public"
+        # The loser's insert must never happen
+        assert not db.add.called
+        assert not db.commit.called
+
 
 class TestResourceServiceLocking:
     """Test row-level locking in ResourceService."""

--- a/tests/unit/mcpgateway/services/test_server_service.py
+++ b/tests/unit/mcpgateway/services/test_server_service.py
@@ -758,6 +758,74 @@ class TestServerService:
         assert "Server not found" in str(exc.value)
 
     @pytest.mark.asyncio
+    async def test_update_server_enabled_field_disable(self, server_service, mock_server, test_db):
+        """ServerUpdate(enabled=False) disables the server via the standard update path."""
+        mock_server.enabled = True
+        mock_server.team_id = None
+        mock_server.visibility = "public"
+        mock_server.owner_email = "user@example.com"
+
+        test_db.get = Mock(return_value=mock_server)
+        # get_for_update (with eager-loading options) resolves via db.execute
+        test_db.execute = Mock(return_value=Mock(scalar_one_or_none=Mock(return_value=mock_server)))
+        test_db.commit = Mock()
+        test_db.refresh = Mock()
+
+        server_service._notify_server_updated = AsyncMock()
+        server_service.convert_server_to_read = Mock(return_value="server_read")
+
+        with patch("mcpgateway.services.permission_service.PermissionService.check_resource_ownership", new=AsyncMock(return_value=True)):
+            await server_service.update_server(test_db, "550e8400e29b41d4a716446655440001", ServerUpdate(enabled=False), "user@example.com")  # pragma: allowlist secret
+
+        assert mock_server.enabled is False
+        test_db.commit.assert_called_once()
+        server_service._notify_server_updated.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_server_enabled_field_enable(self, server_service, mock_server, test_db):
+        """ServerUpdate(enabled=True) re-enables a disabled server."""
+        mock_server.enabled = False
+        mock_server.team_id = None
+        mock_server.visibility = "public"
+        mock_server.owner_email = "user@example.com"
+
+        test_db.get = Mock(return_value=mock_server)
+        test_db.execute = Mock(return_value=Mock(scalar_one_or_none=Mock(return_value=mock_server)))
+        test_db.commit = Mock()
+        test_db.refresh = Mock()
+
+        server_service._notify_server_updated = AsyncMock()
+        server_service.convert_server_to_read = Mock(return_value="server_read")
+
+        with patch("mcpgateway.services.permission_service.PermissionService.check_resource_ownership", new=AsyncMock(return_value=True)):
+            await server_service.update_server(test_db, "550e8400e29b41d4a716446655440001", ServerUpdate(enabled=True), "user@example.com")  # pragma: allowlist secret
+
+        assert mock_server.enabled is True
+        test_db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_server_enabled_unset_preserves_state(self, server_service, mock_server, test_db):
+        """An update without the enabled field leaves the current state untouched."""
+        mock_server.enabled = True
+        mock_server.team_id = None
+        mock_server.visibility = "public"
+        mock_server.owner_email = "user@example.com"
+
+        test_db.get = Mock(return_value=mock_server)
+        test_db.execute = Mock(return_value=Mock(scalar_one_or_none=Mock(return_value=mock_server)))
+        test_db.commit = Mock()
+        test_db.refresh = Mock()
+
+        server_service._notify_server_updated = AsyncMock()
+        server_service.convert_server_to_read = Mock(return_value="server_read")
+
+        with patch("mcpgateway.services.permission_service.PermissionService.check_resource_ownership", new=AsyncMock(return_value=True)):
+            await server_service.update_server(test_db, "550e8400e29b41d4a716446655440001", ServerUpdate(description="new description"), "user@example.com")  # pragma: allowlist secret
+
+        assert mock_server.enabled is True
+        assert mock_server.description == "new description"
+
+    @pytest.mark.asyncio
     async def test_update_server_ignores_client_owner_email(self, server_service, mock_server):
         """Client-supplied owner_email must not transfer server ownership."""
         db = MagicMock()


### PR DESCRIPTION
Closes #5861

## Summary

- **Enable/disable via update**: adds an optional `enabled` field to `ServerUpdate` and applies it in `ServerService.update_server`, so a server can be enabled or disabled through the standard partial-update path (PATCH-style) rather than only via the dedicated state endpoint. A `getattr` guard keeps duck-typed legacy update objects working.
- **Race-safe name-conflict handling**: the row-locked (`SELECT ... FOR UPDATE` via `get_for_update`) name-conflict check in `register_server` already guarantees that of two concurrent same-name creates exactly one succeeds; this PR locks that behavior in with a regression test for the loser path and enriches `ServerNameConflictError`/`GatewayNameConflictError` so the conflicting resource's `visibility` is available as an attribute (previously only baked into the message), alongside the existing `server_id`/`gateway_id`.

## Changes

- `mcpgateway/schemas.py`: `ServerUpdate.enabled: Optional[bool]`.
- `mcpgateway/services/server_service.py`: apply `server_update.enabled` in `update_server`; `ServerNameConflictError.visibility` attribute.
- `mcpgateway/services/gateway_service.py`: `GatewayNameConflictError.visibility` attribute.
- Tests: enable/disable/preserve-state cases for `update_server`; concurrent-create loser test asserting the enriched conflict error (`server_id` + `visibility`) and that no insert/commit occurs on the losing path.

## Verification

- `pytest tests/unit/mcpgateway/services/test_server_service.py tests/unit/mcpgateway/services/test_row_level_locking.py` — 141 passed, 2 skipped (pre-existing skips).
- New enabled-field tests fail without the implementation (verified failing-first).
- `ruff` clean; bandit clean; no new mypy errors (baseline count unchanged).