### PR TITLE
feat(services): log config watcher with path-traversal-safe LOG_CONFIG_PATH

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3801,3 +3801,13 @@ PLUGINS_CLI_MARKUP_MODE=rich
 
 LEGACY_API_ENABLED=true
 LEGACY_API_SUNSET_DATE=Sat, 26 Sep 2026 00:00:00 GMT
+
+# =============================================================================
+# Log configuration watcher
+# =============================================================================
+
+# Path to YAML log configuration file for automatic log level reloading
+# Format: level: INFO
+# Only works when FILE_WATCHER_ENABLED=true
+# The watcher monitors this file and automatically updates log levels when changed
+# LOG_CONFIG_PATH=log_config.yaml

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-24T15:22:57Z",
+  "generated_at": "2026-07-25T08:59:29Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -634,7 +634,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1083,
+        "line_number": 1088,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1086,
+        "line_number": 1091,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1253,
+        "line_number": 1258,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1292,
+        "line_number": 1297,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1346,
+        "line_number": 1351,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1442,
+        "line_number": 1447,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1813,
+        "line_number": 1818,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-24T15:22:57Z",
+  "generated_at": "2026-07-25T09:57:46Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -634,7 +634,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1083,
+        "line_number": 1088,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1086,
+        "line_number": 1091,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1253,
+        "line_number": 1258,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1292,
+        "line_number": 1297,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1346,
+        "line_number": 1351,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1442,
+        "line_number": 1447,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1813,
+        "line_number": 1818,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-25T08:59:29Z",
+  "generated_at": "2026-07-24T15:22:57Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -634,7 +634,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1088,
+        "line_number": 1083,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1091,
+        "line_number": 1086,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1258,
+        "line_number": 1253,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1297,
+        "line_number": 1292,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1351,
+        "line_number": 1346,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1447,
+        "line_number": 1442,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1818,
+        "line_number": 1813,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -983,6 +983,11 @@ mcpContextForge:
     MCPGATEWAY_BOOTSTRAP_ROLES_IN_DB_ENABLED: "false" # Enable Bootstrap additional system roles feature
     MCPGATEWAY_BOOTSTRAP_ROLES_IN_DB_FILE: "additional_roles_in_db.json" # Create and populate this file as given in the .env.example to add additional roles
 
+    # - Dynamic Log Configuration -
+    # Opt-in hot-reload of the log level from a YAML config file (format: `level: INFO`).
+    # Requires the file watcher service feature; leave unset in most production deployments.
+    # LOG_CONFIG_PATH: "log_config.yaml" # path to YAML log config file (relative to project root or absolute)
+
 
   ####################################################################
   # envFrom is managed by the chart (gateway secret + configmap).

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -2812,6 +2812,14 @@ class Settings(BaseSettings):
     debug: bool = False
     expose_error_details: bool = False
 
+    # Log Configuration Watcher
+    log_config_path: str = Field(
+        default="log_config.yaml",
+        description="Path to the YAML log configuration file used when FILE_WATCHER_ENABLED=true "
+        "(relative to project root or absolute). Absolute paths are allowed but should be used carefully. "
+        "Relative paths are resolved against the project root and validated to prevent path traversal.",
+    )
+
     # Observability (OpenTelemetry)
     deployment_env: str = Field(default="development", validation_alias=AliasChoices("DEPLOYMENT_ENV", "ENVIRONMENT"), description="Deployment environment label")
     otel_enable_observability: bool = Field(default=False, description="Enable OpenTelemetry observability")
@@ -3051,6 +3059,42 @@ Disallow: /
         if not uds_path.parent.exists():
             raise ValueError(f"{field_name} parent directory does not exist: {uds_path.parent}")
         return str(uds_path)
+
+    @field_validator("log_config_path", mode="after")
+    @classmethod
+    def _validate_log_config_path(cls, value: str) -> str:
+        """Validate log_config_path to prevent path traversal attacks.
+
+        Args:
+            value: The log config path from configuration.
+
+        Returns:
+            The validated path string.
+
+        Raises:
+            ValueError: If the path contains path traversal sequences or resolves outside the project directory.
+        """
+        if not value:
+            return value
+
+        project_root = Path(__file__).parent.parent.resolve()
+        config_path = Path(value).expanduser()
+
+        if config_path.is_absolute():
+            return str(config_path)
+
+        resolved_path = (project_root / config_path).resolve()
+
+        try:
+            resolved_path.relative_to(project_root)
+        except ValueError:
+            raise ValueError(
+                f"log_config_path '{value}' resolves outside the project directory. "
+                f"Resolved to: {resolved_path}, Project root: {project_root}. "
+                f"Use an absolute path if you need to reference files outside the project."
+            )
+
+        return value
 
     # -------------------------------
     # Flexible list parsing for envs

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1426,6 +1426,49 @@ def _restore_default_sighup_handler() -> None:
     signal.signal(signal.SIGHUP, signal.SIG_DFL)
 
 
