### PR TITLE
fix(security): harden auth — UUID-first user resolution, weak-password guard, streamable-HTTP team checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1245,6 +1245,9 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # PASSWORD_REQUIRE_LOWERCASE=true
 # PASSWORD_REQUIRE_NUMBERS=false
 # PASSWORD_REQUIRE_SPECIAL=true
+# Check for sequential characters in passwords (e.g., '123', 'abc')
+# Set to false to disable this validation (default: true)
+# PASSWORD_CHECK_SEQUENTIAL_CHARS=true
 
 # Password Change Enforcement
 # Master switch for all password change enforcement checks

--- a/.env.example
+++ b/.env.example
@@ -1245,10 +1245,7 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # PASSWORD_REQUIRE_LOWERCASE=true
 # PASSWORD_REQUIRE_NUMBERS=false
 # PASSWORD_REQUIRE_SPECIAL=true
-# Check for sequential characters in passwords (e.g., '123', 'abc')
-# Set to false to disable this validation (default: true)
-# PASSWORD_CHECK_SEQUENTIAL_CHARS=true
-
+# PASSWORD_CHECK_SEQUENTIAL_CHARS=true  # check for sequential chars (e.g. '123', 'abc'); set false to disable (default: true)
 # Password Change Enforcement
 # Master switch for all password change enforcement checks
 # PASSWORD_CHANGE_ENFORCEMENT_ENABLED=true

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-24T15:22:57Z",
+  "generated_at": "2026-07-25T09:19:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -132,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1310,
+        "line_number": 1313,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1345,
+        "line_number": 1348,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1424,
+        "line_number": 1427,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1429,
+        "line_number": 1432,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1434,
+        "line_number": 1437,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1440,
+        "line_number": 1443,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1452,
+        "line_number": 1455,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1470,
+        "line_number": 1473,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1531,
+        "line_number": 1534,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -626,7 +626,7 @@
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 979,
+        "line_number": 980,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -634,7 +634,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1083,
+        "line_number": 1084,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1086,
+        "line_number": 1087,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1253,
+        "line_number": 1254,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1292,
+        "line_number": 1293,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1346,
+        "line_number": 1347,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1442,
+        "line_number": 1443,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1813,
+        "line_number": 1814,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-25T09:19:20Z",
+  "generated_at": "2026-07-24T15:22:57Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -132,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1313,
+        "line_number": 1310,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1348,
+        "line_number": 1345,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1427,
+        "line_number": 1424,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1432,
+        "line_number": 1429,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1437,
+        "line_number": 1434,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1443,
+        "line_number": 1440,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1455,
+        "line_number": 1452,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1473,
+        "line_number": 1470,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1534,
+        "line_number": 1531,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -626,7 +626,7 @@
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 980,
+        "line_number": 979,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -634,7 +634,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1084,
+        "line_number": 1083,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1087,
+        "line_number": 1086,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1254,
+        "line_number": 1253,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1293,
+        "line_number": 1292,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1347,
+        "line_number": 1346,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1443,
+        "line_number": 1442,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1814,
+        "line_number": 1813,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -843,6 +843,7 @@ mcpContextForge:
     PASSWORD_REQUIRE_LOWERCASE: "true"     # require lowercase letters in passwords
     PASSWORD_REQUIRE_NUMBERS: "false"      # require numbers in passwords
     PASSWORD_REQUIRE_SPECIAL: "true"       # require special characters in passwords
+    PASSWORD_CHECK_SEQUENTIAL_CHARS: "true" # check for sequential characters (e.g., '123', 'abc')
     PASSWORD_CHANGE_ENFORCEMENT_ENABLED: "true" # enable password change enforcement checks
     ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP: "true" # force admin to change password after bootstrap
     DETECT_DEFAULT_PASSWORD_ON_LOGIN: "true" # detect default passwords on login

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -833,7 +833,6 @@ mcpContextForge:
     PLATFORM_ADMIN_PASSWORD: changeme     # password for bootstrap platform admin user
     PLATFORM_ADMIN_FULL_NAME: Platform Administrator # full name for bootstrap platform admin
     DEFAULT_USER_PASSWORD: changeme       # default password for new users (bootstrap)
-
     # ─ Password Hashing & Security ─
     ARGON2ID_TIME_COST: "3"                # Argon2id time cost (iterations)
     ARGON2ID_MEMORY_COST: "65536"          # Argon2id memory cost in KiB

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -1007,8 +1007,30 @@ def _get_user_by_email_sync(email: str) -> Optional[EmailUser]:
         # Third-Party
         from sqlalchemy import select  # pylint: disable=import-outside-toplevel
 
-        result = db.execute(select(EmailUser).where(EmailUser.email == email))
-        user = result.scalar_one_or_none()
+        # Try UUID lookup first if input looks like a UUID
+        user = None
+        is_uuid = False
+        try:
+            uuid.UUID(email)
+            is_uuid = True
+            logger.debug("[UUID_RESOLUTION] _get_user_by_email_sync: input=%s is UUID, querying by id", email)
+            result = db.execute(select(EmailUser).where(EmailUser.id == email))
+            user = result.scalar_one_or_none()
+            if user:
+                logger.info("[UUID_RESOLUTION] _get_user_by_email_sync: UUID %s resolved to email %s", email, user.email)
+            else:
+                logger.warning("[UUID_RESOLUTION] _get_user_by_email_sync: UUID %s not found in database", email)
+        except (ValueError, AttributeError):
+            logger.debug("[UUID_RESOLUTION] _get_user_by_email_sync: input=%s is not UUID, will query by email", email)
+
+        # Fall back to email lookup if UUID lookup failed or input wasn't a UUID
+        if user is None:
+            result = db.execute(select(EmailUser).where(EmailUser.email == email))
+            user = result.scalar_one_or_none()
+            if user:
+                logger.debug("[UUID_RESOLUTION] _get_user_by_email_sync: email %s found in database", email)
+            else:
+                logger.warning("[UUID_RESOLUTION] _get_user_by_email_sync: email %s not found in database (is_uuid=%s)", email, is_uuid)
         if user:
             # Detach from session and return a copy of attributes
             # since the session will be closed
