### PR TITLE
fix: scope API token name uniqueness to active tokens (#5931)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Fixed
 
 - Fixed RBAC seeder race condition that produced HTTP 500 under concurrent bootstrap: added partial unique indexes on `roles(name, scope) WHERE is_active` and `user_roles` equivalent columns, plus savepoint/retry in `RoleService.create_role()` and `assign_role_to_user()`. The migration (`d21698ae4a19`) now also remaps `user_roles.role_id` from duplicate roles to the kept role before deactivating the duplicates (so `list_user_roles()` joins remain intact), and prefers unexpired / most-recently-granted assignments when deduplicating user-role rows (#4636)
+- Fixed revoked API token names not being reusable: uniqueness on `email_api_tokens (user_email, name, team_id)` is now scoped to active tokens via partial unique indexes, so revoking a token frees its name for reuse (migration `a7b8c9d0e1f2`) (#5931)
 - **Startup secret validation** - `JWT_SECRET_KEY`, `AUTH_ENCRYPTION_SECRET`, and `BASIC_AUTH_PASSWORD` are validated at startup with a minimum 32-byte length requirement and a comprehensive blocklist of known-weak values. Weak secrets previously only rejected in non-development environments now fail unconditionally across all environments.
 - **Hardened Helm chart defaults** - `JWT_SECRET_KEY` in `charts/mcp-stack/values.yaml` now defaults to an empty string with deployment guidance, rather than shipping a sample weak key.
 - **Docker Compose and entrypoint hardening** - Compose `:?` variable guards and entrypoint secret checks updated to match the new enforcement policy.

--- a/mcpgateway/alembic/versions/a7b8c9d0e1f2_scope_token_name_uniqueness_to_active.py
+++ b/mcpgateway/alembic/versions/a7b8c9d0e1f2_scope_token_name_uniqueness_to_active.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=no-member
+"""Location: ./mcpgateway/alembic/versions/a7b8c9d0e1f2_scope_token_name_uniqueness_to_active.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+scope token name uniqueness to active tokens
+
+Fixes issue #5931 - a revoked API token permanently blocks its name.
+
+Token revocation is a soft delete (is_active = false, row kept for audit), but
+the uniqueness rules on email_api_tokens covered ALL rows, so a revoked token's
+name could never be reused. The service-level duplicate check in
+TokenCatalogService.create_token() already filters on is_active, so the intended
+semantics are "names unique among active tokens". This migration aligns the
+database with that intent:
+
+1. Drops the all-rows UniqueConstraint uq_email_api_tokens_user_name_team
+   (user_email, name, team_id).
+2. Drops the all-rows partial unique index uq_email_api_tokens_user_name_global
+   (user_email, name) WHERE team_id IS NULL.
+3. Recreates both as partial unique indexes filtered on is_active:
+   - uq_email_api_tokens_user_name_team   -> (user_email, name, team_id)
+     WHERE team_id IS NOT NULL AND is_active
+   - uq_email_api_tokens_user_name_global -> (user_email, name)
+     WHERE team_id IS NULL AND is_active
+
+No data deduplication is required: the old all-rows constraint guaranteed at
+most one row per (user_email, name, team_id), so the new partial indexes cannot
+collide on existing data.
+
+Same class of fix as d21698ae4a19 (roles/user_roles, issue #4482).
+
+NOTE: These indexes are ALSO defined in mcpgateway/db.py (__table_args__) for
+fresh databases. This migration only runs on existing databases (if the table
+already exists) and is idempotent.
+
+Supports both PostgreSQL and SQLite databases.
+
+Revision ID: a7b8c9d0e1f2
+Revises: d21698ae4a19
+Create Date: 2026-07-29
+
+"""
+
+# Standard
+from typing import Sequence, Union
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "a7b8c9d0e1f2"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "d21698ae4a19"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Scope email_api_tokens name uniqueness to active tokens only."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # Skip if the table doesn't exist yet (fresh DB is created directly from db.py models)
+    if "email_api_tokens" not in inspector.get_table_names():
+        return
+
+    # Clean up orphaned temp table from a previously failed batch_alter_table run.
+    # On SQLite, DDL is non-transactional so the temp table persists after a rollback.
+    if "_alembic_tmp_email_api_tokens" in inspector.get_table_names():
+        op.drop_table("_alembic_tmp_email_api_tokens")
+
+    existing_constraints = {c["name"] for c in inspector.get_unique_constraints("email_api_tokens")}
+    existing_indexes = {idx["name"] for idx in inspector.get_indexes("email_api_tokens")}
+
+    # batch_alter_table is required for SQLite compatibility (SQLite cannot DROP CONSTRAINT
+    # directly; Alembic reconstructs the table internally under a batch context).
+    with op.batch_alter_table("email_api_tokens") as batch_op:
+        # Drop the old all-rows (user_email, name, team_id) constraint if present.
+        # Also handle the index form in case a previous run partially applied.
+        if "uq_email_api_tokens_user_name_team" in existing_constraints:
+            batch_op.drop_constraint("uq_email_api_tokens_user_name_team", type_="unique")
+
+    # Re-inspect after the batch alter: on SQLite the table (and its indexes) was
+    # reconstructed, so previously collected index names may be stale.
+    inspector = sa.inspect(bind)
+    existing_indexes = {idx["name"] for idx in inspector.get_indexes("email_api_tokens")}
+
+    # Drop the old all-rows partial index for global-scope tokens if present
+    for old_index in ("uq_email_api_tokens_user_name_global", "uq_email_api_tokens_user_name_team"):
+        if old_index in existing_indexes:
+            op.drop_index(old_index, table_name="email_api_tokens")
+            existing_indexes.discard(old_index)
+
+    # Partial unique index for team-scoped ACTIVE tokens.
+    if "uq_email_api_tokens_user_name_team" not in existing_indexes:
+        op.create_index(
+            "uq_email_api_tokens_user_name_team",
+            "email_api_tokens",
+            ["user_email", "name", "team_id"],
+            unique=True,
+            postgresql_where=sa.text("team_id IS NOT NULL AND is_active = true"),
+            sqlite_where=sa.text("team_id IS NOT NULL AND is_active = 1"),
+        )
+
+    # Partial unique index for global-scope ACTIVE tokens (team_id IS NULL).
+    if "uq_email_api_tokens_user_name_global" not in existing_indexes:
+        op.create_index(
+            "uq_email_api_tokens_user_name_global",
+            "email_api_tokens",
+            ["user_email", "name"],
+            unique=True,
+            postgresql_where=sa.text("team_id IS NULL AND is_active = true"),
+            sqlite_where=sa.text("team_id IS NULL AND is_active = 1"),
+        )
+
+
+def downgrade() -> None:
+    """Restore the all-rows uniqueness rules on email_api_tokens.
+
+    Note: if token names were reused after revocations while this migration was
+    applied, restoring the all-rows constraint can fail on the duplicated
+    inactive rows. Those rows must be removed (or renamed) manually first.
+    """
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "email_api_tokens" not in inspector.get_table_names():
+        return
+
+    # Clean up orphaned temp table from a previously failed batch_alter_table run.
+    if "_alembic_tmp_email_api_tokens" in inspector.get_table_names():
+        op.drop_table("_alembic_tmp_email_api_tokens")
+
+    existing_constraints = {c["name"] for c in inspector.get_unique_constraints("email_api_tokens")}
+    existing_indexes = {idx["name"] for idx in inspector.get_indexes("email_api_tokens")}
+
+    # Drop the active-only partial unique indexes
+    for index_name in ("uq_email_api_tokens_user_name_team", "uq_email_api_tokens_user_name_global"):
+        if index_name in existing_indexes:
+            op.drop_index(index_name, table_name="email_api_tokens")
+            existing_indexes.discard(index_name)
+
+    with op.batch_alter_table("email_api_tokens") as batch_op:
+        # Restore the original all-rows per-team constraint
+        if "uq_email_api_tokens_user_name_team" not in existing_constraints:
+            batch_op.create_unique_constraint(
+                "uq_email_api_tokens_user_name_team",
+                ["user_email", "name", "team_id"],
+            )
+
+    # Restore the original all-rows partial index for global-scope tokens
+    if "uq_email_api_tokens_user_name_global" not in existing_indexes:
+        op.create_index(
+            "uq_email_api_tokens_user_name_global",
+            "email_api_tokens",
+            ["user_email", "name"],
+            unique=True,
+            postgresql_where=sa.text("team_id IS NULL"),
+            sqlite_where=sa.text("team_id IS NULL"),
+        )

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -5477,13 +5477,31 @@ class EmailApiToken(Base):
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     tags: Mapped[Optional[List[str]]] = mapped_column(JSON, nullable=True, default=list)
 
-    # Unique constraint for user+name+team_id combination (per-team scope).
-    # The composite UniqueConstraint handles non-NULL team_id rows.  SQL NULL != NULL
-    # semantics mean it cannot protect global-scope tokens (team_id IS NULL), so we add
-    # a partial unique index for that case — matching the pattern used by resources/prompts.
+    # Unique token names among ACTIVE tokens only, per (user_email, name, team_id) scope.
+    # Revocation is a soft delete (is_active=False, row kept for audit), so uniqueness must
+    # be enforced by partial unique indexes filtered on is_active — a plain UniqueConstraint
+    # would block name reuse after revocation forever (issue #5931).
+    # SQL NULL != NULL semantics require two indexes: one for team-scoped tokens
+    # (team_id IS NOT NULL) and one for global-scope tokens (team_id IS NULL) —
+    # matching the pattern used by roles/user_roles (uq_roles_name_scope_active).
     __table_args__ = (
-        UniqueConstraint("user_email", "name", "team_id", name="uq_email_api_tokens_user_name_team"),
-        Index("uq_email_api_tokens_user_name_global", "user_email", "name", unique=True, postgresql_where=text("team_id IS NULL"), sqlite_where=text("team_id IS NULL")),
+        Index(
+            "uq_email_api_tokens_user_name_team",
+            "user_email",
+            "name",
+            "team_id",
+            unique=True,
+            postgresql_where=text("team_id IS NOT NULL AND is_active = true"),
+            sqlite_where=text("team_id IS NOT NULL AND is_active = 1"),
+        ),
+        Index(
+            "uq_email_api_tokens_user_name_global",
+            "user_email",
+            "name",
+            unique=True,
+            postgresql_where=text("team_id IS NULL AND is_active = true"),
+            sqlite_where=text("team_id IS NULL AND is_active = 1"),
+        ),
         Index("idx_email_api_tokens_user_email", "user_email"),
         Index("idx_email_api_tokens_jti", "jti"),
         Index("idx_email_api_tokens_expires_at", "expires_at"),

--- a/mcpgateway/services/token_catalog_service.py
+++ b/mcpgateway/services/token_catalog_service.py
@@ -505,7 +505,8 @@ class TokenCatalogService:
                     raise ValueError(f"User {user_email} is not an active member of team {team_id}. Only team members can create tokens for the team.")
 
         # Check for duplicate active token name for this user within the same team scope,
-        # matching DB constraint uq_email_api_tokens_user_name_team (user_email, name, team_id).
+        # matching the partial unique index uq_email_api_tokens_user_name_team (user_email, name, team_id)
+        # WHERE team_id IS NOT NULL AND is_active.
         # team_id=None tokens are scoped to the global (no-team) bucket.
         if team_id:
             name_check = and_(EmailApiToken.user_email == user_email, EmailApiToken.name == name, EmailApiToken.team_id == team_id, EmailApiToken.is_active.is_(True))

--- a/tests/unit/mcpgateway/db/test_token_active_uniqueness_migration.py
+++ b/tests/unit/mcpgateway/db/test_token_active_uniqueness_migration.py
@@ -1,0 +1,330 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/db/test_token_active_uniqueness_migration.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for issue #5931: revoked API tokens must not block name reuse.
+
+Tests verify:
+- Migration a7b8c9d0e1f2 module structure (import, functions, revision chain)
+- Functional upgrade/downgrade execution on SQLite
+- Model-level partial unique indexes on EmailApiToken scope uniqueness to
+  active tokens only (revoked token names can be reused, active ones cannot)
+"""
+
+# Standard
+import importlib
+import inspect as pyinspect
+
+# Third-Party
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+import pytest
+import sqlalchemy as sa
+
+# First-Party
+from mcpgateway.db import EmailApiToken
+
+MODULE_NAME = "mcpgateway.alembic.versions.a7b8c9d0e1f2_scope_token_name_uniqueness_to_active"
+REVISION = "a7b8c9d0e1f2"  # pragma: allowlist secret
+DOWN_REVISION = "d21698ae4a19"  # pragma: allowlist secret
+
+
+class TestTokenActiveUniquenessModuleStructure:
+    """Test migration a7b8c9d0e1f2 module structure."""
+
+    def test_migration_module_imports(self):
+        """Test that migration module can be imported."""
+        module = importlib.import_module(MODULE_NAME)
+        assert module is not None
+
+    def test_migration_has_upgrade_function(self):
+        """Test that migration has a callable upgrade() function."""
+        module = importlib.import_module(MODULE_NAME)
+        assert hasattr(module, "upgrade")
+        assert callable(module.upgrade)
+
+    def test_migration_has_downgrade_function(self):
+        """Test that migration has a callable downgrade() function."""
+        module = importlib.import_module(MODULE_NAME)
+        assert hasattr(module, "downgrade")
+        assert callable(module.downgrade)
+
+    def test_migration_revision_id(self):
+        """Test migration has the correct revision ID."""
+        module = importlib.import_module(MODULE_NAME)
+        assert module.revision == REVISION
+
+    def test_migration_down_revision(self):
+        """Test migration has the correct down_revision."""
+        module = importlib.import_module(MODULE_NAME)
+        assert module.down_revision == DOWN_REVISION
+
+    def test_migration_functions_have_no_parameters(self):
+        """Test that upgrade() and downgrade() accept no parameters."""
+        module = importlib.import_module(MODULE_NAME)
+        assert len(pyinspect.signature(module.upgrade).parameters) == 0
+        assert len(pyinspect.signature(module.downgrade).parameters) == 0
+
+
+def _create_old_email_api_tokens_table(conn):
+    """Create email_api_tokens with the pre-migration all-rows uniqueness rules."""
+    conn.execute(sa.text("""
+            CREATE TABLE email_api_tokens (
+                id VARCHAR(36) PRIMARY KEY,
+                user_email VARCHAR(255) NOT NULL,
+                name VARCHAR(255) NOT NULL,
+                team_id VARCHAR(36),
+                jti VARCHAR(36) NOT NULL,
+                token_hash VARCHAR(255) NOT NULL,
+                is_active BOOLEAN NOT NULL DEFAULT 1,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                CONSTRAINT uq_email_api_tokens_user_name_team UNIQUE (user_email, name, team_id)
+            )
+            """))
+    conn.execute(sa.text("""
+            CREATE UNIQUE INDEX uq_email_api_tokens_user_name_global
+            ON email_api_tokens (user_email, name)
+            WHERE team_id IS NULL
+            """))
+
+
+def _insert_token(conn, name, user_email="user@example.com", team_id=None, is_active=1, token_id=None):
+    """Insert a minimal email_api_tokens row."""
+    conn.execute(
+        sa.text("INSERT INTO email_api_tokens (id, user_email, name, team_id, jti, token_hash, is_active) VALUES (:id, :email, :name, :team_id, :jti, :hash, :active)"),
+        {
+            "id": token_id or f"id-{name}-{team_id}-{is_active}-{user_email}",
+            "email": user_email,
+            "name": name,
+            "team_id": team_id,
+            "jti": f"jti-{name}-{team_id}-{is_active}-{user_email}",
+            "hash": "x",
+            "active": is_active,
+        },
+    )
+
+
+def _get_index_names(conn):
+    """Return index names on email_api_tokens."""
+    return {idx["name"] for idx in sa.inspect(conn).get_indexes("email_api_tokens")}
+
+
+def _get_constraint_names(conn):
+    """Return unique constraint names on email_api_tokens."""
+    return {c["name"] for c in sa.inspect(conn).get_unique_constraints("email_api_tokens")}
+
+
+class TestUpgradeFunctional:
+    """Functional tests for upgrade() on SQLite."""
+
+    def test_upgrade_replaces_all_rows_constraint_with_active_scoped_indexes(self):
+        """After upgrade, uniqueness is enforced by active-only partial indexes."""
+        engine = sa.create_engine("sqlite:///:memory:")
+        try:
+            with engine.connect() as conn:
+                _create_old_email_api_tokens_table(conn)
+                conn.commit()
+
+                ctx = MigrationContext.configure(conn, opts={"as_sql": False})
+                with Operations.context(ctx):
+                    module = importlib.import_module(MODULE_NAME)
+                    module.upgrade()
+
+                assert "uq_email_api_tokens_user_name_team" not in _get_constraint_names(conn)
+                indexes = _get_index_names(conn)
+                assert "uq_email_api_tokens_user_name_team" in indexes
+                assert "uq_email_api_tokens_user_name_global" in indexes
+        finally:
+            engine.dispose()
+
+    def test_upgrade_allows_name_reuse_after_revocation(self):
+        """Regression test for #5931: a revoked token's name can be reused."""
+        engine = sa.create_engine("sqlite:///:memory:")
+        try:
+            with engine.connect() as conn:
+                _create_old_email_api_tokens_table(conn)
+                _insert_token(conn, "my-token", is_active=1)
+                conn.execute(sa.text("UPDATE email_api_tokens SET is_active = 0 WHERE name = 'my-token'"))
+                conn.commit()
+
+                ctx = MigrationContext.configure(conn, opts={"as_sql": False})
+                with Operations.context(ctx):
+                    module = importlib.import_module(MODULE_NAME)
+                    module.upgrade()
+
+                # Global scope: same name after revocation must succeed
+                _insert_token(conn, "my-token", is_active=1, token_id="id-new-global")
+                # Team scope: same name after revocation must succeed
+                _insert_token(conn, "team-token", team_id="team-1", is_active=0, token_id="id-old-team")
+                _insert_token(conn, "team-token", team_id="team-1", is_active=1, token_id="id-new-team")
+                conn.commit()
+        finally:
+            engine.dispose()
+
+    def test_upgrade_still_blocks_duplicate_active_names(self):
+        """After upgrade, two ACTIVE tokens with the same name in one scope conflict."""
+        engine = sa.create_engine("sqlite:///:memory:")
+        try:
+            with engine.connect() as conn:
+                _create_old_email_api_tokens_table(conn)
+                conn.commit()
+
+                ctx = MigrationContext.configure(conn, opts={"as_sql": False})
+                with Operations.context(ctx):
+                    module = importlib.import_module(MODULE_NAME)
+                    module.upgrade()
+
+                _insert_token(conn, "dup", is_active=1, token_id="id-a")
+                with pytest.raises(sa.exc.IntegrityError):
+                    with conn.begin_nested():
+                        _insert_token(conn, "dup", is_active=1, token_id="id-b")
+
+                _insert_token(conn, "dup-team", team_id="team-1", is_active=1, token_id="id-c")
+                with pytest.raises(sa.exc.IntegrityError):
+                    with conn.begin_nested():
+                        _insert_token(conn, "dup-team", team_id="team-1", is_active=1, token_id="id-d")
+
+                # Same name in a different team scope is still allowed
+                _insert_token(conn, "dup-team", team_id="team-2", is_active=1, token_id="id-e")
+                conn.commit()
+        finally:
+            engine.dispose()
+
+    def test_upgrade_cleans_up_orphaned_temp_table(self):
+        """Upgrade drops a leftover _alembic_tmp_email_api_tokens table."""
+        engine = sa.create_engine("sqlite:///:memory:")
+        try:
+            with engine.connect() as conn:
+                _create_old_email_api_tokens_table(conn)
+                conn.execute(sa.text("CREATE TABLE _alembic_tmp_email_api_tokens (id VARCHAR(36) PRIMARY KEY)"))
+                conn.commit()
+
+                ctx = MigrationContext.configure(conn, opts={"as_sql": False})
+                with Operations.context(ctx):
+                    module = importlib.import_module(MODULE_NAME)
+                    module.upgrade()
+
+                assert "_alembic_tmp_email_api_tokens" not in set(sa.inspect(conn).get_table_names())
+                assert "email_api_tokens" in set(sa.inspect(conn).get_table_names())
+        finally:
+            engine.dispose()
+
+    def test_upgrade_skips_when_table_missing(self):
+        """Upgrade is a no-op when email_api_tokens table doesn't exist."""
+        engine = sa.create_engine("sqlite:///:memory:")
+        try:
+            with engine.connect() as conn:
+                ctx = MigrationContext.configure(conn, opts={"as_sql": False})
+                with Operations.context(ctx):
+                    module = importlib.import_module(MODULE_NAME)
+                    module.upgrade()  # Should not raise
+
+                assert "email_api_tokens" not in set(sa.inspect(conn).get_table_names())
+        finally:
+            engine.dispose()
+
+
+class TestDowngradeFunctional:
+    """Functional tests for downgrade() on SQLite."""
+
+    def test_downgrade_restores_all_rows_uniqueness(self):
+        """Downgrade restores the all-rows constraint and global partial index."""
+        engine = sa.create_engine("sqlite:///:memory:")
+        try:
+            with engine.connect() as conn:
+                _create_old_email_api_tokens_table(conn)
+                conn.commit()
+
+                ctx = MigrationContext.configure(conn, opts={"as_sql": False})
+                with Operations.context(ctx):
+                    module = importlib.import_module(MODULE_NAME)
+                    module.upgrade()
+                    module.downgrade()
+
+                assert "uq_email_api_tokens_user_name_team" in _get_constraint_names(conn)
+                assert "uq_email_api_tokens_user_name_global" in _get_index_names(conn)
+
+                # Restored all-rows rule: revoked token name can no longer be reused
+                _insert_token(conn, "restored", is_active=0, token_id="id-old")
+                with pytest.raises(sa.exc.IntegrityError):
+                    with conn.begin_nested():
+                        _insert_token(conn, "restored", is_active=1, token_id="id-new")
+        finally:
+            engine.dispose()
+
+    def test_downgrade_skips_when_table_missing(self):
+        """Downgrade is a no-op when email_api_tokens table doesn't exist."""
+        engine = sa.create_engine("sqlite:///:memory:")
+        try:
+            with engine.connect() as conn:
+                ctx = MigrationContext.configure(conn, opts={"as_sql": False})
+                with Operations.context(ctx):
+                    module = importlib.import_module(MODULE_NAME)
+                    module.downgrade()  # Should not raise
+
+                assert "email_api_tokens" not in set(sa.inspect(conn).get_table_names())
+        finally:
+            engine.dispose()
+
+
+class TestEmailApiTokenModelIndexes:
+    """Model-level tests: fresh databases (db.py __table_args__) get active-scoped uniqueness."""
+
+    def _create_table(self, engine):
+        """Create only the email_api_tokens table from the model metadata."""
+        EmailApiToken.__table__.create(engine, checkfirst=True)
+
+    def test_model_defines_active_scoped_partial_indexes(self):
+        """Model exposes partial unique indexes filtered on is_active, no all-rows constraint."""
+        constraint_names = {c.name for c in EmailApiToken.__table__.constraints if isinstance(c, sa.UniqueConstraint)}
+        assert "uq_email_api_tokens_user_name_team" not in constraint_names
+
+        index_by_name = {idx.name: idx for idx in EmailApiToken.__table__.indexes}
+        team_idx = index_by_name["uq_email_api_tokens_user_name_team"]
+        global_idx = index_by_name["uq_email_api_tokens_user_name_global"]
+
+        assert team_idx.unique
+        assert [c.name for c in team_idx.columns] == ["user_email", "name", "team_id"]
+        assert global_idx.unique
+        assert [c.name for c in global_idx.columns] == ["user_email", "name"]
+
+        # The is_active filter must be part of both dialect WHERE clauses
+        for idx in (team_idx, global_idx):
+            pg_where = str(idx.dialect_options["postgresql"]["where"])
+            sqlite_where = str(idx.dialect_options["sqlite"]["where"])
+            assert "is_active" in pg_where
+            assert "is_active" in sqlite_where
+
+    def test_fresh_db_allows_name_reuse_after_revocation(self):
+        """On a fresh SQLite DB, a revoked token's name can be reused (#5931)."""
+        engine = sa.create_engine("sqlite:///:memory:")
+        try:
+            self._create_table(engine)
+            with engine.begin() as conn:
+                conn.execute(
+                    EmailApiToken.__table__.insert().values(user_email="user@example.com", name="my-token", team_id=None, token_hash="h1", is_active=False),
+                )
+                # Reusing the revoked token's name must succeed
+                conn.execute(
+                    EmailApiToken.__table__.insert().values(user_email="user@example.com", name="my-token", team_id=None, token_hash="h2", is_active=True),
+                )
+        finally:
+            engine.dispose()
+
+    def test_fresh_db_blocks_duplicate_active_names(self):
+        """On a fresh SQLite DB, two ACTIVE tokens with the same name in one scope conflict."""
+        engine = sa.create_engine("sqlite:///:memory:")
+        try:
+            self._create_table(engine)
+            with engine.begin() as conn:
+                conn.execute(
+                    EmailApiToken.__table__.insert().values(user_email="user@example.com", name="my-token", team_id=None, token_hash="h1", is_active=True),
+                )
+                with pytest.raises(sa.exc.IntegrityError):
+                    with conn.begin_nested():
+                        conn.execute(
+                            EmailApiToken.__table__.insert().values(user_email="user@example.com", name="my-token", team_id=None, token_hash="h2", is_active=True),
+                        )
+        finally:
+            engine.dispose()


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Fixes #5931. A revoked API token permanently blocked its name: token revocation is a soft delete (`is_active = false`, row kept for audit), but the database-level uniqueness rules on `email_api_tokens (user_email, name, team_id)` covered **all** rows, so creating a new token with a previously used name always failed with `409 - A token with this name already exists.` even though no active token held that name.

## 🔁 Reproduction Steps

From the linked issue:

1. Create an API token named `my-token` (UI or `POST /tokens`)
2. Delete/revoke it
3. Create a new token named `my-token` again

**Expected**: token is created (no active token holds that name).
**Actual**: `409 Conflict - A token with this name already exists. Please choose a different name.`

Server log:

```
Token creation integrity error: duplicate key value violates unique constraint "uq_email_api_tokens_user_name_global" DETAIL: Key (user_email, name)=(user@example.com, my-token) already exists.
```

## 🐞 Root Cause

The service-level duplicate check in `TokenCatalogService.create_token()` already filters on `is_active.is_(True)` (intended semantics: names unique among *active* tokens), but the DB-level rules contradicted it:

- `UniqueConstraint("user_email", "name", "team_id", name="uq_email_api_tokens_user_name_team")` — covered all rows, active or not
- `Index("uq_email_api_tokens_user_name_global", ...)` — partial on `team_id IS NULL` only, with no `is_active` filter

Since `revoke_token()` only sets `is_active = False` and blacklists the JTI (correctly keeping the row for audit), the revoked row collided with the name forever. This is the same class of problem fixed for `roles`/`user_roles` in #4482 / migration `d21698ae4a19`.

## 💡 Fix Description

Scoped DB-level token name uniqueness to active tokens, matching the existing service-level semantics and the `d21698ae4a19` (#4482) pattern:

- `mcpgateway/db.py`: `EmailApiToken.__table_args__` now defines both `uq_email_api_tokens_user_name_team` (team-scoped) and `uq_email_api_tokens_user_name_global` (`team_id IS NULL`) as **partial unique indexes** filtered on `is_active` (active rows only).
- Alembic migration `a7b8c9d0e1f2` (`scope_token_name_uniqueness_to_active`): idempotent migration for existing databases on both PostgreSQL and SQLite — drops the old constraint/index and recreates them as partial unique indexes. No deduplication step is needed because the old constraint already guaranteed at most one row per `(user_email, name, team_id)`.
- Tests: migration structure/functional tests plus model-level tests proving that revoked token names can be reused and that duplicates among *active* tokens are still rejected.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

`make` is unavailable on this Windows development machine, so tests and linters were invoked directly via `uv run`.

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | ⚠️ Not runnable (no `make` on this machine); `uv run ruff check` and `uv run black --check` pass clean on the changed source files (remaining findings in test files verified pre-existing on `main`) |
| Unit tests                            | `make test`          | ✅ Targeted suites via `uv run pytest`: `tests/unit/mcpgateway/db/test_token_active_uniqueness_migration.py` 16 passed; 331 related tests passed |
| Migration round-trip                  | `alembic upgrade head` | ✅ Verified on a real SQLite database (upgrade + downgrade round-trip) |
| Coverage ≥ 80 %                       | `make coverage`      | ⚠️ Not run locally; CI runs the full coverage gate. New model/migration code is exercised by the included tests |
| Docker / postgres + redis             | `make docker docker-run-ssl` | ⚠️ Not run locally; migration is written to be dialect-safe for PostgreSQL and SQLite, and CI runs the full matrix |
| Manual regression no longer fails     | steps / screenshots  | ✅ Covered by tests reproducing the exact issue flow: create token → revoke → recreate with same name now succeeds; duplicate names among active tokens still rejected |

## 📐 MCP Compliance (if relevant)

- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

This change affects only the `email_api_tokens` table constraints; no MCP protocol surface is involved.

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit` — via `uv run black --check` / `ruff check` on changed files)
- [x] No secrets/credentials committed

Closes #5931
