### PR TITLE
Remove remaining dead feature flags (oauth discovery, gRPC reflection/TLS, catalog auto health check, performance tracking)

### DIFF
--- a/charts/mcp-stack/README.md
+++ b/charts/mcp-stack/README.md
@@ -295,7 +295,6 @@ For detailed guidance on resource limits and process management, see `docs/docs/
 | mcpContextForge.config.MCPGATEWAY_DIRECT_PROXY_TIMEOUT | string | `"30"` |  |
 | mcpContextForge.config.MCPGATEWAY_CATALOG_ENABLED | string | `"true"` |  |
 | mcpContextForge.config.MCPGATEWAY_CATALOG_FILE | string | `"mcp-catalog.yml"` |  |
-| mcpContextForge.config.MCPGATEWAY_CATALOG_AUTO_HEALTH_CHECK | string | `"true"` |  |
 | mcpContextForge.config.MCPGATEWAY_CATALOG_CACHE_TTL | string | `"3600"` |  |
 | mcpContextForge.config.MCPGATEWAY_CATALOG_PAGE_SIZE | string | `"100"` |  |
 | mcpContextForge.config.MCPGATEWAY_UI_TOOL_TEST_TIMEOUT | string | `"60000"` |  |
@@ -375,7 +374,6 @@ For detailed guidance on resource limits and process management, see `docs/docs/
 | mcpContextForge.config.PERFORMANCE_THRESHOLD_HTTP_REQUEST_MS | string | `"500.0"` |  |
 | mcpContextForge.config.PERFORMANCE_THRESHOLD_RESOURCE_READ_MS | string | `"1000.0"` |  |
 | mcpContextForge.config.PERFORMANCE_THRESHOLD_TOOL_INVOCATION_MS | string | `"2000.0"` |  |
-| mcpContextForge.config.PERFORMANCE_TRACKING_ENABLED | string | `"true"` |  |
 | mcpContextForge.config.PERMISSION_AUDIT_ENABLED | string | `"false"` |  |
 | mcpContextForge.config.PLUGINS_CLIENT_MTLS_CA_BUNDLE | string | `""` |  |
 | mcpContextForge.config.PLUGINS_CLIENT_MTLS_CERTFILE | string | `""` |  |
@@ -706,9 +704,6 @@ For detailed guidance on resource limits and process management, see `docs/docs/
 | mcpContextForge.config.MCPGATEWAY_GRPC_ENABLED | string | `"false"` |  |
 | mcpContextForge.config.MCPGATEWAY_GRPC_TIMEOUT | string | `"30"` |  |
 | mcpContextForge.config.MCPGATEWAY_GRPC_MAX_MESSAGE_SIZE | string | `"4194304"` |  |
-| mcpContextForge.config.MCPGATEWAY_GRPC_REFLECTION_ENABLED | string | `"true"` |  |
-| mcpContextForge.config.MCPGATEWAY_GRPC_TLS_ENABLED | string | `"false"` |  |
-| mcpContextForge.config.PERFORMANCE_TRACKING_ENABLED | string | `"true"` |  |
 | mcpContextForge.config.PERFORMANCE_THRESHOLD_DATABASE_QUERY_MS | string | `"100.0"` |  |
 | mcpContextForge.config.PERFORMANCE_THRESHOLD_RESOURCE_READ_MS | string | `"1000.0"` |  |
 | mcpContextForge.config.PERFORMANCE_THRESHOLD_TOOL_INVOCATION_MS | string | `"2000.0"` |  |
@@ -815,7 +810,6 @@ For detailed guidance on resource limits and process management, see `docs/docs/
 | mcpContextForge.secret.DCR_METADATA_CACHE_TTL | string | `"3600"` |  |
 | mcpContextForge.secret.DCR_CLIENT_NAME_TEMPLATE | string | `"ContextForge ({gateway_name})"` |  |
 | mcpContextForge.secret.DCR_REQUEST_REFRESH_TOKEN_WHEN_UNSUPPORTED | string | `"false"` |  |
