### PR TITLE
feat(security): support SSL_CERT_FILE custom CA bundles across HTTP/OAuth/SSL layers

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-24T15:22:57Z",
+  "generated_at": "2026-07-25T08:54:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4688,7 +4688,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1470,
+        "line_number": 1509,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-25T08:54:10Z",
+  "generated_at": "2026-07-24T15:22:57Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4688,7 +4688,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1509,
+        "line_number": 1470,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/services/http_client_service.py
+++ b/mcpgateway/services/http_client_service.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import asynccontextmanager
 import logging
+import os
 import ssl
 from typing import AsyncIterator, Optional
 
@@ -98,6 +99,7 @@ class SharedHttpClient:
         Initialize the HTTP client with configured limits and timeouts.
 
         Reads configuration from settings and creates the shared AsyncClient.
+        Respects SSL_CERT_FILE environment variable for custom CA bundles.
         """
         # Import here to avoid circular imports
         # First-Party
@@ -116,20 +118,43 @@ class SharedHttpClient:
             pool=settings.httpx_pool_timeout,
         )
 
+        # Determine SSL verification setting
+        # Priority: SKIP_SSL_VERIFY > SSL_CERT_FILE (combined with system) > default
+        if settings.skip_ssl_verify:
+            verify_setting = False
+            logger.info("SSL verification disabled via SKIP_SSL_VERIFY")
+        else:
+            # Check for SSL_CERT_FILE environment variable (used in containers)
+            ssl_cert_file = os.environ.get("SSL_CERT_FILE")
+            if ssl_cert_file:
+                if not os.path.isfile(ssl_cert_file):
+                    raise ValueError(f"SSL_CERT_FILE is set but the file does not exist or is not a regular file: {ssl_cert_file}")
+                # Create SSL context that combines system CAs with custom CA bundle
+                # ssl.create_default_context() loads system CAs automatically
+                # then we add the custom CA file on top
+                ssl_context = ssl.create_default_context()
+                ssl_context.load_verify_locations(cafile=ssl_cert_file)
+                verify_setting = ssl_context
+                logger.info("Using SSL context with custom CA bundle + system CAs: %s", ssl_cert_file)
+            else:
+                verify_setting = True
+                logger.debug("Using default system CA bundle")
+
         self._client = httpx.AsyncClient(
             limits=self._limits,
             timeout=timeout,
             http2=settings.httpx_http2_enabled,
             follow_redirects=False,
-            verify=not settings.skip_ssl_verify,
+            verify=verify_setting,
         )
         self._initialized = True
 
         logger.info(
-            "Shared HTTP client initialized: max_connections=%d, keepalive=%d, http2=%s",
+            "Shared HTTP client initialized: max_connections=%d, keepalive=%d, http2=%s, ssl_verify=%s",
             settings.httpx_max_connections,
             settings.httpx_max_keepalive_connections,
             settings.httpx_http2_enabled,
+            verify_setting if isinstance(verify_setting, bool) else "custom_ca",
         )
 
     @property
@@ -284,20 +309,41 @@ def get_admin_timeout() -> httpx.Timeout:
     )
 
 
-def get_default_verify() -> bool:
+def get_default_verify() -> bool | ssl.SSLContext:
     """
-    Get the default SSL verification setting based on skip_ssl_verify config.
+    Get the default SSL verification setting based on skip_ssl_verify config and SSL_CERT_FILE.
 
     Use this when creating factory clients that should respect the global
-    skip_ssl_verify setting when no custom SSL context is provided.
+    skip_ssl_verify setting and SSL_CERT_FILE environment variable when no custom SSL context is provided.
 
     Returns:
-        bool: True if SSL should be verified, False if skip_ssl_verify is enabled.
+        bool | ssl.SSLContext: False if skip_ssl_verify is enabled,
+                               SSL context if SSL_CERT_FILE is set (combines system + custom CAs),
+                               True for default system CA verification.
+
+    Raises:
+        ValueError: If SSL_CERT_FILE is set but the file does not exist.
     """
     # First-Party
     from mcpgateway.config import settings  # pylint: disable=import-outside-toplevel
 
-    return not settings.skip_ssl_verify
+    if settings.skip_ssl_verify:
+        return False
+
+    # Check for SSL_CERT_FILE environment variable (used in containers)
+    ssl_cert_file = os.environ.get("SSL_CERT_FILE")
+    if ssl_cert_file:
+        if not os.path.isfile(ssl_cert_file):
+            raise ValueError(f"SSL_CERT_FILE is set but the file does not exist or is not a regular file: {ssl_cert_file}")
+        # Create SSL context that combines system CAs with custom CA bundle
+        # ssl.create_default_context() loads system CAs automatically
+        # then we add the custom CA file on top
+        ssl_context = ssl.create_default_context()
+        ssl_context.load_verify_locations(cafile=ssl_cert_file)
+        logger.info("get_default_verify: Using SSL context with custom CA bundle + system CAs: %s", ssl_cert_file)
+        return ssl_context
+
+    return True
 
 
 @asynccontextmanager

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -609,7 +609,7 @@ class OAuthManager:
                 logger.info("""Successfully obtained access token via client credentials""")
                 return token_response["access_token"]
 
-            except ValueError:
+            except ValueError:  # pylint: disable=try-except-raise
                 # Re-raise ValueError immediately (e.g., mTLS validation errors from get_cached_ssl_context)
                 # These are configuration errors that should not be retried
                 raise

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -343,7 +343,12 @@ class OAuthManager:
         context so that OAuth token exchange works against self-signed or
         custom-CA upstream servers and/or presents client certificates for mTLS.
         Otherwise the shared HTTP client (which respects the global
-        ``SKIP_SSL_VERIFY`` setting) is used.
+        ``SKIP_SSL_VERIFY`` and ``SSL_CERT_FILE`` settings) is used.
+
+        The global ``SKIP_SSL_VERIFY`` setting is respected even when custom
+        CA certificates are provided, allowing SSL verification to be disabled
+        for development/testing environments. Similarly, ``SSL_CERT_FILE`` is
+        respected when no custom CA is provided.
 
         Note:
             When only ``client_cert``/``client_key`` are provided (no custom CA),
@@ -360,15 +365,31 @@ class OAuthManager:
 
         Returns:
             The HTTP response from the token endpoint.
+
+        Raises:
+            ValueError: If only one of client_cert/client_key is provided (mTLS requires both).
         """
