### PR TITLE
fix: remove Python comment from JavaScript code in OAuth callback

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-29T12:59:58Z",
+  "generated_at": "2026-07-30T09:44:50Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -3873,6 +3873,16 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 269,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/routers/oauth_router.py": [
+      {
+        "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 838,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -835,7 +835,7 @@ async def oauth_callback(
                         try {{
                             const response = await fetch('{safe_root_path}/oauth/fetch-tools/{escape(str(gateway_id), quote=True)}', {{
                                 method: 'POST',
-                                credentials: 'include',  # pragma: allowlist secret
+                                credentials: 'include',
                                 headers: {{
                                     'Accept': 'application/json',
                                     'X-CSRF-Token': {json.dumps(csrf_token)}


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #

---

## 📝 Summary

Fixes the "Fetch Tools from MCP Server" button that appears after successful OAuth 2.0 authorization. The button was non-functional due to a Python pragma comment (`# pragma: allowlist secret`) embedded in JavaScript code at line 838 of `oauth_router.py`. JavaScript doesn't recognize `#` as a comment syntax (outside of hashbangs), causing the fetch request to fail silently. Removed the Python comment to restore proper JavaScript execution.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

**Manual Testing Required**: Complete OAuth flow with an MCP server (e.g., GitHub Copilot), verify the "Fetch Tools from MCP Server" button now triggers a POST request to `/oauth/fetch-tools/{gateway_id}` and tools are successfully fetched.

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | Pass     |
| Unit tests                | `make test`     | Pass     |
| Coverage ≥ 80%            | `make coverage` | Pass     |

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

**Changed File**: [`mcpgateway/routers/oauth_router.py:838`](mcpgateway/routers/oauth_router.py#L838)

**Before**:
```javascript
credentials: 'include',  # pragma: allowlist secret
```

**After**:
```javascript
credentials: 'include',
```

The pragma comment was likely added by detect-secrets scanning but incorrectly placed in JavaScript rather than Python code.
