### PR TITLE
feat(api): recent activity feed endpoint (audit + security union)

### DIFF
--- a/docs/docs/manage/logging.md
+++ b/docs/docs/manage/logging.md
@@ -412,6 +412,7 @@ When `STRUCTURED_LOGGING_DATABASE_ENABLED=true`, you get:
 | **Performance Metrics** | `GET /api/logs/performance-metrics` | Aggregated p50/p95/p99 latencies, error rates by component |
 | **Security Events** | `GET /api/logs/security-events` | Authentication failures, threat detection, security audit |
 | **Audit Trails** | `GET /api/logs/audit-trails` | CRUD operations, data access compliance logging |
+| **Recent Activity** | `GET /api/logs/activity` | Unified newest-first feed merging audit trails and security events (powers the UI home page) |
 
 ### Example: Search Logs via API
 
@@ -428,6 +429,23 @@ curl -X POST "http://localhost:4444/api/logs/search" \
 
 # Trace all logs for a specific request
 curl "http://localhost:4444/api/logs/trace/abc-123-correlation-id" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Recent Activity Feed
+
+`GET /api/logs/activity` returns a single newest-first list merging audit trails and security
+events, with a server-rendered title, description and status per entry.
+
+- Entry is gated by `audit:read`. Security events are **additive**: they appear only when the
+  caller also holds `security:read`. Lacking it narrows the feed rather than returning `403`.
+- Non-admin callers see audit rows for their own teams, security events they triggered, and no
+  `restricted`-classified rows.
+- `limit` (default `50`, max `100`) caps the merged list; `since` is strictly-after.
+
+```bash
+# Newest 20 activity entries since a timestamp
+curl "http://localhost:4444/api/logs/activity?limit=20&since=2025-01-01T12:00:00Z" \
   -H "Authorization: Bearer $TOKEN"
 ```
 

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -738,6 +738,9 @@ async def check_permission_inline(
     never raises for a denial — it returns ``False`` so callers can degrade a response
     (e.g. omit a section of a feed) instead of rejecting the request.
 
+    Layer 1 (API token scopes) is enforced here, before plugin hooks and RBAC, so direct
+    callers get the same gate as the ``@require_permission`` decorator.
+
     Args:
         user_context: Authenticated user context dict; must contain ``email``.
         permission: Permission string to check (e.g. ``"security:read"``).
@@ -769,6 +772,16 @@ async def check_permission_inline(
         False
     """
     if not user_context or not isinstance(user_context, dict) or "email" not in user_context:
+        return False
+
+    # SECURITY: Check API token scopes BEFORE plugin hooks and RBAC (Layer 1).
+    # A scoped API token must carry the required permission; this is independent of
+    # the RBAC role checks below (Layer 2). Session tokens and tokens whose scopes
+    # are empty ("inherit from RBAC") pass through — see token_scope_grants().
+    token_scopes = user_context.get("token_scopes")
+    if not token_scope_grants(token_scopes, permission):
+        # Log detailed info server-side but return generic error message to avoid permission disclosure
+        logger.warning(f"API token scope check failed: user={user_context['email']}, permission={permission}, token_scopes={token_scopes}")
         return False
 
     # First, check if any plugins want to handle permission checking
@@ -963,16 +976,6 @@ def require_permission(permission: str, resource_type: Optional[str] = None, all
             user_context = kwargs.get("user") or kwargs.get("_user") or kwargs.get("current_user") or kwargs.get("current_user_ctx")
             if not user_context or not isinstance(user_context, dict) or "email" not in user_context:
                 raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User authentication required")
-
-            # SECURITY: Check API token scopes BEFORE RBAC (Layer 1)
-            # A scoped API token must carry the required permission; this is independent of
-            # the RBAC role checks below (Layer 2). Session tokens and tokens whose scopes
-            # are empty ("inherit from RBAC") pass through — see token_scope_grants().
-            token_scopes = user_context.get("token_scopes")
-            if not token_scope_grants(token_scopes, permission):
-                # Log detailed info server-side but return generic error message to avoid permission disclosure
-                logger.warning(f"API token scope check failed: user={user_context['email']}, permission={permission}, token_scopes={token_scopes}")
-                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=_ACCESS_DENIED_MSG)
 
             team_id, check_any_team = await _resolve_team_and_check_mode(user_context, kwargs)
 

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -720,6 +720,186 @@ def _is_mutate_permission(permission: str) -> bool:
     return parts[-1] in _MUTATE_PERMISSION_ACTIONS if len(parts) >= 2 else False
 
 
+async def check_permission_inline(
+    user_context: dict,
+    permission: str,
+    *,
+    resource_type: Optional[str] = None,
+    team_id: Optional[str] = None,
+    check_any_team: bool = False,
+    db: Optional[Session] = None,
+    request: Optional[Request] = None,
+    allow_admin_bypass: bool = True,
+) -> bool:
+    """Check a permission without raising, for additive in-handler checks.
+
+    Shares one code path with :func:`require_permission`: plugin ``HTTP_AUTH_CHECK_PERMISSION``
+    hooks are consulted first, then the standard RBAC check. Unlike the decorator this
+    never raises for a denial — it returns ``False`` so callers can degrade a response
+    (e.g. omit a section of a feed) instead of rejecting the request.
+
+    Args:
+        user_context: Authenticated user context dict; must contain ``email``.
+        permission: Permission string to check (e.g. ``"security:read"``).
+        resource_type: Optional resource type for resource-specific permissions.
+        team_id: Optional team scope for the check.
+        check_any_team: If True, grant when the permission holds in any of the user's teams.
+        db: Optional existing session; a fresh session is opened when omitted.
+        request: Optional request, used only to derive plugin content-type context.
+        allow_admin_bypass: If True, platform admins bypass the RBAC check.
+
+    Returns:
+        bool: True when the permission is granted, False otherwise.
+
+    Examples:
+        >>> import asyncio
+        >>> class DummyPS:
+        ...     def __init__(self, db):
+        ...         pass
+        ...     async def check_permission(self, **kwargs):
+        ...         return True
+        >>> from unittest.mock import patch
+        >>> with patch('mcpgateway.middleware.rbac.PermissionService', DummyPS):
+        ...     asyncio.run(check_permission_inline({"email": "u"}, "tools.read", db=object()))
+        True
+
+        Malformed context is denied rather than raising:
+        >>> asyncio.run(check_permission_inline({}, "tools.read"))
+        False
+    """
+    if not user_context or not isinstance(user_context, dict) or "email" not in user_context:
+        return False
+
+    # First, check if any plugins want to handle permission checking
+    # Third-Party
+    from cpex.framework import HttpAuthCheckPermissionPayload, HttpHookType  # pylint: disable=import-outside-toplevel
+
+    # First-Party
+    from mcpgateway.plugins import get_plugin_manager  # pylint: disable=import-outside-toplevel
+
+    plugin_manager = await get_plugin_manager()
+    if plugin_manager and plugin_manager.has_hooks_for(HttpHookType.HTTP_AUTH_CHECK_PERMISSION):
+        # Get plugin contexts from user_context (stored in request.state by HttpAuthMiddleware)
+        # These enable cross-hook context sharing between HTTP_PRE_REQUEST and HTTP_AUTH_CHECK_PERMISSION
+        plugin_context_table = user_context.get("plugin_context_table")
+        plugin_global_context = user_context.get("plugin_global_context")
+
+        # Reuse existing global context from middleware if available for consistency
+        # Otherwise create a new one (fallback for cases where middleware didn't run)
+        if plugin_global_context:
+            global_context = plugin_global_context
+        else:
+            request_id = user_context.get("request_id") or uuid.uuid4().hex
+            content_type = request.headers.get("content-type") if request and hasattr(request, "headers") else None
+            global_context = GlobalContext(
+                request_id=request_id,
+                server_id=None,
+                tenant_id=None,
+                content_type=content_type,
+            )
+
+        # Invoke permission check hook, passing plugin contexts from HTTP_PRE_REQUEST hook
+        result, _ = await plugin_manager.invoke_hook(
+            HttpHookType.HTTP_AUTH_CHECK_PERMISSION,
+            payload=HttpAuthCheckPermissionPayload(
+                user_email=user_context["email"],
+                permission=permission,
+                resource_type=resource_type,
+                team_id=team_id,
+                is_admin=user_context.get("is_admin", False),
+                auth_method=user_context.get("auth_method"),
+                client_host=user_context.get("ip_address"),
+                user_agent=user_context.get("user_agent"),
+            ),
+            global_context=global_context,
+            local_contexts=plugin_context_table,  # Pass context table for cross-hook state
+            extensions=build_request_extensions(),
+        )
+        record_plugin_metrics(current_trace_id.get(), result.metadata)
+
+        # If a plugin made a decision, respect it
+        if result and result.modified_payload and hasattr(result.modified_payload, "granted"):
+            decision_plugin = "unknown"
+            decision_reason = getattr(result.modified_payload, "reason", None)
+            result_metadata = result.metadata if isinstance(result.metadata, dict) else {}
+            if result_metadata.get("_decision_plugin"):
+                decision_plugin = str(result_metadata["_decision_plugin"])
+            for key in ("plugin_name", "plugin", "source_plugin", "handler"):
+                if decision_plugin != "unknown":
+                    break
+                plugin_name = result_metadata.get(key)
+                if plugin_name:
+                    decision_plugin = str(plugin_name)
+
+            logger.info(
+                "Plugin permission decision: plugin=%s user=%s permission=%s granted=%s reason=%s",
+                decision_plugin,
+                user_context["email"],
+                permission,
+                result.modified_payload.granted,
+                decision_reason,
+            )
+
+            if result.modified_payload.granted:
+                if settings.plugins_can_override_rbac:
+                    logger.warning(
+                        "Plugin RBAC grant override applied: plugin=%s user=%s permission=%s reason=%s",
+                        decision_plugin,
+                        user_context["email"],
+                        permission,
+                        decision_reason,
+                    )
+                    return True
+
+                logger.info(
+                    "Plugin RBAC grant decision ignored by default policy: plugin=%s user=%s permission=%s",
+                    decision_plugin,
+                    user_context["email"],
+                    permission,
+                )
+            else:
+                logger.warning(
+                    "Permission denied by plugin: plugin=%s user=%s permission=%s reason=%s",
+                    decision_plugin,
+                    user_context["email"],
+                    permission,
+                    decision_reason,
+                )
+                return False
+
+    # No plugin handled it, fall through to standard RBAC check
+    if db:
+        permission_service = PermissionService(db)
+        granted = await permission_service.check_permission(
+            user_email=user_context["email"],
+            permission=permission,
+            resource_type=resource_type,
+            team_id=team_id,
+            token_teams=user_context.get("token_teams"),
+            ip_address=user_context.get("ip_address"),
+            user_agent=user_context.get("user_agent"),
+            allow_admin_bypass=allow_admin_bypass,
+            check_any_team=check_any_team,
+        )
+    else:
+        # Create fresh db session for permission check
+        with fresh_db_session() as fresh_db:
+            permission_service = PermissionService(fresh_db)
+            granted = await permission_service.check_permission(
+                user_email=user_context["email"],
+                permission=permission,
+                resource_type=resource_type,
+                team_id=team_id,
+                token_teams=user_context.get("token_teams"),
+                ip_address=user_context.get("ip_address"),
+                user_agent=user_context.get("user_agent"),
+                allow_admin_bypass=allow_admin_bypass,
+                check_any_team=check_any_team,
+            )
+
+    return granted
+
+
 def require_permission(permission: str, resource_type: Optional[str] = None, allow_admin_bypass: bool = True):
     """Decorator to require specific permission for accessing an endpoint.
 
@@ -795,139 +975,16 @@ def require_permission(permission: str, resource_type: Optional[str] = None, all
 
             team_id, check_any_team = await _resolve_team_and_check_mode(user_context, kwargs)
 
-            # First, check if any plugins want to handle permission checking
-            # Third-Party
-            from cpex.framework import HttpAuthCheckPermissionPayload, HttpHookType  # pylint: disable=import-outside-toplevel
-
-            # First-Party
-            from mcpgateway.plugins import get_plugin_manager  # pylint: disable=import-outside-toplevel
-
-            plugin_manager = await get_plugin_manager()
-            if plugin_manager and plugin_manager.has_hooks_for(HttpHookType.HTTP_AUTH_CHECK_PERMISSION):
-                # Get plugin contexts from user_context (stored in request.state by HttpAuthMiddleware)
-                # These enable cross-hook context sharing between HTTP_PRE_REQUEST and HTTP_AUTH_CHECK_PERMISSION
-                plugin_context_table = user_context.get("plugin_context_table")
-                plugin_global_context = user_context.get("plugin_global_context")
-
-                # Reuse existing global context from middleware if available for consistency
-                # Otherwise create a new one (fallback for cases where middleware didn't run)
-                if plugin_global_context:
-                    global_context = plugin_global_context
-                else:
-                    request_id = user_context.get("request_id") or uuid.uuid4().hex
-                    request: Optional[Request] = kwargs.get("request")
-                    content_type = request.headers.get("content-type") if request and hasattr(request, "headers") else None
-                    global_context = GlobalContext(
-                        request_id=request_id,
-                        server_id=None,
-                        tenant_id=None,
-                        content_type=content_type,
-                    )
-
-                # Invoke permission check hook, passing plugin contexts from HTTP_PRE_REQUEST hook
-                result, _ = await plugin_manager.invoke_hook(
-                    HttpHookType.HTTP_AUTH_CHECK_PERMISSION,
-                    payload=HttpAuthCheckPermissionPayload(
-                        user_email=user_context["email"],
-                        permission=permission,
-                        resource_type=resource_type,
-                        team_id=team_id,
-                        is_admin=user_context.get("is_admin", False),
-                        auth_method=user_context.get("auth_method"),
-                        client_host=user_context.get("ip_address"),
-                        user_agent=user_context.get("user_agent"),
-                    ),
-                    global_context=global_context,
-                    local_contexts=plugin_context_table,  # Pass context table for cross-hook state
-                    extensions=build_request_extensions(),
-                )
-                record_plugin_metrics(current_trace_id.get(), result.metadata)
-
-                # If a plugin made a decision, respect it
-                if result and result.modified_payload and hasattr(result.modified_payload, "granted"):
-                    decision_plugin = "unknown"
-                    decision_reason = getattr(result.modified_payload, "reason", None)
-                    result_metadata = result.metadata if isinstance(result.metadata, dict) else {}
-                    if result_metadata.get("_decision_plugin"):
-                        decision_plugin = str(result_metadata["_decision_plugin"])
-                    for key in ("plugin_name", "plugin", "source_plugin", "handler"):
-                        if decision_plugin != "unknown":
-                            break
-                        plugin_name = result_metadata.get(key)
-                        if plugin_name:
-                            decision_plugin = str(plugin_name)
-
-                    logger.info(
-                        "Plugin permission decision: plugin=%s user=%s permission=%s granted=%s reason=%s",
-                        decision_plugin,
-                        user_context["email"],
-                        permission,
-                        result.modified_payload.granted,
-                        decision_reason,
-                    )
-
-                    if result.modified_payload.granted:
-                        if settings.plugins_can_override_rbac:
-                            logger.warning(
-                                "Plugin RBAC grant override applied: plugin=%s user=%s permission=%s reason=%s",
-                                decision_plugin,
-                                user_context["email"],
-                                permission,
-                                decision_reason,
-                            )
-                            return await func(*args, **kwargs)
-
-                        logger.info(
-                            "Plugin RBAC grant decision ignored by default policy: plugin=%s user=%s permission=%s",
-                            decision_plugin,
-                            user_context["email"],
-                            permission,
-                        )
-                    else:
-                        logger.warning(
-                            "Permission denied by plugin: plugin=%s user=%s permission=%s reason=%s",
-                            decision_plugin,
-                            user_context["email"],
-                            permission,
-                            decision_reason,
-                        )
-                        raise HTTPException(
-                            status_code=status.HTTP_403_FORBIDDEN,
-                            detail=_ACCESS_DENIED_MSG,
-                        )
-
-            # No plugin handled it, fall through to standard RBAC check
-            # Get db session: prefer endpoint's db param, then user_context["db"], then create fresh
-            db_session = kwargs.get("db") or user_context.get("db")
-            if db_session:
-                # Use existing session from endpoint or user_context
-                permission_service = PermissionService(db_session)
-                granted = await permission_service.check_permission(
-                    user_email=user_context["email"],
-                    permission=permission,
-                    resource_type=resource_type,
-                    team_id=team_id,
-                    token_teams=user_context.get("token_teams"),
-                    ip_address=user_context.get("ip_address"),
-                    user_agent=user_context.get("user_agent"),
-                    allow_admin_bypass=allow_admin_bypass,
-                    check_any_team=check_any_team,
-                )
-            else:
-                # Create fresh db session for permission check
-                with fresh_db_session() as db:
-                    permission_service = PermissionService(db)
-                    granted = await permission_service.check_permission(
-                        user_email=user_context["email"],
-                        permission=permission,
-                        resource_type=resource_type,
-                        team_id=team_id,
-                        token_teams=user_context.get("token_teams"),
-                        ip_address=user_context.get("ip_address"),
-                        user_agent=user_context.get("user_agent"),
-                        allow_admin_bypass=allow_admin_bypass,
-                        check_any_team=check_any_team,
-                    )
+            granted = await check_permission_inline(
+                user_context,
+                permission,
+                resource_type=resource_type,
+                team_id=team_id,
+                check_any_team=check_any_team,
+                db=kwargs.get("db") or user_context.get("db"),
+                request=kwargs.get("request"),
+                allow_admin_bypass=allow_admin_bypass,
+            )
 
             if not granted:
                 logger.warning(f"Permission denied: user={user_context['email']}, permission={permission}, resource_type={resource_type}")

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -758,9 +758,10 @@ async def check_permission_inline(
         ...         pass
         ...     async def check_permission(self, **kwargs):
         ...         return True
-        >>> from unittest.mock import patch
-        >>> with patch('mcpgateway.middleware.rbac.PermissionService', DummyPS):
-        ...     asyncio.run(check_permission_inline({"email": "u"}, "tools.read", db=object()))
+        >>> from unittest.mock import AsyncMock, patch
+        >>> with patch('mcpgateway.plugins.get_plugin_manager', AsyncMock(return_value=None)):
+        ...     with patch('mcpgateway.middleware.rbac.PermissionService', DummyPS):
+        ...         asyncio.run(check_permission_inline({"email": "u"}, "tools.read", db=object()))
         True
 
         Malformed context is denied rather than raising:

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -135,6 +135,8 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     # MCP registry catalog (v1 prefix stripped by middleware before matching)
     ("GET", re.compile(r"^/catalog(?:$|/)"), Permissions.SERVERS_READ),
     ("POST", re.compile(r"^/catalog/[^/]+/register(?:$|/)"), Permissions.SERVERS_CREATE),
+    # Recent activity feed (unversioned /api prefix; not subject to /v1 stripping)
+    ("GET", re.compile(r"^/api/logs/activity(?:$|/)"), Permissions.AUDIT_READ),
     # Metrics permissions
     ("GET", re.compile(r"^/metrics(?:$|/)"), Permissions.ADMIN_METRICS),
     ("POST", re.compile(r"^/metrics/reset(?:$|/)"), Permissions.ADMIN_METRICS),

--- a/mcpgateway/routers/log_search.py
+++ b/mcpgateway/routers/log_search.py
@@ -34,6 +34,7 @@ from mcpgateway.db import (
     StructuredLogEntry,
 )
 from mcpgateway.middleware.rbac import check_permission_inline, get_current_user_with_permissions, require_permission
+from mcpgateway.services.audit_trail_service import DataClassification
 from mcpgateway.services.log_aggregator import get_log_aggregator
 
 logger = logging.getLogger(__name__)
@@ -361,7 +362,8 @@ def _audit_to_activity(row: AuditTrail) -> ActivityItem:
         ActivityItem: Feed entry with server-rendered title, description and status.
     """
     label = _RESOURCE_LABELS.get(row.resource_type) or row.resource_type.replace("_", " ").capitalize()
-    verb = _ACTION_VERBS.get(row.action, row.action)
+    action_text = row.action.replace("_", " ")
+    verb = _ACTION_VERBS.get(row.action, action_text)
     actor = row.user_email or row.user_id or ""
     resource_name = row.resource_name or row.resource_id or ""
     name_part = f" '{resource_name}'" if resource_name else ""
@@ -377,8 +379,8 @@ def _audit_to_activity(row: AuditTrail) -> ActivityItem:
         status = "success"
 
     if status == "error":
-        title = f"{label} {row.action} failed"
-        description = f"{label}{name_part} {row.action} failed."
+        title = f"{label} {action_text} failed"
+        description = f"{label}{name_part} {action_text} failed."
         if row.error_message:
             description += f" {row.error_message}"
     else:
@@ -866,14 +868,20 @@ async def get_activity_feed(
         if not is_admin_feed:
             # Filtered in SQL so restricted-row counts are not observable to non-admins.
             # The IS NULL arm is required: a bare != silently drops NULL-classified rows.
-            conditions.append(or_(AuditTrail.data_classification.is_(None), AuditTrail.data_classification != "restricted"))
+            # Only `restricted` is filtered; `confidential` rows stay visible and already
+            # render as a warning via requires_review.
+            conditions.append(or_(AuditTrail.data_classification.is_(None), AuditTrail.data_classification != DataClassification.RESTRICTED.value))
             # AuditTrail has no owner_email/visibility columns, so scoping is team-based
-            # (public NULL-team rows + own teams) rather than the usual
-            # get_scoped_resource_access_context public+team+own-private shape.
+            # rather than the usual get_scoped_resource_access_context
+            # public+team+own-private shape. A NULL team_id means "the writer passed no
+            # team" (e.g. tool_service bulk imports), not "public", so those rows are
+            # visible only to their actor. user_email None fails closed: SQL NULL
+            # comparison matches no row.
+            null_team_own = and_(AuditTrail.team_id.is_(None), AuditTrail.user_email == user_email)
             if token_teams:
-                conditions.append(or_(AuditTrail.team_id.is_(None), AuditTrail.team_id.in_(token_teams)))
+                conditions.append(or_(null_team_own, AuditTrail.team_id.in_(token_teams)))
             else:
-                conditions.append(AuditTrail.team_id.is_(None))
+                conditions.append(null_team_own)
 
         stmt = select(AuditTrail)
         if conditions:
@@ -881,7 +889,9 @@ async def get_activity_feed(
         audit_rows = db.execute(stmt.order_by(desc(AuditTrail.timestamp), desc(AuditTrail.id)).limit(limit)).scalars().all()
 
         security_rows = []
-        if await check_permission_inline(user, Permissions.SECURITY_READ, db=db, request=request):
+        # check_any_team mirrors what the decorator's team resolver picks for this route
+        # (no team kwarg on a read endpoint -> any-team aggregation).
+        if await check_permission_inline(user, Permissions.SECURITY_READ, check_any_team=True, db=db, request=request):
             if is_admin_feed or user_email:
                 sec_conditions = []
                 if since:
@@ -901,6 +911,8 @@ async def get_activity_feed(
 
         return ActivityListResponse(items=items[:limit])
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Activity feed query failed: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Activity feed query failed")

--- a/mcpgateway/routers/log_search.py
+++ b/mcpgateway/routers/log_search.py
@@ -12,26 +12,28 @@ security events, audit trails, and performance metrics.
 # Standard
 from datetime import datetime, timedelta, timezone
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 # Third-Party
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import and_, delete, desc, or_, select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import func as sa_func
 
 # First-Party
+from mcpgateway.auth_context import get_scoped_resource_access_context
 from mcpgateway.common.query_params import QueryAggregation, QueryIdentifierDottedComponent, QueryUserIdentifierNoDescription
 from mcpgateway.config import settings
 from mcpgateway.db import (
     AuditTrail,
     get_db,
     PerformanceMetric,
+    Permissions,
     SecurityEvent,
     StructuredLogEntry,
 )
-from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
+from mcpgateway.middleware.rbac import check_permission_inline, get_current_user_with_permissions, require_permission
 from mcpgateway.services.log_aggregator import get_log_aggregator
 
 logger = logging.getLogger(__name__)
@@ -295,6 +297,129 @@ class AuditTrailResponse(BaseModel):
     data_classification: Optional[str]
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class ActivityItem(BaseModel):
+    """Unified feed entry derived from AuditTrail or SecurityEvent rows.
+
+    The server owns presentation: title, description, and status are rendered
+    here and MUST NOT be re-derived by clients (contract: #5129 / #5944).
+    """
+
+    id: str
+    timestamp: datetime
+    source: Literal["audit", "security"]
+    title: str
+    description: str
+    status: Literal["success", "error", "warning", "info"]
+    resource_type: str
+    resource_name: str
+    actor: str
+    correlation_id: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ActivityListResponse(BaseModel):
+    """Response envelope for GET /api/logs/activity."""
+
+    items: List[ActivityItem]
+
+
+_ACTION_VERBS = {"create": "created", "update": "updated", "delete": "deleted", "read": "accessed", "execute": "executed", "login": "logged in"}
+_RESOURCE_LABELS = {"mcp_server": "MCP server", "a2a_agent": "A2A agent"}
+_SEVERITY_STATUS = {"critical": "error", "high": "error", "medium": "warning", "low": "info"}
+
+
+def _as_utc(ts: datetime) -> datetime:
+    """Return a timezone-aware UTC datetime.
+
+    SQLite hands back naive datetimes; the feed merges rows from two tables and
+    the contract promises ISO 8601, so a missing offset is pinned to UTC here.
+
+    Args:
+        ts: Timestamp that may be naive or timezone-aware.
+
+    Returns:
+        datetime: The same instant, guaranteed timezone-aware.
+
+    Examples:
+        >>> from datetime import datetime, timezone
+        >>> _as_utc(datetime(2025, 1, 1)).tzinfo == timezone.utc
+        True
+    """
+    return ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
+
+
+def _audit_to_activity(row: AuditTrail) -> ActivityItem:
+    """Render an audit trail row as a feed entry.
+
+    Args:
+        row: Audit trail ORM row.
+
+    Returns:
+        ActivityItem: Feed entry with server-rendered title, description and status.
+    """
+    label = _RESOURCE_LABELS.get(row.resource_type) or row.resource_type.replace("_", " ").capitalize()
+    verb = _ACTION_VERBS.get(row.action, row.action)
+    actor = row.user_email or row.user_id or ""
+    resource_name = row.resource_name or row.resource_id or ""
+    name_part = f" '{resource_name}'" if resource_name else ""
+    by_part = f" by {actor}" if actor else ""
+
+    if not row.success:
+        status = "error"
+    elif row.requires_review:
+        status = "warning"
+    elif row.action in ("read", "execute"):
+        status = "info"
+    else:
+        status = "success"
+
+    if status == "error":
+        title = f"{label} {row.action} failed"
+        description = f"{label}{name_part} {row.action} failed."
+        if row.error_message:
+            description += f" {row.error_message}"
+    else:
+        title = f"{label} {verb}"
+        description = f"{label}{name_part} was {verb}{by_part}."
+
+    return ActivityItem(
+        id=f"audit:{row.id}",
+        timestamp=_as_utc(row.timestamp),
+        source="audit",
+        title=title,
+        description=description,
+        status=status,
+        resource_type=row.resource_type,
+        resource_name=resource_name,
+        actor=actor,
+        correlation_id=row.correlation_id or "",
+    )
+
+
+def _security_to_activity(row: SecurityEvent) -> ActivityItem:
+    """Render a security event row as a feed entry.
+
+    Args:
+        row: Security event ORM row.
+
+    Returns:
+        ActivityItem: Feed entry with status derived from event severity.
+    """
+    return ActivityItem(
+        id=f"security:{row.id}",
+        timestamp=_as_utc(row.timestamp),
+        source="security",
+        title=row.event_type.replace("_", " ").capitalize(),
+        description=row.description,
+        status=_SEVERITY_STATUS.get((row.severity or "").lower(), "info"),
+        resource_type=row.category or "",
+        resource_name=row.user_email or "",
+        actor=row.user_email or "system",
+        correlation_id=row.correlation_id or "",
+    )
 
 
 class PerformanceMetricResponse(BaseModel):
@@ -701,6 +826,80 @@ async def get_audit_trails(
     except Exception as e:
         logger.error(f"Audit trails query failed: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Audit trails query failed")
+
+
+@router.get("/activity", response_model=ActivityListResponse)
+@require_permission("audit:read")
+async def get_activity_feed(
+    request: Request,
+    limit: int = Query(50, ge=1, le=100),
+    since: Optional[datetime] = Query(None),
+    user=Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+) -> ActivityListResponse:
+    """Get the recent activity feed as a union of audit trails and security events.
+
+    Entry is gated by ``audit:read``. Security events are additive: they are included
+    only when the caller also holds ``security:read``, and their absence narrows the
+    feed rather than rejecting the request.
+
+    Args:
+        request: Incoming request, used to resolve token-scoped access context.
+        limit: Maximum number of merged items to return.
+        since: Only return items strictly newer than this timestamp.
+        user: Current authenticated user.
+        db: Database session.
+
+    Returns:
+        ActivityListResponse: Newest-first merged feed entries.
+
+    Raises:
+        HTTPException: On database or validation errors
+    """
+    try:
+        user_email, token_teams = get_scoped_resource_access_context(request, user)
+        is_admin_feed = token_teams is None
+
+        conditions = []
+        if since:
+            conditions.append(AuditTrail.timestamp > since)
+        if not is_admin_feed:
+            # Filtered in SQL so restricted-row counts are not observable to non-admins.
+            # The IS NULL arm is required: a bare != silently drops NULL-classified rows.
+            conditions.append(or_(AuditTrail.data_classification.is_(None), AuditTrail.data_classification != "restricted"))
+            if token_teams:
+                conditions.append(or_(AuditTrail.team_id.is_(None), AuditTrail.team_id.in_(token_teams)))
+            else:
+                conditions.append(AuditTrail.team_id.is_(None))
+
+        stmt = select(AuditTrail)
+        if conditions:
+            stmt = stmt.where(and_(*conditions))
+        audit_rows = db.execute(stmt.order_by(desc(AuditTrail.timestamp)).limit(limit)).scalars().all()
+
+        security_rows = []
+        if await check_permission_inline(user, Permissions.SECURITY_READ, db=db, request=request):
+            if is_admin_feed or user_email:
+                sec_conditions = []
+                if since:
+                    sec_conditions.append(SecurityEvent.timestamp > since)
+                if not is_admin_feed:
+                    # SecurityEvent has no team_id, so non-admins see only their own events.
+                    sec_conditions.append(SecurityEvent.user_email == user_email)
+                sstmt = select(SecurityEvent)
+                if sec_conditions:
+                    sstmt = sstmt.where(and_(*sec_conditions))
+                security_rows = db.execute(sstmt.order_by(desc(SecurityEvent.timestamp)).limit(limit)).scalars().all()
+
+        # Each source over-fetches at most `limit`, so the merged top-`limit` is exact.
+        items = [_audit_to_activity(row) for row in audit_rows] + [_security_to_activity(row) for row in security_rows]
+        items.sort(key=lambda i: (i.timestamp, i.id), reverse=True)
+
+        return ActivityListResponse(items=items[:limit])
+
+    except Exception as e:
+        logger.error(f"Activity feed query failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Activity feed query failed")
 
 
 @router.get("/performance-metrics", response_model=List[PerformanceMetricResponse])

--- a/mcpgateway/routers/log_search.py
+++ b/mcpgateway/routers/log_search.py
@@ -867,6 +867,9 @@ async def get_activity_feed(
             # Filtered in SQL so restricted-row counts are not observable to non-admins.
             # The IS NULL arm is required: a bare != silently drops NULL-classified rows.
             conditions.append(or_(AuditTrail.data_classification.is_(None), AuditTrail.data_classification != "restricted"))
+            # AuditTrail has no owner_email/visibility columns, so scoping is team-based
+            # (public NULL-team rows + own teams) rather than the usual
+            # get_scoped_resource_access_context public+team+own-private shape.
             if token_teams:
                 conditions.append(or_(AuditTrail.team_id.is_(None), AuditTrail.team_id.in_(token_teams)))
             else:
@@ -875,7 +878,7 @@ async def get_activity_feed(
         stmt = select(AuditTrail)
         if conditions:
             stmt = stmt.where(and_(*conditions))
-        audit_rows = db.execute(stmt.order_by(desc(AuditTrail.timestamp)).limit(limit)).scalars().all()
+        audit_rows = db.execute(stmt.order_by(desc(AuditTrail.timestamp), desc(AuditTrail.id)).limit(limit)).scalars().all()
 
         security_rows = []
         if await check_permission_inline(user, Permissions.SECURITY_READ, db=db, request=request):
@@ -889,9 +892,10 @@ async def get_activity_feed(
                 sstmt = select(SecurityEvent)
                 if sec_conditions:
                     sstmt = sstmt.where(and_(*sec_conditions))
-                security_rows = db.execute(sstmt.order_by(desc(SecurityEvent.timestamp)).limit(limit)).scalars().all()
+                security_rows = db.execute(sstmt.order_by(desc(SecurityEvent.timestamp), desc(SecurityEvent.id)).limit(limit)).scalars().all()
 
-        # Each source over-fetches at most `limit`, so the merged top-`limit` is exact.
+        # Each source over-fetches at most `limit`, so the merged top-`limit` is exact;
+        # the id tiebreak (also in each source's ORDER BY) keeps timestamp ties deterministic.
         items = [_audit_to_activity(row) for row in audit_rows] + [_security_to_activity(row) for row in security_rows]
         items.sort(key=lambda i: (i.timestamp, i.id), reverse=True)
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -7254,7 +7254,7 @@ class TokenScopeRequest(BaseModel):
     def validate_permissions(cls, v: List[str]) -> List[str]:
         """Validate permission scope format.
 
-        Permissions must be in format 'resource.action' or wildcard '*'.
+        Permissions must be in format 'resource.action' (or the legacy colon form 'resource:action') or wildcard '*'.
 
         Args:
             v: List of permission strings to validate.
@@ -7270,12 +7270,16 @@ class TokenScopeRequest(BaseModel):
             ['tools.read', 'resources.write']
             >>> TokenScopeRequest.validate_permissions(["*"])
             ['*']
+            >>> TokenScopeRequest.validate_permissions(["audit:read", "security:read"])
+            ['audit:read', 'security:read']
         """
         if not v:
             return v
 
-        # Permission pattern: resource.action (alphanumeric with underscores)
-        permission_pattern = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*\.[a-zA-Z][a-zA-Z0-9_]*$")
+        # Permission pattern: resource.action or resource:action (alphanumeric with underscores).
+        # Colon form covers the handful of Permissions constants (audit:read, security:read,
+        # logs:read, metrics:read) that predate the dot-form convention.
+        permission_pattern = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*[.:][a-zA-Z][a-zA-Z0-9_]*$")
 
         validated = []
         for perm in v:

--- a/tests/unit/mcpgateway/middleware/test_rbac.py
+++ b/tests/unit/mcpgateway/middleware/test_rbac.py
@@ -3059,3 +3059,157 @@ async def test_proxy_trust_missing_header_valid_cookie_rejects():
         with pytest.raises(HTTPException) as exc:
             await rbac.get_current_user_with_permissions(mock_request, credentials=None, jwt_token=None)
     assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+# --- check_permission_inline: non-raising permission check for additive in-handler use ---
+
+
+def _mock_plugin_manager(granted: bool, reason: str = "test"):
+    """Build a plugin manager mock whose permission hook returns a decision.
+
+    Args:
+        granted: The decision the plugin hook reports.
+        reason: Reason string attached to the decision.
+
+    Returns:
+        MagicMock: Plugin manager exposing has_hooks_for and invoke_hook.
+    """
+    mock_result = MagicMock()
+    mock_result.modified_payload.granted = granted
+    mock_result.modified_payload.reason = reason
+    mock_result.metadata = {"plugin_name": "test-plugin"}
+
+    mock_pm = MagicMock()
+    mock_pm.has_hooks_for.return_value = True
+    mock_pm.invoke_hook = AsyncMock(return_value=(mock_result, None))
+    return mock_pm
+
+
+class TestCheckPermissionInline:
+    """check_permission_inline returns a bool instead of raising on denial."""
+
+    @pytest.mark.asyncio
+    async def test_rbac_grant_returns_true(self, monkeypatch):
+        """A granted RBAC check returns True."""
+        mock_perm_service = AsyncMock()
+        mock_perm_service.check_permission.return_value = True
+        monkeypatch.setattr(rbac, "PermissionService", lambda db: mock_perm_service)
+
+        granted = await rbac.check_permission_inline({"email": "user@test.com"}, "security:read", db=MagicMock())
+
+        assert granted is True
+        mock_perm_service.check_permission.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rbac_deny_returns_false_without_raising(self, monkeypatch):
+        """A denied RBAC check returns False rather than raising HTTPException."""
+        mock_perm_service = AsyncMock()
+        mock_perm_service.check_permission.return_value = False
+        monkeypatch.setattr(rbac, "PermissionService", lambda db: mock_perm_service)
+
+        granted = await rbac.check_permission_inline({"email": "user@test.com"}, "security:read", db=MagicMock())
+
+        assert granted is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("user_context", [None, {}, {"not_email": "x"}, "not-a-dict"])
+    async def test_malformed_user_context_returns_false(self, user_context, monkeypatch):
+        """Missing or malformed user context is denied without raising."""
+        mock_perm_service = AsyncMock()
+        monkeypatch.setattr(rbac, "PermissionService", lambda db: mock_perm_service)
+
+        granted = await rbac.check_permission_inline(user_context, "security:read", db=MagicMock())
+
+        assert granted is False
+        mock_perm_service.check_permission.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_uses_fresh_db_session_when_no_db_supplied(self, monkeypatch):
+        """Without a db argument the helper opens a fresh session."""
+        mock_perm_service = AsyncMock()
+        mock_perm_service.check_permission.return_value = True
+        monkeypatch.setattr(rbac, "PermissionService", lambda db: mock_perm_service)
+
+        mock_db = MagicMock()
+        with patch("mcpgateway.middleware.rbac.fresh_db_session", _make_fresh_db(mock_db)):
+            granted = await rbac.check_permission_inline({"email": "user@test.com"}, "security:read")
+
+        assert granted is True
+        mock_perm_service.check_permission.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_plugin_deny_returns_false_without_consulting_rbac(self, monkeypatch):
+        """A plugin denial short-circuits before the RBAC check runs."""
+        mock_perm_service = AsyncMock()
+        mock_perm_service.check_permission.return_value = True
+        monkeypatch.setattr(rbac, "PermissionService", lambda db: mock_perm_service)
+        mock_pm = _mock_plugin_manager(granted=False)
+
+        with patch("mcpgateway.plugins.get_plugin_manager", return_value=mock_pm):
+            granted = await rbac.check_permission_inline({"email": "user@test.com"}, "security:read", db=MagicMock())
+
+        assert granted is False
+        mock_perm_service.check_permission.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_plugin_grant_with_override_returns_true_without_consulting_rbac(self, monkeypatch):
+        """A plugin grant wins outright when plugins may override RBAC."""
+        mock_perm_service = AsyncMock()
+        mock_perm_service.check_permission.return_value = False
+        monkeypatch.setattr(rbac, "PermissionService", lambda db: mock_perm_service)
+        monkeypatch.setattr(rbac.settings, "plugins_can_override_rbac", True)
+        mock_pm = _mock_plugin_manager(granted=True)
+
+        with patch("mcpgateway.plugins.get_plugin_manager", return_value=mock_pm):
+            granted = await rbac.check_permission_inline({"email": "user@test.com"}, "security:read", db=MagicMock())
+
+        assert granted is True
+        mock_perm_service.check_permission.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_plugin_grant_without_override_falls_through_to_rbac(self, monkeypatch):
+        """By default a plugin grant is audit-only and RBAC decides."""
+        mock_perm_service = AsyncMock()
+        mock_perm_service.check_permission.return_value = False
+        monkeypatch.setattr(rbac, "PermissionService", lambda db: mock_perm_service)
+        monkeypatch.setattr(rbac.settings, "plugins_can_override_rbac", False)
+        mock_pm = _mock_plugin_manager(granted=True)
+
+        with patch("mcpgateway.plugins.get_plugin_manager", return_value=mock_pm):
+            granted = await rbac.check_permission_inline({"email": "user@test.com"}, "security:read", db=MagicMock())
+
+        assert granted is False
+        mock_perm_service.check_permission.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_require_permission_still_403s_on_deny(self, monkeypatch):
+        """Delegation regression: the decorator keeps raising 403 when the helper denies."""
+
+        async def dummy_func(user=None):
+            return "should-not-reach"
+
+        mock_perm_service = AsyncMock()
+        mock_perm_service.check_permission.return_value = False
+        monkeypatch.setattr(rbac, "PermissionService", lambda db: mock_perm_service)
+
+        decorated = rbac.require_permission("tools.read")(dummy_func)
+        with pytest.raises(HTTPException) as exc:
+            await decorated(user={"email": "user@test.com", "db": MagicMock()})
+
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.asyncio
+    async def test_require_permission_still_calls_func_on_grant(self, monkeypatch):
+        """Delegation regression: the decorator keeps invoking the handler when granted."""
+
+        async def dummy_func(user=None):
+            return "reached"
+
+        mock_perm_service = AsyncMock()
+        mock_perm_service.check_permission.return_value = True
+        monkeypatch.setattr(rbac, "PermissionService", lambda db: mock_perm_service)
+
+        decorated = rbac.require_permission("tools.read")(dummy_func)
+        result = await decorated(user={"email": "user@test.com", "db": MagicMock()})
+
+        assert result == "reached"

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -350,6 +350,24 @@ class TestTokenScopingMiddleware:
         assert result is False, "POST /catalog/{id} without the /register suffix must stay default-denied"
 
     @pytest.mark.asyncio
+    async def test_activity_feed_endpoint_requires_audit_read(self, middleware):
+        """GET /api/logs/activity must be mapped to audit:read, not default-denied.
+
+        _check_permission_restrictions default-denies unmapped paths, so a scoped token
+        holding audit:read would be rejected before reaching the handler without an
+        explicit _PERMISSION_PATTERNS entry. security:read alone must not open the route:
+        security events are an additive section of the feed, not its entry gate.
+        """
+        result = middleware._check_permission_restrictions("/api/logs/activity", "GET", [Permissions.AUDIT_READ])
+        assert result is True, "GET /api/logs/activity should be allowed when token has audit:read"
+
+        result = middleware._check_permission_restrictions("/api/logs/activity", "GET", ["*"])
+        assert result is True, "GET /api/logs/activity should be allowed with wildcard permission"
+
+        result = middleware._check_permission_restrictions("/api/logs/activity", "GET", [Permissions.SECURITY_READ])
+        assert result is False, "GET /api/logs/activity should be denied when token has only security:read"
+
+    @pytest.mark.asyncio
     async def test_sse_endpoint_allowed_with_servers_use_permission(self, middleware):
         """GET /sse must be reachable for tokens that carry servers.use.
 

--- a/tests/unit/mcpgateway/routers/test_log_search.py
+++ b/tests/unit/mcpgateway/routers/test_log_search.py
@@ -17,7 +17,6 @@ import pytest
 
 # First-Party
 from mcpgateway.middleware import rbac as rbac_module
-import cpex.framework as plugin_framework
 from mcpgateway.routers import log_search
 
 
@@ -31,7 +30,7 @@ def allow_permissions(monkeypatch: pytest.MonkeyPatch):
     async def _no_plugin_manager():
         return None
 
-    monkeypatch.setattr(plugin_framework, "get_plugin_manager", _no_plugin_manager)
+    monkeypatch.setattr("mcpgateway.plugins.get_plugin_manager", _no_plugin_manager)
 
 
 def test_align_to_window_rounds_down():

--- a/tests/unit/mcpgateway/routers/test_log_search_activity.py
+++ b/tests/unit/mcpgateway/routers/test_log_search_activity.py
@@ -22,7 +22,6 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 # First-Party
-import cpex.framework as plugin_framework
 from mcpgateway.db import AuditTrail, Base, SecurityEvent
 from mcpgateway.middleware import rbac as rbac_module
 from mcpgateway.routers import log_search
@@ -55,7 +54,7 @@ def no_plugin_manager(monkeypatch: pytest.MonkeyPatch):
     async def _no_plugin_manager():
         return None
 
-    monkeypatch.setattr(plugin_framework, "get_plugin_manager", _no_plugin_manager)
+    monkeypatch.setattr("mcpgateway.plugins.get_plugin_manager", _no_plugin_manager)
 
 
 @pytest.fixture
@@ -64,10 +63,12 @@ def grant_permissions(monkeypatch: pytest.MonkeyPatch):
 
     def _configure(denied=()):
         async def _check(self, **kwargs):  # type: ignore[no-self-use]
+            _configure.calls.append(kwargs)
             return kwargs.get("permission") not in denied
 
         monkeypatch.setattr(rbac_module.PermissionService, "check_permission", _check)
 
+    _configure.calls = []
     return _configure
 
 
@@ -144,7 +145,7 @@ def make_security(db, *, offset_seconds=0, severity="HIGH", user_email="user@exa
     return row
 
 
-async def call_feed(db, *, user_email="user@example.com", limit=50, since=None):
+async def call_feed(db, *, user_email="user@example.com", limit=50, since=None, token_scopes=None):
     """Invoke the activity feed handler directly.
 
     Args:
@@ -152,6 +153,7 @@ async def call_feed(db, *, user_email="user@example.com", limit=50, since=None):
         user_email: Email placed in the authenticated user context.
         limit: Maximum merged items to request.
         since: Strictly-after timestamp filter.
+        token_scopes: Layer 1 token scopes for the user context, or None for unscoped.
 
     Returns:
         ActivityListResponse: The handler's response.
@@ -160,7 +162,7 @@ async def call_feed(db, *, user_email="user@example.com", limit=50, since=None):
         request=MagicMock(),
         limit=limit,
         since=since,
-        user={"email": user_email, "db": db},
+        user={"email": user_email, "db": db, "token_scopes": token_scopes},
         db=db,
     )
 
@@ -278,30 +280,32 @@ async def test_non_admin_sees_only_own_security_events(db_session, grant_permiss
 
 @pytest.mark.asyncio
 async def test_team_scoped_feed_excludes_other_teams(db_session, grant_permissions, scope):
-    """A team-scoped token sees its own team's rows plus public (NULL-team) rows."""
+    """A team-scoped token sees its own team's rows plus NULL-team rows it authored."""
     grant_permissions()
     scope("user@x.com", ["team-a"])
     make_audit(db_session, offset_seconds=10, team_id="team-a", resource_name="a-row")
     make_audit(db_session, offset_seconds=20, team_id="team-b", resource_name="b-row")
-    make_audit(db_session, offset_seconds=30, team_id=None, resource_name="public-row")
+    make_audit(db_session, offset_seconds=30, team_id=None, user_email="user@x.com", resource_name="own-teamless")
+    make_audit(db_session, offset_seconds=40, team_id=None, user_email="other@x.com", resource_name="foreign-teamless")
 
     response = await call_feed(db_session, user_email="user@x.com")
 
     names = {i.resource_name for i in response.items}
-    assert names == {"a-row", "public-row"}
+    assert names == {"a-row", "own-teamless"}
 
 
 @pytest.mark.asyncio
-async def test_public_only_token_sees_only_null_team_rows(db_session, grant_permissions, scope):
-    """An empty team list is public-only: team-owned audit rows are excluded."""
+async def test_public_only_token_sees_only_own_null_team_rows(db_session, grant_permissions, scope):
+    """NULL team_id means "no team was recorded", not "public": only the actor sees it."""
     grant_permissions()
     scope("user@x.com", [])
     make_audit(db_session, offset_seconds=10, team_id="team-a", resource_name="a-row")
-    make_audit(db_session, offset_seconds=20, team_id=None, resource_name="public-row")
+    make_audit(db_session, offset_seconds=20, team_id=None, user_email="user@x.com", resource_name="own-teamless")
+    make_audit(db_session, offset_seconds=30, team_id=None, user_email="other@x.com", resource_name="foreign-teamless")
 
     response = await call_feed(db_session, user_email="user@x.com")
 
-    assert [i.resource_name for i in response.items] == ["public-row"]
+    assert [i.resource_name for i in response.items] == ["own-teamless"]
 
 
 @pytest.mark.asyncio
@@ -343,6 +347,70 @@ async def test_error_path_returns_500(grant_permissions, scope):
 
     assert exc_info.value.status_code == 500
     assert exc_info.value.detail == "Activity feed query failed"
+
+
+@pytest.mark.asyncio
+async def test_token_without_security_scope_gets_audit_only(db_session, grant_permissions, scope):
+    """Layer 1: a token scoped to audit:read only drops security rows even when RBAC grants all."""
+    grant_permissions()
+    scope("admin@example.com", None)
+    make_audit(db_session, offset_seconds=10)
+    make_security(db_session, offset_seconds=20)
+
+    response = await call_feed(db_session, token_scopes=["audit:read"])
+
+    assert [i.source for i in response.items] == ["audit"]
+
+
+@pytest.mark.asyncio
+async def test_token_with_security_scope_keeps_both_sources(db_session, grant_permissions, scope):
+    """A token carrying both scopes still sees the merged feed."""
+    grant_permissions()
+    scope("admin@example.com", None)
+    make_audit(db_session, offset_seconds=10)
+    make_security(db_session, offset_seconds=20)
+
+    response = await call_feed(db_session, token_scopes=["audit:read", "security:read"])
+
+    assert {i.source for i in response.items} == {"audit", "security"}
+
+
+@pytest.mark.asyncio
+async def test_security_read_is_checked_across_all_teams(db_session, grant_permissions, scope):
+    """The additive security:read check aggregates across teams, matching the decorator."""
+    grant_permissions()
+    scope("user@x.com", ["team-a"])
+    make_audit(db_session, offset_seconds=10, team_id="team-a")
+
+    await call_feed(db_session, user_email="user@x.com")
+
+    security_calls = [c for c in grant_permissions.calls if c.get("permission") == "security:read"]
+    assert len(security_calls) == 1
+    assert security_calls[0]["check_any_team"] is True
+
+
+@pytest.mark.asyncio
+async def test_missing_audit_read_is_rejected(db_session, grant_permissions, scope):
+    """Entry stays gated: without audit:read the request is denied, not narrowed."""
+    grant_permissions(denied={"audit:read"})
+    scope("user@x.com", ["team-a"])
+
+    with pytest.raises(HTTPException) as exc_info:
+        await call_feed(db_session, user_email="user@x.com")
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_request_is_rejected(db_session, grant_permissions, scope):
+    """An absent user context is a 401 before any query runs."""
+    grant_permissions()
+    scope("user@x.com", ["team-a"])
+
+    with pytest.raises(HTTPException) as exc_info:
+        await log_search.get_activity_feed(request=MagicMock(), limit=50, since=None, user=None, db=db_session)
+
+    assert exc_info.value.status_code == 401
 
 
 class TestAuditMapper:
@@ -406,6 +474,16 @@ class TestAuditMapper:
         assert item.resource_name == ""
         assert item.correlation_id == ""
         assert item.description == "Tool was deleted by u."
+
+    def test_unmapped_action_is_humanised(self):
+        """An action with no verb mapping loses its underscores instead of leaking them."""
+        row = AuditTrail(id="6", timestamp=BASE_TIME, action="bulk_create_tools", resource_type="tool", user_id="u", success=True, requires_review=False)
+
+        assert log_search._audit_to_activity(row).title == "Tool bulk create tools"
+
+        row.success = False
+
+        assert log_search._audit_to_activity(row).title == "Tool bulk create tools failed"
 
 
 class TestSecurityMapper:

--- a/tests/unit/mcpgateway/routers/test_log_search_activity.py
+++ b/tests/unit/mcpgateway/routers/test_log_search_activity.py
@@ -1,0 +1,399 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/routers/test_log_search_activity.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Tests for the recent activity feed endpoint (GET /api/logs/activity).
+
+Uses an in-memory SQLite database with real AuditTrail and SecurityEvent rows so
+the visibility rules (team scoping, self-only security events, restricted-row
+exclusion) are exercised as actual SQL rather than mocked query results.
+"""
+
+# Standard
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+# Third-Party
+from fastapi import HTTPException
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+import cpex.framework as plugin_framework
+from mcpgateway.db import AuditTrail, Base, SecurityEvent
+from mcpgateway.middleware import rbac as rbac_module
+from mcpgateway.routers import log_search
+
+BASE_TIME = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def db_session():
+    """In-memory SQLite session shared across all connections within one test."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = TestSession()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def no_plugin_manager(monkeypatch: pytest.MonkeyPatch):
+    """Keep plugin hooks out of the permission path for these tests."""
+
+    async def _no_plugin_manager():
+        return None
+
+    monkeypatch.setattr(plugin_framework, "get_plugin_manager", _no_plugin_manager)
+
+
+@pytest.fixture
+def grant_permissions(monkeypatch: pytest.MonkeyPatch):
+    """Return a helper that grants or denies specific permissions by name."""
+
+    def _configure(denied=()):
+        async def _check(self, **kwargs):  # type: ignore[no-self-use]
+            return kwargs.get("permission") not in denied
+
+        monkeypatch.setattr(rbac_module.PermissionService, "check_permission", _check)
+
+    return _configure
+
+
+@pytest.fixture
+def scope(monkeypatch: pytest.MonkeyPatch):
+    """Return a helper that pins the token-scoped access context tuple."""
+
+    def _configure(email, teams):
+        monkeypatch.setattr(log_search, "get_scoped_resource_access_context", lambda request, user: (email, teams))
+
+    return _configure
+
+
+def make_audit(db, *, offset_seconds=0, action="create", resource_type="mcp_server", success=True, requires_review=False, team_id=None, data_classification=None, **kwargs):
+    """Insert one AuditTrail row and return it.
+
+    Args:
+        db: Database session.
+        offset_seconds: Seconds added to BASE_TIME for this row's timestamp.
+        action: Audited action verb.
+        resource_type: Audited resource type.
+        success: Whether the audited action succeeded.
+        requires_review: Whether the row is flagged for review.
+        team_id: Owning team, or None for a public row.
+        data_classification: Sensitivity label, or None.
+        **kwargs: Extra AuditTrail column overrides.
+
+    Returns:
+        AuditTrail: The persisted row.
+    """
+    row = AuditTrail(
+        timestamp=BASE_TIME + timedelta(seconds=offset_seconds),
+        action=action,
+        resource_type=resource_type,
+        resource_name=kwargs.pop("resource_name", "widget"),
+        user_id=kwargs.pop("user_id", "user@example.com"),
+        user_email=kwargs.pop("user_email", "user@example.com"),
+        team_id=team_id,
+        data_classification=data_classification,
+        success=success,
+        requires_review=requires_review,
+        **kwargs,
+    )
+    db.add(row)
+    db.commit()
+    return row
+
+
+def make_security(db, *, offset_seconds=0, severity="HIGH", user_email="user@example.com", **kwargs):
+    """Insert one SecurityEvent row and return it.
+
+    Args:
+        db: Database session.
+        offset_seconds: Seconds added to BASE_TIME for this row's timestamp.
+        severity: Event severity label.
+        user_email: Email the event is attributed to.
+        **kwargs: Extra SecurityEvent column overrides.
+
+    Returns:
+        SecurityEvent: The persisted row.
+    """
+    row = SecurityEvent(
+        timestamp=BASE_TIME + timedelta(seconds=offset_seconds),
+        event_type=kwargs.pop("event_type", "failed_login"),
+        severity=severity,
+        category=kwargs.pop("category", "authentication"),
+        client_ip=kwargs.pop("client_ip", "10.0.0.1"),
+        description=kwargs.pop("description", "Repeated failed login attempts detected."),
+        user_email=user_email,
+        **kwargs,
+    )
+    db.add(row)
+    db.commit()
+    return row
+
+
+async def call_feed(db, *, user_email="user@example.com", limit=50, since=None):
+    """Invoke the activity feed handler directly.
+
+    Args:
+        db: Database session.
+        user_email: Email placed in the authenticated user context.
+        limit: Maximum merged items to request.
+        since: Strictly-after timestamp filter.
+
+    Returns:
+        ActivityListResponse: The handler's response.
+    """
+    return await log_search.get_activity_feed(
+        request=MagicMock(),
+        limit=limit,
+        since=since,
+        user={"email": user_email, "db": db},
+        db=db,
+    )
+
+
+@pytest.mark.asyncio
+async def test_union_returns_both_sources_newest_first(db_session, grant_permissions, scope):
+    """Admin feed merges audit and security rows into one newest-first list."""
+    grant_permissions()
+    scope("admin@example.com", None)
+    make_audit(db_session, offset_seconds=10)
+    make_security(db_session, offset_seconds=20)
+
+    response = await call_feed(db_session)
+
+    assert [i.source for i in response.items] == ["security", "audit"]
+    assert response.items[0].id.startswith("security:")
+    assert response.items[1].id.startswith("audit:")
+    for item in response.items:
+        assert item.source in ("audit", "security")
+        assert item.status in ("success", "error", "warning", "info")
+        for field in ("id", "title", "description", "resource_type", "resource_name", "actor", "correlation_id"):
+            assert isinstance(getattr(item, field), str)
+        assert item.timestamp.tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_limit_truncates_across_the_union(db_session, grant_permissions, scope):
+    """The merged list is truncated to `limit`, keeping the newest items overall."""
+    grant_permissions()
+    scope("admin@example.com", None)
+    for i in range(5):
+        make_audit(db_session, offset_seconds=i * 2)
+        make_security(db_session, offset_seconds=i * 2 + 1)
+
+    response = await call_feed(db_session, limit=4)
+
+    assert len(response.items) == 4
+    timestamps = [i.timestamp for i in response.items]
+    assert timestamps == sorted(timestamps, reverse=True)
+    assert timestamps == [BASE_TIME + timedelta(seconds=s) for s in (9, 8, 7, 6)]
+
+
+@pytest.mark.asyncio
+async def test_since_excludes_row_exactly_at_boundary(db_session, grant_permissions, scope):
+    """`since` is strictly-after: a row whose timestamp equals it is excluded."""
+    grant_permissions()
+    scope("admin@example.com", None)
+    boundary = BASE_TIME + timedelta(seconds=10)
+    make_audit(db_session, offset_seconds=10)
+    make_audit(db_session, offset_seconds=20)
+    make_security(db_session, offset_seconds=10)
+    make_security(db_session, offset_seconds=20)
+
+    response = await call_feed(db_session, since=boundary)
+
+    assert len(response.items) == 2
+    assert all(i.timestamp > boundary for i in response.items)
+
+
+@pytest.mark.asyncio
+async def test_feed_narrows_to_audit_only_without_security_read(db_session, grant_permissions, scope):
+    """Missing security:read omits security rows instead of rejecting the request."""
+    grant_permissions(denied={"security:read"})
+    scope("admin@example.com", None)
+    make_audit(db_session, offset_seconds=10)
+    make_security(db_session, offset_seconds=20)
+
+    response = await call_feed(db_session)
+
+    assert [i.source for i in response.items] == ["audit"]
+
+
+@pytest.mark.asyncio
+async def test_non_admin_sees_only_own_security_events(db_session, grant_permissions, scope):
+    """SecurityEvent has no team column, so non-admins see only their own events."""
+    grant_permissions()
+    scope("user@x.com", ["team-a"])
+    make_security(db_session, offset_seconds=10, user_email="user@x.com")
+    make_security(db_session, offset_seconds=20, user_email="other@x.com")
+
+    response = await call_feed(db_session, user_email="user@x.com")
+
+    security_items = [i for i in response.items if i.source == "security"]
+    assert len(security_items) == 1
+    assert security_items[0].actor == "user@x.com"
+
+
+@pytest.mark.asyncio
+async def test_team_scoped_feed_excludes_other_teams(db_session, grant_permissions, scope):
+    """A team-scoped token sees its own team's rows plus public (NULL-team) rows."""
+    grant_permissions()
+    scope("user@x.com", ["team-a"])
+    make_audit(db_session, offset_seconds=10, team_id="team-a", resource_name="a-row")
+    make_audit(db_session, offset_seconds=20, team_id="team-b", resource_name="b-row")
+    make_audit(db_session, offset_seconds=30, team_id=None, resource_name="public-row")
+
+    response = await call_feed(db_session, user_email="user@x.com")
+
+    names = {i.resource_name for i in response.items}
+    assert names == {"a-row", "public-row"}
+
+
+@pytest.mark.asyncio
+async def test_public_only_token_sees_only_null_team_rows(db_session, grant_permissions, scope):
+    """An empty team list is public-only: team-owned audit rows are excluded."""
+    grant_permissions()
+    scope("user@x.com", [])
+    make_audit(db_session, offset_seconds=10, team_id="team-a", resource_name="a-row")
+    make_audit(db_session, offset_seconds=20, team_id=None, resource_name="public-row")
+
+    response = await call_feed(db_session, user_email="user@x.com")
+
+    assert [i.resource_name for i in response.items] == ["public-row"]
+
+
+@pytest.mark.asyncio
+async def test_non_admin_never_receives_restricted_rows(db_session, grant_permissions, scope):
+    """Restricted rows are filtered in SQL; NULL-classified rows stay visible."""
+    grant_permissions()
+    scope("user@x.com", ["team-a"])
+    make_audit(db_session, offset_seconds=10, team_id="team-a", data_classification="restricted", resource_name="secret")
+    make_audit(db_session, offset_seconds=20, team_id="team-a", data_classification="internal", resource_name="internal-row")
+    make_audit(db_session, offset_seconds=30, team_id="team-a", data_classification=None, resource_name="unclassified")
+
+    response = await call_feed(db_session, user_email="user@x.com")
+
+    assert {i.resource_name for i in response.items} == {"internal-row", "unclassified"}
+
+
+@pytest.mark.asyncio
+async def test_admin_receives_restricted_rows(db_session, grant_permissions, scope):
+    """Admin bypass sees restricted rows the team-scoped feed hides."""
+    grant_permissions()
+    scope("admin@example.com", None)
+    make_audit(db_session, offset_seconds=10, data_classification="restricted", resource_name="secret")
+
+    response = await call_feed(db_session)
+
+    assert [i.resource_name for i in response.items] == ["secret"]
+
+
+@pytest.mark.asyncio
+async def test_error_path_returns_500(grant_permissions, scope):
+    """A failing query surfaces as a 500 rather than an unhandled exception."""
+    grant_permissions()
+    scope("admin@example.com", None)
+    db = MagicMock()
+    db.execute.side_effect = Exception("boom")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await call_feed(db)
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "Activity feed query failed"
+
+
+class TestAuditMapper:
+    """_audit_to_activity renders server-owned title, description and status."""
+
+    def test_successful_create(self):
+        """A successful create is a success item with a humanised resource label."""
+        row = AuditTrail(id="1", timestamp=BASE_TIME, action="create", resource_type="mcp_server", resource_name="github", user_id="u", user_email="u@x.com", success=True, requires_review=False)
+
+        item = log_search._audit_to_activity(row)
+
+        assert item.status == "success"
+        assert item.title == "MCP server created"
+        assert item.description == "MCP server 'github' was created by u@x.com."
+        assert item.id == "audit:1"
+
+    def test_failed_create_carries_error_message(self):
+        """A failed action is an error item whose description includes the error."""
+        row = AuditTrail(id="2", timestamp=BASE_TIME, action="create", resource_type="mcp_server", resource_name="github", user_id="u", user_email="u@x.com", success=False, requires_review=False, error_message="Connection refused")
+
+        item = log_search._audit_to_activity(row)
+
+        assert item.status == "error"
+        assert item.title == "MCP server create failed"
+        assert "Connection refused" in item.description
+
+    def test_requires_review_is_warning(self):
+        """A row flagged for review outranks the default success status."""
+        row = AuditTrail(id="3", timestamp=BASE_TIME, action="update", resource_type="tool", user_id="u", success=True, requires_review=True)
+
+        item = log_search._audit_to_activity(row)
+
+        assert item.status == "warning"
+
+    def test_read_action_is_info(self):
+        """Read and execute actions are informational, not successes."""
+        row = AuditTrail(id="4", timestamp=BASE_TIME, action="read", resource_type="tool", user_id="u", success=True, requires_review=False)
+
+        item = log_search._audit_to_activity(row)
+
+        assert item.status == "info"
+        assert item.title == "Tool accessed"
+
+    def test_missing_optional_fields_become_empty_strings(self):
+        """Contract fields are never null even when source columns are missing."""
+        row = AuditTrail(id="5", timestamp=BASE_TIME, action="delete", resource_type="tool", user_id="u", success=True, requires_review=False)
+
+        item = log_search._audit_to_activity(row)
+
+        assert item.resource_name == ""
+        assert item.correlation_id == ""
+        assert item.description == "Tool was deleted by u."
+
+
+class TestSecurityMapper:
+    """_security_to_activity derives status from severity."""
+
+    @pytest.mark.parametrize(
+        "severity,expected",
+        [("CRITICAL", "error"), ("HIGH", "error"), ("MEDIUM", "warning"), ("LOW", "info"), ("bogus", "info"), (None, "info")],
+    )
+    def test_severity_maps_to_status(self, severity, expected):
+        """Each severity level maps to its contract status, unknown values to info."""
+        row = SecurityEvent(id="1", timestamp=BASE_TIME, event_type="failed_login", severity=severity, category="auth", client_ip="10.0.0.1", description="Something happened.")
+
+        assert log_search._security_to_activity(row).status == expected
+
+    def test_actor_falls_back_to_system(self):
+        """An event with no attributed user is reported as a system actor."""
+        row = SecurityEvent(id="2", timestamp=BASE_TIME, event_type="rate_limit_exceeded", severity="LOW", category="abuse", client_ip="10.0.0.1", description="Rate limit exceeded.")
+
+        item = log_search._security_to_activity(row)
+
+        assert item.actor == "system"
+        assert item.resource_name == ""
+        assert item.title == "Rate limit exceeded"
+
+    def test_naive_timestamp_gets_utc(self):
+        """Naive timestamps from SQLite are pinned to UTC for the ISO 8601 contract."""
+        row = SecurityEvent(id="3", timestamp=datetime(2025, 1, 1, 12, 0, 0), event_type="x", severity="LOW", category="auth", client_ip="10.0.0.1", description="d")
+
+        assert log_search._security_to_activity(row).timestamp.tzinfo == timezone.utc

--- a/tests/unit/mcpgateway/routers/test_log_search_activity.py
+++ b/tests/unit/mcpgateway/routers/test_log_search_activity.py
@@ -361,7 +361,18 @@ class TestAuditMapper:
 
     def test_failed_create_carries_error_message(self):
         """A failed action is an error item whose description includes the error."""
-        row = AuditTrail(id="2", timestamp=BASE_TIME, action="create", resource_type="mcp_server", resource_name="github", user_id="u", user_email="u@x.com", success=False, requires_review=False, error_message="Connection refused")
+        row = AuditTrail(
+            id="2",
+            timestamp=BASE_TIME,
+            action="create",
+            resource_type="mcp_server",
+            resource_name="github",
+            user_id="u",
+            user_email="u@x.com",
+            success=False,
+            requires_review=False,
+            error_message="Connection refused",
+        )
 
         item = log_search._audit_to_activity(row)
 

--- a/tests/unit/mcpgateway/routers/test_log_search_activity.py
+++ b/tests/unit/mcpgateway/routers/test_log_search_activity.py
@@ -221,6 +221,34 @@ async def test_since_excludes_row_exactly_at_boundary(db_session, grant_permissi
 
 
 @pytest.mark.asyncio
+async def test_audit_timestamp_ties_at_limit_resolve_by_id(db_session, grant_permissions, scope):
+    """Rows sharing a timestamp survive the SQL LIMIT by id, not DB row order."""
+    grant_permissions()
+    scope("admin@example.com", None)
+    # Insertion order is deliberately not id order: without the SQL tiebreak SQLite
+    # returns these ties in reverse-insertion order, which would keep tie-a instead.
+    for suffix in ("b", "c", "a"):
+        make_audit(db_session, offset_seconds=0, id=f"tie-{suffix}")
+
+    response = await call_feed(db_session, limit=2)
+
+    assert [i.id for i in response.items] == ["audit:tie-c", "audit:tie-b"]
+
+
+@pytest.mark.asyncio
+async def test_security_timestamp_ties_at_limit_resolve_by_id(db_session, grant_permissions, scope):
+    """The security source has the same deterministic (timestamp, id) boundary."""
+    grant_permissions()
+    scope("admin@example.com", None)
+    for suffix in ("b", "c", "a"):
+        make_security(db_session, offset_seconds=0, id=f"tie-{suffix}")
+
+    response = await call_feed(db_session, limit=2)
+
+    assert [i.id for i in response.items] == ["security:tie-c", "security:tie-b"]
+
+
+@pytest.mark.asyncio
 async def test_feed_narrows_to_audit_only_without_security_read(db_session, grant_permissions, scope):
     """Missing security:read omits security rows instead of rejecting the request."""
     grant_permissions(denied={"security:read"})

--- a/tests/unit/mcpgateway/test_schemas_validators_extra.py
+++ b/tests/unit/mcpgateway/test_schemas_validators_extra.py
@@ -864,6 +864,9 @@ def test_password_team_token_and_grpc_validators(monkeypatch):
     assert TokenScopeRequest.validate_ip_restrictions(["   ", "10.0.0.1"]) == ["10.0.0.1"]
     assert TokenScopeRequest.validate_permissions([]) == []
     assert TokenScopeRequest.validate_permissions(["   ", "tools.read", "*"]) == ["tools.read", "*"]
+    assert TokenScopeRequest.validate_permissions(["audit:read", "security:read"]) == ["audit:read", "security:read"]
+    with pytest.raises(ValueError, match="Invalid permission format"):
+        TokenScopeRequest.validate_permissions(["audit:"])
 
     with pytest.raises((ValidationError, ValueError)):
         GrpcServiceCreate(name="svc", target="localhost")


### PR DESCRIPTION
Closes #5944

Adds `GET /api/logs/activity?limit=&since=` returning `{ items: ActivityItem[] }`, a Python-level union of `AuditTrail` and `SecurityEvent` rows. The React Home page Recent Activity feed (#5531) currently runs on `VITE_USE_MOCK_ACTIVITY` fixtures because no backend existed; this is that backend, matching the contract locked in `client/src/types/activity.ts` — that file lives on the UI branch `5531-recent-activity-feed-V2`, not on `main`.

## Server-owned presentation

`title`, `description`, and `status` are rendered server-side and must not be re-derived by clients. Audit status precedence is `not success` → `error`, else `requires_review` → `warning`, else `read`/`execute` → `info`, else `success`. Security status derives from severity (`CRITICAL`/`HIGH` → `error`, `MEDIUM` → `warning`, else `info`).

All contract fields are required strings, so a missing source column becomes `""` rather than null — security rows have no resource name, so `resource_name` falls back to `user_email` and `actor` to `"system"`.

## Permissions

Entry is gated by `audit:read`. Security events are **additive**: included only when the caller also holds `security:read`. A caller without it gets a narrower feed, not a 403.

That additive check needed a permission check that reports denial instead of raising, so this extracts `check_permission_inline()` in `mcpgateway/middleware/rbac.py` and makes `require_permission` delegate to it. Plugin-hook and RBAC-fallback logic now live on one shared path rather than being duplicated. The decorator behaviour table is unchanged: plugin deny → 403, plugin grant + `plugins_can_override_rbac` → call handler, plugin grant without override → RBAC fallthrough, no plugin → RBAC.

## Visibility

- **Audit rows** are team-scoped: own teams, plus NULL-team rows the caller authored. A NULL `team_id` means the writer recorded no team (e.g. `tool_service` bulk imports), not "public", so a public-only token (`[]`) sees only its own NULL-team rows.
- **Security rows** are self-only for non-admins — `SecurityEvent` has no `team_id` column.
- **`data_classification == "restricted"`** rows are excluded for non-admins **in SQL**, so their existence is not observable via counts. The predicate is OR-ed with `IS NULL` because a bare `!=` would silently drop NULL-classified rows.
- Admin bypass (`token_teams is None`) sees everything.

`get_scoped_resource_access_context()` derives admin status from the verified token, not a raw `user["is_admin"]` flag.

## Token scoping

`_check_permission_restrictions` default-denies unmapped paths, so `/api/logs/activity` is mapped to `audit:read` in `_PERMISSION_PATTERNS`. Without that entry a correctly-scoped `audit:read` token would be rejected at the middleware layer before reaching the handler. `security:read` alone does not open the route.

Scope note: this maps only the new route. The pre-existing `/api/logs/*` routes are unmapped and left for a separate issue.

## Deferred (per the issue)

Free-text search/filter params, error/warning counts, `?cursor=`, SSE streaming.

## Notes for reviewers

- `limit` defaults to 50, max 100, matching the client’s own clamp in `activity.ts`. Siblings in this file use 100/1000 — say the word if you prefer consistency with them over the client.
- `since` is strictly-after, as documented in `client/src/api/activity.ts`.
- Each source over-fetches at most `limit`, so the merged top-`limit` is exact.
- Presentation wording (`_ACTION_VERBS`, `_RESOURCE_LABELS`) is our design within the "server owns presentation" rule; the fixtures only established tone. Changing it touches the two mappers and their tests, nothing else.
- No migration: `timestamp` is already indexed and the feed caps at 100 rows, so a composite `(team_id, timestamp)` index was not worth adding.