### PR TITLE
fix(plugins): export real tool args when payload.args is a CopyOnWriteDict

### DIFF
--- a/plugins/tools_telemetry_exporter/telemetry_exporter.py
+++ b/plugins/tools_telemetry_exporter/telemetry_exporter.py
@@ -168,7 +168,7 @@ class ToolsTelemetryExporterPlugin(Plugin):
             "tool.name": context_attributes["tool"]["name"],
             "tool.target_tool_name": context_attributes["tool"]["target_tool_name"],
             "tool.description": context_attributes["tool"]["description"],
-            "tool.invocation.args": orjson.dumps(payload.args, default=str).decode(),
+            "tool.invocation.args": orjson.dumps(dict(payload.args) if payload.args else {}, default=str).decode(),
             "headers": self._serialize_headers(payload),
         }
 

--- a/tests/unit/mcpgateway/plugins/plugins/tools_telemetry_exporter/test_tools_telemetry_exporter.py
+++ b/tests/unit/mcpgateway/plugins/plugins/tools_telemetry_exporter/test_tools_telemetry_exporter.py
@@ -15,6 +15,7 @@ import pytest
 
 # First-Party
 from cpex.framework import GlobalContext, HttpHeaderPayload, PluginConfig, PluginContext, ToolHookType, ToolPostInvokePayload, ToolPreInvokePayload
+from cpex.framework.memory import CopyOnWriteDict
 from plugins.tools_telemetry_exporter.telemetry_exporter import ToolsTelemetryExporterPlugin
 
 
@@ -78,6 +79,21 @@ class TestToolsTelemetryExporterPlugin:
         assert exported_headers["X-Vault-Tokens"] == "******"
         assert exported_headers["Content-Type"] == "application/json"
         assert exported_headers["X-Request-Id"] == "req-123"
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_exports_copy_on_write_args(self):
+        """Args arriving as a CopyOnWriteDict should still be exported in full."""
+        plugin = _create_plugin()
+        payload = ToolPreInvokePayload.model_construct(
+            name="test_tool",
+            args=CopyOnWriteDict({"sysid": "PRD", "client": "999"}),
+            headers=HttpHeaderPayload({}),
+        )
+
+        await plugin.tool_pre_invoke(payload, _create_context())
+
+        attrs = plugin._export_telemetry.await_args.kwargs["attributes"]
+        assert json.loads(attrs["tool.invocation.args"]) == {"sysid": "PRD", "client": "999"}
 
     @pytest.mark.asyncio
     async def test_pre_invoke_redacts_broad_token_header_patterns(self):


### PR DESCRIPTION
Closes #5699

## 📌 Summary

`ToolsTelemetryExporter` always exported `tool.invocation.args` as `{}` on the `tool.pre_invoke` span, even when the tool was invoked with real arguments, so tool telemetry lost all input data.

## 🔁 Reproduction Steps

Issue #5699. Offline reproduction of the root cause:

```python
>>> import orjson
>>> from cpex.framework.memory import CopyOnWriteDict
>>> orjson.dumps(CopyOnWriteDict({"sysid": "PRD", "client": "999"}), default=str)
b'{}'
>>> orjson.dumps(dict(CopyOnWriteDict({"sysid": "PRD", "client": "999"})), default=str)
b'{"sysid":"PRD","client":"999"}'
```

## 🐞 Root Cause

`tool_pre_invoke` passes `payload.args` straight to `orjson.dumps` (`plugins/tools_telemetry_exporter/telemetry_exporter.py:171`). When the plugin framework hands over a `cpex.framework.memory.CopyOnWriteDict`, orjson serializes a `dict` subclass by reading its internal C-level storage and bypasses the Python-level overrides the copy-on-write wrapper relies on. The backing shell is empty, so the export is `{}` while `repr()` and normal access show the real arguments.

## 💡 Fix Description

Convert to a plain `dict` before dumping. One line, no behaviour change for the plain-`dict` case (nested values are already plain containers).

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

New `test_pre_invoke_exports_copy_on_write_args` in the plugin's existing test module. Verified fail-without-fix / pass-with-fix by stashing the source change:

| Check | Command | Status |
|---|---|---|
| Plugin unit tests | `pytest tests/unit/mcpgateway/plugins/plugins/tools_telemetry_exporter/` | 6 passed |
| New test without the source fix | same, `-k copy_on_write` | 1 failed (expected) |
| Lint / format | `ruff check`, `ruff format --check` on both changed files | clean |

## 📐 MCP Compliance (if relevant)

- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