@@ -1128,9 +1150,31 @@ def _get_auth_context_batched_sync(email: str, jti: Optional[str] = None) -> Dic
             "team_names": {},
         }
 
-        # Query 1: Get user data
-        user_result = db.execute(select(EmailUser).where(EmailUser.email == email))
-        user = user_result.scalar_one_or_none()
+        # Query 1: Get user data (handle both UUID and email)
+        user = None
+        is_uuid = False
+        try:
+            # Try UUID lookup first if input looks like a UUID
+            uuid.UUID(email)
+            is_uuid = True
+            logger.debug("[UUID_RESOLUTION] _get_auth_context_batched_sync: input=%s is UUID, querying by id", email)
+            user_result = db.execute(select(EmailUser).where(EmailUser.id == email))
+            user = user_result.scalar_one_or_none()
+            if user:
+                logger.info("[UUID_RESOLUTION] _get_auth_context_batched_sync: UUID %s resolved to email %s", email, user.email)
+            else:
+                logger.warning("[UUID_RESOLUTION] _get_auth_context_batched_sync: UUID %s not found in database", email)
+        except (ValueError, AttributeError):
+            logger.debug("[UUID_RESOLUTION] _get_auth_context_batched_sync: input=%s is not UUID, will query by email", email)
+
+        # Fall back to email lookup if UUID lookup failed or input wasn't a UUID
+        if user is None:
+            user_result = db.execute(select(EmailUser).where(EmailUser.email == email))
+            user = user_result.scalar_one_or_none()
+            if user:
+                logger.debug("[UUID_RESOLUTION] _get_auth_context_batched_sync: email %s found in database", email)
+            else:
+                logger.warning("[UUID_RESOLUTION] _get_auth_context_batched_sync: email %s not found in database (is_uuid=%s)", email, is_uuid)
 
         if user:
             # Detach user data as dict (session will close)
@@ -1148,11 +1192,13 @@ def _get_auth_context_batched_sync(email: str, jti: Optional[str] = None) -> Dic
             }
 
             # Query 2: Get personal team (only if user exists)
+            # Use user.email (resolved email) instead of email parameter (which may be UUID)
+            logger.debug("[UUID_RESOLUTION] _get_auth_context_batched_sync: querying personal team with user.email=%s", user.email)
             team_result = db.execute(
                 select(EmailTeam)
                 .join(EmailTeamMember)
                 .where(
-                    EmailTeamMember.user_email == email,
+                    EmailTeamMember.user_email == user.email,
                     EmailTeam.is_personal.is_(True),
                 )
             )
@@ -1161,16 +1207,19 @@ def _get_auth_context_batched_sync(email: str, jti: Optional[str] = None) -> Dic
                 result["personal_team_id"] = personal_team.id
 
             # Query 4: Get all active team memberships (for session token team resolution)
+            # Use user.email (resolved email) instead of email parameter (which may be UUID)
+            logger.debug("[UUID_RESOLUTION] _get_auth_context_batched_sync: querying team memberships with user.email=%s", user.email)
             team_ids_result = db.execute(
                 select(EmailTeamMember.team_id, EmailTeam.name)
                 .join(EmailTeam, EmailTeam.id == EmailTeamMember.team_id)
                 .where(
-                    EmailTeamMember.user_email == email,
+                    EmailTeamMember.user_email == user.email,
                     EmailTeamMember.is_active.is_(True),
                     EmailTeam.is_active.is_(True),
                 )
             )
             team_rows = team_ids_result.all()
+            logger.info("[UUID_RESOLUTION] _get_auth_context_batched_sync: found %d team memberships for user.email=%s", len(team_rows), user.email)
             team_ids: list[str] = []
             team_names: dict[str, str] = {}
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -368,6 +368,12 @@ class Settings(BaseSettings):
         default=SecretStr("__REPLACE_ME__run_init-secrets_before_starting"),
         description="HMAC secret for JWT signing. MUST be set explicitly in staging/production. Generate with: python -m mcpgateway.scripts.init_secrets --stdout",
     )
+
+    # Password Policy Settings
+    password_check_sequential_chars: bool = Field(
+        default=True,
+        description="Check for sequential characters in passwords (e.g., '123', 'abc'). Set to False to disable this validation.",
+    )
     jwt_public_key_path: str = ""
     jwt_private_key_path: str = ""
     jwt_audience: str = "mcpgateway-api"
@@ -1281,22 +1287,30 @@ class Settings(BaseSettings):
     max_interval: float = Field(default=5.0, description="Maximum polling interval in seconds when the session is idle")
     backoff_factor: float = Field(default=1.5, description="Multiplier used to gradually increase the polling interval during inactivity")
 
