### PR TITLE
fix: propagate JSON-RPC errors from internal /rpc hop to SSE clients

### DIFF
--- a/mcpgateway/cache/session_registry.py
+++ b/mcpgateway/cache/session_registry.py
@@ -2366,11 +2366,28 @@ class SessionRegistry(SessionBackend):
                         headers=headers,
                     )
                     logger.info(f"SSE RPC: Got response status {rpc_response.status_code}")
-                    result = rpc_response.json()
-                    logger.info(f"SSE RPC: Response content: {result}")
-                    result = result.get("result", {})
+                    rpc_payload = rpc_response.json()
+                    logger.info(f"SSE RPC: Response content: {rpc_payload}")
 
-                response = {"jsonrpc": "2.0", "result": result, "id": req_id}
+                if isinstance(rpc_payload, dict) and "error" in rpc_payload:
+                    # Propagate JSON-RPC error objects (plugin violations, RBAC
+                    # denials, upstream failures) back to the SSE client instead
+                    # of collapsing them into an empty ``result: {}`` — which
+                    # both hides the failure reason and breaks strict MCP SDK
+                    # clients that validate ``CallToolResult`` (missing
+                    # ``content``).
+                    response = {"jsonrpc": "2.0", "error": rpc_payload["error"], "id": req_id}
+                elif isinstance(rpc_payload, dict) and "result" in rpc_payload:
+                    response = {"jsonrpc": "2.0", "result": rpc_payload["result"], "id": req_id}
+                else:
+                    # Not a JSON-RPC envelope at all — e.g. an auth/authz
+                    # middleware body like ``{"detail": "..."}`` from a 401/403
+                    # on the internal /rpc hop. Surface it as a JSON-RPC error
+                    # rather than a silent empty result.
+                    status_code = getattr(rpc_response, "status_code", None)
+                    detail = rpc_payload.get("detail") if isinstance(rpc_payload, dict) else None
+                    message_text = str(detail) if detail else f"Internal RPC call failed (HTTP {status_code})"
+                    response = {"jsonrpc": "2.0", "error": {"code": -32000, "message": message_text}, "id": req_id}
             except JSONRPCError as e:
                 logger.error(f"SSE RPC: JSON-RPC error: {e}")
                 result = e.to_dict()

--- a/tests/unit/mcpgateway/cache/test_session_registry.py
+++ b/tests/unit/mcpgateway/cache/test_session_registry.py
@@ -515,6 +515,90 @@ async def test_generate_response_ping(registry: SessionRegistry):
 
 
 @pytest.mark.asyncio
+async def test_generate_response_propagates_jsonrpc_error(registry: SessionRegistry, stub_db, stub_services):
+    """A JSON-RPC *error* from the internal /rpc hop reaches the SSE client verbatim.
+
+    Regression test: the relay used to do ``.get("result", {})`` on the /rpc
+    response, so plugin violations / RBAC denials surfaced as an empty
+    ``result: {}`` with no diagnostic at all.
+    """
+    tr = FakeSSETransport("rpc_error")
+    await registry.add_session("rpc_error", tr)
+
+    error_obj = {
+        "code": -32003,
+        "message": "Access denied",
+        "data": {"method": "tools/call"},
+    }
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"jsonrpc": "2.0", "error": error_obj, "id": 55}
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+
+    class MockAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return mock_client
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            return None
+
+    msg = {"method": "tools/call", "id": 55, "params": {"name": "demo", "arguments": {}}}
+    with patch("mcpgateway.cache.session_registry.ResilientHttpClient", MockAsyncClient):
+        await registry.generate_response(
+            message=msg,
+            transport=tr,
+            server_id=None,
+            user={"auth_token": "tok", "email": "user@test.com"},
+        )
+
+    assert tr.sent[-1] == {"jsonrpc": "2.0", "error": error_obj, "id": 55}
+
+
+@pytest.mark.asyncio
+async def test_generate_response_maps_non_jsonrpc_body_to_error(registry: SessionRegistry, stub_db, stub_services):
+    """A non-JSON-RPC body (e.g. ``{"detail": ...}`` from a 401 on /rpc) becomes a JSON-RPC error."""
+    tr = FakeSSETransport("rpc_401")
+    await registry.add_session("rpc_401", tr)
+
+    mock_response = Mock()
+    mock_response.status_code = 401
+    mock_response.json.return_value = {"detail": "Invalid authentication credentials"}
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+
+    class MockAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return mock_client
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            return None
+
+    msg = {"method": "tools/call", "id": 56, "params": {"name": "demo", "arguments": {}}}
+    with patch("mcpgateway.cache.session_registry.ResilientHttpClient", MockAsyncClient):
+        await registry.generate_response(
+            message=msg,
+            transport=tr,
+            server_id=None,
+            user={"auth_token": "tok", "email": "user@test.com"},
+        )
+
+    sent = tr.sent[-1]
+    assert sent["id"] == 56
+    assert "result" not in sent
+    assert sent["error"]["code"] == -32000
+    assert sent["error"]["message"] == "Invalid authentication credentials"
+
+
+@pytest.mark.asyncio
 async def test_generate_response_tools_list(registry: SessionRegistry, stub_db, stub_services):
     """*tools/list* responds with the stubbed ToolService payload."""
     tr = FakeSSETransport("tools")


