### PR TITLE
fix: duplicate last_seen, team visibility scoping, dead-session eviction, Redis ping timeout, worker-id after fork

### DIFF
--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -139,32 +139,6 @@ def post_fork(server, worker):
     except ImportError:
         pass
 
-    # Recompute the session-affinity WORKER_ID per worker, but only when the feature
-    # is enabled. Captured at import time, so under --preload every worker would
-    # otherwise inherit the master's id ({hostname}:1) and subscribe to the same Redis
-    # channel, collapsing point-to-point forwarding into a per-container broadcast that
-    # fans every request out to all workers and degrades throughput by an order of
-    # magnitude. With the affinity flag off, no request path reads WORKER_ID, so gating
-    # the rebind (and the session_affinity import at fork) keeps "flag off" a clean
-    # no-op for the affinity machinery.
-    if settings.mcpgateway_session_affinity_enabled:
-        try:
-            import socket
-
-            from mcpgateway.services import session_affinity
-
-            session_affinity.WORKER_ID = f"{socket.gethostname()}:{worker.pid}"
-        except Exception as exc:  # noqa: BLE001 - fail loud, never crash the worker
-            # Silent fallback would re-introduce the per-container broadcast amplification.
-            server.log.warning(
-                "post_fork(pid=%s): failed to rebind session_affinity.WORKER_ID (%s: %s) — "
-                "workers may share the master's WORKER_ID and session-affinity forwarding "
-                "may broadcast each request to every worker in the container.",
-                worker.pid,
-                type(exc).__name__,
-                exc,
-            )
-
 
 def post_worker_init(worker):
     worker.log.info("worker initialization completed")

--- a/mcpgateway/common/models.py
+++ b/mcpgateway/common/models.py
@@ -1212,7 +1212,6 @@ class Gateway(CommonAttributes):
     last_seen: Optional[datetime] = None
     slug: str
     transport: str
