### PR TITLE
feat(helm): add nodeSelector, tolerations and annotation support to all deployments

### DIFF
--- a/charts/mcp-stack/templates/deployment-mcp-fast-time-server.yaml
+++ b/charts/mcp-stack/templates/deployment-mcp-fast-time-server.yaml
@@ -34,6 +34,14 @@ spec:
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with (coalesce .Values.mcpFastTimeServer.nodeSelector .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (coalesce .Values.mcpFastTimeServer.tolerations .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if gt (int .Values.mcpFastTimeServer.replicaCount) 1 }}
       affinity:
         podAntiAffinity:

--- a/charts/mcp-stack/templates/deployment-mcp-fast-time-server.yaml
+++ b/charts/mcp-stack/templates/deployment-mcp-fast-time-server.yaml
@@ -13,6 +13,10 @@ metadata:
   labels:
     {{- include "mcp-stack.labels" . | nindent 4 }}
     app: {{ include "mcp-stack.fullname" . }}-mcp-fast-time-server
+  {{- with merge (default dict .Values.mcpFastTimeServer.annotations) (default dict .Values.annotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.mcpFastTimeServer.replicaCount }}
   selector:
@@ -22,6 +26,13 @@ spec:
     metadata:
       labels:
         app: {{ include "mcp-stack.fullname" . }}-mcp-fast-time-server
+        {{- with merge (default dict .Values.mcpFastTimeServer.podLabels) (default dict .Values.podLabels) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with merge (default dict .Values.mcpFastTimeServer.podAnnotations) (default dict .Values.podAnnotations) }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       # Image pull secrets
       {{- if .Values.global.imagePullSecrets }}

--- a/charts/mcp-stack/templates/deployment-mcpgateway.yaml
+++ b/charts/mcp-stack/templates/deployment-mcpgateway.yaml
@@ -15,6 +15,10 @@ metadata:
   name: {{ include "mcp-stack.fullname" . }}-mcpgateway
   labels:
     {{- include "mcp-stack.labels" . | nindent 4 }}
+  {{- with merge (default dict .Values.mcpContextForge.annotations) (default dict .Values.annotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.mcpContextForge.replicaCount }}
 
@@ -26,6 +30,13 @@ spec:
     metadata:
       labels:
         app: {{ include "mcp-stack.fullname" . }}-mcpgateway
+        {{- with merge (default dict .Values.mcpContextForge.podLabels) (default dict .Values.podLabels) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with merge (default dict .Values.mcpContextForge.podAnnotations) (default dict .Values.podAnnotations) }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 
     spec:
       # Image pull secrets

--- a/charts/mcp-stack/templates/deployment-mcpgateway.yaml
+++ b/charts/mcp-stack/templates/deployment-mcpgateway.yaml
@@ -50,6 +50,14 @@ spec:
                     app: {{ include "mcp-stack.fullname" . }}-mcpgateway
                 topologyKey: kubernetes.io/hostname
       {{- end }}
+      {{- with (coalesce .Values.mcpContextForge.nodeSelector .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (coalesce .Values.mcpContextForge.tolerations .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.mcpContextForge.podSecurityContext | nindent 8 }}
         seccompProfile:

--- a/charts/mcp-stack/templates/deployment-nginx-proxy.yaml
+++ b/charts/mcp-stack/templates/deployment-nginx-proxy.yaml
@@ -26,6 +26,14 @@ spec:
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with (coalesce .Values.nginxProxy.nodeSelector .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (coalesce .Values.nginxProxy.tolerations .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.nginxProxy.sysctls }}
       securityContext:
         sysctls:

--- a/charts/mcp-stack/templates/deployment-nginx-proxy.yaml
+++ b/charts/mcp-stack/templates/deployment-nginx-proxy.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "mcp-stack.labels" . | nindent 4 }}
     app: {{ include "mcp-stack.fullname" . }}-nginx
+  {{- with merge (default dict .Values.nginxProxy.annotations) (default dict .Values.annotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.nginxProxy.replicaCount | default 1 }}
   selector:
@@ -15,6 +19,13 @@ spec:
     metadata:
       labels:
         app: {{ include "mcp-stack.fullname" . }}-nginx
+        {{- with merge (default dict .Values.nginxProxy.podLabels) (default dict .Values.podLabels) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with merge (default dict .Values.nginxProxy.podAnnotations) (default dict .Values.podAnnotations) }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/mcp-stack/templates/deployment-pgadmin.yaml
+++ b/charts/mcp-stack/templates/deployment-pgadmin.yaml
@@ -32,6 +32,14 @@ spec:
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with (coalesce .Values.pgadmin.nodeSelector .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (coalesce .Values.pgadmin.tolerations .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/charts/mcp-stack/templates/deployment-pgadmin.yaml
+++ b/charts/mcp-stack/templates/deployment-pgadmin.yaml
@@ -9,6 +9,10 @@ metadata:
   labels:
     {{- include "mcp-stack.labels" . | nindent 4 }}
     app: pgadmin
+  {{- with merge (default dict .Values.pgadmin.annotations) (default dict .Values.annotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:
@@ -20,6 +24,13 @@ spec:
       labels:
         app: pgadmin
         release: {{ .Release.Name }}
+        {{- with merge (default dict .Values.pgadmin.podLabels) (default dict .Values.podLabels) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with merge (default dict .Values.pgadmin.podAnnotations) (default dict .Values.podAnnotations) }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       # Image pull secrets
       {{- if .Values.global.imagePullSecrets }}

--- a/charts/mcp-stack/templates/deployment-pgbouncer.yaml
+++ b/charts/mcp-stack/templates/deployment-pgbouncer.yaml
@@ -14,6 +14,10 @@ metadata:
   labels:
     {{- include "mcp-stack.labels" . | nindent 4 }}
     app: {{ include "mcp-stack.fullname" . }}-pgbouncer
+  {{- with merge (default dict .Values.pgbouncer.annotations) (default dict .Values.annotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:
@@ -23,6 +27,13 @@ spec:
     metadata:
       labels:
         app: {{ include "mcp-stack.fullname" . }}-pgbouncer
+        {{- with merge (default dict .Values.pgbouncer.podLabels) (default dict .Values.podLabels) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with merge (default dict .Values.pgbouncer.podAnnotations) (default dict .Values.podAnnotations) }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/mcp-stack/templates/deployment-pgbouncer.yaml
+++ b/charts/mcp-stack/templates/deployment-pgbouncer.yaml
@@ -34,6 +34,14 @@ spec:
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with (coalesce .Values.pgbouncer.nodeSelector .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (coalesce .Values.pgbouncer.tolerations .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/charts/mcp-stack/templates/deployment-postgres.yaml
+++ b/charts/mcp-stack/templates/deployment-postgres.yaml
@@ -28,6 +28,10 @@ metadata:
   labels:
     {{- include "mcp-stack.labels" . | nindent 4 }}
     app: {{ include "mcp-stack.fullname" . }}-postgres
+  {{- with merge (default dict .Values.postgres.annotations) (default dict .Values.annotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1                   # one DB pod; use StatefulSet if you ever scale
   selector:
@@ -41,6 +45,13 @@ spec:
     metadata:
       labels:
         app: {{ include "mcp-stack.fullname" . }}-postgres
+        {{- with merge (default dict .Values.postgres.podLabels) (default dict .Values.podLabels) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with merge (default dict .Values.postgres.podAnnotations) (default dict .Values.podAnnotations) }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       # Image pull secrets
       {{- if .Values.global.imagePullSecrets }}

--- a/charts/mcp-stack/templates/deployment-postgres.yaml
+++ b/charts/mcp-stack/templates/deployment-postgres.yaml
@@ -53,6 +53,14 @@ spec:
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with (coalesce .Values.postgres.nodeSelector .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (coalesce .Values.postgres.tolerations .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/charts/mcp-stack/templates/deployment-redis-commander.yaml
+++ b/charts/mcp-stack/templates/deployment-redis-commander.yaml
@@ -32,6 +32,14 @@ spec:
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with (coalesce .Values.redisCommander.nodeSelector .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (coalesce .Values.redisCommander.tolerations .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/charts/mcp-stack/templates/deployment-redis-commander.yaml
+++ b/charts/mcp-stack/templates/deployment-redis-commander.yaml
@@ -9,6 +9,10 @@ metadata:
   labels:
     {{- include "mcp-stack.labels" . | nindent 4 }}
     app: redis-commander
+  {{- with merge (default dict .Values.redisCommander.annotations) (default dict .Values.annotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:
@@ -20,6 +24,13 @@ spec:
       labels:
         app: redis-commander
         release: {{ .Release.Name }}
+        {{- with merge (default dict .Values.redisCommander.podLabels) (default dict .Values.podLabels) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with merge (default dict .Values.redisCommander.podAnnotations) (default dict .Values.podAnnotations) }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       # Image pull secrets
       {{- if .Values.global.imagePullSecrets }}

--- a/charts/mcp-stack/templates/deployment-redis.yaml
+++ b/charts/mcp-stack/templates/deployment-redis.yaml
@@ -14,6 +14,10 @@ metadata:
   labels:
     {{- include "mcp-stack.labels" . | nindent 4 }}
     app: {{ include "mcp-stack.fullname" . }}-redis
+  {{- with merge (default dict .Values.redis.annotations) (default dict .Values.annotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1                   # single instance; swap for StatefulSet if HA
   selector:
@@ -23,6 +27,13 @@ spec:
     metadata:
       labels:
         app: {{ include "mcp-stack.fullname" . }}-redis
+        {{- with merge (default dict .Values.redis.podLabels) (default dict .Values.podLabels) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with merge (default dict .Values.redis.podAnnotations) (default dict .Values.podAnnotations) }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       # Image pull secrets
       {{- if .Values.global.imagePullSecrets }}

--- a/charts/mcp-stack/templates/deployment-redis.yaml
+++ b/charts/mcp-stack/templates/deployment-redis.yaml
@@ -35,6 +35,14 @@ spec:
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with (coalesce .Values.redis.nodeSelector .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (coalesce .Values.redis.tolerations .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/charts/mcp-stack/templates/job-migration.yaml
+++ b/charts/mcp-stack/templates/job-migration.yaml
@@ -11,6 +11,9 @@ metadata:
     "helm.sh/hook": {{ .Values.migration.hookPhase | default "post-install,pre-upgrade" }}
     # Delete old Job before new one and clean up succeeded ones
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.migration.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   # Job configuration
   backoffLimit: {{ .Values.migration.backoffLimit }}
@@ -22,6 +25,13 @@ spec:
       labels:
         {{- include "mcp-stack.labels" . | nindent 8 }}
         app.kubernetes.io/component: migration
+        {{- with merge (default dict .Values.migration.podLabels) (default dict .Values.podLabels) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with merge (default dict .Values.migration.podAnnotations) (default dict .Values.podAnnotations) }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       restartPolicy: {{ .Values.migration.restartPolicy }}
       {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}

--- a/charts/mcp-stack/templates/job-migration.yaml
+++ b/charts/mcp-stack/templates/job-migration.yaml
@@ -28,6 +28,14 @@ spec:
       serviceAccountName: {{ include "mcp-stack.serviceAccountName" . }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with (coalesce .Values.migration.nodeSelector .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (coalesce .Values.migration.tolerations .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- if .Values.migration.podSecurityContext }}
         {{- toYaml .Values.migration.podSecurityContext | nindent 8 }}

--- a/charts/mcp-stack/tests/deployment_mcp_fast_time_server_test.yaml
+++ b/charts/mcp-stack/tests/deployment_mcp_fast_time_server_test.yaml
@@ -1,0 +1,86 @@
+suite: mcp-fast-time-server deployment scheduling
+templates:
+  - templates/deployment-mcp-fast-time-server.yaml
+
+tests:
+  - it: no nodeSelector rendered by default
+    set:
+      mcpFastTimeServer.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.nodeSelector
+
+  - it: global nodeSelector is applied when set
+    set:
+      mcpFastTimeServer.enabled: true
+      nodeSelector:
+        kubernetes.io/os: linux
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            kubernetes.io/os: linux
+
+  - it: component nodeSelector overrides global
+    set:
+      mcpFastTimeServer.enabled: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      mcpFastTimeServer.nodeSelector:
+        node-role: fast-time
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            node-role: fast-time
+
+  - it: no tolerations rendered by default
+    set:
+      mcpFastTimeServer.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations
+
+  - it: global tolerations are applied when set
+    set:
+      mcpFastTimeServer.enabled: true
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: mcp
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: dedicated
+            operator: Equal
+            value: mcp
+            effect: NoSchedule
+
+  - it: component tolerations override global
+    set:
+      mcpFastTimeServer.enabled: true
+      tolerations:
+        - key: global-key
+          operator: Exists
+          effect: NoSchedule
+      mcpFastTimeServer.tolerations:
+        - key: fast-time-key
+          operator: Equal
+          value: fast-time
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: fast-time-key
+            operator: Equal
+            value: fast-time
+            effect: NoSchedule
+      - notContains:
+          path: spec.template.spec.tolerations
+          content:
+            key: global-key
+            operator: Exists
+            effect: NoSchedule

--- a/charts/mcp-stack/tests/deployment_mcp_fast_time_server_test.yaml
+++ b/charts/mcp-stack/tests/deployment_mcp_fast_time_server_test.yaml
@@ -84,3 +84,102 @@ tests:
             key: global-key
             operator: Exists
             effect: NoSchedule
+
+  - it: no podAnnotations rendered by default
+    set:
+      mcpFastTimeServer.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations
+
+  - it: global podAnnotations applied when set
+    set:
+      mcpFastTimeServer.enabled: true
+      podAnnotations:
+        com.rapid7.insightops/log: app.log
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            com.rapid7.insightops/log: app.log
+
+  - it: component podAnnotations merged with global
+    set:
+      mcpFastTimeServer.enabled: true
+      podAnnotations:
+        com.rapid7.insightops/log: app.log
+      mcpFastTimeServer.podAnnotations:
+        app-specific: mcpFastTimeServer
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["com.rapid7.insightops/log"]
+          value: app.log
+      - equal:
+          path: spec.template.metadata.annotations["app-specific"]
+          value: mcpFastTimeServer
+
+  - it: component podAnnotations override global on same key
+    set:
+      mcpFastTimeServer.enabled: true
+      podAnnotations:
+        shared-key: global-value
+      mcpFastTimeServer.podAnnotations:
+        shared-key: component-value
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["shared-key"]
+          value: component-value
+
+  - it: global podLabels applied to pod template
+    set:
+      mcpFastTimeServer.enabled: true
+      podLabels:
+        env: production
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["env"]
+          value: production
+
+  - it: deployment annotations rendered when set
+    set:
+      mcpFastTimeServer.enabled: true
+      mcpFastTimeServer.annotations:
+        example.com/owner: platform
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform
+
+  - it: no deployment annotations rendered by default
+    set:
+      mcpFastTimeServer.enabled: true
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: global annotations merged with component annotations
+    set:
+      mcpFastTimeServer.enabled: true
+      annotations:
+        example.com/owner: platform-team
+      mcpFastTimeServer.annotations:
+        example.com/component: mcpFastTimeServer
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform-team
+      - equal:
+          path: metadata.annotations["example.com/component"]
+          value: mcpFastTimeServer
+
+  - it: component annotations override global on same key
+    set:
+      mcpFastTimeServer.enabled: true
+      annotations:
+        example.com/owner: global-value
+      mcpFastTimeServer.annotations:
+        example.com/owner: component-value
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: component-value

--- a/charts/mcp-stack/tests/deployment_mcpgateway_test.yaml
+++ b/charts/mcp-stack/tests/deployment_mcpgateway_test.yaml
@@ -127,3 +127,96 @@ tests:
             key: global-key
             operator: Exists
             effect: NoSchedule
+
+  - it: no podAnnotations rendered by default
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations
+
+  - it: global podAnnotations applied when set
+    set:
+      podAnnotations:
+        com.rapid7.insightops/log: app.log
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            com.rapid7.insightops/log: app.log
+
+  - it: component podAnnotations merged with global
+    set:
+      podAnnotations:
+        com.rapid7.insightops/log: app.log
+      mcpContextForge.podAnnotations:
+        app-specific: gateway
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["com.rapid7.insightops/log"]
+          value: app.log
+      - equal:
+          path: spec.template.metadata.annotations["app-specific"]
+          value: gateway
+
+  - it: component podAnnotations override global on same key
+    set:
+      podAnnotations:
+        shared-key: global-value
+      mcpContextForge.podAnnotations:
+        shared-key: component-value
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["shared-key"]
+          value: component-value
+
+  - it: no podLabels rendered by default
+    asserts:
+      - notExists:
+          path: spec.template.metadata.labels["env"]
+
+  - it: global podLabels applied to pod template
+    set:
+      podLabels:
+        env: production
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["env"]
+          value: production
+
+  - it: deployment annotations rendered when set
+    set:
+      mcpContextForge.annotations:
+        secret.reloader.stakater.com/reload: my-secret
+    asserts:
+      - equal:
+          path: metadata.annotations["secret.reloader.stakater.com/reload"]
+          value: my-secret
+
+  - it: no deployment annotations rendered by default
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: global annotations merged with component annotations
+    set:
+      annotations:
+        example.com/owner: platform-team
+      mcpContextForge.annotations:
+        example.com/component: gateway
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform-team
+      - equal:
+          path: metadata.annotations["example.com/component"]
+          value: gateway
+
+  - it: component annotations override global on same key
+    set:
+      annotations:
+        example.com/owner: global-value
+      mcpContextForge.annotations:
+        example.com/owner: component-value
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: component-value

--- a/charts/mcp-stack/tests/deployment_mcpgateway_test.yaml
+++ b/charts/mcp-stack/tests/deployment_mcpgateway_test.yaml
@@ -53,3 +53,77 @@ tests:
       - equal:
           path: spec.template.spec.automountServiceAccountToken
           value: false
+
+  - it: no nodeSelector rendered by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.nodeSelector
+
+  - it: global nodeSelector is applied when set
+    set:
+      nodeSelector:
+        kubernetes.io/os: linux
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            kubernetes.io/os: linux
+
+  - it: component nodeSelector overrides global
+    set:
+      nodeSelector:
+        kubernetes.io/os: linux
+      mcpContextForge.nodeSelector:
+        node-role: mcp-workloads
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            node-role: mcp-workloads
+
+  - it: no tolerations rendered by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations
+
+  - it: global tolerations are applied when set
+    set:
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: mcp
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: dedicated
+            operator: Equal
+            value: mcp
+            effect: NoSchedule
+
+  - it: component tolerations override global
+    set:
+      tolerations:
+        - key: global-key
+          operator: Exists
+          effect: NoSchedule
+      mcpContextForge.tolerations:
+        - key: mcp-key
+          operator: Equal
+          value: mcp
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: mcp-key
+            operator: Equal
+            value: mcp
+            effect: NoSchedule
+      - notContains:
+          path: spec.template.spec.tolerations
+          content:
+            key: global-key
+            operator: Exists
+            effect: NoSchedule

--- a/charts/mcp-stack/tests/deployment_nginx_proxy_test.yaml
+++ b/charts/mcp-stack/tests/deployment_nginx_proxy_test.yaml
@@ -84,3 +84,102 @@ tests:
             key: global-key
             operator: Exists
             effect: NoSchedule
+
+  - it: no podAnnotations rendered by default
+    set:
+      nginxProxy.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations
+
+  - it: global podAnnotations applied when set
+    set:
+      nginxProxy.enabled: true
+      podAnnotations:
+        com.rapid7.insightops/log: app.log
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            com.rapid7.insightops/log: app.log
+
+  - it: component podAnnotations merged with global
+    set:
+      nginxProxy.enabled: true
+      podAnnotations:
+        com.rapid7.insightops/log: app.log
+      nginxProxy.podAnnotations:
+        app-specific: nginxProxy
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["com.rapid7.insightops/log"]
+          value: app.log
+      - equal:
+          path: spec.template.metadata.annotations["app-specific"]
+          value: nginxProxy
+
+  - it: component podAnnotations override global on same key
+    set:
+      nginxProxy.enabled: true
+      podAnnotations:
+        shared-key: global-value
+      nginxProxy.podAnnotations:
+        shared-key: component-value
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["shared-key"]
+          value: component-value
+
+  - it: global podLabels applied to pod template
+    set:
+      nginxProxy.enabled: true
+      podLabels:
+        env: production
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["env"]
+          value: production
+
+  - it: deployment annotations rendered when set
+    set:
+      nginxProxy.enabled: true
+      nginxProxy.annotations:
+        example.com/owner: platform
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform
+
+  - it: no deployment annotations rendered by default
+    set:
+      nginxProxy.enabled: true
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: global annotations merged with component annotations
+    set:
+      nginxProxy.enabled: true
+      annotations:
+        example.com/owner: platform-team
+      nginxProxy.annotations:
+        example.com/component: nginxProxy
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform-team
+      - equal:
+          path: metadata.annotations["example.com/component"]
+          value: nginxProxy
+
+  - it: component annotations override global on same key
+    set:
+      nginxProxy.enabled: true
+      annotations:
+        example.com/owner: global-value
+      nginxProxy.annotations:
+        example.com/owner: component-value
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: component-value

--- a/charts/mcp-stack/tests/deployment_nginx_proxy_test.yaml
+++ b/charts/mcp-stack/tests/deployment_nginx_proxy_test.yaml
@@ -1,0 +1,86 @@
+suite: nginx-proxy deployment scheduling
+templates:
+  - templates/deployment-nginx-proxy.yaml
+
+tests:
+  - it: no nodeSelector rendered by default
+    set:
+      nginxProxy.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.nodeSelector
+
+  - it: global nodeSelector is applied when set
+    set:
+      nginxProxy.enabled: true
+      nodeSelector:
+        kubernetes.io/os: linux
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            kubernetes.io/os: linux
+
+  - it: component nodeSelector overrides global
+    set:
+      nginxProxy.enabled: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      nginxProxy.nodeSelector:
+        node-role: nginx-proxy
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            node-role: nginx-proxy
+
+  - it: no tolerations rendered by default
+    set:
+      nginxProxy.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations
+
+  - it: global tolerations are applied when set
+    set:
+      nginxProxy.enabled: true
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: mcp
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: dedicated
+            operator: Equal
+            value: mcp
+            effect: NoSchedule
+
+  - it: component tolerations override global
+    set:
+      nginxProxy.enabled: true
+      tolerations:
+        - key: global-key
+          operator: Exists
+          effect: NoSchedule
+      nginxProxy.tolerations:
+        - key: nginx-key
+          operator: Equal
+          value: nginx
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: nginx-key
+            operator: Equal
+            value: nginx
+            effect: NoSchedule
+      - notContains:
+          path: spec.template.spec.tolerations
+          content:
+            key: global-key
+            operator: Exists
+            effect: NoSchedule

--- a/charts/mcp-stack/tests/deployment_pgadmin_test.yaml
+++ b/charts/mcp-stack/tests/deployment_pgadmin_test.yaml
@@ -1,0 +1,86 @@
+suite: pgadmin deployment scheduling
+templates:
+  - templates/deployment-pgadmin.yaml
+
+tests:
+  - it: no nodeSelector rendered by default
+    set:
+      pgadmin.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.nodeSelector
+
+  - it: global nodeSelector is applied when set
+    set:
+      pgadmin.enabled: true
+      nodeSelector:
+        kubernetes.io/os: linux
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            kubernetes.io/os: linux
+
+  - it: component nodeSelector overrides global
+    set:
+      pgadmin.enabled: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      pgadmin.nodeSelector:
+        node-role: pgadmin
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            node-role: pgadmin
+
+  - it: no tolerations rendered by default
+    set:
+      pgadmin.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations
+
+  - it: global tolerations are applied when set
+    set:
+      pgadmin.enabled: true
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: mcp
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: dedicated
+            operator: Equal
+            value: mcp
+            effect: NoSchedule
+
+  - it: component tolerations override global
+    set:
+      pgadmin.enabled: true
+      tolerations:
+        - key: global-key
+          operator: Exists
+          effect: NoSchedule
+      pgadmin.tolerations:
+        - key: pgadmin-key
+          operator: Equal
+          value: pgadmin
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: pgadmin-key
+            operator: Equal
+            value: pgadmin
+            effect: NoSchedule
+      - notContains:
+          path: spec.template.spec.tolerations
+          content:
+            key: global-key
+            operator: Exists
+            effect: NoSchedule

--- a/charts/mcp-stack/tests/deployment_pgadmin_test.yaml
+++ b/charts/mcp-stack/tests/deployment_pgadmin_test.yaml
@@ -84,3 +84,102 @@ tests:
             key: global-key
             operator: Exists
             effect: NoSchedule
+
+  - it: no podAnnotations rendered by default
+    set:
+      pgadmin.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations
+
+  - it: global podAnnotations applied when set
+    set:
+      pgadmin.enabled: true
+      podAnnotations:
+        com.rapid7.insightops/log: app.log
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            com.rapid7.insightops/log: app.log
+
+  - it: component podAnnotations merged with global
+    set:
+      pgadmin.enabled: true
+      podAnnotations:
+        com.rapid7.insightops/log: app.log
+      pgadmin.podAnnotations:
+        app-specific: pgadmin
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["com.rapid7.insightops/log"]
+          value: app.log
+      - equal:
+          path: spec.template.metadata.annotations["app-specific"]
+          value: pgadmin
+
+  - it: component podAnnotations override global on same key
+    set:
+      pgadmin.enabled: true
+      podAnnotations:
+        shared-key: global-value
+      pgadmin.podAnnotations:
+        shared-key: component-value
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["shared-key"]
+          value: component-value
+
+  - it: global podLabels applied to pod template
+    set:
+      pgadmin.enabled: true
+      podLabels:
+        env: production
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["env"]
+          value: production
+
+  - it: deployment annotations rendered when set
+    set:
+      pgadmin.enabled: true
+      pgadmin.annotations:
+        example.com/owner: platform
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform
+
+  - it: no deployment annotations rendered by default
+    set:
+      pgadmin.enabled: true
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: global annotations merged with component annotations
+    set:
+      pgadmin.enabled: true
+      annotations:
+        example.com/owner: platform-team
+      pgadmin.annotations:
+        example.com/component: pgadmin
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform-team
+      - equal:
+          path: metadata.annotations["example.com/component"]
+          value: pgadmin
+
+  - it: component annotations override global on same key
+    set:
+      pgadmin.enabled: true
+      annotations:
+        example.com/owner: global-value
+      pgadmin.annotations:
+        example.com/owner: component-value
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: component-value

--- a/charts/mcp-stack/tests/deployment_pgbouncer_test.yaml
+++ b/charts/mcp-stack/tests/deployment_pgbouncer_test.yaml
@@ -84,3 +84,102 @@ tests:
             key: global-key
             operator: Exists
             effect: NoSchedule
+
+  - it: no podAnnotations rendered by default
+    set:
+      pgbouncer.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations
+
+  - it: global podAnnotations applied when set
+    set:
+      pgbouncer.enabled: true
+      podAnnotations:
+        com.rapid7.insightops/log: app.log
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            com.rapid7.insightops/log: app.log
+
+  - it: component podAnnotations merged with global
+    set:
+      pgbouncer.enabled: true
+      podAnnotations:
+        com.rapid7.insightops/log: app.log
+      pgbouncer.podAnnotations:
+        app-specific: pgbouncer
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["com.rapid7.insightops/log"]
+          value: app.log
+      - equal:
+          path: spec.template.metadata.annotations["app-specific"]
+          value: pgbouncer
+
+  - it: component podAnnotations override global on same key
+    set:
+      pgbouncer.enabled: true
+      podAnnotations:
+        shared-key: global-value
+      pgbouncer.podAnnotations:
+        shared-key: component-value
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["shared-key"]
+          value: component-value
+
+  - it: global podLabels applied to pod template
+    set:
+      pgbouncer.enabled: true
+      podLabels:
+        env: production
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["env"]
+          value: production
+
+  - it: deployment annotations rendered when set
+    set:
+      pgbouncer.enabled: true
+      pgbouncer.annotations:
+        example.com/owner: platform
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform
+
+  - it: no deployment annotations rendered by default
+    set:
+      pgbouncer.enabled: true
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: global annotations merged with component annotations
+    set:
+      pgbouncer.enabled: true
+      annotations:
+        example.com/owner: platform-team
+      pgbouncer.annotations:
+        example.com/component: pgbouncer
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform-team
+      - equal:
+          path: metadata.annotations["example.com/component"]
+          value: pgbouncer
+
+  - it: component annotations override global on same key
+    set:
+      pgbouncer.enabled: true
+      annotations:
+        example.com/owner: global-value
+      pgbouncer.annotations:
+        example.com/owner: component-value
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: component-value

--- a/charts/mcp-stack/tests/deployment_pgbouncer_test.yaml
+++ b/charts/mcp-stack/tests/deployment_pgbouncer_test.yaml
@@ -1,0 +1,86 @@
+suite: pgbouncer deployment scheduling
+templates:
+  - templates/deployment-pgbouncer.yaml
+
+tests:
+  - it: no nodeSelector rendered by default
+    set:
+      pgbouncer.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.nodeSelector
+
+  - it: global nodeSelector is applied when set
+    set:
+      pgbouncer.enabled: true
+      nodeSelector:
+        kubernetes.io/os: linux
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            kubernetes.io/os: linux
+
+  - it: component nodeSelector overrides global
+    set:
+      pgbouncer.enabled: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      pgbouncer.nodeSelector:
+        node-role: pgbouncer
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            node-role: pgbouncer
+
+  - it: no tolerations rendered by default
+    set:
+      pgbouncer.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations
+
+  - it: global tolerations are applied when set
+    set:
+      pgbouncer.enabled: true
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: mcp
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: dedicated
+            operator: Equal
+            value: mcp
+            effect: NoSchedule
+
+  - it: component tolerations override global
+    set:
+      pgbouncer.enabled: true
+      tolerations:
+        - key: global-key
+          operator: Exists
+          effect: NoSchedule
+      pgbouncer.tolerations:
+        - key: pgbouncer-key
+          operator: Equal
+          value: pgbouncer
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: pgbouncer-key
+            operator: Equal
+            value: pgbouncer
+            effect: NoSchedule
+      - notContains:
+          path: spec.template.spec.tolerations
+          content:
+            key: global-key
+            operator: Exists
+            effect: NoSchedule

--- a/charts/mcp-stack/tests/deployment_postgres_test.yaml
+++ b/charts/mcp-stack/tests/deployment_postgres_test.yaml
@@ -84,3 +84,102 @@ tests:
             key: global-key
             operator: Exists
             effect: NoSchedule
+
+  - it: no podAnnotations rendered by default
+    set:
+      postgres.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations
+
+  - it: global podAnnotations applied when set
+    set:
+      postgres.enabled: true
+      podAnnotations:
+        com.rapid7.insightops/log: app.log
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            com.rapid7.insightops/log: app.log
+
+  - it: component podAnnotations merged with global
+    set:
+      postgres.enabled: true
+      podAnnotations:
+        com.rapid7.insightops/log: app.log
+      postgres.podAnnotations:
+        app-specific: postgres
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["com.rapid7.insightops/log"]
+          value: app.log
+      - equal:
+          path: spec.template.metadata.annotations["app-specific"]
+          value: postgres
+
+  - it: component podAnnotations override global on same key
+    set:
+      postgres.enabled: true
+      podAnnotations:
+        shared-key: global-value
+      postgres.podAnnotations:
+        shared-key: component-value
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["shared-key"]
+          value: component-value
+
+  - it: global podLabels applied to pod template
+    set:
+      postgres.enabled: true
+      podLabels:
+        env: production
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["env"]
+          value: production
+
+  - it: deployment annotations rendered when set
+    set:
+      postgres.enabled: true
+      postgres.annotations:
+        example.com/owner: platform
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform
+
+  - it: no deployment annotations rendered by default
+    set:
+      postgres.enabled: true
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: global annotations merged with component annotations
+    set:
+      postgres.enabled: true
+      annotations:
+        example.com/owner: platform-team
+      postgres.annotations:
+        example.com/component: postgres
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform-team
+      - equal:
+          path: metadata.annotations["example.com/component"]
+          value: postgres
+
+  - it: component annotations override global on same key
+    set:
+      postgres.enabled: true
+      annotations:
+        example.com/owner: global-value
+      postgres.annotations:
+        example.com/owner: component-value
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: component-value

--- a/charts/mcp-stack/tests/deployment_postgres_test.yaml
+++ b/charts/mcp-stack/tests/deployment_postgres_test.yaml
@@ -1,0 +1,86 @@
+suite: postgres deployment scheduling
+templates:
+  - templates/deployment-postgres.yaml
+
+tests:
+  - it: no nodeSelector rendered by default
+    set:
+      postgres.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.nodeSelector
+
+  - it: global nodeSelector is applied when set
+    set:
+      postgres.enabled: true
+      nodeSelector:
+        kubernetes.io/os: linux
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            kubernetes.io/os: linux
+
+  - it: component nodeSelector overrides global
+    set:
+      postgres.enabled: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      postgres.nodeSelector:
+        node-role: postgres
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            node-role: postgres
+
+  - it: no tolerations rendered by default
+    set:
+      postgres.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations
+
+  - it: global tolerations are applied when set
+    set:
+      postgres.enabled: true
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: mcp
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: dedicated
+            operator: Equal
+            value: mcp
+            effect: NoSchedule
+
+  - it: component tolerations override global
+    set:
+      postgres.enabled: true
+      tolerations:
+        - key: global-key
+          operator: Exists
+          effect: NoSchedule
+      postgres.tolerations:
+        - key: postgres-key
+          operator: Equal
+          value: postgres
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: postgres-key
+            operator: Equal
+            value: postgres
+            effect: NoSchedule
+      - notContains:
+          path: spec.template.spec.tolerations
+          content:
+            key: global-key
+            operator: Exists
+            effect: NoSchedule

--- a/charts/mcp-stack/tests/deployment_redis_commander_test.yaml
+++ b/charts/mcp-stack/tests/deployment_redis_commander_test.yaml
@@ -84,3 +84,102 @@ tests:
             key: global-key
             operator: Exists
             effect: NoSchedule
+
+  - it: no podAnnotations rendered by default
+    set:
+      redisCommander.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations
+
+  - it: global podAnnotations applied when set
+    set:
+      redisCommander.enabled: true
+      podAnnotations:
+        com.rapid7.insightops/log: app.log
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            com.rapid7.insightops/log: app.log
+
+  - it: component podAnnotations merged with global
+    set:
+      redisCommander.enabled: true
+      podAnnotations:
+        com.rapid7.insightops/log: app.log
+      redisCommander.podAnnotations:
+        app-specific: redisCommander
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["com.rapid7.insightops/log"]
+          value: app.log
+      - equal:
+          path: spec.template.metadata.annotations["app-specific"]
+          value: redisCommander
+
+  - it: component podAnnotations override global on same key
+    set:
+      redisCommander.enabled: true
+      podAnnotations:
+        shared-key: global-value
+      redisCommander.podAnnotations:
+        shared-key: component-value
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["shared-key"]
+          value: component-value
+
+  - it: global podLabels applied to pod template
+    set:
+      redisCommander.enabled: true
+      podLabels:
+        env: production
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["env"]
+          value: production
+
+  - it: deployment annotations rendered when set
+    set:
+      redisCommander.enabled: true
+      redisCommander.annotations:
+        example.com/owner: platform
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform
+
+  - it: no deployment annotations rendered by default
+    set:
+      redisCommander.enabled: true
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: global annotations merged with component annotations
+    set:
+      redisCommander.enabled: true
+      annotations:
+        example.com/owner: platform-team
+      redisCommander.annotations:
+        example.com/component: redisCommander
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform-team
+      - equal:
+          path: metadata.annotations["example.com/component"]
+          value: redisCommander
+
+  - it: component annotations override global on same key
+    set:
+      redisCommander.enabled: true
+      annotations:
+        example.com/owner: global-value
+      redisCommander.annotations:
+        example.com/owner: component-value
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: component-value

--- a/charts/mcp-stack/tests/deployment_redis_commander_test.yaml
+++ b/charts/mcp-stack/tests/deployment_redis_commander_test.yaml
@@ -1,0 +1,86 @@
+suite: redis-commander deployment scheduling
+templates:
+  - templates/deployment-redis-commander.yaml
+
+tests:
+  - it: no nodeSelector rendered by default
+    set:
+      redisCommander.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.nodeSelector
+
+  - it: global nodeSelector is applied when set
+    set:
+      redisCommander.enabled: true
+      nodeSelector:
+        kubernetes.io/os: linux
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            kubernetes.io/os: linux
+
+  - it: component nodeSelector overrides global
+    set:
+      redisCommander.enabled: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      redisCommander.nodeSelector:
+        node-role: redis-commander
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            node-role: redis-commander
+
+  - it: no tolerations rendered by default
+    set:
+      redisCommander.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations
+
+  - it: global tolerations are applied when set
+    set:
+      redisCommander.enabled: true
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: mcp
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: dedicated
+            operator: Equal
+            value: mcp
+            effect: NoSchedule
+
+  - it: component tolerations override global
+    set:
+      redisCommander.enabled: true
+      tolerations:
+        - key: global-key
+          operator: Exists
+          effect: NoSchedule
+      redisCommander.tolerations:
+        - key: redis-commander-key
+          operator: Equal
+          value: redis-commander
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: redis-commander-key
+            operator: Equal
+            value: redis-commander
+            effect: NoSchedule
+      - notContains:
+          path: spec.template.spec.tolerations
+          content:
+            key: global-key
+            operator: Exists
+            effect: NoSchedule

--- a/charts/mcp-stack/tests/deployment_redis_test.yaml
+++ b/charts/mcp-stack/tests/deployment_redis_test.yaml
@@ -58,3 +58,91 @@ tests:
           content:
             name: redis-config
             mountPath: /usr/local/etc/redis
+
+  - it: no nodeSelector rendered by default
+    set:
+      redis.enabled: true
+      redis.external.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.nodeSelector
+
+  - it: global nodeSelector is applied when set
+    set:
+      redis.enabled: true
+      redis.external.enabled: false
+      nodeSelector:
+        kubernetes.io/os: linux
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            kubernetes.io/os: linux
+
+  - it: component nodeSelector overrides global
+    set:
+      redis.enabled: true
+      redis.external.enabled: false
+      nodeSelector:
+        kubernetes.io/os: linux
+      redis.nodeSelector:
+        node-role: redis
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            node-role: redis
+
+  - it: no tolerations rendered by default
+    set:
+      redis.enabled: true
+      redis.external.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations
+
+  - it: global tolerations are applied when set
+    set:
+      redis.enabled: true
+      redis.external.enabled: false
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: mcp
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: dedicated
+            operator: Equal
+            value: mcp
+            effect: NoSchedule
+
+  - it: component tolerations override global
+    set:
+      redis.enabled: true
+      redis.external.enabled: false
+      tolerations:
+        - key: global-key
+          operator: Exists
+          effect: NoSchedule
+      redis.tolerations:
+        - key: redis-key
+          operator: Equal
+          value: redis
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: redis-key
+            operator: Equal
+            value: redis
+            effect: NoSchedule
+      - notContains:
+          path: spec.template.spec.tolerations
+          content:
+            key: global-key
+            operator: Exists
+            effect: NoSchedule

--- a/charts/mcp-stack/tests/deployment_redis_test.yaml
+++ b/charts/mcp-stack/tests/deployment_redis_test.yaml
@@ -146,3 +146,111 @@ tests:
             key: global-key
             operator: Exists
             effect: NoSchedule
+
+  - it: no podAnnotations rendered by default
+    set:
+      redis.enabled: true
+      redis.external.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations
+
+  - it: global podAnnotations applied when set
+    set:
+      redis.enabled: true
+      redis.external.enabled: false
+      podAnnotations:
+        com.rapid7.insightops/log: app.log
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            com.rapid7.insightops/log: app.log
+
+  - it: component podAnnotations merged with global
+    set:
+      redis.enabled: true
+      redis.external.enabled: false
+      podAnnotations:
+        com.rapid7.insightops/log: app.log
+      redis.podAnnotations:
+        app-specific: redis
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["com.rapid7.insightops/log"]
+          value: app.log
+      - equal:
+          path: spec.template.metadata.annotations["app-specific"]
+          value: redis
+
+  - it: component podAnnotations override global on same key
+    set:
+      redis.enabled: true
+      redis.external.enabled: false
+      podAnnotations:
+        shared-key: global-value
+      redis.podAnnotations:
+        shared-key: component-value
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["shared-key"]
+          value: component-value
+
+  - it: global podLabels applied to pod template
+    set:
+      redis.enabled: true
+      redis.external.enabled: false
+      podLabels:
+        env: production
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["env"]
+          value: production
+
+  - it: deployment annotations rendered when set
+    set:
+      redis.enabled: true
+      redis.external.enabled: false
+      redis.annotations:
+        example.com/owner: platform
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform
+
+  - it: no deployment annotations rendered by default
+    set:
+      redis.enabled: true
+      redis.external.enabled: false
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: global annotations merged with component annotations
+    set:
+      redis.enabled: true
+      redis.external.enabled: false
+      annotations:
+        example.com/owner: platform-team
+      redis.annotations:
+        example.com/component: redis
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform-team
+      - equal:
+          path: metadata.annotations["example.com/component"]
+          value: redis
+
+  - it: component annotations override global on same key
+    set:
+      redis.enabled: true
+      redis.external.enabled: false
+      annotations:
+        example.com/owner: global-value
+      redis.annotations:
+        example.com/owner: component-value
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: component-value

--- a/charts/mcp-stack/values.schema.json
+++ b/charts/mcp-stack/values.schema.json
@@ -1804,18 +1804,25 @@
             },
             "AUTH_ENCRYPTION_SECRET": {
               "type": "string",
-              "description": "Auth encryption secret — must be set to a strong value before deploy (run make init-secrets-patch-env)",
+              "description": "Auth encryption secret \u2014 must be set to a strong value before deploy (run make init-secrets-patch-env)",
               "default": ""
             },
             "IDENTITY_PROPAGATION_ENABLED": {
               "type": "string",
-              "enum": ["true", "false"],
+              "enum": [
+                "true",
+                "false"
+              ],
               "description": "Enable end-user identity propagation to upstream MCP servers",
               "default": "false"
             },
             "IDENTITY_PROPAGATION_MODE": {
               "type": "string",
-              "enum": ["headers", "meta", "both"],
+              "enum": [
+                "headers",
+                "meta",
+                "both"
+              ],
               "description": "How to propagate identity: headers (HTTP), meta (MCP _meta), or both",
               "default": "both"
             },
@@ -1831,7 +1838,10 @@
             },
             "IDENTITY_SIGN_CLAIMS": {
               "type": "string",
-              "enum": ["true", "false"],
+              "enum": [
+                "true",
+                "false"
+              ],
               "description": "Sign propagated user claims with HMAC-SHA256 for upstream verification",
               "default": "false"
             },
@@ -1953,7 +1963,7 @@
             },
             "JWT_SECRET_KEY": {
               "type": "string",
-              "description": "JWT secret key — must be set to a strong value before deploy (run make init-secrets-patch-env)",
+              "description": "JWT secret key \u2014 must be set to a strong value before deploy (run make init-secrets-patch-env)",
               "default": ""
             },
             "MAX_FAILED_LOGIN_ATTEMPTS": {
@@ -2225,6 +2235,46 @@
             }
           },
           "description": "Service configuration"
+        },
+        "nodeSelector": {
+          "type": "object",
+          "description": "Node labels for pod assignment. Component-specific value takes precedence over top-level nodeSelector.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tolerations": {
+          "type": "array",
+          "description": "Tolerations for pod scheduling onto tainted nodes. Component-specific value takes precedence over top-level tolerations.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "operator": {
+                "type": "string",
+                "enum": [
+                  "Equal",
+                  "Exists"
+                ]
+              },
+              "value": {
+                "type": "string"
+              },
+              "effect": {
+                "type": "string",
+                "enum": [
+                  "NoSchedule",
+                  "PreferNoSchedule",
+                  "NoExecute"
+                ]
+              },
+              "tolerationSeconds": {
+                "type": "integer"
+              }
+            }
+          }
         }
       },
       "description": "ContextForge Gateway configuration"
@@ -2447,6 +2497,46 @@
             }
           },
           "description": "Resource limits and requests"
+        },
+        "nodeSelector": {
+          "type": "object",
+          "description": "Node labels for pod assignment. Component-specific value takes precedence over top-level nodeSelector.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tolerations": {
+          "type": "array",
+          "description": "Tolerations for pod scheduling onto tainted nodes. Component-specific value takes precedence over top-level tolerations.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "operator": {
+                "type": "string",
+                "enum": [
+                  "Equal",
+                  "Exists"
+                ]
+              },
+              "value": {
+                "type": "string"
+              },
+              "effect": {
+                "type": "string",
+                "enum": [
+                  "NoSchedule",
+                  "PreferNoSchedule",
+                  "NoExecute"
+                ]
+              },
+              "tolerationSeconds": {
+                "type": "integer"
+              }
+            }
+          }
         }
       },
       "description": "MCP Fast Time Server configuration"
@@ -2551,6 +2641,46 @@
             "OnFailure",
             "Always"
           ]
+        },
+        "nodeSelector": {
+          "type": "object",
+          "description": "Node labels for pod assignment. Component-specific value takes precedence over top-level nodeSelector.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tolerations": {
+          "type": "array",
+          "description": "Tolerations for pod scheduling onto tainted nodes. Component-specific value takes precedence over top-level tolerations.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "operator": {
+                "type": "string",
+                "enum": [
+                  "Equal",
+                  "Exists"
+                ]
+              },
+              "value": {
+                "type": "string"
+              },
+              "effect": {
+                "type": "string",
+                "enum": [
+                  "NoSchedule",
+                  "PreferNoSchedule",
+                  "NoExecute"
+                ]
+              },
+              "tolerationSeconds": {
+                "type": "integer"
+              }
+            }
+          }
         }
       },
       "description": "Database migration configuration"
@@ -3635,6 +3765,46 @@
           "items": {
             "type": "string"
           }
+        },
+        "nodeSelector": {
+          "type": "object",
+          "description": "Node labels for pod assignment. Component-specific value takes precedence over top-level nodeSelector.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tolerations": {
+          "type": "array",
+          "description": "Tolerations for pod scheduling onto tainted nodes. Component-specific value takes precedence over top-level tolerations.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "operator": {
+                "type": "string",
+                "enum": [
+                  "Equal",
+                  "Exists"
+                ]
+              },
+              "value": {
+                "type": "string"
+              },
+              "effect": {
+                "type": "string",
+                "enum": [
+                  "NoSchedule",
+                  "PreferNoSchedule",
+                  "NoExecute"
+                ]
+              },
+              "tolerationSeconds": {
+                "type": "integer"
+              }
+            }
+          }
         }
       },
       "description": "Optional nginx reverse-proxy profile values"
@@ -3815,6 +3985,46 @@
             }
           },
           "description": "PgAdmin service configuration"
+        },
+        "nodeSelector": {
+          "type": "object",
+          "description": "Node labels for pod assignment. Component-specific value takes precedence over top-level nodeSelector.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tolerations": {
+          "type": "array",
+          "description": "Tolerations for pod scheduling onto tainted nodes. Component-specific value takes precedence over top-level tolerations.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "operator": {
+                "type": "string",
+                "enum": [
+                  "Equal",
+                  "Exists"
+                ]
+              },
+              "value": {
+                "type": "string"
+              },
+              "effect": {
+                "type": "string",
+                "enum": [
+                  "NoSchedule",
+                  "PreferNoSchedule",
+                  "NoExecute"
+                ]
+              },
+              "tolerationSeconds": {
+                "type": "integer"
+              }
+            }
+          }
         }
       },
       "description": "PgAdmin configuration"
@@ -4035,6 +4245,46 @@
             }
           },
           "description": "PgBouncer service configuration"
+        },
+        "nodeSelector": {
+          "type": "object",
+          "description": "Node labels for pod assignment. Component-specific value takes precedence over top-level nodeSelector.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tolerations": {
+          "type": "array",
+          "description": "Tolerations for pod scheduling onto tainted nodes. Component-specific value takes precedence over top-level tolerations.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "operator": {
+                "type": "string",
+                "enum": [
+                  "Equal",
+                  "Exists"
+                ]
+              },
+              "value": {
+                "type": "string"
+              },
+              "effect": {
+                "type": "string",
+                "enum": [
+                  "NoSchedule",
+                  "PreferNoSchedule",
+                  "NoExecute"
+                ]
+              },
+              "tolerationSeconds": {
+                "type": "integer"
+              }
+            }
+          }
         }
       },
       "description": "PgBouncer connection pooler configuration"
@@ -4368,6 +4618,46 @@
             }
           },
           "description": "PostgreSQL upgrade configuration"
+        },
+        "nodeSelector": {
+          "type": "object",
+          "description": "Node labels for pod assignment. Component-specific value takes precedence over top-level nodeSelector.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tolerations": {
+          "type": "array",
+          "description": "Tolerations for pod scheduling onto tainted nodes. Component-specific value takes precedence over top-level tolerations.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "operator": {
+                "type": "string",
+                "enum": [
+                  "Equal",
+                  "Exists"
+                ]
+              },
+              "value": {
+                "type": "string"
+              },
+              "effect": {
+                "type": "string",
+                "enum": [
+                  "NoSchedule",
+                  "PreferNoSchedule",
+                  "NoExecute"
+                ]
+              },
+              "tolerationSeconds": {
+                "type": "integer"
+              }
+            }
+          }
         }
       },
       "description": "PostgreSQL database configuration"
