### PR TITLE
fix(a2a): supervise A2A cache-invalidation task scheduling

### DIFF
--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -16,7 +16,7 @@ import base64
 import binascii
 from datetime import datetime, timezone
 import json
-from typing import Any, AsyncGenerator, Dict, List, Optional, Union
+from typing import Any, AsyncGenerator, Dict, List, Optional, Set, Union
 from urllib.parse import urlparse
 
 # Third-Party
@@ -290,6 +290,60 @@ async def _publish_a2a_invalidation(message_type: str, **kwargs: Any) -> None:
         await redis.publish("mcpgw:a2a:invalidate", payload)
     except Exception as e:
         logger.warning("Failed to publish A2A cache invalidation: %s", e)
+
+
+# Strong references to in-flight invalidation tasks. The event loop only keeps a
+# weak reference to a task, so without this a fire-and-forget task can be garbage
+# collected before it completes.
+_BACKGROUND_TASKS: Set[Any] = set()
+
+
+def _log_invalidation_task_exception(task: Any) -> None:
+    """Log an exception raised inside a background invalidation task.
+
+    Args:
+        task: The completed invalidation task.
+    """
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.warning("A2A cache invalidation task failed: %s", exc)
+
+
+def _schedule_a2a_invalidation(agent_name: str) -> None:
+    """Schedule a best-effort A2A cache invalidation publish.
+
+    The coroutine is constructed only after a running loop is confirmed and the
+    task is retained until completion, so a scheduling failure cannot leak an
+    un-awaited coroutine and a live task cannot be garbage collected early.
+
+    Args:
+        agent_name: Name of the agent whose cache entry should be invalidated.
+    """
+    # Standard
+    import asyncio  # pylint: disable=import-outside-toplevel
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return  # No running event loop (e.g., in tests)
+
+    coro = _publish_a2a_invalidation("agent", name=agent_name)
+    try:
+        task = loop.create_task(coro)
+    except Exception as exc:  # pylint: disable=broad-except
+        # Close the coroutine we just built so it cannot raise
+        # "coroutine ... was never awaited" during garbage collection.
+        coro.close()
+        # Best-effort, but log so a Redis outage stops being invisible - stale
+        # Rust L1 caches silently serve old agent data until TTL expires.
+        logger.warning("Rust-cache invalidation scheduling failed for agent %s: %s", agent_name, exc)
+        return
+
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
+    task.add_done_callback(_log_invalidation_task_exception)
 
 
 class A2AAgentError(Exception):
@@ -817,19 +871,7 @@ class A2AAgentService(BaseService):
                 except Exception as cache_error:
                     logger.warning("Cache invalidation failed after agent commit: %s", cache_error)
 
-                try:
-                    # Standard
-                    import asyncio  # pylint: disable=import-outside-toplevel
-
-                    loop = asyncio.get_running_loop()
-                    loop.create_task(_publish_a2a_invalidation("agent", name=new_agent.name))
-                except RuntimeError:
-                    pass  # No running event loop (e.g., in tests)
-                except Exception as exc:
-                    # Best-effort, but log so a Redis outage stops being
-                    # invisible — stale Rust L1 caches silently serve old
-                    # agent data until TTL expires.
-                    logger.warning("Rust-cache invalidation scheduling failed for agent %s: %s", new_agent.name, exc)
+                _schedule_a2a_invalidation(new_agent.name)
 
                 # Automatically create a tool for the A2A agent if not already present
                 # Tool creation is wrapped in try/except to ensure agent registration succeeds
@@ -1680,16 +1722,7 @@ class A2AAgentService(BaseService):
 
             await admin_stats_cache.invalidate_tags()
 
-            try:
-                # Standard
-                import asyncio  # pylint: disable=import-outside-toplevel
-
-                loop = asyncio.get_running_loop()
-                loop.create_task(_publish_a2a_invalidation("agent", name=agent.name))
-            except RuntimeError:
-                pass  # No running event loop (e.g., in tests)
-            except Exception as exc:
-                logger.warning("Rust-cache invalidation scheduling failed for agent %s: %s", agent.name, exc)
+            _schedule_a2a_invalidation(agent.name)
 
             # Update the associated tool if it exists
             # Wrap in try/except to handle tool sync failures gracefully - the agent
@@ -1881,16 +1914,7 @@ class A2AAgentService(BaseService):
 
                 await admin_stats_cache.invalidate_tags()
 
-                try:
-                    # Standard
-                    import asyncio  # pylint: disable=import-outside-toplevel
-
-                    loop = asyncio.get_running_loop()
-                    loop.create_task(_publish_a2a_invalidation("agent", name=agent_name))
-                except RuntimeError:
-                    pass  # No running event loop (e.g., in tests)
-                except Exception as exc:
-                    logger.warning("Rust-cache invalidation scheduling failed for agent %s: %s", agent_name, exc)
+                _schedule_a2a_invalidation(agent_name)
 
                 logger.info("Deleted A2A agent: %s (ID: %s)", agent_name, agent_id)
 

