### PR TITLE
feat(api): add MCP handshake test endpoint for Test Connection

### DIFF
--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -138,6 +138,7 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("DELETE", re.compile(r"^/oauth/registered-clients/[^/]+(?:$|/)"), Permissions.ADMIN_OAUTH_CLIENTS_DELETE),
     # MCP Servers REST API (v1 prefix stripped by middleware before matching)
     ("POST", re.compile(r"^/mcp-servers/test(?:$|/)"), Permissions.GATEWAYS_READ),
+    ("POST", re.compile(r"^/mcp-servers/test-handshake(?:$|/)"), Permissions.GATEWAYS_READ),
     # MCP registry catalog (v1 prefix stripped by middleware before matching)
     ("GET", re.compile(r"^/catalog(?:$|/)"), Permissions.SERVERS_READ),
     ("POST", re.compile(r"^/catalog/[^/]+/register(?:$|/)"), Permissions.SERVERS_CREATE),

--- a/mcpgateway/routers/mcp_servers_router.py
+++ b/mcpgateway/routers/mcp_servers_router.py
@@ -6,7 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 MCP Servers REST API router.
 
 Endpoints:
-    POST /v1/mcp-servers/test  — Test MCP server / gateway connectivity
+    POST /v1/mcp-servers/test            — Test MCP server / gateway connectivity
+    POST /v1/mcp-servers/test-handshake  — Test whether a server URL speaks MCP
 """
 
 # Standard
@@ -18,10 +19,11 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 # First-Party
+from mcpgateway.auth_context import extract_token_team_ids
 from mcpgateway.db import get_db
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
-from mcpgateway.schemas import GatewayTestRequest, GatewayTestResponse
-from mcpgateway.services.gateway_service import test_gateway_connectivity
+from mcpgateway.schemas import GatewayHandshakeRequest, GatewayHandshakeResponse, GatewayTestRequest, GatewayTestResponse
+from mcpgateway.services.gateway_service import test_gateway_connectivity, test_gateway_handshake
 from mcpgateway.services.logging_service import LoggingService
 
 logging_service = LoggingService()
@@ -100,3 +102,45 @@ async def check_mcp_server_connectivity(
             raise HTTPException(status_code=403, detail="Access to requested team is not permitted")
 
     return await test_gateway_connectivity(request, team_id, user, db)
+
+
+@router.post("/test-handshake", response_model=GatewayHandshakeResponse)
+@require_permission("gateways.read", allow_admin_bypass=False)
+async def check_mcp_server_handshake(
+    request: GatewayHandshakeRequest,
+    team_id: Optional[str] = Depends(_validated_team_id),
+    user=Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+) -> GatewayHandshakeResponse:
+    """Test whether an MCP server URL speaks MCP via a protocol handshake.
+
+    Delegates to ``test_gateway_handshake`` in
+    ``mcpgateway.services.gateway_service``, which tries the stateless
+    ``server/discover`` method first and falls back to a stateful SDK
+    ``initialize`` round-trip, classifying failures for actionable UI copy.
+
+    Args:
+        request (GatewayHandshakeRequest): The request object containing the server URL and optional headers.
+        team_id (Optional[str]): Optional team ID for team-specific gateways.
+        user: Authenticated user context.
+        db (Session): Database session dependency.
+
+    Returns:
+        GatewayHandshakeResponse: The handshake outcome, including negotiation path,
+            server identity, capabilities, component counts, and failure classification.
+
+    Examples:
+        >>> callable(check_mcp_server_handshake)
+        True
+        >>> check_mcp_server_handshake.__name__
+        'check_mcp_server_handshake'
+    """
+    # Reject cross-team access: token_teams=None means admin bypass; a list means the
+    # caller is scoped to those teams only. A caller-supplied team_id outside that list
+    # would allow enumerating other teams' registered gateway hostnames (SSRF allowlist).
+    if team_id is not None:
+        token_teams = extract_token_team_ids(user)
+        if token_teams is not None and team_id not in token_teams:
+            raise HTTPException(status_code=403, detail="Access to requested team is not permitted")
+
+    return await test_gateway_handshake(request, team_id, user, db)

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -4881,6 +4881,50 @@ class GatewayTestResponse(BaseModelWithConfigDict):
     body: Optional[Union[str, Dict[str, Any]]] = Field(None, description="Response body, can be a string or JSON object")
 
 
+class GatewayHandshakeRequest(BaseModelWithConfigDict):
+    """Request to run an MCP handshake test against a server URL."""
+
+    base_url: AnyHttpUrl = Field(..., description="Base URL of the MCP server to test")
+    path: Optional[str] = Field(None, description="Optional path appended to the base URL")
+    headers: Optional[Dict[str, str]] = Field(None, description="Optional headers (e.g. Authorization) sent with the handshake")
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, value: Optional[str]) -> Optional[str]:
+        """Reject control characters, which httpx refuses when it builds the request URL.
+
+        Args:
+            value: Candidate path.
+
+        Returns:
+            The path unchanged.
+
+        Raises:
+            ValueError: If the path contains a control character.
+        """
+        if value and any(character < " " or character == "\x7f" for character in value):
+            raise ValueError("Path must not contain control characters")
+        return value
+
+
+class GatewayHandshakeResponse(BaseModelWithConfigDict):
+    """Result of an MCP handshake test."""
+
+    success: bool
+    latency_ms: int
+    negotiation_path: Optional[Literal["server_discover", "initialize"]] = Field(None, description="Which handshake path produced the result")
+    protocol_version: Optional[str] = None
+    server_name: Optional[str] = None
+    server_version: Optional[str] = None
+    capabilities: Optional[Dict[str, Any]] = None
+    component_counts: Optional[Dict[str, int]] = Field(None, description="Counts for tools/resources/prompts; a key is absent when the capability is not advertised")
+    counts_partial: bool = Field(False, description="True when any list result had a nextCursor (counts are first-page lower bounds)")
+    credential_source: Literal["stored", "form", "none"] = "none"
+    failure_class: Optional[Literal["transport", "protocol", "auth", "invalid_response"]] = None
+    error: Optional[str] = None
+    raw_preview: Optional[str] = Field(None, description="Size-capped JSON preview of the final handshake payload")
+
+
 class TaggedEntity(BaseModelWithConfigDict):
     """A simplified representation of an entity that has a tag."""
 

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -45,13 +45,14 @@ import asyncio
 import binascii
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+import json
 import logging
 import mimetypes
 import os
 import ssl
 import tempfile
 import time
-from typing import Any, AsyncGenerator, Awaitable, Callable, cast, Dict, List, Optional, Set, TYPE_CHECKING, Union
+from typing import Any, AsyncGenerator, Awaitable, Callable, cast, Dict, List, Literal, Optional, Set, TYPE_CHECKING, Union
 from urllib.parse import urlparse, urlunparse
 import uuid
 
@@ -61,6 +62,7 @@ import httpx
 from mcp import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamablehttp_client
+from mcp.shared.exceptions import McpError
 from pydantic import ValidationError
 from sqlalchemy import and_, delete, desc, or_, select, update
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
@@ -78,6 +80,7 @@ except ImportError:
     logging.info("Redis is not utilized in this environment.")
 
 # First-Party
+from mcpgateway import __version__
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.db import EmailTeam as DbEmailTeam
@@ -92,7 +95,19 @@ from mcpgateway.db import ResourceMetric, ResourceSubscription, server_prompt_as
 from mcpgateway.db import Tool as DbTool
 from mcpgateway.db import ToolMetric
 from mcpgateway.observability import create_span, set_span_attribute, set_span_error
-from mcpgateway.schemas import GATEWAY_SUPPORTED_TRANSPORTS, GatewayCreate, GatewayRead, GatewayTestRequest, GatewayTestResponse, GatewayUpdate, PromptCreate, ResourceCreate, ToolCreate
+from mcpgateway.schemas import (
+    GATEWAY_SUPPORTED_TRANSPORTS,
+    GatewayCreate,
+    GatewayHandshakeRequest,
+    GatewayHandshakeResponse,
+    GatewayRead,
+    GatewayTestRequest,
+    GatewayTestResponse,
+    GatewayUpdate,
+    PromptCreate,
+    ResourceCreate,
+    ToolCreate,
+)
 
 # logging.getLogger("httpx").setLevel(logging.WARNING)  # Disables httpx logs for regular health checks
 from mcpgateway.services.audit_trail_service import get_audit_trail_service
@@ -7203,6 +7218,259 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
         raise GatewayConnectionError(f"Failed to initialize gateway at {sanitized_url}: Connection could not be established")
 
 
+MCP_STATELESS_PROTOCOL_VERSION = "2026-07-28"  # Hand-written: the pinned MCP SDK predates this spec version.
+
+_HANDSHAKE_TRANSPORT_COPY = "Could not reach the MCP server. Verify the URL and that the server is running and reachable from this host."
+_HANDSHAKE_AUTH_COPY = "The MCP server rejected the credentials. Check the stored credentials for this server or supply an Authorization header."
+_HANDSHAKE_PROTOCOL_COPY = (
+    "The server responded but MCP negotiation failed. Confirm the URL points at an MCP endpoint (for example /mcp or /sse) and supports an MCP protocol this gateway understands."
+)
+_HANDSHAKE_INVALID_COPY = "The server's response is not valid MCP. The URL may point at a service that does not speak MCP."
+
+
+class _SniPinningTransport(httpx.AsyncHTTPTransport):
+    """Dial a DNS-pinned address while keeping the request's hostname authority and TLS identity.
+
+    The MCP SDK compares the origin it connected to against the origin the
+    server advertises (``mcp.client.sse`` raises on a mismatch), so pinning has
+    to happen below the SDK: requests keep the validated hostname in their URL
+    and ``Host`` header, while every connection goes to the address resolved at
+    validation time and TLS is verified against that hostname.
+    """
+
+    def __init__(self, sni_hostname: str, pinned_host: str, **kwargs: Any) -> None:
+        """Record the validated hostname and the address to dial in its place.
+
+        Args:
+            sni_hostname: Validated hostname whose certificate must match.
+            pinned_host: Address resolved at validation time, dialled instead of re-resolving.
+            **kwargs: Forwarded to ``httpx.AsyncHTTPTransport``.
+        """
+        super().__init__(**kwargs)
+        self._sni_hostname = sni_hostname
+        self._pinned_host = pinned_host
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        """Send the request to the pinned address with TLS pinned to the validated hostname.
+
+        Args:
+            request: Outbound request addressed to the validated hostname.
+
+        Returns:
+            httpx.Response: The upstream response.
+
+        Raises:
+            httpx.UnsupportedProtocol: If the request targets any other host.
+        """
+        # Compare the IDNA-encoded form: httpx decodes punycode back to Unicode on `url.host`,
+        # while the validated hostname arrives punycode-encoded from the request schema.
+        if request.url.raw_host.decode("ascii") != self._sni_hostname:
+            raise httpx.UnsupportedProtocol(f"Gateway test refused a request to unvalidated host {request.url.host}", request=request)
+        request.extensions.setdefault("sni_hostname", self._sni_hostname)
+        # httpx derived the Host header from the hostname URL at construction time; rewriting the
+        # URL afterwards keeps that header while sending the bytes to the pinned address.
+        request.url = request.url.copy_with(host=self._pinned_host)
+        return await super().handle_async_request(request)
+
+
+def _gateway_test_visibility_filters(db: Session, user: Any) -> List[Any]:
+    """Build Layer-1 visibility conditions for gateway-test queries.
+
+    Mirrors :meth:`GatewayService._check_gateway_access`: public rows are always
+    visible; admin bypass (per ``is_admin_bypass_granted``) adds team rows plus
+    the caller's own private rows but never another user's; a team-scoped token
+    adds only its own teams; and a public-only token (``token_teams == []``) or
+    a caller without an email sees public rows alone. A non-admin caller whose
+    context carries no token scope is deliberately not expanded to its database
+    teams here, keeping these test endpoints fail-closed.
+
+    Args:
+        db: Database session, used to resolve admin status.
+        user: Authenticated user context dict.
+
+    Returns:
+        Conditions to OR together; never empty.
+    """
+    # First-Party
+    from mcpgateway.auth_context import extract_token_team_ids, get_user_email  # pylint: disable=import-outside-toplevel
+
+    token_teams = extract_token_team_ids(user)
+    # get_user_email returns the literal "unknown" for an identity-less context; treat that as no
+    # identity rather than letting it own-match gateways persisted with the same sentinel.
+    resolved_email = get_user_email(user)
+    scoped_user_email = None if resolved_email == "unknown" else resolved_email
+    visibility_filters: List[Any] = [DbGateway.visibility == "public"]
+
+    if is_admin_bypass_granted(db, scoped_user_email, token_teams):
+        visibility_filters.append(DbGateway.visibility == "team")
+        if scoped_user_email:
+            visibility_filters.append(and_(DbGateway.visibility == "private", DbGateway.owner_email == scoped_user_email))
+        return visibility_filters
+
+    if not scoped_user_email or token_teams == []:
+        return visibility_filters
+
+    if token_teams:
+        visibility_filters.append(and_(DbGateway.visibility == "team", DbGateway.team_id.in_(token_teams)))
+    visibility_filters.append(and_(DbGateway.visibility == "private", DbGateway.owner_email == scoped_user_email))
+    return visibility_filters
+
+
+def _gateway_test_endpoint_url(base_url: str, path_suffix: str) -> str:
+    """Append a gateway-test request path to a base URL without disturbing its query string.
+
+    Args:
+        base_url: Validated base URL, which may carry a query or fragment.
+        path_suffix: Request path, with or without a leading slash.
+
+    Returns:
+        The base URL with ``path_suffix`` appended to its path component.
+    """
+    parsed = urlparse(base_url)
+    joined_path = (parsed.path.rstrip("/") + "/" + path_suffix.lstrip("/")).rstrip("/")
+    return urlunparse(parsed._replace(path=joined_path))
+
+
+def _gateway_url_match_variants(validated_base_url: str) -> List[str]:
+    """Return the spellings of a validated base URL that a registered gateway may be stored under.
+
+    ``AnyHttpUrl`` normalizes a root URL to a trailing slash, while ``GatewayCreate.url``
+    stores whatever was registered, so matching one spelling exactly would miss the other.
+    Only the root path is ambiguous: a non-root path is matched exactly, so ``/mcp`` never
+    resolves the credentials of a separately registered ``/mcp/``.
+
+    Args:
+        validated_base_url: Validated base URL of the test target.
+
+    Returns:
+        The candidate spellings to match against ``DbGateway.url``.
+    """
+    parsed = urlparse(validated_base_url)
+    if parsed.path not in ("", "/"):
+        return [validated_base_url]
+    return [urlunparse(parsed._replace(path="")), urlunparse(parsed._replace(path="/"))]
+
+
+async def _validate_gateway_test_target(
+    base_url: str,
+    team_id: Optional[str],
+    user: Any,
+    db: Session,
+) -> Optional[Dict[str, str]]:
+    """Validate a gateway-test URL against the allowlist and DNS-pin the resolved address.
+
+    Shared prelude for the raw connectivity test and the MCP handshake test.
+
+    Args:
+        base_url: The URL to validate.
+        team_id: Optional team ID used to scope the registered-gateway allowlist.
+        user: Authenticated user context dict.
+        db: Database session.
+
+    Returns:
+        Dict with ``validated_base_url``, ``validated_hostname``, ``pinned_base_url``,
+        ``resolved_ip`` and ``original_authority``, or ``None`` when the URL is rejected.
+    """
+    # First-Party
+    from mcpgateway.auth_context import get_user_email  # pylint: disable=import-outside-toplevel
+
+    # Build allowlist for gateway test endpoint
+    allowed_hosts_set: set[str] = set()
+
+    if settings.gateway_test_allow_registered_only:
+        # Mode 1: Only allow testing registered gateway URLs
+        # Query all enabled gateways to build allowlist from their base URLs
+        try:
+            query = select(DbGateway.url).where(DbGateway.enabled, or_(*_gateway_test_visibility_filters(db, user)))
+            if team_id:
+                query = query.where(DbGateway.team_id == team_id)
+            registered_urls = db.execute(query).scalars().all()
+
+            # Extract hostnames from registered gateway URLs
+            for url in registered_urls:
+                try:
+                    parsed = urlparse(url)
+                    if parsed.hostname:
+                        # Normalize: lowercase and strip trailing dots
+                        hostname = parsed.hostname.lower().rstrip(".")
+                        allowed_hosts_set.add(hostname)
+                except (ValueError, AttributeError) as e:
+                    # Log parse failures to help debug "URL not in allowlist" mysteries
+                    logger.debug("Failed to parse registered gateway URL '%s': %s", url, e)
+                    continue
+        except SQLAlchemyError as e:
+            logger.warning("Failed to build allowlist from registered gateways: %s", e)
+    else:
+        # Mode 2: Use configured host patterns from settings
+        allowed_hosts_set = set(settings.gateway_test_allowed_hosts)
+
+    allowed_hosts = list(allowed_hosts_set)
+
+    # Validate URL with allowlist enforcement and pin a safe resolved IP to close
+    # the DNS rebinding gap between validation-time and connection-time resolution.
+    try:
+        validated_gateway_target = await SecurityValidator.validate_gateway_test_url(base_url, allowed_hosts, "Gateway test URL")
+    except ValueError as e:
+        # Log the actual error for security monitoring, but return generic message
+        safe_url = sanitize_url_for_logging(base_url)
+        logger.warning(
+            "Gateway test URL validation failed for %s by user %s: %s",
+            safe_url,
+            get_user_email(user),
+            str(e),
+        )
+        return None
+
+    validated_base_url = validated_gateway_target["validated_url"]
+    validated_hostname = validated_gateway_target["hostname"]
+    pinned_resolved_ip = validated_gateway_target["resolved_ip"]
+
+    parsed_validated_base_url = urlparse(validated_base_url)
+    pinned_ip_is_ipv6 = ":" in pinned_resolved_ip
+    if parsed_validated_base_url.port is not None:
+        pinned_netloc = f"[{pinned_resolved_ip}]:{parsed_validated_base_url.port}" if pinned_ip_is_ipv6 else f"{pinned_resolved_ip}:{parsed_validated_base_url.port}"
+        original_authority = f"{validated_hostname}:{parsed_validated_base_url.port}"
+    else:
+        pinned_netloc = f"[{pinned_resolved_ip}]" if pinned_ip_is_ipv6 else pinned_resolved_ip
+        original_authority = validated_hostname
+
+    pinned_base_url = urlunparse(parsed_validated_base_url._replace(netloc=pinned_netloc))
+    safe_validated_url = sanitize_url_for_logging(validated_base_url)
+    logger.info(
+        "Gateway test pinned outbound address for user %s: url=%s hostname=%s pinned_ip=%s",
+        get_user_email(user),
+        safe_validated_url,
+        validated_hostname,
+        pinned_resolved_ip,
+    )
+
+    return {
+        "validated_base_url": validated_base_url,
+        "validated_hostname": validated_hostname,
+        "pinned_base_url": pinned_base_url,
+        "resolved_ip": pinned_resolved_ip,
+        "original_authority": original_authority,
+    }
+
+
+def _classify_handshake_error(root_cause: BaseException) -> tuple[str, str]:
+    """Classify a handshake failure into a failure class and actionable copy.
+
+    Args:
+        root_cause: The unwrapped exception that aborted the handshake.
+
+    Returns:
+        Tuple of (failure_class, actionable error copy).
+    """
+    if isinstance(root_cause, httpx.HTTPStatusError) and root_cause.response.status_code in (401, 403):
+        return "auth", _HANDSHAKE_AUTH_COPY
+    if isinstance(root_cause, (httpx.RequestError, OSError)):
+        return "transport", _HANDSHAKE_TRANSPORT_COPY
+    if isinstance(root_cause, McpError) or (isinstance(root_cause, RuntimeError) and "protocol" in str(root_cause).lower()):
+        return "protocol", _HANDSHAKE_PROTOCOL_COPY
+    return "invalid_response", _HANDSHAKE_INVALID_COPY
+
+
 async def test_gateway_connectivity(
     request: GatewayTestRequest,
     team_id: Optional[str],
@@ -7234,91 +7502,30 @@ async def test_gateway_connectivity(
 
     start_time: float = time.monotonic()
 
-    # Build allowlist for gateway test endpoint
-    allowed_hosts_set: set[str] = set()
-
-    if settings.gateway_test_allow_registered_only:
-        # Mode 1: Only allow testing registered gateway URLs
-        # Query all enabled gateways to build allowlist from their base URLs
-        try:
-            query = select(DbGateway.url).where(DbGateway.enabled)
-            if team_id:
-                query = query.where(DbGateway.team_id == team_id)
-            registered_urls = db.execute(query).scalars().all()
-
-            # Extract hostnames from registered gateway URLs
-            for url in registered_urls:
-                try:
-                    parsed = urlparse(url)
-                    if parsed.hostname:
-                        # Normalize: lowercase and strip trailing dots
-                        hostname = parsed.hostname.lower().rstrip(".")
-                        allowed_hosts_set.add(hostname)
-                except (ValueError, AttributeError) as e:
-                    # Log parse failures to help debug "URL not in allowlist" mysteries
-                    logger.debug("Failed to parse registered gateway URL '%s': %s", url, e)
-                    continue
-        except SQLAlchemyError as e:
-            logger.warning("Failed to build allowlist from registered gateways: %s", e)
-    else:
-        # Mode 2: Use configured host patterns from settings
-        allowed_hosts_set = set(settings.gateway_test_allowed_hosts)
-
-    allowed_hosts = list(allowed_hosts_set)
-
-    # Validate URL with allowlist enforcement and pin a safe resolved IP to close
-    # the DNS rebinding gap between validation-time and connection-time resolution.
-    try:
-        validated_gateway_target = await SecurityValidator.validate_gateway_test_url(str(request.base_url), allowed_hosts, "Gateway test URL")
-    except ValueError as e:
-        # Log the actual error for security monitoring, but return generic message
-        safe_url = sanitize_url_for_logging(str(request.base_url))
-        logger.warning(
-            "Gateway test URL validation failed for %s by user %s: %s",
-            safe_url,
-            get_user_email(user),
-            str(e),
-        )
+    target = await _validate_gateway_test_target(str(request.base_url), team_id, user, db)
+    if target is None:
         latency_ms = int((time.monotonic() - start_time) * 1000)
         # Generic error message - don't expose allowlist or validation details
         return GatewayTestResponse(
             status_code=400, latency_ms=latency_ms, body={"error": "The MCP server URL is not allowed for testing. Confirm the URL is correct and the host is permitted by your test policy."}
         )
 
-    validated_base_url = validated_gateway_target["validated_url"]
-    validated_hostname = validated_gateway_target["hostname"]
-    pinned_resolved_ip = validated_gateway_target["resolved_ip"]
-
-    parsed_validated_base_url = urlparse(validated_base_url)
-    pinned_ip_is_ipv6 = ":" in pinned_resolved_ip
-    if parsed_validated_base_url.port is not None:
-        pinned_netloc = f"[{pinned_resolved_ip}]:{parsed_validated_base_url.port}" if pinned_ip_is_ipv6 else f"{pinned_resolved_ip}:{parsed_validated_base_url.port}"
-        original_authority = f"{validated_hostname}:{parsed_validated_base_url.port}"
-    else:
-        pinned_netloc = f"[{pinned_resolved_ip}]" if pinned_ip_is_ipv6 else pinned_resolved_ip
-        original_authority = validated_hostname
-
-    pinned_base_url = urlunparse(parsed_validated_base_url._replace(netloc=pinned_netloc))
-    full_url = pinned_base_url.rstrip("/") + "/" + request.path.lstrip("/")
-    full_url = full_url.rstrip("/")
+    validated_base_url = target["validated_base_url"]
+    validated_hostname = target["validated_hostname"]
+    full_url = _gateway_test_endpoint_url(target["pinned_base_url"], request.path)
     safe_validated_url = sanitize_url_for_logging(validated_base_url)
-    logger.info(
-        "Gateway test pinned outbound address for user %s: url=%s hostname=%s pinned_ip=%s",
-        get_user_email(user),
-        safe_validated_url,
-        validated_hostname,
-        pinned_resolved_ip,
-    )
 
-    headers = dict(request.headers or {})
-    headers["Host"] = original_authority
+    # SECURITY: the authority comes from the validated URL. Dropping any caller-supplied Host
+    # first also prevents a differently-cased key from being sent as a second Host header.
+    headers = {key: value for key, value in (request.headers or {}).items() if key.lower() != "host"}
+    headers["Host"] = target["original_authority"]
 
     # Attempt to find a registered gateway matching this URL and team.
     # Query the raw DB object directly so we get the unmasked auth_value
     # (get_first_gateway_by_url returns a masked GatewayRead where
     # auth_value="*****", which cannot be decoded).
     try:
-        query = select(DbGateway).where(DbGateway.url == validated_base_url, DbGateway.enabled)
+        query = select(DbGateway).where(DbGateway.url.in_(_gateway_url_match_variants(validated_base_url)), DbGateway.enabled, or_(*_gateway_test_visibility_filters(db, user)))
         if team_id:
             query = query.where(DbGateway.team_id == team_id)
         gateway = db.execute(query).scalars().first()
@@ -7465,6 +7672,338 @@ async def test_gateway_connectivity(
         return GatewayTestResponse(
             status_code=502, latency_ms=latency_ms, body={"error": "The MCP server request failed. Verify the MCP server is running and reachable from this host.", "details": str(e)}
         )
+
+
+async def test_gateway_handshake(
+    request: GatewayHandshakeRequest,
+    team_id: Optional[str],
+    user: Any,
+    db: Session,
+) -> GatewayHandshakeResponse:
+    """Test whether a URL speaks MCP by attempting a protocol handshake.
+
+    Tries the stateless ``server/discover`` method (MCP 2026-07-28+) first and
+    falls back to a stateful SDK ``initialize`` round-trip for earlier specs.
+    Purely a probe: performs no DB writes and never touches gateway health
+    state (no ``_mark_gateway_reachable`` / ``_handle_gateway_failure`` /
+    ``_refresh_gateway_tools_resources_prompts`` calls).
+
+    Args:
+        request (GatewayHandshakeRequest): The request object containing the server URL and optional headers.
+        team_id (Optional[str]): Optional team ID for team-specific gateways.
+        user (Any): Authenticated user context dict.
+        db (Session): Database session.
+
+    Returns:
+        GatewayHandshakeResponse: The handshake outcome, including negotiation path,
+            server identity, capabilities, component counts, and failure classification.
+
+    Examples:
+        >>> import asyncio
+        >>> callable(test_gateway_handshake)
+        True
+    """
+    # First-Party
+    from mcpgateway.auth_context import get_user_email  # pylint: disable=import-outside-toplevel
+
+    start_time: float = time.monotonic()
+
+    def _latency_ms() -> int:
+        """Elapsed milliseconds since the handshake attempt started."""
+        return int((time.monotonic() - start_time) * 1000)
+
+    def _failure(failure_class: Literal["transport", "protocol", "auth", "invalid_response"], error: str) -> GatewayHandshakeResponse:
+        """Build a failed handshake response preserving the resolved credential source."""
+        return GatewayHandshakeResponse(success=False, latency_ms=_latency_ms(), credential_source=credential_source, failure_class=failure_class, error=error)
+
+    target = await _validate_gateway_test_target(str(request.base_url), team_id, user, db)
+    if target is None:
+        latency_ms = int((time.monotonic() - start_time) * 1000)
+        # Generic error message - don't expose allowlist or validation details
+        return GatewayHandshakeResponse(
+            success=False,
+            latency_ms=latency_ms,
+            failure_class="transport",
+            error="The MCP server URL is not allowed for testing. Confirm the URL is correct and the host is permitted by your test policy.",
+        )
+
+    validated_base_url = target["validated_base_url"]
+    validated_hostname = target["validated_hostname"]
+    path_suffix = (request.path or "").lstrip("/")
+    hostname_url = _gateway_test_endpoint_url(validated_base_url, path_suffix)
+    full_url = _gateway_test_endpoint_url(target["pinned_base_url"], path_suffix)
+
+    try:
+        query = select(DbGateway).where(DbGateway.url.in_(_gateway_url_match_variants(validated_base_url)), DbGateway.enabled, or_(*_gateway_test_visibility_filters(db, user)))
+        if team_id:
+            query = query.where(DbGateway.team_id == team_id)
+        gateway = db.execute(query).scalars().first()
+    except Exception:
+        gateway = None
+
+    credential_source: Literal["stored", "form", "none"] = "none"
+    headers: Dict[str, str] = {}
+    user_email = get_user_email(user)
+    # SECURITY: the authority is derived from the validated URL, never chosen by the caller.
+    # A caller-supplied Host would aim the stored credentials at another virtual host on the
+    # pinned address, and a differently-cased key would be sent as a second Host header.
+    form_headers = {key: value for key, value in (request.headers or {}).items() if key.lower() != "host"}
+    # A form-supplied Authorization header replaces stored credentials, so don't fail the
+    # handshake on an unobtainable stored OAuth token the caller is not going to use.
+    form_supplies_authorization = any(key.lower() == "authorization" for key in form_headers)
+    if gateway and gateway.auth_type == "oauth" and gateway.oauth_config and not form_supplies_authorization:
+        grant_type = gateway.oauth_config.get("grant_type", "client_credentials")
+        try:
+            if grant_type == "authorization_code":
+                # First-Party
+                from mcpgateway.services.token_storage_service import TokenStorageService  # pylint: disable=import-outside-toplevel
+
+                token_storage = TokenStorageService(db)
+                access_token: Optional[str] = await token_storage.get_user_token(gateway.id, user_email) if user_email else None
+                if not access_token:
+                    return GatewayHandshakeResponse(
+                        success=False,
+                        latency_ms=_latency_ms(),
+                        failure_class="auth",
+                        error=f"Please authorize {gateway.name} first. Visit /oauth/authorize/{gateway.id} to complete OAuth flow.",
+                    )
+                headers["Authorization"] = f"Bearer {access_token}"
+            else:
+                oauth_manager = OAuthManager(request_timeout=int(os.getenv("OAUTH_REQUEST_TIMEOUT", "30")), max_retries=int(os.getenv("OAUTH_MAX_RETRIES", "3")))
+                access_token = await oauth_manager.get_access_token(gateway.oauth_config, ca_certificate=gateway.ca_certificate, client_cert=gateway.client_cert, client_key=gateway.client_key)
+                headers["Authorization"] = f"Bearer {access_token}"
+            credential_source = "stored"
+        except Exception as e:
+            logger.error("Failed to obtain OAuth access token for gateway %s: %s", gateway.name, sanitize_exception_message(str(e)))
+            return GatewayHandshakeResponse(
+                success=False,
+                latency_ms=_latency_ms(),
+                failure_class="auth",
+                error=f"Token retrieval failed for MCP server '{gateway.name}': {sanitize_exception_message(str(e))}. Check the OAuth client credentials and token URL.",
+            )
+    elif gateway and gateway.auth_type in ("basic", "bearer", "authheaders") and gateway.auth_value:
+        if isinstance(gateway.auth_value, dict):
+            headers.update(gateway.auth_value)
+        elif isinstance(gateway.auth_value, str):
+            headers.update(decode_auth(gateway.auth_value))
+        credential_source = "stored"
+
+    if form_headers:
+        # `headers` holds only stored credential headers at this point (protocol headers are
+        # layered on later), so its keys are exactly the stored credential key set.
+        stored_credential_keys = {key.lower() for key in headers} if credential_source == "stored" else set()
+        form_header_keys = {key.lower() for key in form_headers}
+        overridden_stored_keys = form_header_keys & stored_credential_keys
+        if overridden_stored_keys:
+            # Drop the stored variant so a differently-cased form header really replaces it
+            # instead of both being sent to the target.
+            headers = {key: value for key, value in headers.items() if key.lower() not in overridden_stored_keys}
+        headers.update(form_headers)
+        if "authorization" in form_header_keys or overridden_stored_keys:
+            credential_source = "form"
+
+    handshake_verify: Any = get_default_verify()
+    if gateway and gateway.ca_certificate and not validated_base_url.lower().startswith("http://"):
+        handshake_verify = get_cached_ssl_context(gateway.ca_certificate, client_cert=gateway.client_cert, client_key=gateway.client_key)
+
+    def get_httpx_client_factory(
+        headers: Optional[Dict[str, str]] = None,
+        timeout: Optional[httpx.Timeout] = None,
+        auth: Optional[httpx.Auth] = None,
+    ) -> httpx.AsyncClient:
+        """Build the SDK's httpx client so it dials the pinned address with the gateway's TLS settings.
+
+        Args:
+            headers: Optional headers for the client
+            timeout: Optional timeout for the client
+            auth: Optional auth for the client
+
+        Returns:
+            httpx.AsyncClient: Configured HTTPX async client
+        """
+        # An explicit transport is what makes address pinning possible; it also opts this client
+        # out of httpx's environment-proxy discovery, unlike the stateless discover probe.
+        return httpx.AsyncClient(
+            follow_redirects=False,
+            headers=headers,
+            timeout=timeout if timeout else get_http_timeout(),
+            auth=auth,
+            transport=_SniPinningTransport(
+                sni_hostname=validated_hostname,
+                pinned_host=target["resolved_ip"],
+                verify=handshake_verify,
+                limits=httpx.Limits(
+                    max_connections=settings.httpx_max_connections,
+                    max_keepalive_connections=settings.httpx_max_keepalive_connections,
+                    keepalive_expiry=settings.httpx_keepalive_expiry,
+                ),
+            ),
+        )
+
+    try:
+        async with asyncio.timeout(settings.health_check_timeout):
+            discover_headers = {
+                **headers,
+                "Host": target["original_authority"],
+                "MCP-Protocol-Version": MCP_STATELESS_PROTOCOL_VERSION,
+                "Mcp-Method": "server/discover",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            }
+            # Per-request metadata required by the stateless mode: the server reads the requested
+            # protocol version from `_meta`, not just from the HTTP header.
+            request_meta = {
+                "io.modelcontextprotocol/protocolVersion": MCP_STATELESS_PROTOCOL_VERSION,
+                "io.modelcontextprotocol/clientInfo": {"name": "contextforge", "version": __version__},
+                "io.modelcontextprotocol/clientCapabilities": {},
+            }
+            discover_payload = {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "server/discover",
+                "params": {"_meta": request_meta},
+            }
+            discover_result: Optional[Dict[str, Any]] = None
+            async with ResilientHttpClient(client_args={"timeout": settings.federation_timeout, "verify": handshake_verify}) as client:
+                try:
+                    response: httpx.Response = await client.request(method="POST", url=full_url, headers=discover_headers, json=discover_payload, extensions={"sni_hostname": validated_hostname})
+                except httpx.RequestError as e:
+                    logger.warning("MCP handshake discover failed for %s: %s", sanitize_url_for_logging(validated_base_url), sanitize_exception_message(str(e)))
+                    return _failure("transport", f"{_HANDSHAKE_TRANSPORT_COPY}: {sanitize_exception_message(str(e))}")
+
+                if response.status_code in (401, 403):
+                    return _failure("auth", _HANDSHAKE_AUTH_COPY)
+
+                if 200 <= response.status_code < 300:
+                    try:
+                        body = response.json()
+                        result_payload = body.get("result") if isinstance(body, dict) else None
+                        # A bare `{"result": {}}`, or another method's result, is not evidence that
+                        # the server implements discovery: fall through to the initialize probe.
+                        if isinstance(result_payload, dict) and (isinstance(result_payload.get("capabilities"), dict) or isinstance(result_payload.get("supportedVersions"), list)):
+                            discover_result = result_payload
+                    except ValueError:
+                        discover_result = None
+
+                if discover_result is not None:
+                    capabilities = discover_result.get("capabilities") if isinstance(discover_result.get("capabilities"), dict) else None
+                    result_meta = discover_result.get("_meta") if isinstance(discover_result.get("_meta"), dict) else {}
+                    server_info = result_meta.get("io.modelcontextprotocol/serverInfo")
+                    if not isinstance(server_info, dict):
+                        # Servers predating the namespaced metadata put serverInfo at the top level.
+                        server_info = discover_result.get("serverInfo") if isinstance(discover_result.get("serverInfo"), dict) else {}
+                    component_counts: Dict[str, int] = {}
+                    counts_partial = False
+                    if capabilities:
+                        list_methods = {"tools": "tools/list", "resources": "resources/list", "prompts": "prompts/list"}
+                        for cap_key, method in list_methods.items():
+                            if cap_key not in capabilities:
+                                continue
+                            try:
+                                list_headers = {**discover_headers, "Mcp-Method": method}
+                                list_response: httpx.Response = await client.request(
+                                    method="POST",
+                                    url=full_url,
+                                    headers=list_headers,
+                                    json={"jsonrpc": "2.0", "id": 2, "method": method, "params": {"_meta": request_meta}},
+                                    extensions={"sni_hostname": validated_hostname},
+                                )
+                                list_body = list_response.json()
+                                list_result = list_body.get("result") if isinstance(list_body, dict) else None
+                                if isinstance(list_result, dict) and isinstance(list_result.get(cap_key), list):
+                                    component_counts[cap_key] = len(list_result[cap_key])
+                                    if list_result.get("nextCursor"):
+                                        counts_partial = True
+                            except Exception as list_exc:
+                                logger.debug("MCP handshake %s failed for %s: %s", method, sanitize_url_for_logging(validated_base_url), list_exc)
+
+                    return GatewayHandshakeResponse(
+                        success=True,
+                        latency_ms=_latency_ms(),
+                        negotiation_path="server_discover",
+                        protocol_version=MCP_STATELESS_PROTOCOL_VERSION,
+                        server_name=server_info.get("name"),
+                        server_version=server_info.get("version"),
+                        capabilities=capabilities,
+                        component_counts=component_counts or None,
+                        counts_partial=counts_partial,
+                        credential_source=credential_source,
+                        raw_preview=json.dumps(discover_result, default=str)[:4096],
+                    )
+
+            async def _probe_session(session: ClientSession) -> GatewayHandshakeResponse:
+                """Run initialize plus first-page component listings on an open session.
+
+                Args:
+                    session: The connected MCP client session.
+
+                Returns:
+                    GatewayHandshakeResponse: The successful initialize-path result.
+                """
+                init = await session.initialize()
+                capabilities = init.capabilities.model_dump(by_alias=True, exclude_none=True)
+                component_counts: Dict[str, int] = {}
+                counts_partial = False
+                for capability, list_call, attr in (
+                    (init.capabilities.tools, session.list_tools, "tools"),
+                    (init.capabilities.resources, session.list_resources, "resources"),
+                    (init.capabilities.prompts, session.list_prompts, "prompts"),
+                ):
+                    if capability is None:
+                        continue
+                    try:
+                        list_result = await list_call()
+                        component_counts[attr] = len(getattr(list_result, attr))
+                        if getattr(list_result, "nextCursor", None):
+                            counts_partial = True
+                    except Exception as list_exc:
+                        logger.debug("MCP handshake list_%s failed for %s: %s", attr, sanitize_url_for_logging(validated_base_url), list_exc)
+
+                return GatewayHandshakeResponse(
+                    success=True,
+                    latency_ms=_latency_ms(),
+                    negotiation_path="initialize",
+                    protocol_version=str(init.protocolVersion),
+                    server_name=init.serverInfo.name,
+                    server_version=init.serverInfo.version,
+                    capabilities=capabilities,
+                    component_counts=component_counts or None,
+                    counts_partial=counts_partial,
+                    credential_source=credential_source,
+                    raw_preview=json.dumps(init.model_dump(by_alias=True, exclude_none=True), default=str)[:4096],
+                )
+
+            try:
+                # SECURITY: the SDK keeps the validated hostname (it rejects a server-advertised
+                # endpoint whose origin differs from the one it connected to), while
+                # _SniPinningTransport sends every request to the IP pinned at validation time
+                # with TLS verified against that hostname, closing the same DNS rebinding window
+                # as server/discover, on the follow-up requests too.
+                if gateway and str(gateway.transport).lower() == "sse":
+                    async with sse_client(url=hostname_url, headers=headers, httpx_client_factory=get_httpx_client_factory) as (read_stream, write_stream):
+                        async with ClientSession(read_stream, write_stream) as session:
+                            return await _probe_session(session)
+                else:
+                    async with streamablehttp_client(url=hostname_url, headers=headers, timeout=settings.health_check_timeout, httpx_client_factory=get_httpx_client_factory) as (
+                        read_stream,
+                        write_stream,
+                        _get_session_id,
+                    ):
+                        async with ClientSession(read_stream, write_stream) as session:
+                            return await _probe_session(session)
+            except TimeoutError:
+                raise
+            except Exception as e:
+                root_cause: BaseException = e
+                while isinstance(root_cause, BaseExceptionGroup) and root_cause.exceptions:  # pylint: disable=no-member
+                    root_cause = root_cause.exceptions[0]  # pylint: disable=no-member
+                failure_class, copy = _classify_handshake_error(root_cause)
+                if failure_class == "transport":
+                    copy = f"{copy}: {sanitize_exception_message(str(root_cause))}"
+                logger.warning("MCP handshake initialize failed for %s: %s", sanitize_url_for_logging(validated_base_url), sanitize_exception_message(str(root_cause)))
+                return _failure(failure_class, copy)
+    except TimeoutError:
+        return _failure("transport", _HANDSHAKE_TRANSPORT_COPY)
 
 
 # Lazy singleton - created on first access, not at module import time.

--- a/tests/unit/mcpgateway/routers/test_mcp_servers_router.py
+++ b/tests/unit/mcpgateway/routers/test_mcp_servers_router.py
@@ -12,15 +12,32 @@ Tests cover:
 
 # Standard
 import socket
+import ssl
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
+import httpx
+from mcp.shared.exceptions import McpError
+from mcp.types import ErrorData
+from pydantic import ValidationError
 import pytest
+from sqlalchemy import create_engine, or_, select
+from sqlalchemy.orm import sessionmaker
 
 # First-Party
-from mcpgateway.routers.mcp_servers_router import _validated_team_id, check_mcp_server_connectivity
-from mcpgateway.schemas import GatewayTestRequest, GatewayTestResponse
+from mcpgateway.db import Base, Gateway as DbGateway
+from mcpgateway.routers.mcp_servers_router import _validated_team_id, check_mcp_server_connectivity, check_mcp_server_handshake
+from mcpgateway.schemas import GatewayHandshakeRequest, GatewayHandshakeResponse, GatewayTestRequest, GatewayTestResponse
+from mcpgateway.services.gateway_service import (
+    _classify_handshake_error,
+    _gateway_test_visibility_filters,
+    _HANDSHAKE_AUTH_COPY,
+    _HANDSHAKE_INVALID_COPY,
+    _HANDSHAKE_PROTOCOL_COPY,
+    _HANDSHAKE_TRANSPORT_COPY,
+    _SniPinningTransport,
+)
 
 # Local
 from tests.utils.rbac_mocks import patch_rbac_decorators, restore_rbac_decorators
@@ -577,3 +594,1212 @@ async def test_admin_bypass_cross_team_team_id_allowed(gateway_test_request, db_
             )
 
     assert result.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /test-handshake
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def handshake_request() -> GatewayHandshakeRequest:
+    """A valid GatewayHandshakeRequest pointing at a public test host."""
+    return GatewayHandshakeRequest(base_url="http://example.com", path="/mcp", headers={})
+
+
+def _mock_resilient_client(*responses):
+    """Build a mock ResilientHttpClient whose request() returns the given responses in order."""
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(side_effect=list(responses))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return mock_client
+
+
+def _json_response(status_code: int, payload):
+    """Build a mock httpx.Response with a JSON body."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    return response
+
+
+@pytest.mark.asyncio
+async def test_handshake_allowlist_rejection(user_ctx, db_session, monkeypatch):
+    """URL rejected by the test policy returns a generic transport failure with no outbound call."""
+    from mcpgateway import config
+
+    monkeypatch.setattr(config.settings, "gateway_test_allow_registered_only", False)
+    monkeypatch.setattr(config.settings, "gateway_test_allowed_hosts", [])
+
+    request = GatewayHandshakeRequest(base_url="http://internal.private.host", path="/mcp")
+
+    mock_client = _mock_resilient_client()
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=request, team_id=None, user=user_ctx, db=db_session)
+
+    assert isinstance(result, GatewayHandshakeResponse)
+    assert result.success is False
+    assert result.failure_class == "transport"
+    assert "not allowed" in result.error
+    mock_client.request.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_discover_success(handshake_request, user_ctx, db_session):
+    """server/discover 200 with a JSON-RPC result yields the server_discover negotiation path."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    tools_list = _json_response(200, {"jsonrpc": "2.0", "id": 2, "result": {"tools": [{}, {}, {}]}})
+    mock_client = _mock_resilient_client(_discover_success(capabilities={"tools": {}}), tools_list)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is True
+    assert result.negotiation_path == "server_discover"
+    assert result.protocol_version == "2026-07-28"
+    assert result.server_name == "srv"
+    assert result.server_version == "1.0"
+    assert result.component_counts == {"tools": 3}
+    assert result.counts_partial is False
+    assert result.credential_source == "none"
+
+
+def _mock_sdk_session(init_side_effect=None):
+    """Build mocked streamablehttp_client / ClientSession context managers."""
+    init_result = MagicMock()
+    init_result.protocolVersion = "2025-11-25"
+    init_result.serverInfo.name = "legacy-srv"
+    init_result.serverInfo.version = "2.0"
+    init_result.capabilities.tools = MagicMock()
+    init_result.capabilities.resources = None
+    init_result.capabilities.prompts = None
+    init_result.capabilities.model_dump.return_value = {"tools": {}}
+    init_result.model_dump.return_value = {"protocolVersion": "2025-11-25"}
+
+    tools_result = MagicMock()
+    tools_result.tools = [MagicMock(), MagicMock()]
+    tools_result.nextCursor = None
+
+    session = MagicMock()
+    session.initialize = AsyncMock(side_effect=init_side_effect, return_value=init_result) if init_side_effect else AsyncMock(return_value=init_result)
+    session.list_tools = AsyncMock(return_value=tools_result)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+
+    transport_cm = MagicMock()
+    transport_cm.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock(), MagicMock()))
+    transport_cm.__aexit__ = AsyncMock(return_value=None)
+
+    return transport_cm, session
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_discover_fallback_to_initialize(handshake_request, user_ctx, db_session):
+    """A JSON-RPC -32601 from server/discover falls back to the SDK initialize path."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    discover = _json_response(200, {"jsonrpc": "2.0", "id": 1, "error": {"code": -32601, "message": "Method not found"}})
+    mock_client = _mock_resilient_client(discover)
+    transport_cm, session = _mock_sdk_session()
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is True
+    assert result.negotiation_path == "initialize"
+    assert result.protocol_version == "2025-11-25"
+    assert result.server_name == "legacy-srv"
+    assert result.component_counts == {"tools": 2}
+    # The SDK keeps the validated hostname; _SniPinningTransport dials the pinned address.
+    assert mock_streamable.call_args.kwargs["url"] == "http://example.com/mcp"
+
+    with patch("mcpgateway.services.gateway_service._SniPinningTransport", wraps=_SniPinningTransport) as mock_transport:
+        factory_client = mock_streamable.call_args.kwargs["httpx_client_factory"]()
+        await factory_client.aclose()
+
+    assert mock_transport.call_args.kwargs["sni_hostname"] == "example.com"
+    assert mock_transport.call_args.kwargs["pinned_host"] == "8.8.8.8"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_discover_401_is_auth_failure(handshake_request, user_ctx, db_session):
+    """HTTP 401 from server/discover short-circuits as an auth failure with no initialize attempt."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    mock_client = _mock_resilient_client(_json_response(401, {"error": "unauthorized"}))
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client") as mock_streamable:
+            result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is False
+    assert result.failure_class == "auth"
+    mock_streamable.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_connect_error_is_transport_failure(handshake_request, user_ctx, db_session):
+    """httpx.ConnectError during server/discover is a transport failure."""
+    import httpx
+
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is False
+    assert result.failure_class == "transport"
+    assert "Could not reach the MCP server" in result.error
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_initialize_garbage_is_invalid_response(handshake_request, user_ctx, db_session):
+    """A decode error during initialize classifies as invalid_response."""
+    import json as stdlib_json
+
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    discover = _json_response(404, {"error": "not found"})
+    mock_client = _mock_resilient_client(discover)
+    transport_cm, session = _mock_sdk_session(init_side_effect=stdlib_json.JSONDecodeError("Expecting value", "doc", 0))
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm):
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is False
+    assert result.failure_class == "invalid_response"
+    assert "not valid MCP" in result.error
+
+
+@pytest.mark.asyncio
+async def test_handshake_unauthenticated_request_returns_401(handshake_request, db_session):
+    """Request without authenticated user context raises 401."""
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        await check_mcp_server_handshake(request=handshake_request, team_id=None, user=None, db=db_session)
+
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_handshake_insufficient_permission_returns_403(handshake_request, user_ctx, db_session):
+    """User without gateways.read permission is denied with 403."""
+    from fastapi import HTTPException
+
+    with patch("mcpgateway.middleware.rbac.PermissionService") as mock_ps_class:
+        mock_ps = MagicMock()
+        mock_ps.check_permission = AsyncMock(return_value=False)
+        mock_ps_class.return_value = mock_ps
+
+        with pytest.raises(HTTPException) as exc_info:
+            await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_handshake_cross_team_team_id_returns_403(handshake_request, db_session):
+    """Non-admin user supplying a team_id outside their authorized teams raises 403."""
+    import uuid
+    from fastapi import HTTPException
+
+    authorized_team = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").hex
+    foreign_team = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb").hex
+
+    non_admin_user = {
+        "email": "user@example.com",
+        "full_name": "Regular User",
+        "is_admin": False,
+        "token_teams": [authorized_team],
+        "db": db_session,
+    }
+
+    with pytest.raises(HTTPException) as exc_info:
+        await check_mcp_server_handshake(request=handshake_request, team_id=foreign_team, user=non_admin_user, db=db_session)
+
+    assert exc_info.value.status_code == 403
+    assert "team" in exc_info.value.detail.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests: handshake failure classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("root_cause", "expected"),
+    [
+        (httpx.HTTPStatusError("unauthorized", request=MagicMock(), response=MagicMock(status_code=401)), ("auth", _HANDSHAKE_AUTH_COPY)),
+        (httpx.HTTPStatusError("forbidden", request=MagicMock(), response=MagicMock(status_code=403)), ("auth", _HANDSHAKE_AUTH_COPY)),
+        (httpx.HTTPStatusError("teapot", request=MagicMock(), response=MagicMock(status_code=418)), ("invalid_response", _HANDSHAKE_INVALID_COPY)),
+        (httpx.ConnectError("connection refused"), ("transport", _HANDSHAKE_TRANSPORT_COPY)),
+        (httpx.ReadError("stream closed"), ("transport", _HANDSHAKE_TRANSPORT_COPY)),
+        (httpx.PoolTimeout("no free connection"), ("transport", _HANDSHAKE_TRANSPORT_COPY)),
+        (httpx.RemoteProtocolError("peer closed connection"), ("transport", _HANDSHAKE_TRANSPORT_COPY)),
+        (OSError("network unreachable"), ("transport", _HANDSHAKE_TRANSPORT_COPY)),
+        (McpError(ErrorData(code=-32000, message="server error")), ("protocol", _HANDSHAKE_PROTOCOL_COPY)),
+        (RuntimeError("protocol version mismatch"), ("protocol", _HANDSHAKE_PROTOCOL_COPY)),
+        (RuntimeError("something else"), ("invalid_response", _HANDSHAKE_INVALID_COPY)),
+        (ValueError("junk"), ("invalid_response", _HANDSHAKE_INVALID_COPY)),
+    ],
+)
+def test_classify_handshake_error_classification(root_cause, expected):
+    """Each handshake root cause maps to its failure class and actionable copy."""
+    assert _classify_handshake_error(root_cause) == expected
+
+
+# ---------------------------------------------------------------------------
+# Tests: handshake credential resolution
+# ---------------------------------------------------------------------------
+
+
+def _mock_gateway(**attributes):
+    """Build a registered-gateway row stand-in for credential-resolution tests."""
+    gateway = MagicMock()
+    gateway.id = "gateway-1"
+    gateway.name = "Test Server"
+    gateway.auth_type = None
+    gateway.auth_value = None
+    gateway.oauth_config = None
+    gateway.ca_certificate = None
+    for key, value in attributes.items():
+        setattr(gateway, key, value)
+    return gateway
+
+
+def _discover_success(capabilities=None):
+    """Build a spec-shaped server/discover response, optionally advertising capabilities."""
+    result = {
+        "resultType": "complete",
+        "supportedVersions": ["2026-07-28"],
+        "_meta": {"io.modelcontextprotocol/serverInfo": {"name": "srv", "version": "1.0"}},
+    }
+    if capabilities is not None:
+        result["capabilities"] = capabilities
+    return _json_response(200, {"jsonrpc": "2.0", "id": 1, "result": result})
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_gateway_lookup_error_degrades_to_no_credentials(handshake_request, user_ctx, db_session):
+    """A failing registered-gateway lookup probes unauthenticated instead of failing the handshake."""
+    db_session.execute.side_effect = Exception("db down")
+
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is True
+    assert result.credential_source == "none"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_team_scoped_lookup_filters_by_team(handshake_request, db_session):
+    """A supplied team_id narrows the registered-gateway credential lookup to that team."""
+    import uuid
+
+    team_id = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb").hex
+    admin_user = {"email": "admin@example.com", "full_name": "Admin User", "is_admin": True, "token_teams": None, "db": db_session}
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=team_id, user=admin_user, db=db_session)
+
+    assert result.success is True
+    assert "team_id" in str(db_session.execute.call_args[0][0])
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_stored_authcode_without_token_is_auth_failure(handshake_request, user_ctx, db_session):
+    """An authorization_code gateway with no stored user token asks the caller to authorize first."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = _mock_gateway(auth_type="oauth", oauth_config={"grant_type": "authorization_code"})
+
+    mock_client = _mock_resilient_client()
+    token_storage = MagicMock()
+    token_storage.get_user_token = AsyncMock(return_value=None)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.token_storage_service.TokenStorageService", return_value=token_storage):
+            result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is False
+    assert result.failure_class == "auth"
+    assert "Please authorize Test Server" in result.error
+    mock_client.request.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_stored_authcode_token_sets_bearer_header(handshake_request, user_ctx, db_session):
+    """A stored authorization_code token is sent as a bearer header and reported as a stored credential."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = _mock_gateway(auth_type="oauth", oauth_config={"grant_type": "authorization_code"})
+
+    mock_client = _mock_resilient_client(_discover_success())
+    token_storage = MagicMock()
+    token_storage.get_user_token = AsyncMock(return_value="stored-token")
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.token_storage_service.TokenStorageService", return_value=token_storage):
+            result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is True
+    assert result.credential_source == "stored"
+    assert mock_client.request.call_args.kwargs["headers"]["Authorization"] == "Bearer stored-token"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_stored_client_credentials_token_used(handshake_request, user_ctx, db_session):
+    """A client_credentials gateway mints a token through OAuthManager and sends it."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = _mock_gateway(auth_type="oauth", oauth_config={"grant_type": "client_credentials"})
+
+    mock_client = _mock_resilient_client(_discover_success())
+    oauth_manager = MagicMock()
+    oauth_manager.get_access_token = AsyncMock(return_value="minted-token")
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.OAuthManager", return_value=oauth_manager):
+            result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is True
+    assert result.credential_source == "stored"
+    assert mock_client.request.call_args.kwargs["headers"]["Authorization"] == "Bearer minted-token"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_stored_token_retrieval_failure_is_auth(handshake_request, user_ctx, db_session):
+    """A token-minting failure surfaces as an auth failure naming the server, with no outbound probe."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = _mock_gateway(auth_type="oauth", oauth_config={"grant_type": "client_credentials"})
+
+    mock_client = _mock_resilient_client()
+    oauth_manager = MagicMock()
+    oauth_manager.get_access_token = AsyncMock(side_effect=Exception("token endpoint down"))
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.OAuthManager", return_value=oauth_manager):
+            result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is False
+    assert result.failure_class == "auth"
+    assert result.error.startswith("Token retrieval failed for MCP server 'Test Server'")
+    mock_client.request.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_stored_basic_auth_dict_is_sent(handshake_request, user_ctx, db_session):
+    """A stored basic-auth header dict is forwarded verbatim on the probe."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = _mock_gateway(auth_type="basic", auth_value={"Authorization": "Basic abc"})
+
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.credential_source == "stored"
+    assert mock_client.request.call_args.kwargs["headers"]["Authorization"] == "Basic abc"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_stored_basic_auth_string_is_decoded(handshake_request, user_ctx, db_session):
+    """An encoded stored auth value is decoded into headers before the probe."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = _mock_gateway(auth_type="bearer", auth_value="encoded-value")
+
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.decode_auth", return_value={"Authorization": "Bearer decoded"}) as mock_decode:
+            result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    mock_decode.assert_called_once_with("encoded-value")
+    assert result.credential_source == "stored"
+    assert mock_client.request.call_args.kwargs["headers"]["Authorization"] == "Bearer decoded"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_form_headers_win_over_stored(user_ctx, db_session):
+    """Headers supplied on the request override stored credentials and are reported as form-sourced."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = _mock_gateway(auth_type="basic", auth_value={"Authorization": "Basic stored"})
+
+    request = GatewayHandshakeRequest(base_url="http://example.com", path="/mcp", headers={"Authorization": "Bearer typed"})
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.credential_source == "form"
+    assert mock_client.request.call_args.kwargs["headers"]["Authorization"] == "Bearer typed"
+
+
+# ---------------------------------------------------------------------------
+# Tests: handshake negotiation fallbacks and transports
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_discover_non_json_falls_back_to_initialize(handshake_request, user_ctx, db_session):
+    """A 200 server/discover response that is not JSON falls back to the SDK initialize path."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    discover = MagicMock()
+    discover.status_code = 200
+    discover.json.side_effect = ValueError("not json")
+    mock_client = _mock_resilient_client(discover)
+    transport_cm, session = _mock_sdk_session()
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm):
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is True
+    assert result.negotiation_path == "initialize"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_discover_list_failure_keeps_success(handshake_request, user_ctx, db_session):
+    """A failing component listing on the discover path still reports a successful handshake."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    mock_client = _mock_resilient_client(_discover_success(capabilities={"tools": {}}), httpx.ReadError("stream closed"))
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is True
+    assert result.negotiation_path == "server_discover"
+    assert result.component_counts is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_initialize_list_failure_keeps_success(handshake_request, user_ctx, db_session):
+    """A failing component listing on the initialize path still reports a successful handshake."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    mock_client = _mock_resilient_client(_json_response(404, {"error": "not found"}))
+    transport_cm, session = _mock_sdk_session()
+    session.list_tools = AsyncMock(side_effect=Exception("list failed"))
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm):
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is True
+    assert result.negotiation_path == "initialize"
+    assert result.component_counts is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_sse_gateway_uses_sse_client(handshake_request, user_ctx, db_session):
+    """A registered SSE gateway negotiates over the SSE transport with a TLS-verifying client factory."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = _mock_gateway(transport="sse")
+
+    mock_client = _mock_resilient_client(_json_response(404, {"error": "not found"}))
+    _unused_cm, session = _mock_sdk_session()
+    sse_cm = MagicMock()
+    sse_cm.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock()))
+    sse_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.sse_client", return_value=sse_cm) as mock_sse:
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is True
+    assert result.negotiation_path == "initialize"
+    mock_sse.assert_called_once()
+    # The SDK must see the validated hostname: it rejects an endpoint event whose origin
+    # differs from the URL it connected to. Pinning happens in the transport instead.
+    assert mock_sse.call_args.kwargs["url"] == "http://example.com/mcp"
+
+    factory = mock_sse.call_args.kwargs["httpx_client_factory"]
+    with patch("mcpgateway.services.gateway_service._SniPinningTransport", wraps=_SniPinningTransport) as mock_transport:
+        factory_client = factory()
+        try:
+            assert isinstance(factory_client, httpx.AsyncClient)
+            assert factory_client.follow_redirects is False
+        finally:
+            await factory_client.aclose()
+
+    assert mock_transport.call_args.kwargs["sni_hostname"] == "example.com"
+    assert mock_transport.call_args.kwargs["pinned_host"] == "8.8.8.8"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_initialize_timeout_is_transport(handshake_request, user_ctx, db_session):
+    """An initialize timeout reports the generic transport copy without exception detail."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    mock_client = _mock_resilient_client(_json_response(404, {"error": "not found"}))
+    transport_cm, session = _mock_sdk_session(init_side_effect=TimeoutError())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm):
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is False
+    assert result.failure_class == "transport"
+    assert result.error == _HANDSHAKE_TRANSPORT_COPY
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_exception_group_unwraps_root_cause(handshake_request, user_ctx, db_session):
+    """A grouped initialize failure is classified from its root cause and keeps the detail suffix."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    mock_client = _mock_resilient_client(_json_response(404, {"error": "not found"}))
+    transport_cm, session = _mock_sdk_session(init_side_effect=ExceptionGroup("handshake failed", [httpx.ConnectError("connection refused")]))
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm):
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is False
+    assert result.failure_class == "transport"
+    assert result.error == f"{_HANDSHAKE_TRANSPORT_COPY}: connection refused"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_discover_paginated_counts_are_partial(handshake_request, user_ctx, db_session):
+    """A paginated component listing on the discover path flags the counts as partial."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    tools_page = _json_response(200, {"jsonrpc": "2.0", "id": 2, "result": {"tools": [{}, {}], "nextCursor": "page-2"}})
+    mock_client = _mock_resilient_client(_discover_success(capabilities={"tools": {}}), tools_page)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.component_counts == {"tools": 2}
+    assert result.counts_partial is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_initialize_paginated_counts_are_partial(handshake_request, user_ctx, db_session):
+    """A paginated component listing on the initialize path flags the counts as partial."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    mock_client = _mock_resilient_client(_json_response(404, {"error": "not found"}))
+    transport_cm, session = _mock_sdk_session()
+    tools_result = MagicMock()
+    tools_result.tools = [MagicMock()]
+    tools_result.nextCursor = "page-2"
+    session.list_tools = AsyncMock(return_value=tools_result)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm):
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.component_counts == {"tools": 1}
+    assert result.counts_partial is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: handshake credential-source accuracy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_non_credential_form_header_keeps_stored_source(user_ctx, db_session):
+    """A form header carrying no credential leaves the stored credential and its reported source intact."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = _mock_gateway(auth_type="basic", auth_value={"Authorization": "Basic stored"})
+
+    request = GatewayHandshakeRequest(base_url="http://example.com", path="/mcp", headers={"X-Trace-Id": "abc"})
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.credential_source == "stored"
+    sent_headers = mock_client.request.call_args.kwargs["headers"]
+    assert sent_headers["Authorization"] == "Basic stored"
+    assert sent_headers["X-Trace-Id"] == "abc"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_non_credential_form_header_without_gateway_stays_none(user_ctx, db_session):
+    """A form header carrying no credential does not claim a credential when nothing is stored."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    request = GatewayHandshakeRequest(base_url="http://example.com", path="/mcp", headers={"X-Trace-Id": "abc"})
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.credential_source == "none"
+    assert mock_client.request.call_args.kwargs["headers"]["X-Trace-Id"] == "abc"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_form_header_replaces_stored_header_of_different_case(user_ctx, db_session):
+    """A form header overriding a stored credential header replaces it outright and is reported as form-sourced."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = _mock_gateway(auth_type="authheaders", auth_value={"X-API-Key": "stored-key"})  # pragma: allowlist secret
+
+    request = GatewayHandshakeRequest(base_url="http://example.com", path="/mcp", headers={"x-api-key": "typed-key"})  # pragma: allowlist secret
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.credential_source == "form"
+    sent_headers = mock_client.request.call_args.kwargs["headers"]
+    assert sent_headers["x-api-key"] == "typed-key"
+    assert "X-API-Key" not in sent_headers
+
+
+# ---------------------------------------------------------------------------
+# Tests: handshake Layer-1 team scoping
+# ---------------------------------------------------------------------------
+
+
+def _mock_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+    """Resolve every hostname to a public address so URL validation stays deterministic."""
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", port or 80))]
+
+
+@pytest.fixture
+def team_b_gateway_db():
+    """Build in-memory sessions holding one enabled team-B gateway with stored basic auth."""
+    engines = []
+    sessions = []
+
+    def _build(visibility="team", owner_email="owner@example.com", url="http://example.com"):
+        engine = create_engine("sqlite:///:memory:")
+        session_factory = sessionmaker(autocommit=False, autoflush=False, expire_on_commit=False, bind=engine)
+        Base.metadata.create_all(bind=engine)
+        engines.append(engine)
+        with session_factory() as setup_session:
+            setup_session.add(
+                DbGateway(
+                    id="gw-team-b",
+                    name="Team B Server",
+                    slug="team-b-server",
+                    url=url,
+                    transport="STREAMABLEHTTP",
+                    capabilities={},
+                    enabled=True,
+                    auth_type="basic",
+                    auth_value={"Authorization": "Basic teamb"},
+                    visibility=visibility,
+                    team_id="team-b",
+                    owner_email=owner_email,
+                )
+            )
+            setup_session.commit()
+        session = session_factory()
+        sessions.append(session)
+        return session
+
+    yield _build
+
+    for session in sessions:
+        session.close()
+    for engine in engines:
+        engine.dispose()
+
+
+@pytest.fixture
+def narrowed_user() -> dict[str, Any]:
+    """Non-admin user context narrowed to team-a only."""
+    return {
+        "email": "user@example.com",
+        "full_name": "Narrowed User",
+        "is_admin": False,
+        "token_teams": ["team-a"],
+        "permissions": ["gateways.read"],
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_narrowed_token_cannot_borrow_other_teams_credentials(handshake_request, narrowed_user, team_b_gateway_db):
+    """A token scoped to team-a probes without team-b's stored credentials even when no team_id is supplied."""
+    db = team_b_gateway_db()
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=narrowed_user, db=db)
+
+    assert result.success is True
+    assert result.credential_source == "none"
+    assert "Authorization" not in mock_client.request.call_args.kwargs["headers"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_token_scoped_to_owning_team_uses_stored_credentials(handshake_request, team_b_gateway_db):
+    """A token scoped to the owning team still resolves that team's stored credentials."""
+    db = team_b_gateway_db()
+    team_b_user = {"email": "user@example.com", "is_admin": False, "token_teams": ["team-b"], "permissions": ["gateways.read"]}
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=team_b_user, db=db)
+
+    assert result.success is True
+    assert result.credential_source == "stored"
+    assert mock_client.request.call_args.kwargs["headers"]["Authorization"] == "Basic teamb"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_admin_token_uses_stored_credentials_across_teams(handshake_request, user_ctx, team_b_gateway_db, monkeypatch):
+    """An admin recognised by the platform keeps visibility over team-scoped gateways."""
+    from mcpgateway import config
+
+    monkeypatch.setattr(config.settings, "platform_admin_email", "admin@example.com")
+    db = team_b_gateway_db()
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db)
+
+    assert result.success is True
+    assert result.credential_source == "stored"
+    assert mock_client.request.call_args.kwargs["headers"]["Authorization"] == "Basic teamb"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_admin_bypass_excludes_other_users_private_gateways(handshake_request, user_ctx, team_b_gateway_db, monkeypatch):
+    """Admin bypass covers public and team rows but never another user's private gateway."""
+    from mcpgateway import config
+
+    monkeypatch.setattr(config.settings, "platform_admin_email", "admin@example.com")
+    db = team_b_gateway_db(visibility="private", owner_email="someone-else@example.com")
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db)
+
+    assert result.success is True
+    assert result.credential_source == "none"
+    assert "Authorization" not in mock_client.request.call_args.kwargs["headers"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_context_without_token_scope_is_not_treated_as_admin(handshake_request, team_b_gateway_db):
+    """A non-admin context carrying no token_teams key gets public-only scope, not an admin bypass."""
+    db = team_b_gateway_db()
+    unscoped_user = {"email": "anonymous", "is_admin": False, "permissions": ["gateways.read"]}
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=unscoped_user, db=db)
+
+    assert result.success is True
+    assert result.credential_source == "none"
+    assert "Authorization" not in mock_client.request.call_args.kwargs["headers"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_public_only_token_sees_no_private_gateway(handshake_request, team_b_gateway_db):
+    """A public-only token (token_teams == []) gets no private row, not even its own."""
+    db = team_b_gateway_db(visibility="private", owner_email="user@example.com")
+    public_only_user = {"email": "user@example.com", "is_admin": False, "token_teams": [], "permissions": ["gateways.read"]}
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=public_only_user, db=db)
+
+    assert result.success is True
+    assert result.credential_source == "none"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_owner_reaches_own_private_gateway(handshake_request, narrowed_user, team_b_gateway_db):
+    """A team-scoped token still resolves credentials for a private gateway it owns."""
+    db = team_b_gateway_db(visibility="private", owner_email="user@example.com")
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=narrowed_user, db=db)
+
+    assert result.success is True
+    assert result.credential_source == "stored"
+    assert mock_client.request.call_args.kwargs["headers"]["Authorization"] == "Basic teamb"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_connectivity_narrowed_token_does_not_forward_other_teams_credentials(narrowed_user, team_b_gateway_db):
+    """POST /test applies the same Layer-1 scope, so team-b's stored header is not forwarded."""
+    db = team_b_gateway_db()
+    request = GatewayTestRequest(base_url="http://example.com", path="/mcp", method="GET", headers={}, body=None)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"ok": True}
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.get_structured_logger", return_value=MagicMock(log=MagicMock())):
+            result = await check_mcp_server_connectivity(request=request, team_id=None, user=narrowed_user, db=db)
+
+    assert result.status_code == 200
+    assert "Authorization" not in mock_client.request.call_args.kwargs["headers"]
+
+
+@pytest.mark.asyncio
+async def test_handshake_registered_only_allowlist_excludes_other_teams_gateways(handshake_request, narrowed_user, team_b_gateway_db, monkeypatch):
+    """registered_only=True: a team-b gateway is invisible to a team-a token, so its host is not probeable."""
+    from mcpgateway import config
+
+    monkeypatch.setattr(config.settings, "gateway_test_allow_registered_only", True)
+    monkeypatch.setattr("mcpgateway.common.validators.socket.getaddrinfo", _mock_getaddrinfo)
+
+    db = team_b_gateway_db()
+    # A response is queued so a regression reports the explicit assertions below, not a drained-mock error.
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=narrowed_user, db=db)
+
+    assert result.success is False
+    assert result.failure_class == "transport"
+    assert "not allowed" in result.error
+    mock_client.request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handshake_registered_only_allowlist_keeps_public_gateways_probeable(handshake_request, narrowed_user, team_b_gateway_db, monkeypatch):
+    """registered_only=True: a public gateway stays probeable by a narrowed token, since public is platform-wide scope."""
+    from mcpgateway import config
+
+    monkeypatch.setattr(config.settings, "gateway_test_allow_registered_only", True)
+    monkeypatch.setattr("mcpgateway.common.validators.socket.getaddrinfo", _mock_getaddrinfo)
+
+    db = team_b_gateway_db(visibility="public")
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=narrowed_user, db=db)
+
+    assert result.success is True
+    assert result.credential_source == "stored"
+
+
+# ---------------------------------------------------------------------------
+# Tests: handshake SDK fallback address pinning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sni_pinning_transport_dials_pinned_host_with_hostname_identity():
+    """The transport rewrites the request onto the pinned address while keeping Host and TLS identity."""
+    transport = _SniPinningTransport(sni_hostname="example.com", pinned_host="8.8.8.8")
+    request = httpx.Request("GET", "http://example.com/mcp")
+
+    with patch.object(httpx.AsyncHTTPTransport, "handle_async_request", AsyncMock(return_value=httpx.Response(200))):
+        await transport.handle_async_request(request)
+
+    assert str(request.url) == "http://8.8.8.8/mcp"
+    assert request.headers["Host"] == "example.com"
+    assert request.extensions["sni_hostname"] == "example.com"
+    await transport.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sni_pinning_transport_refuses_unvalidated_host():
+    """The transport refuses to send anywhere but the validated hostname."""
+    transport = _SniPinningTransport(sni_hostname="example.com", pinned_host="8.8.8.8")
+    request = httpx.Request("GET", "http://attacker.example.net/mcp")
+
+    with pytest.raises(httpx.UnsupportedProtocol):
+        await transport.handle_async_request(request)
+
+    await transport.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_form_authorization_skips_unobtainable_stored_oauth_token(user_ctx, db_session):
+    """A form Authorization header is used instead of failing on a stored OAuth token the caller overrode."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = _mock_gateway(auth_type="oauth", oauth_config={"grant_type": "authorization_code"})
+
+    request = GatewayHandshakeRequest(base_url="http://example.com", path="/mcp", headers={"Authorization": "Bearer typed"})
+    mock_client = _mock_resilient_client(_discover_success())
+    token_storage = MagicMock()
+    token_storage.get_user_token = AsyncMock(return_value=None)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.token_storage_service.TokenStorageService", return_value=token_storage):
+            result = await check_mcp_server_handshake(request=request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is True
+    assert result.credential_source == "form"
+    assert mock_client.request.call_args.kwargs["headers"]["Authorization"] == "Bearer typed"
+    token_storage.get_user_token.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_uses_gateway_custom_ca_for_tls(user_ctx, db_session):
+    """A registered gateway's private CA and client certificate are used for the SDK connection."""
+    gateway = _mock_gateway(transport="STREAMABLEHTTP", ca_certificate="ca-pem", client_cert="client-pem", client_key="key-pem")
+    db_session.execute.return_value.scalars.return_value.first.return_value = gateway
+
+    request = GatewayHandshakeRequest(base_url="https://example.com", path="/mcp", headers={})
+    mock_client = _mock_resilient_client(_json_response(404, {"error": "not found"}))
+    transport_cm, session = _mock_sdk_session()
+    ssl_context = ssl.create_default_context()
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client) as mock_resilient:
+        with patch("mcpgateway.services.gateway_service.get_cached_ssl_context", return_value=ssl_context) as mock_ssl:
+            with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
+                with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                    result = await check_mcp_server_handshake(request=request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is True
+    mock_ssl.assert_called_once_with("ca-pem", client_cert="client-pem", client_key="key-pem")
+
+    with patch("mcpgateway.services.gateway_service._SniPinningTransport", wraps=_SniPinningTransport) as mock_transport:
+        factory_client = mock_streamable.call_args.kwargs["httpx_client_factory"]()
+        await factory_client.aclose()
+
+    assert mock_transport.call_args.kwargs["verify"] is ssl_context
+    # The stateless discover probe runs first, so it needs the same TLS settings or it fails
+    # the handshake before the SDK client is ever built.
+    assert mock_resilient.call_args.kwargs["client_args"]["verify"] is ssl_context
+
+
+@pytest.mark.asyncio
+async def test_sni_pinning_transport_accepts_punycode_host():
+    """An internationalized hostname is matched in its IDNA-encoded form, not rejected."""
+    transport = _SniPinningTransport(sni_hostname="xn--nicode-2ya.com", pinned_host="8.8.8.8")
+    request = httpx.Request("GET", "http://xn--nicode-2ya.com/mcp")
+
+    with patch.object(httpx.AsyncHTTPTransport, "handle_async_request", AsyncMock(return_value=httpx.Response(200))):
+        await transport.handle_async_request(request)
+
+    assert str(request.url) == "http://8.8.8.8/mcp"
+    await transport.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_ignores_caller_supplied_host_header(user_ctx, db_session):
+    """A form Host header cannot re-aim stored credentials at another virtual host."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = _mock_gateway(auth_type="authheaders", auth_value={"X-API-Key": "stored-key"})  # pragma: allowlist secret
+
+    request = GatewayHandshakeRequest(base_url="http://example.com", path="/mcp", headers={"host": "internal-vhost.corp"})
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is True
+    assert result.credential_source == "stored"
+    sent_headers = mock_client.request.call_args.kwargs["headers"]
+    assert sent_headers["Host"] == "example.com"
+    assert "host" not in sent_headers
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_connectivity_ignores_caller_supplied_host_header(user_ctx, db_session):
+    """POST /test also derives the authority from the validated URL, not from a form header."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    request = GatewayTestRequest(base_url="http://example.com", path="/api/test", method="GET", headers={"host": "internal-vhost.corp"}, body=None)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"ok": True}
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.get_structured_logger", return_value=MagicMock(log=MagicMock())):
+            result = await check_mcp_server_connectivity(request=request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.status_code == 200
+    sent_headers = mock_client.request.call_args.kwargs["headers"]
+    assert sent_headers["Host"] == "example.com"
+    assert "host" not in sent_headers
+
+
+def test_gateway_test_visibility_filters_treat_unknown_owner_as_no_identity(team_b_gateway_db):
+    """The "unknown" email sentinel is not an identity, so it must not own-match private rows."""
+    db = team_b_gateway_db(visibility="private", owner_email="unknown")
+
+    for context in ({"is_admin": False, "token_teams": ["team-a"]}, {"email": "unknown", "is_admin": False, "token_teams": ["team-a"]}):
+        visible = db.execute(select(DbGateway.id).where(or_(*_gateway_test_visibility_filters(db, context)))).scalars().all()
+        assert visible == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_discover_sends_required_request_metadata(handshake_request, user_ctx, db_session):
+    """Both the discover call and the component listings carry the per-request protocol metadata."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    tools_list = _json_response(200, {"jsonrpc": "2.0", "id": 2, "result": {"tools": []}})
+    mock_client = _mock_resilient_client(_discover_success(capabilities={"tools": {}}), tools_list)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is True
+    for call in mock_client.request.call_args_list:
+        sent_meta = call.kwargs["json"]["params"]["_meta"]
+        assert sent_meta["io.modelcontextprotocol/protocolVersion"] == "2026-07-28"
+        assert sent_meta["io.modelcontextprotocol/clientCapabilities"] == {}
+        assert sent_meta["io.modelcontextprotocol/clientInfo"]["name"] == "contextforge"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_discover_reads_top_level_server_info_as_fallback(handshake_request, user_ctx, db_session):
+    """A server reporting identity at the top level of the result is still named in the response."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    legacy = _json_response(200, {"jsonrpc": "2.0", "id": 1, "result": {"supportedVersions": ["2026-07-28"], "serverInfo": {"name": "legacy-shape", "version": "0.9"}}})
+    mock_client = _mock_resilient_client(legacy)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is True
+    assert result.negotiation_path == "server_discover"
+    assert result.server_name == "legacy-shape"
+    assert result.server_version == "0.9"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_shapeless_discover_result_falls_back_to_initialize(handshake_request, user_ctx, db_session):
+    """An empty JSON-RPC result is not evidence of discovery support, so the SDK probe runs."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    mock_client = _mock_resilient_client(_json_response(200, {"jsonrpc": "2.0", "id": 1, "result": {}}))
+    transport_cm, session = _mock_sdk_session()
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm):
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is True
+    assert result.negotiation_path == "initialize"
+    assert result.server_name == "legacy-srv"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_appends_path_before_base_url_query(user_ctx, db_session):
+    """A base URL carrying a query string keeps it after the handshake path is appended."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    request = GatewayHandshakeRequest(base_url="http://example.com/api?tenant=one", path="/mcp", headers={})
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=request, team_id=None, user=user_ctx, db=db_session)
+
+    assert result.success is True
+    assert mock_client.request.call_args.kwargs["url"] == "http://8.8.8.8/api/mcp?tenant=one"
+
+
+def test_handshake_request_rejects_control_characters_in_path():
+    """A control character in the path is rejected at the boundary instead of failing mid-request."""
+    with pytest.raises(ValidationError):
+        GatewayHandshakeRequest(base_url="http://example.com", path="/mcp\r\nX-Injected: 1")
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+@pytest.mark.parametrize("registered_url", ["http://example.com", "http://example.com/"])
+async def test_handshake_matches_registered_root_url_either_spelling(handshake_request, team_b_gateway_db, registered_url):
+    """A root gateway resolves its stored credentials whether or not it was registered with a trailing slash."""
+    db = team_b_gateway_db(url=registered_url)
+    team_b_user = {"email": "user@example.com", "is_admin": False, "token_teams": ["team-b"], "permissions": ["gateways.read"]}
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=handshake_request, team_id=None, user=team_b_user, db=db)
+
+    assert result.success is True
+    assert result.credential_source == "stored"
+    assert mock_client.request.call_args.kwargs["headers"]["Authorization"] == "Basic teamb"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_does_not_alias_non_root_registered_paths(team_b_gateway_db):
+    """Only the root path is trailing-slash ambiguous: /mcp must not borrow /mcp/'s credentials."""
+    db = team_b_gateway_db(url="http://example.com/mcp/")
+    team_b_user = {"email": "user@example.com", "is_admin": False, "token_teams": ["team-b"], "permissions": ["gateways.read"]}
+    request = GatewayHandshakeRequest(base_url="http://example.com/mcp", path="", headers={})
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=request, team_id=None, user=team_b_user, db=db)
+
+    assert result.success is True
+    assert result.credential_source == "none"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_handshake_matches_registered_root_url_with_query_string(team_b_gateway_db):
+    """A root URL carrying a query keeps the query in both candidate spellings."""
+    db = team_b_gateway_db(url="http://example.com?tenant=one")
+    team_b_user = {"email": "user@example.com", "is_admin": False, "token_teams": ["team-b"], "permissions": ["gateways.read"]}
+    request = GatewayHandshakeRequest(base_url="http://example.com?tenant=one", path="/mcp", headers={})
+    mock_client = _mock_resilient_client(_discover_success())
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        result = await check_mcp_server_handshake(request=request, team_id=None, user=team_b_user, db=db)
+
+    assert result.success is True
+    assert result.credential_source == "stored"


