### PR TITLE
fix: show gateway description in tool details

### DIFF
--- a/client/src/components/tools/ToolDetailsPanel.test.tsx
+++ b/client/src/components/tools/ToolDetailsPanel.test.tsx
@@ -91,21 +91,45 @@ describe("ToolDetailsPanel", () => {
     expect(aside).toHaveAttribute("aria-hidden", "false");
   });
 
-  it("displays gateway name and integration type", () => {
+  it("displays gateway name, description, and integration type", () => {
     const tools = [createMockTool(1, { integrationType: "MCP" })];
     render(
       <ToolDetailsPanel
         tools={tools}
         gatewaySlug="test-gateway"
+        gatewayDescription="Gateway for test tools"
         open={true}
         onClose={mockOnClose}
       />,
     );
 
     expect(screen.getAllByText("test-gateway").length).toBeGreaterThan(0);
-    // "MCP Server" appears in the subtitle and in Component details Type row
-    expect(screen.getAllByText("MCP Server").length).toBeGreaterThan(0);
+    expect(screen.getByText("Gateway for test tools")).toBeInTheDocument();
+    expect(screen.getByText("MCP Server")).toBeInTheDocument();
   });
+
+  it.each([undefined, "", "   "])(
+    "does not render a subtitle when gateway description is %p",
+    (gatewayDescription) => {
+      const tools = [createMockTool(1, { integrationType: "MCP" })];
+      const { container } = render(
+        <ToolDetailsPanel
+          tools={tools}
+          gatewaySlug="test-gateway"
+          gatewayDescription={gatewayDescription}
+          open={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const heading = screen.getByRole("heading", { name: "test-gateway", level: 3 });
+      expect(heading.closest("div.mb-6")?.nextElementSibling).not.toBeInstanceOf(
+        HTMLParagraphElement,
+      );
+      expect(container.querySelector("p.mb-8")).not.toBeInTheDocument();
+      expect(screen.getByText("MCP Server")).toBeInTheDocument();
+    },
+  );
 
   it("displays all tools in table", () => {
     const tools = [createMockTool(1), createMockTool(2), createMockTool(3)];

--- a/client/src/components/tools/ToolDetailsPanel.tsx
+++ b/client/src/components/tools/ToolDetailsPanel.tsx
@@ -31,6 +31,7 @@ function DetailRow({
 export function ToolDetailsPanel({
   tools,
   gatewaySlug,
+  gatewayDescription,
   open,
   selectedToolId,
   onClose,
@@ -41,6 +42,7 @@ export function ToolDetailsPanel({
 }: {
   tools: Tool[];
   gatewaySlug: string;
+  gatewayDescription?: string;
   open: boolean;
   selectedToolId?: string | null;
   onClose: () => void;
@@ -172,10 +174,9 @@ export function ToolDetailsPanel({
                 </div>
               </div>
 
-              {/* Subtitle */}
-              <p className="mb-8 text-sm text-muted-foreground">
-                {getIntegrationTypeLabel(tools[0]?.integrationType)}
-              </p>
+              {gatewayDescription?.trim() && (
+                <p className="mb-8 text-sm text-muted-foreground">{gatewayDescription.trim()}</p>
+              )}
 
               {/* Table */}
               <ToolsTable

--- a/client/src/pages/Tools.test.tsx
+++ b/client/src/pages/Tools.test.tsx
@@ -158,6 +158,35 @@ describe("Tools", () => {
     expect(screen.getByText("Inactive")).toBeInTheDocument();
   });
 
+  it("shows the gateway description in the tool details panel", async () => {
+    const mockTools: Tool[] = [createMockTool(1, "described-gateway")];
+    server.use(
+      http.get("/tools", () => HttpResponse.json(mockTools)),
+      http.get("/gateways", () =>
+        HttpResponse.json({
+          gateways: [
+            {
+              id: "gateway-described-gateway",
+              name: "Described gateway",
+              url: "https://example.com/mcp",
+              description: "Tools for repository automation",
+            },
+          ],
+          nextCursor: null,
+        }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderWithRouter(<Tools />);
+
+    await waitFor(() => expect(screen.getByText("described-gateway")).toBeInTheDocument());
+    await user.click(screen.getByLabelText("More options for described-gateway"));
+    await user.click(await screen.findByText("View Details"));
+
+    expect(await screen.findByText("Tools for repository automation")).toBeInTheDocument();
+  });
+
   it("renders Add tools card", async () => {
     server.use(http.get("/tools", () => HttpResponse.json([])));
 

--- a/client/src/pages/Tools.tsx
+++ b/client/src/pages/Tools.tsx
@@ -8,6 +8,7 @@ import { ApiError } from "@/api/client";
 import { useRouter } from "@/router";
 import { extractApiErrorDetail, sanitizeError } from "@/utils/errors";
 import type { Tool, ToolGroup } from "@/types/tool";
+import type { CursorPaginatedGatewaysResponse, GatewayRead } from "@/generated/types";
 import { Card, CardHeader, CardContent } from "@/components/ui/card";
 import { CardTag } from "@/components/ui/card-tag";
 import { Button } from "@/components/ui/button";
@@ -21,12 +22,22 @@ import { ToolDetailsPanel } from "@/components/tools/ToolDetailsPanel";
 import { ToolForm } from "@/components/tools/ToolForm";
 import { ConfirmDialog } from "@/components/servers/ConfirmDialog";
 
-function buildGroups(tools: Tool[], restToolsLabel: string): ToolGroup[] {
+function buildGroups(
+  tools: Tool[],
+  gatewayDescriptionById: Map<string, string>,
+  restToolsLabel: string,
+): ToolGroup[] {
   const map = new Map<string, ToolGroup>();
   for (const tool of tools) {
     const slug = tool.gatewaySlug || restToolsLabel;
     if (!map.has(slug)) {
-      map.set(slug, { gatewaySlug: slug, gatewayId: tool.gatewayId, tools: [], isActive: false });
+      map.set(slug, {
+        gatewaySlug: slug,
+        gatewayId: tool.gatewayId,
+        gatewayDescription: tool.gatewayId ? gatewayDescriptionById.get(tool.gatewayId) : undefined,
+        tools: [],
+        isActive: false,
+      });
     }
     const group = map.get(slug)!;
     group.tools.push(tool);
@@ -188,6 +199,12 @@ export function Tools() {
     refetch,
     setData: setToolsData,
   } = useQuery<Tool[]>("/tools?limit=0&include_inactive=true");
+  const { data: gatewaysData } = useQuery<CursorPaginatedGatewaysResponse>(
+    "/gateways?limit=0&include_pagination=true",
+    {
+      enabled: !isLoading,
+    },
+  );
 
   useEffect(() => {
     if (toolsData) setAllTools(toolsData);
@@ -199,8 +216,23 @@ export function Tools() {
 
   const toolForForm = editedToolData?.id === editingTool?.id ? editedToolData : editingTool;
 
+  const gatewayDescriptionById = useMemo(() => {
+    const gateways: NonNullable<GatewayRead>[] = (gatewaysData?.gateways ?? []).filter(
+      (gateway): gateway is NonNullable<GatewayRead> => gateway !== null,
+    );
+    const entries: [string, string][] = [];
+    for (const gateway of gateways) {
+      const description = gateway.description?.trim();
+      if (gateway.id && description) entries.push([gateway.id, description]);
+    }
+    return new Map(entries);
+  }, [gatewaysData]);
+
   const restToolsLabel = intl.formatMessage({ id: "tools.restToolsGroup" });
-  const groups = useMemo(() => buildGroups(allTools, restToolsLabel), [allTools, restToolsLabel]);
+  const groups = useMemo(
+    () => buildGroups(allTools, gatewayDescriptionById, restToolsLabel),
+    [allTools, gatewayDescriptionById, restToolsLabel],
+  );
 
   // Keep the open details panel pointed at the latest group data so status
   // changes (e.g. activate/deactivate) are reflected once the list is updated.
@@ -439,6 +471,7 @@ export function Tools() {
             <ToolDetailsPanel
               tools={activeGroup.tools}
               gatewaySlug={activeGroup.gatewaySlug}
+              gatewayDescription={activeGroup.gatewayDescription}
               open={isDetailsPanelOpen}
               selectedToolId={selectedToolIdForDetails}
               onClose={handleCloseDetails}

--- a/client/src/types/tool.ts
+++ b/client/src/types/tool.ts
@@ -13,6 +13,7 @@ export type Tool = NonNullable<ToolRead>;
 export interface ToolGroup {
   gatewaySlug: string;
   gatewayId?: string | null;
+  gatewayDescription?: string;
   tools: Tool[];
   isActive: boolean;
 }


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #5713

---

## 📝 Summary

Shows each gateway's description beneath its heading in the tool details panel.

The tools page now fetches gateway metadata, maps descriptions by gateway ID, and passes the matching description through each tool group. Missing, empty, and whitespace-only descriptions omit the subtitle entirely. Integration type remains available in the component details Type row.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Production build | `npm run build` | Passed |
| Lint auto-fix | `npm run lint:fix` | Passed |
| Unit tests | `npm run test:run` | Passed — 2520 passed, 1 skipped |
| End-to-end tests | `npm run e2e` | Passed — 135 passed |

---

## ✅ Checklist

- [x] Code formatted
- [x] Tests added/updated for changes
- [x] Documentation updated (not applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

Gateway descriptions are trimmed before display. REST/local tool groups without a gateway ID do not render a subtitle.
