### PR TITLE
chore: show startup build provenance

### DIFF
--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -33,6 +33,7 @@ on:
     paths:
       - '.dockerignore'
       - 'Containerfile'
+      - 'run-gunicorn.sh'
       - 'mcpgateway/**'
       - 'plugins/**'
       - 'pyproject.toml'
@@ -45,6 +46,7 @@ on:
     paths:
       - '.dockerignore'
       - 'Containerfile'
+      - 'run-gunicorn.sh'
       - 'mcpgateway/**'
       - 'plugins/**'
       - 'pyproject.toml'
@@ -100,7 +102,7 @@ jobs:
             local path="$1"
 
             case "${path}" in
-              .dockerignore|Containerfile|pyproject.toml|uv.lock|.github/workflows/docker-multiplatform.yml)
+              .dockerignore|Containerfile|run-gunicorn.sh|pyproject.toml|uv.lock|.github/workflows/docker-multiplatform.yml)
                 return 0
                 ;;
               infra/wheels/*|mcpgateway/*|plugins/*)
@@ -335,7 +337,12 @@ jobs:
         if: steps.gate.outputs.build == 'true'
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Generate build provenance
+        if: steps.gate.outputs.build == 'true'
+        run: python3 -m mcpgateway.build_info --build-sha "${{ github.sha }}"
 
       - name: Set image name lowercase
         if: steps.gate.outputs.build == 'true'

--- a/.github/workflows/docker-required.yml
+++ b/.github/workflows/docker-required.yml
@@ -23,6 +23,7 @@ on:
     paths-ignore:
       - '.dockerignore'
       - 'Containerfile'
+      - 'run-gunicorn.sh'
       - 'mcpgateway/**'
       - 'plugins/**'
       - 'pyproject.toml'

--- a/mcpgateway/build_info.py
+++ b/mcpgateway/build_info.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Build provenance resolution for ContextForge.
+Location: ./mcpgateway/build_info.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Resolve release-tag and source-revision metadata before a container build, then
+read the embedded result at runtime without requiring Git or network access.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import argparse
+from dataclasses import asdict, dataclass
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+from typing import Sequence
+
+# First-Party
+from mcpgateway import __version__
+
+_BUILD_INFO_PATH = Path(__file__).with_name("_build_info.json")
+_COMMIT_PATTERN = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
+_RELEASE_TAG_PATTERN = "v[0-9]*"
+
+
+@dataclass(frozen=True)
+class BuildInfo:
+    """Immutable version and source-revision metadata."""
+
+    display_version: str
+    commit_sha: str
+    base_version: str
+
+
+def _package_tag(package_version: str) -> str:
+    """Return the package version in the repository's release-tag form."""
+    return package_version if package_version.startswith("v") else f"v{package_version}"
+
+
+def _git_output(repository: Path, arguments: Sequence[str]) -> str | None:
+    """Run a read-only Git query and return its stripped output when available."""
+    try:
+        result = subprocess.run(
+            ["git", *arguments],
+            cwd=repository,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+    output = result.stdout.strip()
+    return output if result.returncode == 0 and output else None
+
+
+def resolve_build_info(
+    repository: Path,
+    *,
+    package_version: str = __version__,
+    build_sha: str | None = None,
+) -> BuildInfo:
+    """Resolve deterministic display and full-SHA metadata for one source tree."""
+    package_tag = _package_tag(package_version)
+    revision = build_sha or "HEAD"
+    full_sha = _git_output(repository, ["rev-parse", f"{revision}^{{commit}}"])
+
+    if full_sha is None:
+        supplied_sha = (build_sha or "").lower()
+        if _COMMIT_PATTERN.fullmatch(supplied_sha):
+            return BuildInfo(
+                display_version=f"{package_tag}+{supplied_sha[:9]}",
+                commit_sha=supplied_sha,
+                base_version=package_tag,
+            )
+        return BuildInfo(
+            display_version=f"{package_tag}+unknown",
+            commit_sha="unknown",
+            base_version=package_tag,
+        )
+
+    full_sha = full_sha.lower()
+    exact_tag = _git_output(
+        repository,
+        ["describe", "--tags", "--exact-match", "--match", _RELEASE_TAG_PATTERN, full_sha],
+    )
+    if exact_tag is not None:
+        return BuildInfo(
+            display_version=exact_tag,
+            commit_sha=full_sha,
+            base_version=exact_tag,
+        )
+
+    nearest_tag = _git_output(
+        repository,
+        ["describe", "--tags", "--abbrev=0", "--match", _RELEASE_TAG_PATTERN, full_sha],
+    )
+    base_version = nearest_tag or package_tag
+    return BuildInfo(
+        display_version=f"{base_version}+{full_sha[:9]}",
+        commit_sha=full_sha,
+        base_version=base_version,
+    )
+
+
+def write_build_info(build_info: BuildInfo, destination: Path = _BUILD_INFO_PATH) -> None:
+    """Atomically write build metadata for inclusion in an image or package."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(f".{destination.name}.tmp")
+    temporary.write_text(
+        json.dumps(asdict(build_info), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, destination)
+
+
+def get_build_info(source: Path = _BUILD_INFO_PATH) -> BuildInfo:
+    """Read embedded metadata, falling back safely when it is absent or invalid."""
+    fallback = BuildInfo(
+        display_version=f"{_package_tag(__version__)}+unknown",
+        commit_sha="unknown",
+        base_version=_package_tag(__version__),
+    )
+    try:
+        payload = json.loads(source.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError):
+        return fallback
+
+    if not isinstance(payload, dict):
+        return fallback
+
+    display_version = payload.get("display_version")
+    commit_sha = payload.get("commit_sha")
+    base_version = payload.get("base_version")
+    if not isinstance(display_version, str) or not display_version:
+        return fallback
+    if not isinstance(commit_sha, str) or not commit_sha:
+        return fallback
+    if not isinstance(base_version, str) or not base_version:
+        return fallback
+    if commit_sha != "unknown" and _COMMIT_PATTERN.fullmatch(commit_sha) is None:
+        return fallback
+
+    return BuildInfo(
+        display_version=display_version,
+        commit_sha=commit_sha,
+        base_version=base_version,
+    )
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    """Generate embedded build metadata and print the display version."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", type=Path, default=Path.cwd())
+    parser.add_argument("--package-version", default=__version__)
+    parser.add_argument("--build-sha")
+    parser.add_argument("--output", type=Path, default=_BUILD_INFO_PATH)
+    parsed = parser.parse_args(arguments)
+
+    build_info = resolve_build_info(
+        parsed.repository,
+        package_version=parsed.package_version,
+        build_sha=parsed.build_sha,
+    )
+    write_build_info(build_info, parsed.output)
+    print(build_info.display_version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/run-gunicorn.sh
+++ b/run-gunicorn.sh
@@ -217,6 +217,9 @@ cat <<'EOF'
 ╚═╝     ╚═╝ ╚═════╝╚═╝          ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝   ╚═╝
 EOF
 
+BUILD_VERSION="$("${PYTHON}" -c 'from mcpgateway.build_info import get_build_info; print(get_build_info().display_version)' 2>/dev/null || printf 'unknown')"
+printf 'Version: %s\n' "${BUILD_VERSION}"
+
 #────────────────────────────────────────────────────────────────────────────────
 # SECTION 6: Configure Gunicorn Settings
 # Set up Gunicorn parameters with sensible defaults that can be overridden

--- a/tests/unit/mcpgateway/test_build_info.py
+++ b/tests/unit/mcpgateway/test_build_info.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for ContextForge build provenance resolution.
+Location: ./tests/unit/mcpgateway/test_build_info.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+"""
+
+# Standard
+import json
+from pathlib import Path
+import subprocess
+
+# Third-Party
+from pytest import CaptureFixture, MonkeyPatch
+
+# First-Party
+from mcpgateway import build_info
+from mcpgateway.build_info import BuildInfo, get_build_info, main, resolve_build_info, write_build_info
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    """Run Git in a temporary test repository and return stdout."""
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _repository(tmp_path: Path) -> Path:
+    """Create a repository with one tagged release commit."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.name", "ContextForge Tests")
+    _git(tmp_path, "config", "user.email", "contextforge-tests@example.invalid")
+    (tmp_path / "tracked.txt").write_text("release\n", encoding="utf-8")
+    _git(tmp_path, "add", "tracked.txt")
+    _git(tmp_path, "commit", "--quiet", "-m", "release")
+    _git(tmp_path, "tag", "v1.0.6")
+    return tmp_path
+
+
+def test_resolve_build_info_uses_exact_release_tag(tmp_path: Path) -> None:
+    """An exact release commit renders the matching release tag."""
+    repository = _repository(tmp_path)
+    expected_sha = _git(repository, "rev-parse", "HEAD")
+
+    result = resolve_build_info(repository, package_version="1.0.6")
+
+    assert result == BuildInfo(
+        display_version="v1.0.6",
+        commit_sha=expected_sha,
+        base_version="v1.0.6",
+    )
+
+
+def test_resolve_build_info_combines_nearest_tag_and_build_sha(tmp_path: Path) -> None:
+    """A post-release build renders the nearest tag plus its own short SHA."""
+    repository = _repository(tmp_path)
+    (repository / "tracked.txt").write_text("post-release\n", encoding="utf-8")
+    _git(repository, "commit", "--quiet", "-am", "post release")
+    expected_sha = _git(repository, "rev-parse", "HEAD")
+
+    result = resolve_build_info(repository, package_version="1.0.6", build_sha=expected_sha)
+
+    assert result == BuildInfo(
+        display_version=f"v1.0.6+{expected_sha[:9]}",
+        commit_sha=expected_sha,
+        base_version="v1.0.6",
+    )
+
+
+def test_resolve_build_info_uses_package_version_when_no_tag_exists(tmp_path: Path) -> None:
+    """An untagged repository falls back to package version plus build SHA."""
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.name", "ContextForge Tests")
+    _git(tmp_path, "config", "user.email", "contextforge-tests@example.invalid")
+    (tmp_path / "tracked.txt").write_text("untagged\n", encoding="utf-8")
+    _git(tmp_path, "add", "tracked.txt")
+    _git(tmp_path, "commit", "--quiet", "-m", "untagged")
+    expected_sha = _git(tmp_path, "rev-parse", "HEAD")
+
+    result = resolve_build_info(tmp_path, package_version="1.0.6")
+
+    assert result == BuildInfo(
+        display_version=f"v1.0.6+{expected_sha[:9]}",
+        commit_sha=expected_sha,
+        base_version="v1.0.6",
+    )
+
+
+def test_resolve_build_info_survives_missing_git_metadata(tmp_path: Path) -> None:
+    """A source tree without Git metadata does not make the build fail."""
+    result = resolve_build_info(tmp_path, package_version="1.0.6")
+
+    assert result == BuildInfo(
+        display_version="v1.0.6+unknown",
+        commit_sha="unknown",
+        base_version="v1.0.6",
+    )
+
+
+def test_resolve_build_info_preserves_supplied_sha_without_git(tmp_path: Path) -> None:
+    """A trusted build-system SHA remains available when Git is unavailable."""
+    build_sha = "a" * 40
+
+    result = resolve_build_info(tmp_path, package_version="1.0.6", build_sha=build_sha)
+
+    assert result == BuildInfo(
+        display_version=f"v1.0.6+{build_sha[:9]}",
+        commit_sha=build_sha,
+        base_version="v1.0.6",
+    )
+
+
+def test_resolve_build_info_survives_unavailable_git(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    """An unavailable Git executable produces safe fallback metadata."""
+
+    def unavailable(*_arguments: object, **_keywords: object) -> None:
+        raise OSError("git unavailable")
+
+    monkeypatch.setattr(build_info.subprocess, "run", unavailable)
+
+    result = resolve_build_info(tmp_path, package_version="1.0.6")
+
+    assert result.commit_sha == "unknown"
+    assert result.display_version == "v1.0.6+unknown"
+
+
+def test_write_and_get_build_info_round_trip(tmp_path: Path) -> None:
+    """Embedded metadata round-trips without changing fields."""
+    destination = tmp_path / "_build_info.json"
+    expected = BuildInfo(
+        display_version="v1.0.6+abcdef123",
+        commit_sha="abcdef123" + ("0" * 31),
+        base_version="v1.0.6",
+    )
+
+    write_build_info(expected, destination)
+
+    assert get_build_info(destination) == expected
+
+
+def test_get_build_info_survives_missing_file(tmp_path: Path) -> None:
+    """A missing embedded file returns package-version fallback metadata."""
+    result = get_build_info(tmp_path / "missing.json")
+
+    assert result.commit_sha == "unknown"
+    assert result.display_version.endswith("+unknown")
+
+
+def test_get_build_info_rejects_invalid_shapes(tmp_path: Path) -> None:
+    """Non-object and incomplete metadata never reaches the startup banner."""
+    source = tmp_path / "_build_info.json"
+    invalid_payloads = [
+        [],
+        {"display_version": 1, "commit_sha": "a" * 40, "base_version": "v1.0.6"},
+        {"display_version": "v1.0.6", "commit_sha": None, "base_version": "v1.0.6"},
+        {"display_version": "v1.0.6", "commit_sha": "a" * 40, "base_version": ""},
+    ]
+
+    for payload in invalid_payloads:
+        source.write_text(json.dumps(payload), encoding="utf-8")
+        assert get_build_info(source).commit_sha == "unknown"
+
+
+def test_get_build_info_rejects_malformed_metadata(tmp_path: Path) -> None:
+    """Malformed embedded metadata falls back instead of blocking startup."""
+    source = tmp_path / "_build_info.json"
+    source.write_text(
+        json.dumps(
+            {
+                "display_version": "v1.0.6+forged",
+                "commit_sha": "../not-a-commit",
+                "base_version": "v1.0.6",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = get_build_info(source)
+
+    assert result.commit_sha == "unknown"
+    assert result.display_version.endswith("+unknown")
+
+
+def test_main_writes_embedded_metadata(tmp_path: Path, capsys: CaptureFixture[str]) -> None:
+    """The build CLI writes JSON and reports the resolved display version."""
+    repository = _repository(tmp_path / "repository")
+    output = tmp_path / "_build_info.json"
+
+    result = main(
+        [
+            "--repository",
+            str(repository),
+            "--package-version",
+            "1.0.6",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert result == 0
+    assert capsys.readouterr().out.strip() == "v1.0.6"
+    assert get_build_info(output).display_version == "v1.0.6"


### PR DESCRIPTION
## 🔗 Related Issue

Closes #5986

---

## 📝 Summary

Add deterministic build provenance directly below the startup banner:

- exact release builds display their matching `v*` tag;
- non-tagged builds display the nearest release tag plus the 9-character SHA of the revision being built;
- the full build SHA remains available in embedded JSON metadata;
- missing Git or build metadata falls back safely to the package version plus `unknown`.

The multi-platform image workflow now fetches complete tag history and generates one metadata file from `github.sha` before the shared build context is consumed. Runtime startup reads that embedded file and does not require Git or network access.

Risk is limited to build metadata generation, Docker workflow path routing, and one startup banner line. This does not change existing CLI, API, UI, dependency, or scanner behavior.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked separately
- [x] Tests are included with the code they validate
- [x] This was AI-assisted; I understand and can explain the changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (CI and build provenance)
- [ ] Other

---

## 🧪 Verification

| Check | Command | Result |
|---|---|---|
| Focused resolver tests and coverage | `.venv/bin/python -m pytest tests/unit/mcpgateway/test_build_info.py --cov=mcpgateway.build_info --cov-report=term-missing -q` | 11 passed; 100% module coverage |
| Full Python suite | `make test` | 21,089 passed; 804 skipped; 2 xfailed |
| Full JavaScript suite | `npm test -- --reporter=dot` | 52 files passed; 2,309 tests passed; 3 skipped |
| Python lint | `make ruff` | Passed |
| Shell syntax | `bash -n run-gunicorn.sh` | Passed |
| Workflow structure | `.venv/bin/python scripts/pre-commit/check_ci_workflows.py` | Passed |

Manual provenance smoke on current upstream commit `75e9ccc01de7e2b61b41b3dfa16699e41f379689` resolved:

```text
v1.0.6+75e9ccc01
```

The same focused test file also passed under Python 3.11, 3.12, and 3.13.

---

## ✅ Checklist

- [x] Code formatted
- [x] Tests added for tagged, non-tagged, missing-Git, invalid-metadata, and CLI generation behavior
- [x] No dependency or lockfile changes
- [x] No secrets or credentials committed
- [x] Commit includes the required DCO sign-off

## 📓 Notes

The generated `_build_info.json` remains an ephemeral build-workspace artifact. This PR does not commit or push generated provenance after builds.
