### PR TITLE
feat(api): non-admin v1 catalog register endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-07T13:52:41Z",
+  "generated_at": "2026-08-07T14:56:50Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1894,7 +1894,7 @@
         "hashed_secret": "1a6222d0fd7cf8ec9f3da30d4369f45b30e81afb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 489,
+        "line_number": 507,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/manage/catalog.md
+++ b/docs/docs/manage/catalog.md
@@ -251,6 +251,24 @@ curl -H "Authorization: Bearer $TOKEN" \
   http://localhost:4444/admin/catalog/servers
 ```
 
+### Registering a Catalog Server (API)
+
+Registration requires both `servers.create` and `gateways.create` (a catalog registration
+creates a federated gateway, the same capability as `POST /v1/gateways`). Admin bypass is
+disabled: platform admins need the permissions granted through their roles.
+
+```bash
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "My Asana", "api_key": "sk-..."}' \
+  http://localhost:4444/v1/catalog/asana/register
+```
+
+The body is optional; `name` and `api_key` override the catalog defaults. Responses:
+`404` unknown catalog id (or catalog feature disabled), `409` already registered,
+`200` with `success: false` and a descriptive `message` for connectivity or auth failures,
+`200` with `success: true` on registration (OAuth servers register disabled until configured).
+
 ### Filtering by Tags
 
 ```bash

--- a/docs/docs/manage/catalog.md
+++ b/docs/docs/manage/catalog.md
@@ -260,7 +260,7 @@ disabled: platform admins need the permissions granted through their roles.
 ```bash
 curl -X POST -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"name": "My Asana", "api_key": "sk-..."}' \
+  -d "{\"name\": \"My Asana\", \"api_key\": \"$ASANA_API_KEY\"}" \
   http://localhost:4444/v1/catalog/asana/register
 ```
 

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -132,6 +132,9 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("DELETE", re.compile(r"^/gateways/[^/]+(?:$|/)"), Permissions.GATEWAYS_DELETE),
     # MCP Servers REST API (v1 prefix stripped by middleware before matching)
     ("POST", re.compile(r"^/mcp-servers/test(?:$|/)"), Permissions.GATEWAYS_READ),
+    # MCP registry catalog (v1 prefix stripped by middleware before matching)
+    ("GET", re.compile(r"^/catalog(?:$|/)"), Permissions.SERVERS_READ),
+    ("POST", re.compile(r"^/catalog/[^/]+/register(?:$|/)"), Permissions.SERVERS_CREATE),
     # Metrics permissions
     ("GET", re.compile(r"^/metrics(?:$|/)"), Permissions.ADMIN_METRICS),
     ("POST", re.compile(r"^/metrics/reset(?:$|/)"), Permissions.ADMIN_METRICS),