-| mcpContextForge.secret.OAUTH_DISCOVERY_ENABLED | string | `"true"` |  |
 | mcpContextForge.secret.OAUTH_PREFERRED_CODE_CHALLENGE_METHOD | string | `"S256"` |  |
 | mcpContextForge.secret.JWT_AUDIENCE_VERIFICATION | string | `"true"` |  |
 | mcpContextForge.secret.JWT_ISSUER_VERIFICATION | string | `"true"` |  |

--- a/charts/mcp-stack/values.schema.json
+++ b/charts/mcp-stack/values.schema.json
@@ -734,9 +734,6 @@
             "MCPGATEWAY_BULK_IMPORT_RATE_LIMIT": {
               "type": "string"
             },
-            "MCPGATEWAY_CATALOG_AUTO_HEALTH_CHECK": {
-              "type": "string"
-            },
             "MCPGATEWAY_CATALOG_CACHE_TTL": {
               "type": "string"
             },
@@ -969,9 +966,6 @@
               "type": "string"
             },
             "PAGINATION_MIN_PAGE_SIZE": {
-              "type": "string"
-            },
-            "PERFORMANCE_TRACKING_ENABLED": {
               "type": "string"
             },
             "PERMISSION_AUDIT_ENABLED": {
@@ -1981,9 +1975,6 @@
               "type": "string"
             },
             "MIN_SECRET_LENGTH": {
-              "type": "string"
-            },
-            "OAUTH_DISCOVERY_ENABLED": {
               "type": "string"
             },
             "OAUTH_MAX_RETRIES": {

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -343,7 +343,6 @@ mcpContextForge:
     # ─ MCP Server Catalog Configuration ─
     MCPGATEWAY_CATALOG_ENABLED: "true"  # enable MCP server catalog feature
     MCPGATEWAY_CATALOG_FILE: "mcp-catalog.yml" # path to catalog configuration file
-    MCPGATEWAY_CATALOG_AUTO_HEALTH_CHECK: "true" # automatically health check catalog servers
     MCPGATEWAY_CATALOG_CACHE_TTL: "3600" # catalog cache TTL in seconds
     MCPGATEWAY_CATALOG_PAGE_SIZE: "100" # number of catalog servers per page
 
@@ -748,11 +747,6 @@ mcpContextForge:
     # Uncomment when enabling gRPC:
     # MCPGATEWAY_GRPC_TIMEOUT: "30"
     # MCPGATEWAY_GRPC_MAX_MESSAGE_SIZE: "4194304"
-    # MCPGATEWAY_GRPC_REFLECTION_ENABLED: "false"  # keep false in production (exposes service definitions)
-    # MCPGATEWAY_GRPC_TLS_ENABLED: "false"
-
-    # Performance tracking (internal thresholds — config.py defaults are fine)
-    PERFORMANCE_TRACKING_ENABLED: "false" # enable performance tracking
 
     # Performance monitoring (net/host — disabled by default)
     MCPGATEWAY_PERFORMANCE_TRACKING: "false" # enable gateway performance monitoring UI tab
@@ -901,7 +895,6 @@ mcpContextForge:
     DCR_METADATA_CACHE_TTL: "3600"         # AS metadata cache TTL in seconds (RFC 8414 discovery)
     DCR_CLIENT_NAME_TEMPLATE: "ContextForge ({gateway_name})" # template for client_name in DCR requests
     DCR_REQUEST_REFRESH_TOKEN_WHEN_UNSUPPORTED: "false" # request refresh_token when AS omits grant_types_supported
-    OAUTH_DISCOVERY_ENABLED: "true"        # enable AS metadata discovery (RFC 8414)
     OAUTH_PREFERRED_CODE_CHALLENGE_METHOD: "S256" # PKCE code challenge method (S256 or plain)
 
     # ─ JWT Configuration (Advanced) ─

--- a/docs/docs/architecture/oauth-authorization-code-ui-design.md
+++ b/docs/docs/architecture/oauth-authorization-code-ui-design.md
@@ -245,7 +245,6 @@ For user authentication and RBAC configuration, see [RBAC Configuration](../mana
 | `DCR_METADATA_CACHE_TTL` | `3600` | Cache TTL for AS metadata discovery |
 | `DCR_CLIENT_NAME_TEMPLATE` | `ContextForge ({gateway_name})` | DCR client_name template |
 | `DCR_REQUEST_REFRESH_TOKEN_WHEN_UNSUPPORTED` | `false` | Request refresh token even if AS metadata omits support |
-| `OAUTH_DISCOVERY_ENABLED` | `true` | Enable RFC 8414 discovery |
 | `OAUTH_PREFERRED_CODE_CHALLENGE_METHOD` | `S256` | Defined but currently unused; PKCE is always S256 |
 
 ## Validation Checklist

--- a/docs/docs/manage/catalog.md
+++ b/docs/docs/manage/catalog.md
@@ -29,9 +29,6 @@ MCPGATEWAY_CATALOG_ENABLED=true
 # Path to catalog configuration file (default: mcp-catalog.yml)
 MCPGATEWAY_CATALOG_FILE=mcp-catalog.yml
 
-# Automatically health check catalog servers (default: true)
-MCPGATEWAY_CATALOG_AUTO_HEALTH_CHECK=true
-
 # Catalog cache TTL in seconds (default: 3600)
 MCPGATEWAY_CATALOG_CACHE_TTL=3600
 

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -544,7 +544,6 @@ ContextForge implements **OAuth 2.0 Dynamic Client Registration (RFC 7591)** and
 | `DCR_METADATA_CACHE_TTL`                   | AS metadata cache TTL in seconds                               | `3600`                         | int           |
 | `DCR_CLIENT_NAME_TEMPLATE`                 | Template for client_name in DCR requests                       | `ContextForge ({gateway_name})` | string        |
 | `DCR_REQUEST_REFRESH_TOKEN_WHEN_UNSUPPORTED` | Request refresh_token when AS omits grant_types_supported    | `false`                        | bool          |
-| `OAUTH_DISCOVERY_ENABLED`                  | Enable AS metadata discovery (RFC 8414)                        | `true`                         | bool          |
 | `OAUTH_PREFERRED_CODE_CHALLENGE_METHOD`    | PKCE code challenge method                                     | `S256`                         | `S256`, `plain` |
 
 ### Personal Teams Configuration
@@ -568,7 +567,6 @@ ContextForge implements **OAuth 2.0 Dynamic Client Registration (RFC 7591)** and
 | ------------------------------------ | ------------------------------------------------ | ------------------ | ------- |
 | `MCPGATEWAY_CATALOG_ENABLED`        | Enable MCP server catalog feature                | `true`             | bool    |
 | `MCPGATEWAY_CATALOG_FILE`           | Path to catalog configuration file               | `mcp-catalog.yml`  | string  |
-| `MCPGATEWAY_CATALOG_AUTO_HEALTH_CHECK` | Automatically health check catalog servers    | `true`             | bool    |
 | `MCPGATEWAY_CATALOG_CACHE_TTL`      | Catalog cache TTL in seconds                     | `3600`             | int > 0 |
 | `MCPGATEWAY_CATALOG_PAGE_SIZE`      | Number of catalog servers per page               | `12`               | int > 0 |
 

--- a/docs/docs/manage/oauth-troubleshooting.md
+++ b/docs/docs/manage/oauth-troubleshooting.md
@@ -461,7 +461,6 @@ OAUTH_REQUEST_TIMEOUT=30
 OAUTH_MAX_RETRIES=3
 
 # PKCE settings
-OAUTH_DISCOVERY_ENABLED=true
 OAUTH_PREFERRED_CODE_CHALLENGE_METHOD=S256
 
 # Secret for signing state (CRITICAL - must be consistent across instances)

--- a/docs/docs/manage/tuning.md
+++ b/docs/docs/manage/tuning.md
@@ -688,7 +688,6 @@ These settings were tested and found to have less than ~3% effect on MCP through
 | `VALIDATION_MIDDLEWARE_ENABLED` | Deprecated as of 2026-06-11; sunsets on 2026-07-07. MCP requests bypass most validation. See [Deprecations](../deprecations.md). |
 | `DB_METRICS_RECORDING_ENABLED` | Writes are buffered, minimal per-request overhead |
 | `REGISTRY_CACHE_ENABLED` | MCP handlers use their own DB queries, not the registry cache |
-| `PERFORMANCE_TRACKING_ENABLED` | Lightweight in-memory tracking |
 | `TOKEN_USAGE_LOGGING_ENABLED` | Rate-limited to one DB write per 5 minutes per token |
 | `CORRELATION_ID_ENABLED` | Adds/reads one header per request |
 
@@ -760,7 +759,6 @@ These add some overhead but are useful in most deployments. Disable only if you 
 | Feature | Setting | Default | When to Disable |
 |---------|---------|---------|-----------------|
 | **Correlation ID** | `CORRELATION_ID_ENABLED` | `true` | If your external proxy already handles trace IDs |
-| **Performance tracking** | `PERFORMANCE_TRACKING_ENABLED` | `true` | If using external APM (Datadog, New Relic, etc.) |
 | **Metrics aggregation** | `METRICS_AGGREGATION_ENABLED` | `true` | If using external metrics (Prometheus, Grafana) |
 | **Metrics rollup** | `METRICS_ROLLUP_ENABLED` | `true` | If raw metrics are exported externally |
 | **Metrics cleanup** | `METRICS_CLEANUP_ENABLED` | `true` | Only disable if you manage retention externally |
@@ -768,7 +766,6 @@ These add some overhead but are useful in most deployments. Disable only if you 
 | **Tool cancellation** | `MCPGATEWAY_TOOL_CANCELLATION_ENABLED` | `true` | If clients do not cancel in-flight tool calls |
 | **SSE keepalive** | `SSE_KEEPALIVE_ENABLED` | `true` | If not using SSE transport |
 | **Dynamic client registration** | `DCR_ENABLED` | `true` | If not using OAuth DCR flow |
-| **OAuth discovery** | `OAUTH_DISCOVERY_ENABLED` | `true` | If not using OAuth |
 
 ### Low-impact features (safe to leave enabled)
 
@@ -853,7 +850,6 @@ DB_QUERY_LOG_ENABLED=true           # N+1 detection
 STRUCTURED_LOGGING_DATABASE_ENABLED=true
 LOG_LEVEL=INFO
 CORRELATION_ID_ENABLED=true
-PERFORMANCE_TRACKING_ENABLED=true
 ```
 
 ---

--- a/docs/docs/using/grpc-services.md
+++ b/docs/docs/using/grpc-services.md
@@ -185,17 +185,11 @@ The gateway translates between protocols automatically:
 # Enable/disable gRPC support globally
 MCPGATEWAY_GRPC_ENABLED=true
 
-# Enable server reflection by default
-MCPGATEWAY_GRPC_REFLECTION_ENABLED=true
-
 # Maximum message size (bytes)
 MCPGATEWAY_GRPC_MAX_MESSAGE_SIZE=4194304  # 4MB
 
 # Default timeout for gRPC calls (seconds)
 MCPGATEWAY_GRPC_TIMEOUT=30
-
-# Enable TLS by default
-MCPGATEWAY_GRPC_TLS_ENABLED=false
 ```
 
 ### Service Configuration

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -963,8 +963,6 @@ class Settings(BaseSettings):
     # OAuth Discovery (RFC 8414)
     # ===================================
 
-    oauth_discovery_enabled: bool = Field(default=True, description="Enable OAuth AS metadata discovery (RFC 8414)")
-
     oauth_preferred_code_challenge_method: str = Field(default="S256", description="Preferred PKCE code challenge method (S256 or plain)")
 
     # Email-Based Authentication
@@ -1123,10 +1121,8 @@ class Settings(BaseSettings):
 
     # gRPC Support Configuration (EXPERIMENTAL - disabled by default)
     mcpgateway_grpc_enabled: bool = Field(default=False, description="Enable gRPC to MCP translation support (experimental feature)")
-    mcpgateway_grpc_reflection_enabled: bool = Field(default=True, description="Enable gRPC server reflection by default")
     mcpgateway_grpc_max_message_size: int = Field(default=4194304, description="Maximum gRPC message size in bytes (4MB)")
     mcpgateway_grpc_timeout: int = Field(default=30, description="Default gRPC call timeout in seconds")
-    mcpgateway_grpc_tls_enabled: bool = Field(default=False, description="Enable TLS for gRPC connections by default")
 
     # Direct Proxy Configuration (disabled by default)
     mcpgateway_direct_proxy_enabled: bool = Field(default=False, description="Enable direct_proxy gateway mode for pass-through MCP operations")
@@ -1147,7 +1143,6 @@ class Settings(BaseSettings):
     # MCP Server Catalog Configuration
     mcpgateway_catalog_enabled: bool = Field(default=True, description="Enable MCP server catalog feature")
     mcpgateway_catalog_file: str = Field(default="mcp-catalog.yml", description="Path to catalog configuration file")
-    mcpgateway_catalog_auto_health_check: bool = Field(default=True, description="Automatically health check catalog servers")
     mcpgateway_catalog_cache_ttl: int = Field(default=3600, description="Catalog cache TTL in seconds")
     mcpgateway_catalog_page_size: int = Field(default=100, description="Number of catalog servers per page")
 
@@ -1990,7 +1985,6 @@ class Settings(BaseSettings):
     structured_logging_external_enabled: bool = Field(default=False, description="Send logs to external systems")
 
     # Performance Tracking Configuration
-    performance_tracking_enabled: bool = Field(default=True, description="Enable performance tracking and metrics")
     performance_threshold_database_query_ms: float = Field(default=100.0, description="Alert threshold for database queries (ms)")
     performance_threshold_tool_invocation_ms: float = Field(default=2000.0, description="Alert threshold for tool invocations (ms)")
     performance_threshold_resource_read_ms: float = Field(default=1000.0, description="Alert threshold for resource reads (ms)")


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #5848 (the remaining five flags; the three logging-sink flags were removed in #5851)

---

## 📝 Summary

Removes the last five dead feature flags from `mcpgateway/config.py` — `oauth_discovery_enabled`, `performance_tracking_enabled`, `mcpgateway_grpc_reflection_enabled`, `mcpgateway_grpc_tls_enabled`, and `mcpgateway_catalog_auto_health_check`. No code reads any of them (no `settings.<name>` references, no `os.getenv` reads, no matching `getattr(settings, ...)` literals, no test references), so setting e.g. `MCPGATEWAY_GRPC_TLS_ENABLED=true` silently does nothing — a security-relevant trap in the TLS case.

The issue suggested wiring up may be right for some of these, but in each case the real behavior is already controlled elsewhere, so removal keeps a single source of truth:

- gRPC reflection and TLS are configured **per service** via the `GrpcService` DB model (`reflection_enabled`, TLS fields) — the global defaults were never consulted.
- The active performance tracking flag is `mcpgateway_performance_tracking` (read in `mcpgateway/admin.py`); `performance_tracking_enabled` was a dead twin.
- OAuth RFC 8414 discovery and catalog health checks run unconditionally today; if a kill switch is wanted, it can be added with tests in a follow-up.

Also removes the corresponding entries from the Helm chart (`values.yaml`, `values.schema.json`, chart README) and docs (`configuration.md`, `tuning.md`, `catalog.md`, `grpc-services.md`, `oauth-troubleshooting.md`, `oauth-authorization-code-ui-design.md`). None were present in `.env.example`. Remaining mentions are only the generated `docs/docs/design/images/classes.svg` diagram and a historical entry in `charts/mcp-stack/CHANGELOG.md`.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage` (#5848 currently carries the `triage` label)
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate (no tests referenced these settings; removal only)
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Ruff                      | `ruff check mcpgateway/config.py` | ✅ pass |
| YAML lint                 | `yamllint -c .yamllint charts/mcp-stack/values.yaml` | ✅ pass |
| Schema JSON valid         | `python -c "json.load(open('charts/mcp-stack/values.schema.json'))"` | ✅ pass |
| Config tests              | `pytest tests/unit/mcpgateway/test_config.py tests/unit/mcpgateway/test_config_env_isolation.py` | ✅ 193 passed |
| Dead-flag check           | `grep -rn` for each removed name (snake_case and UPPER_CASE) | ✅ no hits outside generated `classes.svg` and chart `CHANGELOG.md` |

Full `make test` was not run locally; relying on CI.

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes (n/a — settings removal, no tests referenced them)
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed
