### PR TITLE
feat(services): file watcher service for config hot-reload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3801,3 +3801,15 @@ PLUGINS_CLI_MARKUP_MODE=rich
 
 LEGACY_API_ENABLED=true
 LEGACY_API_SUNSET_DATE=Sat, 26 Sep 2026 00:00:00 GMT
+
+# =============================================================================
+# File watcher
+# =============================================================================
+
+# Enable file system watcher for automatic configuration reloading
+# Options: true, false (default)
+# Uses watchfiles (native inotify on Linux) for efficient file monitoring
+# Useful for hot-reloading plugin configs, gateway configs, etc. without restart
+# Performance: Minimal overhead on Linux (native inotify), slightly higher on other platforms
+# Recommended: false in production unless hot-reload is required
+# FILE_WATCHER_ENABLED=false

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-24T15:22:57Z",
+  "generated_at": "2026-07-25T08:50:40Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -634,7 +634,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1083,
+        "line_number": 1089,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1086,
+        "line_number": 1092,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1253,
+        "line_number": 1259,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1292,
+        "line_number": 1298,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1346,
+        "line_number": 1352,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1442,
+        "line_number": 1448,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1813,
+        "line_number": 1819,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-25T08:50:40Z",
+  "generated_at": "2026-07-24T15:22:57Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -634,7 +634,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1089,
+        "line_number": 1083,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1092,
+        "line_number": 1086,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1259,
+        "line_number": 1253,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1298,
+        "line_number": 1292,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1352,
+        "line_number": 1346,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1448,
+        "line_number": 1442,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1819,
+        "line_number": 1813,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -983,6 +983,12 @@ mcpContextForge:
     MCPGATEWAY_BOOTSTRAP_ROLES_IN_DB_ENABLED: "false" # Enable Bootstrap additional system roles feature
     MCPGATEWAY_BOOTSTRAP_ROLES_IN_DB_FILE: "additional_roles_in_db.json" # Create and populate this file as given in the .env.example to add additional roles
 
+    # ─ File Watcher ─
+    # Opt-in file system watcher for automatic configuration reloading.
+    # Best suited for development or controlled environments where hot-reload is needed.
+    # Leave disabled in most production deployments to avoid extra file monitoring overhead.
+    FILE_WATCHER_ENABLED: "false"    # enable file watcher for config hot-reload
+
 
   ####################################################################
   # envFrom is managed by the chart (gateway secret + configmap).

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -982,14 +982,8 @@ mcpContextForge:
     # - Bootstrap additional system roles -
     MCPGATEWAY_BOOTSTRAP_ROLES_IN_DB_ENABLED: "false" # Enable Bootstrap additional system roles feature
     MCPGATEWAY_BOOTSTRAP_ROLES_IN_DB_FILE: "additional_roles_in_db.json" # Create and populate this file as given in the .env.example to add additional roles
-
-    # ─ File Watcher ─
-    # Opt-in file system watcher for automatic configuration reloading.
-    # Best suited for development or controlled environments where hot-reload is needed.
-    # Leave disabled in most production deployments to avoid extra file monitoring overhead.
-    FILE_WATCHER_ENABLED: "false"    # enable file watcher for config hot-reload
-
-
+    # ─ File Watcher: opt-in file system watcher for automatic config hot-reload (leave disabled in most production deployments) ─
+    FILE_WATCHER_ENABLED: "false"
   ####################################################################
   # envFrom is managed by the chart (gateway secret + configmap).
   # Use extraEnvFrom to add additional sources.

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -2812,6 +2812,15 @@ class Settings(BaseSettings):
     debug: bool = False
     expose_error_details: bool = False
 