@@ -4647,10 +4937,50 @@
         },
         "maxclients": {
           "type": "integer",
-          "description": "Maximum number of client connections. Formula: replicas × workers × REDIS_MAX_CONNECTIONS × 1.2",
+          "description": "Maximum number of client connections. Formula: replicas \u00d7 workers \u00d7 REDIS_MAX_CONNECTIONS \u00d7 1.2",
           "default": 15000,
           "minimum": 5000,
           "maximum": 30000
+        },
+        "nodeSelector": {
+          "type": "object",
+          "description": "Node labels for pod assignment. Component-specific value takes precedence over top-level nodeSelector.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tolerations": {
+          "type": "array",
+          "description": "Tolerations for pod scheduling onto tainted nodes. Component-specific value takes precedence over top-level tolerations.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "operator": {
+                "type": "string",
+                "enum": [
+                  "Equal",
+                  "Exists"
+                ]
+              },
+              "value": {
+                "type": "string"
+              },
+              "effect": {
+                "type": "string",
+                "enum": [
+                  "NoSchedule",
+                  "PreferNoSchedule",
+                  "NoExecute"
+                ]
+              },
+              "tolerationSeconds": {
+                "type": "integer"
+              }
+            }
+          }
         }
       },
       "description": "Redis cache configuration"