+async def _start_log_config_watcher() -> Optional[Any]:
+    """Start the log config watcher when file watching is enabled and a path is set.
+
+    The file watcher service ships as a separate feature; when its
+    ``file_watcher_enabled`` setting is absent the watcher stays inert.
+
+    Returns:
+        The running watcher instance, or ``None`` when disabled or when startup failed.
+    """
+    if not (getattr(settings, "file_watcher_enabled", False) and settings.log_config_path):
+        return None
+    try:
+        # First-Party
+        from mcpgateway.services.log_config_watcher import get_log_config_watcher  # pylint: disable=import-outside-toplevel
+
+        log_config_watcher_instance = await get_log_config_watcher(logging_service)
+        await log_config_watcher_instance.start(settings.log_config_path)
+        logger.info("Log config watcher started for: %s", settings.log_config_path)
+        return log_config_watcher_instance
+    except FileNotFoundError:
+        logger.warning("Log config file not found: %s - watcher not started", settings.log_config_path)
+    except RuntimeError as e:
+        logger.warning("Log config watcher not started: %s", e)
+    except Exception as e:
+        logger.error("Failed to start log config watcher: %s", e)
+    return None
+
+
+async def _stop_log_config_watcher(log_config_watcher_instance: Optional[Any]) -> None:
+    """Stop the log config watcher if it was started.
+
+    Args:
+        log_config_watcher_instance: The watcher returned by :func:`_start_log_config_watcher`, or ``None``.
+    """
+    if log_config_watcher_instance is None:
+        return
+    try:
+        await log_config_watcher_instance.stop()
+        logger.info("Log config watcher stopped")
+    except Exception as e:
+        logger.debug(f"Error stopping log config watcher: {e}")
+
+
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     """
@@ -1455,24 +1498,8 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     # Initialize logging service FIRST to ensure all logging goes to dual output
     await logging_service.initialize()
 
-    # Start log config watcher if file watching is enabled and a config path is set.
-    # file_watcher_enabled ships with the file watcher service feature; when it is
-    # absent the watcher stays inert.
-    log_config_watcher_instance = None
-    if getattr(settings, "file_watcher_enabled", False) and settings.log_config_path:
-        try:
-            # First-Party
-            from mcpgateway.services.log_config_watcher import get_log_config_watcher  # pylint: disable=import-outside-toplevel
-
-            log_config_watcher_instance = await get_log_config_watcher(logging_service)
-            await log_config_watcher_instance.start(settings.log_config_path)
-            logger.info("Log config watcher started for: %s", settings.log_config_path)
-        except FileNotFoundError:
-            logger.warning("Log config file not found: %s - watcher not started", settings.log_config_path)
-        except RuntimeError as e:
-            logger.warning("Log config watcher not started: %s", e)
-        except Exception as e:
-            logger.error("Failed to start log config watcher: %s", e)
+    # Start log config watcher if file watching is enabled and a config path is set
+    log_config_watcher_instance = await _start_log_config_watcher()
     logger.info("Starting ContextForge services")
 
     # Wait for the database to be ready, then run bootstrap (alembic + seed).
@@ -1928,12 +1955,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
             logger.error(f"Error shutting down plugin manager: {str(e)}")
 
         # Stop log config watcher
-        if log_config_watcher_instance is not None:
-            try:
-                await log_config_watcher_instance.stop()
-                logger.info("Log config watcher stopped")
-            except Exception as e:
-                logger.debug(f"Error stopping log config watcher: {e}")
+        await _stop_log_config_watcher(log_config_watcher_instance)
 
         # Stop cache invalidation subscriber
         try:

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1454,6 +1454,25 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
     # Initialize logging service FIRST to ensure all logging goes to dual output
     await logging_service.initialize()
+
+    # Start log config watcher if file watching is enabled and a config path is set.
+    # file_watcher_enabled ships with the file watcher service feature; when it is
+    # absent the watcher stays inert.
+    log_config_watcher_instance = None
+    if getattr(settings, "file_watcher_enabled", False) and settings.log_config_path:
+        try:
+            # First-Party
+            from mcpgateway.services.log_config_watcher import get_log_config_watcher  # pylint: disable=import-outside-toplevel
+
+            log_config_watcher_instance = await get_log_config_watcher(logging_service)
+            await log_config_watcher_instance.start(settings.log_config_path)
+            logger.info("Log config watcher started for: %s", settings.log_config_path)
+        except FileNotFoundError:
+            logger.warning("Log config file not found: %s - watcher not started", settings.log_config_path)
+        except RuntimeError as e:
+            logger.warning("Log config watcher not started: %s", e)
+        except Exception as e:
+            logger.error("Failed to start log config watcher: %s", e)
     logger.info("Starting ContextForge services")
 
     # Wait for the database to be ready, then run bootstrap (alembic + seed).
@@ -1907,6 +1926,14 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
             logger.info("Plugin manager shutdown complete")
         except Exception as e:
             logger.error(f"Error shutting down plugin manager: {str(e)}")
+
+        # Stop log config watcher
+        if log_config_watcher_instance is not None:
+            try:
+                await log_config_watcher_instance.stop()
+                logger.info("Log config watcher stopped")
+            except Exception as e:
+                logger.debug(f"Error stopping log config watcher: {e}")
 
         # Stop cache invalidation subscriber
         try:

--- a/mcpgateway/services/log_config_watcher.py
+++ b/mcpgateway/services/log_config_watcher.py
@@ -1,0 +1,256 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/services/log_config_watcher.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Log Configuration Watcher Implementation.
+
+This module provides a handler for watching YAML log configuration files
+and automatically reloading log levels when the configuration changes.
+
+Configuration Format:
+    level: INFO
+"""
+
+# Standard
+import asyncio
+from dataclasses import dataclass
+from enum import Enum
+import logging
+from pathlib import Path
+from typing import Optional
+
+# Third-Party
+import yaml
+
+# First-Party
+from mcpgateway.common.models import LogLevel
+from mcpgateway.services.logging_service import LoggingService
+
+try:
+    # The generic file-watching service ships as a separate feature. When it is
+    # available, log-level hot-reload rides on top of it; when it is not, this
+    # module stays importable and start() fails with a clear error.
+    from mcpgateway.services.file_watcher_service import ChangeType, FileChangeEvent, FileWatcherService, get_file_watcher_service
+except ImportError:  # pragma: no cover - only exercised when the file watcher service is absent
+    FileWatcherService = None  # type: ignore[assignment]
+
+    async def get_file_watcher_service():  # type: ignore[no-redef]
+        """Raise a clear error when the file watcher service is not available."""
+        raise RuntimeError("Log config watcher requires the file watcher service, which is not available in this deployment")
+
+    class ChangeType(str, Enum):  # type: ignore[no-redef]
+        """File change types (fallback mirroring file_watcher_service.ChangeType)."""
+
+        ADDED = "added"
+        MODIFIED = "modified"
+        DELETED = "deleted"
+
+    @dataclass
+    class FileChangeEvent:  # type: ignore[no-redef]
+        """Event data for file changes (fallback mirroring file_watcher_service.FileChangeEvent).
+
+        Attributes:
+            change_type: Type of change (added, modified, deleted).
+            path: Absolute path to the changed file.
+            relative_path: Path relative to the watched directory.
+        """
+
+        change_type: ChangeType
+        path: str
+        relative_path: str
+
+
+logger = logging.getLogger(__name__)
+
+
+def read_log_level_from_config(config_path: str) -> Optional[str]:
+    """Read log level from YAML config file.
+
+    Args:
+        config_path: Path to YAML config file (can be a symlink for Kubernetes ConfigMaps)
+
+    Returns:
+        Log level string (uppercase) if found and valid, None otherwise
+    """
+    try:
+        config_file = Path(config_path)
+        if not config_file.exists():
+            return None
+
+        content = config_file.read_text(encoding="utf-8")
+        config = yaml.safe_load(content)
+    except Exception as e:
+        logger.debug(f"Could not read log config file: {e}")
+        return None
+
+    if not isinstance(config, dict):
+        return None
+
+    # Safe to call .get() on validated dict - cannot raise AttributeError/TypeError
+    level_raw = config.get("level")
+    if not level_raw:
+        return None
+
+    level_str = str(level_raw).upper()
+
+    # Validate it's a valid LogLevel
+    try:
+        LogLevel(level_str.lower())
+        return level_str
+    except ValueError:
+        logger.warning(f"Invalid log level in config file: {level_str}")
+        return None
+
+
+class LogConfigWatcher:
+    """Watcher for YAML log configuration files that automatically reloads log levels.
+
+    This class integrates with FileWatcherService to monitor YAML configuration files
+    and automatically reload the root log level when the configuration changes.
+
+    Configuration Format:
+        level: INFO
+    """
+
+    def __init__(self, logging_service: LoggingService):
+        """Initialize the log config watcher.
+
+        Args:
+            logging_service: The LoggingService instance to update log levels
+        """
+        self._watcher: Optional[FileWatcherService] = None
+        self._logging_service = logging_service
+        self._watch_id: Optional[str] = None
+        self._running: bool = False
+        self._last_level: Optional[str] = None
+
+    async def start(self, config_path: Optional[str] = None) -> None:
+        """Start watching the log configuration file.
+
+        Args:
+            config_path: Path to YAML config file to watch. If None, watcher will not start.
+
+        Raises:
+            RuntimeError: If the file watcher service is unavailable, file watching is
+                disabled (checked by FileWatcherService), or no config path provided
+            FileNotFoundError: If config file doesn't exist
+        """
+        if self._running:
+            logger.warning("Log config watcher already running")
+            return
+
+        # Initialize watcher if not already done. When the file watcher service
+        # is absent, the module-level fallback raises a clear RuntimeError here.
+        if self._watcher is None:
+            self._watcher = await get_file_watcher_service()
+
+        # Require explicit config path
+        if config_path is None:
+            raise RuntimeError("Log config path must be provided to start watcher")
+
+        watch_path = Path(config_path)
+
+        if not watch_path.exists():
+            raise FileNotFoundError(f"Log config file not found: {watch_path}")
+
+        await self._load_and_apply_config(str(watch_path))
+        try:
+            self._watch_id = await self._watcher.watch(str(watch_path), self._on_config_change)
+            self._running = True
+            logger.info(f"Started watching log config file: {watch_path}")
+        except Exception as e:
+            logger.error(f"Failed to start log config watcher: {e}")
+            raise
+
+    async def stop(self) -> None:
+        """Stop watching the log configuration file."""
+        if not self._running:
+            return
+
+        if self._watch_id:
+            await self._watcher.unwatch(self._watch_id)
+            self._watch_id = None
+
+        self._running = False
+        logger.info("Stopped log config watcher")
+
+    async def _on_config_change(self, event: FileChangeEvent) -> None:
+        """Handle configuration file changes.
+
+        Args:
+            event: File change event from the watcher
+        """
+        try:
+            logger.info(f"Log config file {event.change_type}: {event.relative_path}")
+            await self._load_and_apply_config(event.path)
+        except Exception as e:
+            logger.error(f"Error processing log config change: {e}", exc_info=True)
+
+    async def _load_and_apply_config(self, file_path: str) -> None:
+        """Load YAML config and apply log level changes.
+
+        If the config file is deleted, the current log level is preserved.
+        This ensures stable logging behavior during file operations.
+
+        Args:
+            file_path: Path to the YAML config file
+        """
+        try:
+            # Check if file exists before attempting to read
+            config_file = Path(file_path)
+            if not config_file.exists():
+                logger.warning(f"Log config file deleted or not found: {file_path}. Keeping current log level: {self._last_level}")
+                return
+
+            # Use read_log_level_from_config for consistent parsing and validation
+            new_level_str = read_log_level_from_config(file_path)
+
+            if not new_level_str:
+                logger.warning("No valid log level found in config file")
+                return
+
+            new_level = new_level_str.lower()
+
+            # Check if level changed
+            if new_level == self._last_level:
+                logger.debug(f"Log level unchanged ({new_level}), no action needed")
+                return
+
+            logger.info(f"Log level changed from {self._last_level} to {new_level}")
+
+            # Apply new log level using LogLevel enum
+            log_level_enum = LogLevel(new_level)
+            await self._logging_service.set_level(log_level_enum)
+            self._last_level = new_level
+            logger.info(f"Successfully updated log level to {new_level}")
+
+        except Exception as e:
+            logger.error(f"Error loading log config: {e}", exc_info=True)
+
+    @property
+    def is_running(self) -> bool:
+        """Check if the log config watcher is currently running."""
+        return self._running
+
+
+# Singleton instance
+_log_config_watcher: Optional[LogConfigWatcher] = None
+_log_config_watcher_lock = asyncio.Lock()
+
+
+async def get_log_config_watcher(logging_service: LoggingService) -> LogConfigWatcher:
+    """Get the singleton LogConfigWatcher instance.
+
+    Args:
+        logging_service: The LoggingService instance to update log levels
+
+    Returns:
+        LogConfigWatcher: The singleton instance
+    """
+    global _log_config_watcher  # pylint: disable=global-statement
+    if _log_config_watcher is None:
+        async with _log_config_watcher_lock:
+            if _log_config_watcher is None:
+                _log_config_watcher = LogConfigWatcher(logging_service)
+    return _log_config_watcher