### PR DESCRIPTION
Relates to #5649 — UI half: contextforge-org/contextforge-web-ui#16; together they complete the issue.

Targets `main`, backend-only. Originally opened against `epic/ui-rewrite` with both halves; split at the maintainers' request now that the React client lives in [contextforge-org/contextforge-web-ui](https://github.com/contextforge-org/contextforge-web-ui) — same treatment as #5786 / web-ui#15.

## Summary

Adds an **MCP handshake** test alongside the raw HTTP probe. Handshake mode verifies the target actually speaks MCP rather than just accepting TCP connections, and reports how the negotiation happened.

- New `POST /v1/mcp-servers/test-handshake` endpoint (`GatewayHandshakeRequest`/`GatewayHandshakeResponse` schemas).
- `test_gateway_handshake()` tries the stateless `server/discover` method (MCP 2026-07-28+) first and falls back to a stateful SDK `initialize` round-trip for earlier specs — a 2026-07-28-only server cannot answer `initialize` (removed), and an older server cheaply rejects `server/discover`, so this order needs no version pre-knowledge.
- Reports negotiation path, protocol version, server name/version, capabilities, and first-page component counts (`countsPartial` flags `nextCursor` truncation).
- Failure classification (`transport` / `protocol` / `auth` / `invalid_response`) with actionable copy; exception text is run through `sanitize_exception_message` before embedding. Auth (401/403) and network failures short-circuit without attempting the fallback.
- The OAuth token-retrieval failure path now also embeds only sanitized exception text (`sanitize_exception_message(str(e))`), addressing the review finding on the first revision. The `logger.error` above it still records the raw detail.
- Shares the raw test's egress allowlist + DNS-pinning prelude (extracted into `_validate_gateway_test_target`, used by both) and its stored-credential resolution; `credentialSource` (`stored`/`form`/`none`) is reported in the response.
- Sessions close on success/failure via the SDK async-with teardown; the whole probe is bounded by `health_check_timeout` and `rawPreview` is capped at 4096 chars. No DB writes, no gateway health-state side effects (`_mark_gateway_reachable`/`_handle_gateway_failure`/`_refresh_gateway_tools_resources_prompts` are never called).
- Token scoping maps the new path to `gateways.read` — required, the existing `^/mcp-servers/test(?:$|/)` regex does not match `test-handshake`.