@@ -4805,6 +5135,46 @@
             }
           },
           "description": "Redis Commander service configuration"
+        },
+        "nodeSelector": {
+          "type": "object",
+          "description": "Node labels for pod assignment. Component-specific value takes precedence over top-level nodeSelector.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tolerations": {
+          "type": "array",
+          "description": "Tolerations for pod scheduling onto tainted nodes. Component-specific value takes precedence over top-level tolerations.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "operator": {
+                "type": "string",
+                "enum": [
+                  "Equal",
+                  "Exists"
+                ]
+              },
+              "value": {
+                "type": "string"
+              },
+              "effect": {
+                "type": "string",
+                "enum": [
+                  "NoSchedule",
+                  "PreferNoSchedule",
+                  "NoExecute"
+                ]
+              },
+              "tolerationSeconds": {
+                "type": "integer"
+              }
+            }
+          }
         }
       },
       "description": "Redis Commander configuration"
@@ -5542,6 +5912,46 @@
         }
       },
       "description": "Optional TLS profile values"
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Global node labels for pod assignment. Applied to all deployments unless overridden per component.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "tolerations": {
+      "type": "array",
+      "description": "Global tolerations for pod scheduling. Applied to all deployments unless overridden per component.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "operator": {
+            "type": "string",
+            "enum": [
+              "Equal",
+              "Exists"
+            ]
+          },
+          "value": {
+            "type": "string"
+          },
+          "effect": {
+            "type": "string",
+            "enum": [
+              "NoSchedule",
+              "PreferNoSchedule",
+              "NoExecute"
+            ]
+          },
+          "tolerationSeconds": {
+            "type": "integer"
+          }
+        }
+      }
     }
   },
   "description": "JSON Schema for MCP Stack Helm Chart values.yaml",

