### PR TITLE
fix(tokens): allow reusing a revoked token's name

### DIFF
--- a/mcpgateway/alembic/versions/f3a8c2d94e17_scope_token_name_uniqueness_to_active_.py
+++ b/mcpgateway/alembic/versions/f3a8c2d94e17_scope_token_name_uniqueness_to_active_.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=no-member
+"""Location: ./mcpgateway/alembic/versions/f3a8c2d94e17_scope_token_name_uniqueness_to_active_.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+scope token name uniqueness to active tokens
+
+Revision ID: f3a8c2d94e17
+Revises: d21698ae4a19
+Create Date: 2026-07-27
+
+Token revocation is a soft delete (is_active = false), but the uniqueness rule on
+email_api_tokens (user_email, name, team_id) applied to ALL rows.  Once a token was
+revoked, its name was blocked forever for that user: creating a new token with the
+same name raised "A token with this name already exists" even though the UI showed
+no such token.  The service-level duplicate check in TokenCatalogService.create_token()
+already filters on is_active, so the DB constraint contradicted the intended semantics.
+
+This migration replaces the uniqueness rule with partial unique indexes that only
+cover active tokens — the same pattern migration d21698ae4a19 applied to the roles
+and user_roles tables:
+
+Old constraint: uq_email_api_tokens_user_name_team   -> (user_email, name, team_id)
+Old index:      uq_email_api_tokens_user_name_global -> (user_email, name) WHERE team_id IS NULL
+New index:      uq_email_api_tokens_user_name_team   -> (user_email, name, team_id) WHERE team_id IS NOT NULL AND is_active
+New index:      uq_email_api_tokens_user_name_global -> (user_email, name) WHERE team_id IS NULL AND is_active
+
+Index names are kept identical to the old constraint/index names so the IntegrityError
+handlers in routers/tokens.py and utils/error_formatter.py keep matching.
+
+No deduplication step is needed: the old (stricter) rule guarantees existing rows
+also satisfy the new (active-only) rule.
+
+Supports PostgreSQL and SQLite.  On other dialects partial indexes are unavailable,
+so the previous full-row uniqueness behavior is kept (with a warning), matching the
+fallback strategy of migration d21698ae4a19.
+"""
+
+# Standard
+from typing import Sequence, Union
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "f3a8c2d94e17"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "d21698ae4a19"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Replace all-rows token name uniqueness with active-only partial unique indexes."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    dialect = bind.dialect.name
+
+    # Skip if the table doesn't exist yet (fresh DB is created directly from db.py models)
+    if "email_api_tokens" not in inspector.get_table_names():
+        return
+
+    # Clean up orphaned temp table from a previously failed batch_alter_table run.
+    # On SQLite, DDL is non-transactional so the temp table persists after a rollback.
+    if "_alembic_tmp_email_api_tokens" in inspector.get_table_names():
+        op.drop_table("_alembic_tmp_email_api_tokens")
+
+    existing_constraints = {c["name"] for c in inspector.get_unique_constraints("email_api_tokens")}
+    existing_indexes = {idx["name"] for idx in inspector.get_indexes("email_api_tokens")}
+
+    # Drop the old (user_email, name, team_id) all-rows unique constraint.
+    # batch_alter_table is required for SQLite compatibility (SQLite cannot DROP
+    # CONSTRAINT directly; Alembic reconstructs the table under a batch context).
+    if "uq_email_api_tokens_user_name_team" in existing_constraints:
+        with op.batch_alter_table("email_api_tokens") as batch_op:
+            batch_op.drop_constraint("uq_email_api_tokens_user_name_team", type_="unique")
+
+    # Drop the old global-scope partial index (no is_active filter)
+    if "uq_email_api_tokens_user_name_global" in existing_indexes:
+        op.drop_index("uq_email_api_tokens_user_name_global", table_name="email_api_tokens")
+
+    # Recompute after the DDL above (batch_alter_table rebuilds the table on SQLite)
+    inspector = sa.inspect(bind)
+    existing_indexes = {idx["name"] for idx in inspector.get_indexes("email_api_tokens")}
+
+    if dialect in ("postgresql", "sqlite"):
+        is_active_true = "is_active = true" if dialect == "postgresql" else "is_active = 1"
+        if "uq_email_api_tokens_user_name_team" not in existing_indexes:
+            op.create_index(
+                "uq_email_api_tokens_user_name_team",
+                "email_api_tokens",
+                ["user_email", "name", "team_id"],
+                unique=True,
+                postgresql_where=sa.text(f"team_id IS NOT NULL AND {is_active_true}"),
+                sqlite_where=sa.text(f"team_id IS NOT NULL AND {is_active_true}"),
+            )
+        if "uq_email_api_tokens_user_name_global" not in existing_indexes:
+            op.create_index(
+                "uq_email_api_tokens_user_name_global",
+                "email_api_tokens",
+                ["user_email", "name"],
+                unique=True,
+                postgresql_where=sa.text(f"team_id IS NULL AND {is_active_true}"),
+                sqlite_where=sa.text(f"team_id IS NULL AND {is_active_true}"),
+            )
+    else:
+        # Partial indexes are not supported (e.g. MySQL): keep the previous all-rows
+        # uniqueness behavior so nothing regresses, even though revoked names stay blocked.
+        print(f"WARNING: Dialect '{dialect}' does not support partial indexes. " "Recreating full unique indexes; revoked token names remain reserved on this dialect.")
+        if "uq_email_api_tokens_user_name_team" not in existing_indexes:
+            op.create_index(
+                "uq_email_api_tokens_user_name_team",
+                "email_api_tokens",
+                ["user_email", "name", "team_id"],
+                unique=True,
+            )
+        if "uq_email_api_tokens_user_name_global" not in existing_indexes:
+            op.create_index(
+                "uq_email_api_tokens_user_name_global",
+                "email_api_tokens",
+                ["user_email", "name"],
+                unique=True,
+            )
+
+
+def downgrade() -> None:
+    """Restore all-rows uniqueness (constraint + partial index without is_active filter)."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "email_api_tokens" not in inspector.get_table_names():
+        return
+
+    # Clean up orphaned temp table from a previously failed batch_alter_table run.
+    if "_alembic_tmp_email_api_tokens" in inspector.get_table_names():
+        op.drop_table("_alembic_tmp_email_api_tokens")
+
+    existing_constraints = {c["name"] for c in inspector.get_unique_constraints("email_api_tokens")}
+    existing_indexes = {idx["name"] for idx in inspector.get_indexes("email_api_tokens")}
+
+    # Drop the active-only partial indexes
+    if "uq_email_api_tokens_user_name_team" in existing_indexes:
+        op.drop_index("uq_email_api_tokens_user_name_team", table_name="email_api_tokens")
+    if "uq_email_api_tokens_user_name_global" in existing_indexes:
+        op.drop_index("uq_email_api_tokens_user_name_global", table_name="email_api_tokens")
+
+    # Restore the original all-rows constraint and global partial index.
+    # NOTE: this can fail if revoked tokens now share a name with an active one;
+    # such rows must be renamed or deleted before downgrading.
+    inspector = sa.inspect(bind)
+    existing_indexes = {idx["name"] for idx in inspector.get_indexes("email_api_tokens")}
+
+    if "uq_email_api_tokens_user_name_team" not in existing_constraints:
+        with op.batch_alter_table("email_api_tokens") as batch_op:
+            batch_op.create_unique_constraint(
+                "uq_email_api_tokens_user_name_team",
+                ["user_email", "name", "team_id"],
+            )
+
+    if "uq_email_api_tokens_user_name_global" not in existing_indexes:
+        op.create_index(
+            "uq_email_api_tokens_user_name_global",
+            "email_api_tokens",
+            ["user_email", "name"],
+            unique=True,
+            postgresql_where=sa.text("team_id IS NULL"),
+            sqlite_where=sa.text("team_id IS NULL"),
+        )

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -5477,13 +5477,33 @@ class EmailApiToken(Base):
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     tags: Mapped[Optional[List[str]]] = mapped_column(JSON, nullable=True, default=list)
 
-    # Unique constraint for user+name+team_id combination (per-team scope).
-    # The composite UniqueConstraint handles non-NULL team_id rows.  SQL NULL != NULL
-    # semantics mean it cannot protect global-scope tokens (team_id IS NULL), so we add
-    # a partial unique index for that case — matching the pattern used by resources/prompts.
+    # Token names must be unique per user per team scope, but only among ACTIVE tokens.
+    # Revocation is a soft delete (is_active = false), so the uniqueness rule must ignore
+    # revoked rows or a deleted token blocks its name forever.  This matches the
+    # service-level duplicate check in TokenCatalogService.create_token(), which already
+    # filters on is_active.  Partial unique indexes (WHERE is_active) replace the previous
+    # UniqueConstraint — same pattern as uq_roles_name_scope_active on the roles table.
+    # The team-scoped index handles non-NULL team_id rows; SQL NULL != NULL semantics mean
+    # it cannot protect global-scope tokens (team_id IS NULL), so a second partial index
+    # covers that case.  Index names are kept stable because error handlers match on them.
     __table_args__ = (
-        UniqueConstraint("user_email", "name", "team_id", name="uq_email_api_tokens_user_name_team"),
-        Index("uq_email_api_tokens_user_name_global", "user_email", "name", unique=True, postgresql_where=text("team_id IS NULL"), sqlite_where=text("team_id IS NULL")),
+        Index(
+            "uq_email_api_tokens_user_name_team",
+            "user_email",
+            "name",
+            "team_id",
+            unique=True,
+            postgresql_where=text("team_id IS NOT NULL AND is_active = true"),
+            sqlite_where=text("team_id IS NOT NULL AND is_active = 1"),
+        ),
+        Index(
+            "uq_email_api_tokens_user_name_global",
+            "user_email",
+            "name",
+            unique=True,
+            postgresql_where=text("team_id IS NULL AND is_active = true"),
+            sqlite_where=text("team_id IS NULL AND is_active = 1"),
+        ),
         Index("idx_email_api_tokens_user_email", "user_email"),
         Index("idx_email_api_tokens_jti", "jti"),
         Index("idx_email_api_tokens_expires_at", "expires_at"),

--- a/tests/integration/test_token_name_reuse_integration.py
+++ b/tests/integration/test_token_name_reuse_integration.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/integration/test_token_name_reuse_integration.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Integration tests for API token name reuse after revocation.
+
+Token revocation is a soft delete (is_active = false).  These tests verify against a
+real database (SQLite, schema from db.py models) that:
+- Creating a token, revoking it, and creating a new token with the same name succeeds
+  (previously failed with IntegrityError: the uniqueness rule covered revoked rows)
+- Duplicate ACTIVE token names are still rejected at the database level
+"""
+
+# Standard
+from datetime import datetime, timezone
+
+# Third-Party
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.db import Base, EmailApiToken, EmailUser
+from mcpgateway.services.token_catalog_service import TokenCatalogService
+
+TEST_EMAIL = "token-reuse@example.com"
+
+
+@pytest.fixture
+def db_session():
+    """Create a real SQLite database session with the full schema and a test user."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    session.add(
+        EmailUser(
+            email=TEST_EMAIL,
+            password_hash="not-a-real-hash",
+            full_name="Token Reuse Test User",
+            is_admin=False,
+            is_active=True,
+            auth_provider="local",
+            email_verified_at=datetime.now(timezone.utc),
+        )
+    )
+    session.commit()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_revoked_token_name_can_be_reused(db_session):
+    """Create -> revoke -> create with the same name must succeed."""
+    service = TokenCatalogService(db_session)
+
+    token, _raw = await service.create_token(user_email=TEST_EMAIL, name="my-token", expires_in_days=30)
+    revoked = await service.revoke_token(token.id, TEST_EMAIL, revoked_by=TEST_EMAIL, reason="test")
+    assert revoked is True
+
+    # The revoked token's name must be reusable
+    new_token, _raw = await service.create_token(user_email=TEST_EMAIL, name="my-token", expires_in_days=30)
+    assert new_token.id != token.id
+    assert new_token.is_active is True
+
+    # Both rows coexist: the revoked one is kept for audit
+    rows = db_session.query(EmailApiToken).filter_by(user_email=TEST_EMAIL, name="my-token").all()
+    assert len(rows) == 2
+    assert sorted(r.is_active for r in rows) == [False, True]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_active_token_name_still_rejected(db_session):
+    """Two ACTIVE tokens with the same name in the same scope must be rejected."""
+    service = TokenCatalogService(db_session)
+
+    await service.create_token(user_email=TEST_EMAIL, name="my-token", expires_in_days=30)
+    with pytest.raises(ValueError, match="already exists"):
+        await service.create_token(user_email=TEST_EMAIL, name="my-token", expires_in_days=30)

--- a/tests/unit/mcpgateway/db/test_token_name_active_uniqueness_migration.py
+++ b/tests/unit/mcpgateway/db/test_token_name_active_uniqueness_migration.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/db/test_token_name_active_uniqueness_migration.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for migration f3a8c2d94e17 (scope token name uniqueness to active tokens).
+
+Tests verify:
+- Migration module structure (import, functions, revision chain)
+- Functional execution on SQLite: after upgrade, a revoked (is_active = 0) token no
+  longer blocks its name, while duplicate ACTIVE names are still rejected
+- Idempotency and missing-table guards in upgrade() and downgrade()
+"""
+
+# Standard
+import importlib
+import inspect as pyinspect
+
+# Third-Party
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+import pytest
+import sqlalchemy as sa
+
+MODULE_NAME = "mcpgateway.alembic.versions.f3a8c2d94e17_scope_token_name_uniqueness_to_active_"
+REVISION = "f3a8c2d94e17"  # pragma: allowlist secret
+DOWN_REVISION = "d21698ae4a19"  # pragma: allowlist secret
+
+
+class TestActiveUniquenessModuleStructure:
+    """Test migration f3a8c2d94e17 module structure."""
+
+    def test_migration_module_imports(self):
+        """Test that migration module can be imported."""
+        module = importlib.import_module(MODULE_NAME)
+        assert module is not None
+
+    def test_migration_has_upgrade_function(self):
+        """Test that migration has a callable upgrade() function."""
+        module = importlib.import_module(MODULE_NAME)
+        assert hasattr(module, "upgrade")
+        assert callable(module.upgrade)
+
+    def test_migration_has_downgrade_function(self):
+        """Test that migration has a callable downgrade() function."""
+        module = importlib.import_module(MODULE_NAME)
+        assert hasattr(module, "downgrade")
+        assert callable(module.downgrade)
+
+    def test_migration_revision_id(self):
+        """Test migration has the correct revision ID."""
+        module = importlib.import_module(MODULE_NAME)
+        assert module.revision == REVISION
+
+    def test_migration_down_revision(self):
+        """Test migration has the correct down_revision."""
+        module = importlib.import_module(MODULE_NAME)
+        assert module.down_revision == DOWN_REVISION
+
+    def test_migration_functions_have_no_parameters(self):
+        """Test that upgrade() and downgrade() accept no parameters."""
+        module = importlib.import_module(MODULE_NAME)
+        assert len(pyinspect.signature(module.upgrade).parameters) == 0
+        assert len(pyinspect.signature(module.downgrade).parameters) == 0
+
+
+def _create_pre_upgrade_table(conn):
+    """Create email_api_tokens in the pre-upgrade state (all-rows uniqueness)."""
+    conn.execute(sa.text("""
+            CREATE TABLE email_api_tokens (
+                id VARCHAR(36) PRIMARY KEY,
+                user_email VARCHAR(255) NOT NULL,
+                name VARCHAR(255) NOT NULL,
+                team_id VARCHAR(36),
+                jti VARCHAR(36) NOT NULL,
+                token_hash VARCHAR(255) NOT NULL,
+                is_active BOOLEAN NOT NULL DEFAULT 1,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                CONSTRAINT uq_email_api_tokens_user_name_team UNIQUE (user_email, name, team_id)
+            )
+            """))
+    conn.execute(sa.text("""
+            CREATE UNIQUE INDEX uq_email_api_tokens_user_name_global
+            ON email_api_tokens (user_email, name)
+            WHERE team_id IS NULL
+            """))
+
+
+def _insert_token(conn, token_id, user_email, name, team_id=None, is_active=1):
+    """Insert a minimal email_api_tokens row."""
+    conn.execute(
+        sa.text("INSERT INTO email_api_tokens (id, user_email, name, team_id, jti, token_hash, is_active) " "VALUES (:id, :user_email, :name, :team_id, :jti, :token_hash, :is_active)"),
+        {"id": token_id, "user_email": user_email, "name": name, "team_id": team_id, "jti": f"jti-{token_id}", "token_hash": f"hash-{token_id}", "is_active": is_active},
+    )
+
+
+def _run_migration(conn, func_name):
+    """Run the migration's upgrade() or downgrade() against the given connection."""
+    ctx = MigrationContext.configure(conn, opts={"as_sql": False})
+    with Operations.context(ctx):
+        module = importlib.import_module(MODULE_NAME)
+        getattr(module, func_name)()
+
+
+def _get_table_names(conn):
+    """Return a set of table names in the current database."""
+    inspector = sa.inspect(conn)
+    return set(inspector.get_table_names())
+
+
+class TestUpgradeFunctional:
+    """Functional tests for upgrade() on SQLite."""
+
+    def test_revoked_token_name_reusable_after_upgrade(self):
+        """A revoked token's name can be reused; the pre-upgrade schema rejected it."""
+        engine = sa.create_engine("sqlite:///:memory:")
+        try:
+            with engine.connect() as conn:
+                _create_pre_upgrade_table(conn)
+                _insert_token(conn, "t1", "user@example.com", "my-token", is_active=0)  # revoked
+                conn.commit()
+
+                # Pre-upgrade: the revoked row still blocks the name (the bug)
+                with pytest.raises(sa.exc.IntegrityError):
+                    _insert_token(conn, "t2", "user@example.com", "my-token")
+                conn.rollback()
+
+                _run_migration(conn, "upgrade")
+
+                # Post-upgrade: the name is reusable
+                _insert_token(conn, "t2", "user@example.com", "my-token")
+                conn.commit()
+        finally:
+            engine.dispose()
+
+    def test_duplicate_active_names_still_rejected_after_upgrade(self):
+        """Active tokens still cannot share a name in the same scope."""
+        engine = sa.create_engine("sqlite:///:memory:")
+        try:
+            with engine.connect() as conn:
+                _create_pre_upgrade_table(conn)
+                conn.commit()
+
+                _run_migration(conn, "upgrade")
+
+                # Global scope (team_id IS NULL)
+                _insert_token(conn, "t1", "user@example.com", "my-token")
+                conn.commit()
+                with pytest.raises(sa.exc.IntegrityError):
+                    _insert_token(conn, "t2", "user@example.com", "my-token")
+                conn.rollback()
+
+                # Team scope
+                _insert_token(conn, "t3", "user@example.com", "team-token", team_id="team-1")
+                conn.commit()
+                with pytest.raises(sa.exc.IntegrityError):
+                    _insert_token(conn, "t4", "user@example.com", "team-token", team_id="team-1")
+                conn.rollback()
+
+                # Same name in a different team scope is allowed
+                _insert_token(conn, "t5", "user@example.com", "team-token", team_id="team-2")
+                conn.commit()
+        finally:
+            engine.dispose()
+
+    def test_upgrade_is_idempotent(self):
+        """Running upgrade twice does not raise."""
+        engine = sa.create_engine("sqlite:///:memory:")
+        try:
+            with engine.connect() as conn:
+                _create_pre_upgrade_table(conn)
+                conn.commit()
+
+                _run_migration(conn, "upgrade")
+                _run_migration(conn, "upgrade")  # Should not raise
+
+                assert "email_api_tokens" in _get_table_names(conn)
+        finally:
+            engine.dispose()
+
+    def test_upgrade_skips_when_table_missing(self):
+        """Test upgrade is a no-op when email_api_tokens table doesn't exist."""
+        engine = sa.create_engine("sqlite:///:memory:")
+        try:
+            with engine.connect() as conn:
+                _run_migration(conn, "upgrade")  # Should not raise
+                assert "email_api_tokens" not in _get_table_names(conn)
+        finally:
+            engine.dispose()
+
+
+class TestDowngradeFunctional:
+    """Functional tests for downgrade() on SQLite."""
+
+    def test_downgrade_restores_all_rows_uniqueness(self):
+        """After downgrade, a revoked token blocks its name again (pre-fix behavior)."""
+        engine = sa.create_engine("sqlite:///:memory:")
+        try:
+            with engine.connect() as conn:
+                _create_pre_upgrade_table(conn)
+                conn.commit()
+
+                _run_migration(conn, "upgrade")
+                _run_migration(conn, "downgrade")
+
+                _insert_token(conn, "t1", "user@example.com", "my-token", is_active=0)
+                conn.commit()
+                with pytest.raises(sa.exc.IntegrityError):
+                    _insert_token(conn, "t2", "user@example.com", "my-token")
+                conn.rollback()
+        finally:
+            engine.dispose()
+
+    def test_downgrade_skips_when_table_missing(self):
+        """Test downgrade is a no-op when email_api_tokens table doesn't exist."""
+        engine = sa.create_engine("sqlite:///:memory:")
+        try:
+            with engine.connect() as conn:
+                _run_migration(conn, "downgrade")  # Should not raise
+                assert "email_api_tokens" not in _get_table_names(conn)
+        finally:
+            engine.dispose()


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #5931