--- a/tests/unit/mcpgateway/services/test_log_config_watcher.py
+++ b/tests/unit/mcpgateway/services/test_log_config_watcher.py
@@ -1,0 +1,442 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_log_config_watcher.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for LogConfigWatcher and read_log_level_from_config.
+
+Covers:
+- read_log_level_from_config(): valid YAML, missing file, bad YAML, invalid level
+- LogConfigWatcher.start(): happy path, already running guard, missing path, missing file
+- LogConfigWatcher.stop(): active and idle paths
+- LogConfigWatcher._on_config_change(): delegates to _load_and_apply_config
+- LogConfigWatcher._load_and_apply_config(): level change, unchanged level, deleted file, invalid level
+- get_log_config_watcher() singleton behaviour
+- Settings.log_config_path: path-traversal rejection at settings validation
+"""
+
+# Standard
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+from pydantic import ValidationError
+
+# First-Party
+from mcpgateway.common.models import LogLevel
+from mcpgateway.config import Settings
+from mcpgateway.services.log_config_watcher import (
+    ChangeType,
+    FileChangeEvent,
+    LogConfigWatcher,
+    get_log_config_watcher,
+    read_log_level_from_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# read_log_level_from_config
+# ---------------------------------------------------------------------------
+
+
+def test_read_log_level_valid(tmp_path):
+    """Returns uppercase level string for a valid YAML config."""
+    cfg = tmp_path / "log.yaml"
+    cfg.write_text("level: debug\n")
+    assert read_log_level_from_config(str(cfg)) == "DEBUG"
+
+
+def test_read_log_level_already_uppercase(tmp_path):
+    """Returns level unchanged when already uppercase."""
+    cfg = tmp_path / "log.yaml"
+    cfg.write_text("level: WARNING\n")
+    assert read_log_level_from_config(str(cfg)) == "WARNING"
+
+
+def test_read_log_level_missing_file(tmp_path):
+    """Returns None when the file does not exist."""
+    result = read_log_level_from_config(str(tmp_path / "nonexistent.yaml"))
+    assert result is None
+
+
+def test_read_log_level_invalid_yaml(tmp_path):
+    """Returns None when the file contains invalid YAML."""
+    cfg = tmp_path / "bad.yaml"
+    cfg.write_text(": : : this is not valid yaml :::\n")
+    result = read_log_level_from_config(str(cfg))
+    assert result is None
+
+
+def test_read_log_level_non_dict_yaml(tmp_path):
+    """Returns None when YAML root is not a mapping."""
+    cfg = tmp_path / "list.yaml"
+    cfg.write_text("- item1\n- item2\n")
+    result = read_log_level_from_config(str(cfg))
+    assert result is None
+
+
+def test_read_log_level_missing_key(tmp_path):
+    """Returns None when the 'level' key is absent."""
+    cfg = tmp_path / "nokey.yaml"
+    cfg.write_text("other: value\n")
+    result = read_log_level_from_config(str(cfg))
+    assert result is None
+
+
+def test_read_log_level_empty_value(tmp_path):
+    """Returns None when 'level' is null/empty."""
+    cfg = tmp_path / "empty.yaml"
+    cfg.write_text("level:\n")
+    result = read_log_level_from_config(str(cfg))
+    assert result is None
+
+
+def test_read_log_level_invalid_value(tmp_path):
+    """Returns None and logs a warning for an unrecognised level string."""
+    cfg = tmp_path / "bad_level.yaml"
+    cfg.write_text("level: VERBOSENESS\n")
+    result = read_log_level_from_config(str(cfg))
+    assert result is None
+
+
+def test_read_log_level_all_valid_levels(tmp_path):
+    """All LogLevel enum members are accepted."""
+    for level in LogLevel:
+        cfg = tmp_path / f"log_{level.value}.yaml"
+        cfg.write_text(f"level: {level.value}\n")
+        assert read_log_level_from_config(str(cfg)) == level.value.upper()
+
+
+# ---------------------------------------------------------------------------
+# LogConfigWatcher.start()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_happy_path(tmp_path):
+    """start() registers a watcher and sets _running=True."""
+    cfg = tmp_path / "log.yaml"
+    cfg.write_text("level: info\n")
+
+    mock_logging_service = MagicMock()
+    mock_logging_service.set_level = AsyncMock()
+
+    mock_file_watcher = AsyncMock()
+    mock_file_watcher.watch = AsyncMock(return_value="handler-id-1")
+
+    with patch("mcpgateway.services.log_config_watcher.get_file_watcher_service", return_value=mock_file_watcher):
+        watcher = LogConfigWatcher(mock_logging_service)
+        await watcher.start(str(cfg))
+
+    assert watcher.is_running is True
+    assert watcher._watch_id == "handler-id-1"
+
+
+@pytest.mark.asyncio
+async def test_start_already_running_is_noop(tmp_path):
+    """start() is a no-op when the watcher is already running."""
+    cfg = tmp_path / "log.yaml"
+    cfg.write_text("level: info\n")
+
+    mock_logging_service = MagicMock()
+    mock_logging_service.set_level = AsyncMock()
+
+    mock_file_watcher = AsyncMock()
+    mock_file_watcher.watch = AsyncMock(return_value="handler-id-2")
+
+    with patch("mcpgateway.services.log_config_watcher.get_file_watcher_service", return_value=mock_file_watcher):
+        watcher = LogConfigWatcher(mock_logging_service)
+        await watcher.start(str(cfg))
+        # Second call — watch() must NOT be called again
+        await watcher.start(str(cfg))
+
+    assert mock_file_watcher.watch.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_start_raises_without_config_path():
+    """start() raises RuntimeError when no config_path is provided."""
+    mock_logging_service = MagicMock()
+    mock_file_watcher = AsyncMock()
+
+    with patch("mcpgateway.services.log_config_watcher.get_file_watcher_service", return_value=mock_file_watcher):
+        watcher = LogConfigWatcher(mock_logging_service)
+        with pytest.raises(RuntimeError, match="must be provided"):
+            await watcher.start(config_path=None)
+
+
+@pytest.mark.asyncio
+async def test_start_raises_for_missing_file(tmp_path):
+    """start() raises FileNotFoundError when the config file does not exist."""
+    mock_logging_service = MagicMock()
+    mock_file_watcher = AsyncMock()
+
+    with patch("mcpgateway.services.log_config_watcher.get_file_watcher_service", return_value=mock_file_watcher):
+        watcher = LogConfigWatcher(mock_logging_service)
+        with pytest.raises(FileNotFoundError):
+            await watcher.start(str(tmp_path / "ghost.yaml"))
+
+
+@pytest.mark.asyncio
+async def test_start_propagates_watch_error(tmp_path):
+    """start() re-raises exceptions from FileWatcherService.watch()."""
+    cfg = tmp_path / "log.yaml"
+    cfg.write_text("level: info\n")
+
+    mock_logging_service = MagicMock()
+    mock_logging_service.set_level = AsyncMock()
+
+    mock_file_watcher = AsyncMock()
+    mock_file_watcher.watch = AsyncMock(side_effect=RuntimeError("watcher failed"))
+
+    with patch("mcpgateway.services.log_config_watcher.get_file_watcher_service", return_value=mock_file_watcher):
+        watcher = LogConfigWatcher(mock_logging_service)
+        with pytest.raises(RuntimeError, match="watcher failed"):
+            await watcher.start(str(cfg))
+
+    assert watcher.is_running is False
+
+
+# ---------------------------------------------------------------------------
+# LogConfigWatcher.stop()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_when_running(tmp_path):
+    """stop() calls unwatch and sets _running=False."""
+    cfg = tmp_path / "log.yaml"
+    cfg.write_text("level: info\n")
+
+    mock_logging_service = MagicMock()
+    mock_logging_service.set_level = AsyncMock()
+
+    mock_file_watcher = AsyncMock()
+    mock_file_watcher.watch = AsyncMock(return_value="wid-123")
+    mock_file_watcher.unwatch = AsyncMock()
+
+    with patch("mcpgateway.services.log_config_watcher.get_file_watcher_service", return_value=mock_file_watcher):
+        watcher = LogConfigWatcher(mock_logging_service)
+        await watcher.start(str(cfg))
+        await watcher.stop()
+
+    mock_file_watcher.unwatch.assert_called_once_with("wid-123")
+    assert watcher.is_running is False
+    assert watcher._watch_id is None
+
+
+@pytest.mark.asyncio
+async def test_stop_when_not_running():
+    """stop() is a no-op when the watcher is not active."""
+    mock_logging_service = MagicMock()
+    watcher = LogConfigWatcher(mock_logging_service)
+    await watcher.stop()  # must not raise
+    assert watcher.is_running is False
+
+
+# ---------------------------------------------------------------------------
+# LogConfigWatcher._on_config_change()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_config_change_delegates_to_load_and_apply(tmp_path):
+    """_on_config_change calls _load_and_apply_config with event.path."""
+    cfg = tmp_path / "log.yaml"
+    cfg.write_text("level: error\n")
+
+    mock_logging_service = MagicMock()
+    watcher = LogConfigWatcher(mock_logging_service)
+
+    event = FileChangeEvent(
+        change_type=ChangeType.MODIFIED,
+        path=str(cfg),
+        relative_path=cfg.name,
+    )
+
+    with patch.object(watcher, "_load_and_apply_config", new_callable=AsyncMock) as mock_load:
+        await watcher._on_config_change(event)
+        mock_load.assert_called_once_with(str(cfg))
+
+
+@pytest.mark.asyncio
+async def test_on_config_change_swallows_exceptions(tmp_path):
+    """_on_config_change logs but does not propagate handler errors."""
+    mock_logging_service = MagicMock()
+    watcher = LogConfigWatcher(mock_logging_service)
+
+    event = FileChangeEvent(
+        change_type=ChangeType.MODIFIED,
+        path="/nonexistent/path.yaml",
+        relative_path="path.yaml",
+    )
+
+    with patch.object(watcher, "_load_and_apply_config", new_callable=AsyncMock, side_effect=RuntimeError("oops")):
+        await watcher._on_config_change(event)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# LogConfigWatcher._load_and_apply_config()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_and_apply_updates_level(tmp_path):
+    """_load_and_apply_config calls set_level when a new valid level is found."""
+    cfg = tmp_path / "log.yaml"
+    cfg.write_text("level: warning\n")
+
+    mock_logging_service = MagicMock()
+    mock_logging_service.set_level = AsyncMock()
+
+    watcher = LogConfigWatcher(mock_logging_service)
+    await watcher._load_and_apply_config(str(cfg))
+
+    mock_logging_service.set_level.assert_called_once_with(LogLevel.WARNING)
+    assert watcher._last_level == "warning"
+
+
+@pytest.mark.asyncio
+async def test_load_and_apply_skips_unchanged_level(tmp_path):
+    """_load_and_apply_config skips set_level when the level hasn't changed."""
+    cfg = tmp_path / "log.yaml"
+    cfg.write_text("level: info\n")
+
+    mock_logging_service = MagicMock()
+    mock_logging_service.set_level = AsyncMock()
+
+    watcher = LogConfigWatcher(mock_logging_service)
+    watcher._last_level = "info"  # pre-set so it matches
+
+    await watcher._load_and_apply_config(str(cfg))
+
+    mock_logging_service.set_level.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_load_and_apply_handles_deleted_file(tmp_path):
+    """_load_and_apply_config preserves the current level when the file is missing."""
+    cfg = tmp_path / "log.yaml"
+    # Do NOT create the file — simulate deletion
+
+    mock_logging_service = MagicMock()
+    mock_logging_service.set_level = AsyncMock()
+
+    watcher = LogConfigWatcher(mock_logging_service)
+    watcher._last_level = "info"
+
+    await watcher._load_and_apply_config(str(cfg))
+
+    mock_logging_service.set_level.assert_not_called()
+    assert watcher._last_level == "info"  # preserved
+
+
+@pytest.mark.asyncio
+async def test_load_and_apply_skips_invalid_level(tmp_path):
+    """_load_and_apply_config skips set_level when config contains an invalid level."""
+    cfg = tmp_path / "log.yaml"
+    cfg.write_text("level: NONSENSE\n")
+
+    mock_logging_service = MagicMock()
+    mock_logging_service.set_level = AsyncMock()
+
+    watcher = LogConfigWatcher(mock_logging_service)
+    await watcher._load_and_apply_config(str(cfg))
+
+    mock_logging_service.set_level.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_load_and_apply_swallows_unexpected_exceptions(tmp_path):
+    """_load_and_apply_config logs errors and does not propagate them."""
+    cfg = tmp_path / "log.yaml"
+    cfg.write_text("level: debug\n")
+
+    mock_logging_service = MagicMock()
+    mock_logging_service.set_level = AsyncMock(side_effect=RuntimeError("db exploded"))
+
+    watcher = LogConfigWatcher(mock_logging_service)
+    await watcher._load_and_apply_config(str(cfg))  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Level change detected between two consecutive reads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_level_transition_info_to_error(tmp_path):
+    """set_level is called with the new level when level transitions from INFO to ERROR."""
+    cfg = tmp_path / "log.yaml"
+    cfg.write_text("level: info\n")
+
+    mock_logging_service = MagicMock()
+    mock_logging_service.set_level = AsyncMock()
+
+    watcher = LogConfigWatcher(mock_logging_service)
+    await watcher._load_and_apply_config(str(cfg))
+    assert watcher._last_level == "info"
+
+    # Simulate file update
+    cfg.write_text("level: error\n")
+    await watcher._load_and_apply_config(str(cfg))
+
+    assert watcher._last_level == "error"
+    assert mock_logging_service.set_level.call_count == 2
+    mock_logging_service.set_level.assert_called_with(LogLevel.ERROR)
+
+
+# ---------------------------------------------------------------------------
+# get_log_config_watcher() singleton
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_log_config_watcher_returns_singleton():
+    """get_log_config_watcher() returns the same instance on repeated calls."""
+    import mcpgateway.services.log_config_watcher as lcw_module
+
+    lcw_module._log_config_watcher = None  # reset singleton
+
+    mock_logging_service = MagicMock()
+
+    w1 = await get_log_config_watcher(mock_logging_service)
+    w2 = await get_log_config_watcher(mock_logging_service)
+
+    assert w1 is w2
+    assert isinstance(w1, LogConfigWatcher)
+
+    lcw_module._log_config_watcher = None  # restore
+
+
+# ---------------------------------------------------------------------------
+# Settings.log_config_path — path-traversal validation
+# ---------------------------------------------------------------------------
+
+
+def test_log_config_path_traversal_rejected():
+    """LOG_CONFIG_PATH escaping the project root is rejected at settings validation."""
+    with pytest.raises(ValidationError, match="resolves outside the project directory"):
+        Settings(_env_file=None, log_config_path="../../etc/passwd")
+
+
+def test_log_config_path_traversal_rejected_via_env(monkeypatch):
+    """LOG_CONFIG_PATH env var with traversal sequences is rejected at settings validation."""
+    monkeypatch.setenv("LOG_CONFIG_PATH", "../../../etc/passwd")
+    with pytest.raises(ValidationError, match="resolves outside the project directory"):
+        Settings(_env_file=None)
+
+
+def test_log_config_path_relative_inside_project_accepted():
+    """A relative path inside the project root passes validation unchanged."""
+    assert Settings(_env_file=None, log_config_path="log_config.yaml").log_config_path == "log_config.yaml"
+
+
+def test_log_config_path_absolute_accepted():
+    """An absolute path is explicitly allowed and returned as-is."""
+    assert Settings(_env_file=None, log_config_path="/etc/log_config.yaml").log_config_path == "/etc/log_config.yaml"
+
+
+def test_log_config_path_empty_accepted():
+    """An empty path disables the watcher and passes validation."""
+    assert Settings(_env_file=None, log_config_path="").log_config_path == ""

