### PR TITLE
fix: SQLite-compatible DROP COLUMN in migration 6c0e5f8a9b1d downgrade

### DIFF
--- a/mcpgateway/alembic/versions/6c0e5f8a9b1d_add_gateway_lifecycle_fields.py
+++ b/mcpgateway/alembic/versions/6c0e5f8a9b1d_add_gateway_lifecycle_fields.py
@@ -117,8 +117,12 @@ def downgrade() -> None:
     if _index_exists(inspector, GATEWAY_TABLE, CLAIM_INDEX):
         op.drop_index(CLAIM_INDEX, table_name=GATEWAY_TABLE)
 
+    # Use batch_alter_table for SQLite compatibility (SQLite < 3.35.0 doesn't support DROP COLUMN)
     inspector = sa.inspect(bind)
     columns = _column_names(inspector, GATEWAY_TABLE)
-    for column_name in reversed(LIFECYCLE_COLUMNS):
-        if column_name in columns:
-            op.drop_column(GATEWAY_TABLE, column_name)
+    columns_to_drop = [col for col in reversed(LIFECYCLE_COLUMNS) if col in columns]
+
+    if columns_to_drop:
+        with op.batch_alter_table(GATEWAY_TABLE, schema=None) as batch_op:
+            for column_name in columns_to_drop:
+                batch_op.drop_column(column_name)


### PR DESCRIPTION
## Summary
The downgrade() function in migration 6c0e5f8a9b1d uses individual op.drop_column() calls outside of batch_alter_table, which fails on SQLite versions prior to 3.35.0.

## Fix
Replaced the per-column op.drop_column loop with a batch_alter_table block following the same pattern used in other SQLite-compatible migrations in this codebase.

## Testing
Local SQLite is 3.51.0 (>= 3.35.0) so the original code would pass here. The fix maintains backward compatibility.

For SQLite < 3.35.0: Original code FAILS, Fixed code WORKS.
For SQLite >= 3.35.0: Both versions WORK.

Closes #5873