---

## 📝 Summary

Token revocation is a soft delete (`is_active = false`), but the uniqueness rule on `email_api_tokens (user_email, name, team_id)` covers all rows. Once a token is revoked, its name is blocked forever for that user: creating a new token with the same name fails with "A token with this name already exists" even though the UI shows no such token.

The service-level duplicate check in `TokenCatalogService.create_token()` already filters on `is_active`, so the DB constraint contradicted the intended semantics. This PR replaces the `UniqueConstraint` and the global partial index with partial unique indexes scoped to active rows (`WHERE is_active`), the same pattern migration `d21698ae4a19` applied to `roles`/`user_roles` for #4482. Index names are unchanged so the existing `IntegrityError` handlers in `routers/tokens.py` and `utils/error_formatter.py` keep matching.

Changes:

- `mcpgateway/db.py`: `EmailApiToken.__table_args__` now uses active-only partial unique indexes (PostgreSQL and SQLite; other dialects keep the previous full-row uniqueness as fallback)
- New Alembic migration `f3a8c2d94e17` (idempotent, `batch_alter_table` for SQLite compatibility, no dedup step needed since the old stricter rule implies the new one)
- Migration unit tests + service-level integration tests covering create → revoke → recreate with the same name, and duplicate-active rejection (global and team scope)

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|-------|---------|--------|
| New tests (migration + integration) | `pytest tests/unit/mcpgateway/db/test_token_name_active_uniqueness_migration.py tests/integration/test_token_name_reuse_integration.py` | ✅ 14 passed |
| Related token suites | `pytest tests/unit/mcpgateway/db/test_token_uniqueness_migration.py tests/unit/mcpgateway/services/test_token_catalog_service.py tests/unit/mcpgateway/routers/test_tokens.py tests/unit/mcpgateway/utils/test_error_formatter.py tests/integration/test_token_security_integration.py` | ✅ 300 passed (4 failures in `test_token_security_integration.py` pre-exist on unmodified `main`) |
| Formatting | `black` / `isort` on changed files | ✅ clean |

The integration test `test_revoked_token_name_can_be_reused` reproduces the bug: it fails with `IntegrityError` on the old schema and passes with this change.

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

- Downgrade restores the original constraint; it can fail if a revoked token now shares a name with an active one — noted in the migration docstring (such rows must be renamed or deleted before downgrading).
- On dialects without partial-index support (e.g. MySQL) the migration recreates full unique indexes with a warning, keeping today's behavior rather than regressing.
