### PR TITLE
ci: create .env before compose-up in prod smoke check

### DIFF
--- a/.github/workflows/compose-prod-smoke.yml
+++ b/.github/workflows/compose-prod-smoke.yml
@@ -63,6 +63,26 @@ jobs:
       - name: Build production image
         run: make docker-prod
 
+      # Compose targets validate against .env (compose-up → compose-validate),
+      # which aborts if the file is missing. `make setup` would create it, but
+      # that path runs `uv run` and this Docker-only job has no Python/uv
+      # toolchain. Seed .env from .env.example directly and patch in strong
+      # secrets so the gateway starts (it refuses the __REPLACE_ME__
+      # placeholders shipped in .env.example).
+      - name: Prepare .env
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp .env.example .env
+          # base64 (not hex) so Shannon entropy clears the >= 3.5 floor that
+          # Settings.validate_security_combinations() enforces at startup; hex
+          # tops out at 4 bits/char and occasionally dips below it. base64's
+          # alphabet has no '|' or '&', so it is safe with the sed delimiter.
+          jwt_secret="$(openssl rand -base64 32)"  # pragma: allowlist secret
+          enc_secret="$(openssl rand -base64 32)"  # pragma: allowlist secret
+          sed -i "s|^JWT_SECRET_KEY=.*|JWT_SECRET_KEY=${jwt_secret}|" .env
+          sed -i "s|^AUTH_ENCRYPTION_SECRET=.*|AUTH_ENCRYPTION_SECRET=${enc_secret}|" .env
+
       # ── Default compose stack ──────────────────────────────────
       # Start the stack, wait up to 3 min for nginx to proxy
       # /health, then verify the admin login page renders and


### PR DESCRIPTION
## 🔗 Related Issue

Follow-up to #5419

---

## 📝 Summary

The `compose-prod-smoke` merge-queue check has failed on every run since it was
added. The job goes straight from `make docker-prod` to `make compose-up`, but
`compose-up` depends on `compose-validate`, which hard-fails when `.env` is
absent.

The workflow never created `.env`, so validation aborted with exit code 2 before
the stack ever started.

This PR adds a **Prepare .env** step (after the image build) that seeds `.env`
from `.env.example` and patches in strong secrets:

- `cp .env.example .env` satisfies the `compose-validate` file check.
- `JWT_SECRET_KEY` and `AUTH_ENCRYPTION_SECRET` are replaced with
  `openssl rand -hex 32` values, since the gateway refuses to start with the
  `__REPLACE_ME__` placeholders shipped in `.env.example`.

I used inline shell rather than the documented `make setup` on purpose: `setup`
runs `uv run python3 …` via `ensure-secrets`, and this is a Docker-only job with
no Python/uv toolchain — using `openssl` keeps the step self-contained.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification