### PR TITLE
fix: populate global_context.tenant_id from JWT teams in MCP transport

### DIFF
--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -333,8 +333,8 @@ server_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("server_id",
 # here for backwards-compat: external callers that already do
 # `from mcpgateway.transports.streamablehttp_transport import request_headers_var`
 # keep working.
+from cpex.framework import GlobalContext  # noqa: E402  # pylint: disable=wrong-import-order,wrong-import-position
 from mcpgateway.transports.context import request_headers_var, user_context_var, user_identity_var  # noqa: E402  # pylint: disable=wrong-import-position
-from cpex.framework import GlobalContext  # noqa: E402  # pylint: disable=wrong-import-position
 
 _oauth_checked_var: contextvars.ContextVar[bool] = contextvars.ContextVar("_oauth_checked", default=False)
 

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -334,6 +334,7 @@ server_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("server_id",
 # `from mcpgateway.transports.streamablehttp_transport import request_headers_var`
 # keep working.
 from mcpgateway.transports.context import request_headers_var, user_context_var, user_identity_var  # noqa: E402  # pylint: disable=wrong-import-position
+from cpex.framework import GlobalContext  # noqa: E402  # pylint: disable=wrong-import-position
 
 _oauth_checked_var: contextvars.ContextVar[bool] = contextvars.ContextVar("_oauth_checked", default=False)
 
@@ -1916,6 +1917,24 @@ async def call_tool(
 
     try:
         async with get_db() as db:
+            # Build global context from authenticated user context (mirrors
+            # http_auth_middleware.py + auth._propagate_tenant_id() for MCP path)
+            plugin_ctx: Optional[GlobalContext] = None
+            user_ctx = user_context_var.get()
+            if user_ctx and isinstance(user_ctx, dict):
+                user_tenant_id: Optional[str] = None
+                user_teams = user_ctx.get("teams")
+                if isinstance(user_teams, list) and len(user_teams) == 1:
+                    tid = user_teams[0]
+                    if isinstance(tid, str):
+                        user_tenant_id = tid
+                plugin_ctx = GlobalContext(
+                    request_id=uuid.uuid4().hex,
+                    server_id=server_id,
+                    tenant_id=user_tenant_id,
+                    user=app_user_email,
+                )
+
             # Use tool service for all tool invocations (handles direct_proxy internally)
             result = await tool_service.invoke_tool(
                 db=db,
@@ -1928,6 +1947,7 @@ async def call_tool(
                 server_id=server_id,
                 meta_data=meta_data,
                 require_model_visible=True,
+                plugin_global_context=plugin_ctx,
             )
             if not result or not result.content:
                 logger.warning("No content returned by tool: %s", name)

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -1929,7 +1929,7 @@ async def call_tool(
                     if isinstance(tid, str):
                         user_tenant_id = tid
                 plugin_ctx = GlobalContext(
-                    request_id=uuid.uuid4().hex,
+                    request_id=uuid4().hex,
                     server_id=server_id,
                     tenant_id=user_tenant_id,
                     user=app_user_email,

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -334,7 +334,7 @@ server_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("server_id",
 # `from mcpgateway.transports.streamablehttp_transport import request_headers_var`
 # keep working.
 from cpex.framework import GlobalContext  # noqa: E402  # pylint: disable=wrong-import-order,wrong-import-position
-from mcpgateway.transports.context import request_headers_var, user_context_var, user_identity_var  # noqa: E402  # pylint: disable=wrong-import-position
+from mcpgateway.transports.context import request_headers_var, user_context_var, user_identity_var  # noqa: E402  # pylint: disable=ungrouped-imports,wrong-import-position
 
 _oauth_checked_var: contextvars.ContextVar[bool] = contextvars.ContextVar("_oauth_checked", default=False)
 


### PR DESCRIPTION
Closes #5915

## Problem

The MCP transport path (streamable HTTP) did not populate `global_context.tenant_id` before calling `invoke_tool()`, causing tenant_id to fall back to the tool's owning team rather than the authenticated user's JWT team. This broke per-tool metering at the tenant level for CLI/API clients using MCP transport.

## Root Cause

`invoke_tool()` in `mcpgateway/transports/streamablehttp_transport.py` accepted an optional `plugin_global_context` parameter but never constructed one, so `GlobalContext.tenant_id` was always `None`. The REST API path had the same logic in `_propagate_tenant_id()` but only worked for HTTP endpoints.

## Solution

Before calling `invoke_tool()`, build a `GlobalContext` with `tenant_id` derived from the user's JWT `teams` claim (via `user_context_var`) — mirrors what `auth._propagate_tenant_id()` does for the REST API.

## Implementation Details

- `streamablehttp_transport.py:1918-1950`: Added import and GlobalContext construction with tenant_id from user_context_var (single-team case matching existing upstream auth patterns)

## Testing

- 540 existing `test_streamablehttp_transport.py` tests pass — the new path is exercised by `call_tool` tests with authenticated user contexts