+    # File Watcher
+    file_watcher_enabled: bool = Field(
+        default=False,
+        description="Opt-in file system watcher for automatic configuration reloading. "
+        "Best suited for development or controlled environments where hot-reload is needed. "
+        "Leave disabled in most production deployments to avoid extra file monitoring overhead. "
+        "Uses watchfiles (native inotify on Linux) for efficient monitoring.",
+    )
+
     # Observability (OpenTelemetry)
     deployment_env: str = Field(default="development", validation_alias=AliasChoices("DEPLOYMENT_ENV", "ENVIRONMENT"), description="Deployment environment label")
     otel_enable_observability: bool = Field(default=False, description="Enable OpenTelemetry observability")

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1908,6 +1908,18 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         except Exception as e:
             logger.error(f"Error shutting down plugin manager: {str(e)}")
 
+        # Stop FileWatcherService singleton (only if enabled)
+        if settings.file_watcher_enabled:
+            try:
+                # First-Party
+                from mcpgateway.services.file_watcher_service import get_file_watcher_service  # pylint: disable=import-outside-toplevel
+
+                file_watcher_service = await get_file_watcher_service()
+                await file_watcher_service.stop_all()
+                logger.info("FileWatcherService stopped")
+            except Exception as e:
+                logger.debug(f"Error stopping FileWatcherService: {e}")
+
         # Stop cache invalidation subscriber
         try:
             # First-Party