--- a/charts/mcp-stack/values.schema.json
+++ b/charts/mcp-stack/values.schema.json
@@ -2275,6 +2275,27 @@
               }
             }
           }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations applied to the Deployment/Job resource itself.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podAnnotations": {
+          "type": "object",
+          "description": "Annotations applied to every pod. Merged with top-level podAnnotations; component values take precedence.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podLabels": {
+          "type": "object",
+          "description": "Extra labels applied to every pod. Merged with top-level podLabels; component values take precedence.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "description": "ContextForge Gateway configuration"
@@ -2537,6 +2558,27 @@
               }
             }
           }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations applied to the Deployment/Job resource itself.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podAnnotations": {
+          "type": "object",
+          "description": "Annotations applied to every pod. Merged with top-level podAnnotations; component values take precedence.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podLabels": {
+          "type": "object",
+          "description": "Extra labels applied to every pod. Merged with top-level podLabels; component values take precedence.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "description": "MCP Fast Time Server configuration"
@@ -2680,6 +2722,27 @@
                 "type": "integer"
               }
             }
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations applied to the Deployment/Job resource itself.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podAnnotations": {
+          "type": "object",
+          "description": "Annotations applied to every pod. Merged with top-level podAnnotations; component values take precedence.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podLabels": {
+          "type": "object",
+          "description": "Extra labels applied to every pod. Merged with top-level podLabels; component values take precedence.",
+          "additionalProperties": {
+            "type": "string"
           }
         }
       },