The UI counterpart (mode toggle, detail rows, count badges, failure badge, raw preview) is contextforge-org/contextforge-web-ui#16.

## Notes

- `server/discover` is a hand-rolled JSON-RPC POST: the pinned MCP SDK predates the 2026-07-28 spec and has no knowledge of it, so `MCP_STATELESS_PROTOCOL_VERSION = "2026-07-28"` is a hand-written constant. The discover result shape is parsed tolerantly since the RC schema may drift; all response fields are Optional.
- Component counts are first-page counts by design — the probe answers "does it speak MCP and expose components", not "exactly how many".
- The legacy `/admin/gateways/test` surface is intentionally not extended.

## Verification

Re-run on the retargeted `main`-based branch:

- `pytest tests/unit/mcpgateway/routers/test_mcp_servers_router.py` — 26 passed, including the 9 handshake tests (allowlist rejection with no outbound call, discover success with component counts, `-32601` fallback to initialize, 401 auth short-circuit, connect error, invalid-response classification, 401/403/cross-team deny paths)
- `pytest tests/unit/mcpgateway/routers/test_mcp_servers_router.py tests/unit/mcpgateway/middleware/test_token_scoping.py` — 344 passed
- Full `make test` — 21873 passed, 818 skipped, 2 xfailed, 0 failed
- `make ruff` clean, `make interrogate` 100%, `pre-commit run --files …` clean on all five touched files
- Live smoke against a running gateway with a real MCP streamable-HTTP target: success → `negotiationPath: initialize`, real `serverName`/`serverVersion`/`protocolVersion`, `componentCounts` populated, `credentialSource: form`; target requiring auth without headers → `failureClass: auth`; closed port → `failureClass: transport` with sanitized detail; host outside the test allowlist → generic allowlist copy; unauthenticated request → `401`

## Note on landing order

#5930 also touches the validation region of `test_gateway_connectivity` on `main`, so whichever of the two lands second takes a small rebase. #5930 first is the cheaper order (it is copy-only) — the extracted `_validate_gateway_test_target` here then carries its new allowlist wording directly. The end state is consistent either way, since this PR independently introduces the same "The MCP server URL is not allowed for testing…" phrasing on the handshake path.
