### PR TITLE
fix(runtime): honor disabled Gunicorn preload

### DIFF
--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -40,9 +40,12 @@ max_requests = 100000  # The maximum number of requests a worker will process be
 max_requests_jitter = 100  # The maximum jitter to add to the max_requests setting.
 
 # Optimization https://docs.gunicorn.org/en/stable/settings.html#preload-app
-# Disable preload on macOS due to fork-safety issues with async libraries
-# On macOS, fork is unsafe with many async frameworks (SQLAlchemy, uvicorn, etc.)
-preload_app = platform.system() != "Darwin"
+# Keep the config and run-gunicorn.sh on one source of truth. Without this,
+# setting GUNICORN_PRELOAD_APP=false only omits the CLI flag while this config
+# silently turns preload back on.
+preload_app = (
+    os.environ.get("GUNICORN_PRELOAD_APP", "false" if platform.system() == "Darwin" else "true").lower() == "true"
+)
 
 reuse_port = True  # Set the SO_REUSEPORT flag on the listening socket
 

--- a/tests/unit/test_gunicorn_config.py
+++ b/tests/unit/test_gunicorn_config.py
@@ -70,6 +70,22 @@ def _make_fake_server() -> SimpleNamespace:
     return SimpleNamespace(log=MagicMock())
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("true", True),
+        ("false", False),
+        ("TRUE", True),
+        ("FALSE", False),
+    ],
+)
+def test_preload_app_honors_environment(monkeypatch, value, expected):
+    """GUNICORN_PRELOAD_APP controls preload in both launcher and config."""
+    monkeypatch.setenv("GUNICORN_PRELOAD_APP", value)
+
+    assert _load_gunicorn_config().preload_app is expected
+
+
 @pytest.fixture
 def fake_worker() -> SimpleNamespace:
     """A gunicorn-worker stand-in with a stable PID."""


### PR DESCRIPTION
## What changed

Make `gunicorn.config.py` honor `GUNICORN_PRELOAD_APP`, matching `run-gunicorn.sh`. Add regression coverage for true/false and case-insensitive values.

## Why

Today `GUNICORN_PRELOAD_APP=false` only prevents the launcher from adding `--preload`; `gunicorn.config.py` still sets `preload_app = True` on Linux. Objects created while importing `mcpgateway.main:app` are therefore forked despite the explicit opt-out. In production this caused the gateway leader `FileLock` to report `inherited across fork` in a tight loop, saturate CPU/memory, and trigger OOM kills.

## Verification

```text
pytest -q tests/unit/test_gunicorn_config.py
11 passed
```

`git diff --check` passes.