### PR TITLE
fix(a2a): supervise invalidation tasks

### DIFF
--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -12,6 +12,7 @@ and interactions with A2A-compatible agents.
 """
 
 # Standard
+import asyncio
 import base64
 import binascii
 from datetime import datetime, timezone
@@ -267,6 +268,9 @@ def _is_jwt_token(token: str) -> bool:
 logging_service = LoggingService()
 logger = logging_service.get_logger(__name__)
 
+# Strong references keep invalidation tasks alive until their done callbacks run.
+_a2a_invalidation_tasks: set[asyncio.Task[None]] = set()
+
 # Initialize structured logger for A2A lifecycle tracking
 structured_logger = get_structured_logger("a2a_service")
 
@@ -290,6 +294,35 @@ async def _publish_a2a_invalidation(message_type: str, **kwargs: Any) -> None:
         await redis.publish("mcpgw:a2a:invalidate", payload)
     except Exception as e:
         logger.warning("Failed to publish A2A cache invalidation: %s", e)
+
+
+def _on_a2a_invalidation_done(task: asyncio.Task[None]) -> None:
+    """Release a completed invalidation task and surface unexpected failures."""
+    _a2a_invalidation_tasks.discard(task)
+    if task.cancelled():
+        return
+    exception = task.exception()
+    if exception is not None:
+        logger.warning("A2A cache invalidation task failed: %s", exception, exc_info=exception)
+
+
+def _schedule_a2a_invalidation(message_type: str, **kwargs: Any) -> None:
+    """Schedule a best-effort A2A invalidation without leaking its coroutine."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+
+    coroutine = _publish_a2a_invalidation(message_type, **kwargs)
+    try:
+        task = loop.create_task(coroutine)
+    except Exception as exception:
+        coroutine.close()
+        logger.warning("A2A cache invalidation scheduling failed: %s", exception)
+        return
+
+    _a2a_invalidation_tasks.add(task)
+    task.add_done_callback(_on_a2a_invalidation_done)
 
 
 class A2AAgentError(Exception):
@@ -817,19 +850,7 @@ class A2AAgentService(BaseService):
                 except Exception as cache_error:
                     logger.warning("Cache invalidation failed after agent commit: %s", cache_error)
 
-                try:
-                    # Standard
-                    import asyncio  # pylint: disable=import-outside-toplevel
-
-                    loop = asyncio.get_running_loop()
-                    loop.create_task(_publish_a2a_invalidation("agent", name=new_agent.name))
-                except RuntimeError:
-                    pass  # No running event loop (e.g., in tests)
-                except Exception as exc:
-                    # Best-effort, but log so a Redis outage stops being
-                    # invisible — stale Rust L1 caches silently serve old
-                    # agent data until TTL expires.
-                    logger.warning("Rust-cache invalidation scheduling failed for agent %s: %s", new_agent.name, exc)
+                _schedule_a2a_invalidation("agent", name=new_agent.name)
 
                 # Automatically create a tool for the A2A agent if not already present
                 # Tool creation is wrapped in try/except to ensure agent registration succeeds
@@ -1680,16 +1701,7 @@ class A2AAgentService(BaseService):
 
             await admin_stats_cache.invalidate_tags()
 
-            try:
-                # Standard
-                import asyncio  # pylint: disable=import-outside-toplevel
-
-                loop = asyncio.get_running_loop()
-                loop.create_task(_publish_a2a_invalidation("agent", name=agent.name))
-            except RuntimeError:
-                pass  # No running event loop (e.g., in tests)
-            except Exception as exc:
-                logger.warning("Rust-cache invalidation scheduling failed for agent %s: %s", agent.name, exc)
+            _schedule_a2a_invalidation("agent", name=agent.name)
 
             # Update the associated tool if it exists
             # Wrap in try/except to handle tool sync failures gracefully - the agent
@@ -1881,16 +1893,7 @@ class A2AAgentService(BaseService):
 
                 await admin_stats_cache.invalidate_tags()
 
