### PR TITLE
fix: finish root_path standardization and admin redirect trailing slashes (#1588)

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -1133,8 +1133,10 @@ def _build_admin_redirect(
         except ValueError:
             pass
     query = urllib.parse.urlencode(params, quote_via=urllib.parse.quote) if params else ""
-    sep = "/?" if query else ""
-    return f"{root_path}/admin{sep}{query}#{fragment}"
+    sep = "?" if query else ""
+    # Always target "/admin/" (the registered admin home route) to avoid a
+    # 307 trailing-slash redirect (issue #1588).
+    return f"{root_path}/admin/{sep}{query}#{fragment}"
 
 
 def get_client_ip(request: Request) -> str:
@@ -4410,7 +4412,7 @@ async def admin_login_page(request: Request) -> Response:
     # Check if email auth is enabled
     if not getattr(settings, "email_auth_enabled", False):
         root_path = _resolve_root_path(request)
-        return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+        return RedirectResponse(url=f"{root_path}/admin/", status_code=303)
 
     root_path = settings.app_root_path
 
@@ -4432,7 +4434,7 @@ async def admin_login_page(request: Request) -> Response:
                 if token_teams is not None and len(token_teams) == 0:
                     pass  # Render login page; do not redirect to /admin
                 elif auth_user.is_admin:
-                    return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+                    return RedirectResponse(url=f"{root_path}/admin/", status_code=303)
                 else:
                     # Non-admin with valid token: check RBAC admin permission
                     with SessionLocal() as db:
@@ -4443,7 +4445,7 @@ async def admin_login_page(request: Request) -> Response:
                             token_teams=token_teams,
                         )
                         if has_admin_access:
-                            return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+                            return RedirectResponse(url=f"{root_path}/admin/", status_code=303)
                         # else: render login page; token is valid but lacks admin access
             except Exception:
                 clear_invalid_cookies = True
@@ -4526,7 +4528,7 @@ async def admin_login_handler(request: Request, db: Session = Depends(get_db)) -
     root_path = _resolve_root_path(request)
 
     if not getattr(settings, "email_auth_enabled", False):
-        return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+        return RedirectResponse(url=f"{root_path}/admin/", status_code=303)
 
     try:
         form = await request.form()
@@ -4620,7 +4622,7 @@ async def admin_login_handler(request: Request, db: Session = Depends(get_db)) -
             token, _ = await create_access_token(user)  # expires_seconds not needed here
 
             # Create redirect response
-            response = RedirectResponse(url=f"{root_path}/admin", status_code=303)
+            response = RedirectResponse(url=f"{root_path}/admin/", status_code=303)
 
             # Set JWT token as secure cookie
             try:
@@ -5116,7 +5118,7 @@ async def change_password_required_page(request: Request) -> HTMLResponse:
     """
     if not getattr(settings, "email_auth_enabled", False):
         root_path = _resolve_root_path(request)
-        return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+        return RedirectResponse(url=f"{root_path}/admin/", status_code=303)
 
     # Get root path for template
     root_path = _resolve_root_path(request)
@@ -5198,7 +5200,7 @@ async def change_password_required_handler(request: Request, db: Session = Depen
     root_path = _resolve_root_path(request)
 
     if not getattr(settings, "email_auth_enabled", False):
-        return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+        return RedirectResponse(url=f"{root_path}/admin/", status_code=303)
 
     try:
         form = await request.form()
@@ -5264,7 +5266,7 @@ async def change_password_required_handler(request: Request, db: Session = Depen
                 token, _ = await create_access_token(current_user)
 
                 # Create redirect response to admin panel
-                response = RedirectResponse(url=f"{root_path}/admin", status_code=303)
+                response = RedirectResponse(url=f"{root_path}/admin/", status_code=303)
 
                 # Update JWT token cookie
                 try:
@@ -16581,7 +16583,7 @@ async def admin_set_a2a_agent_state(
     """
     if not a2a_service or not settings.mcpgateway_a2a_enabled:
         root_path = _resolve_root_path(request)
-        return RedirectResponse(f"{root_path}/admin#a2a-agents", status_code=303)
+        return RedirectResponse(f"{root_path}/admin/#a2a-agents", status_code=303)
 
     user_email = get_user_email(user)
     error_message = None
@@ -16635,7 +16637,7 @@ async def admin_delete_a2a_agent(
     """
     if not a2a_service or not settings.mcpgateway_a2a_enabled:
         root_path = _resolve_root_path(request)
-        return RedirectResponse(f"{root_path}/admin#a2a-agents", status_code=303)
+        return RedirectResponse(f"{root_path}/admin/#a2a-agents", status_code=303)
 
     error_message = None
     is_inactive_checked = "false"

--- a/mcpgateway/middleware/security_headers.py
+++ b/mcpgateway/middleware/security_headers.py
@@ -21,6 +21,7 @@ from starlette.responses import Response
 
 # First-Party
 from mcpgateway.config import settings
+from mcpgateway.utils.paths import resolve_root_path
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
@@ -381,7 +382,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
         # Determine the route-only path (strip root_path for path matching)
         path = request.url.path
-        root_path = request.scope.get("root_path", "")
+        root_path = resolve_root_path(request)
         if root_path and path.startswith(root_path):
             path = path[len(root_path) :]
 
@@ -495,7 +496,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         # Hardened Cache Control for Protected Endpoints
         # Implements defense-in-depth caching policies
         path = request.url.path
-        root_path = request.scope.get("root_path", "")
+        root_path = resolve_root_path(request)
         if root_path and path.startswith(root_path):
             path = path[len(root_path) :]
 

--- a/mcpgateway/routers/sso.py
+++ b/mcpgateway/routers/sso.py
@@ -444,8 +444,8 @@ async def handle_sso_callback(
         is_admin = False
         user_email = user_info.get("email")
 
-    # Determine redirect URL
-    redirect_url = f"{root_path}/admin"
+    # Determine redirect URL (trailing slash: admin UI home is registered at /admin/)
+    redirect_url = f"{root_path}/admin/"
 
     # For non-admin users, try to redirect to their first team's admin view
     if not is_admin and user_email:
@@ -457,7 +457,7 @@ async def handle_sso_callback(
                 # Redirect to first team's admin view
                 # Use first team in list (arbitrary selection - user can switch teams in UI)
                 first_team_id = user_teams[0].id
-                redirect_url = f"{root_path}/admin?team_id={first_team_id}"
+                redirect_url = f"{root_path}/admin/?team_id={first_team_id}"
                 logger.info(f"Redirecting non-admin SSO user {sanitize_for_log(user_email)} to team-scoped admin: {first_team_id}")
             else:
                 # User has no teams - redirect to admin gateways view

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -242,7 +242,7 @@
         <!-- Sidebar Header -->
         <div class="flex items-center h-16 px-4 border-b border-gray-200 dark:border-gray-700 flex-shrink-0"
              :class="sidebarCollapsed ? 'justify-center' : 'justify-between'">
-          <a href="{{ root_path }}/admin" class="flex items-center" x-show="!sidebarCollapsed">
+          <a href="{{ root_path }}/admin/" class="flex items-center" x-show="!sidebarCollapsed">
             <img src="{{ root_path }}/static/contextforge-logo.png" alt="ContextForge logo" class="h-8 dark:hidden" />
             <img src="{{ root_path }}/static/contextforge-logo-white.png" alt="ContextForge logo" class="h-8 hidden dark:block" />
           </a>

--- a/mcpgateway/templates/login.html
+++ b/mcpgateway/templates/login.html
@@ -682,7 +682,7 @@
       if (urlParams.get("sso") === "success") {
         // Redirect to admin panel after successful SSO
         setTimeout(() => {
-          window.location.href = window.ROOT_PATH + "/admin";
+          window.location.href = window.ROOT_PATH + "/admin/";
         }, 1000);
       }
     </script>

--- a/tests/unit/mcpgateway/middleware/test_security_headers_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_security_headers_middleware.py
@@ -330,3 +330,31 @@ async def test_root_path_is_stripped_from_path_for_csp_skip_check():
         assert response.status_code == 200
     finally:
         mock.stop()
+
+
+@pytest.mark.asyncio
+async def test_root_path_fallback_to_app_root_path_for_csp_skip_check():
+    """Empty scope root_path falls back to settings.app_root_path for the CSP skip check."""
+    mock, settings = _mock_settings()
+    try:
+        middleware = SecurityHeadersMiddleware(app=None)
+        request = Request(
+            {
+                "type": "http",
+                "method": "GET",
+                "path": "/app/docs",
+                "root_path": "",
+                "scheme": "https",
+                "headers": [],
+            }
+        )
+
+        with patch("mcpgateway.utils.paths.settings.app_root_path", "/app"):
+            response = await middleware.dispatch(request, _call_next)
+
+        # The fallback root path "/app" must be stripped so the route-only
+        # path "/docs" triggers the CSP skip (no CSP header on docs pages).
+        assert response.status_code == 200
+        assert "Content-Security-Policy" not in response.headers
+    finally:
+        mock.stop()

--- a/tests/unit/mcpgateway/routers/test_sso_router.py
+++ b/tests/unit/mcpgateway/routers/test_sso_router.py
@@ -320,7 +320,7 @@ async def test_handle_sso_callback_success_sets_cookie(monkeypatch: pytest.Monke
 
     assert isinstance(response, RedirectResponse)
     assert response.status_code == 302
-    assert response.headers.get("location", "").endswith("/admin")
+    assert response.headers.get("location", "").endswith("/admin/")
     assert set_cookie.called
 
 
@@ -366,7 +366,7 @@ async def test_handle_sso_callback_keycloak_sets_id_token_hint_cookie(monkeypatc
 
     assert isinstance(response, RedirectResponse)
     assert response.status_code == 302
-    assert response.headers.get("location", "").endswith("/admin")
+    assert response.headers.get("location", "").endswith("/admin/")
     assert "sso_id_token_hint=id-token-hint" in response.headers.get("set-cookie", "")
     assert set_cookie.called
 
@@ -414,7 +414,7 @@ async def test_handle_sso_callback_keycloak_oversized_id_token_skips_hint_cookie
 
     assert isinstance(response, RedirectResponse)
     assert response.status_code == 302
-    assert response.headers.get("location", "").endswith("/admin")
+    assert response.headers.get("location", "").endswith("/admin/")
     assert "sso_id_token_hint=" not in response.headers.get("set-cookie", "")
     assert "id_token too large for cookie storage" in caplog.text
     assert set_cookie.called
@@ -470,7 +470,7 @@ async def test_handle_sso_callback_non_admin_with_team_redirects_to_team(monkeyp
 
     assert isinstance(response, RedirectResponse)
     assert response.status_code == 302
-    assert response.headers.get("location", "") == "/admin?team_id=team-123"
+    assert response.headers.get("location", "") == "/admin/?team_id=team-123"
     assert set_cookie.called
 
 
@@ -578,7 +578,7 @@ async def test_handle_sso_callback_team_service_error_falls_back_to_admin(monkey
 
     assert isinstance(response, RedirectResponse)
     assert response.status_code == 302
-    assert response.headers.get("location", "") == "/admin"
+    assert response.headers.get("location", "") == "/admin/"
     assert set_cookie.called
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -1183,7 +1183,7 @@ class TestAdminServerRoutes:
         mock_set_state.assert_called_once_with(mock_db, "server-1", True, user_email="test-user")
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"] == "/admin#catalog"
+        assert result.headers["location"] == "/admin/#catalog"
 
     @patch.object(ServerService, "set_server_state")
     async def test_admin_set_server_state_deactivate(self, mock_set_state, mock_request, mock_db):
@@ -1197,7 +1197,7 @@ class TestAdminServerRoutes:
         mock_set_state.assert_called_once_with(mock_db, "server-1", False, user_email="test-user")
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"] == "/admin#catalog"
+        assert result.headers["location"] == "/admin/#catalog"
 
     @patch.object(ServerService, "set_server_state")
     async def test_admin_set_server_state_with_inactive_checked(self, mock_set_state, mock_request, mock_db):
@@ -1292,7 +1292,7 @@ class TestAdminServerRoutes:
         response = await admin_delete_server("server-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert isinstance(response, RedirectResponse)
         assert response.status_code == 303
-        assert response.headers["location"] == "/admin#catalog"
+        assert response.headers["location"] == "/admin/#catalog"
         mock_delete_server.assert_called_once()
 
     @patch.object(ServerService, "delete_server")
@@ -1317,7 +1317,7 @@ class TestAdminServerRoutes:
         response = await admin_delete_server("server-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert isinstance(response, RedirectResponse)
         assert "team_id" not in response.headers["location"]
-        assert response.headers["location"] == "/admin#catalog"
+        assert response.headers["location"] == "/admin/#catalog"
 
     @patch.object(ServerService, "delete_server")
     async def test_admin_delete_server_error_handlers(self, mock_delete_server, mock_request, mock_db):
@@ -3864,7 +3864,7 @@ class TestAdminRootRoutes:
         response = await admin_delete_root("/test/root", mock_request, user={"email": "test-user", "db": mock_db})
         assert isinstance(response, RedirectResponse)
         assert response.status_code == 303
-        assert response.headers["location"] == "/root/admin#roots"
+        assert response.headers["location"] == "/root/admin/#roots"
 
     @patch("mcpgateway.admin.root_service.remove_root", new_callable=AsyncMock)
     async def test_admin_delete_root_preserves_team_id(self, mock_remove_root, mock_request, mock_db):
@@ -6279,7 +6279,7 @@ class TestA2AAgentManagement:
         result = await admin_set_a2a_agent_state("agent-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"] == "/root/admin#a2a-agents"
+        assert result.headers["location"] == "/root/admin/#a2a-agents"
 
     @patch.object(A2AAgentService, "delete_agent")
     async def test_admin_delete_a2a_agent_success(self, mock_delete_agent, mock_request, mock_db):
@@ -6355,7 +6355,7 @@ class TestA2AAgentManagement:
         result = await admin_delete_a2a_agent("agent-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"] == "/admin#a2a-agents"
+        assert result.headers["location"] == "/admin/#a2a-agents"
 
     @patch.object(A2AAgentService, "get_agent")
     @patch.object(A2AAgentService, "invoke_agent")
@@ -15971,7 +15971,7 @@ async def test_change_password_required_handler_success(monkeypatch, mock_db):
 
     response = await change_password_required_handler(request, db=mock_db)
     assert isinstance(response, RedirectResponse)
-    assert response.headers["location"].endswith("/root/admin")
+    assert response.headers["location"].endswith("/root/admin/")
 
 
 @pytest.mark.asyncio
@@ -15981,7 +15981,7 @@ async def test_change_password_required_handler_email_auth_disabled(monkeypatch,
     request.scope = {"root_path": "/root"}
     response = await change_password_required_handler(request, db=mock_db)
     assert isinstance(response, RedirectResponse)
-    assert response.headers["location"].endswith("/root/admin")
+    assert response.headers["location"].endswith("/root/admin/")
 
 
 @pytest.mark.asyncio
@@ -17005,7 +17005,7 @@ async def test_admin_delete_tool_success(mock_delete, mock_db):
 
     response = await admin_delete_tool("550e8400e29b41d4a7164466554400b1", request, mock_db, user={"email": "user@example.com"})  # pragma: allowlist secret
     assert response.status_code == 303
-    assert response.headers["location"] == "/root/admin#tools"
+    assert response.headers["location"] == "/root/admin/#tools"
     mock_delete.assert_called_once_with(mock_db, "550e8400e29b41d4a7164466554400b1", user_email="user@example.com", purge_metrics=True)  # pragma: allowlist secret
 
 
@@ -17061,7 +17061,7 @@ async def test_admin_delete_gateway_success(mock_delete, mock_db):
 
     response = await admin_delete_gateway("gateway-1", request, mock_db, user={"email": "user@example.com"})
     assert response.status_code == 303
-    assert response.headers["location"] == "/root/admin#gateways"
+    assert response.headers["location"] == "/root/admin/#gateways"
     mock_delete.assert_called_once_with(mock_db, "gateway-1", user_email="user@example.com")
 
 
@@ -17161,7 +17161,7 @@ async def test_admin_delete_resource_success_inactive_unchecked_redirect(mock_de
 
     response = await admin_delete_resource("550e8400e29b41d4a7164466554400c1", request, mock_db, user={"email": "user@example.com"})  # pragma: allowlist secret
     assert response.status_code == 303
-    assert response.headers["location"] == "/root/admin#resources"
+    assert response.headers["location"] == "/root/admin/#resources"
     mock_delete.assert_called_once_with(mock_db, "550e8400e29b41d4a7164466554400c1", user_email="user@example.com", purge_metrics=False)  # pragma: allowlist secret
 
 
@@ -17211,7 +17211,7 @@ async def test_admin_delete_prompt_success(mock_delete, mock_db):
 
     response = await admin_delete_prompt("550e8400e29b41d4a7164466554400d1", request, mock_db, user={"email": "user@example.com"})  # pragma: allowlist secret
     assert response.status_code == 303
-    assert response.headers["location"] == "/root/admin#prompts"
+    assert response.headers["location"] == "/root/admin/#prompts"
     mock_delete.assert_called_once_with(mock_db, "550e8400e29b41d4a7164466554400d1", user_email="user@example.com", purge_metrics=False)  # pragma: allowlist secret
 
 
@@ -18630,10 +18630,10 @@ class TestUtilityFunctions:
         assert exc_info.value.status_code == 400
 
     def test_build_admin_redirect_no_params(self):
-        assert _build_admin_redirect("", "catalog") == "/admin#catalog"
+        assert _build_admin_redirect("", "catalog") == "/admin/#catalog"
 
     def test_build_admin_redirect_with_root_path(self):
-        assert _build_admin_redirect("/root", "tools") == "/root/admin#tools"
+        assert _build_admin_redirect("/root", "tools") == "/root/admin/#tools"
 
     def test_build_admin_redirect_error_only(self):
         result = _build_admin_redirect("", "catalog", error="Error msg")
@@ -18681,11 +18681,11 @@ class TestUtilityFunctions:
 
     def test_build_admin_redirect_with_invalid_team_id(self):
         result = _build_admin_redirect("", "tools", team_id="invalid-uuid")
-        assert result == "/admin#tools"
+        assert result == "/admin/#tools"
 
     def test_build_admin_redirect_with_empty_team_id(self):
         result = _build_admin_redirect("", "tools", team_id="")
-        assert result == "/admin#tools"
+        assert result == "/admin/#tools"
 
     def test_build_admin_redirect_with_valid_team_id(self):
         uid = "12345678-1234-5678-1234-567812345678"
@@ -18891,7 +18891,7 @@ class TestAuthLogin:
         # Should redirect to admin dashboard, not show login page
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"] == "/app/admin"
+        assert result.headers["location"] == "/app/admin/"
 
     @pytest.mark.asyncio
     async def test_admin_login_page_shows_form_for_invalid_token(self, monkeypatch):
@@ -18998,7 +18998,7 @@ class TestAuthLogin:
         # Should redirect to admin dashboard
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"] == "/app/admin"
+        assert result.headers["location"] == "/app/admin/"
 
     @pytest.mark.asyncio
     async def test_admin_login_page_access_token_cookie_invalid_shows_form(self, monkeypatch):
@@ -19055,7 +19055,7 @@ class TestAuthLogin:
 
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"] == "/app/admin"
+        assert result.headers["location"] == "/app/admin/"
 
     @pytest.mark.asyncio
     async def test_admin_login_page_non_admin_without_rbac_admin_shows_form(self, monkeypatch):
@@ -19359,7 +19359,7 @@ class TestAuthLogin:
         result = await admin_login_handler(request, mock_db)
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"].endswith("/admin")
+        assert result.headers["location"].endswith("/admin/")
 
     @pytest.mark.asyncio
     async def test_admin_login_handler_auth_failure(self, monkeypatch, mock_db):

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -18823,6 +18823,7 @@ class TestAuthLogin:
         result = await admin_login_page(request)
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
+        assert result.headers["location"].endswith("/admin/")
 
     @pytest.mark.asyncio
     async def test_admin_login_page_email_auth_enabled(self, monkeypatch):
@@ -18971,6 +18972,7 @@ class TestAuthLogin:
         result = await admin_login_handler(request, mock_db)
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
+        assert result.headers["location"].endswith("/admin/")
 
     @pytest.mark.asyncio
     async def test_admin_login_page_access_token_cookie_valid_redirects(self, monkeypatch):
@@ -19403,6 +19405,7 @@ class TestAuthLogin:
         result = await change_password_required_page(request)
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
+        assert result.headers["location"].endswith("/admin/")
 
     @pytest.mark.asyncio
     async def test_change_password_required_page_enabled(self, monkeypatch):


### PR DESCRIPTION
# 🐛 Bug-fix PR

Closes #1588

## 📌 Summary

Finishes the `root_path` standardization started in #1547. A handful of leftover call sites still read `request.scope.get("root_path", "")` directly instead of using the shared helper, and several admin-facing redirect/template URLs pointed at `/admin` (no trailing slash), which causes an unnecessary 307 redirect because the admin home route is registered at `/admin/`. Both patterns currently resolve to the same value, but the inconsistency adds cognitive load, depends on FastAPI internals, and the slash-less URLs cost an extra round-trip on every admin login / SSO callback.

## 🔁 Reproduction Steps

From #1588:

1. Grep the codebase: `request.scope.get("root_path", "")` still appears in `mcpgateway/middleware/security_headers.py` and `mcpgateway/routers/sso.py` (and conceptually in the `_build_admin_redirect` helper in `mcpgateway/admin.py`).
2. Log in to the admin UI (email auth or SSO) and observe the redirect `Location` header: it targets `{root_path}/admin`, which FastAPI answers with a `307` to `{root_path}/admin/` before serving the UI.
3. The admin sidebar logo link (`admin.html`) and the SSO success redirect (`login.html`) point at `/admin` as well.

## 🐞 Root Cause

- `mcpgateway/middleware/security_headers.py` read `request.scope.get("root_path", "")` directly in the CSP skip check and the cache-control path matching instead of using `mcpgateway.utils.paths.resolve_root_path()` (which falls back to `settings.app_root_path`).
- Admin redirect builders in `mcpgateway/admin.py` (`_build_admin_redirect`, login page/handler, change-password flow, A2A state/delete guards), `mcpgateway/routers/sso.py` (SSO callback redirect), and the `admin.html` / `login.html` templates constructed URLs ending in `/admin`, while the admin home route is registered at `/admin/` — producing a 307 trailing-slash redirect on every hit.

## 💡 Fix Description

- `mcpgateway/middleware/security_headers.py`: replaced both raw `request.scope.get("root_path", "")` reads with `resolve_root_path(request)`, consistent with the rest of the codebase.
- `mcpgateway/admin.py`: `_build_admin_redirect()` now always targets `{root_path}/admin/` (query separator changed from `/?` to `?` accordingly); all inline `{root_path}/admin` and `{root_path}/admin#...` redirects now use the trailing-slash form.
- `mcpgateway/routers/sso.py`: SSO callback redirect URL changed to `{root_path}/admin/` (and `{root_path}/admin/?team_id=...` for team-scoped redirects).
- Templates: sidebar logo link in `admin.html` and the SSO success JS redirect in `login.html` now point at `{root_path}/admin/`.
- Tests: updated expectations in `tests/unit/mcpgateway/routers/test_sso_router.py` and `tests/unit/mcpgateway/test_admin.py` (redirect `Location` now asserted to end with `/admin/`), and added coverage for the `resolve_root_path()` fallback to `settings.app_root_path` in `tests/unit/mcpgateway/middleware/test_security_headers_middleware.py`.

No functional behavior change beyond eliminating the extra 307 hop; URL semantics are identical.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

Tests run with `uv run pytest` (`make` is not available on this Windows dev machine). Lint run with `uv run ruff check` / `uv run black --check` on the changed files.

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `uv run ruff check` + `uv run black --check` on changed source files | ✅ clean (remaining findings in test files verified pre-existing on `main`) |
| Unit tests (touched areas)            | `uv run pytest tests/unit/mcpgateway/routers/test_sso_router.py tests/unit/mcpgateway/middleware/test_security_headers_middleware.py tests/unit/mcpgateway/utils/test_paths.py` | ✅ 99 passed |
| Unit tests (admin UI redirects)       | `uv run pytest tests/unit/mcpgateway/test_admin.py` | ✅ 1204 passed; 4 pre-existing Windows-only `UnicodeDecodeError` failures in `TestPaginationSwapStyle`, unrelated to this change (also fail on `main`) |
| Coverage ≥ 80 %                       | `make coverage`      | ⚠️ Not run locally (`make` unavailable on Windows); CI runs the full matrix |
| Docker / podman smoke                 | `make docker docker-run-ssl` | ⚠️ Not run locally; no container runtime on this dev machine, CI covers image builds |
| Postgres + redis                      | `make test` with postgres/redis | ⚠️ Not run locally; change touches URL construction only, no DB/cache surface |
| Manual regression no longer fails     | Admin login + SSO callback redirect `Location` asserted in `test_admin.py` / `test_sso_router.py` | ✅ Covered by automated redirect/template tests instead of manual UI check |

## 📐 MCP Compliance (if relevant)

- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

This change only affects admin-UI redirect URLs and internal `root_path` resolution; the MCP protocol surface is untouched.

## ✅ Checklist

- [x] Code formatted (`black --check` / `ruff check` clean on changed files)
- [x] No secrets/credentials committed