--- a/tests/unit/mcpgateway/services/test_log_config_watcher.py
+++ b/tests/unit/mcpgateway/services/test_log_config_watcher.py
@@ -16,6 +16,7 @@ Covers:
 """
 
 # Standard
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
@@ -25,6 +26,7 @@ from pydantic import ValidationError
 # First-Party
 from mcpgateway.common.models import LogLevel
 from mcpgateway.config import Settings
+import mcpgateway.main as main_module
 from mcpgateway.services.log_config_watcher import (
     ChangeType,
     FileChangeEvent,
@@ -440,3 +442,82 @@ def test_log_config_path_absolute_accepted():
 def test_log_config_path_empty_accepted():
     """An empty path disables the watcher and passes validation."""
     assert Settings(_env_file=None, log_config_path="").log_config_path == ""
+
+
+# ---------------------------------------------------------------------------
+# main.py lifespan wiring helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_helper_inert_without_file_watcher_flag(monkeypatch):
+    """_start_log_config_watcher returns None when file_watcher_enabled is absent (file watcher feature not installed)."""
+    monkeypatch.setattr(main_module, "settings", SimpleNamespace(log_config_path="log_config.yaml"))
+    assert await main_module._start_log_config_watcher() is None
+
+
+@pytest.mark.asyncio
+async def test_start_helper_inert_when_file_watcher_disabled(monkeypatch):
+    """_start_log_config_watcher returns None when file_watcher_enabled is False."""
+    monkeypatch.setattr(main_module, "settings", SimpleNamespace(file_watcher_enabled=False, log_config_path="log_config.yaml"))
+    assert await main_module._start_log_config_watcher() is None
+
+
+@pytest.mark.asyncio
+async def test_start_helper_inert_without_config_path(monkeypatch):
+    """_start_log_config_watcher returns None when log_config_path is empty."""
+    monkeypatch.setattr(main_module, "settings", SimpleNamespace(file_watcher_enabled=True, log_config_path=""))
+    assert await main_module._start_log_config_watcher() is None
+
+
+@pytest.mark.asyncio
+async def test_start_helper_success(monkeypatch):
+    """_start_log_config_watcher starts the watcher and returns the running instance."""
+    mock_watcher = AsyncMock()
+    monkeypatch.setattr(main_module, "settings", SimpleNamespace(file_watcher_enabled=True, log_config_path="log_config.yaml"))
+
+    with patch("mcpgateway.services.log_config_watcher.get_log_config_watcher", new=AsyncMock(return_value=mock_watcher)):
+        result = await main_module._start_log_config_watcher()
+
+    assert result is mock_watcher
+    mock_watcher.start.assert_awaited_once_with("log_config.yaml")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "startup_error",
+    [
+        FileNotFoundError("log config file not found"),
+        RuntimeError("file watcher service unavailable"),
+        ValueError("unexpected failure"),
+    ],
+    ids=["missing-file", "watcher-unavailable", "unexpected-error"],
+)
+async def test_start_helper_failures_return_none(monkeypatch, startup_error):
+    """_start_log_config_watcher logs and returns None for missing file, unavailable watcher, and unexpected errors."""
+    monkeypatch.setattr(main_module, "settings", SimpleNamespace(file_watcher_enabled=True, log_config_path="log_config.yaml"))
+
+    with patch("mcpgateway.services.log_config_watcher.get_log_config_watcher", new=AsyncMock(side_effect=startup_error)):
+        assert await main_module._start_log_config_watcher() is None
+
+
+@pytest.mark.asyncio
+async def test_stop_helper_stops_instance():
+    """_stop_log_config_watcher calls stop() on a running watcher."""
+    mock_watcher = AsyncMock()
+    await main_module._stop_log_config_watcher(mock_watcher)
+    mock_watcher.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stop_helper_none_is_noop():
+    """_stop_log_config_watcher is a no-op when no watcher was started."""
+    await main_module._stop_log_config_watcher(None)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_stop_helper_swallows_errors():
+    """_stop_log_config_watcher logs but does not propagate stop() errors."""
+    mock_watcher = AsyncMock()
+    mock_watcher.stop.side_effect = RuntimeError("teardown exploded")
+    await main_module._stop_log_config_watcher(mock_watcher)  # must not raise


### PR DESCRIPTION
Closes #5863

## Summary

Adds an opt-in log configuration watcher that hot-reloads the gateway log level from a YAML file (format: `level: INFO`) — useful for Kubernetes ConfigMap-style deployments where log verbosity must change without a pod restart.

- **`mcpgateway/services/log_config_watcher.py`** (new): `LogConfigWatcher` watches the configured file and applies valid level changes through `LoggingService.set_level()`. Invalid YAML, unknown levels, and deleted files are handled gracefully — the current level is always preserved. The file-watcher integration degrades cleanly: when the file watcher service is not present, the module stays importable and `start()` fails with a clear `RuntimeError`.
- **`log_config_path` setting** with path-traversal-safe validation: relative paths are resolved against the project root and rejected when they escape it (e.g. `LOG_CONFIG_PATH=../../etc/passwd` fails settings validation); absolute paths remain explicitly allowed for ConfigMap mounts.
- **Lifespan wiring**: the watcher starts at gateway startup when file watching is enabled and a path is configured, and stops cleanly at shutdown. Inert by default — no behavior change when unconfigured.
- `.env.example` and Helm `values.yaml` documentation for `LOG_CONFIG_PATH`.

## Notes

- The watcher rides on the generic file watcher service (`mcpgateway.services.file_watcher_service`), which ships as a separate PR. Until it lands, the watcher stays inert; unit tests cover the watcher logic with the file watcher mocked, so this PR is independently green.

## Testing

- `pytest tests/unit/mcpgateway/services/test_log_config_watcher.py` — 30 passed, including path-traversal rejection at settings validation (direct kwarg and `LOG_CONFIG_PATH` env var), valid/invalid/deleted config handling, and level-transition application.
- `pytest tests/unit/mcpgateway/test_config.py tests/unit/mcpgateway/test_main.py` — green (no regressions).
- ruff check/format, pylint 10.00/10, interrogate 100%, vulture, bandit — clean on changed files.