-                try:
-                    # Standard
-                    import asyncio  # pylint: disable=import-outside-toplevel
-
-                    loop = asyncio.get_running_loop()
-                    loop.create_task(_publish_a2a_invalidation("agent", name=agent_name))
-                except RuntimeError:
-                    pass  # No running event loop (e.g., in tests)
-                except Exception as exc:
-                    logger.warning("Rust-cache invalidation scheduling failed for agent %s: %s", agent_name, exc)
+                _schedule_a2a_invalidation("agent", name=agent_name)
 
                 logger.info("Deleted A2A agent: %s (ID: %s)", agent_name, agent_id)
 

--- a/tests/unit/mcpgateway/services/test_a2a_service.py
+++ b/tests/unit/mcpgateway/services/test_a2a_service.py
@@ -7,6 +7,7 @@ Tests for A2A Agent Service functionality.
 """
 
 # Standard
+import asyncio
 from datetime import datetime, timezone
 import json
 from types import SimpleNamespace
@@ -2730,8 +2731,6 @@ class TestInvokeAgentEdgeCases:
             await service.invoke_agent(mock_db, "ag", {})
 
 
-
-
 class TestA2AInvalidationBestEffort:
     @pytest.fixture
     def service(self):
@@ -4450,6 +4449,108 @@ class TestPublishA2AInvalidation:
             await _publish_a2a_invalidation("agent_created", agent_id="a2")
 
 
+class TestScheduleA2AInvalidation:
+    """Unit tests for supervised A2A invalidation scheduling."""
+
+    async def test_retains_task_until_completion(self, monkeypatch):
+        """A scheduled invalidation has a strong reference until it finishes."""
+        # First-Party
+        from mcpgateway.services import a2a_service  # noqa: PLC0415
+
+        release = asyncio.Event()
+
+        async def publish(*_args, **_kwargs):
+            await release.wait()
+
+        monkeypatch.setattr(a2a_service, "_publish_a2a_invalidation", publish)
+
+        a2a_service._schedule_a2a_invalidation("agent", name="held-agent")
+
+        assert len(a2a_service._a2a_invalidation_tasks) == 1
+        task = next(iter(a2a_service._a2a_invalidation_tasks))
+
+        release.set()
+        await task
+        await asyncio.sleep(0)
+
+        assert not a2a_service._a2a_invalidation_tasks
+
+    async def test_removes_cancelled_task_without_warning(self, monkeypatch):
+        """Cancellation releases the task reference without logging a failure."""
+        # First-Party
+        from mcpgateway.services import a2a_service  # noqa: PLC0415
+
+        async def publish(*_args, **_kwargs):
+            await asyncio.Event().wait()
+
+        warning = MagicMock()
+        monkeypatch.setattr(a2a_service, "_publish_a2a_invalidation", publish)
+        monkeypatch.setattr(a2a_service.logger, "warning", warning)
+
+        a2a_service._schedule_a2a_invalidation("agent", name="cancelled-agent")
+        task = next(iter(a2a_service._a2a_invalidation_tasks))
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await asyncio.sleep(0)
+
+        warning.assert_not_called()
+        assert not a2a_service._a2a_invalidation_tasks
+
+    async def test_closes_coroutine_when_task_creation_fails(self, monkeypatch):
+        """A create_task failure closes the already-created coroutine."""
+        # First-Party
+        from mcpgateway.services import a2a_service  # noqa: PLC0415
+
+        created_coroutines = []
+
+        async def publish():
+            return None
+
+        def make_publish_coroutine(*_args, **_kwargs):
+            coroutine = publish()
+            created_coroutines.append(coroutine)
+            return coroutine
+
+        loop = MagicMock()
+        loop.create_task.side_effect = RuntimeError("loop is closing")
+        monkeypatch.setattr(a2a_service, "_publish_a2a_invalidation", make_publish_coroutine)
+        monkeypatch.setattr(a2a_service.asyncio, "get_running_loop", MagicMock(return_value=loop))
+
+        a2a_service._schedule_a2a_invalidation("agent", name="closing-agent")
+
+        assert len(created_coroutines) == 1
+        assert created_coroutines[0].cr_frame is None
+        assert not a2a_service._a2a_invalidation_tasks
+
+    async def test_logs_background_task_exception(self, monkeypatch):
+        """An exception escaping the background coroutine is retrieved and logged."""
+        # First-Party
+        from mcpgateway.services import a2a_service  # noqa: PLC0415
+
+        error = RuntimeError("unexpected publisher failure")
+
+        async def publish(*_args, **_kwargs):
+            raise error
+
+        warning = MagicMock()
+        monkeypatch.setattr(a2a_service, "_publish_a2a_invalidation", publish)
+        monkeypatch.setattr(a2a_service.logger, "warning", warning)
+
+        a2a_service._schedule_a2a_invalidation("agent", name="broken-agent")
+        task = next(iter(a2a_service._a2a_invalidation_tasks))
+        await asyncio.wait({task})
+        await asyncio.sleep(0)
+
+        warning.assert_called_once_with(
+            "A2A cache invalidation task failed: %s",
+            error,
+            exc_info=error,
+        )
+        assert not a2a_service._a2a_invalidation_tasks
+
+
 class TestShadowModeComparison:
     """Unit tests for the observe-only shadow mode block inside invoke_agent.
 