--- a/mcpgateway/services/file_watcher_service.py
+++ b/mcpgateway/services/file_watcher_service.py
@@ -1,0 +1,331 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/services/file_watcher_service.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Reusable file watcher service that monitors file system changes and notifies
+registered handlers. Uses watchfiles library for efficient, async-native file
+monitoring with native inotify support on Linux. Installed as a dependency of
+uvicorn[standard].
+"""
+
+# Standard
+import asyncio
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Coroutine, Dict, Optional
+import uuid
+
+# Third-Party
+from watchfiles import awatch, Change
+
+# First-Party
+from mcpgateway.config import settings
+from mcpgateway.services.logging_service import LoggingService
+
+# Initialize logging
+logging_service = LoggingService()
+logger = logging_service.get_logger(__name__)
+
+
+class ChangeType(str, Enum):
+    """File change types."""
+
+    ADDED = "added"
+    MODIFIED = "modified"
+    DELETED = "deleted"
+
+
+@dataclass
+class FileChangeEvent:
+    """Event data for file changes.
+
+    Attributes:
+        change_type: Type of change (added, modified, deleted).
+        path: Absolute path to the changed file.
+        relative_path: Path relative to the watched directory.
+    """
+
+    change_type: ChangeType
+    path: str
+    relative_path: str
+
+
+# Type alias for handler functions
+FileChangeHandler = Callable[[FileChangeEvent], Coroutine[Any, Any, None]]
+
+
+class FileWatcherService:
+    """Service for monitoring file system changes with callback notifications.
+
+    This service uses watchfiles (Rust-based, async-native) for efficient file
+    monitoring. It supports multiple concurrent watchers, each with their own
+    callback handlers.
+
+    Features:
+        - Async-native using watchfiles (native inotify on Linux)
+        - Multiple concurrent watchers with independent handlers
+        - Optional file filtering (glob patterns)
+        - Recursive directory watching
+        - Graceful error handling and recovery
+        - Clean shutdown support
+
+    Example:
+        >>> watcher = FileWatcherService()
+        >>> async def handler(event: FileChangeEvent):  # doctest: +SKIP
+        ...     print(f"{event.change_type}: {event.path}")  # doctest: +SKIP
+        >>> handler_id = await watcher.watch("./config", handler)  # doctest: +SKIP
+        >>> # Later...
+        >>> await watcher.unwatch(handler_id)  # doctest: +SKIP
+    """
+
+    def __init__(self) -> None:
+        """Initialize the file watcher service."""
+        self._watchers: Dict[str, asyncio.Task[None]] = {}
+        self._watch_configs: Dict[str, Dict[str, Any]] = {}
+        self._shutdown_event = asyncio.Event()
+        logger.info("FileWatcherService initialized")
+
+    async def watch(
+        self,
+        path: str,
+        handler: FileChangeHandler,
+    ) -> str:
+        """Start watching a file and notify handler on changes.
+
+        Args:
+            path: File path to watch (relative or absolute). Must be a file, not a directory.
+                  Can be a symlink (e.g., Kubernetes ConfigMap) - will watch the parent directory
+                  to handle atomic symlink swaps.
+            handler: Async callback function to invoke on file changes.
+                     Receives FileChangeEvent as argument.
+
+        Returns:
+            Unique handler ID that can be used to stop watching via unwatch().
+
+        Raises:
+            FileNotFoundError: If the specified file does not exist.
+            ValueError: If path is a directory or handler is not a coroutine function.
+            RuntimeError: If file watcher is disabled via FILE_WATCHER_ENABLED=false.
+
+        Example:
+            >>> async def my_handler(event: FileChangeEvent):  # doctest: +SKIP
+            ...     print(f"Changed: {event.path}")  # doctest: +SKIP
+            >>> handler_id = await watcher.watch("./config.yaml", my_handler)  # doctest: +SKIP
+        """
+        # Check if file watcher is enabled
+        if not settings.file_watcher_enabled:
+            logger.warning("File watcher is disabled (FILE_WATCHER_ENABLED=false). Enable it in configuration to use file watching.")
+            raise RuntimeError("File watcher is disabled. Set FILE_WATCHER_ENABLED=true to enable.")
+
+        watch_path = Path(path)
+
+        if not watch_path.exists():
+            raise FileNotFoundError(f"Watch path does not exist: {path}")
+
+        if not watch_path.is_file() and not (watch_path.is_symlink() and watch_path.resolve().is_file()):
+            raise ValueError(f"Watch path must be a file, not a directory: {path}")
+
+        # Validate handler is async
+        if not asyncio.iscoroutinefunction(handler):
+            raise ValueError("Handler must be an async function (coroutine)")
+
+        # Generate unique handler ID
+        handler_id = str(uuid.uuid4())
+
+        watch_dir = watch_path.parent
+        self._watch_configs[handler_id] = {
+            "path": str(watch_path),
+            "watch_dir": str(watch_dir),
+            "handler": handler,
+        }
+
+        task = asyncio.create_task(
+            self._watch_loop(handler_id, watch_dir, watch_path, handler),
+            name=f"file_watcher_{handler_id[:8]}",
+        )
+        self._watchers[handler_id] = task
+
+        logger.info(f"Started file watcher {handler_id[:8]} for file: {path} (watching parent: {watch_dir})")
+
+        return handler_id
+
+    async def unwatch(self, handler_id: str) -> bool:
+        """Stop watching a specific path.
+
+        Args:
+            handler_id: The handler ID returned by watch().
+
+        Returns:
+            True if watcher was stopped, False if handler_id not found.
+
+        Example:
+            >>> await watcher.unwatch(handler_id)  # doctest: +SKIP
+        """
+        if handler_id not in self._watchers:
+            logger.warning(f"Handler ID not found: {handler_id[:8]}")
+            return False
+
+        # Cancel the watcher task
+        task = self._watchers[handler_id]
+        task.cancel()
+
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass  # Expected when cancelling
+
+        # Cleanup
+        del self._watchers[handler_id]
+        del self._watch_configs[handler_id]
+
+        logger.info(f"Stopped file watcher {handler_id[:8]}")
+        return True
+
+    async def stop_all(self) -> None:
+        """Stop all active watchers and cleanup resources.
+
+        This should be called during application shutdown to ensure
+        all watcher tasks are properly cancelled.
+
+        Example:
+            >>> await watcher.stop_all()  # doctest: +SKIP
+        """
+        logger.info(f"Stopping all file watchers ({len(self._watchers)} active)")
+
+        # Signal shutdown
+        self._shutdown_event.set()
+
+        # Cancel all watcher tasks
+        for _handler_id, task in list(self._watchers.items()):
+            task.cancel()
+
+        # Wait for all tasks to complete
+        if self._watchers:
+            await asyncio.gather(*self._watchers.values(), return_exceptions=True)
+
+        # Cleanup
+        self._watchers.clear()
+        self._watch_configs.clear()
+
+        logger.info("All file watchers stopped")
+
+    def get_active_watchers(self) -> Dict[str, Dict[str, Any]]:
+        """Get information about all active watchers.
+
+        Returns:
+            Dictionary mapping handler IDs to their configurations.
+
+        Example:
+            >>> watcher = FileWatcherService()
+            >>> watchers = watcher.get_active_watchers()
+            >>> for handler_id, config in watchers.items():  # doctest: +SKIP
+            ...     print(f"{handler_id}: watching {config['path']}")  # doctest: +SKIP
+        """
+        return {
+            handler_id: {
+                "path": config["path"],
+            }
+            for handler_id, config in self._watch_configs.items()
+        }
+
+    async def _watch_loop(
+        self,
+        handler_id: str,
+        watch_dir: Path,
+        target_file: Path,
+        handler: FileChangeHandler,
+    ) -> None:
+        """Internal watch loop that monitors file changes.
+
+        Args:
+            handler_id: Unique identifier for this watcher.
+            watch_dir: Parent directory to watch.
+            target_file: Specific file to monitor within the directory.
+            handler: Callback function to invoke on changes.
+        """
+        try:
+            logger.debug(f"Watch loop started for {handler_id[:8]}: watching {watch_dir} for changes to {target_file.name}")
+
+            # Watch parent directory but use watch_filter to only get events for our target file
+            # This reduces noise from other files in the directory
+            target_filename = target_file.name
+
+            async for changes in awatch(
+                watch_dir,
+                recursive=False,
+                stop_event=self._shutdown_event,
+                watch_filter=lambda change, path: Path(path).name == target_filename,
+            ):
+                for change_type_raw, changed_path in changes:
+                    change_type = self._convert_change_type(change_type_raw)
+                    logger.debug(f"Processing {change_type} event for {changed_path}")
+
+                    # Create event
+                    event = FileChangeEvent(
+                        change_type=change_type,
+                        path=str(changed_path),
+                        relative_path=target_file.name,
+                    )
+
+                    # Invoke handler
+                    try:
+                        await handler(event)
+                    except Exception as e:
+                        logger.error(
+                            f"Error in file change handler {handler_id[:8]} for {changed_path}: {e}",
+                            exc_info=True,
+                        )
+
+        except asyncio.CancelledError:
+            logger.debug(f"Watch loop cancelled for {handler_id[:8]}")
+            raise
+        except Exception as e:
+            logger.error(
+                f"Unexpected error in watch loop {handler_id[:8]}: {e}",
+                exc_info=True,
+            )
+            raise
+
+    @staticmethod
+    def _convert_change_type(change: Change) -> ChangeType:
+        """Convert watchfiles.Change to our ChangeType enum.
+
+        Args:
+            change: watchfiles.Change enum value.
+
+        Returns:
+            Corresponding ChangeType enum value.
+        """
+        if change == Change.added:
+            return ChangeType.ADDED
+        if change == Change.modified:
+            return ChangeType.MODIFIED
+        if change == Change.deleted:
+            return ChangeType.DELETED
+        # Fallback for any future change types
+        return ChangeType.MODIFIED  # type: ignore[unreachable]
+
+
+# Singleton instance for convenience
+_file_watcher_service: Optional[FileWatcherService] = None
+_file_watcher_lock = asyncio.Lock()
+
+
+async def get_file_watcher_service() -> FileWatcherService:
+    """Get or create the singleton FileWatcherService instance.
+
+    Returns:
+        The global FileWatcherService instance.
+
+    Example:
+        >>> watcher = await get_file_watcher_service()  # doctest: +SKIP
+        >>> handler_id = await watcher.watch("./config", my_handler)  # doctest: +SKIP
+    """
+    global _file_watcher_service
+    if _file_watcher_service is None:
+        async with _file_watcher_lock:
+            if _file_watcher_service is None:
+                _file_watcher_service = FileWatcherService()
+    return _file_watcher_service

--- a/tests/unit/mcpgateway/services/test_file_watcher_service.py
+++ b/tests/unit/mcpgateway/services/test_file_watcher_service.py
@@ -1,0 +1,428 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_file_watcher_service.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for FileWatcherService.
+
+Covers:
+- watch() / unwatch() / stop_all() lifecycle
+- FileChangeEvent and ChangeType dataclasses
+- get_file_watcher_service() singleton
+- _watch_loop() happy-path and error branches
+- _convert_change_type() mapping
+- FILE_WATCHER_ENABLED guard
+"""
+
+# Standard
+import asyncio
+from typing import List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+from watchfiles import Change
+
+# First-Party
+from mcpgateway.services.file_watcher_service import (
+    ChangeType,
+    FileChangeEvent,
+    FileWatcherService,
+    get_file_watcher_service,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_handler() -> AsyncMock:
+    """Return an async callable that records every FileChangeEvent it receives."""
+    handler = AsyncMock()
+    handler.events: List[FileChangeEvent] = []
+
+    async def _capture(event: FileChangeEvent) -> None:
+        handler.events.append(event)
+        await handler(event)
+
+    return handler, _capture
+
+
+# ---------------------------------------------------------------------------
+# ChangeType / FileChangeEvent
+# ---------------------------------------------------------------------------
+
+
+def test_change_type_values():
+    """ChangeType enum has the expected string values."""
+    assert ChangeType.ADDED == "added"
+    assert ChangeType.MODIFIED == "modified"
+    assert ChangeType.DELETED == "deleted"
+
+
+def test_file_change_event_fields():
+    """FileChangeEvent stores all three fields correctly."""
+    event = FileChangeEvent(
+        change_type=ChangeType.MODIFIED,
+        path="/tmp/foo.yaml",
+        relative_path="foo.yaml",
+    )
+    assert event.change_type == ChangeType.MODIFIED
+    assert event.path == "/tmp/foo.yaml"
+    assert event.relative_path == "foo.yaml"
+
+
+# ---------------------------------------------------------------------------
+# _convert_change_type
+# ---------------------------------------------------------------------------
+
+
+def test_convert_change_type_added():
+    assert FileWatcherService._convert_change_type(Change.added) == ChangeType.ADDED
+
+
+def test_convert_change_type_modified():
+    assert FileWatcherService._convert_change_type(Change.modified) == ChangeType.MODIFIED
+
+
+def test_convert_change_type_deleted():
+    assert FileWatcherService._convert_change_type(Change.deleted) == ChangeType.DELETED
+
+
+def test_convert_change_type_unknown_falls_back_to_modified():
+    """Any unknown Change value falls back to MODIFIED."""
+    unknown = MagicMock()  # not a real Change enum member
+    assert FileWatcherService._convert_change_type(unknown) == ChangeType.MODIFIED
+
+
+# ---------------------------------------------------------------------------
+# watch() guard: FILE_WATCHER_ENABLED=false
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watch_raises_when_disabled(tmp_path):
+    """watch() raises RuntimeError when FILE_WATCHER_ENABLED=false."""
+    test_file = tmp_path / "cfg.yaml"
+    test_file.write_text("level: INFO")
+
+    with patch("mcpgateway.services.file_watcher_service.settings") as mock_settings:
+        mock_settings.file_watcher_enabled = False
+
+        service = FileWatcherService()
+        handler = AsyncMock()
+
+        with pytest.raises(RuntimeError, match="File watcher is disabled"):
+            await service.watch(str(test_file), handler)
+
+
+# ---------------------------------------------------------------------------
+# watch() validation errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watch_raises_for_missing_file(tmp_path):
+    """watch() raises FileNotFoundError when the file does not exist."""
+    with patch("mcpgateway.services.file_watcher_service.settings") as mock_settings:
+        mock_settings.file_watcher_enabled = True
+
+        service = FileWatcherService()
+        handler = AsyncMock()
+
+        with pytest.raises(FileNotFoundError):
+            await service.watch(str(tmp_path / "nonexistent.yaml"), handler)
+
+
+@pytest.mark.asyncio
+async def test_watch_raises_for_directory(tmp_path):
+    """watch() raises ValueError when the path is a directory."""
+    with patch("mcpgateway.services.file_watcher_service.settings") as mock_settings:
+        mock_settings.file_watcher_enabled = True
+
+        service = FileWatcherService()
+        handler = AsyncMock()
+
+        with pytest.raises(ValueError, match="must be a file"):
+            await service.watch(str(tmp_path), handler)
+
+
+@pytest.mark.asyncio
+async def test_watch_raises_for_sync_handler(tmp_path):
+    """watch() raises ValueError when handler is not a coroutine function."""
+    test_file = tmp_path / "cfg.yaml"
+    test_file.write_text("level: INFO")
+
+    with patch("mcpgateway.services.file_watcher_service.settings") as mock_settings:
+        mock_settings.file_watcher_enabled = True
+
+        service = FileWatcherService()
+
+        def sync_handler(event):
+            pass
+
+        with pytest.raises(ValueError, match="async function"):
+            await service.watch(str(test_file), sync_handler)
+
+
+# ---------------------------------------------------------------------------
+# watch() / unwatch() happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watch_returns_handler_id_and_stores_config(tmp_path):
+    """watch() returns a non-empty string handler ID and stores watcher config."""
+    test_file = tmp_path / "cfg.yaml"
+    test_file.write_text("level: INFO")
+
+    with patch("mcpgateway.services.file_watcher_service.settings") as mock_settings:
+        mock_settings.file_watcher_enabled = True
+        # Patch awatch so the loop doesn't actually run
+        with patch("mcpgateway.services.file_watcher_service.awatch") as mock_awatch:
+            mock_awatch.return_value = _async_empty_iterator()
+
+            service = FileWatcherService()
+            handler = AsyncMock()
+            handler_id = await service.watch(str(test_file), handler)
+
+            assert isinstance(handler_id, str)
+            assert len(handler_id) > 0
+            assert handler_id in service._watch_configs
+            assert handler_id in service._watchers
+
+            # Cleanup
+            await service.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_unwatch_returns_true_for_known_handler(tmp_path):
+    """unwatch() returns True and removes the watcher entry."""
+    test_file = tmp_path / "cfg.yaml"
+    test_file.write_text("level: INFO")
+
+    with patch("mcpgateway.services.file_watcher_service.settings") as mock_settings:
+        mock_settings.file_watcher_enabled = True
+        with patch("mcpgateway.services.file_watcher_service.awatch") as mock_awatch:
+            mock_awatch.return_value = _async_empty_iterator()
+
+            service = FileWatcherService()
+            handler = AsyncMock()
+            handler_id = await service.watch(str(test_file), handler)
+
+            result = await service.unwatch(handler_id)
+
+            assert result is True
+            assert handler_id not in service._watchers
+            assert handler_id not in service._watch_configs
+
+
+@pytest.mark.asyncio
+async def test_unwatch_returns_false_for_unknown_handler():
+    """unwatch() returns False when the handler ID is not found."""
+    service = FileWatcherService()
+    result = await service.unwatch("00000000-0000-0000-0000-000000000000")
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# stop_all()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_all_clears_watchers(tmp_path):
+    """stop_all() cancels all tasks and empties internal dicts."""
+    test_file = tmp_path / "cfg.yaml"
+    test_file.write_text("level: INFO")
+
+    with patch("mcpgateway.services.file_watcher_service.settings") as mock_settings:
+        mock_settings.file_watcher_enabled = True
+        with patch("mcpgateway.services.file_watcher_service.awatch") as mock_awatch:
+            mock_awatch.return_value = _async_empty_iterator()
+
+            service = FileWatcherService()
+            handler = AsyncMock()
+            await service.watch(str(test_file), handler)
+
+            await service.stop_all()
+
+            assert len(service._watchers) == 0
+            assert len(service._watch_configs) == 0
+
+
+@pytest.mark.asyncio
+async def test_stop_all_with_no_watchers():
+    """stop_all() is a no-op when there are no active watchers."""
+    service = FileWatcherService()
+    await service.stop_all()  # should not raise
+    assert len(service._watchers) == 0
+
+
+# ---------------------------------------------------------------------------
+# get_active_watchers()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_active_watchers_returns_paths(tmp_path):
+    """get_active_watchers() returns a dict with path keys."""
+    test_file = tmp_path / "cfg.yaml"
+    test_file.write_text("level: INFO")
+
+    with patch("mcpgateway.services.file_watcher_service.settings") as mock_settings:
+        mock_settings.file_watcher_enabled = True
+        with patch("mcpgateway.services.file_watcher_service.awatch") as mock_awatch:
+            mock_awatch.return_value = _async_empty_iterator()
+
+            service = FileWatcherService()
+            handler = AsyncMock()
+            handler_id = await service.watch(str(test_file), handler)
+
+            active = service.get_active_watchers()
+            assert handler_id in active
+            assert active[handler_id]["path"] == str(test_file)
+
+            # handler key must NOT be exposed externally
+            assert "handler" not in active[handler_id]
+
+            await service.stop_all()
+
+
+# ---------------------------------------------------------------------------
+# _watch_loop() – event delivery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watch_loop_delivers_events_to_handler(tmp_path):
+    """_watch_loop delivers FileChangeEvents to the registered handler."""
+    test_file = tmp_path / "cfg.yaml"
+    test_file.write_text("level: INFO")
+
+    received: List[FileChangeEvent] = []
+
+    async def handler(event: FileChangeEvent) -> None:
+        received.append(event)
+
+    fake_changes = [{(Change.modified, str(test_file))}]
+
+    with patch("mcpgateway.services.file_watcher_service.awatch") as mock_awatch:
+        mock_awatch.return_value = _async_iterator_from(fake_changes)
+
+        service = FileWatcherService()
+        await service._watch_loop(
+            handler_id="test-id-1234",
+            watch_dir=test_file.parent,
+            target_file=test_file,
+            handler=handler,
+        )
+
+    assert len(received) == 1
+    assert received[0].change_type == ChangeType.MODIFIED
+    assert received[0].relative_path == test_file.name
+
+
+@pytest.mark.asyncio
+async def test_watch_loop_swallows_handler_exceptions(tmp_path):
+    """_watch_loop logs but does not propagate exceptions raised in the handler."""
+    test_file = tmp_path / "cfg.yaml"
+    test_file.write_text("level: INFO")
+
+    async def bad_handler(event: FileChangeEvent) -> None:
+        raise ValueError("handler exploded")
+
+    fake_changes = [{(Change.added, str(test_file))}]
+
+    with patch("mcpgateway.services.file_watcher_service.awatch") as mock_awatch:
+        mock_awatch.return_value = _async_iterator_from(fake_changes)
+
+        service = FileWatcherService()
+        # Should not raise
+        await service._watch_loop(
+            handler_id="test-id-5678",
+            watch_dir=test_file.parent,
+            target_file=test_file,
+            handler=bad_handler,
+        )
+
+
+@pytest.mark.asyncio
+async def test_watch_loop_propagates_non_cancelled_exceptions(tmp_path):
+    """_watch_loop re-raises unexpected errors from awatch."""
+    test_file = tmp_path / "cfg.yaml"
+    test_file.write_text("level: INFO")
+
+    async def handler(event: FileChangeEvent) -> None:
+        pass
+
+    with patch("mcpgateway.services.file_watcher_service.awatch", side_effect=RuntimeError("boom")):
+        service = FileWatcherService()
+        with pytest.raises(RuntimeError, match="boom"):
+            await service._watch_loop(
+                handler_id="test-id-abcd",
+                watch_dir=test_file.parent,
+                target_file=test_file,
+                handler=handler,
+            )
+
+
+@pytest.mark.asyncio
+async def test_watch_loop_reraises_cancelled_error(tmp_path):
+    """_watch_loop re-raises CancelledError after logging."""
+    test_file = tmp_path / "cfg.yaml"
+    test_file.write_text("level: INFO")
+
+    async def handler(event: FileChangeEvent) -> None:
+        pass
+
+    with patch("mcpgateway.services.file_watcher_service.awatch", side_effect=asyncio.CancelledError):
+        service = FileWatcherService()
+        with pytest.raises(asyncio.CancelledError):
+            await service._watch_loop(
+                handler_id="test-id-efgh",
+                watch_dir=test_file.parent,
+                target_file=test_file,
+                handler=handler,
+            )
+
+
+# ---------------------------------------------------------------------------
+# get_file_watcher_service() singleton
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_file_watcher_service_returns_singleton():
+    """get_file_watcher_service() returns the same instance on repeated calls."""
+    import mcpgateway.services.file_watcher_service as fws_module
+
+    # Reset singleton so the test is deterministic regardless of import order
+    fws_module._file_watcher_service = None
+
+    svc1 = await get_file_watcher_service()
+    svc2 = await get_file_watcher_service()
+
+    assert svc1 is svc2
+    assert isinstance(svc1, FileWatcherService)
+
+    # Restore so other tests get a fresh instance if needed
+    fws_module._file_watcher_service = None
+
+
+# ---------------------------------------------------------------------------
+# Async iterator helpers
+# ---------------------------------------------------------------------------
+
+
+async def _async_empty_iterator():
+    """Async generator that yields nothing (simulates an idle watcher)."""
+    return
+    yield  # pragma: no cover – makes this an async generator
+
+
+async def _async_iterator_from(items):
+    """Async generator that yields each item from a list, then stops."""
+    for item in items:
+        yield item


### PR DESCRIPTION
Closes #5859

## Summary

Adds a reusable, opt-in `FileWatcherService` that monitors filesystem changes and notifies registered async handlers, gated behind a new `FILE_WATCHER_ENABLED` setting (default: `false`). This provides a generic file-watching primitive that follow-up features (e.g., log config hot-reload) can consume without each re-implementing filesystem monitoring.

## Changes

- **`mcpgateway/services/file_watcher_service.py`** (new): `FileWatcherService` built on `watchfiles` (async-native, native inotify on Linux; already available via `uvicorn[standard]`).
  - `watch()` / `unwatch()` / `stop_all()` lifecycle with unique handler IDs
  - Per-watcher async callbacks receiving `FileChangeEvent` (added / modified / deleted)
  - Watches the target file's parent directory with a filename filter, so atomic symlink swaps (e.g., Kubernetes ConfigMap updates) are handled
  - Fail-closed guard: `watch()` raises `RuntimeError` when `FILE_WATCHER_ENABLED=false`
  - `get_file_watcher_service()` async singleton accessor
- **`mcpgateway/config.py`**: new `file_watcher_enabled` setting (default `False`)
- **`.env.example` / `charts/mcp-stack/values.yaml`**: `FILE_WATCHER_ENABLED` entries (default disabled)
- **`mcpgateway/main.py`**: lifespan teardown stops all watchers on shutdown (only when the flag is enabled)
- **`tests/unit/mcpgateway/services/test_file_watcher_service.py`** (new): 21 tests covering lifecycle, validation errors (missing file, directory path, sync handler), event delivery, handler-exception isolation, cancellation, singleton behavior, and the disabled-flag guard

## Behavior

- **Flag absent/false (default):** zero behavior change — no watcher tasks are created; lifespan startup/shutdown paths are untouched (`tests/unit/mcpgateway/test_main.py` passes unmodified).
- **Flag true:** features may register watchers via `get_file_watcher_service().watch(path, handler)`; watchers are cancelled cleanly during lifespan teardown.

## Verification

- `pytest tests/unit/mcpgateway/services/test_file_watcher_service.py -q` — 21 passed
- `pytest tests/unit/mcpgateway/test_main.py -q` — green (flag absent)
- `pytest tests/unit/mcpgateway/test_config.py -q` — green
- ruff / bandit / pylint (10.00/10) / mypy / ty / pyrefly clean on changed files; `make check-env` green