-    @model_validator(mode="before")
-    @classmethod
-    def apply_environment_aware_defaults(cls, data: Any) -> Any:
-        """Apply defaults that depend on other settings values."""
-        if not isinstance(data, dict):
-            return data
+    @model_validator(mode="after")
+    def apply_environment_aware_defaults(self) -> "Settings":
+        """Apply defaults that depend on other settings values.
 
-        values: dict[str, Any] = dict(data)
-        # require_strong_secrets is a legacy flag; its environment-aware default is kept for
-        # backward compatibility with existing operator configs that read the field, but the
-        # value has no effect on startup security — validate_security_combinations() rejects
-        # weak secrets unconditionally regardless of this flag.
-        if "require_strong_secrets" not in values:
-            environment = str(values.get("environment", "development")).lower()
-            values["require_strong_secrets"] = environment == "production"
-        return values
+        This runs AFTER all field values have been set (including from .env),
+        allowing us to override require_strong_secrets based on environment.
+
+        require_strong_secrets is a legacy flag; its environment-aware default is
+        kept for backward compatibility with existing operator configs that read
+        the field, but the value has no effect on startup security —
+        validate_security_combinations() rejects weak secrets unconditionally
+        regardless of this flag.
+
+        Returns:
+            Itself with require_strong_secrets derived from the environment.
+        """
+        # If require_strong_secrets was not explicitly set to True, derive it from environment
+        # This allows production to automatically enable strong secret enforcement
+        # Skip this logic in client_mode as client mode bypasses server secret enforcement
+        if not self.client_mode and not self.require_strong_secrets:
+            environment = str(self.environment).lower()
+            if environment == "production":
+                self.require_strong_secrets = True
+        return self
 
     # redis configurations for Maintaining Chat Sessions in multi-worker environment
     llmchat_session_ttl: int = Field(default=300, description="Seconds for active_session key TTL")
@@ -1564,6 +1578,15 @@ class Settings(BaseSettings):
                 )
 
         if not self.client_mode:
+            # Validate BASIC_AUTH_PASSWORD when any basic auth method is enabled
+            if self.mcpgateway_ui_enabled or self.api_allow_basic_auth or self.docs_allow_basic_auth:
+                basic_auth_val = self.basic_auth_password.get_secret_value()
+                if basic_auth_val.lower() in weak_secrets:
+                    if env != "development":
+                        raise SecurityConfigurationError(
+                            f"basic_auth_password: Weak/default password rejected in '{env}' environment when basic auth is enabled. "
+                            "Run 'python -m mcpgateway.scripts.init_secrets' to generate strong values."
+                        )
             # Check for dangerous combinations - only log warnings, don't raise errors
             if not self.auth_required and self.mcpgateway_ui_enabled:
                 logger.warning("🔓 SECURITY WARNING: Admin UI is enabled without authentication. Consider setting AUTH_REQUIRED=true for production.")

--- a/mcpgateway/services/password_policy_service.py
+++ b/mcpgateway/services/password_policy_service.py
@@ -182,10 +182,11 @@ class PasswordPolicyService:
             if contains_username:
                 raise PasswordPolicyError("Password must not be based on your username")
 
-        # Check for sequential characters (e.g., "123", "abc")
-        has_sequential = self._has_sequential_chars(password)
-        if has_sequential:
-            raise PasswordPolicyError("Password contains too many sequential characters")
+        # Check for sequential characters (e.g., "123", "abc") - only if enabled
+        if getattr(settings, "password_check_sequential_chars", True):
+            has_sequential = self._has_sequential_chars(password)
+            if has_sequential:
+                raise PasswordPolicyError("Password contains too many sequential characters")
 
         return True
 

--- a/mcpgateway/services/permission_service.py
+++ b/mcpgateway/services/permission_service.py
@@ -119,6 +119,14 @@ class PermissionService:
             True
         """
         try:
+            logger.debug(
+                "[RBAC_CHECK] check_permission: user_email=%s, permission=%s, team_id=%s, token_teams=%s",
+                SecurityValidator.sanitize_log_message(user_email),
+                permission,
+                SecurityValidator.sanitize_log_message(team_id),
+                token_teams,
+            )
+
             # SECURITY: Public-only tokens (teams=[]) must never satisfy ANY permissions
             # via admin bypass or team-scoped roles, even when the backing user identity is an admin.
             # This enforces strict isolation: token_teams=[] means public-only access at both Layer 1 and Layer 2.
@@ -129,13 +137,24 @@ class PermissionService:
                 # Continue to permission check without admin bypass
             elif allow_admin_bypass and await self._is_user_admin(user_email):
                 # Check if user is admin (bypass all permission checks if allowed)
+                logger.info("[RBAC_CHECK] Admin bypass granted: user_email=%s, permission=%s", SecurityValidator.sanitize_log_message(user_email), permission)
                 return True
 
             # Get user's effective permissions (uses cache when valid)
             user_permissions = await self.get_user_permissions(user_email, team_id, include_all_teams=check_any_team, token_teams=token_teams)
+            logger.debug(
+                "[RBAC_CHECK] User permissions retrieved: user_email=%s, permissions=%s", SecurityValidator.sanitize_log_message(user_email), list(user_permissions)[:10]
+            )  # Log first 10 to avoid spam
 
             # Check if user has the specific permission or wildcard
             granted = permission in user_permissions or Permissions.ALL_PERMISSIONS in user_permissions
+
+            if not granted:
+                logger.warning(
+                    "[RBAC_CHECK] Permission DENIED: user_email=%s, permission=%s, user_permissions=%s", SecurityValidator.sanitize_log_message(user_email), permission, list(user_permissions)[:10]
+                )
+            else:
+                logger.info("[RBAC_CHECK] Permission GRANTED: user_email=%s, permission=%s", SecurityValidator.sanitize_log_message(user_email), permission)
 
             # Log the permission check if auditing is enabled
             if self.audit_enabled:
@@ -532,6 +551,15 @@ class PermissionService:
         Returns:
             List[UserRole]: List of active roles for the user
         """
