### PR TITLE
fix: improve Test Connection error messages

### DIFF
--- a/mcpgateway/admin_ui/gateways.js
+++ b/mcpgateway/admin_ui/gateways.js
@@ -1690,7 +1690,6 @@ const handleGatewayTestSubmit = async function (e) {
       result.statusCode && result.statusCode >= 200 && result.statusCode < 300;
 
     const alertType = isSuccess ? "success" : "error";
-    const icon = isSuccess ? "✅" : "❌";
     const title = isSuccess ? "Connection Successful" : "Connection Failed";
     const statusCode = result.statusCode || "Unknown";
     const latency = result.latencyMs != null ? `${result.latencyMs}ms` : "NA";
@@ -1703,7 +1702,7 @@ const handleGatewayTestSubmit = async function (e) {
 
     responseDiv.innerHTML = `
         <div class="alert alert-${alertType}">
-            <h4><strong>${icon} ${title}</strong></h4>
+            <h4><strong>${title}</strong></h4>
             <p><strong>Status Code:</strong> ${statusCode}</p>
             <p><strong>Response Time:</strong> ${latency}</p>
             ${body}
@@ -1714,7 +1713,7 @@ const handleGatewayTestSubmit = async function (e) {
     if (responseDiv) {
       const errorDiv = document.createElement("div");
       errorDiv.className = "text-red-600 p-4";
-      errorDiv.textContent = `❌ Error: ${error.message}`;
+      errorDiv.textContent = `Error: ${error.message}`;
       responseDiv.innerHTML = "";
       responseDiv.appendChild(errorDiv);
     }

--- a/mcpgateway/admin_ui/security.js
+++ b/mcpgateway/admin_ui/security.js
@@ -267,7 +267,7 @@ export function validateInputName(name, type = "input") {
  */
 export function validateUrl(url, label = "") {
   if (!url || typeof url !== "string") {
-    return { valid: false, error: `${label || "URL"} is required` };
+    return { valid: false, error: `Enter a ${label || "URL"}.` };
   }
 
   try {
@@ -277,13 +277,13 @@ export function validateUrl(url, label = "") {
     if (!allowedProtocols.includes(urlObj.protocol)) {
       return {
         valid: false,
-        error: "Only HTTP and HTTPS URLs are allowed",
+        error: "Use http or https for the URL.",
       };
     }
 
     return { valid: true, value: url };
   } catch (error) {
-    return { valid: false, error: "Invalid URL format" };
+    return { valid: false, error: "Enter a complete URL, for example https://example.com." };
   }
 }
 
@@ -301,7 +301,7 @@ export function validateJson(jsonString, fieldName = "JSON") {
   } catch (error) {
     return {
       valid: false,
-      error: `Invalid ${fieldName} format: ${error.message}`,
+      error: `Cannot parse ${fieldName} as JSON: ${error.message}`,
     };
   }
 }

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -7276,7 +7276,9 @@ async def test_gateway_connectivity(
         )
         latency_ms = int((time.monotonic() - start_time) * 1000)
         # Generic error message - don't expose allowlist or validation details
-        return GatewayTestResponse(status_code=400, latency_ms=latency_ms, body={"error": "Invalid gateway URL"})
+        return GatewayTestResponse(
+            status_code=400, latency_ms=latency_ms, body={"error": "The MCP server URL is not allowed for testing. Confirm the URL is correct and the host is permitted by your test policy."}
+        )
 
     validated_base_url = validated_gateway_target["validated_url"]
     validated_hostname = validated_gateway_target["hostname"]
@@ -7335,7 +7337,11 @@ async def test_gateway_connectivity(
                     if not user_email:
                         latency_ms = int((time.monotonic() - start_time) * 1000)
                         return GatewayTestResponse(
-                            status_code=401, latency_ms=latency_ms, body={"error": f"User authentication required for OAuth-protected gateway '{gateway.name}'. Please ensure you are authenticated."}
+                            status_code=401,
+                            latency_ms=latency_ms,
+                            body={
+                                "error": f"Sign in with an email-bound account to test OAuth-protected MCP server '{gateway.name}'. API tokens without an email cannot complete the OAuth user flow."
+                            },
                         )
 
                     access_token: str = await token_storage.get_user_token(gateway.id, user_email)
@@ -7345,12 +7351,16 @@ async def test_gateway_connectivity(
                     else:
                         latency_ms = int((time.monotonic() - start_time) * 1000)
                         return GatewayTestResponse(
-                            status_code=401, latency_ms=latency_ms, body={"error": f"Please authorize {gateway.name} first. Visit /oauth/authorize/{gateway.id} to complete OAuth flow."}
+                            status_code=401, latency_ms=latency_ms, body={"error": f"Authorize '{gateway.name}' before testing. Open /oauth/authorize/{gateway.id} to complete the OAuth flow."}
                         )
                 except Exception as e:
                     logger.error(f"Failed to obtain stored OAuth token for gateway {gateway.name}: {e}")
                     latency_ms = int((time.monotonic() - start_time) * 1000)
-                    return GatewayTestResponse(status_code=500, latency_ms=latency_ms, body={"error": f"OAuth token retrieval failed for gateway: {str(e)}"})
+                    return GatewayTestResponse(
+                        status_code=500,
+                        latency_ms=latency_ms,
+                        body={"error": f"Token retrieval failed for MCP server '{gateway.name}': {sanitize_exception_message(str(e))}. Check the OAuth client credentials and token URL."},
+                    )
             else:
                 # For Client Credentials flow, get token directly
                 try:
@@ -7362,7 +7372,11 @@ async def test_gateway_connectivity(
                 except Exception as e:
                     logger.error(f"Failed to obtain OAuth access token for gateway {gateway.name}: {e}")
                     latency_ms = int((time.monotonic() - start_time) * 1000)
-                    return GatewayTestResponse(status_code=502, latency_ms=latency_ms, body={"error": "OAuth token retrieval failed for gateway"})
+                    return GatewayTestResponse(
+                        status_code=502,
+                        latency_ms=latency_ms,
+                        body={"error": f"Token retrieval failed for MCP server '{gateway.name}': {sanitize_exception_message(str(e))}. Check the OAuth client credentials and token URL."},
+                    )
         elif gateway and gateway.auth_type in ("basic", "bearer", "authheaders") and gateway.auth_value:
             if isinstance(gateway.auth_value, dict):
                 headers.update(gateway.auth_value)
@@ -7443,7 +7457,9 @@ async def test_gateway_connectivity(
             },
         )
 
-        return GatewayTestResponse(status_code=502, latency_ms=latency_ms, body={"error": "Request failed", "details": str(e)})
+        return GatewayTestResponse(
+            status_code=502, latency_ms=latency_ms, body={"error": "The MCP server request failed. Verify the MCP server is running and reachable from this host.", "details": str(e)}
+        )
 
 
 # Lazy singleton - created on first access, not at module import time.

--- a/tests/e2e/test_admin_apis.py
+++ b/tests/e2e/test_admin_apis.py
@@ -812,7 +812,7 @@ class TestAdminGatewayAPIs:
                 data = response.json()
                 assert data["statusCode"] == 400  # Error status in response body (camelCase due to BaseModelWithConfigDict)
                 assert "error" in data["body"]
-                assert data["body"]["error"] == "Invalid gateway URL"
+                assert data["body"]["error"] == "The MCP server URL is not allowed for testing. Confirm the URL is correct and the host is permitted by your test policy."
                 mock_client_class.assert_not_called()
 
     async def test_admin_test_gateway_allowlist_allows_allowlisted(self, client: AsyncClient, mock_settings):
@@ -883,7 +883,7 @@ class TestAdminGatewayAPIs:
                             data = response.json()
                             assert data["statusCode"] == 400  # Error in response body
                             assert "error" in data["body"]
-                            assert data["body"]["error"] == "Invalid gateway URL"
+                            assert data["body"]["error"] == "The MCP server URL is not allowed for testing. Confirm the URL is correct and the host is permitted by your test policy."
                             mock_client_class.assert_not_called()
 
     async def test_gateway_test_endpoint_allowlist_enforcement(self, client: AsyncClient, mock_settings):
@@ -906,7 +906,7 @@ class TestAdminGatewayAPIs:
             assert response.status_code == 200  # HTTP status is always 200
             response_data = response.json()
             assert response_data["statusCode"] == 400  # Gateway test result status
-            assert response_data["body"]["error"] == "Invalid gateway URL"
+            assert response_data["body"]["error"] == "The MCP server URL is not allowed for testing. Confirm the URL is correct and the host is permitted by your test policy."
 
         # Test 2: URL with trailing dot should be normalized and still rejected if not in allowlist
         with patch("mcpgateway.common.validators.socket.getaddrinfo") as mock_dns:
@@ -922,7 +922,7 @@ class TestAdminGatewayAPIs:
             assert response.status_code == 200
             response_data = response.json()
             assert response_data["statusCode"] == 400
-            assert response_data["body"]["error"] == "Invalid gateway URL"
+            assert response_data["body"]["error"] == "The MCP server URL is not allowed for testing. Confirm the URL is correct and the host is permitted by your test policy."
 
         # Test 3: Private IP should be rejected even if in allowlist
         mock_settings.gateway_test_allowed_hosts = ["192.168.1.1"]
@@ -935,7 +935,7 @@ class TestAdminGatewayAPIs:
         assert response.status_code == 200
         response_data = response.json()
         assert response_data["statusCode"] == 400
-        assert response_data["body"]["error"] == "Invalid gateway URL"
+        assert response_data["body"]["error"] == "The MCP server URL is not allowed for testing. Confirm the URL is correct and the host is permitted by your test policy."
 
         # Test 4: Loopback should be rejected
         request_data = {
@@ -978,7 +978,7 @@ class TestAdminGatewayAPIs:
             response_data = response.json()
             # When allowlist is empty (no registered gateways), all requests should be rejected
             assert response_data["statusCode"] == 400
-            assert response_data["body"]["error"] == "Invalid gateway URL"
+            assert response_data["body"]["error"] == "The MCP server URL is not allowed for testing. Confirm the URL is correct and the host is permitted by your test policy."
 
 
 # -------------------------

--- a/tests/unit/js/security.test.js
+++ b/tests/unit/js/security.test.js
@@ -301,7 +301,7 @@ describe("validateJson", () => {
   test("returns error for invalid JSON", () => {
     const result = validateJson("{not valid json}");
     expect(result.valid).toBe(false);
-    expect(result.error).toContain("Invalid");
+    expect(result.error).toContain("Cannot parse");
   });
 
   test("includes field name in error message", () => {

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -16601,7 +16601,7 @@ async def test_admin_test_gateway_rejects_private_ssrf_target(monkeypatch, mock_
     response = await admin_test_gateway(request, None, user={"email": "user@example.com", "db": mock_db}, db=mock_db)
 
     assert response.status_code == 400
-    assert response.body["error"] == "Invalid gateway URL"
+    assert response.body["error"] == "The MCP server URL is not allowed for testing. Confirm the URL is correct and the host is permitted by your test policy."
     assert "details" not in response.body
 
 
@@ -16633,7 +16633,7 @@ async def test_admin_test_gateway_oauth_authorization_code_missing_user_email(mo
     # Satisfy RBAC wrapper ("email" key must exist) while still exercising admin_test_gateway's missing-email branch.
     response = await admin_test_gateway(request, None, user={"email": "user@example.com", "db": mock_db}, db=mock_db)
     assert response.status_code == 401
-    assert "authentication required" in (response.body.get("error") or "").lower()
+    assert "email-bound account" in (response.body.get("error") or "").lower()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #5041

Targets `main`. Originally opened against `epic/ui-rewrite`; retargeted at the maintainers' request — the change is Python + legacy admin-UI JS only, so it cherry-picked onto `main` conflict-free.

## What

Rewrites Test Connection error copy to be actionable, using only information the code already has. Three surfaces:

**Backend** — `test_gateway_connectivity` (`mcpgateway/services/gateway_service.py`), shared by `/admin/gateways/test` and `/v1/mcp-servers/test`. Status codes and response shape unchanged; string literals only:

| Status | Before | After |
|---|---|---|
| 400 (allowlist) | `Invalid gateway URL` | `The MCP server URL is not allowed for testing. Confirm the URL is correct and the host is permitted by your test policy.` |
| 401 (auth-code, no email) | `User authentication required for OAuth-protected gateway '…'. Please ensure you are authenticated.` | `Sign in with an email-bound account to test OAuth-protected MCP server '…'. API tokens without an email cannot complete the OAuth user flow.` |
| 401 (auth-code, no token) | `Please authorize … first. Visit /oauth/authorize/… to complete OAuth flow.` | `Authorize '…' before testing. Open /oauth/authorize/… to complete the OAuth flow.` |
| 500 (stored-token retrieval) | `OAuth token retrieval failed for gateway` | `Token retrieval failed for MCP server '…': {sanitize_exception_message(str(e))}. Check the OAuth client credentials and token URL.` |
| 502 (client-credentials token retrieval) | `OAuth token retrieval failed for gateway` | `Token retrieval failed for MCP server '…': {sanitize_exception_message(str(e))}. Check the OAuth client credentials and token URL.` |
| 502 (request failure) | `Request failed` | `The MCP server request failed. Verify the MCP server is running and reachable from this host.` |

The 400 stays intentionally generic about *which* policy rejected the host (existing comment warns against leaking allowlist details) but now tells the user what to check.

The two token-retrieval messages run the embedded exception text through `sanitize_exception_message`, so an upstream error carrying a token URL with credentials in the query string cannot surface them in the API response. The `logger.error` above each branch still records the raw detail for operators. This follows the convention established in review on #5934.

**Legacy admin UI validation** (`security.js`): `validateUrl`/`validateJson` errors become actionable (`Enter a URL.`, `Use http or https for the URL.`, `Enter a complete URL, for example https://example.com.`, `Cannot parse X as JSON: …`).

**Legacy result banner** (`gateways.js` `handleGatewayTestSubmit`): drops the ✅/❌ icons from the banner and error text. Titles (`Connection Successful`/`Connection Failed`) and the `Invalid gateway URL: ` error prefix are kept (asserted by `tests/unit/js/gateway.test.js`).

**React** — no change needed, and none needed in the new UI repo either: the client now lives in [contextforge-org/contextforge-web-ui](https://github.com/contextforge-org/contextforge-web-ui), and its `TestConnectionPanel` renders the backend `body.error` string verbatim, so the improved copy shows up there without a UI change.

## Tests

- Updated assertions in `tests/e2e/test_admin_apis.py` (6), `tests/unit/mcpgateway/test_admin.py` (2), `tests/unit/js/security.test.js` (1) — each fails without the copy change
- `pytest tests/unit/mcpgateway/test_admin.py -k gateway tests/e2e/test_admin_apis.py` — 1255 passed, 1 skipped (external connectivity)
- `pytest tests/unit/mcpgateway/test_admin.py -k gateway tests/unit/mcpgateway/services/test_gateway_service.py` — 1608 passed, 1 skipped
- `make test-js` — 2332 passed, 3 skipped
- Full `make test` — 21864 passed, 818 skipped, 2 xfailed, 0 failed
- `make ruff` clean; `pre-commit run --files …` clean on all six touched files

## Note on landing order

#5934 touches the same validation region of `test_gateway_connectivity` on `main`, so whichever lands second takes a small rebase. Landing this one first is the cheaper order — it is copy-only, and #5934's extracted `_validate_gateway_test_target` then carries the new allowlist wording directly.