--- a/mcpgateway/routers/catalog.py
+++ b/mcpgateway/routers/catalog.py
@@ -88,9 +88,10 @@ async def list_catalog_servers(
 @require_permission("gateways.create", allow_admin_bypass=False)
 async def register_catalog_server(
     catalog_id: str,
+    request: Request,
     body: Optional[CatalogServerRegisterBody] = None,
     db: Session = Depends(get_db),
-    _user=Depends(get_current_user_with_permissions),
+    user=Depends(get_current_user_with_permissions),
 ) -> CatalogServerRegisterResponse:
     """Register a catalog server as a gateway for the authenticated API caller.
 
@@ -102,9 +103,10 @@ async def register_catalog_server(
 
     Args:
         catalog_id: Catalog server ID to register.
+        request: FastAPI request object.
         body: Optional overrides (custom name, API key).
         db: Database session.
-        _user: Authenticated user.
+        user: Authenticated user.
 
     Returns:
         Registration result envelope.
@@ -116,9 +118,20 @@ async def register_catalog_server(
     if not settings.mcpgateway_catalog_enabled:
         raise HTTPException(status_code=404, detail="Catalog feature is disabled")
 
-    request = CatalogServerRegisterRequest(server_id=catalog_id, name=body.name, api_key=body.api_key) if body else None
+    service_request = CatalogServerRegisterRequest(server_id=catalog_id, name=body.name, api_key=body.api_key) if body else None
 
-    result = await catalog_service.register_catalog_server(catalog_id=catalog_id, request=request, db=db)
+    user_email, token_teams = get_scoped_resource_access_context(request, user)
+    is_public_only_token = token_teams is not None and len(token_teams) == 0
+    team_id = None if is_public_only_token else getattr(request.state, "team_id", None)
+
+    result = await catalog_service.register_catalog_server(
+        catalog_id=catalog_id,
+        request=service_request,
+        db=db,
+        created_by=user_email,
+        owner_email=user_email,
+        team_id=team_id,
+    )
 
     if not result.success:
         if result.message == CATALOG_REGISTER_NOT_FOUND_MSG:

--- a/mcpgateway/routers/catalog.py
+++ b/mcpgateway/routers/catalog.py
@@ -19,7 +19,7 @@ from mcpgateway.config import settings
 from mcpgateway.db import get_db
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
 from mcpgateway.schemas import CatalogListRequest, CatalogListResponse, CatalogServerRegisterBody, CatalogServerRegisterRequest, CatalogServerRegisterResponse
-from mcpgateway.services.catalog_service import catalog_service
+from mcpgateway.services.catalog_service import CATALOG_REGISTER_ALREADY_REGISTERED_MSG, CATALOG_REGISTER_NOT_FOUND_MSG, catalog_service
 
 router = APIRouter(prefix="/catalog", tags=["Catalog"])
 
@@ -81,8 +81,11 @@ async def list_catalog_servers(
     return await catalog_service.get_catalog_servers(catalog_request, db, user_email=user_email, token_teams=token_teams)
 
 
+# Registration bottoms out in gateway_service.register_gateway (a federated peer), so it requires
+# the same gateways.create as POST /v1/gateways in addition to the admin twin's servers.create.
 @router.post("/{catalog_id}/register", response_model=CatalogServerRegisterResponse)
-@require_permission("servers.create")
+@require_permission("servers.create", allow_admin_bypass=False)
+@require_permission("gateways.create", allow_admin_bypass=False)
 async def register_catalog_server(
     catalog_id: str,
     body: Optional[CatalogServerRegisterBody] = None,
@@ -91,9 +94,11 @@ async def register_catalog_server(
 ) -> CatalogServerRegisterResponse:
     """Register a catalog server as a gateway for the authenticated API caller.
 
-    Business failures (unknown catalog id, already registered, unreachable
-    server) are returned as an HTTP 200 envelope with ``success=False`` and a
-    mapped message, matching the admin registration endpoint.
+    Unknown catalog ids map to HTTP 404 and already-registered servers to HTTP 409.
+    Remaining business failures (unreachable server, auth failure) are returned as an
+    HTTP 200 envelope with ``success=False`` and a mapped message; the ``error`` field
+    is blanked because the service captures raw exception text there. The admin
+    registration endpoint keeps its 200-envelope contract unchanged.
 
     Args:
         catalog_id: Catalog server ID to register.
@@ -105,11 +110,21 @@ async def register_catalog_server(
         Registration result envelope.
 
     Raises:
-        HTTPException: If the catalog feature is disabled.
+        HTTPException: If the catalog feature is disabled (404), the catalog id is
+            unknown (404), or the server is already registered (409).
     """
     if not settings.mcpgateway_catalog_enabled:
         raise HTTPException(status_code=404, detail="Catalog feature is disabled")
 
     request = CatalogServerRegisterRequest(server_id=catalog_id, name=body.name, api_key=body.api_key) if body else None
 
-    return await catalog_service.register_catalog_server(catalog_id=catalog_id, request=request, db=db)
+    result = await catalog_service.register_catalog_server(catalog_id=catalog_id, request=request, db=db)
+
+    if not result.success:
+        if result.message == CATALOG_REGISTER_NOT_FOUND_MSG:
+            raise HTTPException(status_code=404, detail="Catalog server not found")
+        if result.message == CATALOG_REGISTER_ALREADY_REGISTERED_MSG:
+            raise HTTPException(status_code=409, detail="Server already registered")
+        result.error = None
+
+    return result

--- a/mcpgateway/routers/catalog.py
+++ b/mcpgateway/routers/catalog.py
@@ -18,7 +18,7 @@ from mcpgateway.auth_context import get_scoped_resource_access_context
 from mcpgateway.config import settings
 from mcpgateway.db import get_db
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
-from mcpgateway.schemas import CatalogListRequest, CatalogListResponse
+from mcpgateway.schemas import CatalogListRequest, CatalogListResponse, CatalogServerRegisterBody, CatalogServerRegisterRequest, CatalogServerRegisterResponse
 from mcpgateway.services.catalog_service import catalog_service
 
 router = APIRouter(prefix="/catalog", tags=["Catalog"])
@@ -79,3 +79,37 @@ async def list_catalog_servers(
     )
 
     return await catalog_service.get_catalog_servers(catalog_request, db, user_email=user_email, token_teams=token_teams)
+
+
+@router.post("/{catalog_id}/register", response_model=CatalogServerRegisterResponse)
+@require_permission("servers.create")
+async def register_catalog_server(
+    catalog_id: str,
+    body: Optional[CatalogServerRegisterBody] = None,
+    db: Session = Depends(get_db),
+    _user=Depends(get_current_user_with_permissions),
+) -> CatalogServerRegisterResponse:
+    """Register a catalog server as a gateway for the authenticated API caller.
+
+    Business failures (unknown catalog id, already registered, unreachable
+    server) are returned as an HTTP 200 envelope with ``success=False`` and a
+    mapped message, matching the admin registration endpoint.
+
+    Args:
+        catalog_id: Catalog server ID to register.
+        body: Optional overrides (custom name, API key).
+        db: Database session.
+        _user: Authenticated user.
+
+    Returns:
+        Registration result envelope.
+
+    Raises:
+        HTTPException: If the catalog feature is disabled.
+    """
+    if not settings.mcpgateway_catalog_enabled:
+        raise HTTPException(status_code=404, detail="Catalog feature is disabled")
+
+    request = CatalogServerRegisterRequest(server_id=catalog_id, name=body.name, api_key=body.api_key) if body else None
+
+    return await catalog_service.register_catalog_server(catalog_id=catalog_id, request=request, db=db)

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -8165,6 +8165,17 @@ class CatalogServerRegisterRequest(BaseModel):
     oauth_credentials: Optional[Dict[str, Any]] = Field(None, description="OAuth credentials if required")
 
 
+class CatalogServerRegisterBody(BaseModel):
+    """Body for the v1 catalog register endpoint.
+
+    The catalog server id comes from the path; this body carries only the
+    optional overrides. OAuth configuration is out of scope here (#5967).
+    """
+
+    name: Optional[str] = Field(None, description="Optional custom name for the server")
+    api_key: Optional[str] = Field(None, description="API key if the catalog entry requires one")
+
+
 class CatalogServerRegisterResponse(BaseModel):
     """Response after registering a catalog server."""
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -8173,7 +8173,22 @@ class CatalogServerRegisterBody(BaseModel):
     """
 
     name: Optional[str] = Field(None, description="Optional custom name for the server")
-    api_key: Optional[str] = Field(None, description="API key if the catalog entry requires one")
+    api_key: Optional[str] = Field(None, max_length=4096, description="API key if the catalog entry requires one")
+
+    @field_validator("name")
+    @classmethod
+    def validate_name_field(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure the override name is safe to render and store.
+
+        Args:
+            v: Server name override to validate.
+
+        Returns:
+            The validated name or None.
+        """
+        if v is None:
+            return v
+        return SecurityValidator.validate_name(v, "Server name")
 
 
 class CatalogServerRegisterResponse(BaseModel):

--- a/mcpgateway/services/catalog_service.py
+++ b/mcpgateway/services/catalog_service.py
@@ -321,7 +321,9 @@ class CatalogService:
                 existing = None
 
             if existing:
-                return CatalogServerRegisterResponse(success=False, server_id=str(existing.id), message=CATALOG_REGISTER_ALREADY_REGISTERED_MSG, error="This server is already registered in the system")
+                return CatalogServerRegisterResponse(
+                    success=False, server_id=str(existing.id), message=CATALOG_REGISTER_ALREADY_REGISTERED_MSG, error="This server is already registered in the system"
+                )
 
             # Prepare gateway creation request using proper schema
             # First-Party

--- a/mcpgateway/services/catalog_service.py
+++ b/mcpgateway/services/catalog_service.py
@@ -282,13 +282,24 @@ class CatalogService:
 
         return False
 
-    async def register_catalog_server(self, catalog_id: str, request: Optional[CatalogServerRegisterRequest], db: Session) -> CatalogServerRegisterResponse:
+    async def register_catalog_server(
+        self,
+        catalog_id: str,
+        request: Optional[CatalogServerRegisterRequest],
+        db: Session,
+        created_by: Optional[str] = None,
+        owner_email: Optional[str] = None,
+        team_id: Optional[str] = None,
+    ) -> CatalogServerRegisterResponse:
         """Register a catalog server as a gateway.
 
         Args:
             catalog_id: Catalog server ID
             request: Registration request with optional overrides
             db: Database session
+            created_by: Identity of the caller creating the gateway
+            owner_email: Email of the gateway owner
+            team_id: Team the gateway belongs to
 
         Returns:
             Registration response
@@ -407,6 +418,9 @@ class CatalogService:
                     enabled=False,  # Disabled until OAuth is configured
                     created_via="catalog",
                     visibility="public",
+                    created_by=created_by,
+                    owner_email=owner_email,
+                    team_id=team_id,
                     version=1,
                 )
 
@@ -474,6 +488,9 @@ class CatalogService:
                 gateway=gateway_create,
                 created_via="catalog",
                 visibility="public",  # Catalog servers should be public
+                created_by=created_by,
+                owner_email=owner_email,
+                team_id=team_id,
                 initialize_timeout=settings.httpx_admin_read_timeout,
             )
 

--- a/mcpgateway/services/catalog_service.py
+++ b/mcpgateway/services/catalog_service.py
@@ -41,6 +41,10 @@ from mcpgateway.validation.tags import validate_tags_field
 
 logger = logging.getLogger(__name__)
 
+# Business-failure messages the v1 router maps to HTTP 404/409.
+CATALOG_REGISTER_NOT_FOUND_MSG = "Server not found in catalog"
+CATALOG_REGISTER_ALREADY_REGISTERED_MSG = "Server already registered"
+
 
 class CatalogService:
     """Service for managing MCP server catalog."""
@@ -302,7 +306,7 @@ class CatalogService:
                     break
 
             if not server_data:
-                return CatalogServerRegisterResponse(success=False, server_id="", message="Server not found in catalog", error="Invalid catalog server ID")
+                return CatalogServerRegisterResponse(success=False, server_id="", message=CATALOG_REGISTER_NOT_FOUND_MSG, error="Invalid catalog server ID")
 
             # Check if already registered
             try:
@@ -317,7 +321,7 @@ class CatalogService:
                 existing = None
 
             if existing:
-                return CatalogServerRegisterResponse(success=False, server_id=str(existing.id), message="Server already registered", error="This server is already registered in the system")
+                return CatalogServerRegisterResponse(success=False, server_id=str(existing.id), message=CATALOG_REGISTER_ALREADY_REGISTERED_MSG, error="This server is already registered in the system")
 
             # Prepare gateway creation request using proper schema
             # First-Party

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -311,6 +311,38 @@ class TestTokenScopingMiddleware:
         assert result is False, "POST /mcp should be denied when token has only non-MCP permissions"
 
     @pytest.mark.asyncio
+    async def test_catalog_endpoint_allowed_with_servers_read_permission(self, middleware):
+        """GET /catalog must be reachable for tokens that carry servers.read.
+
+        Regression: same root cause as /rpc and /mcp — the endpoint's RBAC is
+        servers.read, but without a _PERMISSION_PATTERNS entry scoped tokens were
+        default-denied at the middleware layer.
+        """
+        result = middleware._check_permission_restrictions("/catalog", "GET", [Permissions.SERVERS_READ])
+        assert result is True, "GET /catalog should be allowed when token has servers.read"
+
+        result = middleware._check_permission_restrictions("/catalog", "GET", ["*"])
+        assert result is True, "GET /catalog should be allowed with wildcard permission"
+
+        result = middleware._check_permission_restrictions("/catalog", "GET", [Permissions.TOOLS_READ])
+        assert result is False, "GET /catalog should be denied when token lacks servers.read"
+
+    @pytest.mark.asyncio
+    async def test_catalog_register_endpoint_requires_servers_create(self, middleware):
+        """POST /catalog/{id}/register is gated on servers.create, with /v1 normalization."""
+        result = middleware._check_permission_restrictions("/catalog/asana/register", "POST", [Permissions.SERVERS_CREATE])
+        assert result is True, "POST /catalog/{id}/register should be allowed when token has servers.create"
+
+        result = middleware._check_permission_restrictions("/catalog/asana/register", "POST", ["*"])
+        assert result is True, "POST /catalog/{id}/register should be allowed with wildcard permission"
+
+        result = middleware._check_permission_restrictions("/catalog/asana/register", "POST", [Permissions.SERVERS_READ])
+        assert result is False, "POST /catalog/{id}/register should be denied for a read-only scoped token"
+
+        result = middleware._check_permission_restrictions("/v1/catalog/asana/register", "POST", [Permissions.SERVERS_CREATE])
+        assert result is True, "Versioned path should normalize to /catalog before pattern matching"
+
+    @pytest.mark.asyncio
     async def test_sse_endpoint_allowed_with_servers_use_permission(self, middleware):
         """GET /sse must be reachable for tokens that carry servers.use.
 

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -329,7 +329,11 @@ class TestTokenScopingMiddleware:
 
     @pytest.mark.asyncio
     async def test_catalog_register_endpoint_requires_servers_create(self, middleware):
-        """POST /catalog/{id}/register is gated on servers.create, with /v1 normalization."""
+        """POST /catalog/{id}/register is gated on servers.create, with /v1 normalization.
+
+        Layer 1 here gates on servers.create only: the pattern list maps one permission
+        per route. The route's stacked decorators additionally enforce gateways.create.
+        """
         result = middleware._check_permission_restrictions("/catalog/asana/register", "POST", [Permissions.SERVERS_CREATE])
         assert result is True, "POST /catalog/{id}/register should be allowed when token has servers.create"
 
@@ -341,6 +345,9 @@ class TestTokenScopingMiddleware:
 
         result = middleware._check_permission_restrictions("/v1/catalog/asana/register", "POST", [Permissions.SERVERS_CREATE])
         assert result is True, "Versioned path should normalize to /catalog before pattern matching"
+
+        result = middleware._check_permission_restrictions("/catalog/foo", "POST", [Permissions.SERVERS_CREATE])
+        assert result is False, "POST /catalog/{id} without the /register suffix must stay default-denied"
 
     @pytest.mark.asyncio
     async def test_sse_endpoint_allowed_with_servers_use_permission(self, middleware):

--- a/tests/unit/mcpgateway/routers/test_catalog.py
+++ b/tests/unit/mcpgateway/routers/test_catalog.py
@@ -133,8 +133,10 @@ def test_catalog_router_is_v1_only():
 @pytest.mark.asyncio
 async def test_register_requires_authenticated_user():
     """Calling the register endpoint without an authenticated user returns 401."""
+    request = MagicMock(spec=Request)
+
     with pytest.raises(HTTPException) as exc_info:
-        await register_catalog_server("asana", db=MagicMock())
+        await register_catalog_server("asana", request, db=MagicMock())
 
     assert exc_info.value.status_code == 401
 
@@ -149,9 +151,10 @@ async def test_register_rbac_denied_returns_403(monkeypatch):
     mock_register = AsyncMock()
     monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", mock_register)
     db = MagicMock()
+    request = MagicMock(spec=Request)
 
     with pytest.raises(HTTPException) as exc_info:
-        await register_catalog_server("asana", db=db, _user={"email": "user@example.com", "db": db})
+        await register_catalog_server("asana", request, db=db, user={"email": "user@example.com", "db": db})
 
     assert exc_info.value.status_code == 403
     assert mock_register.await_count == 0
@@ -173,9 +176,10 @@ async def test_register_requires_both_permissions(monkeypatch, denied):
     mock_register = AsyncMock()
     monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", mock_register)
     db = MagicMock()
+    request = MagicMock(spec=Request)
 
     with pytest.raises(HTTPException) as exc_info:
-        await register_catalog_server("asana", db=db, _user={"email": "user@example.com", "db": db})
+        await register_catalog_server("asana", request, db=db, user={"email": "user@example.com", "db": db})
 
     assert exc_info.value.status_code == 403
     assert mock_register.await_count == 0
@@ -193,9 +197,10 @@ async def test_register_disabled_returns_404(monkeypatch, allow_permission):
     mock_register = AsyncMock()
     monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", mock_register)
     db = MagicMock()
+    request = MagicMock(spec=Request)
 
     with pytest.raises(HTTPException) as exc_info:
-        await register_catalog_server("asana", db=db, _user={"email": "user@example.com", "db": db})
+        await register_catalog_server("asana", request, db=db, user={"email": "user@example.com", "db": db})
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.detail == "Catalog feature is disabled"
@@ -206,30 +211,42 @@ async def test_register_disabled_returns_404(monkeypatch, allow_permission):
 async def test_register_open_one_click_no_body(monkeypatch, allow_permission):
     """Registering without a body delegates with request=None and returns the envelope."""
     monkeypatch.setattr("mcpgateway.routers.catalog.settings.mcpgateway_catalog_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.routers.catalog.get_scoped_resource_access_context", MagicMock(return_value=("user@example.com", [])))
     mock_response = CatalogServerRegisterResponse(success=True, server_id="gw-1", message="Successfully registered X", error=None)
     mock_register = AsyncMock(return_value=mock_response)
     monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", mock_register)
     db = MagicMock()
+    request = MagicMock(spec=Request)
 
-    result = await register_catalog_server("asana", db=db, _user={"email": "user@example.com", "db": db})
+    result = await register_catalog_server("asana", request, db=db, user={"email": "user@example.com", "db": db})
 
     assert result == mock_response
-    assert mock_register.await_args.kwargs == {"catalog_id": "asana", "request": None, "db": db}
+    assert mock_register.await_args.kwargs == {
+        "catalog_id": "asana",
+        "request": None,
+        "db": db,
+        "created_by": "user@example.com",
+        "owner_email": "user@example.com",
+        "team_id": None,
+    }
 
 
 @pytest.mark.asyncio
 async def test_register_with_api_key_builds_request(monkeypatch, allow_permission):
     """A body with overrides is mapped onto the service request with the path id."""
     monkeypatch.setattr("mcpgateway.routers.catalog.settings.mcpgateway_catalog_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.routers.catalog.get_scoped_resource_access_context", MagicMock(return_value=("user@example.com", [])))
     mock_register = AsyncMock(return_value=CatalogServerRegisterResponse(success=True, server_id="gw-1", message="Successfully registered Custom", error=None))
     monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", mock_register)
     db = MagicMock()
+    request = MagicMock(spec=Request)
 
     await register_catalog_server(
         "asana",
+        request,
         body=CatalogServerRegisterBody(name="Custom", api_key="sk-123"),  # pragma: allowlist secret
         db=db,
-        _user={"email": "user@example.com", "db": db},
+        user={"email": "user@example.com", "db": db},
     )
 
     service_request = mock_register.await_args.kwargs["request"]
@@ -243,6 +260,7 @@ async def test_register_with_api_key_builds_request(monkeypatch, allow_permissio
 async def test_register_duplicate_returns_409(monkeypatch, allow_permission):
     """An already-registered catalog server maps to HTTP 409."""
     monkeypatch.setattr("mcpgateway.routers.catalog.settings.mcpgateway_catalog_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.routers.catalog.get_scoped_resource_access_context", MagicMock(return_value=("user@example.com", [])))
     mock_response = CatalogServerRegisterResponse(
         success=False,
         server_id="existing-id",
@@ -251,9 +269,10 @@ async def test_register_duplicate_returns_409(monkeypatch, allow_permission):
     )
     monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", AsyncMock(return_value=mock_response))
     db = MagicMock()
+    request = MagicMock(spec=Request)
 
     with pytest.raises(HTTPException) as exc_info:
-        await register_catalog_server("asana", db=db, _user={"email": "user@example.com", "db": db})
+        await register_catalog_server("asana", request, db=db, user={"email": "user@example.com", "db": db})
 
     assert exc_info.value.status_code == 409
     assert exc_info.value.detail == "Server already registered"
@@ -263,6 +282,7 @@ async def test_register_duplicate_returns_409(monkeypatch, allow_permission):
 async def test_register_unknown_id_returns_404(monkeypatch, allow_permission):
     """An unknown catalog id maps to HTTP 404."""
     monkeypatch.setattr("mcpgateway.routers.catalog.settings.mcpgateway_catalog_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.routers.catalog.get_scoped_resource_access_context", MagicMock(return_value=("user@example.com", [])))
     mock_response = CatalogServerRegisterResponse(
         success=False,
         server_id="",
@@ -271,9 +291,10 @@ async def test_register_unknown_id_returns_404(monkeypatch, allow_permission):
     )
     monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", AsyncMock(return_value=mock_response))
     db = MagicMock()
+    request = MagicMock(spec=Request)
 
     with pytest.raises(HTTPException) as exc_info:
-        await register_catalog_server("asana", db=db, _user={"email": "user@example.com", "db": db})
+        await register_catalog_server("asana", request, db=db, user={"email": "user@example.com", "db": db})
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.detail == "Catalog server not found"
@@ -283,6 +304,7 @@ async def test_register_unknown_id_returns_404(monkeypatch, allow_permission):
 async def test_register_failure_envelope_scrubs_error(monkeypatch, allow_permission):
     """Connectivity failures stay a 200 envelope but drop the raw exception text."""
     monkeypatch.setattr("mcpgateway.routers.catalog.settings.mcpgateway_catalog_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.routers.catalog.get_scoped_resource_access_context", MagicMock(return_value=("user@example.com", [])))
     mock_response = CatalogServerRegisterResponse(
         success=False,
         server_id="",
@@ -291,12 +313,50 @@ async def test_register_failure_envelope_scrubs_error(monkeypatch, allow_permiss
     )
     monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", AsyncMock(return_value=mock_response))
     db = MagicMock()
+    request = MagicMock(spec=Request)
 
-    result = await register_catalog_server("asana", db=db, _user={"email": "user@example.com", "db": db})
+    result = await register_catalog_server("asana", request, db=db, user={"email": "user@example.com", "db": db})
 
     assert result.success is False
     assert result.message == "Server is offline or unreachable"
     assert result.error is None
+
+
+@pytest.mark.asyncio
+async def test_register_forwards_identity_and_team(monkeypatch, allow_permission):
+    """The caller's identity and team are stamped onto the registered gateway."""
+    monkeypatch.setattr("mcpgateway.routers.catalog.settings.mcpgateway_catalog_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.routers.catalog.get_scoped_resource_access_context", MagicMock(return_value=("user@example.com", ["team-a"])))
+    mock_register = AsyncMock(return_value=CatalogServerRegisterResponse(success=True, server_id="gw-1", message="Successfully registered X", error=None))
+    monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", mock_register)
+    db = MagicMock()
+    request = MagicMock(spec=Request)
+    request.state.team_id = "team-a"
+
+    await register_catalog_server("asana", request, db=db, user={"email": "user@example.com", "db": db, "token_teams": ["team-a"]})
+
+    kwargs = mock_register.await_args.kwargs
+    assert kwargs["created_by"] == "user@example.com"
+    assert kwargs["owner_email"] == "user@example.com"
+    assert kwargs["team_id"] == "team-a"
+
+
+@pytest.mark.asyncio
+async def test_register_public_only_token_gets_no_team(monkeypatch, allow_permission):
+    """A public-only token registers without a team even if request state carries one."""
+    monkeypatch.setattr("mcpgateway.routers.catalog.settings.mcpgateway_catalog_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.routers.catalog.get_scoped_resource_access_context", MagicMock(return_value=("user@example.com", [])))
+    mock_register = AsyncMock(return_value=CatalogServerRegisterResponse(success=True, server_id="gw-1", message="Successfully registered X", error=None))
+    monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", mock_register)
+    db = MagicMock()
+    request = MagicMock(spec=Request)
+    request.state.team_id = "team-a"
+
+    await register_catalog_server("asana", request, db=db, user={"email": "user@example.com", "db": db, "token_teams": []})
+
+    kwargs = mock_register.await_args.kwargs
+    assert kwargs["owner_email"] == "user@example.com"
+    assert kwargs["team_id"] is None
 
 
 def test_register_body_rejects_unsafe_name():

--- a/tests/unit/mcpgateway/routers/test_catalog.py
+++ b/tests/unit/mcpgateway/routers/test_catalog.py
@@ -16,8 +16,8 @@ import pytest
 # First-Party
 from mcpgateway.api.v1 import build_legacy_router, build_v1_router
 from mcpgateway.config import settings
-from mcpgateway.routers.catalog import list_catalog_servers
-from mcpgateway.schemas import CatalogListResponse
+from mcpgateway.routers.catalog import list_catalog_servers, register_catalog_server
+from mcpgateway.schemas import CatalogListResponse, CatalogServerRegisterBody, CatalogServerRegisterRequest, CatalogServerRegisterResponse
 from tests.helpers.router_helpers import collect_routes
 
 
@@ -124,3 +124,97 @@ def test_catalog_router_is_v1_only():
     assert "/v1/catalog/" not in v1_paths
     assert "/catalog" not in legacy_paths
     assert "/catalog/" not in legacy_paths
+    assert "/v1/catalog/{catalog_id}/register" in v1_paths
+    assert "/catalog/{catalog_id}/register" not in legacy_paths
+
+
+@pytest.mark.asyncio
+async def test_register_requires_authenticated_user():
+    """Calling the register endpoint without an authenticated user returns 401."""
+    with pytest.raises(HTTPException) as exc_info:
+        await register_catalog_server("asana", db=MagicMock())
+
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_register_rbac_denied_returns_403(monkeypatch):
+    """A caller without servers.create is rejected with 403."""
+    mock_perm_service = MagicMock()
+    mock_perm_service.check_permission = AsyncMock(return_value=False)
+    monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", lambda db: mock_perm_service)
+    monkeypatch.setattr("mcpgateway.plugins.get_plugin_manager", AsyncMock(return_value=None))
+    db = MagicMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await register_catalog_server("asana", db=db, _user={"email": "user@example.com", "db": db})
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_register_disabled_returns_404(monkeypatch, allow_permission):
+    """The register endpoint returns 404 when the catalog feature is disabled."""
+    monkeypatch.setattr("mcpgateway.routers.catalog.settings.mcpgateway_catalog_enabled", False, raising=False)
+    db = MagicMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await register_catalog_server("asana", db=db, _user={"email": "user@example.com", "db": db})
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Catalog feature is disabled"
+
+
+@pytest.mark.asyncio
+async def test_register_open_one_click_no_body(monkeypatch, allow_permission):
+    """Registering without a body delegates with request=None and returns the envelope."""
+    monkeypatch.setattr("mcpgateway.routers.catalog.settings.mcpgateway_catalog_enabled", True, raising=False)
+    mock_response = CatalogServerRegisterResponse(success=True, server_id="gw-1", message="Successfully registered X", error=None)
+    mock_register = AsyncMock(return_value=mock_response)
+    monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", mock_register)
+    db = MagicMock()
+
+    result = await register_catalog_server("asana", db=db, _user={"email": "user@example.com", "db": db})
+
+    assert result == mock_response
+    assert mock_register.await_args.kwargs == {"catalog_id": "asana", "request": None, "db": db}
+
+
+@pytest.mark.asyncio
+async def test_register_with_api_key_builds_request(monkeypatch, allow_permission):
+    """A body with overrides is mapped onto the service request with the path id."""
+    monkeypatch.setattr("mcpgateway.routers.catalog.settings.mcpgateway_catalog_enabled", True, raising=False)
+    mock_register = AsyncMock(return_value=CatalogServerRegisterResponse(success=True, server_id="gw-1", message="Successfully registered Custom", error=None))
+    monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", mock_register)
+    db = MagicMock()
+
+    await register_catalog_server(
+        "asana",
+        body=CatalogServerRegisterBody(name="Custom", api_key="sk-123"),  # pragma: allowlist secret
+        db=db,
+        _user={"email": "user@example.com", "db": db},
+    )
+
+    service_request = mock_register.await_args.kwargs["request"]
+    assert isinstance(service_request, CatalogServerRegisterRequest)
+    assert service_request.server_id == "asana"
+    assert service_request.name == "Custom"
+    assert service_request.api_key == "sk-123"
+
+
+@pytest.mark.asyncio
+async def test_register_duplicate_passthrough(monkeypatch, allow_permission):
+    """Business failures are returned unchanged as a success=False envelope."""
+    monkeypatch.setattr("mcpgateway.routers.catalog.settings.mcpgateway_catalog_enabled", True, raising=False)
+    mock_response = CatalogServerRegisterResponse(
+        success=False,
+        server_id="existing-id",
+        message="Server already registered",
+        error="This server is already registered in the system",
+    )
+    monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", AsyncMock(return_value=mock_response))
+    db = MagicMock()
+
+    result = await register_catalog_server("asana", db=db, _user={"email": "user@example.com", "db": db})
+
+    assert result is mock_response

--- a/tests/unit/mcpgateway/routers/test_catalog.py
+++ b/tests/unit/mcpgateway/routers/test_catalog.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 # Third-Party
 from fastapi import APIRouter, HTTPException, Request
+import pydantic
 import pytest
 
 # First-Party
@@ -18,6 +19,7 @@ from mcpgateway.api.v1 import build_legacy_router, build_v1_router
 from mcpgateway.config import settings
 from mcpgateway.routers.catalog import list_catalog_servers, register_catalog_server
 from mcpgateway.schemas import CatalogListResponse, CatalogServerRegisterBody, CatalogServerRegisterRequest, CatalogServerRegisterResponse
+from mcpgateway.services.catalog_service import CATALOG_REGISTER_ALREADY_REGISTERED_MSG, CATALOG_REGISTER_NOT_FOUND_MSG
 from tests.helpers.router_helpers import collect_routes
 
 
@@ -139,23 +141,57 @@ async def test_register_requires_authenticated_user():
 
 @pytest.mark.asyncio
 async def test_register_rbac_denied_returns_403(monkeypatch):
-    """A caller without servers.create is rejected with 403."""
+    """A caller without the required permissions is rejected with 403 before the service runs."""
     mock_perm_service = MagicMock()
     mock_perm_service.check_permission = AsyncMock(return_value=False)
     monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", lambda db: mock_perm_service)
     monkeypatch.setattr("mcpgateway.plugins.get_plugin_manager", AsyncMock(return_value=None))
+    mock_register = AsyncMock()
+    monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", mock_register)
     db = MagicMock()
 
     with pytest.raises(HTTPException) as exc_info:
         await register_catalog_server("asana", db=db, _user={"email": "user@example.com", "db": db})
 
     assert exc_info.value.status_code == 403
+    assert mock_register.await_count == 0
+
+
+@pytest.mark.parametrize("denied", ["servers.create", "gateways.create"])
+@pytest.mark.asyncio
+async def test_register_requires_both_permissions(monkeypatch, denied):
+    """Registration needs servers.create AND gateways.create; denying either yields 403."""
+    monkeypatch.setattr("mcpgateway.routers.catalog.settings.mcpgateway_catalog_enabled", True, raising=False)
+
+    async def check_permission(**kwargs):
+        return kwargs["permission"] != denied
+
+    mock_perm_service = MagicMock()
+    mock_perm_service.check_permission = AsyncMock(side_effect=check_permission)
+    monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", lambda db: mock_perm_service)
+    monkeypatch.setattr("mcpgateway.plugins.get_plugin_manager", AsyncMock(return_value=None))
+    mock_register = AsyncMock()
+    monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", mock_register)
+    db = MagicMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await register_catalog_server("asana", db=db, _user={"email": "user@example.com", "db": db})
+
+    assert exc_info.value.status_code == 403
+    assert mock_register.await_count == 0
+
+
+def test_register_disables_admin_bypass():
+    """Platform admins must hold the permissions explicitly: no admin bypass on this route."""
+    assert register_catalog_server._allow_admin_bypass is False
 
 
 @pytest.mark.asyncio
 async def test_register_disabled_returns_404(monkeypatch, allow_permission):
-    """The register endpoint returns 404 when the catalog feature is disabled."""
+    """The register endpoint returns 404 without touching the service when the feature is disabled."""
     monkeypatch.setattr("mcpgateway.routers.catalog.settings.mcpgateway_catalog_enabled", False, raising=False)
+    mock_register = AsyncMock()
+    monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", mock_register)
     db = MagicMock()
 
     with pytest.raises(HTTPException) as exc_info:
@@ -163,6 +199,7 @@ async def test_register_disabled_returns_404(monkeypatch, allow_permission):
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.detail == "Catalog feature is disabled"
+    assert mock_register.await_count == 0
 
 
 @pytest.mark.asyncio
@@ -203,18 +240,80 @@ async def test_register_with_api_key_builds_request(monkeypatch, allow_permissio
 
 
 @pytest.mark.asyncio
-async def test_register_duplicate_passthrough(monkeypatch, allow_permission):
-    """Business failures are returned unchanged as a success=False envelope."""
+async def test_register_duplicate_returns_409(monkeypatch, allow_permission):
+    """An already-registered catalog server maps to HTTP 409."""
     monkeypatch.setattr("mcpgateway.routers.catalog.settings.mcpgateway_catalog_enabled", True, raising=False)
     mock_response = CatalogServerRegisterResponse(
         success=False,
         server_id="existing-id",
-        message="Server already registered",
+        message=CATALOG_REGISTER_ALREADY_REGISTERED_MSG,
         error="This server is already registered in the system",
+    )
+    monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", AsyncMock(return_value=mock_response))
+    db = MagicMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await register_catalog_server("asana", db=db, _user={"email": "user@example.com", "db": db})
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == "Server already registered"
+
+
+@pytest.mark.asyncio
+async def test_register_unknown_id_returns_404(monkeypatch, allow_permission):
+    """An unknown catalog id maps to HTTP 404."""
+    monkeypatch.setattr("mcpgateway.routers.catalog.settings.mcpgateway_catalog_enabled", True, raising=False)
+    mock_response = CatalogServerRegisterResponse(
+        success=False,
+        server_id="",
+        message=CATALOG_REGISTER_NOT_FOUND_MSG,
+        error="Invalid catalog server ID",
+    )
+    monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", AsyncMock(return_value=mock_response))
+    db = MagicMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await register_catalog_server("asana", db=db, _user={"email": "user@example.com", "db": db})
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Catalog server not found"
+
+
+@pytest.mark.asyncio
+async def test_register_failure_envelope_scrubs_error(monkeypatch, allow_permission):
+    """Connectivity failures stay a 200 envelope but drop the raw exception text."""
+    monkeypatch.setattr("mcpgateway.routers.catalog.settings.mcpgateway_catalog_enabled", True, raising=False)
+    mock_response = CatalogServerRegisterResponse(
+        success=False,
+        server_id="",
+        message="Server is offline or unreachable",
+        error="Traceback (most recent call last): ConnectionRefusedError: [Errno 61] Connection refused",
     )
     monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.register_catalog_server", AsyncMock(return_value=mock_response))
     db = MagicMock()
 
     result = await register_catalog_server("asana", db=db, _user={"email": "user@example.com", "db": db})
 
-    assert result is mock_response
+    assert result.success is False
+    assert result.message == "Server is offline or unreachable"
+    assert result.error is None
+
+
+def test_register_body_rejects_unsafe_name():
+    """The register body validates the name override like other named resources."""
+    with pytest.raises(pydantic.ValidationError):
+        CatalogServerRegisterBody(name="<script>alert(1)</script>")
+
+
+def test_register_body_rejects_oversized_api_key():
+    """The register body caps api_key length."""
+    with pytest.raises(pydantic.ValidationError):
+        CatalogServerRegisterBody(api_key="x" * 5000)  # pragma: allowlist secret
+
+
+def test_register_body_allows_empty_payload():
+    """Both overrides are optional."""
+    body = CatalogServerRegisterBody()
+
+    assert body.name is None
+    assert body.api_key is None

--- a/tests/unit/mcpgateway/services/test_catalog_service.py
+++ b/tests/unit/mcpgateway/services/test_catalog_service.py
@@ -437,6 +437,57 @@ async def test_register_catalog_server_oauth_without_credentials(service):
             db.refresh.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_register_forwards_identity_to_gateway_service(service):
+    """Caller identity is forwarded to gateway registration alongside the public visibility."""
+    fake_catalog = {"catalog_servers": [{"id": "1", "name": "srv", "url": "http://a", "description": "desc"}]}
+    register_gateway = AsyncMock(return_value=MagicMock(id=1, name="srv"))
+    with patch.object(service, "load_catalog", AsyncMock(return_value=fake_catalog)):
+        db = MagicMock()
+        db.execute.return_value.scalar_one_or_none.return_value = None
+        with patch("mcpgateway.services.catalog_service.select"), patch.object(service._gateway_service, "register_gateway", register_gateway):
+            result = await service.register_catalog_server("1", None, db, created_by="u@x.com", owner_email="u@x.com", team_id="t1")
+
+    assert result.success
+    kwargs = register_gateway.await_args.kwargs
+    assert kwargs["created_by"] == "u@x.com"
+    assert kwargs["owner_email"] == "u@x.com"
+    assert kwargs["team_id"] == "t1"
+    assert kwargs["visibility"] == "public"
+
+
+@pytest.mark.asyncio
+async def test_register_oauth_skip_init_stamps_owner(service):
+    """The OAuth skip-initialization path stamps the caller onto the gateway row."""
+    fake_catalog = {
+        "catalog_servers": [{"id": "oauth-server", "name": "OAuth Server", "url": "https://oauth.example.com/mcp", "description": "OAuth server", "auth_type": "OAuth2.1", "tags": []}]
+    }
+
+    with patch.object(service, "load_catalog", AsyncMock(return_value=fake_catalog)):
+        db = MagicMock()
+        db.execute.return_value.scalar_one_or_none.return_value = None
+
+        now = datetime.now(timezone.utc)
+
+        def mock_refresh(obj):
+            obj.id = "test-id"
+            obj.created_at = now
+            obj.updated_at = now
+            obj.reachable = False
+
+        db.refresh = MagicMock(side_effect=mock_refresh)
+
+        with patch("mcpgateway.services.catalog_service.select"), patch("mcpgateway.services.catalog_service.slugify", return_value="oauth-server"):
+            result = await service.register_catalog_server("oauth-server", None, db, created_by="u@x.com", owner_email="u@x.com", team_id="t1")
+
+    assert result.oauth_required is True
+    db_gateway = db.add.call_args[0][0]
+    assert db_gateway.created_by == "u@x.com"
+    assert db_gateway.owner_email == "u@x.com"
+    assert db_gateway.team_id == "t1"
+    assert db_gateway.visibility == "public"
+
+
 # ---------- Exception mapping in register_catalog_server ----------
 
 


### PR DESCRIPTION
Closes #5969

Sub-issue of #5770, extracted from #5967.

## Summary

The React catalog page lists servers from `GET /v1/catalog`, but the only way to register one was the admin router (`POST /admin/mcp-registry/{server_id}/register`). This adds a non-admin equivalent on v1:

`POST /v1/catalog/{catalog_id}/register`

- RBAC: **both** `servers.create` and `gateways.create`, each with `allow_admin_bypass=False`. Registration bottoms out in `gateway_service.register_gateway`, i.e. it creates a federated peer — the same capability the canonical `POST /v1/gateways` gates on `gateways.create` — so a `servers.create`-only token must not reach it, and platform admins need the permissions through their roles like on the admin twin
- Token-scoped via a new `_PERMISSION_PATTERNS` entry — without it, `_check_permission_restrictions` default-denies the route even for a token that holds `servers.create`. That Layer-1 list maps one permission per route; the `gateways.create` half of the conjunction is enforced by the route decorators, which run their own token-scope check per permission
- Returns 404 when `MCPGATEWAY_CATALOG_ENABLED=false`, same gate and wording as the list endpoint
- Delegates to the existing `catalog_service.register_catalog_server`, then maps its business failures onto real status codes

Business failures map to status codes on v1: unknown catalog id → **404**, already registered → **409**. Remaining failures (offline/unreachable, upstream auth failure) stay HTTP 200 with `success: false` and the service's mapped message, but the envelope's `error` field is blanked — the service fills it with raw `str(e)` exception text, which is not for non-admin eyes. The admin endpoint keeps its 200-envelope contract unchanged; no v1 clients exist yet, so this is the moment to take the status codes.

## Body schema

The body is a new minimal `CatalogServerRegisterBody` with optional `name` and `api_key`. `name` is validated through `SecurityValidator.validate_name` (same as `GatewayCreate.name`) and `api_key` is capped at 4096 characters. The existing `CatalogServerRegisterRequest` was not reused because it requires `server_id` — redundant with the path on v1 — and exposes `oauth_credentials`, which the service currently ignores (that is part of #5967). Happy to swap to the shared schema if reviewers prefer; it is a small change to the handler and two tests.

Out of scope, per the issue: OAuth config and guided setup, the `oauth_credentials` fall-through bugs (#5967), v1 disconnect/test/status, and bulk register.

## Notes for reviewers

**Base is now `main`.** Rebased per the note on #5969 that `epic/ui-rewrite` keeps React changes only. The client regeneration (`client/openapi.json`) that was in the earlier revision has been dropped — that file only exists on the epic branch, so it will ride along with the catalog UI work instead. What remains here is backend only: three `mcpgateway/` files, two test files, and the catalog doc page.

**One extra line beyond #5969's scope.** The diff also maps `GET /catalog` → `servers.read` in the same `_PERMISSION_PATTERNS` block (plus a test). That entry is what the catalog *list* page needs for permission-scoped tokens, and it belongs to #5770 — but #5770's branch is React-only now, and having two PRs insert adjacent lines into the same pattern list would conflict on merge. Folding both entries into one commit avoids that. Glad to split it into its own small PR if you would rather keep strict one-issue-per-PR; just say so.

Verified: `tests/unit/mcpgateway/routers/test_catalog.py` (18 tests), `tests/unit/mcpgateway/middleware/test_token_scoping.py`, and the `-k catalog` sweep across `tests/unit/mcpgateway` (256 tests) are green; the new dual-permission and admin-bypass tests fail without the decorator change. Also smoke-tested over HTTP with `TestClient`: 404/409/200-scrubbed/200-success envelopes, 403 for an `is_admin` caller denied `gateways.create`, and 422 for an unsafe `name` or oversized `api_key`.