-    last_seen: Optional[datetime]
     # Header passthrough configuration
     passthrough_headers: Optional[list[str]]  # Store list of strings as JSON array
     # Request type and authentication fields

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -10263,14 +10263,14 @@ async def _maybe_forward_affinitized_rpc_request(
 
     if settings.mcpgateway_session_affinity_enabled and mcp_session_id and method != "initialize" and not is_internally_forwarded:
         # First-Party
-        from mcpgateway.services.session_affinity import SessionAffinity, WORKER_ID  # pylint: disable=import-outside-toplevel
+        from mcpgateway.services.session_affinity import SessionAffinity, get_worker_id  # pylint: disable=import-outside-toplevel
 
         if not SessionAffinity.is_valid_mcp_session_id(mcp_session_id):
             logger.debug("Invalid MCP session id for affinity forwarding, executing locally")
             return None
 
         session_short = mcp_session_id[:8] if len(mcp_session_id) >= 8 else mcp_session_id
-        logger.debug("[AFFINITY] Worker %s | Session %s... | Method: %s | RPC request received, checking affinity", WORKER_ID, session_short, method)
+        logger.debug("[AFFINITY] Worker %s | Session %s... | Method: %s | RPC request received, checking affinity", get_worker_id(), session_short, method)
         try:
             # First-Party
             from mcpgateway.services.session_affinity import get_session_affinity  # pylint: disable=import-outside-toplevel
@@ -10286,20 +10286,20 @@ async def _maybe_forward_affinitized_rpc_request(
                 encoded_auth_context,
             )
             if forwarded_response is not None:
-                logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded response received", WORKER_ID, session_short, method)
+                logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded response received", get_worker_id(), session_short, method)
                 if "error" in forwarded_response:
                     return {"jsonrpc": "2.0", "error": forwarded_response["error"], "id": req_id}
                 return {"jsonrpc": "2.0", "result": forwarded_response.get("result", {}), "id": req_id}
         except RuntimeError:
-            logger.debug("[AFFINITY] Worker %s | Session %s... | Method: %s | Pool not initialized, executing locally", WORKER_ID, session_short, method)
+            logger.debug("[AFFINITY] Worker %s | Session %s... | Method: %s | Pool not initialized, executing locally", get_worker_id(), session_short, method)
         return None
 
     if is_internally_forwarded and mcp_session_id:
         # First-Party
-        from mcpgateway.services.session_affinity import WORKER_ID  # pylint: disable=import-outside-toplevel
+        from mcpgateway.services.session_affinity import get_worker_id  # pylint: disable=import-outside-toplevel
 
         session_short = mcp_session_id[:8] if len(mcp_session_id) >= 8 else mcp_session_id
-        logger.debug("[AFFINITY] Worker %s | Session %s... | Method: %s | Internally forwarded request, executing locally", WORKER_ID, session_short, method)
+        logger.debug("[AFFINITY] Worker %s | Session %s... | Method: %s | Internally forwarded request, executing locally", get_worker_id(), session_short, method)
 
     return None
 
@@ -10369,11 +10369,11 @@ async def _execute_rpc_initialize(
     if settings.mcpgateway_session_affinity_enabled and mcp_session_id and mcp_session_id != "not-provided":
         try:
             # First-Party
-            from mcpgateway.services.session_affinity import get_session_affinity, WORKER_ID  # pylint: disable=import-outside-toplevel
+            from mcpgateway.services.session_affinity import get_session_affinity, get_worker_id  # pylint: disable=import-outside-toplevel
 
             pool = get_session_affinity()
             await pool.register_session_owner(mcp_session_id)
-            logger.debug("[AFFINITY_INIT] Worker %s | Session %s... | Registered ownership after initialize", WORKER_ID, mcp_session_id[:8])
+            logger.debug("[AFFINITY_INIT] Worker %s | Session %s... | Registered ownership after initialize", get_worker_id(), mcp_session_id[:8])
         except Exception as e:
             logger.warning("[AFFINITY_INIT] Failed to register session ownership: %s", e)
 

--- a/mcpgateway/services/base_service.py
+++ b/mcpgateway/services/base_service.py
@@ -165,11 +165,14 @@ class BaseService(ABC):
             Filtered query
         """
         model_cls = self._visibility_model_cls
+        # Global listing: public resources visible to everyone
+        access_conditions = [model_cls.visibility == "public"]
 
         if team_id:
             if team_id not in token_teams:
                 return query.where(False)
 
+            # Scope results strictly to the requested team
             access_conditions = [
                 and_(model_cls.team_id == team_id, model_cls.visibility.in_(["team", "public"])),
                 model_cls.visibility == "public",  # globally public items from any team are always visible
@@ -178,8 +181,9 @@ class BaseService(ABC):
                 access_conditions.append(and_(model_cls.team_id == team_id, model_cls.owner_email == user_email, model_cls.visibility == "private"))
             return query.where(or_(*access_conditions))
 
-        access_conditions = [model_cls.visibility == "public"]
-
+        # Owner can see their own private resources (but NOT team resources
+        # from teams outside token scope — those are covered by the
+        # token_teams condition below)
         if user_email:
             access_conditions.append(and_(model_cls.owner_email == user_email, model_cls.visibility == "private"))
 

--- a/mcpgateway/services/session_affinity.py
+++ b/mcpgateway/services/session_affinity.py
@@ -61,10 +61,22 @@ _MCP_SESSION_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
 # _SERVER_ID_RE in streamablehttp_transport; kept local to avoid a transport import.
 _SERVER_ID_RE = re.compile(r"^/servers/(?P<server_id>[^/]+)/mcp")
 
+
 # Worker ID for multi-worker session affinity
-# Uses hostname + PID to be unique across Docker containers (each container has PID 1)
-# and across gunicorn workers within the same container
-WORKER_ID = f"{socket.gethostname()}:{os.getpid()}"
+# Uses hostname + PID to be unique across Docker containers and gunicorn workers
+# IMPORTANT: Must be a function to get current PID after fork (not cached at import time)
+def get_worker_id() -> str:
+    """Get the current worker ID (hostname:pid).
+
+    This must be a function, not a module-level constant, because with
+    gunicorn's preload_app=True, the module is imported in the parent process
+    before forking. If we cache the PID at import time, all workers will
+    have the parent's PID instead of their own.
+
+    Returns:
+        Worker ID string in format "hostname:pid"
+    """
+    return f"{socket.gethostname()}:{os.getpid()}"
 
 
 logger = logging.getLogger(__name__)
@@ -205,7 +217,7 @@ class SessionAffinity:
 
     def _worker_heartbeat_key(self) -> str:
         """Redis key for this worker's heartbeat."""
-        return f"mcpgw:worker_heartbeat:{WORKER_ID}"
+        return f"mcpgw:worker_heartbeat:{get_worker_id()}"
 
     def start_heartbeat(self) -> None:
         """Start the worker heartbeat background task.
@@ -262,7 +274,7 @@ class SessionAffinity:
         Writes two Redis entries keyed on ``mcp_session_id``:
           * ``mcp_session_id → {url, user_hash, identity_hash, transport_type,
             gateway_id}`` — used cross-worker to locate the owner of a session.
-          * ``session_owner:<mcp_session_id> → WORKER_ID`` via ``SET NX`` —
+          * ``session_owner:<mcp_session_id> → get_worker_id()`` via ``SET NX`` —
             atomically claims this worker as the owner so a second worker
             racing the same session doesn't start creating a parallel
             upstream connection.
@@ -337,12 +349,12 @@ class SessionAffinity:
                 # Atomic claim with TTL (avoids the SETNX/EXPIRE crash window).
                 was_set = await redis.set(
                     owner_key,
-                    WORKER_ID,
+                    get_worker_id(),
                     nx=True,
                     ex=settings.mcpgateway_session_affinity_ttl,
                 )
                 if was_set:
-                    logger.debug("Session ownership claimed (SET NX): %s... → worker %s", mcp_session_id[:8], WORKER_ID)
+                    logger.debug("Session ownership claimed (SET NX): %s... → worker %s", mcp_session_id[:8], get_worker_id())
                 else:
                     # Another worker already claimed ownership
                     existing_owner = await redis.get(owner_key)
@@ -375,7 +387,7 @@ class SessionAffinity:
                 owner = await redis.get(key)
                 if owner:
                     owner_id = owner.decode() if isinstance(owner, bytes) else owner
-                    if owner_id == WORKER_ID:
+                    if owner_id == get_worker_id():
                         await redis.delete(key)
                         logger.debug("Cleaned up session owner owner: %s...", mcp_session_id[:8])
         except Exception as e:
@@ -705,7 +717,7 @@ class SessionAffinity:
                 return 0
                 """
                 ttl = int(settings.mcpgateway_session_affinity_ttl)
-                outcome = await redis.eval(script, 1, key, WORKER_ID, ttl)
+                outcome = await redis.eval(script, 1, key, get_worker_id(), ttl)
                 logger.debug("Owner registration outcome=%s for session %s...", outcome, mcp_session_id[:8])
         except Exception as e:
             # Redis failure is non-fatal - single worker mode still works
@@ -782,7 +794,7 @@ class SessionAffinity:
         # owner can dispatch to the trusted internal endpoint without re-authenticating.
         # Refuse rather than publish an unsigned envelope the consumer would reject.
         if not auth_context:
-            logger.warning("[AFFINITY] Worker %s | Refusing to forward RPC request without an auth context", WORKER_ID)
+            logger.warning("[AFFINITY] Worker %s | Refusing to forward RPC request without an auth context", get_worker_id())
             self._forwarded_request_failures += 1
             return {"error": {"code": -32003, "message": "Forwarded auth context is required"}}
 
@@ -802,12 +814,12 @@ class SessionAffinity:
             owner = await redis.get(self._session_owner_key(mcp_session_id))
             method = request_data.get("method", "unknown")
             if not owner:
-                logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | No owner → execute locally (new session)", WORKER_ID, mcp_session_id[:8], method)
+                logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | No owner → execute locally (new session)", get_worker_id(), mcp_session_id[:8], method)
                 return None  # No owner registered - execute locally (new session)
 
             owner_id = owner.decode() if isinstance(owner, bytes) else owner
-            if owner_id == WORKER_ID:
-                logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | We own it → execute locally", WORKER_ID, mcp_session_id[:8], method)
+            if owner_id == get_worker_id():
+                logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | We own it → execute locally", get_worker_id(), mcp_session_id[:8], method)
                 return None  # We own it - execute locally
 
             if not await self._is_worker_alive(owner_id):
@@ -827,7 +839,7 @@ class SessionAffinity:
                     1,
                     self._session_owner_key(mcp_session_id),
                     owner_id,
-                    WORKER_ID,
+                    get_worker_id(),
                     ttl,
                 )
                 if reclaimed == 1:
@@ -838,11 +850,11 @@ class SessionAffinity:
                 if not new_owner:
                     return None  # Key vanished - execute locally
                 owner_id = new_owner.decode() if isinstance(new_owner, bytes) else new_owner
-                if owner_id == WORKER_ID:
+                if owner_id == get_worker_id():
                     return None  # We ended up as owner
                 logger.info("[AFFINITY] Session %s... reclaimed by %s → forwarding to new owner", mcp_session_id[:8], owner_id)
 
-            logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Owner: %s → forwarding", WORKER_ID, mcp_session_id[:8], method, owner_id)
+            logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Owner: %s → forwarding", get_worker_id(), mcp_session_id[:8], method, owner_id)
 
             # Forward to owner worker via pub/sub
             response_id = str(uuid.uuid4())
@@ -871,7 +883,7 @@ class SessionAffinity:
                     # Publish request to owner's channel
                     await redis.publish(f"mcpgw:pool_rpc:{owner_id}", orjson.dumps(forward_data))
                     self._forwarded_requests += 1
-                    logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Published to worker %s", WORKER_ID, mcp_session_id[:8], method, owner_id)
+                    logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Published to worker %s", get_worker_id(), mcp_session_id[:8], method, owner_id)
 
                     # Wait for response
                     async with asyncio.timeout(effective_timeout):
@@ -895,8 +907,8 @@ class SessionAffinity:
 
         This method subscribes to Redis pub/sub channels specific to this worker
         and processes incoming forwarded requests from other workers:
-        - mcpgw:pool_rpc:{WORKER_ID} - for SSE transport JSON-RPC forwards
-        - mcpgw:pool_http:{WORKER_ID} - for Streamable HTTP request forwards
+        - mcpgw:pool_rpc:{get_worker_id()} - for SSE transport JSON-RPC forwards
+        - mcpgw:pool_http:{get_worker_id()} - for Streamable HTTP request forwards
         """
         if not settings.mcpgateway_session_affinity_enabled:
             return
@@ -912,11 +924,11 @@ class SessionAffinity:
                 logger.debug("Redis not available, RPC listener not started")
                 return
 
-            rpc_channel = f"mcpgw:pool_rpc:{WORKER_ID}"
-            http_channel = f"mcpgw:pool_http:{WORKER_ID}"
+            rpc_channel = f"mcpgw:pool_rpc:{get_worker_id()}"
+            http_channel = f"mcpgw:pool_http:{get_worker_id()}"
             async with redis.pubsub() as pubsub:
                 await pubsub.subscribe(rpc_channel, http_channel)
-                logger.info("RPC/HTTP listener started for worker %s on channels: %s, %s", WORKER_ID, rpc_channel, http_channel)
+                logger.info("RPC/HTTP listener started for worker %s on channels: %s, %s", get_worker_id(), rpc_channel, http_channel)
 
                 try:
                     while not self._closed:
@@ -942,7 +954,7 @@ class SessionAffinity:
                             logger.warning("Error processing forwarded request: %s", e)
                 finally:
                     await pubsub.unsubscribe(rpc_channel, http_channel)
-                    logger.info("RPC/HTTP listener stopped for worker %s", WORKER_ID)
+                    logger.info("RPC/HTTP listener stopped for worker %s", get_worker_id())
 
         except Exception as e:
             logger.warning("RPC/HTTP listener failed: %s", e)
@@ -970,7 +982,7 @@ class SessionAffinity:
             mcp_session_id = request.get("mcp_session_id", "unknown")
             session_short = mcp_session_id[:8] if len(mcp_session_id) >= 8 else mcp_session_id
 
-            logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Received forwarded request, executing locally", WORKER_ID, session_short, method)
+            logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Received forwarded request, executing locally", get_worker_id(), session_short, method)
 
             # Verify the forwarded envelope before trusting it: forward_request_to_owner
             # signs the whole envelope (identity + operation + response_channel) with the
@@ -982,12 +994,12 @@ class SessionAffinity:
             from mcpgateway.auth_context import verify_redis_forward_envelope  # pylint: disable=import-outside-toplevel
 
             if not verify_redis_forward_envelope(request):
-                logger.warning("[AFFINITY] Worker %s | Session %s... | Rejected forwarded request: missing or invalid envelope signature", WORKER_ID, session_short)
+                logger.warning("[AFFINITY] Worker %s | Session %s... | Rejected forwarded request: missing or invalid envelope signature", get_worker_id(), session_short)
                 self._forwarded_request_failures += 1
                 return {"error": {"code": -32003, "message": "Forwarded auth context failed integrity verification"}}
             auth_context = request.get("auth_context") or ""
             if not auth_context:
-                logger.warning("[AFFINITY] Worker %s | Session %s... | Rejected forwarded request: missing auth context", WORKER_ID, session_short)
+                logger.warning("[AFFINITY] Worker %s | Session %s... | Rejected forwarded request: missing auth context", get_worker_id(), session_short)
                 self._forwarded_request_failures += 1
                 return {"error": {"code": -32003, "message": "Forwarded auth context failed integrity verification"}}
 
@@ -1028,12 +1040,12 @@ class SessionAffinity:
 
                 # If body is a JSON-RPC error ({"error": {...}}), propagate it
                 if "error" in response_data and isinstance(response_data["error"], dict):
-                    logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded execution completed with error (HTTP %s)", WORKER_ID, session_short, method, response.status_code)
+                    logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded execution completed with error (HTTP %s)", get_worker_id(), session_short, method, response.status_code)
                     return {"error": response_data["error"]}
 
                 # Non-JSON-RPC error body (e.g. {"detail": "..."}): map to JSON-RPC error
                 detail = response_data.get("detail", response.text[:200] or "Unknown error")
-                logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded execution failed with HTTP %s", WORKER_ID, session_short, method, response.status_code)
+                logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded execution failed with HTTP %s", get_worker_id(), session_short, method, response.status_code)
                 return {
                     "error": {
                         "code": -32603,
@@ -1046,9 +1058,9 @@ class SessionAffinity:
 
             # Extract result or error from JSON-RPC response
             if "error" in response_data:
-                logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded execution completed with error", WORKER_ID, session_short, method)
+                logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded execution completed with error", get_worker_id(), session_short, method)
                 return {"error": response_data["error"]}
-            logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded execution completed successfully", WORKER_ID, session_short, method)
+            logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded execution completed successfully", get_worker_id(), session_short, method)
             return {"result": response_data.get("result", {})}
 
         except httpx.TimeoutException:
@@ -1106,7 +1118,7 @@ class SessionAffinity:
             body = bytes.fromhex(body_hex) if body_hex else b""
 
             session_short = mcp_session_id[:8] if mcp_session_id and len(mcp_session_id) >= 8 else "unknown"
-            logger.debug("[HTTP_AFFINITY] Worker %s | Session %s... | Received forwarded HTTP request: %s %s", WORKER_ID, session_short, method, path)
+            logger.debug("[HTTP_AFFINITY] Worker %s | Session %s... | Received forwarded HTTP request: %s %s", get_worker_id(), session_short, method, path)
 
             # Verify the forwarded envelope before trusting anything about this request.
             # forward_to_owner() signs the whole envelope (identity + operation +
@@ -1122,7 +1134,7 @@ class SessionAffinity:
             if not verify_redis_forward_envelope(request) or not auth_context_header:
                 logger.warning(
                     "[HTTP_AFFINITY] Worker %s | Session %s... | Rejected forwarded request: missing or invalid envelope signature",
-                    WORKER_ID,
+                    get_worker_id(),
                     session_short,
                 )
                 self._forwarded_request_failures += 1
@@ -1198,7 +1210,7 @@ class SessionAffinity:
                     timeout=settings.mcpgateway_pool_rpc_forward_timeout,
                 )
 
-            logger.debug("[HTTP_AFFINITY] Worker %s | Session %s... | Executed in-process via /_internal/mcp/rpc: %s", WORKER_ID, session_short, response.status_code)
+            logger.debug("[HTTP_AFFINITY] Worker %s | Session %s... | Executed in-process via /_internal/mcp/rpc: %s", get_worker_id(), session_short, response.status_code)
 
             resp_headers = {"content-type": "application/json"}
             if mcp_session_id:
@@ -1281,7 +1293,7 @@ class SessionAffinity:
         # (or, worse, accept it). The real Streamable HTTP caller always encodes a context
         # (an empty {} encodes to a non-empty value), so this only trips on a contract bug.
         if not auth_context:
-            logger.warning("[HTTP_AFFINITY] Worker %s | Refusing to forward HTTP request without an auth context", WORKER_ID)
+            logger.warning("[HTTP_AFFINITY] Worker %s | Refusing to forward HTTP request without an auth context", get_worker_id())
             self._forwarded_request_failures += 1
             return {
                 "status": 403,
@@ -1290,7 +1302,7 @@ class SessionAffinity:
             }
 
         session_short = mcp_session_id[:8] if len(mcp_session_id) >= 8 else mcp_session_id
-        logger.debug("[HTTP_AFFINITY] Worker %s | Session %s... | %s %s | Forwarding to worker %s", WORKER_ID, session_short, method, path, owner_worker_id)
+        logger.debug("[HTTP_AFFINITY] Worker %s | Session %s... | %s %s | Forwarding to worker %s", get_worker_id(), session_short, method, path, owner_worker_id)
 
         try:
             # First-Party
@@ -1320,7 +1332,7 @@ class SessionAffinity:
                 "query_string": query_string,
                 "headers": headers,
                 "body": body.hex() if body else "",  # Hex encode binary body
-                "original_worker": WORKER_ID,
+                "original_worker": get_worker_id(),
                 "timestamp": time.time(),
                 # Encoded edge identity; lets the owner dispatch without re-authenticating.
                 "auth_context": auth_context,

--- a/mcpgateway/services/upstream_session_registry.py
+++ b/mcpgateway/services/upstream_session_registry.py
@@ -550,7 +550,11 @@ class UpstreamSessionRegistry:
         try:
             async with session.operation_lock:
                 yield session
-        except (OSError, anyio.ClosedResourceError, anyio.BrokenResourceError) as exc:
+        except (OSError, anyio.ClosedResourceError, anyio.BrokenResourceError, McpError) as exc:
+            # McpError with "Session terminated" indicates the server closed the session.
+            # This can happen when the server terminates after a tool call but before
+            # the SDK's validation completes (e.g., calling list_tools() to verify the result).
+            # Evict the session so the next acquire rebuilds instead of reusing a dead session.
             logger.info(
                 "acquire() caller raised %s for gateway=%s; evicting upstream so next acquire rebuilds",
                 type(exc).__name__,

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -4285,15 +4285,15 @@ class SessionManagerWrapper:
             try:
                 # First-Party - lazy import to avoid circular dependencies
                 # First-Party
-                from mcpgateway.services.session_affinity import get_session_affinity, WORKER_ID  # pylint: disable=import-outside-toplevel
+                from mcpgateway.services.session_affinity import get_session_affinity, get_worker_id  # pylint: disable=import-outside-toplevel
 
                 pool = get_session_affinity()
                 owner = await pool.get_session_owner(mcp_session_id)
-                logger.debug("[HTTP_AFFINITY_CHECK] Worker %s | Session %s... | Owner from Redis: %s", WORKER_ID, mcp_session_id[:8], owner)
+                logger.debug("[HTTP_AFFINITY_CHECK] Worker %s | Session %s... | Owner from Redis: %s", get_worker_id(), mcp_session_id[:8], owner)
 
-                if owner and owner != WORKER_ID:
+                if owner and owner != get_worker_id():
                     # Session owned by another worker - forward the entire HTTP request
-                    logger.info("[HTTP_AFFINITY] Worker %s | Session %s... | Owner: %s | Forwarding HTTP request", WORKER_ID, mcp_session_id[:8], owner)
+                    logger.info("[HTTP_AFFINITY] Worker %s | Session %s... | Owner: %s | Forwarding HTTP request", get_worker_id(), mcp_session_id[:8], owner)
 
                     # Package the edge-validated identity so the owner can dispatch via
                     # the trusted internal /_internal/mcp/rpc endpoint without
@@ -4348,17 +4348,17 @@ class SessionManagerWrapper:
                                 "body": response["body"],
                             }
                         )
-                        logger.debug("[HTTP_AFFINITY] Worker %s | Session %s... | Forwarded response sent to client", WORKER_ID, mcp_session_id[:8])
+                        logger.debug("[HTTP_AFFINITY] Worker %s | Session %s... | Forwarded response sent to client", get_worker_id(), mcp_session_id[:8])
                         return
 
                     # Forwarding failed - fall through to local handling
                     # This may result in "session not found" but it's better than no response
-                    logger.debug("[HTTP_AFFINITY] Worker %s | Session %s... | Forwarding failed, falling back to local", WORKER_ID, mcp_session_id[:8])
+                    logger.debug("[HTTP_AFFINITY] Worker %s | Session %s... | Forwarding failed, falling back to local", get_worker_id(), mcp_session_id[:8])
 
-                elif owner == WORKER_ID and method == "POST":
+                elif owner == get_worker_id() and method == "POST":
                     # We own this session - route POST requests to /rpc to avoid SDK session issues
                     # The SDK's _server_instances gets cleared between requests, so we can't rely on it
-                    logger.debug("[HTTP_AFFINITY_LOCAL] Worker %s | Session %s... | Owner is us, routing to /rpc", WORKER_ID, mcp_session_id[:8])
+                    logger.debug("[HTTP_AFFINITY_LOCAL] Worker %s | Session %s... | Owner is us, routing to /rpc", get_worker_id(), mcp_session_id[:8])
 
                     # Read request body
                     body_parts = []
@@ -4738,13 +4738,13 @@ class SessionManagerWrapper:
                 try:
                     # First-Party - lazy import to avoid circular dependencies
                     # First-Party
-                    from mcpgateway.services.session_affinity import get_session_affinity, WORKER_ID  # pylint: disable=import-outside-toplevel
+                    from mcpgateway.services.session_affinity import get_session_affinity, get_worker_id  # pylint: disable=import-outside-toplevel
 
                     pool = get_session_affinity()
                     await pool.register_session_owner(session_to_register)
                     logger.debug(
                         "[HTTP_AFFINITY_SDK] Worker %s | Session %s... | Registered ownership after SDK handling",
-                        WORKER_ID,
+                        get_worker_id(),
                         session_to_register[:8],
                     )
                 except Exception as e:

--- a/mcpgateway/utils/redis_client.py
+++ b/mcpgateway/utils/redis_client.py
@@ -22,6 +22,7 @@ Usage:
 """
 
 # Standard
+import asyncio
 import logging
 import os
 import ssl as _ssl
@@ -320,13 +321,20 @@ async def get_redis_client() -> Optional[Any]:
         connection_kwargs.update(_build_ssl_kwargs(settings))
 
         _client = aioredis.from_url(settings.redis_url, **connection_kwargs)
-        await _client.ping()
-        logger.info(
-            f"Redis client initialized: parser={_parser_info}, "
-            f"pool_size={settings.redis_max_connections}, "
-            f"timeout={settings.redis_socket_timeout}s, "
-            f"health_check={settings.redis_health_check_interval}s"
-        )
+
+        # Add timeout to ping to prevent hanging on connection issues
+        try:
+            await asyncio.wait_for(_client.ping(), timeout=10.0)
+            logger.info(
+                f"Redis client initialized: parser={_parser_info}, "
+                f"pool_size={settings.redis_max_connections}, "
+                f"timeout={settings.redis_socket_timeout}s, "
+                f"health_check={settings.redis_health_check_interval}s"
+            )
+        except asyncio.TimeoutError:
+            logger.warning("Redis ping timeout after 10s - connection may be unstable")
+            await _client.aclose()
+            _client = None
     except ImportError as e:
         logger.error(f"Redis parser configuration error: {_sanitize(str(e))}")
         _client = None

--- a/tests/unit/mcpgateway/services/test_base_service.py
+++ b/tests/unit/mcpgateway/services/test_base_service.py
@@ -425,3 +425,14 @@ class TestApplyVisibilityFilter:
         sql = _compile_where(result)
         # The standalone public condition must be present in addition to the team-scoped one
         assert "visibility = 'public'" in sql
+
+    def test_team_scoped_multi_team_user_sees_only_requested_team(self, service, base_query):
+        """A user in two teams requesting team_id='team-1' must not leak team-2 team resources.
+
+        Regression test: the team-scoped branch must filter team resources by the
+        requested team_id only, never by the full token_teams membership list.
+        """
+        result = service._apply_visibility_filter(base_query, user_email=None, token_teams=["team-1", "team-2"], team_id="team-1")
+        sql = _compile_where(result)
+        assert "team_id = 'team-1'" in sql
+        assert "team-2" not in sql

--- a/tests/unit/mcpgateway/services/test_session_affinity.py
+++ b/tests/unit/mcpgateway/services/test_session_affinity.py
@@ -209,12 +209,12 @@ def test_session_owner_key_has_expected_prefix():
 
 
 def test_worker_heartbeat_key_uses_module_worker_id():
-    """Heartbeat key embeds the process-wide WORKER_ID constant (hostname+pid)."""
+    """Heartbeat key embeds the process-wide worker ID (hostname+pid)."""
     # First-Party
-    from mcpgateway.services.session_affinity import SessionAffinity, WORKER_ID
+    from mcpgateway.services.session_affinity import SessionAffinity, get_worker_id
 
     affinity = SessionAffinity()
-    assert affinity._worker_heartbeat_key() == f"mcpgw:worker_heartbeat:{WORKER_ID}"  # pylint: disable=protected-access
+    assert affinity._worker_heartbeat_key() == f"mcpgw:worker_heartbeat:{get_worker_id()}"  # pylint: disable=protected-access
 
 
 # ---------------------------------------------------------------------------
@@ -392,7 +392,7 @@ async def test_register_session_mapping_rejects_invalid_session_id(caplog):
 async def test_register_session_mapping_happy_path_writes_mapping_and_claims_ownership():
     """A fresh valid session id stores the mapping JSON and claims ownership with SET NX."""
     # First-Party
-    from mcpgateway.services.session_affinity import SessionAffinity, WORKER_ID
+    from mcpgateway.services.session_affinity import SessionAffinity, get_worker_id
 
     affinity = SessionAffinity()
     fake = _FakeRedis()
@@ -410,7 +410,7 @@ async def test_register_session_mapping_happy_path_writes_mapping_and_claims_own
     assert mapping_keys
     assert owner_keys == ["mcpgw:pool_owner:sess-1"]
     # Ownership value is this worker id.
-    assert fake.store["mcpgw:pool_owner:sess-1"].decode() == WORKER_ID
+    assert fake.store["mcpgw:pool_owner:sess-1"].decode() == get_worker_id()
 
 
 @pytest.mark.asyncio
@@ -486,7 +486,7 @@ async def test_register_session_owner_noop_when_feature_disabled():
 async def test_register_session_owner_fresh_claim_sets_key():
     """A previously-unclaimed session id becomes owned by this worker (Lua CAS returns 1)."""
     # First-Party
-    from mcpgateway.services.session_affinity import SessionAffinity, WORKER_ID
+    from mcpgateway.services.session_affinity import SessionAffinity, get_worker_id
 
     affinity = SessionAffinity()
     fake = _FakeRedis()
@@ -498,18 +498,18 @@ async def test_register_session_owner_fresh_claim_sets_key():
         mock_settings.mcpgateway_session_affinity_ttl = 300
         await affinity.register_session_owner("sess-1")
 
-    assert fake.store.get("mcpgw:pool_owner:sess-1").decode() == WORKER_ID
+    assert fake.store.get("mcpgw:pool_owner:sess-1").decode() == get_worker_id()
 
 
 @pytest.mark.asyncio
 async def test_register_session_owner_refresh_when_same_worker():
     """If this worker already owns the session, Lua CAS refreshes TTL (returns 2) — still a no-op to the caller."""
     # First-Party
-    from mcpgateway.services.session_affinity import SessionAffinity, WORKER_ID
+    from mcpgateway.services.session_affinity import SessionAffinity, get_worker_id
 
     affinity = SessionAffinity()
     fake = _FakeRedis()
-    fake.store["mcpgw:pool_owner:sess-1"] = WORKER_ID.encode()
+    fake.store["mcpgw:pool_owner:sess-1"] = get_worker_id().encode()
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
@@ -520,7 +520,7 @@ async def test_register_session_owner_refresh_when_same_worker():
         await affinity.register_session_owner("sess-1")
 
     # Key still exists, still owned by this worker (no poison).
-    assert fake.store["mcpgw:pool_owner:sess-1"].decode() == WORKER_ID
+    assert fake.store["mcpgw:pool_owner:sess-1"].decode() == get_worker_id()
 
 
 @pytest.mark.asyncio
@@ -635,11 +635,11 @@ async def test_cleanup_session_owner_rejects_invalid_session_id(caplog):
 async def test_cleanup_session_owner_only_deletes_keys_this_worker_owns():
     """Don't delete another worker's claim — only our own."""
     # First-Party
-    from mcpgateway.services.session_affinity import SessionAffinity, WORKER_ID
+    from mcpgateway.services.session_affinity import SessionAffinity, get_worker_id
 
     affinity = SessionAffinity()
     fake = _FakeRedis()
-    fake.store["mcpgw:pool_owner:ours"] = WORKER_ID.encode()
+    fake.store["mcpgw:pool_owner:ours"] = get_worker_id().encode()
     fake.store["mcpgw:pool_owner:theirs"] = b"other-worker:5555"
 
     with patch("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake)):
@@ -824,11 +824,11 @@ async def test_forward_request_to_owner_no_owner_returns_none():
 async def test_forward_request_to_owner_returns_none_when_we_own_the_session():
     """Self-owned session → None (caller executes locally, no forwarding needed)."""
     # First-Party
-    from mcpgateway.services.session_affinity import SessionAffinity, WORKER_ID
+    from mcpgateway.services.session_affinity import SessionAffinity, get_worker_id
 
     affinity = SessionAffinity()
     fake = _FakeRedis()
-    fake.store["mcpgw:pool_owner:sess-1"] = WORKER_ID.encode()
+    fake.store["mcpgw:pool_owner:sess-1"] = get_worker_id().encode()
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
@@ -1518,7 +1518,7 @@ async def test_forward_request_to_owner_raises_and_counts_timeout_when_no_respon
 async def test_forward_request_to_owner_reclaims_session_from_dead_worker():
     """Dead owner worker → Lua CAS reclaims ownership to us; caller executes locally (None)."""
     # First-Party
-    from mcpgateway.services.session_affinity import SessionAffinity, WORKER_ID
+    from mcpgateway.services.session_affinity import SessionAffinity, get_worker_id
 
     affinity = SessionAffinity()
     fake = _FakeRedis()
@@ -1537,7 +1537,7 @@ async def test_forward_request_to_owner_reclaims_session_from_dead_worker():
     # We reclaimed + now own it → execute locally (None).
     assert result is None
     # Ownership was transferred to us.
-    assert fake.store["mcpgw:pool_owner:sess-1"].decode() == WORKER_ID
+    assert fake.store["mcpgw:pool_owner:sess-1"].decode() == get_worker_id()
 
 
 # ---------------------------------------------------------------------------
@@ -2395,7 +2395,7 @@ async def test_forward_request_to_owner_returns_none_when_reclaimed_key_vanishes
 async def test_forward_request_to_owner_returns_none_when_reclaim_race_makes_us_owner():
     """Reclaim CAS lost, but the re-read shows we ended up as owner → execute locally."""
     # First-Party
-    from mcpgateway.services.session_affinity import SessionAffinity, WORKER_ID
+    from mcpgateway.services.session_affinity import SessionAffinity, get_worker_id
 
     affinity = SessionAffinity()
 
@@ -2411,7 +2411,7 @@ async def test_forward_request_to_owner_returns_none_when_reclaim_race_makes_us_
                 if self.get_call_count == 1:
                     return b"dead-worker"
                 # After losing the CAS, the re-read shows WE are now the owner (via concurrent claim).
-                return WORKER_ID.encode()
+                return get_worker_id().encode()
             return self.store.get(key)
 
         async def eval(self, script, numkeys, *args):

--- a/tests/unit/mcpgateway/services/test_upstream_session_registry.py
+++ b/tests/unit/mcpgateway/services/test_upstream_session_registry.py
@@ -858,6 +858,35 @@ async def test_acquire_evicts_on_oserror_in_body(registry, factory_and_records):
 
 
 @pytest.mark.asyncio
+async def test_acquire_evicts_on_mcp_error_in_body(registry, factory_and_records):
+    """McpError (e.g., 'Session terminated') raised inside acquire() body must evict and re-raise.
+
+    This handles the race condition where the MCP server terminates the session after a tool
+    call completes but before the SDK's validation (e.g., list_tools()) finishes. Without
+    eviction, subsequent tool calls would reuse the dead session and fail immediately.
+    """
+    # Third-Party
+    from mcp import McpError
+    from mcp.types import ErrorData
+
+    _, _ = factory_and_records
+    error = McpError(ErrorData(code=-1, message="Session terminated"))
+
+    with pytest.raises(McpError, match="Session terminated"):
+        async with registry.acquire(
+            downstream_session_id="s1",
+            gateway_id="g1",
+            url="http://upstream/mcp",
+            headers=None,
+            transport_type=TransportType.STREAMABLE_HTTP,
+        ):
+            raise error
+
+    # Session must be evicted so next acquire rebuilds instead of reusing dead session
+    assert registry.snapshot().active_sessions == 0
+
+
+@pytest.mark.asyncio
 async def test_acquire_does_not_evict_on_plain_value_error_in_body(registry, factory_and_records):
     """A caller-level exception (ValueError, etc.) leaves the session intact — the transport is fine."""
     _, _ = factory_and_records

--- a/tests/unit/mcpgateway/test_common_models.py
+++ b/tests/unit/mcpgateway/test_common_models.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_common_models.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Regression tests for mcpgateway/common/models.py.
+"""
+
+# First-Party
+from mcpgateway.common.models import Gateway, ServerCapabilities
+
+
+class TestGatewayModel:
+    """Regression tests for the Gateway model."""
+
+    def test_last_seen_is_optional_with_default(self):
+        """Duplicate `last_seen` field declaration must not make the field required.
+
+        The model previously declared `last_seen` twice; the second declaration
+        (no default) shadowed the first and made the field implicitly required.
+        """
+        field = Gateway.model_fields["last_seen"]
+        assert not field.is_required()
+        assert field.default is None
+
+    def test_gateway_instantiates_without_last_seen(self):
+        """A Gateway can be constructed without providing last_seen."""
+        gateway = Gateway(
+            id="g1",
+            name="test-gateway",
+            url="http://example.com",
+            capabilities=ServerCapabilities(),
+            slug="test-gateway",
+            transport="sse",
+            passthrough_headers=None,
+            auth_value=None,
+        )
+        assert gateway.last_seen is None

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -9005,7 +9005,7 @@ async def test_local_affinity_post_injects_server_id_regression(monkeypatch):
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
         patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
         patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls,
     ):
@@ -9078,7 +9078,7 @@ async def test_local_affinity_post_dispatches_to_internal_endpoint_with_auth_con
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
         patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
         patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls,
     ):
@@ -9147,7 +9147,7 @@ async def test_local_affinity_post_preserves_custom_auth_header(monkeypatch):
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
         patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
         patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls,
     ):
@@ -9217,7 +9217,7 @@ async def test_local_affinity_post_injects_server_id_with_non_dict_params(monkey
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
         patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
         patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls,
     ):
@@ -9281,7 +9281,7 @@ async def test_affinity_forward_to_owner_worker(monkeypatch):
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
         patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
     ):
         await wrapper.handle_streamable_http(scope, _make_receive(b'{"jsonrpc":"2.0"}'), send)
@@ -9337,7 +9337,7 @@ async def test_affinity_forward_to_owner_worker_multipart_body(monkeypatch):
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
         patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
     ):
         await wrapper.handle_streamable_http(scope, receive, send)
@@ -9396,7 +9396,7 @@ async def test_affinity_forward_to_owner_propagates_encoded_auth_context(monkeyp
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
         patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
     ):
         await wrapper.handle_streamable_http(scope, _make_receive(b'{"jsonrpc":"2.0"}'), send)
@@ -9442,7 +9442,7 @@ async def test_affinity_forward_failure_falls_through(monkeypatch):
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
         patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
     ):
         await wrapper.handle_streamable_http(scope, _make_receive(b'{"jsonrpc":"2.0"}'), send)
@@ -9481,7 +9481,7 @@ async def test_affinity_disconnect_during_body_read(monkeypatch):
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
         patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
     ):
         await wrapper.handle_streamable_http(scope, _make_receive_disconnect(), send)
@@ -9566,7 +9566,7 @@ async def test_local_affinity_post_routes_to_rpc(monkeypatch):
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
         patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
         patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls,
     ):
@@ -9675,7 +9675,7 @@ async def test_local_affinity_post_denies_non_owner_session_access(monkeypatch):
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
         patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
         patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls,
     ):
@@ -9744,7 +9744,7 @@ async def test_local_affinity_post_routes_to_rpc_multipart_and_auth_header(monke
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
         patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
         patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls,
     ):
@@ -9791,7 +9791,7 @@ async def test_local_affinity_disconnect_during_body_read(monkeypatch):
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
         patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
     ):
         await wrapper.handle_streamable_http(scope, _make_receive_disconnect(), send)
@@ -9830,7 +9830,7 @@ async def test_local_affinity_post_empty_body_returns_202(monkeypatch):
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
         patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
     ):
         await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
@@ -9870,7 +9870,7 @@ async def test_local_affinity_post_notification_returns_202(monkeypatch):
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
         patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
     ):
         await wrapper.handle_streamable_http(scope, _make_receive(body), send)
@@ -9915,7 +9915,7 @@ async def test_local_affinity_post_exception_falls_through(monkeypatch):
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
         patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
         patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls,
     ):
@@ -10051,7 +10051,7 @@ async def test_send_with_capture_registers_session(monkeypatch):
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
     ):
         await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
 
@@ -10094,7 +10094,7 @@ async def test_send_with_capture_str_headers_and_non_matching_header(monkeypatch
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
     ):
         await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
 
@@ -10136,7 +10136,7 @@ async def test_send_with_capture_registration_failure_logged(monkeypatch, caplog
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
         caplog.at_level("WARNING", logger="mcpgateway.transports.streamablehttp_transport"),
     ):
         await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
@@ -10174,7 +10174,7 @@ async def test_send_with_capture_no_session_id_no_registration(monkeypatch):
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
     ):
         await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
 
@@ -10216,7 +10216,7 @@ async def test_send_with_capture_claims_owner_for_new_session(monkeypatch):
     mock_pool.register_session_owner = AsyncMock()
 
     with patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool):
-        with patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"):
+        with patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"):
             token = tr.user_context_var.set(
                 {
                     "email": "dev@example.com",
@@ -10310,7 +10310,7 @@ async def test_send_with_capture_does_not_register_denied_client_supplied_sessio
 
     with (
         patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"),
         patch("mcpgateway.services.session_affinity.SessionAffinity") as mock_session_class,
     ):
         mock_session_class.is_valid_mcp_session_id = MagicMock(return_value=True)
@@ -12651,7 +12651,7 @@ async def test_local_affinity_post_injects_server_id(monkeypatch):
     mock_response.content = b"{}"
 
     with patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool):
-        with patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"):
+        with patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"):
             with patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class):
                 with patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls:
                     mock_client = AsyncMock()
@@ -13391,7 +13391,7 @@ async def test_local_affinity_post_injects_server_id_when_params_missing(monkeyp
     mock_response.content = b"{}"
 
     with patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool):
-        with patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"):
+        with patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"):
             with patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class):
                 with patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls:
                     mock_client = AsyncMock()
@@ -13454,7 +13454,7 @@ async def test_local_affinity_post_no_injection_without_server_url(monkeypatch):
     mock_response.content = b"{}"
 
     with patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool):
-        with patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"):
+        with patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"):
             with patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class):
                 with patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls:
                     mock_client = AsyncMock()
@@ -14698,7 +14698,7 @@ async def test_session_owner_mismatch_logs_warning(monkeypatch, caplog):
     mock_pool.register_session_owner = AsyncMock()
 
     with patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool):
-        with patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"):
+        with patch("mcpgateway.services.session_affinity.get_worker_id", return_value="worker-1"):
             token = tr.user_context_var.set(
                 {
                     "email": "requester@example.com",

--- a/tests/unit/mcpgateway/utils/test_redis_client.py
+++ b/tests/unit/mcpgateway/utils/test_redis_client.py
@@ -7,8 +7,10 @@ Unit tests for the centralized Redis client factory.
 """
 
 # Standard
+import asyncio
 import builtins
 import sys
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
@@ -179,6 +181,53 @@ async def test_get_redis_client_returns_none_on_connection_error():
             client = await get_redis_client()
 
             assert client is None
+
+
+@pytest.mark.asyncio
+async def test_get_redis_client_returns_none_on_ping_timeout(monkeypatch):
+    """A blackholed Redis (ping never returns) must not hang startup.
+
+    get_redis_client wraps the availability ping in asyncio.wait_for; on
+    timeout it must close the client and return None instead of hanging
+    indefinitely.
+    """
+    never = asyncio.Event()  # never set — simulates a blackholed Redis
+
+    async def hanging_ping():
+        await never.wait()
+
+    mock_redis = AsyncMock()
+    mock_redis.ping = hanging_ping
+    mock_redis.aclose = AsyncMock()
+
+    with patch("mcpgateway.config.settings") as mock_settings:
+        mock_settings.cache_type = "redis"
+        mock_settings.redis_url = "redis://localhost:6379"
+        mock_settings.redis_decode_responses = True
+        mock_settings.redis_max_connections = 10
+        mock_settings.redis_socket_timeout = 5.0
+        mock_settings.redis_socket_connect_timeout = 5.0
+        mock_settings.redis_retry_on_timeout = True
+        mock_settings.redis_health_check_interval = 30
+        mock_settings.redis_parser = "auto"
+        mock_settings.redis_ssl = False
+
+        # Shrink the wait_for timeout so the test doesn't take the full 10s.
+        real_wait_for = asyncio.wait_for
+
+        async def short_wait_for(awaitable, timeout):
+            return await real_wait_for(awaitable, 0.05)
+
+        monkeypatch.setattr(asyncio, "wait_for", short_wait_for)
+
+        with patch("redis.asyncio.from_url", return_value=mock_redis):
+            start = time.monotonic()
+            client = await get_redis_client()
+            elapsed = time.monotonic() - start
+
+    assert client is None
+    assert elapsed < 10.0
+    mock_redis.aclose.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -754,7 +803,6 @@ async def test_get_redis_client_warns_when_rediss_url_but_ssl_disabled(caplog):
 
     assert client is mock_redis
     assert any("rediss://" in r.message and "REDIS_SSL=false" in r.message for r in caplog.records)
-
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_gunicorn_config.py
+++ b/tests/unit/test_gunicorn_config.py
@@ -10,16 +10,15 @@ Covers two concerns of the hook:
 - **Engine / Redis pool reset on fork** (``TestPostForkHook``): each worker
   disposes the inherited SQLAlchemy engine pool and resets the Redis client.
 
-- **Per-worker WORKER_ID rebind (#4557)**: the load-bearing fix behind PR #4981.
-  With ``--preload``, ``mcpgateway.services.session_affinity.WORKER_ID`` is
-  captured at import time in the master process, so every forked worker would
-  otherwise inherit ``{hostname}:1`` (the master's PID). A shared WORKER_ID
-  collapses the per-worker pub/sub channels and makes every forwarded request
-  execute on all workers in the container (24x broadcast amplification observed
-  in #4557). The ``post_fork`` hook recomputes WORKER_ID per worker to restore
-  single-executor forwarding, and wraps the rebind in a broad ``except`` that
-  logs a ``warning`` referencing #4557 so silent fallback can't drift production
-  back into the amplification state.
+- **Per-worker worker-id correctness (#4557)**: with ``--preload``, a
+  module-level ``WORKER_ID`` constant would be captured at import time in the
+  master process, so every forked worker would inherit ``{hostname}:1`` (the
+  master's PID). A shared worker id collapses the per-worker pub/sub channels
+  and makes every forwarded request execute on all workers in the container
+  (24x broadcast amplification observed in #4557).
+  ``mcpgateway.services.session_affinity.get_worker_id()`` derives the id from
+  the live PID at call time, so each forked worker reports its own id with no
+  ``post_fork`` rebind required; these tests pin that contract.
 """
 
 # Future
@@ -170,12 +169,26 @@ class TestPostForkHook:
         mock_server.log.info.assert_any_call("SQLAlchemy engine pool reset for worker %s", 12345)
 
 
-def test_post_fork_rebinds_worker_id_per_worker(fake_worker, monkeypatch):
-    """Happy path: with the affinity flag on, ``post_fork`` overrides the master-frozen ``WORKER_ID`` with ``{hostname}:{worker.pid}``.
+def test_get_worker_id_reads_live_pid(monkeypatch):
+    """``get_worker_id()`` derives the id from the live PID at call time.
 
-    Without this, every forked gunicorn worker carries the master's
-    ``{hostname}:1``, so a forwarded request published to the owner's
-    pub/sub channel reaches every worker in the container.
+    This is what makes per-worker identity correct after ``fork()`` without any
+    ``post_fork`` rebind: each forked worker has its own PID, so every worker
+    automatically reports ``{hostname}:{worker.pid}`` instead of the master's
+    import-time-frozen id (#4557's per-container broadcast amplification).
+    """
+    # First-Party
+    from mcpgateway.services import session_affinity
+
+    monkeypatch.setattr(session_affinity.os, "getpid", lambda: 4242)
+    assert session_affinity.get_worker_id() == f"{socket.gethostname()}:4242"
+
+
+def test_post_fork_does_not_rebind_worker_id_constant_enabled(fake_worker, monkeypatch):
+    """With the affinity flag on, ``post_fork`` must not set a module-level ``WORKER_ID``.
+
+    The constant was replaced by ``get_worker_id()``; a stale rebind would be
+    dead state and mask regressions of the live-PID contract.
     """
     # First-Party
     from mcpgateway.config import settings
@@ -183,21 +196,15 @@ def test_post_fork_rebinds_worker_id_per_worker(fake_worker, monkeypatch):
 
     monkeypatch.setattr(settings, "mcpgateway_session_affinity_enabled", True)
     cfg = _load_gunicorn_config()
-    original = session_affinity.WORKER_ID
-    try:
-        cfg.post_fork(_make_fake_server(), fake_worker)
-        assert session_affinity.WORKER_ID == f"{socket.gethostname()}:{fake_worker.pid}"
-    finally:
-        # Restore the module-level constant so other tests aren't affected.
-        session_affinity.WORKER_ID = original
+    cfg.post_fork(_make_fake_server(), fake_worker)
+    assert not hasattr(session_affinity, "WORKER_ID")
 
 
-def test_post_fork_skips_worker_id_rebind_when_affinity_disabled(fake_worker, monkeypatch):
-    """With the affinity flag off, ``post_fork`` must NOT touch ``WORKER_ID``.
+def test_post_fork_does_not_rebind_worker_id_constant_disabled(fake_worker, monkeypatch):
+    """With the affinity flag off, ``post_fork`` likewise sets no ``WORKER_ID``.
 
-    The kill-switch contract: flag off means the affinity machinery is a clean
-    no-op, so the per-worker rebind (and the ``session_affinity`` import at fork)
-    is skipped and ``WORKER_ID`` keeps whatever value it already had.
+    The kill-switch contract stays intact: flag off means the affinity
+    machinery is a clean no-op.
     """
     # First-Party
     from mcpgateway.config import settings
@@ -205,57 +212,5 @@ def test_post_fork_skips_worker_id_rebind_when_affinity_disabled(fake_worker, mo
 
     monkeypatch.setattr(settings, "mcpgateway_session_affinity_enabled", False)
     cfg = _load_gunicorn_config()
-    sentinel = "sentinel-host:0"
-    original = session_affinity.WORKER_ID
-    session_affinity.WORKER_ID = sentinel
-    try:
-        cfg.post_fork(_make_fake_server(), fake_worker)
-        # Unchanged: the rebind block was gated out by the disabled flag.
-        assert session_affinity.WORKER_ID == sentinel
-    finally:
-        session_affinity.WORKER_ID = original
-
-
-def test_post_fork_logs_warning_when_rebind_fails(fake_worker, monkeypatch):
-    """If the rebind raises, the hook must log a ``warning`` referencing #4557 and NOT crash the worker.
-
-    Regression test for the F2 follow-up: the original ``except ImportError: pass``
-    silently fell back to the master's frozen ``WORKER_ID``, so #4557's broadcast
-    amplification could return into production unnoticed. The fix broadens the
-    catch and surfaces the failure via ``server.log.warning(...)``.
-
-    To reproduce a rebind failure deterministically without depending on the
-    real module's internals, monkeypatch ``socket.gethostname`` (called inside
-    the try block) to raise.
-    """
-    # First-Party
-    from mcpgateway.config import settings
-    from mcpgateway.services import session_affinity
-
-    monkeypatch.setattr(settings, "mcpgateway_session_affinity_enabled", True)
-
-    original_worker_id = session_affinity.WORKER_ID
-
-    def _boom() -> str:
-        raise RuntimeError("simulated rebind failure")
-
-    monkeypatch.setattr(socket, "gethostname", _boom)
-
-    cfg = _load_gunicorn_config()
-    server = _make_fake_server()
-    try:
-        # Must not raise — the hook is expected to swallow + log, never propagate.
-        cfg.post_fork(server, fake_worker)
-    finally:
-        session_affinity.WORKER_ID = original_worker_id
-
-    # WORKER_ID was NOT silently rebound (the failure was real, not papered over).
-    assert session_affinity.WORKER_ID == original_worker_id
-
-    # A warning was emitted, mentioning the failing operation (rebind) and the consequence.
-    assert server.log.warning.called, "expected post_fork to log a warning on rebind failure"
-    call_args = server.log.warning.call_args
-    # First arg is the format string; subsequent args are the format params.
-    fmt = call_args.args[0] if call_args.args else ""
-    assert "WORKER_ID" in fmt
-    assert "broadcast" in fmt, "warning should describe the consequence (per-container broadcast) so operators can act on it"
+    cfg.post_fork(_make_fake_server(), fake_worker)
+    assert not hasattr(session_affinity, "WORKER_ID")


### PR DESCRIPTION
Closes #5857

## Summary

Five independent bug fixes, each with a regression test (one commit per fix):

1. **Duplicate `Gateway.last_seen`** (`mcpgateway/common/models.py`) — the model declared `last_seen` twice; the second declaration shadowed the first. Removed the duplicate and pinned its optionality with a test.
2. **Team visibility scoping guard** (`mcpgateway/services/base_service.py`) — clarified `apply_team_visibility_filter` and added a regression test proving that a user belonging to two teams who requests a specific `team_id` only receives that team's team-visibility resources.
3. **Dead upstream sessions** (`mcpgateway/services/upstream_session_registry.py`) — an `McpError` (e.g. "Session terminated") raised inside the `acquire()` body left the dead session cached so subsequent calls failed immediately. `McpError` is now caught alongside the transport errors, evicting the session so the next acquire rebuilds it.
4. **Redis ping hang** (`mcpgateway/utils/redis_client.py`) — the startup availability ping had no timeout, so a blackholed Redis blocked startup indefinitely. The ping is now wrapped in `asyncio.wait_for(..., 10.0)`; on timeout the client is closed and `None` is returned so the gateway degrades to no-Redis operation.
5. **Worker ID stale after fork** (`mcpgateway/services/session_affinity.py`) — `WORKER_ID` was captured once at module import, so under gunicorn's `--preload` every forked worker inherited the master's id and subscribed to the same Redis pub/sub channel, collapsing point-to-point forwarding into a per-container broadcast. The constant is replaced by `get_worker_id()`, which derives the id from the live PID at call time. Call sites updated in `main.py` and `streamablehttp_transport.py`; the now-redundant `post_fork` rebind in `gunicorn.config.py` is removed.

## Notes for reviewers

- The `gunicorn.config.py` change is a direct consequence of fix 5: with the id derived from the live PID, the `post_fork` constant rebind is dead code. The three `tests/unit/test_gunicorn_config.py` rebind tests were rewritten to pin the new live-PID contract.
- The base_service visibility behavior on current main already scopes to the requested team; the code change there is comment-level clarification, and the value of the commit is the regression test.
