### PR TITLE
Added team_id filter into get_gateways

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -2442,6 +2442,9 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
         query = await self._apply_access_control(query, db, user_email, token_teams, team_id)
 
+        if team_id:
+            query = query.where(DbGateway.team_id == team_id)
+
         if visibility:
             query = query.where(DbGateway.visibility == visibility)
 

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -7330,6 +7330,31 @@ class TestListGatewaysTokenTeams:
         assert cursor is None
 
     @pytest.mark.asyncio
+    async def test_admin_specific_team_is_an_exact_filter(self, gateway_service, monkeypatch):
+        """Admin team_id filtering excludes public gateways assigned to other teams."""
+        db = MagicMock()
+        mock_cache = MagicMock()
+        mock_cache.get = AsyncMock(return_value=None)
+        mock_cache.set = AsyncMock()
+        mock_cache.hash_filters = MagicMock(return_value="h")
+        monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: mock_cache)
+
+        mock_paginate = AsyncMock(return_value=([], None))
+        monkeypatch.setattr("mcpgateway.services.gateway_service.unified_paginate", mock_paginate)
+        monkeypatch.setattr("mcpgateway.services.base_service.is_user_admin", MagicMock(return_value=True))
+
+        await gateway_service.list_gateways(
+            db,
+            user_email="admin@test.com",
+            token_teams=None,
+            team_id="team-1",
+        )
+
+        query = mock_paginate.await_args.kwargs["query"]
+        compiled = str(query.compile(compile_kwargs={"literal_binds": True}))
+        assert "AND gateways.team_id = 'team-1'" in compiled
+
+    @pytest.mark.asyncio
     async def test_page_based_pagination(self, gateway_service, monkeypatch):
         """Page-based pagination returns dict format."""
         db = MagicMock()


### PR DESCRIPTION
Fixes the team_id query parameter being silently ignored by the GET /gateways endpoint. The parameter was not wired through the endpoint handler to the service layer, causing all gateways to be returned regardless of the team filter.



# Pull Request

## 🔗 Related Issue

Closes #https://github.com/IBM/mcp-context-forge/issues/5496  
 
---

## 📝 Summary

_What does this PR do and why?_

---

### mcpgateway/admin.py
- Added `team_id: Optional[str] = Depends(_validated_team_id_param)` parameter to `admin_list_gateways()` endpoint
- Updated docstring to document the new parameter
- Passes `team_id` to `gateway_service.list_gateways()` for proper filtering

### tests/unit/mcpgateway/test_admin.py
- Added `test_admin_list_gateways_team_filtering()` test that validates:
  - Filtering by team1_id returns only team1 + public gateways
  - Filtering by team2_id returns only team2 + public gateways
  - Team isolation (team1 filter excludes team2 gateways and vice versa)
- Added `test_admin_list_gateways_with_invalid_team_id()` test for invalid UUID validation


## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

_List exact commands, screenshots, videos, logs, reproduction steps, or manual validation. If evidence is not feasible, explain why._

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |   x    |
| Unit tests                | `make test`     |   x    |
| Coverage ≥ 80%            | `make coverage` |   x    |

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] No secrets or credentials committed

---

## 📓 Notes (optional)

_Screenshots, design decisions, or additional context._