+        # Validate mTLS configuration early (before SSL context creation)
+        if bool(client_cert) != bool(client_key):
+            raise ValueError("mTLS requires both client_cert and client_key; got only one")
+
         # SSRF defense: never follow redirects on token endpoints. The shared HTTP
         # client sets follow_redirects=True, which would let a validated public
         # token_url 302-redirect into an internal target (e.g. 169.254.169.254)
         # after pre-fetch SSRF validation has already passed.
         if ca_certificate or client_cert or client_key:
+            # Check if SSL verification should be skipped globally
+            if self.settings.skip_ssl_verify:
+                # When SKIP_SSL_VERIFY is enabled, disable verification entirely
+                async with httpx.AsyncClient(verify=False) as client:  # nosec B501 - explicit opt-in via SKIP_SSL_VERIFY setting
+                    return await client.post(url, data=data, headers=headers, timeout=self.request_timeout, follow_redirects=False)
+
+            # Use custom SSL context with CA certificate
             ssl_context = get_cached_ssl_context(ca_certificate, client_cert=client_cert, client_key=client_key)
             async with httpx.AsyncClient(verify=ssl_context) as client:
                 return await client.post(url, data=data, headers=headers, timeout=self.request_timeout, follow_redirects=False)
+
+        # No custom CA certificate - use shared client which respects SSL_CERT_FILE
         client = await self._get_client()
         return await client.post(url, data=data, headers=headers, timeout=self.request_timeout, follow_redirects=False)
 
@@ -588,6 +609,10 @@ class OAuthManager:
                 logger.info("""Successfully obtained access token via client credentials""")
                 return token_response["access_token"]
 
+            except ValueError:
+                # Re-raise ValueError immediately (e.g., mTLS validation errors from get_cached_ssl_context)
+                # These are configuration errors that should not be retried
+                raise
             except httpx.HTTPError as e:
                 logger.warning("Token request attempt %s failed: %s", attempt + 1, str(e))
                 if attempt == self.max_retries - 1:

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -24,6 +24,7 @@ import uuid
 
 # Third-Party
 from cpex.framework import GlobalContext, PluginContextTable, PromptHookType, PromptPosthookPayload, PromptPrehookPayload
+import httpx
 from jinja2 import meta, select_autoescape, Template
 from jinja2.exceptions import SecurityError as JinjaSecurityError
 from jinja2.sandbox import SandboxedEnvironment
@@ -447,13 +448,42 @@ class PromptService(BaseService):
                             description=getattr(remote_result, "description", None) or prompt.description,
                         )
 
+            # Create httpx client factory for SSL handling
+            def create_prompt_client() -> httpx.AsyncClient:
+                """Create httpx client with proper SSL verification for prompt fetching."""
+                # First-Party
+                from mcpgateway.services.http_client_service import get_default_verify  # pylint: disable=import-outside-toplevel
+                from mcpgateway.utils.ssl_context_cache import get_cached_ssl_context  # pylint: disable=import-outside-toplevel
+
+                # Handle gateway CA certificate if present
+                if gateway.ca_certificate:
+                    ctx = get_cached_ssl_context(gateway.ca_certificate, client_cert=gateway.client_cert, client_key=gateway.client_key)
+                    verify_setting = ctx
+                else:
+                    verify_setting = get_default_verify()
+
+                return httpx.AsyncClient(
+                    verify=verify_setting,
+                    follow_redirects=True,
+                    timeout=settings.health_check_timeout,
+                    limits=httpx.Limits(
+                        max_connections=settings.httpx_max_connections,
+                        max_keepalive_connections=settings.httpx_max_keepalive_connections,
+                        keepalive_expiry=settings.httpx_keepalive_expiry,
+                    ),
+                )
+
             if transport == "sse":
-                async with sse_client(url=gateway_url, headers=headers, timeout=settings.health_check_timeout) as streams:
+                async with sse_client(url=gateway_url, headers=headers, timeout=settings.health_check_timeout, httpx_client_factory=create_prompt_client) as streams:
                     async with ClientSession(*streams) as session:
                         await session.initialize()
                         remote_result = await _get_prompt_with_meta(session, remote_name, prompt_arguments, meta_data)
             else:
-                async with streamablehttp_client(url=gateway_url, headers=headers, timeout=settings.health_check_timeout) as (read_stream, write_stream, _get_session_id):
+                async with streamablehttp_client(url=gateway_url, headers=headers, timeout=settings.health_check_timeout, httpx_client_factory=create_prompt_client) as (
+                    read_stream,
+                    write_stream,
+                    _get_session_id,
+                ):
                     async with ClientSession(read_stream, write_stream) as session:
                         await session.initialize()
                         remote_result = await _get_prompt_with_meta(session, remote_name, prompt_arguments, meta_data)

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -2503,8 +2503,37 @@ class ResourceService(BaseService):
                             if plugin_global_context and plugin_global_context.user_context:
                                 headers.update(build_identity_headers(plugin_global_context.user_context, gateway))
 