### PR DESCRIPTION
<!-- PR draft para github.com/IBM/mcp-context-forge -->
<!-- Título sugerido: -->
<!-- fix: propagate JSON-RPC errors from internal /rpc hop to SSE clients -->
<!-- Branch: fix/sse-relay-propagate-jsonrpc-errors (1 commit, DCO signed-off) -->

## What

`SessionRegistry.generate_response()` built the SSE reply with
`rpc_response.json().get("result", {})`, which collapses any JSON-RPC `error`
returned by the internal loopback `/rpc` call — plugin `tool_pre_invoke`
violations, RBAC `-32003` denials, upstream failures — into an empty
`result: {}`. Non-JSON-RPC bodies (e.g. `{"detail": ...}` from an auth
middleware 401 on the internal hop) were swallowed the same way.

The SSE client gets `{"jsonrpc":"2.0","result":{},"id":N}` with no diagnostic
at all; strict MCP SDK clients then fail `CallToolResult` validation
(`content: Field required`), masking the real error behind an unrelated
validation error.

Fixes #5956

## How

In `generate_response()`, after the loopback `/rpc` call:

- if the response carries an `"error"` member → forward it verbatim;
- else if it carries `"result"` → forward that (unchanged behavior);
- else (non-JSON-RPC body) → map to a JSON-RPC error `-32000` carrying the
  body's `detail` text when present, or the HTTP status otherwise.

No behavior change for successful calls; the `initialize` notification flow is
untouched.

## Tests

Two regression tests added to
`tests/unit/mcpgateway/cache/test_session_registry.py`, following the existing
mock patterns in that file:

- `test_generate_response_propagates_jsonrpc_error` — a `-32003` error object
  from `/rpc` reaches the SSE transport verbatim.
- `test_generate_response_maps_non_jsonrpc_body_to_error` — a 401
  `{"detail": ...}` body becomes a `-32000` JSON-RPC error, not `result: {}`.

Verified: the full test file passes with the fix (`71 passed`), and both new
tests fail against the previous code (`2 failed` when run against unpatched
`session_registry.py`), confirming they pin the regression.

## Real-world impact

Found while integrating v1.0.6 as a policy-enforcement gateway (auth plugins +
`tool_pre_invoke` OPA/policy hooks): a user with `servers.use` but without
`tools.execute` gets every `tools/call` denied by RBAC on the internal `/rpc`
hop, but the SSE session answers `result: {}` — indistinguishable from a
successful empty result. We initially misdiagnosed it as "hooks never run on
the SSE transport". Propagating the error makes the actual deny (and any
policy-plugin violation message) visible to the caller, as it already is on
the public `/rpc` endpoint.