@@ -3805,6 +3868,27 @@
               }
             }
           }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations applied to the Deployment/Job resource itself.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podAnnotations": {
+          "type": "object",
+          "description": "Annotations applied to every pod. Merged with top-level podAnnotations; component values take precedence.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podLabels": {
+          "type": "object",
+          "description": "Extra labels applied to every pod. Merged with top-level podLabels; component values take precedence.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "description": "Optional nginx reverse-proxy profile values"
@@ -4024,6 +4108,27 @@
                 "type": "integer"
               }
             }
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations applied to the Deployment/Job resource itself.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podAnnotations": {
+          "type": "object",
+          "description": "Annotations applied to every pod. Merged with top-level podAnnotations; component values take precedence.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podLabels": {
+          "type": "object",
+          "description": "Extra labels applied to every pod. Merged with top-level podLabels; component values take precedence.",
+          "additionalProperties": {
+            "type": "string"
           }
         }
       },
@@ -4284,6 +4389,27 @@
                 "type": "integer"
               }
             }
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations applied to the Deployment/Job resource itself.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podAnnotations": {
+          "type": "object",
+          "description": "Annotations applied to every pod. Merged with top-level podAnnotations; component values take precedence.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podLabels": {
+          "type": "object",
+          "description": "Extra labels applied to every pod. Merged with top-level podLabels; component values take precedence.",
+          "additionalProperties": {
+            "type": "string"
           }
         }
       },
