### PR TITLE
chore: soften AssertionError message in live gateway e2e test

### DIFF
--- a/tests/live_gateway/mcp/test_mcp_protocol_e2e.py
+++ b/tests/live_gateway/mcp/test_mcp_protocol_e2e.py
@@ -343,14 +343,11 @@ class TestToolCalls:
 
         Without this guard, a stale fast_test_server image or an incomplete
         federation sync would cause the actual ``tools/call`` tests to
-        fail with a misleading assertion. Fails fast with an actionable
-        message.
+        fail with a misleading assertion. Fails fast with the actual cause.
         """
         tools = await client.list_tools()
         match = next((t for t in tools if t.name == tool_name), None)
-        assert match is not None, (
-            f"Tool {tool_name!r} is not registered in the gateway. " f"Rebuild the fast_test_server image and restart docker-compose so " f"register_fast_test picks up the new schema fixtures."
-        )
+        assert match is not None, f"Tool {tool_name!r} is not registered in the gateway."
         schema = match.outputSchema
         assert schema, (
             f"Tool {tool_name!r} has no outputSchema declared in the gateway: {match}. " "Check that the upstream tool declares an output_schema and that the gateway sync completed successfully."


### PR DESCRIPTION
Closes #5810

## Summary

The `_require_declared_output_schema` preflight assert in `tests/live_gateway/mcp/test_mcp_protocol_e2e.py` failed with prescriptive remediation text (`Rebuild the fast_test_server image and restart docker-compose so register_fast_test picks up the new schema fixtures.`). That kind of instruction rots — the assertion now reports only the failure itself:

```
Tool '…' is not registered in the gateway.
```

The guard's docstring already explains *why* a stale image or incomplete federation sync causes this, so no diagnostic value is lost. The docstring's "Fails fast with an actionable message" line is updated to match.

## Verification

- File parses and collects cleanly (`pytest --collect-only`: 22 tests).
- No remaining `Rebuild the fast_test_server` references in `tests/`.
- The test requires a live gateway stack (`tests/live_gateway` is excluded from the default `make test` run by design); the change is assertion-message text only, no behavior.