### PR TITLE
feat(dataplane): publish per-backend add_headers/remove_headers

### DIFF
--- a/mcpgateway/alembic/versions/e1a2b3c4d5f6_add_add_remove_headers_to_gateways.py
+++ b/mcpgateway/alembic/versions/e1a2b3c4d5f6_add_add_remove_headers_to_gateways.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/alembic/versions/e1a2b3c4d5f6_add_add_remove_headers_to_gateways.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Add add_headers and remove_headers columns to gateways table.
+
+These support per-backend static header injection (add_headers) and header
+stripping (remove_headers) as consumed by the dataplane BackendConfig contract.
+
+Revision ID: e1a2b3c4d5f6
+Revises: d21698ae4a19
+Create Date: 2026-07-30
+"""
+
+# Standard
+from typing import Sequence, Union
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "e1a2b3c4d5f6"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "d21698ae4a19"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add add_headers and remove_headers columns to gateways table."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "gateways" not in inspector.get_table_names():
+        # Fresh database — models create the columns directly via db.py.
+        return
+
+    existing_columns = {col["name"] for col in inspector.get_columns("gateways")}
+
+    if "add_headers" not in existing_columns:
+        op.add_column("gateways", sa.Column("add_headers", sa.JSON(), nullable=True))
+
+    if "remove_headers" not in existing_columns:
+        op.add_column("gateways", sa.Column("remove_headers", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop add_headers and remove_headers columns from gateways table."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "gateways" not in inspector.get_table_names():
+        return
+
+    existing_columns = {col["name"] for col in inspector.get_columns("gateways")}
+
+    if "remove_headers" in existing_columns:
+        op.drop_column("gateways", "remove_headers")
+
+    if "add_headers" in existing_columns:
+        op.drop_column("gateways", "add_headers")

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -4727,6 +4727,8 @@ class Gateway(Base):
 
     # Header passthrough configuration
     passthrough_headers: Mapped[Optional[List[str]]] = mapped_column(JSON, nullable=True)  # Store list of strings as JSON array
+    add_headers: Mapped[Optional[Dict[str, str]]] = mapped_column(JSON, nullable=True, default=None)  # Static headers injected onto upstream connection
+    remove_headers: Mapped[Optional[List[str]]] = mapped_column(JSON, nullable=True, default=None)  # Header names stripped from upstream connection
 
     # CA certificate
     ca_certificate: Mapped[Optional[bytes]] = mapped_column(Text, nullable=True)

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -313,6 +313,8 @@ class DataplanePublisherService:
                         DbGateway.url,
                         DbGateway.transport,
                         DbGateway.passthrough_headers,
+                        DbGateway.add_headers,
+                        DbGateway.remove_headers,
                         DbGateway.capabilities,
                         DbGateway.owner_email,
                         DbGateway.team_id,
@@ -379,10 +381,8 @@ class DataplanePublisherService:
                     "url": gateway.url,
                     "transport": gateway.transport,
                     "passthrough_headers": gateway.passthrough_headers,
-                    # DB columns not yet present; getattr keeps the diff in this file and
-                    # emits the Rust-side defaults ({} / []) until the columns land.
-                    "add_headers": getattr(gateway, "add_headers", None) or {},
-                    "remove_headers": getattr(gateway, "remove_headers", None) or [],
+                    "add_headers": gateway.add_headers or {},
+                    "remove_headers": gateway.remove_headers or [],
                     "capabilities": gateway.capabilities or {},
                 }
                 for gateway in gateway_rows

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -64,6 +64,8 @@ class BackendConfig(TypedDict):
     url: str
     transport: str
     passthrough_headers: list[str]
+    add_headers: dict[str, str]
+    remove_headers: list[str]
     capabilities: dict[str, Any]
     allowed_tool_names: list[str]
     allowed_resource_names: list[str]
@@ -236,6 +238,8 @@ class DataplanePublisherService:
                     "url": gateway["url"],
                     "transport": gateway["transport"],
                     "passthrough_headers": gateway["passthrough_headers"] or [],
+                    "add_headers": gateway.get("add_headers") or {},
+                    "remove_headers": gateway.get("remove_headers") or [],
                     "capabilities": gateway.get("capabilities") or {},
                 }
                 for gateway in gateways
@@ -375,6 +379,10 @@ class DataplanePublisherService:
                     "url": gateway.url,
                     "transport": gateway.transport,
                     "passthrough_headers": gateway.passthrough_headers,
+                    # DB columns not yet present; getattr keeps the diff in this file and
+                    # emits the Rust-side defaults ({} / []) until the columns land.
+                    "add_headers": getattr(gateway, "add_headers", None) or {},
+                    "remove_headers": getattr(gateway, "remove_headers", None) or [],
                     "capabilities": gateway.capabilities or {},
                 }
                 for gateway in gateway_rows

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -185,6 +185,8 @@ async def test_full_payload_generation_with_mock_db():
     gateway1.url = "http://localhost:9000"
     gateway1.transport = "STREAMABLEHTTP"
     gateway1.passthrough_headers = ["Authorization"]
+    gateway1.add_headers = {"X-Tenant": "acme"}
+    gateway1.remove_headers = ["Cookie"]
     gateway1.capabilities = {"resources": {"subscribe": True}}
     gateway1.owner_email = "user1@example.com"
     gateway1.team_id = "team1"
@@ -283,6 +285,8 @@ async def test_full_payload_generation_with_mock_db():
         assert backend["url"] == "http://localhost:9000"
         assert backend["transport"] == "STREAMABLEHTTP"
         assert backend["passthrough_headers"] == ["Authorization"]
+        assert backend["add_headers"] == {"X-Tenant": "acme"}
+        assert backend["remove_headers"] == ["Cookie"]
         assert backend["capabilities"] == {"resources": {"subscribe": True}}
         assert backend["allowed_tool_names"] == ["public_tool", "private_tool"]
         assert backend["allowed_resource_names"] == ["Resource 1"]
@@ -450,6 +454,8 @@ def test_create_payload_normalizes_null_passthrough_headers():
 
     backend = result[USER1_ID]["virtual_hosts"]["server1"]["backends"]["gateway1"]
     assert backend["passthrough_headers"] == []
+    assert backend["add_headers"] == {}
+    assert backend["remove_headers"] == []
     assert backend["capabilities"] == {}
 
 

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -293,6 +293,14 @@ async def test_full_payload_generation_with_mock_db():
         assert backend["allowed_resource_uris"] == ["resource://one"]
         assert backend["allowed_prompt_names"] == ["Prompt 1"]
 
+        # Verify the gateway SELECT projection actually includes the new columns
+        # (guards against getattr-on-Row silently returning None when columns are missing from SELECT)
+        gateway_execute_call = mock_db.execute.call_args_list[3]
+        stmt = gateway_execute_call[0][0]
+        selected_keys = {col.key for col in stmt.selected_columns}
+        assert "add_headers" in selected_keys, "Gateway SELECT must include add_headers"
+        assert "remove_headers" in selected_keys, "Gateway SELECT must include remove_headers"
+
         # Verify user2 sees public server but not private server from user1
         user2_config = payload[USER2_ID]
         assert "s1" in user2_config["virtual_hosts"]  # public


### PR DESCRIPTION
## Dataplane
Related Issue [4544](https://github.com/IBM/mcp-context-forge/issues/4544)

Related Dataplane PR [65](https://github.com/contextforge-org/contextforge-data-plane/pull/65)
## Summary

The dataplane consumer ([contextforge-gateway-rs #4544](https://github.com/IBM/mcp-context-forge)) now accepts two new per-backend header controls alongside the existing `passthrough_headers`:

- `add_headers` — static headers injected onto the upstream connection (override passthrough), a `str -> str` map
- `remove_headers` — header names stripped from the upstream connection (applied last), a list

This threads both fields through `DataplanePublisherService` so the published `BackendConfig` matches the consumer's contract.

## Details

- `BackendConfig` TypedDict gains `add_headers: dict[str, str]` and `remove_headers: list[str]`.
- `create_payload` emits both, normalizing `None` to the consumer-side defaults (`{}` / `[]`).
- `_build_user_data` sources them from the gateway row via `getattr(..., None)`. The `Gateway` model has no columns for these yet, so today the publisher emits the safe defaults; it lights up automatically once the columns are added — no further change needed in this file.

## Tests

Extended `test_dataplane_publisher.py`: asserts the new fields flow through with values and that missing values normalize to `{}` / `[]`. All 24 tests pass.