@@ -4658,6 +4784,27 @@
               }
             }
           }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations applied to the Deployment/Job resource itself.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podAnnotations": {
+          "type": "object",
+          "description": "Annotations applied to every pod. Merged with top-level podAnnotations; component values take precedence.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podLabels": {
+          "type": "object",
+          "description": "Extra labels applied to every pod. Merged with top-level podLabels; component values take precedence.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "description": "PostgreSQL database configuration"
@@ -4981,6 +5128,27 @@
               }
             }
           }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations applied to the Deployment/Job resource itself.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podAnnotations": {
+          "type": "object",
+          "description": "Annotations applied to every pod. Merged with top-level podAnnotations; component values take precedence.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podLabels": {
+          "type": "object",
+          "description": "Extra labels applied to every pod. Merged with top-level podLabels; component values take precedence.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "description": "Redis cache configuration"
@@ -5174,6 +5342,27 @@
                 "type": "integer"
               }
             }
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations applied to the Deployment/Job resource itself.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podAnnotations": {
+          "type": "object",
+          "description": "Annotations applied to every pod. Merged with top-level podAnnotations; component values take precedence.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podLabels": {
+          "type": "object",
+          "description": "Extra labels applied to every pod. Merged with top-level podLabels; component values take precedence.",
+          "additionalProperties": {
+            "type": "string"
           }
         }
       },
