### PR TITLE
fix(ui-rewrite): reserve scrollbar gutter to prevent layout shift

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -182,5 +182,16 @@
   }
   html {
     @apply font-sans;
+    /* Reserve the scrollbar gutter so pages that gain/lose a document scrollbar
+       don't shift centered content when their height crosses the viewport. */
+    scrollbar-gutter: stable;
+  }
+}
+
+/* Fallback for browsers without scrollbar-gutter (Safari < 18.2): always reserve
+   a classic scrollbar track. No effect where scrollbar-gutter is supported. */
+@supports not (scrollbar-gutter: stable) {
+  html {
+    overflow-y: scroll;
   }
 }


### PR DESCRIPTION
Pages scroll at the document level (SidebarProvider uses min-h-svh and the app shell content area is overflow-hidden), so a page whose height crosses the viewport gains a document scrollbar and loses it again when it shrinks. Because content is centered (mx-auto), it then shifts horizontally by the scrollbar width. This is visible, for example, when filtering the activity feed between a long and a short list.

Set scrollbar-gutter: stable on html so the gutter is always reserved and never appears or disappears. On overlay-scrollbar systems it reserves space only where a classic scrollbar would render, so it does not force a permanent visible bar.

Add an @supports fallback (overflow-y: scroll) for browsers without scrollbar-gutter support (Safari < 18.2).

<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

# Pull Request

## 🔗 Related Issue

Closes #

---

## 📝 Summary

_What does this PR do and why?_

---

## 📏 Reviewability

- [ ] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [ ] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

_List exact commands, screenshots, videos, logs, reproduction steps, or manual validation. If evidence is not feasible, explain why._

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] No secrets or credentials committed

---

## 📓 Notes (optional)

_Screenshots, design decisions, or additional context._
