### PR TITLE
fix(resources): show specific message for duplicate resource URI conflicts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-28T09:39:25Z",
+  "generated_at": "2026-07-28T12:35:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1086,7 +1086,7 @@
         "hashed_secret": "e204d28a2874f6123747650d3e4003d4357d75eb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 861,
+        "line_number": 884,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1094,7 +1094,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1156,
+        "line_number": 1179,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1842,7 +1842,7 @@
         "hashed_secret": "848f72afea73993a89ad3dcd66fc152f04f2be41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 999,
+        "line_number": 1028,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1850,7 +1850,7 @@
         "hashed_secret": "5193dda17da630c041fe949c06e7b6dd5ac8628f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1276,
+        "line_number": 1305,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1858,7 +1858,7 @@
         "hashed_secret": "91174c4e6859da80df4e7ce9d45b35501f591210",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1559,
+        "line_number": 1588,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1866,7 +1866,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1600,
+        "line_number": 1629,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3892,7 +3892,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14902,
+        "line_number": 14909,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4658,7 +4658,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7157,
+        "line_number": 7266,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/architecture/multitenancy.md
+++ b/docs/docs/architecture/multitenancy.md
@@ -315,6 +315,29 @@ Enforcement summary:
 - Public-only tokens (token_teams=[]) see only public resources — owner and team access are both suppressed.
 - Read follows the same rules as list; write operations require ownership or delegated/team administrative rights.
 