--- a/tests/unit/mcpgateway/services/test_a2a_service.py
+++ b/tests/unit/mcpgateway/services/test_a2a_service.py
@@ -7,7 +7,9 @@ Tests for A2A Agent Service functionality.
 """
 
 # Standard
+import asyncio
 from datetime import datetime, timezone
+import gc
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -2803,6 +2805,43 @@ class TestA2AInvalidationBestEffort:
         loop.create_task.side_effect = Exception("boom")
         with patch("asyncio.get_running_loop", return_value=loop):
             await service.delete_agent(mock_db, sample_db_agent.id)
+
+    async def test_schedule_invalidation_does_not_leak_coroutine_when_create_task_fails(self, recwarn):
+        """A create_task failure must not leave an un-awaited coroutine behind."""
+        # First-Party
+        from mcpgateway.services.a2a_service import _schedule_a2a_invalidation  # noqa: PLC0415
+
+        loop = MagicMock()
+        loop.create_task.side_effect = Exception("boom")
+        with patch("asyncio.get_running_loop", return_value=loop):
+            _schedule_a2a_invalidation("test-agent")
+
+        coro = loop.create_task.call_args[0][0]
+        gc.collect()
+        assert not [w for w in recwarn.list if issubclass(w.category, RuntimeWarning) and "was never awaited" in str(w.message)]
+        assert getattr(coro, "cr_running", False) is False
+
+    async def test_schedule_invalidation_keeps_a_strong_reference_until_done(self):
+        """The scheduled task must be retained so the GC cannot drop it mid-flight."""
+        # First-Party
+        from mcpgateway.services.a2a_service import _BACKGROUND_TASKS, _schedule_a2a_invalidation  # noqa: PLC0415
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _blocking_publish(*_args, **_kwargs):
+            started.set()
+            await release.wait()
+
+        with patch("mcpgateway.services.a2a_service._publish_a2a_invalidation", _blocking_publish):
+            _schedule_a2a_invalidation("test-agent")
+            await started.wait()
+            assert len(_BACKGROUND_TASKS) == 1
+            task = next(iter(_BACKGROUND_TASKS))
+            release.set()
+            await task
+
+        assert task not in _BACKGROUND_TASKS
 
 
 class TestA2ATaskWireAndUpsert:


### PR DESCRIPTION
Closes #5830

## 📌 Summary

`_publish_a2a_invalidation()` was scheduled fire-and-forget at three call sites in `a2a_service.py` (register/update/delete agent). The coroutine was constructed as the argument to `loop.create_task()`, so a `create_task()` failure left it un-awaited (`RuntimeWarning: coroutine '_publish_a2a_invalidation' was never awaited`), and the task reference was discarded, so the task could be GC'd before completing and its exceptions were silently dropped.

## 🔁 Reproduction Steps

`uv run pytest tests/unit/mcpgateway/services/test_a2a_service.py -k TestA2AInvalidationBestEffort -W error::RuntimeWarning` — the existing `test_update_agent_ignores_generic_invalidation_error` and `test_delete_agent_ignores_generic_invalidation_error` (which force `create_task` to raise) emit the warning.

## 🐞 Root Cause

`a2a_service.py:825/1688/1889` — `loop.create_task(_publish_a2a_invalidation(...))`. The coroutine object exists before `create_task` runs, so the `except` path drops it without awaiting or closing it. The event loop holds only a weak reference to the returned task, and no done-callback logged failures.

## 💡 Fix Description

New `_schedule_a2a_invalidation()` helper, used at all three call sites:

- resolves the running loop first and returns early on `RuntimeError` (no loop, e.g. tests);
- constructs the coroutine, and `coro.close()`s it if `create_task()` raises, so nothing leaks;
- keeps the task in a module-level `_BACKGROUND_TASKS` set, discarded via done-callback, so it cannot be GC'd mid-flight;
- logs any exception raised inside the task, so a Redis outage is no longer invisible.

Behaviour is unchanged on the success path and remains best-effort.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

Two regression tests added to the existing `TestA2AInvalidationBestEffort` class. Under `-W error::RuntimeWarning` they fail on the unmodified source (`git stash` of `a2a_service.py`: 3 passed / 2 failed with the exact reported `RuntimeWarning`) and pass with the fix (5 passed).

| Check | Command | Status |
|---|---|---|
| Lint suite | `ruff check` + `ruff format --check` on both changed files | clean (no new findings vs baseline) |
| Unit tests | `pytest tests/unit/mcpgateway/services/test_a2a_service.py -W error::RuntimeWarning` | 262 passed, 0 warnings |
| Coverage ≥ 80 % | `make coverage` | not run locally (full-suite target) |
| Manual regression no longer fails | stash-verified fail→pass above | pass |

## 📐 MCP Compliance (if relevant)

- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist

- [x] Code formatted (`ruff format` clean on changed files)
- [x] No secrets/credentials committed