+        # Debug: Log the user_email being used for role lookup
+        logger.debug(
+            "[RBAC_DEBUG] _get_user_roles: querying with user_email=%s, team_id=%s, include_all_teams=%s, token_teams=%s",
+            SecurityValidator.sanitize_log_message(user_email),
+            SecurityValidator.sanitize_log_message(team_id),
+            include_all_teams,
+            token_teams,
+        )
+
         query = select(UserRole).join(Role).options(contains_eager(UserRole.role)).where(and_(UserRole.user_email == user_email, UserRole.is_active.is_(True), Role.is_active.is_(True)))
 
         # Include global roles and personal roles

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -1196,13 +1196,23 @@ async def _check_streamable_permission(
     if not user_email:
         return False
 
+    # Extract team_id from token teams for RBAC role lookup.
+    # token_teams is used for Layer 1 (visibility), team_id is used for Layer 2 (RBAC).
+    token_teams = user_context.get("teams")
+    team_id = None
+    if token_teams and len(token_teams) == 1:
+        team_id = token_teams[0]
+    elif token_teams and len(token_teams) > 1:
+        check_any_team = True
+
     try:
         async with get_db() as db:
             permission_service = PermissionService(db)
             granted = await permission_service.check_permission(
                 user_email=user_email,
                 permission=permission,
-                token_teams=user_context.get("teams"),
+                team_id=team_id,
+                token_teams=token_teams,
                 allow_admin_bypass=allow_admin_bypass,
                 check_any_team=check_any_team,
             )
@@ -5087,6 +5097,7 @@ class _StreamableHttpAuthHandler:
 
             jti = user_payload.get("jti")
             user_email = user_payload.get("sub") or user_payload.get("email")
+            logger.info("[UUID_RESOLUTION] streamablehttp: JWT sub=%s, email=%s, jti=%s", user_email, user_payload.get("email"), jti)
             nested_user = user_payload.get("user", {})
             nested_is_admin = nested_user.get("is_admin", False) if isinstance(nested_user, dict) else False
             is_admin = user_payload.get("is_admin", False) or nested_is_admin
@@ -5115,7 +5126,7 @@ class _StreamableHttpAuthHandler:
 
                         if cached_user:
                             db_user_is_admin = bool(cached_user.get("is_admin", False))
-                        elif settings.require_user_in_db and user_email != platform_admin_email:
+                        elif settings.require_user_in_db and user_email != platform_admin_email and not is_admin:
                             return await self._send_error(detail="User not found in database", headers={"WWW-Authenticate": "Bearer"})
 
                         if token_use == "session" and not is_admin:  # nosec B105 - token_use is a JWT claim type, not a password
@@ -5146,7 +5157,17 @@ class _StreamableHttpAuthHandler:
 
                     if cached_user:
                         db_user_is_admin = bool(cached_user.get("is_admin", False))
-                    elif settings.require_user_in_db and user_email != platform_admin_email:
+                        # CRITICAL: Update user_email to resolved email from DB (was UUID from JWT sub)
+                        # The batched auth context resolved UUID->email in _get_auth_context_batched_sync
+                        # Only update if we got a different email (UUID was resolved)
+                        resolved_email = cached_user.get("email")
+                        if resolved_email and resolved_email != user_email:
+                            logger.info("[UUID_RESOLUTION] streamablehttp: user_email updated from UUID %s to email %s", user_email, resolved_email)
+                            user_email = resolved_email
+                        elif not resolved_email:
+                            # User found but no email in cached_user - this shouldn't happen but log it
+                            logger.warning("[UUID_RESOLUTION] streamablehttp: cached_user exists but has no email field")
+                    elif settings.require_user_in_db and user_email != platform_admin_email and not is_admin:
                         return await self._send_error(detail="User not found in database", headers={"WWW-Authenticate": "Bearer"})
 
                     if auth_cache is not None:
@@ -5198,7 +5219,7 @@ class _StreamableHttpAuthHandler:
                         return await self._send_error(detail="Account disabled", headers={"WWW-Authenticate": "Bearer"})
                     if user_record:
                         db_user_is_admin = bool(getattr(user_record, "is_admin", False))
-                    if user_record is None and settings.require_user_in_db and user_email != platform_admin_email:
+                    if user_record is None and settings.require_user_in_db and user_email != platform_admin_email and not is_admin:
                         return await self._send_error(detail="User not found in database", headers={"WWW-Authenticate": "Bearer"})
 
                     if auth_cache is not None:
@@ -5308,6 +5329,7 @@ class _StreamableHttpAuthHandler:
                 else:
                     _record_mcp_auth_cache_event("team_membership_cache_hit")
 
+            logger.info("[UUID_RESOLUTION] streamablehttp: Creating auth context with user_email=%s, final_teams=%s", user_email, final_teams)
             auth_user_ctx: dict[str, Any] = {
                 "email": user_email,
                 "teams": final_teams,

--- a/tests/test_config_security.py
+++ b/tests/test_config_security.py
@@ -133,12 +133,26 @@ def test_client_mode_skips_fail_closed_secret_enforcement():
         get_settings(client_mode=True, environment="production", jwt_secret_key="weak", auth_encryption_secret="UNCONFIGURED", require_strong_secrets=True)  # pragma: allowlist secret
 
 
-def test_apply_environment_aware_defaults_non_dict_passthrough():
-    """Verify non-dict inputs pass through unchanged in the model validator."""
-    sentinel = ("not", "a", "dict")
+def test_apply_environment_aware_defaults_after_validator():
+    """The after-validator derives require_strong_secrets from the environment."""
+    strong_jwt = "T3stJwtS3cr3t!XyZ#9kPqR@vW2mN8hL"  # pragma: allowlist secret
+    strong_enc = "T3stEncS3cr3t!XyZ#9kPqR@vW2mN8hL"  # pragma: allowlist secret
 
-    apply_defaults = getattr(Settings, "apply_environment_aware_defaults")
-    assert apply_defaults(sentinel) is sentinel
+    prod = Settings(
+        jwt_secret_key=strong_jwt,
+        auth_encryption_secret=strong_enc,
+        environment="production",
+        _env_file=None,
+    )
+    assert prod.require_strong_secrets is True
+
+    dev = Settings(
+        jwt_secret_key=strong_jwt,
+        auth_encryption_secret=strong_enc,
+        environment="development",
+        _env_file=None,
+    )
+    assert dev.require_strong_secrets is False
 
 
 def test_secret_below_min_length_raises():

--- a/tests/unit/mcpgateway/test_auth.py
+++ b/tests/unit/mcpgateway/test_auth.py
@@ -38,6 +38,17 @@ from mcpgateway.utils.verify_credentials import (
 )
 
 
+@pytest.fixture(autouse=True)
+def mock_plugin_manager_for_auth():
+    """Mock get_plugin_manager to return None by default for all auth tests.
+
+    This prevents AttributeError when code checks plugin_manager.config.plugin_settings.
+    Individual tests can override this by patching get_plugin_manager themselves.
+    """
+    with patch("mcpgateway.auth.get_plugin_manager", return_value=None):
+        yield
+
+
 class TestGetDb:
     """Test cases for the get_db dependency function."""
 
@@ -6742,3 +6753,238 @@ class TestAuthJwtRoutingReturn:
             result = await handler._auth_jwt(token="unused")
 
         assert result is False
+
+
+class TestGetUserByEmailSyncUuidResolution:
+    """UUID-first resolution in _get_user_by_email_sync (auth hardening).
+
+    New-format JWTs carry the user's UUID in ``sub``; the lookup must try
+    ``EmailUser.id`` first and fall back to ``EmailUser.email``.
+    """
+
+    UUID_SUB = "550e8400-e29b-41d4-a716-446655440000"
+
+    @staticmethod
+    def _user_row(email="resolved@example.com"):
+        return SimpleNamespace(
+            email=email,
+            password_hash="h",
+            full_name="U",
+            is_admin=False,
+            is_active=True,
+            auth_provider="local",
+            password_change_required=False,
+            email_verified_at=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+    @staticmethod
+    def _install_session(monkeypatch, user_by_id=None, user_by_email=None, queries=None):
+        from contextlib import contextmanager
+
+        class DummyResult:
+            def __init__(self, value):
+                self._value = value
+
+            def scalar_one_or_none(self):
+                return self._value
+
+        class DummySession:
+            def execute(self, q):
+                where = str(q).split("WHERE", 1)[-1]
+                if queries is not None:
+                    queries.append(where)
+                if "email_users.id" in where:
+                    return DummyResult(user_by_id)
+                return DummyResult(user_by_email)
+
+        @contextmanager
+        def _session_ctx():
+            yield DummySession()
+
+        monkeypatch.setattr("mcpgateway.auth.fresh_db_session", _session_ctx)
+
+    def test_uuid_input_resolves_via_id_lookup(self, monkeypatch):
+        """UUID input is resolved through the id column and returns the user."""
+        from mcpgateway.auth import _get_user_by_email_sync
+
+        queries: list = []
+        self._install_session(monkeypatch, user_by_id=self._user_row(), user_by_email=None, queries=queries)
+
+        result = _get_user_by_email_sync(self.UUID_SUB)
+
+        assert result is not None
+        assert result.email == "resolved@example.com"
+        assert any("email_users.id" in where for where in queries)
+
+    def test_uuid_input_falls_back_to_email_lookup(self, monkeypatch):
+        """A UUID that misses the id lookup still falls back to the email lookup."""
+        from mcpgateway.auth import _get_user_by_email_sync
+
+        queries: list = []
+        self._install_session(monkeypatch, user_by_id=None, user_by_email=self._user_row(), queries=queries)
+
+        result = _get_user_by_email_sync(self.UUID_SUB)
+
+        assert result is not None
+        assert result.email == "resolved@example.com"
+        assert any("email_users.id" in where for where in queries)
+        assert any("email_users.email" in where for where in queries)
+
+    def test_email_input_skips_id_lookup(self, monkeypatch):
+        """Plain email input goes straight to the email query."""
+        from mcpgateway.auth import _get_user_by_email_sync
+
+        queries: list = []
+        self._install_session(monkeypatch, user_by_id=None, user_by_email=self._user_row(), queries=queries)
+
+        result = _get_user_by_email_sync("resolved@example.com")
+
+        assert result is not None
+        assert not any("email_users.id" in where for where in queries)
+
+
+class TestBatchedAuthContextUuidResolution:
+    """_get_auth_context_batched_sync resolves UUID subs and scopes team queries by resolved email."""
+
+    UUID_SUB = "550e8400-e29b-41d4-a716-446655440000"
+
+    def test_uuid_sub_team_queries_use_resolved_email(self, monkeypatch):
+        """Team membership queries must bind the resolved email, not the UUID sub."""
+        from contextlib import contextmanager
+
+        from mcpgateway.auth import _get_auth_context_batched_sync
+
+        user_row = SimpleNamespace(
+            email="resolved@example.com",
+            password_hash="h",
+            full_name="U",
+            is_admin=False,
+            is_active=True,
+            auth_provider="local",
+            password_change_required=False,
+            email_verified_at=None,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        calls: list = []
+
+        class DummyResult:
+            def __init__(self, scalar=None, rows=None):
+                self._scalar = scalar
+                self._rows = rows or []
+
+            def scalar_one_or_none(self):
+                return self._scalar
+
+            def all(self):
+                return self._rows
+
+        class DummySession:
+            def execute(self, q):
+                calls.append(q.compile().params)
+                where = str(q).split("WHERE", 1)[-1]
+                if "email_users.id" in where:
+                    return DummyResult(scalar=user_row)
+                if "email_users.email" in where:
+                    return DummyResult(scalar=None)
+                if "is_personal" in where:
+                    return DummyResult(scalar=None)
+                return DummyResult(rows=[])
+
+        @contextmanager
+        def _session_ctx():
+            yield DummySession()
+
+        monkeypatch.setattr("mcpgateway.auth.fresh_db_session", _session_ctx)
+
+        result = _get_auth_context_batched_sync(self.UUID_SUB)
+
+        assert result["user"] is not None
+        assert result["user"]["email"] == "resolved@example.com"
+        # First query must target the id column (UUID-first resolution).
+        assert self.UUID_SUB in calls[0].values()
+        # Every subsequent team query must bind the resolved email, never the UUID.
+        bound_values = [value for params in calls[1:] for value in params.values()]
+        assert "resolved@example.com" in bound_values
+        assert self.UUID_SUB not in bound_values
+
+
+class TestStreamableAuthJwtHardening:
+    """Streamable-HTTP JWT auth hardening: admin bypass and UUID→email propagation."""
+
+    @pytest.mark.asyncio
+    async def test_admin_token_not_rejected_by_require_user_in_db(self, monkeypatch):
+        """A token with a valid is_admin claim is not 401'd when the user row is missing."""
+        handler, _responses = _make_handler()
+        payload = {"sub": "no-such-user@example.com", "jti": "jti-1", "is_admin": True, "token_use": "access"}
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", True)
+        monkeypatch.setattr(settings, "require_user_in_db", True)
+        empty_ctx = {"user": None, "personal_team_id": None, "is_token_revoked": False, "team_ids": [], "team_names": {}}
+
+        with (
+            patch("mcpgateway.transports.streamablehttp_transport.verify_credentials", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=empty_ctx),
+            patch("mcpgateway.auth.resolve_trace_team_name", AsyncMock(return_value=None)),
+            patch("mcpgateway.transports.streamablehttp_transport.set_trace_context_from_teams"),
+            patch("mcpgateway.transports.streamablehttp_transport._set_user_identity_from_dict"),
+        ):
+            result = await handler._auth_jwt(token="jwt-token")
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_non_admin_token_rejected_by_require_user_in_db(self, monkeypatch):
+        """Deny-path: non-admin token with no DB user is still rejected."""
+        handler, responses = _make_handler()
+        payload = {"sub": "no-such-user@example.com", "jti": "jti-1", "token_use": "access"}
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", True)
+        monkeypatch.setattr(settings, "require_user_in_db", True)
+        empty_ctx = {"user": None, "personal_team_id": None, "is_token_revoked": False, "team_ids": [], "team_names": {}}
+
+        with (
+            patch("mcpgateway.transports.streamablehttp_transport.verify_credentials", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=empty_ctx),
+            patch("mcpgateway.auth.resolve_trace_team_name", AsyncMock(return_value=None)),
+            patch("mcpgateway.transports.streamablehttp_transport.set_trace_context_from_teams"),
+            patch("mcpgateway.transports.streamablehttp_transport._set_user_identity_from_dict"),
+        ):
+            result = await handler._auth_jwt(token="jwt-token")
+
+        assert result is False
+        start = next(m for m in responses if m["type"] == "http.response.start")
+        assert start["status"] == 401
+
+    @pytest.mark.asyncio
+    async def test_uuid_sub_resolved_email_propagates_to_user_context(self, monkeypatch):
+        """The resolved email (not the UUID sub) flows into the request user context."""
+        from mcpgateway.transports.context import user_context_var
+
+        handler, _responses = _make_handler()
+        uuid_sub = "550e8400-e29b-41d4-a716-446655440000"
+        payload = {"sub": uuid_sub, "jti": "jti-1", "token_use": "access"}
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", True)
+        monkeypatch.setattr(settings, "require_user_in_db", True)
+        batched = {
+            "user": {"email": "resolved@example.com", "is_active": True, "is_admin": False},
+            "personal_team_id": None,
+            "is_token_revoked": False,
+            "team_ids": [],
+            "team_names": {},
+        }
+
+        with (
+            patch("mcpgateway.transports.streamablehttp_transport.verify_credentials", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=batched),
+            patch("mcpgateway.auth.resolve_trace_team_name", AsyncMock(return_value=None)),
+            patch("mcpgateway.transports.streamablehttp_transport.set_trace_context_from_teams"),
+            patch("mcpgateway.transports.streamablehttp_transport._set_user_identity_from_dict"),
+        ):
+            result = await handler._auth_jwt(token="jwt-token")
+
+        assert result is True
+        assert user_context_var.get()["email"] == "resolved@example.com"

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -1962,6 +1962,64 @@ def test_strong_secrets_accepted_in_all_envs():
         assert s.auth_encryption_secret.get_secret_value() == strong_enc
 
 
+def test_weak_basic_auth_password_rejected_in_staging_when_ui_enabled():
+    """Weak basic_auth_password is rejected outside development when the Admin UI uses basic auth."""
+    from mcpgateway.config import SecurityConfigurationError
+
+    with pytest.raises(SecurityConfigurationError, match="basic_auth_password"):
+        Settings(
+            jwt_secret_key=_TEST_JWT_SECRET,
+            auth_encryption_secret=_TEST_ENC_SECRET,
+            basic_auth_password="changeme",  # nosec B106  # pragma: allowlist secret
+            mcpgateway_ui_enabled=True,
+            environment="staging",
+            _env_file=None,
+        )
+
+
+def test_weak_basic_auth_password_rejected_in_production_when_api_basic_auth_enabled():
+    """Weak basic_auth_password is rejected in production when API basic auth is enabled."""
+    from mcpgateway.config import SecurityConfigurationError
+
+    with pytest.raises(SecurityConfigurationError, match="basic_auth_password"):
+        Settings(
+            jwt_secret_key=_TEST_JWT_SECRET,
+            auth_encryption_secret=_TEST_ENC_SECRET,
+            basic_auth_password="changeme",  # nosec B106  # pragma: allowlist secret
+            api_allow_basic_auth=True,
+            environment="production",
+            _env_file=None,
+        )
+
+
+def test_weak_basic_auth_password_allowed_in_development():
+    """Development environments keep the weak-password warning-only posture."""
+    s = Settings(
+        jwt_secret_key=_TEST_JWT_SECRET,
+        auth_encryption_secret=_TEST_ENC_SECRET,
+        basic_auth_password="changeme",  # nosec B106  # pragma: allowlist secret
+        mcpgateway_ui_enabled=True,
+        environment="development",
+        _env_file=None,
+    )
+    assert s.basic_auth_password.get_secret_value() == "changeme"  # nosec B105  # pragma: allowlist secret
+
+
+def test_weak_basic_auth_password_allowed_when_basic_auth_disabled():
+    """No basic-auth method enabled -> basic_auth_password strength is not enforced."""
+    s = Settings(
+        jwt_secret_key=_TEST_JWT_SECRET,
+        auth_encryption_secret=_TEST_ENC_SECRET,
+        basic_auth_password="changeme",  # nosec B106  # pragma: allowlist secret
+        mcpgateway_ui_enabled=False,
+        api_allow_basic_auth=False,
+        docs_allow_basic_auth=False,
+        environment="staging",
+        _env_file=None,
+    )
+    assert s.basic_auth_password.get_secret_value() == "changeme"  # nosec B105  # pragma: allowlist secret
+
+
 def test_empty_secret_raises():
     """Empty jwt_secret_key is rejected unconditionally."""
     from mcpgateway.config import SecurityConfigurationError

--- a/tests/unit/mcpgateway/test_password_policy.py
+++ b/tests/unit/mcpgateway/test_password_policy.py
@@ -86,6 +86,24 @@ class TestPasswordPolicyService:
         with pytest.raises(PasswordPolicyError, match="sequential characters"):
             policy_service.validate_user_password("Abcd!Password1", "user@example.com")
 
+    def test_validate_user_password_sequential_chars_disabled(self, policy_service):
+        """Test that sequential character check can be disabled via config."""
+        with patch("mcpgateway.services.password_policy_service.settings"):
+            # Configure mock to return proper values for all getattr calls
+            def mock_getattr(obj, name, default=None):
+                if name == "password_check_sequential_chars":
+                    return False
+                elif name == "password_min_length_user":
+                    return 12
+                elif name == "password_min_length_privileged":
+                    return 22
+                return default
+
+            with patch("mcpgateway.services.password_policy_service.getattr", side_effect=mock_getattr):
+                # These passwords have sequential chars but should pass when check is disabled
+                assert policy_service.validate_user_password("Pass123word!", "user@example.com")
+                assert policy_service.validate_user_password("Abcd!Password1", "user@example.com")
+
     def test_validate_privileged_password_length(self, policy_service):
         """Test that privileged accounts require 22+ characters."""
         # 22 characters - should pass
@@ -462,13 +480,17 @@ class TestPasswordPolicyIntegration:
 
         service = EmailAuthService(mock_db)
 
-        # Common password should be rejected
-        with pytest.raises(PasswordValidationError):
-            service.validate_password("Password01@!", "user@example.com")
+        # Mock settings to ensure password policy is enabled
+        with patch("mcpgateway.services.email_auth_service.settings") as mock_settings:
+            mock_settings.password_policy_enabled = True
 
-        # Admin-based common password should be rejected
-        with pytest.raises(PasswordValidationError):
-            service.validate_password("Administrator!", "admin@example.com")
+            # Common password should be rejected
+            with pytest.raises(PasswordValidationError):
+                service.validate_password("Password01@!", "user@example.com")
+
+            # Admin-based common password should be rejected
+            with pytest.raises(PasswordValidationError):
+                service.validate_password("Administrator!", "admin@example.com")
 
     def test_minimum_length_enforced(self, mock_db):
         """Test that 12-character minimum is enforced."""
@@ -476,12 +498,16 @@ class TestPasswordPolicyIntegration:
 
         service = EmailAuthService(mock_db)
 
-        # 11 characters - should fail (S-h-o-r-t-!-P-a-s-9-x = 11 chars)
-        with pytest.raises(PasswordValidationError, match="12 characters"):
-            service.validate_password("Short!Pas9x", "user@example.com")
+        # Mock settings to ensure password policy is enabled
+        with patch("mcpgateway.services.email_auth_service.settings") as mock_settings:
+            mock_settings.password_policy_enabled = True
 
-        # 12 characters - should pass
-        service.validate_password("Valid1!Pass2", "user@example.com")
+            # 11 characters - should fail (S-h-o-r-t-!-P-a-s-9-x = 11 chars)
+            with pytest.raises(PasswordValidationError, match="12 characters"):
+                service.validate_password("Short!Pas9x", "user@example.com")
+
+            # 12 characters - should pass
+            service.validate_password("Valid1!Pass2", "user@example.com")
 
 
 # Pentesting Report Compliance Tests

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -17595,3 +17595,85 @@ async def test_list_tools_sso_admin_gets_admin_bypass_at_service_layer(monkeypat
     await list_tools()
 
     assert called["args"] == (None, None)
+
+
+class TestCheckStreamablePermissionTeamExtraction:
+    """team_id / check_any_team derivation from token teams (auth hardening).
+
+    token_teams drives Layer 1 (visibility); the Layer-2 RBAC role lookup must
+    receive team_id for single-team tokens and check_any_team for multi-team
+    tokens, otherwise team-scoped roles are never evaluated.
+    """
+
+    @staticmethod
+    def _install_fakes(monkeypatch, captured):
+        class FakePermissionService:
+            def __init__(self, _db):
+                pass
+
+            async def check_permission(self, **kwargs):
+                captured.update(kwargs)
+                return True
+
+        db_cm = MagicMock()
+        db_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+        db_cm.__aexit__ = AsyncMock(return_value=False)
+
+        monkeypatch.setattr(tr, "PermissionService", FakePermissionService)
+        monkeypatch.setattr(tr, "get_db", lambda: db_cm)
+
+    @pytest.mark.asyncio
+    async def test_single_team_token_passes_team_id(self, monkeypatch):
+        """A token scoped to exactly one team yields team_id for the RBAC lookup."""
+        captured: dict = {}
+        self._install_fakes(monkeypatch, captured)
+
+        granted = await tr._check_streamable_permission(
+            user_context={"email": "user@example.com", "teams": ["team-1"]},
+            permission="tools.execute",
+        )
+
+        assert granted is True
+        assert captured["team_id"] == "team-1"
+        assert captured["token_teams"] == ["team-1"]
+        assert captured["check_any_team"] is False
+
+    @pytest.mark.asyncio
+    async def test_multi_team_token_sets_check_any_team(self, monkeypatch):
+        """A token scoped to multiple teams triggers the any-team RBAC lookup."""
+        captured: dict = {}
+        self._install_fakes(monkeypatch, captured)
+
+        granted = await tr._check_streamable_permission(
+            user_context={"email": "user@example.com", "teams": ["team-1", "team-2"]},
+            permission="tools.execute",
+        )
+
+        assert granted is True
+        assert captured["team_id"] is None
+        assert captured["check_any_team"] is True
+
+    @pytest.mark.asyncio
+    async def test_public_only_token_passes_no_team_scope(self, monkeypatch):
+        """A public-only token (teams=[]) yields neither team_id nor any-team."""
+        captured: dict = {}
+        self._install_fakes(monkeypatch, captured)
+
+        granted = await tr._check_streamable_permission(
+            user_context={"email": "user@example.com", "teams": []},
+            permission="tools.execute",
+        )
+
+        assert granted is True
+        assert captured["team_id"] is None
+        assert captured["check_any_team"] is False
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_context_denied(self, monkeypatch):
+        """Deny-path: missing email in the user context is rejected up-front."""
+        granted = await tr._check_streamable_permission(
+            user_context={"teams": ["team-1"]},
+            permission="tools.execute",
+        )
+
+        assert granted is False

--- a/tests/unit/test_cwe321_hardcoded_jwt.py
+++ b/tests/unit/test_cwe321_hardcoded_jwt.py
@@ -28,6 +28,11 @@ def _make_settings(**kwargs):
     base = {
         "jwt_secret_key": STRONG_JWT_KEY,
         "auth_encryption_secret": STRONG_ENC_KEY,
+        # Explicit values keep the test hermetic when the runner environment
+        # exports basic-auth toggles (e.g. MCPGATEWAY_UI_ENABLED=true in CI).
+        "mcpgateway_ui_enabled": False,
+        "api_allow_basic_auth": False,
+        "docs_allow_basic_auth": False,
     }
     base.update(kwargs)
     return Settings.model_validate(base)


### PR DESCRIPTION
Closes #5864

## Summary

Ports the auth-hardening fixes out of the catch-all PR #5417 into a standalone, reviewable change:

- **UUID-first user resolution** (`mcpgateway/auth.py`): `_get_user_by_email_sync()` and `_get_auth_context_batched_sync()` now try `EmailUser.id` first when the `sub` looks like a UUID and fall back to email lookup. Team queries (personal team, active memberships) bind the resolved `user.email` instead of the raw `sub` parameter, so UUID-sub tokens resolve teams identically to email-form tokens. `normalize_token_teams()`/`resolve_session_teams()` remain the single token-scoping policy points.
- **Weak basic-auth password guard** (`mcpgateway/config.py`): `validate_security_combinations()` now rejects a weak/default `BASIC_AUTH_PASSWORD` when any basic-auth method (Admin UI, API, docs) is enabled in a non-development environment. Also adds the `PASSWORD_CHECK_SEQUENTIAL_CHARS` setting (honored by the password policy service; exposed in `.env.example` and the Helm chart values) and converts `apply_environment_aware_defaults` to `model_validator(mode="after")` so `require_strong_secrets` is derived after all field values are set.
- **Streamable-HTTP auth fixes** (`mcpgateway/transports/streamablehttp_transport.py`): `_check_streamable_permission()` derives `team_id` from single-team tokens and sets `check_any_team` for multi-team tokens so team-scoped RBAC roles are actually evaluated; `require_user_in_db` no longer rejects tokens whose `is_admin` claim is valid; the UUID→email resolution from the batched auth context is propagated into the request user context.
- **Sanitized RBAC logging** (`mcpgateway/services/permission_service.py`): debug/info traces around `check_permission` and `_get_user_roles`, all identity fields passed through `SecurityValidator.sanitize_log_message`.

## Security notes

- Deny-path regression coverage: unauthenticated context denied up-front, non-admin token with no DB row still rejected by `require_user_in_db`, public-only tokens get no team scope, weak basic-auth password rejected in staging/production but still allowed in development and when no basic-auth method is enabled.
- No behavior change to token-scoping policy functions; no new transports or flags gated behind this change beyond the documented `PASSWORD_CHECK_SEQUENTIAL_CHARS` default-true setting.