+                            # Create httpx client factory for SSL handling
+                            def create_resource_client() -> httpx.AsyncClient:
+                                """Create httpx client with proper SSL verification for resource reading."""
+                                # First-Party
+                                from mcpgateway.services.http_client_service import get_default_verify  # pylint: disable=import-outside-toplevel
+                                from mcpgateway.utils.ssl_context_cache import get_cached_ssl_context  # pylint: disable=import-outside-toplevel
+
+                                # Handle gateway CA certificate if present
+                                if gateway.ca_certificate:
+                                    ctx = get_cached_ssl_context(gateway.ca_certificate, client_cert=gateway.client_cert, client_key=gateway.client_key)
+                                    verify_setting = ctx
+                                else:
+                                    verify_setting = get_default_verify()
+
+                                return httpx.AsyncClient(
+                                    verify=verify_setting,
+                                    follow_redirects=True,
+                                    timeout=settings.mcpgateway_direct_proxy_timeout,
+                                    limits=httpx.Limits(
+                                        max_connections=settings.httpx_max_connections,
+                                        max_keepalive_connections=settings.httpx_max_keepalive_connections,
+                                        keepalive_expiry=settings.httpx_keepalive_expiry,
+                                    ),
+                                )
+
                             # Use MCP SDK to connect and read resource
-                            async with streamablehttp_client(url=gateway.url, headers=headers, timeout=settings.mcpgateway_direct_proxy_timeout) as (read_stream, write_stream, _get_session_id):
+                            async with streamablehttp_client(url=gateway.url, headers=headers, timeout=settings.mcpgateway_direct_proxy_timeout, httpx_client_factory=create_resource_client) as (
+                                read_stream,
+                                write_stream,
+                                _get_session_id,
+                            ):
                                 async with ClientSession(read_stream, write_stream) as session:
                                     await session.initialize()
                                     result = await _read_resource_with_meta(session, uri, meta_data)

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -2508,7 +2508,6 @@ class ResourceService(BaseService):
                                 """Create httpx client with proper SSL verification for resource reading."""
                                 # First-Party
                                 from mcpgateway.services.http_client_service import get_default_verify  # pylint: disable=import-outside-toplevel
-                                from mcpgateway.utils.ssl_context_cache import get_cached_ssl_context  # pylint: disable=import-outside-toplevel
 
                                 # Handle gateway CA certificate if present
                                 if gateway.ca_certificate:

--- a/mcpgateway/utils/ssl_context_cache.py
+++ b/mcpgateway/utils/ssl_context_cache.py
@@ -168,8 +168,8 @@ def get_cached_ssl_context(
         ca_cert_bytes = str(ca_certificate).encode()
 
     # Client cert/key may be either path-like content or inlined PEM string.
-    client_cert_value = client_cert or ""
-    client_key_value = client_key or ""
+    client_cert_value = str(client_cert) if client_cert else ""
+    client_key_value = str(client_key) if client_key else ""
 
     # Build stable cache key incrementally (avoids delimiter collisions).
     key_hash = hashlib.sha256()
@@ -195,9 +195,25 @@ def get_cached_ssl_context(
         raise ValueError("mTLS requires both client_cert and client_key; got only one")
 
     # Create new SSL context and configure CA cert
+    # ssl.create_default_context() automatically loads system CAs
     ctx = ssl.create_default_context()
+
+    # Load the provided CA certificate (from gateway/server config)
     if ca_certificate:
         ctx.load_verify_locations(cadata=ca_certificate)
+
+    # Also load SSL_CERT_FILE if set (for custom CAs like OpenShift)
+    # This allows both the gateway-specific CA AND custom environment CAs to work
+    ssl_cert_file = os.environ.get("SSL_CERT_FILE")
+    if ssl_cert_file:
+        if not os.path.isfile(ssl_cert_file):
+            logger.warning("SSL_CERT_FILE is set but the file does not exist or is not a regular file: %s", ssl_cert_file)
+        else:
+            try:
+                ctx.load_verify_locations(cafile=ssl_cert_file)
+                logger.debug("Loaded additional CA certificates from SSL_CERT_FILE: %s", ssl_cert_file)
+            except Exception as e:
+                logger.warning("Failed to load SSL_CERT_FILE %s: %s", ssl_cert_file, e)
 
     # Load client certificates for mTLS when provided
     if client_cert and client_key:

--- a/tests/unit/mcpgateway/services/test_http_client_service.py
+++ b/tests/unit/mcpgateway/services/test_http_client_service.py
@@ -414,3 +414,45 @@ async def test_shared_http_client_ssl_cert_file_missing_fails_fast(monkeypatch):
         client = SharedHttpClient()
         with pytest.raises(ValueError, match="SSL_CERT_FILE"):
             await client._initialize()
+
+
+@pytest.mark.asyncio
+async def test_shared_http_client_skip_ssl_verify_disables_verification():
+    """SharedHttpClient passes verify=False to httpx when skip_ssl_verify is enabled."""
+    with patch("mcpgateway.config.settings") as mock_settings:
+        mock_settings.httpx_max_connections = 10
+        mock_settings.httpx_max_keepalive_connections = 5
+        mock_settings.httpx_keepalive_expiry = 30
+        mock_settings.httpx_connect_timeout = 5
+        mock_settings.httpx_read_timeout = 120
+        mock_settings.httpx_write_timeout = 30
+        mock_settings.httpx_pool_timeout = 10
+        mock_settings.httpx_http2_enabled = False
+        mock_settings.skip_ssl_verify = True
+
+        with patch("mcpgateway.services.http_client_service.httpx.AsyncClient") as mock_client_cls:
+            client = SharedHttpClient()
+            await client._initialize()
+            assert mock_client_cls.call_args.kwargs["verify"] is False
+
+
+@pytest.mark.asyncio
+async def test_shared_http_client_with_ssl_cert_file(tmp_path, monkeypatch):
+    """SharedHttpClient builds an SSL context from SSL_CERT_FILE when set."""
+    ca_path = _generate_ca_pem(tmp_path)
+    monkeypatch.setenv("SSL_CERT_FILE", ca_path)
+    with patch("mcpgateway.config.settings") as mock_settings:
+        mock_settings.httpx_max_connections = 10
+        mock_settings.httpx_max_keepalive_connections = 5
+        mock_settings.httpx_keepalive_expiry = 30
+        mock_settings.httpx_connect_timeout = 5
+        mock_settings.httpx_read_timeout = 120
+        mock_settings.httpx_write_timeout = 30
+        mock_settings.httpx_pool_timeout = 10
+        mock_settings.httpx_http2_enabled = False
+        mock_settings.skip_ssl_verify = False
+
+        with patch("mcpgateway.services.http_client_service.httpx.AsyncClient") as mock_client_cls:
+            client = SharedHttpClient()
+            await client._initialize()
+            assert isinstance(mock_client_cls.call_args.kwargs["verify"], ssl.SSLContext)

--- a/tests/unit/mcpgateway/services/test_http_client_service.py
+++ b/tests/unit/mcpgateway/services/test_http_client_service.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import ssl
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -342,3 +342,75 @@ async def test_get_isolated_http_client_with_explicit_verify():
 
         async with get_isolated_http_client(verify=False, http2=True) as client:
             assert isinstance(client, httpx.AsyncClient)
+
+
+# --- SSL_CERT_FILE support ---
+
+
+def _generate_ca_pem(tmp_path):
+    """Generate a minimal self-signed CA certificate PEM for SSL_CERT_FILE tests."""
+    # Standard
+    import datetime
+
+    # Third-Party
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test-ca")])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    pem_path = tmp_path / "custom-ca.pem"
+    pem_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    return str(pem_path)
+
+
+def test_get_default_verify_with_ssl_cert_file(tmp_path, monkeypatch):
+    """get_default_verify() returns an SSL context combining system + custom CAs when SSL_CERT_FILE is set."""
+    ca_path = _generate_ca_pem(tmp_path)
+    monkeypatch.setenv("SSL_CERT_FILE", ca_path)
+    with patch("mcpgateway.config.settings") as mock_settings:
+        mock_settings.skip_ssl_verify = False
+        result = get_default_verify()
+    assert isinstance(result, ssl.SSLContext)
+
+
+def test_get_default_verify_ssl_cert_file_missing_raises(monkeypatch):
+    """SSL_CERT_FILE pointing at a nonexistent path fails with a clear error (no silent fallback)."""
+    monkeypatch.setenv("SSL_CERT_FILE", "/nonexistent/path/to/ca.pem")
+    with patch("mcpgateway.config.settings") as mock_settings:
+        mock_settings.skip_ssl_verify = False
+        with pytest.raises(ValueError, match="SSL_CERT_FILE"):
+            get_default_verify()
+
+
+@pytest.mark.asyncio
+async def test_shared_http_client_ssl_cert_file_missing_fails_fast(monkeypatch):
+    """SharedHttpClient initialization fails fast with a clear error when SSL_CERT_FILE does not exist."""
+    monkeypatch.setenv("SSL_CERT_FILE", "/nonexistent/path/to/ca.pem")
+    with patch("mcpgateway.config.settings") as mock_settings:
+        mock_settings.httpx_max_connections = 10
+        mock_settings.httpx_max_keepalive_connections = 5
+        mock_settings.httpx_keepalive_expiry = 30
+        mock_settings.httpx_connect_timeout = 5
+        mock_settings.httpx_read_timeout = 120
+        mock_settings.httpx_write_timeout = 30
+        mock_settings.httpx_pool_timeout = 10
+        mock_settings.httpx_http2_enabled = False
+        mock_settings.skip_ssl_verify = False
+
+        client = SharedHttpClient()
+        with pytest.raises(ValueError, match="SSL_CERT_FILE"):
+            await client._initialize()

--- a/tests/unit/mcpgateway/services/test_prompt_service.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service.py
@@ -3964,3 +3964,106 @@ class TestFetchGatewayPromptRegistryPath:
             result = await service._fetch_gateway_prompt_result(prompt, None, meta_data=None)
 
         assert result.description == "from fallback"
+
+    @pytest.mark.asyncio
+    async def test_fetch_gateway_prompt_sse_client_factory_ssl(self):
+        """SSE path receives an httpx client factory; the factory builds a default-verify client when no gateway CA is set."""
+        # First-Party
+        import httpx
+
+        service = PromptService()
+        prompt = self._build_gateway_prompt()
+        prompt.gateway.transport = "sse"
+        prompt.gateway.ca_certificate = None
+
+        remote_result = MagicMock()
+        remote_result.messages = []
+        remote_result.description = "sse-factory"
+
+        captured = {}
+
+        class _FakeStreamsCtx:
+            async def __aenter__(self):
+                return (MagicMock(), MagicMock())
+
+            async def __aexit__(self, *_exc):
+                return False
+
+        class _FakeClientSessionCtx:
+            async def __aenter__(self):
+                session = MagicMock()
+                session.initialize = AsyncMock()
+                return session
+
+            async def __aexit__(self, *_exc):
+                return False
+
+        def _fake_sse_client(*_args, **kwargs):
+            captured["factory"] = kwargs.get("httpx_client_factory")
+            return _FakeStreamsCtx()
+
+        with (
+            patch("mcpgateway.services.prompt_service._downstream_session_id_from_request", return_value=None),
+            patch("mcpgateway.services.prompt_service.sse_client", side_effect=_fake_sse_client),
+            patch("mcpgateway.services.prompt_service.ClientSession", return_value=_FakeClientSessionCtx()),
+            patch("mcpgateway.services.prompt_service._get_prompt_with_meta", new_callable=AsyncMock, return_value=remote_result),
+        ):
+            result = await service._fetch_gateway_prompt_result(prompt, None, meta_data=None)
+
+        assert result.description == "sse-factory"
+        client = captured["factory"]()
+        assert isinstance(client, httpx.AsyncClient)
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_fetch_gateway_prompt_client_factory_with_ca_certificate(self):
+        """The httpx client factory uses the gateway CA certificate through the SSL context cache when present."""
+        # First-Party
+        import httpx
+
+        service = PromptService()
+        prompt = self._build_gateway_prompt()
+        prompt.gateway.ca_certificate = "CA-PEM"
+        prompt.gateway.client_cert = None
+        prompt.gateway.client_key = None
+
+        remote_result = MagicMock()
+        remote_result.messages = []
+        remote_result.description = "ca-factory"
+
+        captured = {}
+
+        class _FakeStreamsCtx:
+            async def __aenter__(self):
+                return (MagicMock(), MagicMock(), MagicMock())
+
+            async def __aexit__(self, *_exc):
+                return False
+
+        class _FakeClientSessionCtx:
+            async def __aenter__(self):
+                session = MagicMock()
+                session.initialize = AsyncMock()
+                return session
+
+            async def __aexit__(self, *_exc):
+                return False
+
+        def _fake_streamable_client(*_args, **kwargs):
+            captured["factory"] = kwargs.get("httpx_client_factory")
+            return _FakeStreamsCtx()
+
+        with (
+            patch("mcpgateway.services.prompt_service._downstream_session_id_from_request", return_value=None),
+            patch("mcpgateway.services.prompt_service.streamablehttp_client", side_effect=_fake_streamable_client),
+            patch("mcpgateway.services.prompt_service.ClientSession", return_value=_FakeClientSessionCtx()),
+            patch("mcpgateway.services.prompt_service._get_prompt_with_meta", new_callable=AsyncMock, return_value=remote_result),
+            patch("mcpgateway.utils.ssl_context_cache.get_cached_ssl_context", return_value=MagicMock()) as mock_ssl_cache,
+        ):
+            result = await service._fetch_gateway_prompt_result(prompt, None, meta_data=None)
+            client = captured["factory"]()
+            mock_ssl_cache.assert_called_once_with("CA-PEM", client_cert=None, client_key=None)
+            assert isinstance(client, httpx.AsyncClient)
+            await client.aclose()
+
+        assert result.description == "ca-factory"

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -7927,6 +7927,116 @@ class TestReadResourceDirectProxy:
         session_mock.read_resource.assert_awaited_once_with(uri="http://example.com/dp-resource")
 
     @pytest.mark.asyncio
+    async def test_read_resource_direct_proxy_client_factory_default_verify(self, resource_service, mock_direct_proxy_resource):
+        """The httpx client factory builds a default-verify client when the gateway has no CA certificate."""
+        # Standard
+        from contextlib import asynccontextmanager
+
+        # First-Party
+        import httpx
+
+        mock_direct_proxy_resource.gateway.ca_certificate = None
+        db = self._make_mock_db(mock_direct_proxy_resource)
+
+        first_content = MagicMock()
+        first_content.text = "hello from remote"
+        first_content.mimeType = "text/plain"
+        result_mock = MagicMock()
+        result_mock.contents = [first_content]
+
+        client_session_cm, _session_mock = self._make_session_mock(result_mock)
+
+        captured = {}
+
+        @asynccontextmanager
+        async def mock_streamable_client(*_args, **kwargs):
+            captured["factory"] = kwargs.get("httpx_client_factory")
+            yield ("read", "write", None)
+
+        with (
+            patch("mcpgateway.services.resource_service.settings") as mock_settings,
+            patch("mcpgateway.services.resource_service.check_gateway_access", new_callable=AsyncMock, return_value=True),
+            patch("mcpgateway.services.resource_service.build_gateway_auth_headers", return_value={"Authorization": "Bearer remote-token"}),
+            patch("mcpgateway.services.resource_service.streamablehttp_client", mock_streamable_client),
+            patch("mcpgateway.services.resource_service.ClientSession", return_value=client_session_cm),
+            self._common_patches(resource_service),
+        ):
+            mock_settings.mcpgateway_direct_proxy_enabled = True
+            mock_settings.mcpgateway_direct_proxy_timeout = 30
+            mock_settings.experimental_validate_io = False
+            mock_settings.httpx_max_connections = 10
+            mock_settings.httpx_max_keepalive_connections = 5
+            mock_settings.httpx_keepalive_expiry = 30
+
+            await resource_service.read_resource(
+                db,
+                resource_uri="http://example.com/dp-resource",
+                user="user@example.com",
+                token_teams=["team-1"],
+            )
+
+            client = captured["factory"]()
+            assert isinstance(client, httpx.AsyncClient)
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_read_resource_direct_proxy_client_factory_with_ca_certificate(self, resource_service, mock_direct_proxy_resource):
+        """The httpx client factory uses the gateway CA certificate through the SSL context cache when present."""
+        # Standard
+        from contextlib import asynccontextmanager
+
+        # First-Party
+        import httpx
+
+        mock_direct_proxy_resource.gateway.ca_certificate = "CA-PEM"
+        mock_direct_proxy_resource.gateway.client_cert = None
+        mock_direct_proxy_resource.gateway.client_key = None
+        db = self._make_mock_db(mock_direct_proxy_resource)
+
+        first_content = MagicMock()
+        first_content.text = "hello from remote"
+        first_content.mimeType = "text/plain"
+        result_mock = MagicMock()
+        result_mock.contents = [first_content]
+
+        client_session_cm, _session_mock = self._make_session_mock(result_mock)
+
+        captured = {}
+
+        @asynccontextmanager
+        async def mock_streamable_client(*_args, **kwargs):
+            captured["factory"] = kwargs.get("httpx_client_factory")
+            yield ("read", "write", None)
+
+        with (
+            patch("mcpgateway.services.resource_service.settings") as mock_settings,
+            patch("mcpgateway.services.resource_service.check_gateway_access", new_callable=AsyncMock, return_value=True),
+            patch("mcpgateway.services.resource_service.build_gateway_auth_headers", return_value={"Authorization": "Bearer remote-token"}),
+            patch("mcpgateway.services.resource_service.streamablehttp_client", mock_streamable_client),
+            patch("mcpgateway.services.resource_service.ClientSession", return_value=client_session_cm),
+            patch("mcpgateway.services.resource_service.get_cached_ssl_context", return_value=MagicMock()) as mock_ssl_cache,
+            self._common_patches(resource_service),
+        ):
+            mock_settings.mcpgateway_direct_proxy_enabled = True
+            mock_settings.mcpgateway_direct_proxy_timeout = 30
+            mock_settings.experimental_validate_io = False
+            mock_settings.httpx_max_connections = 10
+            mock_settings.httpx_max_keepalive_connections = 5
+            mock_settings.httpx_keepalive_expiry = 30
+
+            await resource_service.read_resource(
+                db,
+                resource_uri="http://example.com/dp-resource",
+                user="user@example.com",
+                token_teams=["team-1"],
+            )
+
+            client = captured["factory"]()
+            mock_ssl_cache.assert_called_once_with("CA-PEM", client_cert=None, client_key=None)
+            assert isinstance(client, httpx.AsyncClient)
+            await client.aclose()
+
+    @pytest.mark.asyncio
     async def test_read_resource_direct_proxy_blob_content(self, resource_service, mock_direct_proxy_resource):
         """Happy path: resource gateway in direct_proxy mode returns blob content."""
         # Standard

--- a/tests/unit/mcpgateway/test_oauth_manager.py
+++ b/tests/unit/mcpgateway/test_oauth_manager.py
@@ -1250,6 +1250,7 @@ class TestOAuthManager:
     async def test_exchange_code_for_tokens_with_ca_certificate(self):
         """Test _exchange_code_for_tokens with CA certificate (lines 1271-1277)."""
         manager = OAuthManager()
+        manager.settings.skip_ssl_verify = False  # Ensure SSL verification is enabled
         credentials = {
             "client_id": "test_client",
             "client_secret": "test_secret",
@@ -1263,6 +1264,42 @@ class TestOAuthManager:
                 result = await manager._exchange_code_for_tokens(credentials, "auth_code_123", ca_certificate=ca_cert, client_cert=client_cert, client_key=client_key)
                 assert result["access_token"] == "ssl_token_123"
                 mock_get_ssl.assert_called_once_with(ca_cert, client_cert=client_cert, client_key=client_key)
+
+    @pytest.mark.asyncio
+    async def test_post_token_request_mtls_cert_without_key_raises(self):
+        """_post_token_request raises ValueError when only client_cert is provided (mTLS requires both)."""
+        manager = OAuthManager()
+        with pytest.raises(ValueError, match="mTLS requires both client_cert and client_key"):
+            await manager._post_token_request("https://oauth.example.com/token", data={}, client_cert="cert-only")
+
+    @pytest.mark.asyncio
+    async def test_post_token_request_mtls_key_without_cert_raises(self):
+        """_post_token_request raises ValueError when only client_key is provided (mTLS requires both)."""
+        manager = OAuthManager()
+        with pytest.raises(ValueError, match="mTLS requires both client_cert and client_key"):
+            await manager._post_token_request("https://oauth.example.com/token", data={}, client_key="key-only")  # pragma: allowlist secret
+
+    @pytest.mark.asyncio
+    async def test_client_credentials_flow_value_error_not_retried(self):
+        """ValueError from _post_token_request is re-raised immediately without retries (config errors are not transient)."""
+        manager = OAuthManager(max_retries=3)
+        credentials = {"client_id": "test_client", "client_secret": "test_secret", "token_url": "https://oauth.example.com/token"}  # pragma: allowlist secret
+        with patch.object(manager, "_post_token_request", new=AsyncMock(side_effect=ValueError("mTLS requires both client_cert and client_key; got only one"))) as mock_post:
+            with pytest.raises(ValueError, match="mTLS requires both"):
+                await manager._client_credentials_flow(credentials, client_cert="cert", client_key="key")  # pragma: allowlist secret
+            assert mock_post.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_post_token_request_skip_ssl_verify_disables_verification_with_ca_cert(self, monkeypatch):
+        """SKIP_SSL_VERIFY disables verification even when a custom CA certificate is provided."""
+        manager = OAuthManager()
+        monkeypatch.setattr(manager.settings, "skip_ssl_verify", True)
+        _, _, mock_client, ca_cert, _, _ = self._make_ca_cert_mocks()
+
+        with patch("mcpgateway.services.oauth_manager.httpx.AsyncClient", return_value=mock_client) as mock_client_cls:
+            result = await manager._post_token_request("https://oauth.example.com/token", data={}, ca_certificate=ca_cert)
+            assert result.status_code == 200
+            assert mock_client_cls.call_args.kwargs["verify"] is False
 
     @pytest.mark.asyncio
     async def test_exchange_code_for_token_decryption_success(self):
@@ -1445,6 +1482,7 @@ class TestOAuthManager:
     async def test_client_credentials_flow_with_ca_certificate(self):
         """Test client credentials flow with custom CA certificate."""
         manager = OAuthManager()
+        manager.settings.skip_ssl_verify = False  # Ensure SSL verification is enabled
         credentials = {
             "grant_type": "client_credentials",
             "client_id": "test_client",
@@ -1464,6 +1502,7 @@ class TestOAuthManager:
     async def test_password_flow_with_ca_certificate(self):
         """Test password flow with custom CA certificate."""
         manager = OAuthManager()
+        manager.settings.skip_ssl_verify = False  # Ensure SSL verification is enabled
         credentials = {
             "grant_type": "password",
             "client_id": "test_client",
@@ -1519,6 +1558,7 @@ class TestOAuthManager:
     async def test_refresh_token_with_ca_certificate(self):
         """Test refresh token with custom CA certificate."""
         manager = OAuthManager()
+        manager.settings.skip_ssl_verify = False  # Ensure SSL verification is enabled
         credentials = {
             "client_id": "test_client",
             "client_secret": "test_secret",  # pragma: allowlist secret

--- a/tests/unit/mcpgateway/test_oauth_manager.py
+++ b/tests/unit/mcpgateway/test_oauth_manager.py
@@ -1266,42 +1266,6 @@ class TestOAuthManager:
                 mock_get_ssl.assert_called_once_with(ca_cert, client_cert=client_cert, client_key=client_key)
 
     @pytest.mark.asyncio
-    async def test_post_token_request_mtls_cert_without_key_raises(self):
-        """_post_token_request raises ValueError when only client_cert is provided (mTLS requires both)."""
-        manager = OAuthManager()
-        with pytest.raises(ValueError, match="mTLS requires both client_cert and client_key"):
-            await manager._post_token_request("https://oauth.example.com/token", data={}, client_cert="cert-only")
-
-    @pytest.mark.asyncio
-    async def test_post_token_request_mtls_key_without_cert_raises(self):
-        """_post_token_request raises ValueError when only client_key is provided (mTLS requires both)."""
-        manager = OAuthManager()
-        with pytest.raises(ValueError, match="mTLS requires both client_cert and client_key"):
-            await manager._post_token_request("https://oauth.example.com/token", data={}, client_key="key-only")  # pragma: allowlist secret
-
-    @pytest.mark.asyncio
-    async def test_client_credentials_flow_value_error_not_retried(self):
-        """ValueError from _post_token_request is re-raised immediately without retries (config errors are not transient)."""
-        manager = OAuthManager(max_retries=3)
-        credentials = {"client_id": "test_client", "client_secret": "test_secret", "token_url": "https://oauth.example.com/token"}  # pragma: allowlist secret
-        with patch.object(manager, "_post_token_request", new=AsyncMock(side_effect=ValueError("mTLS requires both client_cert and client_key; got only one"))) as mock_post:
-            with pytest.raises(ValueError, match="mTLS requires both"):
-                await manager._client_credentials_flow(credentials, client_cert="cert", client_key="key")  # pragma: allowlist secret
-            assert mock_post.await_count == 1
-
-    @pytest.mark.asyncio
-    async def test_post_token_request_skip_ssl_verify_disables_verification_with_ca_cert(self, monkeypatch):
-        """SKIP_SSL_VERIFY disables verification even when a custom CA certificate is provided."""
-        manager = OAuthManager()
-        monkeypatch.setattr(manager.settings, "skip_ssl_verify", True)
-        _, _, mock_client, ca_cert, _, _ = self._make_ca_cert_mocks()
-
-        with patch("mcpgateway.services.oauth_manager.httpx.AsyncClient", return_value=mock_client) as mock_client_cls:
-            result = await manager._post_token_request("https://oauth.example.com/token", data={}, ca_certificate=ca_cert)
-            assert result.status_code == 200
-            assert mock_client_cls.call_args.kwargs["verify"] is False
-
-    @pytest.mark.asyncio
     async def test_exchange_code_for_token_decryption_success(self):
         """Test exchange code for token when decryption succeeds (lines 213-215)."""
         manager = OAuthManager()
@@ -1499,6 +1463,46 @@ class TestOAuthManager:
                 mock_get_ssl.assert_called_once_with(ca_cert, client_cert=None, client_key=None)
 
     @pytest.mark.asyncio
+    async def test_client_credentials_flow_value_error_not_retried(self):
+        """ValueError from _post_token_request is re-raised immediately without retries (config errors are not transient)."""
+        manager = OAuthManager(max_retries=3)
+        credentials = {
+            "client_secret": "test_secret",
+            "client_id": "test_client",
+            "token_url": "https://oauth.example.com/token",
+        }
+        with patch.object(manager, "_post_token_request", new=AsyncMock(side_effect=ValueError("mTLS requires both client_cert and client_key; got only one"))) as mock_post:
+            with pytest.raises(ValueError, match="mTLS requires both"):
+                await manager._client_credentials_flow(credentials, client_cert="cert", client_key="key")  # pragma: allowlist secret
+            assert mock_post.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_post_token_request_mtls_cert_without_key_raises(self):
+        """_post_token_request raises ValueError when only client_cert is provided (mTLS requires both)."""
+        manager = OAuthManager()
+        with pytest.raises(ValueError, match="mTLS requires both client_cert and client_key"):
+            await manager._post_token_request("https://oauth.example.com/token", data={}, client_cert="cert-only")
+
+    @pytest.mark.asyncio
+    async def test_post_token_request_mtls_key_without_cert_raises(self):
+        """_post_token_request raises ValueError when only client_key is provided (mTLS requires both)."""
+        manager = OAuthManager()
+        with pytest.raises(ValueError, match="mTLS requires both client_cert and client_key"):
+            await manager._post_token_request("https://oauth.example.com/token", data={}, client_key="key-only")  # pragma: allowlist secret
+
+    @pytest.mark.asyncio
+    async def test_post_token_request_skip_ssl_verify_disables_verification_with_ca_cert(self, monkeypatch):
+        """SKIP_SSL_VERIFY disables verification even when a custom CA certificate is provided."""
+        manager = OAuthManager()
+        monkeypatch.setattr(manager.settings, "skip_ssl_verify", True)
+        _, _, mock_client, ca_cert, _, _ = self._make_ca_cert_mocks()
+
+        with patch("mcpgateway.services.oauth_manager.httpx.AsyncClient", return_value=mock_client) as mock_client_cls:
+            result = await manager._post_token_request("https://oauth.example.com/token", data={}, ca_certificate=ca_cert)
+            assert result.status_code == 200
+            assert mock_client_cls.call_args.kwargs["verify"] is False
+
+    @pytest.mark.asyncio
     async def test_password_flow_with_ca_certificate(self):
         """Test password flow with custom CA certificate."""
         manager = OAuthManager()
@@ -1506,7 +1510,7 @@ class TestOAuthManager:
         credentials = {
             "grant_type": "password",
             "client_id": "test_client",
-            "client_secret": "test_secret",
+            "client_secret": "test_secret",  # pragma: allowlist secret
             "token_url": "https://oauth.example.com/token",
             "username": "user@example.com",
             "password": "secret",

--- a/tests/unit/mcpgateway/utils/test_ssl_context_cache.py
+++ b/tests/unit/mcpgateway/utils/test_ssl_context_cache.py
@@ -9,6 +9,7 @@ Unit tests for mcpgateway.utils.ssl_context_cache.
 # Standard
 import hashlib
 from datetime import datetime, timedelta
+import ssl
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -366,3 +367,41 @@ def test_is_expired_returns_false_when_no_timestamp(monkeypatch):
     monkeypatch.setattr(ssl_context_cache, "_SSL_CONTEXT_CACHE_TTL", 60)
     result = ssl_context_cache._is_expired("nonexistent-key")
     assert result is False
+
+
+def test_ssl_cert_file_loaded_into_context(monkeypatch, tmp_path) -> None:
+    """SSL_CERT_FILE bundle is loaded on top of the default context (lines 212-214)."""
+    pem_path = tmp_path / "extra-ca.pem"
+    pem_path.write_text("-----BEGIN CERTIFICATE-----\nFAKEENV\n-----END CERTIFICATE-----")
+    monkeypatch.setenv("SSL_CERT_FILE", str(pem_path))
+
+    with patch("mcpgateway.utils.ssl_context_cache.ssl.create_default_context") as mock_create:
+        ctx = Mock()
+        mock_create.return_value = ctx
+
+        result = ssl_context_cache.get_cached_ssl_context("ENV-CA-VALID")
+
+    assert result is ctx
+    ctx.load_verify_locations.assert_any_call(cafile=str(pem_path))
+
+
+def test_ssl_cert_file_missing_logs_warning(monkeypatch, caplog) -> None:
+    """A set-but-nonexistent SSL_CERT_FILE logs a warning instead of failing silently (lines 209-210)."""
+    monkeypatch.setenv("SSL_CERT_FILE", "/nonexistent/path/ca.pem")
+
+    result = ssl_context_cache.get_cached_ssl_context(None)
+
+    assert isinstance(result, ssl.SSLContext)
+    assert any("SSL_CERT_FILE" in record.message and "does not exist" in record.message for record in caplog.records)
+
+
+def test_ssl_cert_file_invalid_content_logs_warning(monkeypatch, tmp_path, caplog) -> None:
+    """An unreadable SSL_CERT_FILE bundle logs a warning and context creation continues (lines 215-216)."""
+    pem_path = tmp_path / "garbage.pem"
+    pem_path.write_text("this is not a certificate")
+    monkeypatch.setenv("SSL_CERT_FILE", str(pem_path))
+
+    result = ssl_context_cache.get_cached_ssl_context(None)
+
+    assert isinstance(result, ssl.SSLContext)
+    assert any("Failed to load SSL_CERT_FILE" in record.message for record in caplog.records)


### PR DESCRIPTION
Closes #5854

## Summary

Support the standard `SSL_CERT_FILE` environment variable across the gateway's HTTP/OAuth/SSL layers so operators behind corporate MITM proxies or internal PKI can point ContextForge at a custom CA bundle without disabling verification:

- **`http_client_service.py`** — the shared httpx client and `get_default_verify()` (now `bool | ssl.SSLContext`) honor `SSL_CERT_FILE`, combining the custom bundle with the system trust store.
- **`oauth_manager.py`** — early `ValueError` validation when only one of `client_cert`/`client_key` is provided (mTLS requires both); `SKIP_SSL_VERIFY` is honored in token requests even when a custom CA certificate is supplied; the shared client (which respects `SSL_CERT_FILE`) is used when no custom CA is given; `ValueError` configuration errors are re-raised immediately rather than retried.
- **`ssl_context_cache.py`** — `SSL_CERT_FILE` is loaded on top of the gateway-specific CA certificate; `client_cert`/`client_key` values are coerced to strings.
- **`prompt_service.py` / `resource_service.py`** — SSE/streamable-HTTP federation now builds httpx clients through an SSL-aware factory (gateway CA when present, `get_default_verify()` otherwise).

## Failure behavior

A set-but-nonexistent `SSL_CERT_FILE` fails fast with a clear `ValueError` at client construction instead of silently falling back to default verification; the SSL context cache logs a warning for the same misconfiguration. Verification is never disabled implicitly — `SKIP_SSL_VERIFY` remains an explicit opt-in.

## Security notes

- `verify=False` is only ever used under the explicit `SKIP_SSL_VERIFY` setting (flagged `nosec B501` with justification).
- OAuth token requests continue to use `follow_redirects=False` (existing SSRF defense preserved).

## Verification

- `pytest tests/unit/mcpgateway/services/test_http_client_service.py tests/unit/mcpgateway/test_oauth_manager.py tests/unit/mcpgateway/services/test_oauth_manager.py tests/unit/mcpgateway/utils/test_ssl_context_cache.py tests/unit/mcpgateway/services/test_prompt_service.py tests/unit/mcpgateway/services/test_resource_service.py -q` — green
- New regression tests: `SSL_CERT_FILE` valid bundle returns an `ssl.SSLContext`; nonexistent path raises `ValueError` (client construction and `get_default_verify()`); mTLS cert-without-key / key-without-cert raise `ValueError`; `SKIP_SSL_VERIFY` disables verification in the custom-CA path; `ValueError` is not retried in the client-credentials flow
- `make ruff`, bandit, interrogate — green