@@ -5206,7 +5307,6 @@ class TestCrossGatewayRoutingCoverage:
         )
 
         assert captured_headers.get("X-Contextforge-UAID-Hop") == "2", f"local-agent outbound must stamp hop+1; headers={captured_headers!r}"
-
 
     async def test_federation_chain_increments_hop_and_rejects_at_max(self, service, mock_db, monkeypatch):
         """Three-hop chain locks in the stamp-N+1 vs reject-at-max


### PR DESCRIPTION
# Bug-fix PR

## Summary

Fixes #5830.

A2A agent registration, update, and deletion now schedule Rust L1 cache invalidation through one supervised helper. The helper keeps a strong task reference until completion, closes the coroutine if task creation fails, cleans up completed or cancelled tasks, and reports unexpected background failures.

## Reproduction Steps

1. Make `loop.create_task()` raise while an A2A invalidation is being scheduled.
2. Observe that the previous code had already created `_publish_a2a_invalidation(...)`, leaving an unawaited coroutine.
3. Let a fire-and-forget task escape with an exception and observe that no retained task reference or explicit exception retrieval existed.

## Root Cause

Each of the three call sites constructed a coroutine inline and discarded the task returned by `create_task()`. A scheduling failure could therefore leak the coroutine, while successful scheduling relied only on the event loop's weak task reference and did not supervise escaped exceptions.

## Fix Description

- Add a single `_schedule_a2a_invalidation()` helper.
- Confirm a running event loop before constructing the publish coroutine.
- Close the coroutine when `create_task()` raises.
- Retain scheduled tasks in a module-level set until their done callback runs.
- Remove completed and cancelled tasks, and log unexpected task exceptions.
- Route registration, update, and deletion through the helper.
- Add focused tests for retention, normal cleanup, cancellation, scheduling failure, and exception logging.

## Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked separately
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

AI assistance was used for codebase analysis and test scaffolding. I reviewed the implementation, diff, and validation results.

## Verification

| Check | Command | Status |
|---|---|---|
| Focused scheduler tests | `uv run pytest -q tests/unit/mcpgateway/services/test_a2a_service.py -k TestScheduleA2AInvalidation` | 4 passed |
| A2A service suite | `uv run pytest -q tests/unit/mcpgateway/services/test_a2a_service.py` | 264 passed |
| Ruff | `make ruff RUFF_MODE=check TARGET='mcpgateway/services/a2a_service.py tests/unit/mcpgateway/services/test_a2a_service.py'` | passed |
| Pylint | `make pylint TARGET='mcpgateway/services/a2a_service.py'` | 10.00/10 |
| Diff coverage | `uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=100` | 100% |
| Secret scan | IBM `detect-secrets` scan on both changed files | no findings |
| Full test suite | `make test` | 20,780 passed, 798 skipped, 2 xfailed; 67 unrelated Windows/POSIX/browser/Docker-environment failures |

The focused regression is fully covered. Docker, PostgreSQL, Redis, and UI manual checks were not run because this change only supervises the existing best-effort coroutine scheduling path and does not alter persistence, transport, protocol, or UI behavior.

## MCP Compliance

- [x] No MCP protocol behavior changes
- [x] No breaking change to MCP clients

## Checklist

- [x] Changed files pass Ruff
- [x] No secrets or credentials committed