### PR TITLE
fix(ui-rewrite): reserve scrollbar gutter to prevent layout shift

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -182,5 +182,16 @@
   }
   html {
     @apply font-sans;
+    /* Reserve the scrollbar gutter so pages that gain/lose a document scrollbar
+       don't shift centered content when their height crosses the viewport. */
+    scrollbar-gutter: stable;
+  }
+}
+
+/* Fallback for browsers without scrollbar-gutter (Safari < 18.2): always reserve
+   a classic scrollbar track. No effect where scrollbar-gutter is supported. */
+@supports not (scrollbar-gutter: stable) {
+  html {
+    overflow-y: scroll;
   }
 }


### PR DESCRIPTION
**Scope**
Small global layout fix to avoid layout shift (polish)

Reserve the scrollbar gutter globally so pages don't shift centered content when a document scrollbar appears or disappears. 

Scrolling happens at the document level (`SidebarProvider` uses `min-h-svh`; the app-shell content area is `overflow-hidden`). A page whose height crosses the viewport gains the document scrollbar and loses it again when it shrinks; because content is centered (`mx-auto`), it then jumps horizontally by the scrollbar width. Reproducible by filtering the activity feed between a long and a short list.

**Change**

- `html { scrollbar-gutter: stable }`: the gutter is always reserved, so it never appears or disappears. On overlay-scrollbar systems it reserves space only where a classic scrollbar would render, so it does not force a permanent visible bar.
- `@supports not (scrollbar-gutter: stable) { html { overflow-y: scroll } }`: fallback for browsers without support (Safari < 18.2).