@@ -5951,6 +6140,27 @@
             "type": "integer"
           }
         }
+      }
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Global pod annotations applied to all deployments. Merged with per-component podAnnotations.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Global pod labels applied to all deployments. Merged with per-component podLabels.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "annotations": {
+      "type": "object",
+      "description": "Global annotations applied to all Deployment/Job resources. Merged with per-component annotations; component values take precedence.",
+      "additionalProperties": {
+        "type": "string"
       }
     }
   },

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -43,6 +43,21 @@ tolerations: []
   #   effect: "NoSchedule"
 
 ########################################################################
+# ANNOTATIONS & LABELS
+# Applied to all Deployments/Jobs and pod templates in the release when
+# set. Per-component values are merged with these globals; component
+# values take precedence on conflicting keys.
+########################################################################
+annotations: {}
+  # example.com/owner: platform-team
+
+podAnnotations: {}
+  # prometheus.io/scrape: "true"
+
+podLabels: {}
+  # env: production
+
+########################################################################
 # NETWORK POLICIES
 # Conservative, ingress-focused micro-segmentation for in-cluster data
 # services. Disable globally if your CNI does not enforce NetworkPolicy
@@ -185,6 +200,17 @@ mcpContextForge:
   # Node scheduling overrides — takes precedence over top-level nodeSelector/tolerations
   nodeSelector: {}
   tolerations: []
+
+  # Annotations applied to the Deployment resource itself
+  annotations: {}
+    # example.com/owner: platform-team
+
+  # Annotations applied to every pod in this Deployment
+  podAnnotations: {}
+    # prometheus.io/scrape: "true"
+
+  # Extra labels applied to every pod in this Deployment
+  podLabels: {}
 
   # Optional ingress for HTTP traffic
   ingress:
@@ -1061,6 +1087,11 @@ migration:
   # Node scheduling overrides — takes precedence over top-level nodeSelector/tolerations
   nodeSelector: {}
   tolerations: []
+  # Annotations applied to every pod in this Job
+  podAnnotations: {}
+
+  # Extra labels applied to every pod in this Job
+  podLabels: {}
 
   # Migration command configuration
   command:
@@ -1120,6 +1151,14 @@ postgres:
   # Node scheduling overrides — takes precedence over top-level nodeSelector/tolerations
   nodeSelector: {}
   tolerations: []
+  # Annotations applied to the Deployment resource itself
+  annotations: {}
+
+  # Annotations applied to every pod in this Deployment
+  podAnnotations: {}
+
+  # Extra labels applied to every pod in this Deployment
+  podLabels: {}
 
   # Graceful shutdown helps prevent WAL/checkpoint corruption on restart.
   terminationGracePeriodSeconds: 120