+### Resource URI uniqueness
+
+Applies to the **Resources** entity specifically, not to the other entity types listed above. Per the MCP specification, `uri` is the resource identifier and `name` is a human-readable display label — so URIs are constrained and **names are deliberately not unique** (a name-uniqueness constraint was added in [#5158](https://github.com/IBM/mcp-context-forge/pull/5158) and reverted in [#5664](https://github.com/IBM/mcp-context-forge/pull/5664) because it broke legitimate task-scoped resources sharing a type name).
+
+Uniqueness is enforced at two levels, and they are not identical:
+
+**Database (`mcpgateway/db.py`, `Resource.__table_args__`)** — visibility is *not* part of any key:
+
+| Constraint | Key | Applies when |
+|---|---|---|
+| `uq_team_owner_gateway_uri_resource` | `(team_id, owner_email, gateway_id, uri)` | Always |
+| `uq_team_owner_uri_resource_local` (partial unique index) | `(team_id, owner_email, uri)` | `gateway_id IS NULL` |
+
+**Application pre-check (`mcpgateway/services/resource_service.py`)** — runs before the insert so a collision surfaces as a `409` with a specific message rather than a raw `IntegrityError`. This check *is* visibility-dependent and is narrower or wider than the DB key depending on visibility:
+
+| Visibility | Pre-check key on create |
+|---|---|
+| `public` | `(uri, visibility, gateway_id)` — collides across teams and owners |
+| `team` | `(uri, visibility, team_id, gateway_id)` |
+| `private` | `(uri, visibility, owner_email, team_id, gateway_id)` |
+
+On update the `public` and `team` branches match on `(uri, visibility[, team_id])` without `gateway_id`; only the `private` branch includes it. Anything the pre-check misses is still caught by the database constraints above and reported as `409` via `ErrorFormatter.format_database_error`.
+
 ---
 
 ## Token Scoping Model

--- a/docs/docs/manage/api-usage.md
+++ b/docs/docs/manage/api-usage.md
@@ -902,6 +902,25 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
   $BASE_URL/resources | jq '.'
 ```
 
+!!! note "Resource URI uniqueness"
+    `uri` is the resource identifier and must be unique within the scope the resource is created in; `name` is a human-readable display label and **may repeat**. Registering a resource whose URI already exists in that scope returns `409 Conflict`. The scope depends on `visibility` — see [Resource URI uniqueness](../architecture/multitenancy.md#resource-uri-uniqueness) for the exact keys.
+
+**Error responses:**
+
+| Status | Condition |
+|--------|-----------|
+| `409 Conflict` | A resource with this URI already exists in the target scope. |
+| `422 Unprocessable Entity` | Payload failed schema or resource validation. |
+| `400 Bad Request` | Other resource errors (for example, `visibility=team` without a `team_id`). |
+
+`409` bodies use the standard FastAPI shape:
+
+```json
+{
+  "detail": "Public resource already exists with URI: file:///etc/config.json — resource URIs must be unique within this scope (names may repeat)."
+}
+```
+
 ### Get Resource Details
 
 ```bash
@@ -957,6 +976,16 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
   }' \
   $BASE_URL/resources/$RESOURCE_ID | jq '.'
 ```
+
+**Error responses:**
+
+| Status | Condition |
+|--------|-----------|
+| `409 Conflict` | The new `uri` collides with an existing resource in the target scope, or a database uniqueness constraint was violated. |
+| `422 Unprocessable Entity` | Payload failed schema or resource validation. |
+| `413 Payload Too Large` | Resource content exceeded the configured size limit. |
+| `415 Unsupported Media Type` | MIME type is not in the allowed list. |
+| `400 Bad Request` | Other resource errors, including a concurrent-update lock conflict. |
 
 ### Enable/Disable Resource
 
@@ -1729,6 +1758,16 @@ echo "=== E2E Test Complete ==="
 ```
 
 **Solution**: Verify the resource ID exists using the list endpoint.
+
+#### 409 Conflict
+
+```json
+{
+  "detail": "Public resource already exists with URI: file:///etc/config.json — resource URIs must be unique within this scope (names may repeat)."
+}
+```
+
+**Solution**: The identifier already exists in the scope you are writing to. For resources the identifier is `uri` (not `name` — names may repeat); for gateways it is the URL or name. Choose a different identifier, or update the existing record instead of creating a new one.
 
 #### 422 Validation Error
 

--- a/mcpgateway/admin_ui/formSubmitHandlers.js
+++ b/mcpgateway/admin_ui/formSubmitHandlers.js
@@ -1,5 +1,6 @@
 import { HEADER_NAME_REGEX } from "./constants";
 import { generateSchema } from "./formFieldHandlers";
+import { FIELD_ERROR_CLASSES } from "./formValidation";
 import { navigateAdmin } from "./navigation";
 import {
   safeParseJsonResponse,
@@ -151,6 +152,73 @@ export const handleGatewayFormSubmit = async function (e) {
   }
 };
 
+/**
+ * Detect whether a server error message describes a resource URI-uniqueness
+ * conflict. Both backend messages ("A resource with this URI already exists
+ * in this scope…" and "<Visibility> Resource already exists with URI: …")
+ * mention the URI and the fact that it already exists, so match on that pair
+ * rather than pinning either exact string. ``uri`` is matched on a word
+ * boundary so unrelated messages containing it as a substring (e.g. "during")
+ * do not trip the check.
+ *
+ * @param {string} message - Human-readable server error message
+ * @returns {boolean}
+ */
+function isUriConflictMessage(message) {
+  if (typeof message !== "string") {
+    return false;
+  }
+  return /\buri\b/i.test(message) && /already exists/i.test(message);
+}
+
+/**
+ * Attribute a server error to a specific form field: show the inline
+ * ``p[data-error-message-for="<field>"]`` message, ring the input in red and
+ * focus it. No-ops for fields that do not declare an inline error element.
+ *
+ * @param {HTMLFormElement} form - Form containing the inline error element
+ * @param {string} field - ``data-error-message-for`` value (e.g. "uri")
+ * @param {string} inputId - id of the input to highlight and focus
+ * @param {string} message - Message to render inline
+ */
+function showFieldError(form, field, inputId, message) {
+  const errorElement = form?.querySelector(
+    `p[data-error-message-for="${field}"]`
+  );
+  if (errorElement) {
+    errorElement.textContent = message;
+    errorElement.classList.remove("invisible");
+  }
+  const input = safeGetElement(inputId);
+  if (input) {
+    input.classList.add(...FIELD_ERROR_CLASSES);
+    input.focus();
+  }
+}
+
+/**
+ * Inverse of {@link showFieldError}. Needed because ``modals.js`` only resets
+ * inline field errors for forms inside a modal, and the add-resource panel is
+ * an inline page section - without this a stale conflict message would survive
+ * a resubmit that fails for an unrelated reason.
+ *
+ * @param {HTMLFormElement} form - Form containing the inline error element
+ * @param {string} field - ``data-error-message-for`` value (e.g. "uri")
+ * @param {string} inputId - id of the highlighted input
+ */
+function clearFieldError(form, field, inputId) {
+  const errorElement = form?.querySelector(
+    `p[data-error-message-for="${field}"]`
+  );
+  if (errorElement) {
+    errorElement.classList.add("invisible");
+  }
+  const input = safeGetElement(inputId);
+  if (input) {
+    input.classList.remove(...FIELD_ERROR_CLASSES);
+  }
+}
+
 export const handleResourceFormSubmit = async function (e) {
   e.preventDefault();
   const form = e.target;
@@ -189,6 +257,7 @@ export const handleResourceFormSubmit = async function (e) {
       status.textContent = "";
       status.classList.remove("error-status");
     }
+    clearFieldError(form, "uri", "resource-uri");
 
     const isInactiveCheckedBool = isInactiveChecked("resources");
     formData.append("is_inactive_checked", isInactiveCheckedBool);
@@ -223,6 +292,12 @@ export const handleResourceFormSubmit = async function (e) {
     if (status) {
       status.textContent = error.message || "An error occurred!";
       status.classList.add("error-status");
+    }
+    // A duplicate URI is the one server-side conflict the user can act on, and
+    // it is easy to mistake for a duplicate *name* (names may legitimately
+    // repeat), so point at the offending field in addition to banner + toast.
+    if (isUriConflictMessage(error.message)) {
+      showFieldError(form, "uri", "resource-uri", error.message);
     }
     showErrorMessage(error.message);
   } finally {

--- a/mcpgateway/admin_ui/formSubmitHandlers.js
+++ b/mcpgateway/admin_ui/formSubmitHandlers.js
@@ -155,7 +155,7 @@ export const handleGatewayFormSubmit = async function (e) {
 /**
  * Detect whether a server error message describes a resource URI-uniqueness
  * conflict. Both backend messages ("A resource with this URI already exists
- * in this scope…" and "<Visibility> Resource already exists with URI: …")
+ * in this scope…" and "<Visibility> resource already exists with URI: …")
  * mention the URI and the fact that it already exists, so match on that pair
  * rather than pinning either exact string. ``uri`` is matched on a word
  * boundary so unrelated messages containing it as a substring (e.g. "during")

--- a/mcpgateway/admin_ui/formValidation.js
+++ b/mcpgateway/admin_ui/formValidation.js
@@ -4,6 +4,23 @@
 
 import { validateInputName, validateUrl } from "./security.js";
 
+/**
+ * Tailwind utility classes applied to an input to signal a field-level error.
+ *
+ * Shared so that client-side validation and server-side error attribution
+ * (formSubmitHandlers.js) render identically. ``modals.js`` clears this exact
+ * set when resetting a form *inside a modal*; forms rendered inline on a page
+ * must clear it themselves.
+ *
+ * @type {ReadonlyArray<string>}
+ */
+export const FIELD_ERROR_CLASSES = [
+  "border-red-500",
+  "focus:ring-red-500",
+  "dark:border-red-500",
+  "dark:ring-red-500",
+];
+
 export const setupFormValidation = function () {
   // Add validation to all forms on the page
   const forms = document.querySelectorAll("form");
@@ -39,12 +56,7 @@ export const setupFormValidation = function () {
         );
         if (!validation.valid) {
           this.setCustomValidity(validation.error);
-          this.classList.add(
-            "border-red-500",
-            "focus:ring-red-500",
-            "dark:border-red-500",
-            "dark:ring-red-500",
-          );
+          this.classList.add(...FIELD_ERROR_CLASSES);
           if (errorMessageElement) {
             errorMessageElement.innerText = validation.error;
             errorMessageElement.classList.remove("invisible");
@@ -52,12 +64,7 @@ export const setupFormValidation = function () {
         } else {
           this.setCustomValidity("");
           this.value = validation.value;
-          this.classList.remove(
-            "border-red-500",
-            "focus:ring-red-500",
-            "dark:border-red-500",
-            "dark:ring-red-500",
-          );
+          this.classList.remove(...FIELD_ERROR_CLASSES);
           if (errorMessageElement) {
             errorMessageElement.classList.add("invisible");
           }
@@ -74,12 +81,7 @@ export const setupFormValidation = function () {
         // Skip validation for empty optional URL fields
         if (!this.value && !this.required) {
           this.setCustomValidity("");
-          this.classList.remove(
-            "border-red-500",
-            "focus:ring-red-500",
-            "dark:border-red-500",
-            "dark:ring-red-500",
-          );
+          this.classList.remove(...FIELD_ERROR_CLASSES);
           const errorMessageElement = this.parentNode?.querySelector(
             'p[data-error-message-for="url"]',
           );
@@ -101,12 +103,7 @@ export const setupFormValidation = function () {
         );
         if (!validation.valid) {
           this.setCustomValidity(validation.error);
-          this.classList.add(
-            "border-red-500",
-            "focus:ring-red-500",
-            "dark:border-red-500",
-            "dark:ring-red-500",
-          );
+          this.classList.add(...FIELD_ERROR_CLASSES);
           if (errorMessageElement) {
             errorMessageElement.innerText = validation.error;
             errorMessageElement.classList.remove("invisible");
@@ -114,12 +111,7 @@ export const setupFormValidation = function () {
         } else {
           this.setCustomValidity("");
           this.value = validation.value;
-          this.classList.remove(
-            "border-red-500",
-            "focus:ring-red-500",
-            "dark:border-red-500",
-            "dark:ring-red-500",
-          );
+          this.classList.remove(...FIELD_ERROR_CLASSES);
           if (errorMessageElement) {
             errorMessageElement.classList.add("invisible");
           }

--- a/mcpgateway/admin_ui/security.js
+++ b/mcpgateway/admin_ui/security.js
@@ -51,7 +51,11 @@ export function escapeAttrValue(value) {
 
 /**
  * Extract a human-readable error message from an API error response.
- * Handles both string errors and Pydantic validation error arrays.
+ * Handles string errors, Pydantic validation error arrays, and nested error
+ * objects (FastAPI serialises ``HTTPException(detail={...})`` as
+ * ``{"detail": {"message": "...", "success": false}}``).
+ * Precedence: ``message`` -> string ``detail`` -> array ``detail`` ->
+ * object ``detail`` -> ``fallback``.
  * @param {Object} error - The parsed JSON error response
  * @param {string} fallback - Fallback message if no detail found
  * @returns {string} Human-readable error message
@@ -69,6 +73,14 @@ export function extractApiError(error, fallback = "An error occurred") {
   if (Array.isArray(error.detail)) {
     // Pydantic validation errors - extract messages
     return error.detail.map((err) => err.msg || JSON.stringify(err)).join("; ");
+  }
+  if (
+    error.detail &&
+    typeof error.detail === "object" &&
+    !Array.isArray(error.detail)
+  ) {
+    // Nested detail object, e.g. ErrorFormatter output wrapped by HTTPException
+    return error.detail.message || error.detail.error || fallback;
   }
   return fallback;
 }

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -6639,6 +6639,10 @@ async def update_resource(
         raise HTTPException(status_code=409, detail=ErrorFormatter.format_database_error(e))
     except ResourceURIConflictError as e:
         raise HTTPException(status_code=409, detail=str(e))
+    except ResourceValidationError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    except ResourceError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except ContentSizeError as e:
         logger.error(f"Content size exceeded in updating resource: {e}")
         raise HTTPException(status_code=413, detail={"error": f"{e.content_type} size limit exceeded", "message": str(e), "actual_size": e.actual_size, "max_size": e.max_size})

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -168,7 +168,7 @@ class ResourceURIConflictError(ResourceError):
         self.uri = uri
         self.enabled = enabled
         self.resource_id = resource_id
-        message = f"{visibility.capitalize()} Resource already exists with URI: {uri} — resource URIs must be unique within this scope (names may repeat)."
+        message = f"{visibility.capitalize()} resource already exists with URI: {uri} — resource URIs must be unique within this scope (names may repeat)."
         if not enabled:
             message += f" (currently inactive, ID: {resource_id})"
         super().__init__(message)

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -168,7 +168,7 @@ class ResourceURIConflictError(ResourceError):
         self.uri = uri
         self.enabled = enabled
         self.resource_id = resource_id
-        message = f"{visibility.capitalize()} Resource already exists with URI: {uri}"
+        message = f"{visibility.capitalize()} Resource already exists with URI: {uri} — resource URIs must be unique within this scope (names may repeat)."
         if not enabled:
             message += f" (currently inactive, ID: {resource_id})"
         super().__init__(message)
@@ -559,11 +559,27 @@ class ResourceService(BaseService):
                 if existing_resource:
                     raise ResourceURIConflictError(resource.uri, enabled=existing_resource.enabled, resource_id=existing_resource.id, visibility=existing_resource.visibility)
             elif visibility.lower() == "team":
-                # team_id is guaranteed non-None here: the name-check above already raised
-                # ResourceValidationError for team visibility without a team_id.
+                # team_id is guaranteed non-None here: a ResourceValidationError is raised above for
+                # team visibility without a team_id.
                 # Check for existing team resource with the same uri and gateway_id
                 existing_resource = db.execute(
                     select(DbResource).where(DbResource.uri == resource.uri, DbResource.visibility == "team", DbResource.team_id == team_id, DbResource.gateway_id == gateway_id)
+                ).scalar_one_or_none()
+                if existing_resource:
+                    raise ResourceURIConflictError(resource.uri, enabled=existing_resource.enabled, resource_id=existing_resource.id, visibility=existing_resource.visibility)
+            elif visibility.lower() == "private":
+                # Scope the check to the DB constraint UniqueConstraint("team_id", "owner_email", "gateway_id", "uri"),
+                # mirroring the team_id/owner_email precedence used when DbResource is constructed below.
+                effective_team_id = getattr(resource, "team_id", None) or team_id
+                effective_owner = getattr(resource, "owner_email", None) or owner_email or created_by
+                existing_resource = db.execute(
+                    select(DbResource).where(
+                        DbResource.uri == resource.uri,
+                        DbResource.visibility == "private",
+                        DbResource.owner_email == effective_owner,
+                        DbResource.team_id == effective_team_id,
+                        DbResource.gateway_id == gateway_id,
+                    )
                 ).scalar_one_or_none()
                 if existing_resource:
                     raise ResourceURIConflictError(resource.uri, enabled=existing_resource.enabled, resource_id=existing_resource.id, visibility=existing_resource.visibility)
@@ -3134,6 +3150,23 @@ class ResourceService(BaseService):
                     # Check for existing team resource with the same uri
                     existing_resource = get_for_update(
                         db, DbResource, where=and_(DbResource.uri == resource_update.uri, DbResource.visibility == "team", DbResource.team_id == team_id, DbResource.id != resource_id)
+                    )
+                    if existing_resource:
+                        raise ResourceURIConflictError(resource_update.uri, enabled=existing_resource.enabled, resource_id=existing_resource.id, visibility=existing_resource.visibility)
+                elif visibility.lower() == "private":
+                    # Scope the check to the DB constraint UniqueConstraint("team_id", "owner_email", "gateway_id", "uri").
+                    effective_owner = resource_update.owner_email or resource.owner_email
+                    existing_resource = get_for_update(
+                        db,
+                        DbResource,
+                        where=and_(
+                            DbResource.uri == resource_update.uri,
+                            DbResource.visibility == "private",
+                            DbResource.owner_email == effective_owner,
+                            DbResource.team_id == team_id,
+                            DbResource.gateway_id == resource.gateway_id,
+                            DbResource.id != resource_id,
+                        ),
                     )
                     if existing_resource:
                         raise ResourceURIConflictError(resource_update.uri, enabled=existing_resource.enabled, resource_id=existing_resource.id, visibility=existing_resource.visibility)

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -4294,9 +4294,10 @@
           </h3>
           <form method="POST" id="add-resource-form">
             <div class="grid grid-cols-1 gap-7">
-              <div>
+              <div class="relative">
                 <label
                   class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                  for="resource-uri"
                   >URI</label
                 >
                 <input
@@ -4306,6 +4307,7 @@
                   required
                   class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                 />
+                <p data-error-message-for="uri" class="absolute top-full left-0 mt-1 text-xs text-red-500 invisible">URI is required.</p>
               </div>
               <div class="relative">
                 <label
@@ -4318,8 +4320,13 @@
                   name="name"
                   required
                   id="resource-name"
+                  aria-describedby="resource-name-helper"
                   class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                 />
+                <p id="resource-name-helper" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  Display label &mdash; does not need to be unique. The URI
+                  identifies the resource.
+                </p>
                 <p data-error-message-for="name" class="absolute top-full left-0 mt-1 text-xs text-red-500 invisible">Name is required.</p>
               </div>
               <div>

--- a/mcpgateway/utils/error_formatter.py
+++ b/mcpgateway/utils/error_formatter.py
@@ -190,11 +190,17 @@ class ErrorFormatter:
             >>> result['message']
             'A tool with this name already exists'
 
-            >>> # Test UNIQUE constraint on resource URI
+            >>> # Test UNIQUE constraint on resource URI (SQLite)
             >>> mock_error.orig.__str__ = lambda self: "UNIQUE constraint failed: resources.uri"
             >>> result = ErrorFormatter.format_database_error(mock_error)
             >>> result['message']
-            'A resource with this URI already exists'
+            'A resource with this URI already exists in this scope. Resource URIs must be unique; names may repeat.'
+
+            >>> # Test unique constraint on resource URI (PostgreSQL reports the constraint name)
+            >>> mock_error.orig.__str__ = lambda self: 'duplicate key value violates unique constraint "uq_team_owner_gateway_uri_resource"'
+            >>> result = ErrorFormatter.format_database_error(mock_error)
+            >>> result['message']
+            'A resource with this URI already exists in this scope. Resource URIs must be unique; names may repeat.'
 
             >>> # Test UNIQUE constraint on server name
             >>> mock_error.orig.__str__ = lambda self: "UNIQUE constraint failed: servers.name"
@@ -260,9 +266,12 @@ class ErrorFormatter:
                     "message": detail,
                     "success": False,
                 }
-            # PostgreSQL reports constraint names; SQLite reports column paths.
-            if "uq_team_owner_gateway_name_resource" in error_str or "uq_team_owner_name_resource_local" in error_str:
-                return {"message": "A resource with this name already exists", "success": False}
+            # Resource URI uniqueness: check before the generic UNIQUE handler so the specific message
+            # takes priority. PostgreSQL reports the constraint name ("duplicate key value violates
+            # unique constraint \"...\""), which matches none of the SQLite-shaped column-path patterns
+            # below. Only the URI is unique -- resource names are display labels and may repeat.
+            if "uq_team_owner_gateway_uri_resource" in error_str or "uq_team_owner_uri_resource_local" in error_str:
+                return {"message": "A resource with this URI already exists in this scope. Resource URIs must be unique; names may repeat.", "success": False}
             if "UNIQUE constraint failed" in error_str:
                 if "gateways.url" in error_str:
                     return {"message": "A gateway with this URL already exists", "success": False}
@@ -271,9 +280,7 @@ class ErrorFormatter:
                 elif "tools.name" in error_str:
                     return {"message": "A tool with this name already exists", "success": False}
                 elif "resources.uri" in error_str:
-                    return {"message": "A resource with this URI already exists", "success": False}
-                elif "resources.name" in error_str:
-                    return {"message": "A resource with this name already exists", "success": False}
+                    return {"message": "A resource with this URI already exists in this scope. Resource URIs must be unique; names may repeat.", "success": False}
                 elif "servers.name" in error_str:
                     return {"message": "A server with this name already exists", "success": False}
                 elif "prompts.name" in error_str:

--- a/tests/unit/js/formSubmitHandlers.test.js
+++ b/tests/unit/js/formSubmitHandlers.test.js
@@ -218,6 +218,112 @@ describe("handleResourceFormSubmit", () => {
 
     expect(globalThis.fetch).toHaveBeenCalled();
   });
+
+  // Issue #4991: a duplicate URI must be attributed to the URI field instead of
+  // only surfacing as a generic banner/toast message.
+  test("attributes a 409 URI conflict to the URI field", async () => {
+    const event = createFormEvent(`
+      <form>
+        <input name="name" value="TestResource" />
+        <div class="relative">
+          <input name="uri" id="resource-uri" value="resource://test" />
+          <p data-error-message-for="uri" class="absolute top-full left-0 mt-1 text-xs text-red-500 invisible">URI is required.</p>
+        </div>
+        <input name="visibility" value="public" />
+      </form>
+      <div id="status-resources"></div>
+      <div id="add-resource-loading" style="display:none"></div>
+    `);
+
+    const conflictMessage =
+      "Public Resource already exists with URI: resource://test — resource URIs must be unique within this scope (names may repeat).";
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: false, status: 409 });
+    // safeParseJsonResponse throws for non-OK responses (see security.js).
+    safeParseJsonResponse.mockRejectedValue(new Error(conflictMessage));
+
+    await handleResourceFormSubmit(event);
+
+    const inlineError = document.querySelector(
+      'p[data-error-message-for="uri"]'
+    );
+    expect(inlineError.classList.contains("invisible")).toBe(false);
+    expect(inlineError.textContent).toBe(conflictMessage);
+
+    const uriInput = document.getElementById("resource-uri");
+    expect(uriInput.classList.contains("border-red-500")).toBe(true);
+    expect(uriInput.classList.contains("focus:ring-red-500")).toBe(true);
+    expect(document.activeElement).toBe(uriInput);
+
+    // Existing banner + toast behaviour is preserved.
+    expect(document.getElementById("status-resources").textContent).toBe(
+      conflictMessage
+    );
+    expect(showErrorMessage).toHaveBeenCalledWith(conflictMessage);
+  });
+
+  test("leaves the URI field untouched for non-conflict errors", async () => {
+    const event = createFormEvent(`
+      <form>
+        <input name="name" value="TestResource" />
+        <div class="relative">
+          <input name="uri" id="resource-uri" value="resource://test" />
+          <p data-error-message-for="uri" class="absolute top-full left-0 mt-1 text-xs text-red-500 invisible">URI is required.</p>
+        </div>
+        <input name="visibility" value="public" />
+      </form>
+      <div id="status-resources"></div>
+      <div id="add-resource-loading" style="display:none"></div>
+    `);
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: false, status: 500 });
+    safeParseJsonResponse.mockRejectedValue(new Error("Internal Server Error"));
+
+    await handleResourceFormSubmit(event);
+
+    const inlineError = document.querySelector(
+      'p[data-error-message-for="uri"]'
+    );
+    expect(inlineError.classList.contains("invisible")).toBe(true);
+    expect(
+      document
+        .getElementById("resource-uri")
+        .classList.contains("border-red-500")
+    ).toBe(false);
+    expect(showErrorMessage).toHaveBeenCalledWith("Internal Server Error");
+  });
+
+  test("clears a stale URI conflict error on resubmit", async () => {
+    // The add-resource panel is not inside a modal, so modals.js does not reset
+    // it - the handler must clear the previous conflict itself.
+    const event = createFormEvent(`
+      <form>
+        <input name="name" value="TestResource" />
+        <div class="relative">
+          <input name="uri" id="resource-uri" class="border-red-500 focus:ring-red-500" value="resource://other" />
+          <p data-error-message-for="uri" class="absolute top-full left-0 mt-1 text-xs text-red-500">Resource already exists with URI: resource://test</p>
+        </div>
+        <input name="visibility" value="public" />
+      </form>
+      <div id="status-resources"></div>
+      <div id="add-resource-loading" style="display:none"></div>
+    `);
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: false, status: 500 });
+    safeParseJsonResponse.mockRejectedValue(new Error("Internal Server Error"));
+
+    await handleResourceFormSubmit(event);
+
+    const inlineError = document.querySelector(
+      'p[data-error-message-for="uri"]'
+    );
+    expect(inlineError.classList.contains("invisible")).toBe(true);
+    expect(
+      document
+        .getElementById("resource-uri")
+        .classList.contains("border-red-500")
+    ).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/js/formSubmitHandlers.test.js
+++ b/tests/unit/js/formSubmitHandlers.test.js
@@ -236,7 +236,7 @@ describe("handleResourceFormSubmit", () => {
     `);
 
     const conflictMessage =
-      "Public Resource already exists with URI: resource://test — resource URIs must be unique within this scope (names may repeat).";
+      "Public resource already exists with URI: resource://test — resource URIs must be unique within this scope (names may repeat).";
 
     vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: false, status: 409 });
     // safeParseJsonResponse throws for non-OK responses (see security.js).

--- a/tests/unit/js/security.test.js
+++ b/tests/unit/js/security.test.js
@@ -165,6 +165,54 @@ describe("extractApiError", () => {
   test("uses custom fallback", () => {
     expect(extractApiError({}, "Custom fallback")).toBe("Custom fallback");
   });
+
+  // Nested `detail` object: FastAPI serialises HTTPException(detail={...})
+  // as {"detail": {"message": "...", "success": false}} (issue #4991).
+  test("returns message from nested detail object", () => {
+    const error = {
+      detail: {
+        message:
+          "A resource with this URI already exists in this scope. Resource URIs must be unique; names may repeat.",
+        success: false,
+      },
+    };
+    expect(extractApiError(error, "Failed to add Resource (HTTP 409)")).toBe(
+      "A resource with this URI already exists in this scope. Resource URIs must be unique; names may repeat."
+    );
+  });
+
+  test("returns error from nested detail object when message is absent", () => {
+    const error = { detail: { error: "Conflict detected" } };
+    expect(extractApiError(error, "Oops")).toBe("Conflict detected");
+  });
+
+  test("prefers message over error in nested detail object", () => {
+    const error = { detail: { message: "message wins", error: "error loses" } };
+    expect(extractApiError(error)).toBe("message wins");
+  });
+
+  test("returns fallback for empty nested detail object", () => {
+    // `{}` is falsy for the top-level guard's purposes only when both detail
+    // and message are absent, so this exercises the new branch's fallback.
+    expect(extractApiError({ detail: {} }, "Oops")).toBe("Oops");
+  });
+
+  test("returns fallback for nested detail object without message or error", () => {
+    expect(extractApiError({ detail: { success: false } }, "Oops")).toBe(
+      "Oops"
+    );
+  });
+
+  test("nested detail object does not shadow top-level message", () => {
+    const error = { message: "top wins", detail: { message: "nested loses" } };
+    expect(extractApiError(error)).toBe("top wins");
+  });
+
+  test("nested detail branch does not regress array detail handling", () => {
+    // Arrays are objects too - the array branch must still win.
+    const error = { detail: [{ msg: "field required" }] };
+    expect(extractApiError(error, "Oops")).toBe("field required");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -313,7 +313,7 @@ class TestResourceRegistration:
         with pytest.raises(ResourceURIConflictError) as exc_info:
             await resource_service.register_resource(mock_db, sample_resource_create)
 
-        assert "Public Resource already exists with URI" in str(exc_info.value)
+        assert "Public resource already exists with URI" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_register_resource_uri_conflict_inactive(self, resource_service, mock_db, sample_resource_create, mock_inactive_resource):
@@ -325,7 +325,7 @@ class TestResourceRegistration:
         with pytest.raises(ResourceURIConflictError) as exc_info:
             await resource_service.register_resource(mock_db, sample_resource_create)
 
-        assert "Resource already exists with URI" in str(exc_info.value)
+        assert "resource already exists with URI" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_register_resource_team_without_team_id_raises_validation_error(self, resource_service, mock_db, sample_resource_create):
@@ -5179,7 +5179,7 @@ class TestResourceServiceCoverageEdges:
 
         with pytest.raises(ResourceURIConflictError) as exc_info:
             await resource_service.register_resource(mock_db, sample_resource_create, visibility="team", team_id="team-1")
-        assert "Team Resource already exists with URI" in str(exc_info.value)
+        assert "Team resource already exists with URI" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_register_resources_bulk_unknown_conflict_strategy_does_nothing(self, resource_service, mock_db):
@@ -8706,7 +8706,7 @@ class TestResourceUriUniquenessScope:
             await service.register_resource(db, self._create("file://dup.txt", "Second"), **kwargs)
 
         message = str(exc_info.value)
-        assert "Resource already exists with URI" in message
+        assert "resource already exists with URI" in message
         assert "file://dup.txt" in message
         assert "resource URIs must be unique within this scope (names may repeat)." in message
 

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -2779,6 +2779,8 @@ class TestResourceUrlDetectedMimeTypePriority:
         mock_db.get = MagicMock(return_value=mock_resource)
         mock_db.commit = MagicMock()
         mock_db.refresh = MagicMock()
+        # No competing resource holds the new URI (private visibility is pre-checked too).
+        mock_db.execute.return_value.scalar_one_or_none.return_value = None
 
         # Update with new URI that has .json extension
         update = ResourceUpdate(uri="https://api.example.com/data.json", mime_type="text/html")  # User provides wrong type
@@ -2814,6 +2816,8 @@ class TestResourceUrlDetectedMimeTypePriority:
         mock_db.get = MagicMock(return_value=mock_resource)
         mock_db.commit = MagicMock()
         mock_db.refresh = MagicMock()
+        # No competing resource holds the new URI (private visibility is pre-checked too).
+        mock_db.execute.return_value.scalar_one_or_none.return_value = None
 
         # Update with new URI and empty MIME type
         update = ResourceUpdate(uri="https://example.com/document.pdf", mime_type="")  # Empty string
@@ -8604,3 +8608,153 @@ class TestReadResourceMetaDataValidationIntegration:
             await service.invoke_resource(db, resource_id="res-1", resource_uri="file:///test.txt", meta_data=hidden_depth)
 
         db.execute.assert_not_called()
+
+
+class TestResourceUriUniquenessScope:
+    """URI-scoped uniqueness behaviour (issue #4991).
+
+    Uses a real in-memory SQLite session so the DB constraints
+    ``uq_team_owner_gateway_uri_resource`` / ``uq_team_owner_uri_resource_local``
+    participate in the assertions rather than being mocked away.
+    """
+
+    @pytest.fixture
+    def db(self):
+        """Create a real in-memory SQLite session with the full schema."""
+        # Third-Party
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+        from sqlalchemy.pool import StaticPool
+
+        # First-Party
+        from mcpgateway.db import Base
+
+        engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+        Base.metadata.create_all(bind=engine)
+        session = sessionmaker(bind=engine)()
+        try:
+            yield session
+        finally:
+            session.close()
+            engine.dispose()
+
+    @pytest.fixture
+    def service(self, monkeypatch):
+        """Create a ResourceService with plugins disabled and notifications stubbed out."""
+        monkeypatch.setenv("PLUGINS_ENABLED", "false")
+        svc = ResourceService()
+        monkeypatch.setattr(svc, "_notify_resource_added", AsyncMock())
+        monkeypatch.setattr(svc, "_notify_resource_updated", AsyncMock())
+        return svc
+
+    @staticmethod
+    def _create(uri: str, name: str) -> ResourceCreate:
+        """Build a minimal ResourceCreate.
+
+        Args:
+            uri: Resource URI.
+            name: Resource display name.
+
+        Returns:
+            ResourceCreate: The populated creation schema.
+        """
+        return ResourceCreate(uri=uri, name=name, description="d", mime_type="text/plain", content="content")
+
+    # ------------------------------------------------------------------ #
+    # Regression guard for #5664: names are display labels, not keys.    #
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("visibility", ["public", "team", "private"])
+    async def test_duplicate_name_with_distinct_uri_succeeds(self, service, db, visibility):
+        """Duplicate resource *names* must remain legal as long as the URIs differ.
+
+        This is the #5664 regression guard: PR #5158 added name uniqueness, which
+        violates the MCP spec (``uri`` is the identifier, ``name`` is a display
+        label) and crash-looped a production deployment. Do not reintroduce it.
+        """
+        kwargs = {"visibility": visibility, "created_by": "owner@example.com", "owner_email": "owner@example.com"}
+        if visibility == "team":
+            kwargs["team_id"] = "team-1"
+
+        first = await service.register_resource(db, self._create("file://first.txt", "Shared Label"), **kwargs)
+        second = await service.register_resource(db, self._create("file://second.txt", "Shared Label"), **kwargs)
+
+        assert first.name == second.name == "Shared Label"
+        assert {first.uri, second.uri} == {"file://first.txt", "file://second.txt"}
+
+    @pytest.mark.asyncio
+    async def test_duplicate_name_distinct_uri_survives_db_flush(self, service, db):
+        """The duplicate-name rows must actually persist -- no DB-level name constraint."""
+        await service.register_resource(db, self._create("file://a.txt", "Same Name"), visibility="public")
+        await service.register_resource(db, self._create("file://b.txt", "Same Name"), visibility="public")
+
+        rows = db.query(DbResource).filter(DbResource.name == "Same Name").all()
+        assert len(rows) == 2
+
+    # ------------------------------------------------------------------ #
+    # private visibility duplicate URI -> friendly conflict, not 500     #
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.asyncio
+    async def test_register_private_duplicate_uri_raises_conflict(self, service, db):
+        """A private duplicate URI must raise ResourceURIConflictError, not a raw IntegrityError."""
+        kwargs = {"visibility": "private", "created_by": "owner@example.com", "owner_email": "owner@example.com", "team_id": "team-1"}
+        await service.register_resource(db, self._create("file://dup.txt", "First"), **kwargs)
+
+        with pytest.raises(ResourceURIConflictError) as exc_info:
+            await service.register_resource(db, self._create("file://dup.txt", "Second"), **kwargs)
+
+        message = str(exc_info.value)
+        assert "Resource already exists with URI" in message
+        assert "file://dup.txt" in message
+        assert "resource URIs must be unique within this scope (names may repeat)." in message
+
+    @pytest.mark.asyncio
+    async def test_register_private_same_uri_different_owner_succeeds(self, service, db):
+        """The private pre-check is scoped to (team_id, owner_email, gateway_id, uri)."""
+        await service.register_resource(db, self._create("file://mine.txt", "Mine"), visibility="private", created_by="a@example.com", owner_email="a@example.com")
+        result = await service.register_resource(db, self._create("file://mine.txt", "Mine"), visibility="private", created_by="b@example.com", owner_email="b@example.com")
+
+        assert result.uri == "file://mine.txt"
+
+    @pytest.mark.asyncio
+    async def test_register_private_conflict_reports_inactive_suffix(self, service, db):
+        """The ``(currently inactive, ID: ...)`` suffix must still append after the new wording."""
+        kwargs = {"visibility": "private", "created_by": "owner@example.com", "owner_email": "owner@example.com"}
+        created = await service.register_resource(db, self._create("file://off.txt", "Off"), **kwargs)
+        row = db.query(DbResource).filter(DbResource.id == created.id).one()
+        row.enabled = False
+        db.commit()
+
+        with pytest.raises(ResourceURIConflictError) as exc_info:
+            await service.register_resource(db, self._create("file://off.txt", "Off Again"), **kwargs)
+
+        message = str(exc_info.value)
+        assert "resource URIs must be unique within this scope (names may repeat)." in message
+        assert f"(currently inactive, ID: {created.id})" in message
+
+    @pytest.mark.asyncio
+    async def test_update_private_duplicate_uri_raises_conflict(self, service, db):
+        """update_resource must also pre-check private duplicates instead of hitting the DB constraint."""
+        kwargs = {"visibility": "private", "created_by": "owner@example.com", "owner_email": "owner@example.com"}
+        existing = await service.register_resource(db, self._create("file://taken.txt", "Taken"), **kwargs)
+        target = await service.register_resource(db, self._create("file://free.txt", "Free"), **kwargs)
+
+        with pytest.raises(ResourceURIConflictError) as exc_info:
+            await service.update_resource(db, target.id, ResourceUpdate(uri="file://taken.txt"))
+
+        message = str(exc_info.value)
+        assert "file://taken.txt" in message
+        assert "resource URIs must be unique within this scope (names may repeat)." in message
+        assert existing.id != target.id
+
+    @pytest.mark.asyncio
+    async def test_update_private_duplicate_name_succeeds(self, service, db):
+        """Renaming a private resource to an existing name must stay legal."""
+        await service.register_resource(db, self._create("file://one.txt", "Original"), visibility="private", created_by="o@example.com", owner_email="o@example.com")
+        target = await service.register_resource(db, self._create("file://two.txt", "Other"), visibility="private", created_by="o@example.com", owner_email="o@example.com")
+
+        result = await service.update_resource(db, target.id, ResourceUpdate(name="Original"))
+
+        assert result.name == "Original"

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -2799,6 +2799,115 @@ class TestAdminResourceRoutes:
         resp = await admin_add_resource(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert resp.status_code == 409
 
+    @patch.object(ResourceService, "register_resource")
+    async def test_admin_add_resource_postgres_uri_constraint_message_is_specific(self, mock_register_resource, mock_request, mock_db, monkeypatch):
+        """Postgres URI-constraint IntegrityError must yield the specific message, not the generic fallback (issue #4991)."""
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value=None)
+        monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+        monkeypatch.setattr(
+            "mcpgateway.admin.MetadataCapture.extract_creation_metadata",
+            lambda *_args, **_kwargs: {"created_by": "u", "created_from_ip": None, "created_via": "ui", "created_user_agent": None, "import_batch_id": None, "federation_source": None},
+        )
+
+        for constraint in ("uq_team_owner_gateway_uri_resource", "uq_team_owner_uri_resource_local"):
+            orig = Exception(f'duplicate key value violates unique constraint "{constraint}"')
+            mock_register_resource.side_effect = IntegrityError("insert into resources", params={}, orig=orig)
+
+            resp = await admin_add_resource(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+            body = json.loads(resp.body)
+
+            assert resp.status_code == 409
+            assert body["message"] == "A resource with this URI already exists in this scope. Resource URIs must be unique; names may repeat."
+            assert body["success"] is False
+            assert "Unable to complete the operation" not in body["message"]
+
+
+class TestAdminResourceUriConflictMessage:
+    """POST /admin/resources duplicate-URI messaging (issue #4991).
+
+    Exercises the real ResourceService against an in-memory SQLite session so the
+    409 body is produced by the same code path the Admin UI hits.
+    """
+
+    @pytest.fixture
+    def real_db(self):
+        """Create a real in-memory SQLite session with the full schema."""
+        # Third-Party
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+        from sqlalchemy.pool import StaticPool
+
+        # First-Party
+        from mcpgateway.db import Base
+
+        engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+        Base.metadata.create_all(bind=engine)
+        session = sessionmaker(bind=engine)()
+        try:
+            yield session
+        finally:
+            session.close()
+            engine.dispose()
+
+    @pytest.fixture(autouse=True)
+    def _stub_admin_deps(self, monkeypatch):
+        """Stub team resolution, metadata capture and resource notifications."""
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(side_effect=lambda _email, team_id: team_id or "team-1")
+        monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+        monkeypatch.setattr(
+            "mcpgateway.admin.MetadataCapture.extract_creation_metadata",
+            lambda *_args, **_kwargs: {"created_by": "owner@example.com", "created_from_ip": None, "created_via": "ui", "created_user_agent": None, "import_batch_id": None, "federation_source": None},
+        )
+        monkeypatch.setattr(ResourceService, "_notify_resource_added", AsyncMock())
+
+    @staticmethod
+    def _request(uri, name, visibility):
+        """Build a mock admin request carrying add-resource form data.
+
+        Args:
+            uri: Resource URI form value.
+            name: Resource name form value.
+            visibility: Visibility form value.
+
+        Returns:
+            MagicMock: A Request stand-in whose ``form()`` returns the data.
+        """
+        request = MagicMock(spec=Request)
+        request.scope = {"root_path": ""}
+        request.form = AsyncMock(return_value=FakeForm({"uri": uri, "name": name, "content": "body", "mimeType": "text/plain", "visibility": visibility, "team_id": "team-1"}))
+        return request
+
+    @pytest.mark.parametrize("visibility", ["public", "team", "private"])
+    async def test_duplicate_uri_returns_specific_409_message(self, real_db, visibility):
+        """A duplicate URI must return 409 with the URI-specific message for every visibility."""
+        user = {"email": "owner@example.com", "db": real_db}
+
+        first = await admin_add_resource(self._request("file://dup.txt", "First", visibility), real_db, user=user)
+        assert first.status_code == 200
+
+        second = await admin_add_resource(self._request("file://dup.txt", "Second", visibility), real_db, user=user)
+        body = json.loads(second.body)
+
+        assert second.status_code == 409
+        assert body["success"] is False
+        assert "Unable to complete the operation" not in body["message"]
+        assert "Resource already exists with URI" in body["message"]
+        assert "file://dup.txt" in body["message"]
+        assert "resource URIs must be unique within this scope (names may repeat)." in body["message"]
+
+    @pytest.mark.parametrize("visibility", ["public", "team", "private"])
+    async def test_duplicate_name_with_distinct_uri_returns_200(self, real_db, visibility):
+        """Duplicate names remain legal -- regression guard for the reverted PR #5158/#5664."""
+        user = {"email": "owner@example.com", "db": real_db}
+
+        first = await admin_add_resource(self._request("file://one.txt", "Same Label", visibility), real_db, user=user)
+        second = await admin_add_resource(self._request("file://two.txt", "Same Label", visibility), real_db, user=user)
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+
     @patch.object(ResourceService, "update_resource")
     async def test_admin_edit_resource_special_uri_characters(self, mock_update_resource, mock_request, mock_db):
         """Test editing resource with special characters in URI."""

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -2893,7 +2893,7 @@ class TestAdminResourceUriConflictMessage:
         assert second.status_code == 409
         assert body["success"] is False
         assert "Unable to complete the operation" not in body["message"]
-        assert "Resource already exists with URI" in body["message"]
+        assert "resource already exists with URI" in body["message"]
         assert "file://dup.txt" in body["message"]
         assert "resource URIs must be unique within this scope (names may repeat)." in body["message"]
 

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -4252,6 +4252,50 @@ class TestCrudEndpoints:
         assert excinfo.value.status_code == 409
 
     @pytest.mark.asyncio
+    async def test_update_resource_validation_error_maps_to_422(self, monkeypatch, allow_permission):
+        """ResourceValidationError on update must map to 422, matching create_resource (issue #4991)."""
+        request = _make_request("/resources/res-1")
+        monkeypatch.setattr(
+            "mcpgateway.main.MetadataCapture.extract_modification_metadata",
+            lambda *_args, **_kwargs: {
+                "modified_by": "user",
+                "modified_from_ip": "127.0.0.1",
+                "modified_via": "api",
+                "modified_user_agent": "test",
+            },
+        )
+        # First-Party
+        from mcpgateway.services.resource_service import ResourceValidationError
+
+        monkeypatch.setattr("mcpgateway.main.resource_service.update_resource", AsyncMock(side_effect=ResourceValidationError("Cannot create a team-scoped resource without a team_id")))
+        with pytest.raises(HTTPException) as excinfo:
+            await update_resource("res-1", ResourceUpdate(name="Res Updated"), request, db=MagicMock(), user={"email": "user@example.com"})
+        assert excinfo.value.status_code == 422
+        assert excinfo.value.detail == "Cannot create a team-scoped resource without a team_id"
+
+    @pytest.mark.asyncio
+    async def test_update_resource_resource_error_maps_to_400(self, monkeypatch, allow_permission):
+        """A plain ResourceError on update must map to 400 rather than escaping as a 500 (issue #4991)."""
+        request = _make_request("/resources/res-1")
+        monkeypatch.setattr(
+            "mcpgateway.main.MetadataCapture.extract_modification_metadata",
+            lambda *_args, **_kwargs: {
+                "modified_by": "user",
+                "modified_from_ip": "127.0.0.1",
+                "modified_via": "api",
+                "modified_user_agent": "test",
+            },
+        )
+        # First-Party
+        from mcpgateway.services.resource_service import ResourceError
+
+        monkeypatch.setattr("mcpgateway.main.resource_service.update_resource", AsyncMock(side_effect=ResourceError("resource update failed")))
+        with pytest.raises(HTTPException) as excinfo:
+            await update_resource("res-1", ResourceUpdate(name="Res Updated"), request, db=MagicMock(), user={"email": "user@example.com"})
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail == "resource update failed"
+
+    @pytest.mark.asyncio
     async def test_update_resource_mcp_apps_validation_error_maps_to_422(self, monkeypatch, allow_permission):
         request = _make_request("/resources/res-1")
         monkeypatch.setattr(

--- a/tests/unit/mcpgateway/utils/test_error_formatter.py
+++ b/tests/unit/mcpgateway/utils/test_error_formatter.py
@@ -197,10 +197,34 @@ def make_mock_integrity_error(msg):
         ("UNIQUE constraint failed: gateways.url", "A gateway with this URL already exists"),
         ("UNIQUE constraint failed: gateways.slug", "A gateway with this name already exists"),
         ("UNIQUE constraint failed: tools.name", "A tool with this name already exists"),
-        ("UNIQUE constraint failed: resources.uri", "A resource with this URI already exists"),
-        ("UNIQUE constraint failed: resources.name", "A resource with this name already exists"),
-        ("uq_team_owner_gateway_name_resource", "A resource with this name already exists"),
-        ("uq_team_owner_name_resource_local", "A resource with this name already exists"),
+        # Resource URI uniqueness - SQLite single-column variant
+        (
+            "UNIQUE constraint failed: resources.uri",
+            "A resource with this URI already exists in this scope. Resource URIs must be unique; names may repeat.",
+        ),
+        # Resource URI uniqueness - SQLite multi-column variant emitted by the real composite constraint
+        (
+            "UNIQUE constraint failed: resources.team_id, resources.owner_email, resources.gateway_id, resources.uri",
+            "A resource with this URI already exists in this scope. Resource URIs must be unique; names may repeat.",
+        ),
+        # Resource URI uniqueness - PostgreSQL reports the constraint name, not column paths
+        (
+            "uq_team_owner_gateway_uri_resource",
+            "A resource with this URI already exists in this scope. Resource URIs must be unique; names may repeat.",
+        ),
+        (
+            "uq_team_owner_uri_resource_local",
+            "A resource with this URI already exists in this scope. Resource URIs must be unique; names may repeat.",
+        ),
+        # Resource URI uniqueness - realistic full PostgreSQL error text
+        (
+            'duplicate key value violates unique constraint "uq_team_owner_gateway_uri_resource"',
+            "A resource with this URI already exists in this scope. Resource URIs must be unique; names may repeat.",
+        ),
+        (
+            'duplicate key value violates unique constraint "uq_team_owner_uri_resource_local"',
+            "A resource with this URI already exists in this scope. Resource URIs must be unique; names may repeat.",
+        ),
         ("UNIQUE constraint failed: servers.name", "A server with this name already exists"),
         ("UNIQUE constraint failed: prompts.name", "A prompt with this name already exists"),
         ("UNIQUE constraint failed: servers.id", "A server with this ID already exists"),


### PR DESCRIPTION
## 🔗 Related Issue

Closes #4991

---

## 📝 Summary

Creating a resource whose URI already exists showed `Failed to add Resource (HTTP 409)` in the Admin UI, with no indication of which field was at fault. Two independent defects each produced that exact string on their own, so both needed fixing:

**1. `ErrorFormatter.format_database_error` only understood SQLite.** It matched `UNIQUE constraint failed: <table>.<column>` plus a list of column paths. PostgreSQL reports `duplicate key value violates unique constraint "uq_team_owner_gateway_uri_resource"`, which matched nothing and fell through to the generic `Unable to complete the operation. Please try again.` SQLite escaped this only by accident — its multi-column message happens to contain the `resources.uri` substring.

**2. `extractApiError` could not read a nested `detail`.** It handled `error.message`, `detail` as a string and `detail` as an array, but not `detail` as an object — which is exactly what FastAPI emits for `HTTPException(detail={...})`. It therefore returned the caller's fallback, i.e. the reported string. This affected every admin form (servers, tools, prompts, gateways), not just resources, so the fix is deliberately generic.

**Names are not the conflict.** #5664 reverted the name-uniqueness constraint added by #5158, because the MCP specification treats `uri` as the identifier and `name` as a human-readable display label — and the constraint broke a legitimate pattern of task-scoped resources sharing a type name. The new messages say that rule out loud, and the add-resource form attributes the error inline to the URI field so a duplicate URI can no longer be misread as a duplicate name. Helper text under the Name input states that names need not be unique.

---

## 🐛 Additional fixes in the same paths

- **Private visibility skipped the friendly error.** `register_resource` / `update_resource` pre-checked URIs only for `public` and `team`. `private` is a valid visibility and is exposed as a radio on the add-resource form, so private duplicates bypassed `ResourceURIConflictError` and surfaced as a raw `IntegrityError`. Both now have a `private` branch scoped to the `(team_id, owner_email, gateway_id, uri)` constraint, mirroring the precedence used when the row is constructed.
- **`PUT /resources/{id}` lost exceptions to 500s.** It caught neither `ResourceValidationError` nor plain `ResourceError`. Now 422 and 400 respectively, matching `POST /resources`, and ordered after `ResourceURIConflictError` since both are `ResourceError` subclasses.
- **Dead code from the #5664 revert removed** — the `uq_team_owner_*_name_resource` and `resources.name` mappings in `error_formatter.py`, and a stale comment in `resource_service.py` referring to a deleted name check.

No schema change, no migration, and name uniqueness is not reintroduced at any layer. A regression test asserts that a duplicate name with a distinct URI still succeeds, for all three visibilities, against a real in-memory session so the actual DB constraints participate.

---

## ⚠️ Behaviour change worth flagging

`ResourceLockConflictError` on update now returns **400** instead of escaping as a 500, because it subclasses `ResourceError`. This matches the existing create path, which also has a bare `except ResourceError → 400` with no lock-conflict case. Arguably lock conflicts should be 409 everywhere (`admin_set_resource_state` already maps them that way) — happy to follow up separately if you agree.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

---

## 🏷️ Type of Change

- [x] Bug fix

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Full pytest suite | `make test` | ✅ 20869 passed, 799 skipped, 2 xfailed, 0 failed |
| Doctests | `make doctest` | ✅ 1197 passed, 55 skipped |
| JS unit tests | `make test-js` | ✅ 51 files, 2298 tests |
| Lint | `make ruff` | ✅ |
| Static analysis | `pylint` on changed files | ✅ 9.99/10 (sole finding pre-exists on `main`) |
| Docstring coverage | `interrogate` on changed files | ✅ 100% |
| Secrets | `make detect-secrets-scan` | ✅ no new findings (baseline churn is timestamp + 2 line shifts) |

---

## ✅ Checklist

- [x] Tests added/updated for changes
- [x] No secrets or credentials committed