### PR TITLE
fix(ui-rewrite): reserve scrollbar gutter to prevent layout shift (#5…

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -182,5 +182,16 @@
   }
   html {
     @apply font-sans;
+    /* Reserve the scrollbar gutter so pages that gain/lose a document scrollbar
+       don't shift centered content when their height crosses the viewport. */
+    scrollbar-gutter: stable;
+  }
+}
+
+/* Fallback for browsers without scrollbar-gutter (Safari < 18.2): always reserve
+   a classic scrollbar track. No effect where scrollbar-gutter is supported. */
+@supports not (scrollbar-gutter: stable) {
+  html {
+    overflow-y: scroll;
   }
 }


### PR DESCRIPTION
…946)

Pages scroll at the document level (SidebarProvider uses min-h-svh and the app shell content area is overflow-hidden), so a page whose height crosses the viewport gains a document scrollbar and loses it again when it shrinks. Because content is centered (mx-auto), it then shifts horizontally by the scrollbar width. This is visible, for example, when filtering the activity feed between a long and a short list.

Set scrollbar-gutter: stable on html so the gutter is always reserved and never appears or disappears. On overlay-scrollbar systems it reserves space only where a classic scrollbar would render, so it does not force a permanent visible bar.

Add an @supports fallback (overflow-y: scroll) for browsers without scrollbar-gutter support (Safari < 18.2).