### PR TITLE
feat(ui): split MCP server drawer into Try it | Components tabs

### DIFF
--- a/client/e2e/servers.spec.ts
+++ b/client/e2e/servers.spec.ts
@@ -535,7 +535,7 @@ test.describe("MCP Servers page", () => {
 
     // Wait for the details panel to open (heading "GitHub MCP Server" appears in the panel header)
     await expect(page.getByRole("heading", { name: "GitHub MCP Server" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Components" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Components" })).toBeVisible();
   });
 
   test("shows per-page selector in the servers footer", async ({ page }) => {

--- a/client/src/components/prompts/PromptDetailsPanel.tsx
+++ b/client/src/components/prompts/PromptDetailsPanel.tsx
@@ -17,7 +17,7 @@ import { PromptDefinitionTable } from "./PromptDefinitionTable";
 
 // Segmented-control styling for the Try it / Definition tab triggers.
 const SEGMENTED_TRIGGER_CLASS =
-  "rounded-md px-3 py-1 font-medium data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm";
+  "flex-1 rounded-sm px-3 py-1.5 font-medium data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm";
 
 function DetailRow({ label, children }: { label: string; children: ReactNode }) {
   return (
@@ -180,7 +180,7 @@ export function PromptDetailsPanel({
             <div className="my-8 h-px bg-border" />
 
             <Tabs value={activeTab} onValueChange={setActiveTab}>
-              <TabsList className="inline-flex h-9 w-fit items-center gap-1 rounded-lg bg-muted p-1">
+              <TabsList className="inline-flex h-10 w-[248px] items-center gap-0 rounded-md bg-muted p-1">
                 <TabsTrigger value="tryIt" className={SEGMENTED_TRIGGER_CLASS}>
                   {intl.formatMessage({ id: "prompts.details.tab.tryIt" })}
                 </TabsTrigger>

--- a/client/src/components/servers/MCPServerDetailsPanel.test.tsx
+++ b/client/src/components/servers/MCPServerDetailsPanel.test.tsx
@@ -124,13 +124,13 @@ describe("MCPServerDetailsPanel", () => {
     expect(region).toHaveAttribute("aria-hidden", "false");
   });
 
-  it("shows the Test Connection tab with the server URL prefilled", async () => {
+  it("opens the Try it tab with the test form and the server URL prefilled", async () => {
     const user = userEvent.setup();
     renderWithProviders(
       <MCPServerDetailsPanel server={mockServer} error={null} open={true} onClose={() => {}} />,
     );
 
-    await user.click(screen.getByRole("tab", { name: /test connection/i }));
+    await user.click(screen.getByRole("tab", { name: "Try it" }));
     expect(screen.getByDisplayValue("http://test.example.com")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^test connection$/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /search components/i })).not.toBeInTheDocument();

--- a/client/src/components/servers/MCPServerDetailsPanel.test.tsx
+++ b/client/src/components/servers/MCPServerDetailsPanel.test.tsx
@@ -124,13 +124,12 @@ describe("MCPServerDetailsPanel", () => {
     expect(region).toHaveAttribute("aria-hidden", "false");
   });
 
-  it("opens the Try it tab with the test form and the server URL prefilled", async () => {
-    const user = userEvent.setup();
+  it("opens on the Try it tab by default with the test form and the server URL prefilled", async () => {
     renderWithProviders(
       <MCPServerDetailsPanel server={mockServer} error={null} open={true} onClose={() => {}} />,
     );
 
-    await user.click(screen.getByRole("tab", { name: "Try it" }));
+    expect(screen.getByRole("tab", { name: "Try it" })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByDisplayValue("http://test.example.com")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^test connection$/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /search components/i })).not.toBeInTheDocument();
@@ -145,7 +144,13 @@ describe("MCPServerDetailsPanel", () => {
     );
 
     renderWithProviders(
-      <MCPServerDetailsPanel server={mockServer} error={null} open={true} onClose={() => {}} />,
+      <MCPServerDetailsPanel
+        server={mockServer}
+        error={null}
+        open={true}
+        onClose={() => {}}
+        initialTab="components"
+      />,
     );
 
     expect(screen.getByText(/loading components/i)).toBeInTheDocument();
@@ -158,6 +163,7 @@ describe("MCPServerDetailsPanel", () => {
         error={{ message: "Failed to load server" }}
         open={true}
         onClose={() => {}}
+        initialTab="components"
       />,
     );
 
@@ -166,7 +172,13 @@ describe("MCPServerDetailsPanel", () => {
 
   it("fetches and displays tools, resources, and prompts", async () => {
     renderWithProviders(
-      <MCPServerDetailsPanel server={mockServer} error={null} open={true} onClose={() => {}} />,
+      <MCPServerDetailsPanel
+        server={mockServer}
+        error={null}
+        open={true}
+        onClose={() => {}}
+        initialTab="components"
+      />,
     );
 
     await waitFor(() => {
@@ -181,7 +193,13 @@ describe("MCPServerDetailsPanel", () => {
     const user = userEvent.setup();
 
     renderWithProviders(
-      <MCPServerDetailsPanel server={mockServer} error={null} open={true} onClose={() => {}} />,
+      <MCPServerDetailsPanel
+        server={mockServer}
+        error={null}
+        open={true}
+        onClose={() => {}}
+        initialTab="components"
+      />,
     );
 
     await waitFor(() => {
@@ -226,7 +244,13 @@ describe("MCPServerDetailsPanel", () => {
     const user = userEvent.setup();
 
     renderWithProviders(
-      <MCPServerDetailsPanel server={mockServer} error={null} open={true} onClose={() => {}} />,
+      <MCPServerDetailsPanel
+        server={mockServer}
+        error={null}
+        open={true}
+        onClose={() => {}}
+        initialTab="components"
+      />,
     );
 
     await waitFor(() => {
@@ -247,7 +271,13 @@ describe("MCPServerDetailsPanel", () => {
     const user = userEvent.setup();
 
     renderWithProviders(
-      <MCPServerDetailsPanel server={mockServer} error={null} open={true} onClose={() => {}} />,
+      <MCPServerDetailsPanel
+        server={mockServer}
+        error={null}
+        open={true}
+        onClose={() => {}}
+        initialTab="components"
+      />,
     );
 
     await waitFor(() => {
@@ -280,7 +310,13 @@ describe("MCPServerDetailsPanel", () => {
     const user = userEvent.setup();
 
     renderWithProviders(
-      <MCPServerDetailsPanel server={mockServer} error={null} open={true} onClose={() => {}} />,
+      <MCPServerDetailsPanel
+        server={mockServer}
+        error={null}
+        open={true}
+        onClose={() => {}}
+        initialTab="components"
+      />,
     );
 
     await waitFor(() => {
@@ -304,7 +340,13 @@ describe("MCPServerDetailsPanel", () => {
     const user = userEvent.setup();
 
     renderWithProviders(
-      <MCPServerDetailsPanel server={mockServer} error={null} open={true} onClose={() => {}} />,
+      <MCPServerDetailsPanel
+        server={mockServer}
+        error={null}
+        open={true}
+        onClose={() => {}}
+        initialTab="components"
+      />,
     );
 
     await waitFor(() => {
@@ -326,7 +368,13 @@ describe("MCPServerDetailsPanel", () => {
 
   it("displays component with title and identifier", async () => {
     renderWithProviders(
-      <MCPServerDetailsPanel server={mockServer} error={null} open={true} onClose={() => {}} />,
+      <MCPServerDetailsPanel
+        server={mockServer}
+        error={null}
+        open={true}
+        onClose={() => {}}
+        initialTab="components"
+      />,
     );
 
     await waitFor(() => {
@@ -339,7 +387,13 @@ describe("MCPServerDetailsPanel", () => {
 
   it("displays component without title showing only identifier", async () => {
     renderWithProviders(
-      <MCPServerDetailsPanel server={mockServer} error={null} open={true} onClose={() => {}} />,
+      <MCPServerDetailsPanel
+        server={mockServer}
+        error={null}
+        open={true}
+        onClose={() => {}}
+        initialTab="components"
+      />,
     );
 
     await waitFor(() => {
@@ -518,7 +572,13 @@ describe("MCPServerDetailsPanel", () => {
     const user = userEvent.setup();
 
     const { rerender } = renderWithProviders(
-      <MCPServerDetailsPanel server={mockServer} error={null} open={true} onClose={() => {}} />,
+      <MCPServerDetailsPanel
+        server={mockServer}
+        error={null}
+        open={true}
+        onClose={() => {}}
+        initialTab="components"
+      />,
     );
 
     await waitFor(() => {
@@ -547,7 +607,13 @@ describe("MCPServerDetailsPanel", () => {
     );
 
     rerender(
-      <MCPServerDetailsPanel server={newServer} error={null} open={true} onClose={() => {}} />,
+      <MCPServerDetailsPanel
+        server={newServer}
+        error={null}
+        open={true}
+        onClose={() => {}}
+        initialTab="components"
+      />,
     );
 
     await waitFor(() => {
@@ -566,7 +632,13 @@ describe("MCPServerDetailsPanel", () => {
     );
 
     renderWithProviders(
-      <MCPServerDetailsPanel server={mockServer} error={null} open={true} onClose={() => {}} />,
+      <MCPServerDetailsPanel
+        server={mockServer}
+        error={null}
+        open={true}
+        onClose={() => {}}
+        initialTab="components"
+      />,
     );
 
     await waitFor(() => {
@@ -584,7 +656,13 @@ describe("MCPServerDetailsPanel", () => {
     );
 
     renderWithProviders(
-      <MCPServerDetailsPanel server={mockServer} error={null} open={true} onClose={() => {}} />,
+      <MCPServerDetailsPanel
+        server={mockServer}
+        error={null}
+        open={true}
+        onClose={() => {}}
+        initialTab="components"
+      />,
     );
 
     await waitFor(() => {
@@ -607,7 +685,13 @@ describe("MCPServerDetailsPanel", () => {
     );
 
     renderWithProviders(
-      <MCPServerDetailsPanel server={mockServer} error={null} open={true} onClose={() => {}} />,
+      <MCPServerDetailsPanel
+        server={mockServer}
+        error={null}
+        open={true}
+        onClose={() => {}}
+        initialTab="components"
+      />,
     );
 
     await waitFor(() => {
@@ -620,7 +704,13 @@ describe("MCPServerDetailsPanel", () => {
 
   it("displays component badges with correct types", async () => {
     renderWithProviders(
-      <MCPServerDetailsPanel server={mockServer} error={null} open={true} onClose={() => {}} />,
+      <MCPServerDetailsPanel
+        server={mockServer}
+        error={null}
+        open={true}
+        onClose={() => {}}
+        initialTab="components"
+      />,
     );
 
     await waitFor(() => {
@@ -651,7 +741,13 @@ describe("MCPServerDetailsPanel", () => {
 
   it("displays activity timestamps from camelCase fields", async () => {
     renderWithProviders(
-      <MCPServerDetailsPanel server={mockServer} error={null} open={true} onClose={() => {}} />,
+      <MCPServerDetailsPanel
+        server={mockServer}
+        error={null}
+        open={true}
+        onClose={() => {}}
+        initialTab="components"
+      />,
     );
 
     await waitFor(() => {
@@ -665,7 +761,13 @@ describe("MCPServerDetailsPanel", () => {
 
   it("displays copy buttons for identifiers", async () => {
     renderWithProviders(
-      <MCPServerDetailsPanel server={mockServer} error={null} open={true} onClose={() => {}} />,
+      <MCPServerDetailsPanel
+        server={mockServer}
+        error={null}
+        open={true}
+        onClose={() => {}}
+        initialTab="components"
+      />,
     );
 
     await waitFor(() => {
@@ -706,7 +808,13 @@ describe("MCPServerDetailsPanel", () => {
     it("copies titled and untitled component identifiers", async () => {
       const user = userEvent.setup();
       renderWithProviders(
-        <MCPServerDetailsPanel server={mockServer} error={null} open onClose={() => {}} />,
+        <MCPServerDetailsPanel
+          server={mockServer}
+          error={null}
+          open
+          onClose={() => {}}
+          initialTab="components"
+        />,
       );
 
       // A titled tool copies via its title label; an untitled one via its identifier.
@@ -720,7 +828,13 @@ describe("MCPServerDetailsPanel", () => {
     it("moves the active component tab with arrow keys", async () => {
       const user = userEvent.setup();
       renderWithProviders(
-        <MCPServerDetailsPanel server={mockServer} error={null} open onClose={() => {}} />,
+        <MCPServerDetailsPanel
+          server={mockServer}
+          error={null}
+          open
+          onClose={() => {}}
+          initialTab="components"
+        />,
       );
       await screen.findByRole("button", { name: "Copy Tool One" });
 
@@ -804,7 +918,13 @@ describe("MCPServerDetailsPanel", () => {
     it("collapses the search box on blur when empty", async () => {
       const user = userEvent.setup();
       renderWithProviders(
-        <MCPServerDetailsPanel server={mockServer} error={null} open onClose={() => {}} />,
+        <MCPServerDetailsPanel
+          server={mockServer}
+          error={null}
+          open
+          onClose={() => {}}
+          initialTab="components"
+        />,
       );
       await screen.findByRole("button", { name: "Copy Tool One" });
 

--- a/client/src/components/servers/MCPServerDetailsPanel.tsx
+++ b/client/src/components/servers/MCPServerDetailsPanel.tsx
@@ -24,22 +24,25 @@ import type { MCPServer as BaseMCPServer, VirtualServerTag } from "@/types/serve
 import { copyToClipboard } from "@/lib/clipboard";
 import { useQuery } from "@/hooks/useQuery";
 import { TestConnectionPanel } from "./TestConnectionPanel";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 interface MCPServer extends BaseMCPServer {
   tags?: Array<string | VirtualServerTag>;
 }
 
 type ComponentTab = "all" | "tools" | "resources" | "prompts";
-// Kept separate from ComponentTab so the component-filtering logic stays typed to real kinds.
-type DrawerTab = ComponentTab | "test";
+type TopTab = "tryit" | "components";
 
-const TABS: Array<{ value: DrawerTab; label: string }> = [
+const TABS: Array<{ value: ComponentTab; label: string }> = [
   { value: "all", label: "All" },
   { value: "tools", label: "Tools" },
   { value: "resources", label: "Resources" },
   { value: "prompts", label: "Prompts" },
-  { value: "test", label: "Test Connection" },
 ];
+
+// Segmented-control styling for the Try it / Components tab triggers.
+const SEGMENTED_TRIGGER_CLASS =
+  "rounded-md px-3 py-1 font-medium data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm";
 
 interface Tool {
   id: string;
@@ -138,7 +141,8 @@ export function MCPServerDetailsPanel({
    */
   onAddTag?: (serverId: string, tags: string[]) => Promise<void>;
 }) {
-  const [activeTab, setActiveTab] = useState<DrawerTab>("all");
+  const [topTab, setTopTab] = useState<TopTab>("components");
+  const [activeTab, setActiveTab] = useState<ComponentTab>("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [isSearchExpanded, setIsSearchExpanded] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -148,6 +152,7 @@ export function MCPServerDetailsPanel({
 
   // Reset tab and search when server changes
   useEffect(() => {
+    setTopTab("components");
     setActiveTab("all");
     setSearchQuery("");
     setIsSearchExpanded(false);
@@ -259,7 +264,7 @@ export function MCPServerDetailsPanel({
   }, []);
 
   const handleTabKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLButtonElement>, currentValue: DrawerTab) => {
+    (e: KeyboardEvent<HTMLButtonElement>, currentValue: ComponentTab) => {
       if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
       e.preventDefault();
       const currentIndex = TABS.findIndex((t) => t.value === currentValue);
@@ -273,8 +278,6 @@ export function MCPServerDetailsPanel({
     },
     [],
   );
-
-  const isTestTab = activeTab === "test";
 
   return (
     <>
@@ -333,168 +336,175 @@ export function MCPServerDetailsPanel({
 
               <div className="my-8 h-px bg-border" />
 
-              {/* Rendered on every tab so the row below doesn't shift when switching. */}
-              <div className="flex items-center justify-between gap-4">
-                <h3 className="text-sm font-semibold text-foreground">
-                  {isTestTab ? "Test connection" : "Components"}
-                </h3>
-              </div>
+              <Tabs value={topTab} onValueChange={(v) => setTopTab(v as TopTab)}>
+                <TabsList className="inline-flex h-9 w-fit items-center gap-1 rounded-lg bg-muted p-1">
+                  <TabsTrigger value="tryit" className={SEGMENTED_TRIGGER_CLASS}>
+                    Try it
+                  </TabsTrigger>
+                  <TabsTrigger value="components" className={SEGMENTED_TRIGGER_CLASS}>
+                    Components
+                  </TabsTrigger>
+                </TabsList>
 
-              <div className="mt-8 flex min-w-0 items-center justify-between gap-6">
-                <div
-                  role="tablist"
-                  aria-label="Filter components"
-                  className="flex min-w-0 items-center gap-6"
-                >
-                  {TABS.map((tab) => (
-                    <Button
-                      key={tab.value}
-                      id={`tab-${tab.value}`}
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      role="tab"
-                      aria-selected={activeTab === tab.value}
-                      tabIndex={activeTab === tab.value ? 0 : -1}
-                      className={`text-sm font-semibold transition-colors ${
-                        activeTab === tab.value
-                          ? "text-foreground"
-                          : "text-muted-foreground hover:text-foreground"
-                      }`}
-                      onClick={() => setActiveTab(tab.value)}
-                      onKeyDown={(e) => handleTabKeyDown(e, tab.value)}
+                <TabsContent value="components" className="mt-8">
+                  <div className="flex min-w-0 items-center justify-between gap-6">
+                    <div
+                      role="tablist"
+                      aria-label="Filter components"
+                      className="flex min-w-0 items-center gap-6"
                     >
-                      {tab.label}
-                    </Button>
-                  ))}
-                </div>
-
-                {!isTestTab && (
-                  <div className="flex items-center gap-2">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-xs"
-                      onClick={() => searchInputRef.current?.focus()}
-                      className="size-8 rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                      aria-label="Search components"
-                    >
-                      <Search className="size-4" />
-                    </Button>
-                    <Input
-                      ref={searchInputRef}
-                      type="search"
-                      aria-label="Search components"
-                      tabIndex={isSearchExpanded || searchQuery.length > 0 ? 0 : -1}
-                      value={searchQuery}
-                      onChange={(e) => setSearchQuery(e.target.value)}
-                      onFocus={() => setIsSearchExpanded(true)}
-                      onBlur={() => setIsSearchExpanded(searchQuery.length > 0)}
-                      placeholder={isSearchExpanded || searchQuery.length > 0 ? "Search..." : ""}
-                      className={cn(
-                        "h-8 rounded-md border-border bg-muted/50 text-sm shadow-none transition-[width,padding,color,background-color,border-color] duration-200 ease-out placeholder:text-muted-foreground focus-visible:bg-background",
-                        isSearchExpanded || searchQuery.length > 0
-                          ? "w-48 px-3 text-foreground"
-                          : "w-0 px-0 text-transparent caret-foreground border-transparent",
-                      )}
-                    />
-                  </div>
-                )}
-              </div>
-
-              {error && (
-                <div
-                  role="alert"
-                  className="mt-6 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
-                >
-                  {error.message}
-                </div>
-              )}
-
-              <div
-                role="tabpanel"
-                aria-labelledby={`tab-${activeTab}`}
-                className="mt-5 divide-y divide-transparent"
-              >
-                {isTestTab && <TestConnectionPanel key={server.id} serverUrl={server.url} />}
-
-                {!isTestTab && componentsLoading && (
-                  <div
-                    role="status"
-                    aria-live="polite"
-                    className="flex items-center gap-2 py-8 text-muted-foreground"
-                  >
-                    <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-                    <span>Loading components...</span>
-                  </div>
-                )}
-
-                {!isTestTab && !componentsLoading && visibleComponents.length === 0 && (
-                  <div className="py-8 text-sm text-muted-foreground">
-                    No {activeTab === "all" ? "components" : activeTab} found
-                  </div>
-                )}
-
-                {!isTestTab &&
-                  !componentsLoading &&
-                  visibleComponents.map((component) => {
-                    const title = component.title;
-                    const identifier =
-                      component.type === "resources" ? component.uri : component.originalName;
-
-                    return (
-                      <div
-                        key={`${component.type}-${component.id}`}
-                        className="grid min-h-10 grid-cols-[128px_minmax(0,1fr)_minmax(180px,0.9fr)] items-center gap-4 py-1 text-sm"
-                      >
-                        <Badge
-                          variant="draft"
-                          className="w-fit rounded-md px-2 py-0.5 text-[12px] font-medium text-muted-foreground"
+                      {TABS.map((tab) => (
+                        <Button
+                          key={tab.value}
+                          id={`tab-${tab.value}`}
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          role="tab"
+                          aria-selected={activeTab === tab.value}
+                          tabIndex={activeTab === tab.value ? 0 : -1}
+                          className={`text-sm font-semibold transition-colors ${
+                            activeTab === tab.value
+                              ? "text-foreground"
+                              : "text-muted-foreground hover:text-foreground"
+                          }`}
+                          onClick={() => setActiveTab(tab.value)}
+                          onKeyDown={(e) => handleTabKeyDown(e, tab.value)}
                         >
-                          <span className="mr-1.5 inline-flex">
-                            {getComponentIcon(component.type)}
-                          </span>
-                          {component.type.slice(0, -1)}
-                        </Badge>
-                        {title ? (
-                          <>
-                            <span className="min-w-0 truncate text-muted-foreground">{title}</span>
-                            <span className="flex min-w-0 items-center gap-2 font-mono text-[13px] text-muted-foreground">
-                              <span className="truncate">{identifier}</span>
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon-xs"
-                                aria-label={`Copy ${title}`}
-                                className="size-5 text-muted-foreground"
-                                onClick={() => copyToClipboard(identifier)}
-                              >
-                                <Copy className="size-3.5" />
-                              </Button>
-                            </span>
-                          </>
-                        ) : (
-                          <>
-                            <span className="flex min-w-0 items-center gap-2 font-mono text-[13px] text-muted-foreground">
-                              <span className="truncate">{identifier}</span>
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon-xs"
-                                aria-label={`Copy ${identifier}`}
-                                className="size-5 text-muted-foreground"
-                                onClick={() => copyToClipboard(identifier)}
-                              >
-                                <Copy className="size-3.5" />
-                              </Button>
-                            </span>
-                            <span aria-hidden="true" />
-                          </>
+                          {tab.label}
+                        </Button>
+                      ))}
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-xs"
+                        onClick={() => searchInputRef.current?.focus()}
+                        className="size-8 rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                        aria-label="Search components"
+                      >
+                        <Search className="size-4" />
+                      </Button>
+                      <Input
+                        ref={searchInputRef}
+                        type="search"
+                        aria-label="Search components"
+                        tabIndex={isSearchExpanded || searchQuery.length > 0 ? 0 : -1}
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        onFocus={() => setIsSearchExpanded(true)}
+                        onBlur={() => setIsSearchExpanded(searchQuery.length > 0)}
+                        placeholder={isSearchExpanded || searchQuery.length > 0 ? "Search..." : ""}
+                        className={cn(
+                          "h-8 rounded-md border-border bg-muted/50 text-sm shadow-none transition-[width,padding,color,background-color,border-color] duration-200 ease-out placeholder:text-muted-foreground focus-visible:bg-background",
+                          isSearchExpanded || searchQuery.length > 0
+                            ? "w-48 px-3 text-foreground"
+                            : "w-0 px-0 text-transparent caret-foreground border-transparent",
                         )}
+                      />
+                    </div>
+                  </div>
+
+                  {error && (
+                    <div
+                      role="alert"
+                      className="mt-6 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                    >
+                      {error.message}
+                    </div>
+                  )}
+
+                  <div
+                    role="tabpanel"
+                    aria-labelledby={`tab-${activeTab}`}
+                    className="mt-5 divide-y divide-transparent"
+                  >
+                    {componentsLoading && (
+                      <div
+                        role="status"
+                        aria-live="polite"
+                        className="flex items-center gap-2 py-8 text-muted-foreground"
+                      >
+                        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                        <span>Loading components...</span>
                       </div>
-                    );
-                  })}
-              </div>
+                    )}
+
+                    {!componentsLoading && visibleComponents.length === 0 && (
+                      <div className="py-8 text-sm text-muted-foreground">
+                        No {activeTab === "all" ? "components" : activeTab} found
+                      </div>
+                    )}
+
+                    {!componentsLoading &&
+                      visibleComponents.map((component) => {
+                        const title = component.title;
+                        const identifier =
+                          component.type === "resources" ? component.uri : component.originalName;
+
+                        return (
+                          <div
+                            key={`${component.type}-${component.id}`}
+                            className="grid min-h-10 grid-cols-[128px_minmax(0,1fr)_minmax(180px,0.9fr)] items-center gap-4 py-1 text-sm"
+                          >
+                            <Badge
+                              variant="draft"
+                              className="w-fit rounded-md px-2 py-0.5 text-[12px] font-medium text-muted-foreground"
+                            >
+                              <span className="mr-1.5 inline-flex">
+                                {getComponentIcon(component.type)}
+                              </span>
+                              {component.type.slice(0, -1)}
+                            </Badge>
+                            {title ? (
+                              <>
+                                <span className="min-w-0 truncate text-muted-foreground">
+                                  {title}
+                                </span>
+                                <span className="flex min-w-0 items-center gap-2 font-mono text-[13px] text-muted-foreground">
+                                  <span className="truncate">{identifier}</span>
+                                  <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon-xs"
+                                    aria-label={`Copy ${title}`}
+                                    className="size-5 text-muted-foreground"
+                                    onClick={() => copyToClipboard(identifier)}
+                                  >
+                                    <Copy className="size-3.5" />
+                                  </Button>
+                                </span>
+                              </>
+                            ) : (
+                              <>
+                                <span className="flex min-w-0 items-center gap-2 font-mono text-[13px] text-muted-foreground">
+                                  <span className="truncate">{identifier}</span>
+                                  <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon-xs"
+                                    aria-label={`Copy ${identifier}`}
+                                    className="size-5 text-muted-foreground"
+                                    onClick={() => copyToClipboard(identifier)}
+                                  >
+                                    <Copy className="size-3.5" />
+                                  </Button>
+                                </span>
+                                <span aria-hidden="true" />
+                              </>
+                            )}
+                          </div>
+                        );
+                      })}
+                  </div>
+                </TabsContent>
+
+                <TabsContent value="tryit" className="mt-8">
+                  <TestConnectionPanel key={server.id} serverUrl={server.url} />
+                </TabsContent>
+              </Tabs>
             </div>
 
             <aside className="relative border-t border-border bg-background lg:border-l lg:border-t-0">

--- a/client/src/components/servers/MCPServerDetailsPanel.tsx
+++ b/client/src/components/servers/MCPServerDetailsPanel.tsx
@@ -128,12 +128,15 @@ export function MCPServerDetailsPanel({
   error,
   open,
   onClose,
+  initialTab = "tryit",
   onAddTag,
 }: {
   server: MCPServer | null;
   error: { message: string } | null;
   open: boolean;
   onClose: () => void;
+  /** Tab to select each time the panel opens. Defaults to "tryit". */
+  initialTab?: TopTab;
   /**
    * Persists the server's full tag list after an inline add. Receives the server
    * (gateway) ID and the new complete list of tag labels. When omitted, the tag
@@ -141,7 +144,7 @@ export function MCPServerDetailsPanel({
    */
   onAddTag?: (serverId: string, tags: string[]) => Promise<void>;
 }) {
-  const [topTab, setTopTab] = useState<TopTab>("components");
+  const [topTab, setTopTab] = useState<TopTab>(initialTab);
   const [activeTab, setActiveTab] = useState<ComponentTab>("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [isSearchExpanded, setIsSearchExpanded] = useState(false);
@@ -152,11 +155,18 @@ export function MCPServerDetailsPanel({
 
   // Reset tab and search when server changes
   useEffect(() => {
-    setTopTab("components");
+    setTopTab(initialTab);
     setActiveTab("all");
     setSearchQuery("");
     setIsSearchExpanded(false);
-  }, [server?.id]);
+  }, [server?.id, initialTab]);
+
+  // Land on `initialTab` (default "Try it") each time the panel opens, regardless
+  // of which tab was active when it was last closed. Keyed on `open` only so a
+  // data refetch while the panel is open doesn't yank the user off their tab.
+  useEffect(() => {
+    if (open) setTopTab(initialTab);
+  }, [open, initialTab]);
 
   // Focus close on open; restore focus on close/unmount.
   useEffect(() => {

--- a/client/src/components/servers/MCPServerDetailsPanel.tsx
+++ b/client/src/components/servers/MCPServerDetailsPanel.tsx
@@ -346,7 +346,11 @@ export function MCPServerDetailsPanel({
 
               <div className="my-8 h-px bg-border" />
 
-              <Tabs value={topTab} onValueChange={(v) => setTopTab(v as TopTab)}>
+              <Tabs
+                value={topTab}
+                onValueChange={(v) => setTopTab(v as TopTab)}
+                aria-label="Server details view"
+              >
                 <TabsList className="inline-flex h-10 w-[248px] items-center gap-0 rounded-md bg-muted p-1">
                   <TabsTrigger value="tryit" className={SEGMENTED_TRIGGER_CLASS}>
                     Try it

--- a/client/src/components/servers/MCPServerDetailsPanel.tsx
+++ b/client/src/components/servers/MCPServerDetailsPanel.tsx
@@ -42,7 +42,7 @@ const TABS: Array<{ value: ComponentTab; label: string }> = [
 
 // Segmented-control styling for the Try it / Components tab triggers.
 const SEGMENTED_TRIGGER_CLASS =
-  "rounded-md px-3 py-1 font-medium data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm";
+  "flex-1 rounded-sm px-3 py-1.5 font-medium data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm";
 
 interface Tool {
   id: string;
@@ -347,7 +347,7 @@ export function MCPServerDetailsPanel({
               <div className="my-8 h-px bg-border" />
 
               <Tabs value={topTab} onValueChange={(v) => setTopTab(v as TopTab)}>
-                <TabsList className="inline-flex h-9 w-fit items-center gap-1 rounded-lg bg-muted p-1">
+                <TabsList className="inline-flex h-10 w-[248px] items-center gap-0 rounded-md bg-muted p-1">
                   <TabsTrigger value="tryit" className={SEGMENTED_TRIGGER_CLASS}>
                     Try it
                   </TabsTrigger>

--- a/client/src/components/servers/TestConnectionPanel.tsx
+++ b/client/src/components/servers/TestConnectionPanel.tsx
@@ -392,8 +392,11 @@ export function TestConnectionPanel({ serverUrl }: TestConnectionPanelProps) {
         </div>
 
         {/* Right column — action button + response panel */}
-        <div className="flex flex-col gap-3">
-          <div className="flex justify-end gap-3">
+        <div className="flex flex-col gap-2">
+          {/* Mirror the left column's label row: a fixed label-height band so the
+              response panel below lines up with the URL input. The button is taller
+              than the band and overflows it upward instead of pushing the panel down. */}
+          <div className="flex h-5 items-end justify-end gap-3">
             {isTesting && (
               <Button variant="ghost" onClick={handleCancel}>
                 Cancel
@@ -413,7 +416,7 @@ export function TestConnectionPanel({ serverUrl }: TestConnectionPanelProps) {
             </Button>
           </div>
 
-          <div className="flex min-h-[300px] flex-col overflow-hidden rounded-md border border-input bg-transparent">
+          <div className="flex min-h-[200px] flex-1 flex-col overflow-hidden rounded-md border border-input bg-transparent">
             {status === "idle" && (
               <div className="flex flex-1 items-center justify-center p-6 text-center">
                 <p className="text-sm text-muted-foreground">
@@ -441,7 +444,7 @@ export function TestConnectionPanel({ serverUrl }: TestConnectionPanelProps) {
                     variant="ghost"
                     size="icon-xs"
                     aria-label="Copy response body"
-                    className="absolute right-2 top-2 size-6 bg-neutral-800/80 text-neutral-400 hover:bg-neutral-700 hover:text-neutral-100"
+                    className="absolute right-2 top-2 size-6 bg-background/80 text-muted-foreground backdrop-blur-sm hover:bg-muted hover:text-foreground"
                     onClick={() => copyToClipboard(responseBodyText)}
                   >
                     <Copy className="size-3.5" />

--- a/client/src/components/servers/TestConnectionPanel.tsx
+++ b/client/src/components/servers/TestConnectionPanel.tsx
@@ -228,8 +228,8 @@ export function TestConnectionPanel({ serverUrl }: TestConnectionPanelProps) {
   const hasResult = status === "success" || status === "error";
 
   return (
-    <div className="space-y-6">
-      <div className="grid gap-6 md:grid-cols-2">
+    <div className="@container space-y-6">
+      <div className="grid gap-6 @3xl:grid-cols-2">
         {/* Left column — request form */}
         <div className="space-y-4">
           {/* URL */}

--- a/client/src/components/servers/TestConnectionPanel.tsx
+++ b/client/src/components/servers/TestConnectionPanel.tsx
@@ -471,7 +471,7 @@ export function TestConnectionPanel({ serverUrl }: TestConnectionPanelProps) {
                 {responseBodyText && (
                   <div className="mt-2 space-y-1">
                     <p className="text-[13px] text-muted-foreground">Response body:</p>
-                    <pre className="overflow-auto text-[13px] leading-relaxed break-words whitespace-pre-wrap text-foreground">
+                    <pre className="max-h-[420px] overflow-auto text-[13px] leading-relaxed break-words whitespace-pre-wrap text-foreground">
                       <code className="break-words">
                         <JsonHighlighter text={responseBodyText} />
                       </code>

--- a/client/src/components/servers/TestConnectionPanel.tsx
+++ b/client/src/components/servers/TestConnectionPanel.tsx
@@ -391,87 +391,94 @@ export function TestConnectionPanel({ serverUrl }: TestConnectionPanelProps) {
           )}
         </div>
 
-        {/* Right column — response panel */}
-        <div className="flex min-h-[300px] flex-col overflow-hidden rounded-md border border-input bg-transparent">
-          {status === "idle" && (
-            <div className="flex flex-1 items-center justify-center p-6 text-center">
-              <p className="text-sm text-muted-foreground">Run a test to see the response here.</p>
-            </div>
-          )}
-
-          {isTesting && (
-            <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6">
-              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-              <p className="text-sm text-muted-foreground">Running test…</p>
-            </div>
-          )}
-
-          {hasResult && (
-            <div
-              className="relative flex flex-1 flex-col gap-2 overflow-auto p-4"
-              role={status === "error" ? "alert" : "status"}
-              aria-live="polite"
-            >
-              {responseBodyText && (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  aria-label="Copy response body"
-                  className="absolute right-2 top-2 size-6 bg-neutral-800/80 text-neutral-400 hover:bg-neutral-700 hover:text-neutral-100"
-                  onClick={() => copyToClipboard(responseBodyText)}
-                >
-                  <Copy className="size-3.5" />
-                </Button>
+        {/* Right column — action button + response panel */}
+        <div className="flex flex-col gap-3">
+          <div className="flex justify-end gap-3">
+            {isTesting && (
+              <Button variant="ghost" onClick={handleCancel}>
+                Cancel
+              </Button>
+            )}
+            <Button onClick={handleTest} disabled={isTesting}>
+              {isTesting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Running test…
+                </>
+              ) : hasResult ? (
+                "Re-test connection"
+              ) : (
+                "Test connection"
               )}
+            </Button>
+          </div>
 
-              <div className="flex items-start gap-2 pr-8">
-                {status === "success" ? (
-                  <CircleCheck className="mt-0.5 size-4 shrink-0 text-green-500" />
-                ) : (
-                  <CircleAlert className="mt-0.5 size-4 shrink-0 text-destructive" />
-                )}
-                <span className="text-sm font-medium break-words text-foreground">{headline}</span>
-              </div>
-
-              {response && (
-                <p className="pl-6 text-[13px] text-muted-foreground">
-                  Latency: {response.latencyMs} ms
+          <div className="flex min-h-[300px] flex-col overflow-hidden rounded-md border border-input bg-transparent">
+            {status === "idle" && (
+              <div className="flex flex-1 items-center justify-center p-6 text-center">
+                <p className="text-sm text-muted-foreground">
+                  Run a test to see the response here.
                 </p>
-              )}
+              </div>
+            )}
 
-              {responseBodyText && (
-                <div className="mt-2 space-y-1">
-                  <p className="text-[13px] text-muted-foreground">Response body:</p>
-                  <pre className="overflow-auto text-[13px] leading-relaxed break-words whitespace-pre-wrap text-foreground">
-                    <code className="break-words">
-                      <JsonHighlighter text={responseBodyText} />
-                    </code>
-                  </pre>
+            {isTesting && (
+              <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                <p className="text-sm text-muted-foreground">Running test…</p>
+              </div>
+            )}
+
+            {hasResult && (
+              <div
+                className="relative flex flex-1 flex-col gap-2 overflow-auto p-4"
+                role={status === "error" ? "alert" : "status"}
+                aria-live="polite"
+              >
+                {responseBodyText && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    aria-label="Copy response body"
+                    className="absolute right-2 top-2 size-6 bg-neutral-800/80 text-neutral-400 hover:bg-neutral-700 hover:text-neutral-100"
+                    onClick={() => copyToClipboard(responseBodyText)}
+                  >
+                    <Copy className="size-3.5" />
+                  </Button>
+                )}
+
+                <div className="flex items-start gap-2 pr-8">
+                  {status === "success" ? (
+                    <CircleCheck className="mt-0.5 size-4 shrink-0 text-green-500" />
+                  ) : (
+                    <CircleAlert className="mt-0.5 size-4 shrink-0 text-destructive" />
+                  )}
+                  <span className="text-sm font-medium break-words text-foreground">
+                    {headline}
+                  </span>
                 </div>
-              )}
-            </div>
-          )}
+
+                {response && (
+                  <p className="pl-6 text-[13px] text-muted-foreground">
+                    Latency: {response.latencyMs} ms
+                  </p>
+                )}
+
+                {responseBodyText && (
+                  <div className="mt-2 space-y-1">
+                    <p className="text-[13px] text-muted-foreground">Response body:</p>
+                    <pre className="overflow-auto text-[13px] leading-relaxed break-words whitespace-pre-wrap text-foreground">
+                      <code className="break-words">
+                        <JsonHighlighter text={responseBodyText} />
+                      </code>
+                    </pre>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
         </div>
-      </div>
-
-      <div className="flex items-center gap-3">
-        <Button onClick={handleTest} disabled={isTesting}>
-          {isTesting ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Running test…
-            </>
-          ) : (
-            "Test connection"
-          )}
-        </Button>
-
-        {isTesting && (
-          <Button variant="ghost" onClick={handleCancel}>
-            Cancel
-          </Button>
-        )}
       </div>
     </div>
   );


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

# Pull Request

## 🔗 Related Issue

Closes #5963 

---

## 📝 Summary


https://github.com/user-attachments/assets/cb64bbb4-7a7c-4427-9c0a-6d2bb3d3134e



Follow-up to #5648 (shipped in #5928). Splits the MCP server details drawer into a top-level **`Try it` / `Components`** segmented tab shell, per the reviewer's design, separating the connection-testing affordance from the server's tools/resources/prompts. Matches the drawer-tab pattern used by Prompts (#5448), Resources (#5593), and Tools (#5630).

- Wraps the drawer body in a shadcn `<Tabs>` shell with two panes, styled to match the Prompts drawer's segmented control.
- **Components** tab keeps today's layout: the `All / Tools / Resources / Prompts` sub-tabs, search, and component list — unchanged, just nested under this tab.
- **Try it** tab renders the existing `TestConnectionPanel` (URL, method, path, headers, body, content-type, in-flight cancel, and response rendering — all preserved).
- Moves the **Test connection** button to the top-right of the response column and relabels it to **"Re-test connection"** after a result, per the mockup.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

Client toolchain:

| Check | Command | Status |
|---|---|---|
| Lint | `cd client && npm run lint` | ✅ clean |
| Unit tests | `cd client && npm run test:run` | ✅ full suite green |
| Type check | `cd client && npx tsc -b` | ✅ clean |

Manual verification against a local gateway:

1. Drawer opens on **Components** with the existing tools/resources/prompts list unchanged.
2. **Try it** tab shows the test form with the URL prefilled and the button positioned at the top-right. Running a test renders a real response and relabels the button to **"Re-test connection"**.
3. In-flight cancellation and tab switching behave correctly.

---

## ✅ Checklist

- [x] Code formatted (ESLint/Prettier via the `client` toolchain)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

- **Files (3):** `MCPServerDetailsPanel.tsx` (tab shell), `TestConnectionPanel.tsx` (button placement and "Re-test connection" relabel), and `MCPServerDetailsPanel.test.tsx` (drawer-tab test). Much of the drawer diff is re-indentation from nesting the existing component list under the Components tab. The real change is approximately 30 lines; use GitHub's **Hide whitespace** option to see it clearly.
- **Default tab:** Opens on **Components**, matching the server's prior behaviour. The mockup frames the **Try it** tab to demonstrate the test feature; happy to flip the default to **Try it** if preferred.