@@ -1189,6 +1228,14 @@ pgbouncer:
   # Node scheduling overrides — takes precedence over top-level nodeSelector/tolerations
   nodeSelector: {}
   tolerations: []
+  # Annotations applied to the Deployment resource itself
+  annotations: {}
+
+  # Annotations applied to every pod in this Deployment
+  podAnnotations: {}
+
+  # Extra labels applied to every pod in this Deployment
+  podLabels: {}
 
   image:
     repository: edoburu/pgbouncer
@@ -1254,6 +1301,14 @@ redis:
   # Node scheduling overrides — takes precedence over top-level nodeSelector/tolerations
   nodeSelector: {}
   tolerations: []
+  # Annotations applied to the Deployment resource itself
+  annotations: {}
+
+  # Annotations applied to every pod in this Deployment
+  podAnnotations: {}
+
+  # Extra labels applied to every pod in this Deployment
+  podLabels: {}
 
   image:
     repository: redis
@@ -1366,6 +1421,14 @@ pgadmin:
   # Node scheduling overrides — takes precedence over top-level nodeSelector/tolerations
   nodeSelector: {}
   tolerations: []
+  # Annotations applied to the Deployment resource itself
+  annotations: {}
+
+  # Annotations applied to every pod in this Deployment
+  podAnnotations: {}
+
+  # Extra labels applied to every pod in this Deployment
+  podLabels: {}
 
   image:
     repository: dpage/pgadmin4
@@ -1424,6 +1487,14 @@ redisCommander:
   # Node scheduling overrides — takes precedence over top-level nodeSelector/tolerations
   nodeSelector: {}
   tolerations: []
+  # Annotations applied to the Deployment resource itself
+  annotations: {}
+
+  # Annotations applied to every pod in this Deployment
+  podAnnotations: {}
+
+  # Extra labels applied to every pod in this Deployment
+  podLabels: {}
 
   image:
     repository: rediscommander/redis-commander
@@ -1517,6 +1588,14 @@ mcpFastTimeServer:
   # Node scheduling overrides — takes precedence over top-level nodeSelector/tolerations
   nodeSelector: {}
   tolerations: []
+  # Annotations applied to the Deployment resource itself
+  annotations: {}
+
+  # Annotations applied to every pod in this Deployment
+  podAnnotations: {}
+
+  # Extra labels applied to every pod in this Deployment
+  podLabels: {}
 
   image:
     repository: ghcr.io/ibm/fast-time-server
@@ -1589,6 +1668,14 @@ nginxProxy:
   # Node scheduling overrides — takes precedence over top-level nodeSelector/tolerations
   nodeSelector: {}
   tolerations: []
+  # Annotations applied to the Deployment resource itself
+  annotations: {}
+
+  # Annotations applied to every pod in this Deployment
+  podAnnotations: {}
+
+  # Extra labels applied to every pod in this Deployment
+  podLabels: {}
 
   image:
     repository: mcpgateway/nginx-cache

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -28,6 +28,21 @@ serviceAccount:
   automountServiceAccountToken: false
 
 ########################################################################
+# NODE SCHEDULING
+# Applied to all pods in the release when set. Per-component nodeSelector
+# and tolerations (e.g. mcpContextForge.nodeSelector) take precedence.
+########################################################################
+nodeSelector: {}
+  # kubernetes.io/os: linux
+  # node-role: mcp-workloads
+
+tolerations: []
+  # - key: "dedicated"
+  #   operator: "Equal"
+  #   value: "mcp"
+  #   effect: "NoSchedule"
+
+########################################################################
 # NETWORK POLICIES
 # Conservative, ingress-focused micro-segmentation for in-cluster data
 # services. Disable globally if your CNI does not enforce NetworkPolicy
@@ -166,6 +181,10 @@ mcpContextForge:
       drop:
         - ALL
     readOnlyRootFilesystem: true
+
+  # Node scheduling overrides — takes precedence over top-level nodeSelector/tolerations
+  nodeSelector: {}
+  tolerations: []
 
   # Optional ingress for HTTP traffic
   ingress:
@@ -1039,6 +1058,10 @@ migration:
       cpu: 250m
       memory: 512Mi
 
+  # Node scheduling overrides — takes precedence over top-level nodeSelector/tolerations
+  nodeSelector: {}
+  tolerations: []
+
   # Migration command configuration
   command:
     waitForDb: "python3 /app/mcpgateway/utils/db_isready.py --max-tries 30 --interval 2 --timeout 5"
@@ -1093,6 +1116,10 @@ postgres:
     requests:
       cpu: 500m           # guaranteed half-core
       memory: 512Mi
+
+  # Node scheduling overrides — takes precedence over top-level nodeSelector/tolerations
+  nodeSelector: {}
+  tolerations: []
 
   # Graceful shutdown helps prevent WAL/checkpoint corruption on restart.
   terminationGracePeriodSeconds: 120
@@ -1159,6 +1186,10 @@ postgres:
 pgbouncer:
   enabled: false                     # Set to true to route DB traffic through PgBouncer
 
+  # Node scheduling overrides — takes precedence over top-level nodeSelector/tolerations
+  nodeSelector: {}
+  tolerations: []
+
   image:
     repository: edoburu/pgbouncer
     tag: latest
@@ -1219,6 +1250,10 @@ pgbouncer:
 redis:
   enabled: true
   # Note: if redis.external.enabled=true, in-cluster Redis resources are skipped.
+
+  # Node scheduling overrides — takes precedence over top-level nodeSelector/tolerations
+  nodeSelector: {}
+  tolerations: []
 
   image:
     repository: redis
@@ -1328,6 +1363,10 @@ redis:
 pgadmin:
   enabled: false                    # Hardened default: enable only for temporary admin workflows
 
+  # Node scheduling overrides — takes precedence over top-level nodeSelector/tolerations
+  nodeSelector: {}
+  tolerations: []
+
   image:
     repository: dpage/pgadmin4
     tag: latest
@@ -1381,6 +1420,10 @@ pgadmin:
 ########################################################################
 redisCommander:
   enabled: false                    # Hardened default: enable only for temporary troubleshooting
+
+  # Node scheduling overrides — takes precedence over top-level nodeSelector/tolerations
+  nodeSelector: {}
+  tolerations: []
 
   image:
     repository: rediscommander/redis-commander
@@ -1470,6 +1513,11 @@ minio:
 mcpFastTimeServer:
   enabled: true            # switch to true to deploy
   replicaCount: 2
+
+  # Node scheduling overrides — takes precedence over top-level nodeSelector/tolerations
+  nodeSelector: {}
+  tolerations: []
+
   image:
     repository: ghcr.io/ibm/fast-time-server
     tag: "0.8.0"
@@ -1537,6 +1585,10 @@ mcpFastTimeServer:
 ########################################################################
 nginxProxy:
   enabled: false
+
+  # Node scheduling overrides — takes precedence over top-level nodeSelector/tolerations
+  nodeSelector: {}
+  tolerations: []
 
   image:
     repository: mcpgateway/nginx-cache


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue
Partially resolves #1911

## Description:
Adds nodeSelector and tolerations scheduling support to all Helm-managed Deployments and the migration Job, partially closing #1911 
Also adds support for annotations, pod annotations and pod labels.

A top-level `nodeSelector` and `tolerations` in values.yaml apply globally across all components. Per-component overrides (e.g. `mcpContextForge.nodeSelector`, `redis.tolerations`) take precedence over the global values via Helm's coalesce function. Both fields default to empty, so this change is fully backward-compatible.
Similarly, with annotations and labels any configuration per-component takes precedence over the global values using Helm's merge function.

## Changes:

- values.yaml — top-level nodeSelector/tolerations/annotations/podAnnotations/podLables + per-component fields for mcpContextForge, postgres, redis, pgbouncer, pgadmin, redisCommander, nginxProxy, mcpFastTimeServer, and migration
- values.schema.json — JSON Schema validation for all new fields
- All 8 deployment templates and job-migration.yaml wired with coalesce-based rendering
- Unit tests added/extended for all affected deployments covering: global applies, component overrides global, empty renders nothing

## Reason:
We are currently patching these in after deploying the Helm Chart, which is flakey and prone to them being removed - they are required for our scheduler to place these workloads reliably. As stated in the issue these values are common in most Helm Charts and should be exposed for configuration.
The labels and annotations are also required for certain in-cluster workloads to do with observability

## Tests run:
- `helm lint --strict .` - passed
- `helm unittest .` - all suites passed (2 extended, 6 new test files)
