### PR TITLE
feat: consume Cpex control execution records

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3009,6 +3009,44 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 PLUGINS_CLI_MARKUP_MODE=rich
 
 # =============================================================================
+# CPEX Control-Execution Telemetry
+# =============================================================================
+#
+# Structured observability for CPEX plugin enforcement decisions on every tool
+# invocation. Requires CPEX >= 0.1.2. Silent no-op on older CPEX builds.
+#
+# How it works:
+#   - One cpex.control.summary span per tool call (aggregate counts + outcome)
+#   - One cpex.control.result span per plugin evaluated (name, status, decision,
+#     duration, reason, error_code, config key names)
+#   - Both written to the internal observability_spans DB table and, when OTel
+#     tracing is active, also exported via the OTel SDK sink.
+#
+# Master switch — disable to suppress all cpex.control.* span writes.
+# Default: true
+# CPEX_CONTROL_TELEMETRY_ENABLED=true
+
+# Independently toggle the DB sink (cpex.control.summary + cpex.control.result rows).
+# Default: true
+# CPEX_CONTROL_TELEMETRY_DB_ENABLED=true
+
+# Emit flattened cpex.control.results.<plugin_name>.* attributes on the summary span.
+# Off by default. Enable only when downstream tooling requires dynamic key names.
+# The fixed-schema cpex.control.result child spans remain the source of truth.
+# Default: false
+# CPEX_CONTROL_TELEMETRY_FLATTEN_RESULTS=false
+
+# Max per-control result records exported per tool invocation (0–128).
+# Controls how many cpex.control.result child spans are written per call.
+# Default: 32
+# CPEX_CONTROL_TELEMETRY_MAX_RESULTS=32
+
+# Informational attribute-count hint for external OTel-collector configuration
+# (e.g. transform/attributes processor limits). Not enforced gateway-side.
+# Default: 256
+# CPEX_CONTROL_TELEMETRY_MAX_ATTRIBUTES=256
+
+# =============================================================================
 # Well-Known URI Configuration
 # =============================================================================
 

--- a/.env.example
+++ b/.env.example
@@ -3022,9 +3022,12 @@ PLUGINS_CLI_MARKUP_MODE=rich
 #   - Both written to the internal observability_spans DB table and, when OTel
 #     tracing is active, also exported via the OTel SDK sink.
 #
-# Master switch — disable to suppress all cpex.control.* span writes.
-# Default: true
-# CPEX_CONTROL_TELEMETRY_ENABLED=true
+# Master switch — enable to emit cpex.control.* spans.
+# DISABLED BY DEFAULT: each traced tool call creates up to 1 summary +
+# CPEX_CONTROL_TELEMETRY_MAX_RESULTS result DB spans. Review storage and
+# cardinality implications before enabling in production.
+# Default: false
+# CPEX_CONTROL_TELEMETRY_ENABLED=false
 
 # Independently toggle the DB sink (cpex.control.summary + cpex.control.result rows).
 # Default: true
@@ -3053,6 +3056,12 @@ PLUGINS_CLI_MARKUP_MODE=rich
 # in place.
 # Default: false
 # CPEX_CONTROL_TELEMETRY_EMIT_REASON=false
+
+# Emit cpex.control.agent.id (authenticated caller email) on the summary span.
+# DISABLED BY DEFAULT: high-cardinality PII field with GDPR/data-residency implications.
+# Enable only when the observability sink is secured and a redaction boundary is in place.
+# Default: false
+# CPEX_CONTROL_TELEMETRY_EMIT_AGENT_ID=false
 
 # =============================================================================
 # Well-Known URI Configuration

--- a/.env.example
+++ b/.env.example
@@ -3042,9 +3042,17 @@ PLUGINS_CLI_MARKUP_MODE=rich
 # CPEX_CONTROL_TELEMETRY_MAX_RESULTS=32
 
 # Informational attribute-count hint for external OTel-collector configuration
-# (e.g. transform/attributes processor limits). Not enforced gateway-side.
+# (e.g. transform/attributes processor limits). Not enforced gateway-side;
+# gateway-side enforcement is planned for Phase 5 attribute-policy wiring.
 # Default: 256
 # CPEX_CONTROL_TELEMETRY_MAX_ATTRIBUTES=256
+
+# Emit cpex.control.result.reason and cpex.control.result.error_code on per-control spans.
+# DISABLED BY DEFAULT: these fields may contain PII, tool argument values, or exception
+# content. Enable only when the observability sink is secured and a redaction boundary is
+# in place.
+# Default: false
+# CPEX_CONTROL_TELEMETRY_EMIT_REASON=false
 
 # =============================================================================
 # Well-Known URI Configuration

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -217,10 +217,6 @@ jobs:
 
       - name: Upload SARIF to CodeQL
         if: always() && (github.event_name == 'merge_group' || github.event_name == 'push') && steps.scan-fedramp.outputs.sarif != ''
-        # The merge-queue ephemeral ref is deleted on ejection; a retried run then
-        # fails "ref not found" on the stale ref baked into the job context.  The
-        # scan itself is unaffected — SARIF lands on the push-to-main re-run.
-        continue-on-error: true
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: "${{ steps.scan-fedramp.outputs.sarif }}"
@@ -295,8 +291,6 @@ jobs:
 
       - name: Upload SARIF to CodeQL
         if: always() && (github.event_name == 'merge_group' || github.event_name == 'push') && steps.scan.outputs.sarif != ''
-        # Same stale-ref guard as the fedramp job above.
-        continue-on-error: true
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: "${{ steps.scan.outputs.sarif }}"

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -217,6 +217,10 @@ jobs:
 
       - name: Upload SARIF to CodeQL
         if: always() && (github.event_name == 'merge_group' || github.event_name == 'push') && steps.scan-fedramp.outputs.sarif != ''
+        # The merge-queue ephemeral ref is deleted on ejection; a retried run then
+        # fails "ref not found" on the stale ref baked into the job context.  The
+        # scan itself is unaffected — SARIF lands on the push-to-main re-run.
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: "${{ steps.scan-fedramp.outputs.sarif }}"
@@ -291,6 +295,8 @@ jobs:
 
       - name: Upload SARIF to CodeQL
         if: always() && (github.event_name == 'merge_group' || github.event_name == 'push') && steps.scan.outputs.sarif != ''
+        # Same stale-ref guard as the fedramp job above.
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: "${{ steps.scan.outputs.sarif }}"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-04T12:52:10Z",
+  "generated_at": "2026-08-04T13:25:06Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -258,7 +258,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1931,
+        "line_number": 1938,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2019,
+        "line_number": 2026,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2369,
+        "line_number": 2376,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3734,
+        "line_number": 3741,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3825,
+        "line_number": 3832,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3868,
+        "line_number": 3875,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3873,
+        "line_number": 3880,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3878,
+        "line_number": 3885,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@
 
 ### Added
 
+- **CPEX Control-Execution Telemetry** - Structured per-plugin enforcement observability on every tool invocation. Requires CPEX ≥ 0.1.2; silent no-op on older builds. Two new span types are written to `observability_spans` (and OTel when active):
+  - `cpex.control.summary` — one per tool call; aggregate counts (`invocation_count`, `matched_count`, `applied_count`, `error_count`, `timeout_count`, `duration`), effective `result.allowed`, `enforcement_point`, and calling identity (`tool.name`, `agent.id`, `binding.name`).
+  - `cpex.control.result` — one per plugin evaluated; per-plugin `name`, `hook_name`, `mode`, `status`, `result.allowed`, `duration`, and optional `result.reason`, `result.error_code`, `config.keys`.
+  - Wildcard-aware attribute rename/drop policy (`cpex.control.results.*.result.reason` etc.) via `compile_attribute_policy()` for use by `SpanAttributeCustomizerPlugin`.
+  - New config flags: `CPEX_CONTROL_TELEMETRY_ENABLED` (default `true`), `CPEX_CONTROL_TELEMETRY_DB_ENABLED` (default `true`), `CPEX_CONTROL_TELEMETRY_FLATTEN_RESULTS` (default `false`), `CPEX_CONTROL_TELEMETRY_MAX_RESULTS` (default `32`), `CPEX_CONTROL_TELEMETRY_MAX_ATTRIBUTES` (default `256`, informational).
+  - `pyproject.toml` minimum `cpex` version bumped to `>=0.1.2`; `uv.lock` updated accordingly.
+
 - **`make init-secrets-patch-env`** - Generates cryptographically strong values for `JWT_SECRET_KEY`, `AUTH_ENCRYPTION_SECRET`, and `BASIC_AUTH_PASSWORD` and patches them into an existing `.env` file in-place.
 - **`make setup`** - For fresh checkouts: copies `.env.example` → `.env` and runs `init-secrets-patch-env` to provision real secrets before first use.
 - **`mcpgateway/scripts/init_secrets.py`** - Script backing both Makefile targets; generates secrets using `secrets.token_hex(32)` and rewrites the relevant lines in `.env` without touching unrelated configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
   - `cpex.control.summary` — one per tool call; aggregate counts (`invocation_count`, `matched_count`, `applied_count`, `error_count`, `timeout_count`, `duration`), effective `result.allowed`, `enforcement_point`, and calling identity (`tool.name`, `agent.id`, `binding.name`).
   - `cpex.control.result` — one per plugin evaluated; per-plugin `name`, `hook_name`, `mode`, `status`, `result.allowed`, `duration`, and optional `result.reason`, `result.error_code`, `config.keys`.
   - Wildcard-aware attribute rename/drop policy (`cpex.control.results.*.result.reason` etc.) via `compile_attribute_policy()` for use by `SpanAttributeCustomizerPlugin`.
-  - New config flags: `CPEX_CONTROL_TELEMETRY_ENABLED` (default `true`), `CPEX_CONTROL_TELEMETRY_DB_ENABLED` (default `true`), `CPEX_CONTROL_TELEMETRY_FLATTEN_RESULTS` (default `false`), `CPEX_CONTROL_TELEMETRY_MAX_RESULTS` (default `32`), `CPEX_CONTROL_TELEMETRY_MAX_ATTRIBUTES` (default `256`, informational).
+  - New config flags: `CPEX_CONTROL_TELEMETRY_ENABLED` (default `false`), `CPEX_CONTROL_TELEMETRY_DB_ENABLED` (default `true`), `CPEX_CONTROL_TELEMETRY_FLATTEN_RESULTS` (default `false`), `CPEX_CONTROL_TELEMETRY_MAX_RESULTS` (default `32`), `CPEX_CONTROL_TELEMETRY_MAX_ATTRIBUTES` (default `256`, informational), `CPEX_CONTROL_TELEMETRY_EMIT_REASON` (default `false`), `CPEX_CONTROL_TELEMETRY_EMIT_AGENT_ID` (default `false`).
   - `pyproject.toml` minimum `cpex` version bumped to `>=0.1.2`; `uv.lock` updated accordingly.
 
 - **`make init-secrets-patch-env`** - Generates cryptographically strong values for `JWT_SECRET_KEY`, `AUTH_ENCRYPTION_SECRET`, and `BASIC_AUTH_PASSWORD` and patches them into an existing `.env` file in-place.

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1982,6 +1982,45 @@ class Settings(BaseSettings):
     plugin_metrics_db_numeric_rows_enabled: bool = Field(default=True, description="Additionally record numeric plugin metadata fields as internal ObservabilityMetric rows")
     plugin_metrics_max_numeric_per_call: int = Field(default=16, ge=0, description="Max numeric ObservabilityMetric rows written per invoke_hook() call, across all plugins")
 
+    # CPEX control-execution telemetry (G2: ControlExecutionRecord -> observability).
+    # Enabled only when the installed CPEX version exposes ControlExecutionRecord (>=0.1.2).
+    # A no-op when execution_records_supported() returns False (older CPEX build).
+    cpex_control_telemetry_enabled: bool = Field(
+        default=True,
+        description=("Emit structured CPEX control-execution telemetry on tool invocations. No-op when CPEX execution records are unavailable (CPEX < 0.1.2). Env: CPEX_CONTROL_TELEMETRY_ENABLED."),
+    )
+    cpex_control_telemetry_db_enabled: bool = Field(
+        default=True,
+        description=("Write cpex.control.summary and cpex.control.result DB spans for each tool invocation. Env: CPEX_CONTROL_TELEMETRY_DB_ENABLED."),
+    )
+    cpex_control_telemetry_flatten_results: bool = Field(
+        default=False,
+        description=(
+            "Also emit flattened cpex.control.results.<name>.* attributes on the summary span. "
+            "Bounded by cpex_control_telemetry_max_results. "
+            "Use only when downstream tooling requires dynamic key names. "
+            "Env: CPEX_CONTROL_TELEMETRY_FLATTEN_RESULTS."
+        ),
+    )
+    cpex_control_telemetry_max_results: int = Field(
+        default=32,
+        ge=0,
+        le=128,
+        description=("Max per-control result records exported per tool invocation. Env: CPEX_CONTROL_TELEMETRY_MAX_RESULTS."),
+    )
+    cpex_control_telemetry_max_attributes: int = Field(
+        default=256,
+        ge=0,
+        description=(
+            "Informational cap on total span attributes across all control telemetry per "
+            "invocation. Not enforced gateway-side; intended as a hint for external "
+            "OTel-collector attribute-limit configuration (e.g. transform/attributes "
+            "processor). Actual enforcement, if required, should be added alongside "
+            "Phase 5 attribute-policy wiring (see issue #5785). "
+            "Env: CPEX_CONTROL_TELEMETRY_MAX_ATTRIBUTES."
+        ),
+    )
+
     # Correlation ID Settings
     correlation_id_enabled: bool = Field(default=True, description="Enable automatic correlation ID tracking for requests")
     correlation_id_header: str = Field(default="X-Correlation-ID", description="HTTP header name for correlation ID")

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -2015,9 +2015,19 @@ class Settings(BaseSettings):
             "Informational cap on total span attributes across all control telemetry per "
             "invocation. Not enforced gateway-side; intended as a hint for external "
             "OTel-collector attribute-limit configuration (e.g. transform/attributes "
-            "processor). Actual enforcement, if required, should be added alongside "
-            "Phase 5 attribute-policy wiring (see issue #5785). "
+            "processor). Gateway-side enforcement is planned alongside Phase 5 "
+            "attribute-policy wiring. Until then, the internal DB sink is unbounded. "
             "Env: CPEX_CONTROL_TELEMETRY_MAX_ATTRIBUTES."
+        ),
+    )
+    cpex_control_telemetry_emit_reason: bool = Field(
+        default=False,
+        description=(
+            "Emit cpex.control.result.reason and cpex.control.result.error_code on "
+            "per-control spans. Disabled by default because these fields may contain "
+            "PII, tool argument values, or exception content. Enable only when the "
+            "observability sink is appropriately secured and a redaction boundary is "
+            "in place. Env: CPEX_CONTROL_TELEMETRY_EMIT_REASON."
         ),
     )
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1986,8 +1986,15 @@ class Settings(BaseSettings):
     # Enabled only when the installed CPEX version exposes ControlExecutionRecord (>=0.1.2).
     # A no-op when execution_records_supported() returns False (older CPEX build).
     cpex_control_telemetry_enabled: bool = Field(
-        default=True,
-        description=("Emit structured CPEX control-execution telemetry on tool invocations. No-op when CPEX execution records are unavailable (CPEX < 0.1.2). Env: CPEX_CONTROL_TELEMETRY_ENABLED."),
+        default=False,
+        description=(
+            "Emit structured CPEX control-execution telemetry on tool invocations. "
+            "Disabled by default — each traced tool call creates up to 1 summary + "
+            "CPEX_CONTROL_TELEMETRY_MAX_RESULTS result DB spans. Enable only after "
+            "reviewing storage and cardinality implications. "
+            "No-op when CPEX execution records are unavailable (CPEX < 0.1.2). "
+            "Env: CPEX_CONTROL_TELEMETRY_ENABLED."
+        ),
     )
     cpex_control_telemetry_db_enabled: bool = Field(
         default=True,
@@ -2028,6 +2035,16 @@ class Settings(BaseSettings):
             "PII, tool argument values, or exception content. Enable only when the "
             "observability sink is appropriately secured and a redaction boundary is "
             "in place. Env: CPEX_CONTROL_TELEMETRY_EMIT_REASON."
+        ),
+    )
+    cpex_control_telemetry_emit_agent_id: bool = Field(
+        default=False,
+        description=(
+            "Emit cpex.control.agent.id on the summary span. Disabled by default "
+            "because the value is the authenticated caller email — a high-cardinality "
+            "PII field with GDPR/data-residency implications. Enable only when the "
+            "observability sink is appropriately secured and a redaction boundary is "
+            "in place. Env: CPEX_CONTROL_TELEMETRY_EMIT_AGENT_ID."
         ),
     )
 

--- a/mcpgateway/plugins/control_telemetry.py
+++ b/mcpgateway/plugins/control_telemetry.py
@@ -89,6 +89,7 @@ class ControlTelemetryAccumulator:
     _pre_denied: bool = False
     _post_denied: bool = False
     _truncated: int = 0  # records dropped due to per-call cap OR per-hook cap
+    _export_cap_dropped: int = 0  # records dropped at emit time by the per-invocation export cap
 
     def add(self, result: Any, *, hook: str) -> None:
         """Consume executions from one ``invoke_hook`` result.
@@ -172,12 +173,39 @@ class ControlTelemetryAccumulator:
 
     @property
     def truncated(self) -> int:
-        """Number of records dropped due to the per-hook or per-call cap.
+        """Total records dropped across all three truncation tiers:
+
+        - Tier 1: per-hook cap (``_MAX_RECORDS_PER_HOOK``)
+        - Tier 2: per-call accumulation cap (``_MAX_RECORDS_PER_CALL``)
+        - Tier 3: per-invocation export cap (``CPEX_CONTROL_TELEMETRY_MAX_RESULTS``)
+
+        Tier-3 drops are recorded by ``mark_export_cap_dropped()`` after the
+        export cap is applied in ``record_control_telemetry()``.
 
         Returns:
-            Count of dropped records (0 when no overflow).
+            Total count of dropped records (0 when no overflow on any tier).
         """
-        return self._truncated
+        return self._truncated + self._export_cap_dropped
+
+    def mark_export_cap_dropped(self, count: int) -> None:
+        """Record the number of records silently dropped by the export cap.
+
+        Called once per ``record_control_telemetry()`` invocation, after
+        ``_get_max_results()`` is applied, so the ``cpex.control.truncated``
+        summary attribute reflects all three truncation tiers.
+
+        Args:
+            count: Number of records that exceeded ``CPEX_CONTROL_TELEMETRY_MAX_RESULTS``
+                   and were not exported to any sink.
+
+        Examples:
+            >>> acc = ControlTelemetryAccumulator()
+            >>> acc.mark_export_cap_dropped(5)
+            >>> acc.truncated
+            5
+        """
+        if count > 0:
+            self._export_cap_dropped += count
 
     @property
     def effective_allowed(self) -> bool:
@@ -306,6 +334,16 @@ def record_control_telemetry(
                 "cpex.control.enforcement_point": _enforcement_point(accumulator),
             }
         )
+        # Compute and record export-cap (tier-3) drops before building the summary span.
+        # records_received is the count before any export cap; results_count is the cap-bounded
+        # export count.  The difference is exactly the number of records the islice will skip.
+        records_received = aggregate.get("cpex.control.records_received", 0)
+        max_results = _get_max_results()
+        export_cap_dropped = max(0, records_received - max_results)
+        if export_cap_dropped:
+            accumulator.mark_export_cap_dropped(export_cap_dropped)
+
+        # cpex.control.truncated now covers all three tiers (hook cap + call cap + export cap).
         if accumulator.truncated:
             aggregate["cpex.control.truncated"] = accumulator.truncated
 

--- a/mcpgateway/plugins/control_telemetry.py
+++ b/mcpgateway/plugins/control_telemetry.py
@@ -7,8 +7,10 @@ Accumulator and emitter for CPEX control-execution telemetry.
 
 Mirrors the structure of ``record_plugin_metrics()`` in ``plugins/utils.py``
 but consumes **trusted** ``ControlExecutionRecord`` fields rather than
-untrusted plugin metadata.  All bounds and sanitization follow the same S4
-principles.
+untrusted plugin metadata.  All bounds and sanitization follow the same
+principles of bounded cardinality and field-level sanitization applied
+throughout the plugin telemetry pipeline (see ``plugins/utils.py`` for the
+shared ``_safe_str``/``_safe_num`` helpers and field-name allowlists).
 
 Architecture
 ------------
@@ -227,9 +229,10 @@ class ControlTelemetryAccumulator:
     def mark_export_cap_dropped(self, count: int) -> None:
         """Record the number of records silently dropped by the export cap.
 
-        Called once per ``record_control_telemetry()`` invocation, after
-        ``_get_max_results()`` is applied, so the ``cpex.control.truncated``
-        summary attribute reflects all three truncation tiers.
+        Idempotent: the first call with ``count > 0`` sets the value; subsequent
+        calls on the same accumulator are no-ops.  This prevents ``cpex.control.truncated``
+        from being inflated when ``record_control_telemetry()`` is called more than once
+        on the same accumulator (e.g. on a retry path or in tests).
 
         Args:
             count: Number of records that exceeded ``CPEX_CONTROL_TELEMETRY_MAX_RESULTS``
@@ -240,9 +243,12 @@ class ControlTelemetryAccumulator:
             >>> acc.mark_export_cap_dropped(5)
             >>> acc.truncated
             5
+            >>> acc.mark_export_cap_dropped(5)  # second call is a no-op
+            >>> acc.truncated
+            5
         """
-        if count > 0:
-            self._export_cap_dropped += count
+        if count > 0 and self._export_cap_dropped == 0:
+            self._export_cap_dropped = count
 
     @property
     def effective_allowed(self) -> bool:

--- a/mcpgateway/plugins/control_telemetry.py
+++ b/mcpgateway/plugins/control_telemetry.py
@@ -46,9 +46,9 @@ from mcpgateway.plugins.utils import _IDENTIFIER_RE  # re-use the same identifie
 logger = logging.getLogger(__name__)
 
 # ── Bounds (mirrors _MAX_PLUGIN_KEYS / _MAX_PLUGINS_PER_CALL in utils.py) ──────
-_MAX_RECORDS_PER_HOOK = 64   # max ControlExecutionRecords consumed per invoke_hook call
+_MAX_RECORDS_PER_HOOK = 64  # max ControlExecutionRecords consumed per invoke_hook call
 _MAX_RECORDS_PER_CALL = 128  # cap across pre + post combined
-_MAX_REASON_LEN = 256        # CPEX already bounds this; enforce again defensively
+_MAX_REASON_LEN = 256  # CPEX already bounds this; enforce again defensively
 _MAX_ERROR_CODE_LEN = 256
 _MAX_CONFIG_KEYS = 64
 
@@ -197,7 +197,7 @@ class ControlTelemetryAccumulator:
             "cpex.control.matched_count": matched_count,
             "cpex.control.applied_count": applied_count,
             "cpex.control.results_count": len(self._records),
-            "cpex.control.duration": duration_ns,   # nanoseconds
+            "cpex.control.duration": duration_ns,  # nanoseconds
             "cpex.control.result.allowed": self.effective_allowed,
             "cpex.control.error_count": error_count,
             "cpex.control.timeout_count": timeout_count,

--- a/mcpgateway/plugins/control_telemetry.py
+++ b/mcpgateway/plugins/control_telemetry.py
@@ -88,7 +88,7 @@ class ControlTelemetryAccumulator:
     _records: list = field(default_factory=list)
     _pre_denied: bool = False
     _post_denied: bool = False
-    _truncated: int = 0  # records dropped due to per-call cap
+    _truncated: int = 0  # records dropped due to per-call cap OR per-hook cap
 
     def add(self, result: Any, *, hook: str) -> None:
         """Consume executions from one ``invoke_hook`` result.
@@ -101,7 +101,13 @@ class ControlTelemetryAccumulator:
             return
 
         records = get_executions(result)
-        for rec in itertools.islice(records, _MAX_RECORDS_PER_HOOK):
+        hook_count = 0
+        for rec in records:
+            if hook_count >= _MAX_RECORDS_PER_HOOK:
+                # Per-hook cap exceeded — count these as truncated and stop.
+                self._truncated += 1
+                continue
+            hook_count += 1
             if len(self._records) >= _MAX_RECORDS_PER_CALL:
                 self._truncated += 1
                 continue
@@ -113,6 +119,29 @@ class ControlTelemetryAccumulator:
                 self._pre_denied = True
             else:
                 self._post_denied = True
+
+    def mark_denied(self, *, hook: str) -> None:
+        """Explicitly mark a denial when ``violations_as_exceptions=True`` causes
+        ``invoke_hook()`` to raise before returning, so ``add()`` is never called.
+
+        Call this from the ``except PluginViolationError`` handler immediately
+        after catching the exception and before re-raising.
+
+        Args:
+            hook: ``"pre"`` or ``"post"`` — which enforcement point was denied.
+
+        Examples:
+            >>> acc = ControlTelemetryAccumulator()
+            >>> acc.mark_denied(hook="pre")
+            >>> acc.pre_denied
+            True
+            >>> acc.effective_allowed
+            False
+        """
+        if hook == "pre":
+            self._pre_denied = True
+        else:
+            self._post_denied = True
 
     @property
     def records(self) -> list:
@@ -143,7 +172,7 @@ class ControlTelemetryAccumulator:
 
     @property
     def truncated(self) -> int:
-        """Number of records dropped due to the per-call cap.
+        """Number of records dropped due to the per-hook or per-call cap.
 
         Returns:
             Count of dropped records (0 when no overflow).
@@ -165,6 +194,18 @@ class ControlTelemetryAccumulator:
         Returns a ``dict`` of ``cpex.control.*`` attributes safe for span
         attachment.  Only uses trusted ``ControlExecutionRecord`` fields —
         never plugin metadata.
+
+        Count semantics:
+
+        - ``invocation_count``: controls that *actually ran* — status in
+          ``{completed, error, timeout}``.  Disabled, skipped, and cancelled
+          records are excluded (matches CPEX semantics).
+        - ``records_received``: total records accumulated before any export
+          cap is applied.  Includes disabled/skipped/cancelled.
+        - ``results_count``: records that will actually be exported to sinks,
+          i.e. ``min(records_received, CPEX_CONTROL_TELEMETRY_MAX_RESULTS)``.
+          Downstream operators can derive ``records_dropped = records_received
+          - results_count + truncated`` to understand total loss.
 
         Returns:
             Dictionary of aggregate control telemetry attributes.
@@ -196,13 +237,15 @@ class ControlTelemetryAccumulator:
             except Exception:  # noqa: BLE001
                 logger.debug("Failed to aggregate one ControlExecutionRecord", exc_info=True)
 
+        records_received = len(self._records)
         # results_count = records exported after the per-invocation cap (not raw accumulated count).
-        results_count = min(len(self._records), _get_max_results())
+        results_count = min(records_received, _get_max_results())
 
         return {
             "cpex.control.invocation_count": invocation_count,
             "cpex.control.matched_count": matched_count,
             "cpex.control.applied_count": applied_count,
+            "cpex.control.records_received": records_received,
             "cpex.control.results_count": results_count,
             "cpex.control.duration_ns": total_duration_ns,  # nanoseconds — OTel unit suffix convention
             "cpex.control.result.allowed": self.effective_allowed,
@@ -432,11 +475,23 @@ def _per_control_attributes(hook: str, rec: Any) -> dict:
         # requested_allow: only emit when present (None means not applicable to this mode)
         if rec.requested_allow is not None:
             attrs["cpex.control.result.requested_allowed"] = bool(rec.requested_allow)
-        # Optional free-text fields — only emit when present
-        if rec.reason:
-            attrs["cpex.control.result.reason"] = _safe_str(rec.reason, _MAX_REASON_LEN)
-        if rec.error_code:
-            attrs["cpex.control.result.error_code"] = _safe_str(rec.error_code, _MAX_ERROR_CODE_LEN)
+        # Artifact identity — only emit when CPEX record carries them (optional fields)
+        artifact_name = getattr(rec, "artifact_name", None)
+        if artifact_name:
+            attrs["cpex.control.artifact.name"] = _safe_str(artifact_name, 128)
+        artifact_id = getattr(rec, "artifact_id", None)
+        if artifact_id:
+            attrs["cpex.control.artifact.id"] = _safe_str(artifact_id, 128)
+        # Optional free-text fields — gated by CPEX_CONTROL_TELEMETRY_EMIT_REASON (default: false).
+        # reason and error_code can contain PII, tool argument values, or exception content.
+        # They are opt-in until Phase 5 central attribute-policy wiring provides a redaction
+        # boundary.  Set CPEX_CONTROL_TELEMETRY_EMIT_REASON=true only in environments where
+        # these fields are known safe and the observability sink is appropriately secured.
+        if _emit_reason_enabled():
+            if rec.reason:
+                attrs["cpex.control.result.reason"] = _safe_str(rec.reason, _MAX_REASON_LEN)
+            if rec.error_code:
+                attrs["cpex.control.result.error_code"] = _safe_str(rec.error_code, _MAX_ERROR_CODE_LEN)
         if rec.config_keys:
             # Key names only (CPEX never includes values); bounded list join
             attrs["cpex.control.config.keys"] = ",".join(rec.config_keys[:_MAX_CONFIG_KEYS])
@@ -502,6 +557,29 @@ def _get_max_results() -> int:
         return 32
 
 
+def _emit_reason_enabled() -> bool:
+    """Return True when ``result.reason`` and ``result.error_code`` emission is enabled.
+
+    These fields are opt-in (default: False) because they may contain PII, tool argument
+    values, or exception content that should not leave the process without passing through
+    a redaction boundary.  Enable via ``CPEX_CONTROL_TELEMETRY_EMIT_REASON=true`` only in
+    environments where the observability sink is appropriately secured.
+
+    Returns:
+        True when ``cpex_control_telemetry_emit_reason`` is set to True in settings.
+
+    Examples:
+        >>> isinstance(_emit_reason_enabled(), bool)
+        True
+    """
+    try:
+        from mcpgateway.config import settings  # pylint: disable=import-outside-toplevel
+
+        return bool(getattr(settings, "cpex_control_telemetry_emit_reason", False))
+    except Exception:  # noqa: BLE001
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Flattened-results projection helper
 # ---------------------------------------------------------------------------
@@ -556,18 +634,33 @@ def _build_flattened_attributes(
                 seen_names.add(raw_name)
 
                 prefix = f"cpex.control.results.{raw_name}"
+                result[f"{prefix}.name"] = _safe_str(raw_name, 64)
                 result[f"{prefix}.status"] = _safe_str(str(getattr(rec, "status", "")), 32)
                 result[f"{prefix}.enforcement_point"] = hook
                 result[f"{prefix}.result.allowed"] = bool(getattr(rec, "effective_allow", True))
-                result[f"{prefix}.duration"] = int(getattr(rec, "duration_ns", 0))
+                result[f"{prefix}.duration_ns"] = int(getattr(rec, "duration_ns", 0))  # nanoseconds — OTel unit suffix convention
 
-                reason = getattr(rec, "reason", None)
-                if reason:
-                    result[f"{prefix}.result.reason"] = _safe_str(reason, _MAX_REASON_LEN)
+                artifact_name = getattr(rec, "artifact_name", None)
+                if artifact_name:
+                    result[f"{prefix}.artifact.name"] = _safe_str(artifact_name, 128)
 
-                error_code = getattr(rec, "error_code", None)
-                if error_code:
-                    result[f"{prefix}.result.error_code"] = _safe_str(error_code, _MAX_ERROR_CODE_LEN)
+                artifact_id = getattr(rec, "artifact_id", None)
+                if artifact_id:
+                    result[f"{prefix}.artifact.id"] = _safe_str(artifact_id, 128)
+
+                config_keys = getattr(rec, "config_keys", None)
+                if config_keys:
+                    result[f"{prefix}.config.keys"] = ",".join(config_keys[:_MAX_CONFIG_KEYS])
+
+                # reason/error_code gated by CPEX_CONTROL_TELEMETRY_EMIT_REASON (default: false)
+                if _emit_reason_enabled():
+                    reason = getattr(rec, "reason", None)
+                    if reason:
+                        result[f"{prefix}.result.reason"] = _safe_str(reason, _MAX_REASON_LEN)
+
+                    error_code = getattr(rec, "error_code", None)
+                    if error_code:
+                        result[f"{prefix}.result.error_code"] = _safe_str(error_code, _MAX_ERROR_CODE_LEN)
             except Exception:  # noqa: BLE001
                 logger.debug("Failed to flatten one ControlExecutionRecord", exc_info=True)
 

--- a/mcpgateway/plugins/control_telemetry.py
+++ b/mcpgateway/plugins/control_telemetry.py
@@ -53,11 +53,20 @@ _MAX_RECORDS_PER_CALL = 128  # cap across pre + post combined
 _MAX_REASON_LEN = 256  # CPEX already bounds this; enforce again defensively
 _MAX_ERROR_CODE_LEN = 256
 _MAX_CONFIG_KEYS = 64
-_MAX_CONFIG_KEY_LEN = 128  # per-key length cap before joining
+_MAX_CONFIG_KEY_LEN = 128  # per-key byte cap before joining
 _MAX_CONFIG_KEYS_JOINED_LEN = 4096  # max total byte length of the joined config_keys string
 
 # Statuses that represent controls that actually ran (exclude disabled/skipped/cancelled).
 _ACTIVE_STATUSES = frozenset({"completed", "error", "timeout"})
+
+# Config-key sanitization: allow printable identifier-like characters only.
+# Commas are the joining delimiter so must be excluded; control characters
+# (CR, LF, NUL, tab, …) and non-ASCII are rejected to prevent log injection and
+# telemetry-ambiguity attacks through key names.  The pattern deliberately does
+# NOT use _IDENTIFIER_RE (which allows dots and hyphens) because config-key names
+# are opaque tokens whose cardinality and format are determined by CPEX control
+# authors, not the gateway; the charset is the safest defensible subset.
+_CONFIG_KEY_RE = _IDENTIFIER_RE  # re-use: ^[A-Za-z0-9_.-]{1,64}$
 
 
 # ---------------------------------------------------------------------------
@@ -96,6 +105,7 @@ class ControlTelemetryAccumulator:
     _pre_denied: bool = False
     _post_denied: bool = False
     _plugin_errored: bool = False  # True when a PluginError (outage) was caught on any hook
+    _plugin_error_hook: str = ""   # "pre" | "post" | "" — which hook the error occurred on
     _truncated: int = 0  # records dropped due to per-call cap OR per-hook cap
     _export_cap_dropped: int = 0  # records dropped at emit time by the per-invocation export cap
 
@@ -152,27 +162,42 @@ class ControlTelemetryAccumulator:
         else:
             self._post_denied = True
 
-    def mark_plugin_error(self) -> None:
+    def mark_plugin_error(self, *, hook: str = "") -> None:
         """Explicitly record that a ``PluginError`` (outage/crash/misconfiguration) occurred.
 
         Call this from the ``except PluginError`` handler before re-raising so that
         the emitted summary span carries ``cpex.control.plugin_error=True``.  This
         distinguishes a plugin infrastructure failure from both a successful allow
-        decision (``result.allowed=True``, no error) and a deliberate policy denial
-        (``result.allowed=False`` set via ``mark_denied()``).
+        decision and a deliberate policy denial (``result.allowed=False`` via
+        ``mark_denied()``).
 
-        When the failing plugin is the first in the chain the accumulator may have no
+        When the failing plugin is first in the chain the accumulator may have no
         records and no denial flags — without this flag ``record_control_telemetry()``
         would silently skip emission.  Including ``_plugin_errored`` in the empty-guard
         ensures the summary span is always emitted so the outage is visible in dashboards.
 
+        Because a ``PluginError`` makes the control-chain decision *indeterminate*
+        (neither allowed nor denied), ``aggregate()`` omits ``cpex.control.result.allowed``
+        when this flag is set and no explicit denial flag is present.  Downstream dashboards
+        must treat the absence of ``result.allowed`` as "decision unknown" rather than
+        as an allow.
+
+        Args:
+            hook: ``"pre"`` or ``"post"`` — which enforcement point the error occurred on.
+                  Used to derive ``enforcement_point`` when no records exist.  Pass ``""``
+                  when the hook is unknown or not applicable.
+
         Examples:
             >>> acc = ControlTelemetryAccumulator()
-            >>> acc.mark_plugin_error()
+            >>> acc.mark_plugin_error(hook="pre")
             >>> acc.plugin_errored
             True
+            >>> acc.plugin_error_hook
+            'pre'
         """
         self._plugin_errored = True
+        if hook in ("pre", "post"):
+            self._plugin_error_hook = hook
 
     @property
     def plugin_errored(self) -> bool:
@@ -182,6 +207,15 @@ class ControlTelemetryAccumulator:
             True if any plugin raised ``PluginError``; False otherwise.
         """
         return self._plugin_errored
+
+    @property
+    def plugin_error_hook(self) -> str:
+        """The hook on which the ``PluginError`` occurred (``"pre"``, ``"post"``, or ``""``).
+
+        Returns:
+            Hook name string, or empty string when not set.
+        """
+        return self._plugin_error_hook
 
     @property
     def records(self) -> list:
@@ -320,10 +354,19 @@ class ControlTelemetryAccumulator:
             "cpex.control.records_received": records_received,
             "cpex.control.results_count": results_count,
             "cpex.control.duration_ns": total_duration_ns,  # nanoseconds — OTel unit suffix convention
-            "cpex.control.result.allowed": self.effective_allowed,
             "cpex.control.error_count": error_count,
             "cpex.control.timeout_count": timeout_count,
         }
+        # cpex.control.result.allowed is the overall enforcement decision.
+        # When a PluginError occurred and no explicit denial was also set, the decision
+        # is INDETERMINATE — the chain did not complete normally so we cannot assert
+        # "allowed".  Omitting the key signals "unknown" to dashboards rather than
+        # implying a clean allow.  If a denial flag was also set (unusual but possible),
+        # the denial takes precedence and we do emit result.allowed=False.
+        decision_indeterminate = self._plugin_errored and self.effective_allowed
+        if not decision_indeterminate:
+            result["cpex.control.result.allowed"] = self.effective_allowed
+
         # cpex.control.plugin_error distinguishes a plugin infrastructure failure
         # (PluginError: crash/timeout/misconfiguration) from both a successful allow
         # and a deliberate policy denial (result.allowed=False).  Only emitted when
@@ -589,12 +632,14 @@ def _per_control_attributes(hook: str, rec: Any) -> dict:
                 attrs["cpex.control.result.error_code"] = _safe_str(rec.error_code, _MAX_ERROR_CODE_LEN)
         if rec.config_keys:
             # Key names only (CPEX never includes values).
-            # Each key is byte-capped via _safe_str; the joined string is also byte-capped
-            # via _safe_str so multibyte characters do not exceed the intended byte budget
-            # (a plain char-slice would under-count bytes for non-ASCII key names).
-            safe_keys = [_safe_str(k, _MAX_CONFIG_KEY_LEN) for k in rec.config_keys[:_MAX_CONFIG_KEYS]]
-            joined = ",".join(safe_keys)
-            attrs["cpex.control.config.keys"] = _safe_str(joined, _MAX_CONFIG_KEYS_JOINED_LEN)
+            # _sanitize_config_key() validates each key against _CONFIG_KEY_RE:
+            # commas, CR/LF, control chars, non-ASCII, and secret-shaped text are
+            # rejected (key dropped entirely, not truncated) to prevent CSV ambiguity
+            # and log/telemetry injection.  The joined string is also byte-bounded.
+            safe_keys = [s for k in rec.config_keys[:_MAX_CONFIG_KEYS] if (s := _sanitize_config_key(k)) is not None]
+            if safe_keys:
+                joined = ",".join(safe_keys)
+                attrs["cpex.control.config.keys"] = _safe_str(joined, _MAX_CONFIG_KEYS_JOINED_LEN)
         return attrs
     except Exception:  # noqa: BLE001
         logger.debug("Failed to build per-control attributes", exc_info=True)
@@ -623,13 +668,62 @@ def _safe_str(value: Any, max_len: int) -> str:
     return encoded[: max_len - 3].decode("utf-8", errors="ignore") + "..."
 
 
+def _sanitize_config_key(raw: Any) -> Optional[str]:
+    """Validate and return a single config-key name, or ``None`` if unsafe.
+
+    Config-key names are opaque tokens from CPEX control configuration.  Even
+    though CPEX only stores key *names* (never values), a malicious or
+    misconfigured control could supply key names that contain:
+
+    - Commas — ambiguous in the CSV join used for the attribute value.
+    - CR/LF/NUL/TAB — log-injection and telemetry-injection vectors.
+    - Non-ASCII / multibyte sequences — encoding ambiguity.
+    - Secret-shaped text (e.g. ``my_api_key=sk-abc123``) that leaks sensitive
+      strings into span attributes.
+
+    Safe set: ASCII letters, digits, underscores, dots, and hyphens — matching
+    ``_CONFIG_KEY_RE`` (``^[A-Za-z0-9_.-]{1,64}$``).  The per-key byte cap
+    ``_MAX_CONFIG_KEY_LEN`` is applied first so an oversized key is rejected
+    rather than silently truncated into something that looks valid.
+
+    Args:
+        raw: Raw key candidate (will be coerced to ``str``).
+
+    Returns:
+        The validated key string if safe, ``None`` otherwise.
+
+    Examples:
+        >>> _sanitize_config_key("my_key")
+        'my_key'
+        >>> _sanitize_config_key("bad,key") is None
+        True
+        >>> _sanitize_config_key("bad\\nkey") is None
+        True
+        >>> _sanitize_config_key("") is None
+        True
+    """
+    try:
+        key = str(raw)
+        # Byte-cap first — an oversized key is silently dropped, not truncated.
+        if len(key.encode("utf-8")) > _MAX_CONFIG_KEY_LEN:
+            return None
+        if _CONFIG_KEY_RE.match(key):
+            return key
+        return None
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _enforcement_point(acc: "ControlTelemetryAccumulator") -> str:
     """Derive the enforcement-point label from which hooks contributed records.
 
-    When CPEX raises ``PluginViolationError`` with ``violations_as_exceptions=True``
-    it does so *before* appending a ``ControlExecutionRecord``, so the accumulator
-    may have no records even though a hook fired.  Fall back to the denial flags so
-    a pre-invoke denial with zero records still reports ``"pre"`` rather than ``"none"``.
+    Three fallback tiers (in priority order):
+
+    1. Accumulated records — any ``"pre"`` or ``"post"`` tag in the records list.
+    2. Denial flags — set by ``mark_denied()`` when ``violations_as_exceptions=True``
+       raises before a record is appended.
+    3. Plugin-error hook — set by ``mark_plugin_error(hook=)`` when a ``PluginError``
+       fires before any record is appended (e.g. first-plugin crash).
 
     Args:
         acc: The populated accumulator.
@@ -637,8 +731,8 @@ def _enforcement_point(acc: "ControlTelemetryAccumulator") -> str:
     Returns:
         One of ``"pre"``, ``"post"``, ``"pre+post"``, or ``"none"``.
     """
-    has_pre = any(h == "pre" for h, _ in acc.records) or acc.pre_denied
-    has_post = any(h == "post" for h, _ in acc.records) or acc.post_denied
+    has_pre = any(h == "pre" for h, _ in acc.records) or acc.pre_denied or acc.plugin_error_hook == "pre"
+    has_post = any(h == "post" for h, _ in acc.records) or acc.post_denied or acc.plugin_error_hook == "post"
     if has_pre and has_post:
         return "pre+post"
     if has_pre:
@@ -779,9 +873,10 @@ def _build_flattened_attributes(
 
                 config_keys = getattr(rec, "config_keys", None)
                 if config_keys:
-                    safe_keys = [_safe_str(k, _MAX_CONFIG_KEY_LEN) for k in config_keys[:_MAX_CONFIG_KEYS]]
-                    joined = ",".join(safe_keys)
-                    result[f"{prefix}.config.keys"] = _safe_str(joined, _MAX_CONFIG_KEYS_JOINED_LEN)
+                    safe_keys = [s for k in config_keys[:_MAX_CONFIG_KEYS] if (s := _sanitize_config_key(k)) is not None]
+                    if safe_keys:
+                        joined = ",".join(safe_keys)
+                        result[f"{prefix}.config.keys"] = _safe_str(joined, _MAX_CONFIG_KEYS_JOINED_LEN)
 
                 # reason/error_code gated by CPEX_CONTROL_TELEMETRY_EMIT_REASON (default: false)
                 if _emit_reason_enabled():

--- a/mcpgateway/plugins/control_telemetry.py
+++ b/mcpgateway/plugins/control_telemetry.py
@@ -52,6 +52,9 @@ _MAX_REASON_LEN = 256  # CPEX already bounds this; enforce again defensively
 _MAX_ERROR_CODE_LEN = 256
 _MAX_CONFIG_KEYS = 64
 
+# Statuses that represent controls that actually ran (exclude disabled/skipped/cancelled).
+_ACTIVE_STATUSES = frozenset({"completed", "error", "timeout"})
+
 
 # ---------------------------------------------------------------------------
 # ControlTelemetryAccumulator
@@ -244,9 +247,6 @@ class ControlTelemetryAccumulator:
         total_duration_ns = 0
         error_count = 0
         timeout_count = 0
-
-        # Statuses that represent controls that actually ran (exclude disabled/skipped/cancelled).
-        _ACTIVE_STATUSES = {"completed", "error", "timeout"}
 
         for _hook, rec in self._records:
             try:

--- a/mcpgateway/plugins/control_telemetry.py
+++ b/mcpgateway/plugins/control_telemetry.py
@@ -105,7 +105,7 @@ class ControlTelemetryAccumulator:
     _pre_denied: bool = False
     _post_denied: bool = False
     _plugin_errored: bool = False  # True when a PluginError (outage) was caught on any hook
-    _plugin_error_hook: str = ""   # "pre" | "post" | "" — which hook the error occurred on
+    _plugin_error_hook: str = ""  # "pre" | "post" | "" — which hook the error occurred on
     _truncated: int = 0  # records dropped due to per-call cap OR per-hook cap
     _export_cap_dropped: int = 0  # records dropped at emit time by the per-invocation export cap
 

--- a/mcpgateway/plugins/control_telemetry.py
+++ b/mcpgateway/plugins/control_telemetry.py
@@ -51,7 +51,7 @@ _MAX_RECORDS_PER_CALL = 128  # cap across pre + post combined
 _MAX_REASON_LEN = 256  # CPEX already bounds this; enforce again defensively
 _MAX_ERROR_CODE_LEN = 256
 _MAX_CONFIG_KEYS = 64
-_MAX_CONFIG_KEY_LEN = 128   # per-key length cap before joining
+_MAX_CONFIG_KEY_LEN = 128  # per-key length cap before joining
 _MAX_CONFIG_KEYS_JOINED_LEN = 4096  # max total byte length of the joined config_keys string
 
 # Statuses that represent controls that actually ran (exclude disabled/skipped/cancelled).

--- a/mcpgateway/plugins/control_telemetry.py
+++ b/mcpgateway/plugins/control_telemetry.py
@@ -93,6 +93,7 @@ class ControlTelemetryAccumulator:
     _records: list = field(default_factory=list)
     _pre_denied: bool = False
     _post_denied: bool = False
+    _plugin_errored: bool = False  # True when a PluginError (outage) was caught on any hook
     _truncated: int = 0  # records dropped due to per-call cap OR per-hook cap
     _export_cap_dropped: int = 0  # records dropped at emit time by the per-invocation export cap
 
@@ -148,6 +149,37 @@ class ControlTelemetryAccumulator:
             self._pre_denied = True
         else:
             self._post_denied = True
+
+    def mark_plugin_error(self) -> None:
+        """Explicitly record that a ``PluginError`` (outage/crash/misconfiguration) occurred.
+
+        Call this from the ``except PluginError`` handler before re-raising so that
+        the emitted summary span carries ``cpex.control.plugin_error=True``.  This
+        distinguishes a plugin infrastructure failure from both a successful allow
+        decision (``result.allowed=True``, no error) and a deliberate policy denial
+        (``result.allowed=False`` set via ``mark_denied()``).
+
+        When the failing plugin is the first in the chain the accumulator may have no
+        records and no denial flags — without this flag ``record_control_telemetry()``
+        would silently skip emission.  Including ``_plugin_errored`` in the empty-guard
+        ensures the summary span is always emitted so the outage is visible in dashboards.
+
+        Examples:
+            >>> acc = ControlTelemetryAccumulator()
+            >>> acc.mark_plugin_error()
+            >>> acc.plugin_errored
+            True
+        """
+        self._plugin_errored = True
+
+    @property
+    def plugin_errored(self) -> bool:
+        """True when a ``PluginError`` was caught on any hook during this invocation.
+
+        Returns:
+            True if any plugin raised ``PluginError``; False otherwise.
+        """
+        return self._plugin_errored
 
     @property
     def records(self) -> list:
@@ -216,6 +248,10 @@ class ControlTelemetryAccumulator:
     def effective_allowed(self) -> bool:
         """True only if neither the pre nor post hook chain produced a denial.
 
+        Note: a ``PluginError`` outage does **not** set ``effective_allowed=False``.
+        Enforcement decisions and infrastructure failures are intentionally distinct.
+        Check ``plugin_errored`` to detect the latter.
+
         Returns:
             True when the overall control chain allowed the invocation.
         """
@@ -271,7 +307,7 @@ class ControlTelemetryAccumulator:
         # results_count = records exported after the per-invocation cap (not raw accumulated count).
         results_count = min(records_received, _get_max_results())
 
-        return {
+        result: dict = {
             "cpex.control.invocation_count": invocation_count,
             "cpex.control.matched_count": matched_count,
             "cpex.control.applied_count": applied_count,
@@ -282,6 +318,13 @@ class ControlTelemetryAccumulator:
             "cpex.control.error_count": error_count,
             "cpex.control.timeout_count": timeout_count,
         }
+        # cpex.control.plugin_error distinguishes a plugin infrastructure failure
+        # (PluginError: crash/timeout/misconfiguration) from both a successful allow
+        # and a deliberate policy denial (result.allowed=False).  Only emitted when
+        # mark_plugin_error() was called; absent means no outage occurred.
+        if self._plugin_errored:
+            result["cpex.control.plugin_error"] = True
+        return result
 
 
 # ---------------------------------------------------------------------------
@@ -313,8 +356,10 @@ def record_control_telemetry(
         return
     if not execution_records_supported():
         return
-    if not accumulator.records and not accumulator.pre_denied and not accumulator.post_denied:
-        # Nothing ran — no-op, don't emit empty spans
+    if not accumulator.records and not accumulator.pre_denied and not accumulator.post_denied and not accumulator.plugin_errored:
+        # Nothing ran and no error/denial flag set — no-op, don't emit empty spans.
+        # plugin_errored is included so a PluginError on the first plugin in the chain
+        # (where no records were appended before the raise) still emits a summary span.
         return
 
     try:
@@ -538,11 +583,12 @@ def _per_control_attributes(hook: str, rec: Any) -> dict:
                 attrs["cpex.control.result.error_code"] = _safe_str(rec.error_code, _MAX_ERROR_CODE_LEN)
         if rec.config_keys:
             # Key names only (CPEX never includes values).
-            # Each key is length-capped, list is count-capped, and the final joined
-            # string is byte-capped to prevent telemetry amplification.
+            # Each key is byte-capped via _safe_str; the joined string is also byte-capped
+            # via _safe_str so multibyte characters do not exceed the intended byte budget
+            # (a plain char-slice would under-count bytes for non-ASCII key names).
             safe_keys = [_safe_str(k, _MAX_CONFIG_KEY_LEN) for k in rec.config_keys[:_MAX_CONFIG_KEYS]]
             joined = ",".join(safe_keys)
-            attrs["cpex.control.config.keys"] = joined[:_MAX_CONFIG_KEYS_JOINED_LEN]
+            attrs["cpex.control.config.keys"] = _safe_str(joined, _MAX_CONFIG_KEYS_JOINED_LEN)
         return attrs
     except Exception:  # noqa: BLE001
         logger.debug("Failed to build per-control attributes", exc_info=True)
@@ -574,14 +620,19 @@ def _safe_str(value: Any, max_len: int) -> str:
 def _enforcement_point(acc: "ControlTelemetryAccumulator") -> str:
     """Derive the enforcement-point label from which hooks contributed records.
 
+    When CPEX raises ``PluginViolationError`` with ``violations_as_exceptions=True``
+    it does so *before* appending a ``ControlExecutionRecord``, so the accumulator
+    may have no records even though a hook fired.  Fall back to the denial flags so
+    a pre-invoke denial with zero records still reports ``"pre"`` rather than ``"none"``.
+
     Args:
         acc: The populated accumulator.
 
     Returns:
         One of ``"pre"``, ``"post"``, ``"pre+post"``, or ``"none"``.
     """
-    has_pre = any(h == "pre" for h, _ in acc.records)
-    has_post = any(h == "post" for h, _ in acc.records)
+    has_pre = any(h == "pre" for h, _ in acc.records) or acc.pre_denied
+    has_post = any(h == "post" for h, _ in acc.records) or acc.post_denied
     if has_pre and has_post:
         return "pre+post"
     if has_pre:
@@ -724,7 +775,7 @@ def _build_flattened_attributes(
                 if config_keys:
                     safe_keys = [_safe_str(k, _MAX_CONFIG_KEY_LEN) for k in config_keys[:_MAX_CONFIG_KEYS]]
                     joined = ",".join(safe_keys)
-                    result[f"{prefix}.config.keys"] = joined[:_MAX_CONFIG_KEYS_JOINED_LEN]
+                    result[f"{prefix}.config.keys"] = _safe_str(joined, _MAX_CONFIG_KEYS_JOINED_LEN)
 
                 # reason/error_code gated by CPEX_CONTROL_TELEMETRY_EMIT_REASON (default: false)
                 if _emit_reason_enabled():

--- a/mcpgateway/plugins/control_telemetry.py
+++ b/mcpgateway/plugins/control_telemetry.py
@@ -51,6 +51,8 @@ _MAX_RECORDS_PER_CALL = 128  # cap across pre + post combined
 _MAX_REASON_LEN = 256  # CPEX already bounds this; enforce again defensively
 _MAX_ERROR_CODE_LEN = 256
 _MAX_CONFIG_KEYS = 64
+_MAX_CONFIG_KEY_LEN = 128   # per-key length cap before joining
+_MAX_CONFIG_KEYS_JOINED_LEN = 4096  # max total byte length of the joined config_keys string
 
 # Statuses that represent controls that actually ran (exclude disabled/skipped/cancelled).
 _ACTIVE_STATUSES = frozenset({"completed", "error", "timeout"})
@@ -318,7 +320,7 @@ def record_control_telemetry(
     try:
         from mcpgateway.config import settings  # pylint: disable=import-outside-toplevel
 
-        if not getattr(settings, "cpex_control_telemetry_enabled", True):
+        if not getattr(settings, "cpex_control_telemetry_enabled", False):
             return
 
         from mcpgateway.services.observability_service import ObservabilityService  # pylint: disable=import-outside-toplevel,cyclic-import
@@ -329,11 +331,15 @@ def record_control_telemetry(
             {
                 "cpex.control.type": "tool",
                 "cpex.control.tool.name": _safe_str(tool_name, 128),
-                "cpex.control.agent.id": _safe_str(agent_id, 128),
                 "cpex.control.binding.name": _safe_str(binding_name, 128),
                 "cpex.control.enforcement_point": _enforcement_point(accumulator),
             }
         )
+        # cpex.control.agent.id contains the authenticated user email — a high-cardinality
+        # PII field.  Opt-in only (CPEX_CONTROL_TELEMETRY_EMIT_AGENT_ID=false by default)
+        # until Phase 5 central attribute-policy wiring provides a redaction boundary.
+        if _emit_agent_id_enabled():
+            aggregate["cpex.control.agent.id"] = _safe_str(agent_id, 128)
         # Compute and record export-cap (tier-3) drops before building the summary span.
         # records_received is the count before any export cap; results_count is the cap-bounded
         # export count.  The difference is exactly the number of records the islice will skip.
@@ -531,8 +537,12 @@ def _per_control_attributes(hook: str, rec: Any) -> dict:
             if rec.error_code:
                 attrs["cpex.control.result.error_code"] = _safe_str(rec.error_code, _MAX_ERROR_CODE_LEN)
         if rec.config_keys:
-            # Key names only (CPEX never includes values); bounded list join
-            attrs["cpex.control.config.keys"] = ",".join(rec.config_keys[:_MAX_CONFIG_KEYS])
+            # Key names only (CPEX never includes values).
+            # Each key is length-capped, list is count-capped, and the final joined
+            # string is byte-capped to prevent telemetry amplification.
+            safe_keys = [_safe_str(k, _MAX_CONFIG_KEY_LEN) for k in rec.config_keys[:_MAX_CONFIG_KEYS]]
+            joined = ",".join(safe_keys)
+            attrs["cpex.control.config.keys"] = joined[:_MAX_CONFIG_KEYS_JOINED_LEN]
         return attrs
     except Exception:  # noqa: BLE001
         logger.debug("Failed to build per-control attributes", exc_info=True)
@@ -618,6 +628,30 @@ def _emit_reason_enabled() -> bool:
         return False
 
 
+def _emit_agent_id_enabled() -> bool:
+    """Return True when ``cpex.control.agent.id`` emission is enabled.
+
+    The agent ID is the authenticated caller email — a high-cardinality PII field.
+    Opt-in only (default: False) until Phase 5 central attribute-policy wiring
+    provides a redaction boundary.  Enable via
+    ``CPEX_CONTROL_TELEMETRY_EMIT_AGENT_ID=true`` only in environments where
+    the observability sink is appropriately secured.
+
+    Returns:
+        True when ``cpex_control_telemetry_emit_agent_id`` is set to True in settings.
+
+    Examples:
+        >>> isinstance(_emit_agent_id_enabled(), bool)
+        True
+    """
+    try:
+        from mcpgateway.config import settings  # pylint: disable=import-outside-toplevel
+
+        return bool(getattr(settings, "cpex_control_telemetry_emit_agent_id", False))
+    except Exception:  # noqa: BLE001
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Flattened-results projection helper
 # ---------------------------------------------------------------------------
@@ -688,7 +722,9 @@ def _build_flattened_attributes(
 
                 config_keys = getattr(rec, "config_keys", None)
                 if config_keys:
-                    result[f"{prefix}.config.keys"] = ",".join(config_keys[:_MAX_CONFIG_KEYS])
+                    safe_keys = [_safe_str(k, _MAX_CONFIG_KEY_LEN) for k in config_keys[:_MAX_CONFIG_KEYS]]
+                    joined = ",".join(safe_keys)
+                    result[f"{prefix}.config.keys"] = joined[:_MAX_CONFIG_KEYS_JOINED_LEN]
 
                 # reason/error_code gated by CPEX_CONTROL_TELEMETRY_EMIT_REASON (default: false)
                 if _emit_reason_enabled():

--- a/mcpgateway/plugins/control_telemetry.py
+++ b/mcpgateway/plugins/control_telemetry.py
@@ -1,0 +1,563 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/plugins/control_telemetry.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Accumulator and emitter for CPEX control-execution telemetry.
+
+Mirrors the structure of ``record_plugin_metrics()`` in ``plugins/utils.py``
+but consumes **trusted** ``ControlExecutionRecord`` fields rather than
+untrusted plugin metadata.  All bounds and sanitization follow the same S4
+principles.
+
+Architecture
+------------
+One ``ControlTelemetryAccumulator`` is created per ``invoke_tool()`` call,
+collects records from both ``tool_pre_invoke`` and ``tool_post_invoke`` hooks,
+and is then flushed via ``record_control_telemetry()`` into two sinks:
+
+  - Internal DB: a ``cpex.control.summary`` span + one ``cpex.control.result``
+    child span per record, all batched in a single DB session.
+  - OTel SDK: equivalent child spans under the active trace context (no-op
+    when OTel is disabled or no context is active).
+
+Feature gate
+------------
+The feature is a no-op when:
+
+  - ``CPEX_CONTROL_TELEMETRY_ENABLED=false`` (config setting), or
+  - the installed CPEX version does not expose ``ControlExecutionRecord``
+    (``execution_records_supported()`` returns False).
+
+Existing ``tool.invoke`` spans, ``plugin.metrics.*`` spans, and CPEX
+violation/on_error handling are untouched.
+"""
+
+# Standard
+import itertools
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+# First-Party
+from mcpgateway.plugins.cpex_compat import execution_records_supported, get_executions
+from mcpgateway.plugins.utils import _IDENTIFIER_RE  # re-use the same identifier validator
+
+logger = logging.getLogger(__name__)
+
+# ── Bounds (mirrors _MAX_PLUGIN_KEYS / _MAX_PLUGINS_PER_CALL in utils.py) ──────
+_MAX_RECORDS_PER_HOOK = 64   # max ControlExecutionRecords consumed per invoke_hook call
+_MAX_RECORDS_PER_CALL = 128  # cap across pre + post combined
+_MAX_REASON_LEN = 256        # CPEX already bounds this; enforce again defensively
+_MAX_ERROR_CODE_LEN = 256
+_MAX_CONFIG_KEYS = 64
+
+
+# ---------------------------------------------------------------------------
+# ControlTelemetryAccumulator
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ControlTelemetryAccumulator:
+    """Invocation-local accumulator for CPEX execution records.
+
+    One instance per ``invoke_tool()`` call.  Never shared across requests.
+    Collect pre-hook records first, then post-hook records.
+
+    Usage::
+
+        acc = ControlTelemetryAccumulator()
+        ...
+        pre_result, _ = await plugin_manager.invoke_hook(TOOL_PRE_INVOKE, ...)
+        acc.add(pre_result, hook="pre")
+        ...
+        post_result, _ = await plugin_manager.invoke_hook(TOOL_POST_INVOKE, ...)
+        acc.add(post_result, hook="post")
+        ...
+        record_control_telemetry(trace_id, acc, tool_name=name, agent_id=...)
+
+    Examples:
+        >>> acc = ControlTelemetryAccumulator()
+        >>> acc.records
+        []
+        >>> acc.effective_allowed
+        True
+    """
+
+    _records: list = field(default_factory=list)
+    _pre_denied: bool = False
+    _post_denied: bool = False
+    _truncated: int = 0  # records dropped due to per-call cap
+
+    def add(self, result: Any, *, hook: str) -> None:
+        """Consume executions from one ``invoke_hook`` result.
+
+        Args:
+            result: ``PluginResult`` from ``invoke_hook`` (may be None on early exit).
+            hook: ``"pre"`` or ``"post"`` — enforcement point tag for each record.
+        """
+        if not execution_records_supported():
+            return
+
+        records = get_executions(result)
+        for rec in itertools.islice(records, _MAX_RECORDS_PER_HOOK):
+            if len(self._records) >= _MAX_RECORDS_PER_CALL:
+                self._truncated += 1
+                continue
+            self._records.append((hook, rec))
+
+        # Track denial at each phase independently
+        if result is not None and not getattr(result, "continue_processing", True):
+            if hook == "pre":
+                self._pre_denied = True
+            else:
+                self._post_denied = True
+
+    @property
+    def records(self) -> list:
+        """All accumulated ``(hook, ControlExecutionRecord)`` pairs.
+
+        Returns:
+            A new list of ``(hook_str, record)`` tuples.
+        """
+        return list(self._records)
+
+    @property
+    def pre_denied(self) -> bool:
+        """True when the pre-invoke hook chain produced a denial.
+
+        Returns:
+            True if pre-hook denied; False otherwise.
+        """
+        return self._pre_denied
+
+    @property
+    def post_denied(self) -> bool:
+        """True when the post-invoke hook chain produced a denial.
+
+        Returns:
+            True if post-hook denied; False otherwise.
+        """
+        return self._post_denied
+
+    @property
+    def truncated(self) -> int:
+        """Number of records dropped due to the per-call cap.
+
+        Returns:
+            Count of dropped records (0 when no overflow).
+        """
+        return self._truncated
+
+    @property
+    def effective_allowed(self) -> bool:
+        """True only if neither the pre nor post hook chain produced a denial.
+
+        Returns:
+            True when the overall control chain allowed the invocation.
+        """
+        return not self._pre_denied and not self._post_denied
+
+    def aggregate(self) -> dict:
+        """Compute aggregate scalar attributes from all accumulated records.
+
+        Returns a ``dict`` of ``cpex.control.*`` attributes safe for span
+        attachment.  Only uses trusted ``ControlExecutionRecord`` fields —
+        never plugin metadata.
+
+        Returns:
+            Dictionary of aggregate control telemetry attributes.
+        """
+        invocation_count = 0
+        matched_count = 0
+        applied_count = 0
+        duration_ns = 0
+        error_count = 0
+        timeout_count = 0
+
+        for _hook, rec in self._records:
+            try:
+                invocation_count += 1
+                if getattr(rec, "matched", None) is True:
+                    matched_count += 1
+                if getattr(rec, "applied", False):
+                    applied_count += 1
+                duration_ns += int(getattr(rec, "duration_ns", 0))
+                status = str(getattr(rec, "status", ""))
+                if status == "error":
+                    error_count += 1
+                elif status == "timeout":
+                    timeout_count += 1
+            except Exception:  # noqa: BLE001
+                logger.debug("Failed to aggregate one ControlExecutionRecord", exc_info=True)
+
+        return {
+            "cpex.control.invocation_count": invocation_count,
+            "cpex.control.matched_count": matched_count,
+            "cpex.control.applied_count": applied_count,
+            "cpex.control.results_count": len(self._records),
+            "cpex.control.duration": duration_ns,   # nanoseconds
+            "cpex.control.result.allowed": self.effective_allowed,
+            "cpex.control.error_count": error_count,
+            "cpex.control.timeout_count": timeout_count,
+        }
+
+
+# ---------------------------------------------------------------------------
+# record_control_telemetry — public entry point
+# ---------------------------------------------------------------------------
+
+
+def record_control_telemetry(
+    trace_id: Optional[str],
+    accumulator: "ControlTelemetryAccumulator",
+    *,
+    tool_name: str = "",
+    agent_id: str = "",
+    binding_name: str = "",
+) -> None:
+    """Emit CPEX control-execution telemetry for one tool invocation.
+
+    Best-effort (L4): never raises into the request path.
+    Mirrors ``record_plugin_metrics()`` — same sink ordering, same session pattern.
+
+    Args:
+        trace_id: Active trace ID from ``current_trace_id.get()``.
+        accumulator: Populated ``ControlTelemetryAccumulator`` for this invocation.
+        tool_name: Tool name from the CF side (trusted, not from plugin output).
+        agent_id: Agent/user identifier from the CF side (trusted).
+        binding_name: Gateway/server binding name (trusted).
+    """
+    if not trace_id:
+        return
+    if not execution_records_supported():
+        return
+    if not accumulator.records and not accumulator.pre_denied and not accumulator.post_denied:
+        # Nothing ran — no-op, don't emit empty spans
+        return
+
+    try:
+        from mcpgateway.config import settings  # pylint: disable=import-outside-toplevel
+
+        if not getattr(settings, "cpex_control_telemetry_enabled", True):
+            return
+
+        from mcpgateway.services.observability_service import ObservabilityService  # pylint: disable=import-outside-toplevel,cyclic-import
+
+        # Build aggregate attributes — all from trusted CF + CPEX sources
+        aggregate = accumulator.aggregate()
+        aggregate.update(
+            {
+                "cpex.control.type": "tool",
+                "cpex.control.tool.name": _safe_str(tool_name, 128),
+                "cpex.control.agent.id": _safe_str(agent_id, 128),
+                "cpex.control.binding.name": _safe_str(binding_name, 128),
+                "cpex.control.enforcement_point": _enforcement_point(accumulator),
+            }
+        )
+        if accumulator.truncated:
+            aggregate["cpex.control.truncated"] = accumulator.truncated
+
+        # ── Optional: flattened cpex.control.results.<name>.* attributes ─────
+        # Off by default (CPEX_CONTROL_TELEMETRY_FLATTEN_RESULTS=false).
+        # Only emit when downstream tooling requires dynamic key names.
+        # The fixed-schema child spans remain the internal source of truth.
+        if getattr(settings, "cpex_control_telemetry_flatten_results", False):
+            flattened = _build_flattened_attributes(accumulator, _get_max_results())
+            aggregate.update(flattened)
+
+        service = ObservabilityService()
+
+        # ── Sink 1: internal DB — summary span + per-control child spans ──────
+        if getattr(settings, "cpex_control_telemetry_db_enabled", True):
+            _emit_db_spans(service, trace_id, aggregate, accumulator)
+
+        # ── Sink 2: OTel SDK — child spans under the active trace context ─────
+        _emit_otel_spans(aggregate, accumulator)
+
+    except Exception:  # noqa: BLE001  — L4: best-effort, never raises
+        logger.debug("record_control_telemetry failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# DB sink helper
+# ---------------------------------------------------------------------------
+
+
+def _emit_db_spans(
+    service: Any,
+    trace_id: str,
+    aggregate: dict,
+    accumulator: "ControlTelemetryAccumulator",
+) -> None:
+    """Write summary + per-control DB spans in a single session.
+
+    Args:
+        service: ObservabilityService instance.
+        trace_id: Active trace identifier.
+        aggregate: Pre-built aggregate attribute dict.
+        accumulator: Source of per-control records.
+    """
+    from mcpgateway.db import SessionLocal  # pylint: disable=import-outside-toplevel
+
+    db = None
+    try:
+        db = SessionLocal()
+
+        # Summary span
+        summary_id = service.start_span(
+            trace_id=trace_id,
+            name="cpex.control.summary",
+            kind="internal",
+            resource_type="control",
+            resource_name="summary",
+            attributes=aggregate,
+            commit=False,
+            obs_db=db,
+        )
+        service.end_span(summary_id, status="ok", commit=False, obs_db=db)
+
+        # Per-control child spans — linked to summary via parent_span_id so trace
+        # UIs render them nested under the summary rather than as siblings.
+        max_results = _get_max_results()
+        for hook, rec in itertools.islice(accumulator.records, max_results):
+            attrs = _per_control_attributes(hook, rec)
+            if not attrs:
+                continue
+            span_id = service.start_span(
+                trace_id=trace_id,
+                name="cpex.control.result",
+                parent_span_id=summary_id,
+                kind="internal",
+                resource_type="control",
+                resource_name=attrs.get("cpex.control.name", ""),
+                attributes=attrs,
+                commit=False,
+                obs_db=db,
+            )
+            service.end_span(span_id, status="ok", commit=False, obs_db=db)
+
+        db.commit()
+    except Exception:  # noqa: BLE001
+        logger.debug("Failed to write control telemetry DB spans", exc_info=True)
+        if db:
+            try:
+                db.rollback()
+            except Exception:  # nosec B110
+                pass
+    finally:
+        if db:
+            try:
+                db.close()
+            except Exception:  # nosec B110
+                pass
+
+
+# ---------------------------------------------------------------------------
+# OTel sink helper
+# ---------------------------------------------------------------------------
+
+
+def _emit_otel_spans(aggregate: dict, accumulator: "ControlTelemetryAccumulator") -> None:
+    """Emit control telemetry through the OTel SDK when a trace context is active.
+
+    Args:
+        aggregate: Pre-built aggregate attribute dict.
+        accumulator: Source of per-control records.
+    """
+    try:
+        from mcpgateway.observability import (  # pylint: disable=import-outside-toplevel
+            create_span,
+            otel_context_active,
+            otel_tracing_enabled,
+        )
+
+        if not otel_tracing_enabled() or not otel_context_active():
+            return
+
+        with create_span("cpex.control.summary", dict(aggregate)):
+            max_results = _get_max_results()
+            for hook, rec in itertools.islice(accumulator.records, max_results):
+                attrs = _per_control_attributes(hook, rec)
+                if attrs:
+                    with create_span("cpex.control.result", attrs):
+                        pass
+    except Exception:  # noqa: BLE001
+        logger.debug("OTel control telemetry export failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Per-control attribute builder
+# ---------------------------------------------------------------------------
+
+
+def _per_control_attributes(hook: str, rec: Any) -> dict:
+    """Build the fixed-schema attribute dict for one ControlExecutionRecord.
+
+    Only uses trusted CPEX record fields.  Never accesses plugin metadata.
+    Returns empty dict on any error so callers can skip cleanly.
+
+    Args:
+        hook: Enforcement-point tag (``"pre"`` or ``"post"``).
+        rec: A ``ControlExecutionRecord`` instance.
+
+    Returns:
+        Attribute dict or empty dict on error.
+    """
+    try:
+        attrs: dict = {
+            "cpex.control.name": _safe_str(str(rec.plugin_name), 64),
+            "cpex.control.hook_name": _safe_str(str(rec.hook_name), 64),
+            "cpex.control.mode": _safe_str(str(rec.mode), 32),
+            "cpex.control.status": _safe_str(str(rec.status), 32),
+            "cpex.control.enforcement_point": hook,
+            "cpex.control.result.allowed": bool(rec.effective_allow),
+            "cpex.control.duration": int(rec.duration_ns),
+        }
+        # Optional fields — only emit when present
+        if rec.reason:
+            attrs["cpex.control.result.reason"] = _safe_str(rec.reason, _MAX_REASON_LEN)
+        if rec.error_code:
+            attrs["cpex.control.result.error_code"] = _safe_str(rec.error_code, _MAX_ERROR_CODE_LEN)
+        if rec.config_keys:
+            # Key names only (CPEX never includes values); bounded list join
+            attrs["cpex.control.config.keys"] = ",".join(rec.config_keys[:_MAX_CONFIG_KEYS])
+        return attrs
+    except Exception:  # noqa: BLE001
+        logger.debug("Failed to build per-control attributes", exc_info=True)
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+def _safe_str(value: Any, max_len: int) -> str:
+    """Truncate ``value`` to ``max_len`` UTF-8 bytes.  Never raises.
+
+    Args:
+        value: Value to stringify and truncate.
+        max_len: Maximum byte length of the result.
+
+    Returns:
+        String truncated to ``max_len`` bytes (with trailing ``...`` if cut).
+    """
+    s = str(value) if not isinstance(value, str) else value
+    encoded = s.encode("utf-8")
+    if len(encoded) <= max_len:
+        return s
+    return encoded[: max_len - 3].decode("utf-8", errors="ignore") + "..."
+
+
+def _enforcement_point(acc: "ControlTelemetryAccumulator") -> str:
+    """Derive the enforcement-point label from which hooks contributed records.
+
+    Args:
+        acc: The populated accumulator.
+
+    Returns:
+        One of ``"pre"``, ``"post"``, ``"pre+post"``, or ``"none"``.
+    """
+    has_pre = any(h == "pre" for h, _ in acc.records)
+    has_post = any(h == "post" for h, _ in acc.records)
+    if has_pre and has_post:
+        return "pre+post"
+    if has_pre:
+        return "pre"
+    if has_post:
+        return "post"
+    return "none"
+
+
+def _get_max_results() -> int:
+    """Read the configured per-invocation result cap.
+
+    Returns:
+        Maximum number of per-control result records to export (default 32).
+    """
+    try:
+        from mcpgateway.config import settings  # pylint: disable=import-outside-toplevel
+
+        return int(getattr(settings, "cpex_control_telemetry_max_results", 32))
+    except Exception:  # noqa: BLE001
+        return 32
+
+
+# ---------------------------------------------------------------------------
+# Flattened-results projection helper
+# ---------------------------------------------------------------------------
+
+
+def _build_flattened_attributes(
+    accumulator: "ControlTelemetryAccumulator",
+    max_results: int,
+) -> dict:
+    """Build flattened ``cpex.control.results.<name>.*`` attributes (optional projection).
+
+    This is a **projection layer only** — the fixed-schema child spans emitted by
+    ``_emit_db_spans`` / ``_emit_otel_spans`` remain the internal source of truth.
+    Enabled only when ``CPEX_CONTROL_TELEMETRY_FLATTEN_RESULTS=true``.
+
+    Safety rules (mirrors issue #5785 spec):
+    - ``plugin_name`` is validated against ``_IDENTIFIER_RE`` before use in a key.
+    - Collisions (two records with the same sanitized name) → both dropped; a bounded
+      counter ``cpex.control.results._collision_count`` is emitted instead.
+    - Bounded to ``max_results`` records.
+    - Never raises.
+
+    Args:
+        accumulator: The populated ``ControlTelemetryAccumulator``.
+        max_results: Maximum records to flatten.
+
+    Returns:
+        Dict of flattened attributes, empty on error or when nothing to flatten.
+    """
+    try:
+        result: dict = {}
+        collision_count = 0
+        seen_names: set = set()
+
+        for hook, rec in itertools.islice(accumulator.records, max_results):
+            try:
+                raw_name = str(getattr(rec, "plugin_name", ""))
+                # Validate and sanitize the name segment used in the attribute key
+                if not _IDENTIFIER_RE.match(raw_name):
+                    logger.debug("Skipping flatten for record: plugin_name %r is not a valid identifier", raw_name)
+                    continue
+
+                if raw_name in seen_names:
+                    # Collision: two records with the same plugin_name — drop both
+                    logger.debug("Flatten collision for plugin_name %r — dropping both records", raw_name)
+                    # Remove previously written keys for this name
+                    to_remove = [k for k in result if k.startswith(f"cpex.control.results.{raw_name}.")]
+                    for k in to_remove:
+                        del result[k]
+                    collision_count += 1
+                    continue
+                seen_names.add(raw_name)
+
+                prefix = f"cpex.control.results.{raw_name}"
+                result[f"{prefix}.status"] = _safe_str(str(getattr(rec, "status", "")), 32)
+                result[f"{prefix}.enforcement_point"] = hook
+                result[f"{prefix}.result.allowed"] = bool(getattr(rec, "effective_allow", True))
+                result[f"{prefix}.duration"] = int(getattr(rec, "duration_ns", 0))
+
+                reason = getattr(rec, "reason", None)
+                if reason:
+                    result[f"{prefix}.result.reason"] = _safe_str(reason, _MAX_REASON_LEN)
+
+                error_code = getattr(rec, "error_code", None)
+                if error_code:
+                    result[f"{prefix}.result.error_code"] = _safe_str(error_code, _MAX_ERROR_CODE_LEN)
+            except Exception:  # noqa: BLE001
+                logger.debug("Failed to flatten one ControlExecutionRecord", exc_info=True)
+
+        if collision_count:
+            result["cpex.control.results._collision_count"] = collision_count
+
+        return result
+    except Exception:  # noqa: BLE001
+        logger.debug("_build_flattened_attributes failed", exc_info=True)
+        return {}

--- a/mcpgateway/plugins/control_telemetry.py
+++ b/mcpgateway/plugins/control_telemetry.py
@@ -172,19 +172,23 @@ class ControlTelemetryAccumulator:
         invocation_count = 0
         matched_count = 0
         applied_count = 0
-        duration_ns = 0
+        total_duration_ns = 0
         error_count = 0
         timeout_count = 0
 
+        # Statuses that represent controls that actually ran (exclude disabled/skipped/cancelled).
+        _ACTIVE_STATUSES = {"completed", "error", "timeout"}
+
         for _hook, rec in self._records:
             try:
-                invocation_count += 1
+                status = str(getattr(rec, "status", ""))
+                if status in _ACTIVE_STATUSES:
+                    invocation_count += 1
                 if getattr(rec, "matched", None) is True:
                     matched_count += 1
                 if getattr(rec, "applied", False):
                     applied_count += 1
-                duration_ns += int(getattr(rec, "duration_ns", 0))
-                status = str(getattr(rec, "status", ""))
+                total_duration_ns += int(getattr(rec, "duration_ns", 0))
                 if status == "error":
                     error_count += 1
                 elif status == "timeout":
@@ -192,12 +196,15 @@ class ControlTelemetryAccumulator:
             except Exception:  # noqa: BLE001
                 logger.debug("Failed to aggregate one ControlExecutionRecord", exc_info=True)
 
+        # results_count = records exported after the per-invocation cap (not raw accumulated count).
+        results_count = min(len(self._records), _get_max_results())
+
         return {
             "cpex.control.invocation_count": invocation_count,
             "cpex.control.matched_count": matched_count,
             "cpex.control.applied_count": applied_count,
-            "cpex.control.results_count": len(self._records),
-            "cpex.control.duration": duration_ns,  # nanoseconds
+            "cpex.control.results_count": results_count,
+            "cpex.control.duration_ns": total_duration_ns,  # nanoseconds — OTel unit suffix convention
             "cpex.control.result.allowed": self.effective_allowed,
             "cpex.control.error_count": error_count,
             "cpex.control.timeout_count": timeout_count,
@@ -407,15 +414,25 @@ def _per_control_attributes(hook: str, rec: Any) -> dict:
     """
     try:
         attrs: dict = {
+            # Identity fields — from trusted CPEX framework PluginRef config
             "cpex.control.name": _safe_str(str(rec.plugin_name), 64),
+            "cpex.control.plugin_id": _safe_str(str(rec.plugin_id), 64),
+            "cpex.control.plugin_kind": _safe_str(str(rec.plugin_kind), 32),
             "cpex.control.hook_name": _safe_str(str(rec.hook_name), 64),
             "cpex.control.mode": _safe_str(str(rec.mode), 32),
+            # Execution outcome fields
             "cpex.control.status": _safe_str(str(rec.status), 32),
             "cpex.control.enforcement_point": hook,
             "cpex.control.result.allowed": bool(rec.effective_allow),
-            "cpex.control.duration": int(rec.duration_ns),
+            "cpex.control.duration_ns": int(rec.duration_ns),  # nanoseconds — OTel unit suffix convention
+            "cpex.control.matched": rec.matched if rec.matched is not None else False,
+            "cpex.control.applied": bool(rec.applied),
+            "cpex.control.payload_modified": bool(rec.payload_modified),
         }
-        # Optional fields — only emit when present
+        # requested_allow: only emit when present (None means not applicable to this mode)
+        if rec.requested_allow is not None:
+            attrs["cpex.control.result.requested_allowed"] = bool(rec.requested_allow)
+        # Optional free-text fields — only emit when present
         if rec.reason:
             attrs["cpex.control.result.reason"] = _safe_str(rec.reason, _MAX_REASON_LEN)
         if rec.error_code:

--- a/mcpgateway/plugins/cpex_compat.py
+++ b/mcpgateway/plugins/cpex_compat.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/plugins/cpex_compat.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+CPEX version compatibility helpers.
+
+Feature-detects ``ControlExecutionRecord`` availability rather than pinning
+a hard import, so the gateway degrades gracefully against older CPEX builds
+that do not yet expose execution records.
+
+The minimum supported CPEX version for control-execution telemetry is 0.1.2.
+``execution_records_supported()`` is the single guard that all consumption
+sites must check before accessing ``PluginResult.executions``.
+
+Examples:
+    >>> # When cpex 0.1.2+ is installed:
+    >>> from mcpgateway.plugins.cpex_compat import execution_records_supported, get_executions
+    >>> isinstance(execution_records_supported(), bool)
+    True
+    >>> get_executions(None)
+    []
+"""
+
+# Standard
+from typing import Any, List, Optional
+
+_EXECUTION_RECORDS_SUPPORTED: Optional[bool] = None
+
+
+def execution_records_supported() -> bool:
+    """Return True if the installed CPEX version exposes ControlExecutionRecord.
+
+    Result is cached after the first call — config is frozen after startup.
+    Safe to call from any thread; the cache write is idempotent.
+
+    Returns:
+        True when ``cpex.framework.ControlExecutionRecord`` can be imported,
+        False otherwise (older CPEX build or CPEX not installed).
+
+    Examples:
+        >>> isinstance(execution_records_supported(), bool)
+        True
+    """
+    global _EXECUTION_RECORDS_SUPPORTED  # pylint: disable=global-statement
+    if _EXECUTION_RECORDS_SUPPORTED is None:
+        try:
+            from cpex.framework import ControlExecutionRecord, ControlExecutionStatus  # noqa: F401  # pylint: disable=import-outside-toplevel
+            _EXECUTION_RECORDS_SUPPORTED = True
+        except ImportError:
+            _EXECUTION_RECORDS_SUPPORTED = False
+    return _EXECUTION_RECORDS_SUPPORTED
+
+
+def get_executions(result: Any) -> List[Any]:
+    """Safely extract the executions list from a PluginResult.
+
+    Returns an empty list if the field is absent (older CPEX), the result is
+    None, or any unexpected error occurs.  Never raises.
+
+    Args:
+        result: PluginResult returned by ``invoke_hook()`` (may be None).
+
+    Returns:
+        A new list containing the ``ControlExecutionRecord`` entries, or ``[]``.
+
+    Examples:
+        >>> get_executions(None)
+        []
+    """
+    if result is None:
+        return []
+    try:
+        return list(getattr(result, "executions", None) or [])
+    except Exception:  # noqa: BLE001
+        return []

--- a/mcpgateway/plugins/cpex_compat.py
+++ b/mcpgateway/plugins/cpex_compat.py
@@ -45,7 +45,8 @@ def execution_records_supported() -> bool:
     global _EXECUTION_RECORDS_SUPPORTED  # pylint: disable=global-statement
     if _EXECUTION_RECORDS_SUPPORTED is None:
         try:
-            from cpex.framework import ControlExecutionRecord, ControlExecutionStatus  # noqa: F401  # pylint: disable=import-outside-toplevel
+            from cpex.framework import ControlExecutionRecord, ControlExecutionStatus  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+
             _EXECUTION_RECORDS_SUPPORTED = True
         except ImportError:
             _EXECUTION_RECORDS_SUPPORTED = False

--- a/mcpgateway/plugins/utils.py
+++ b/mcpgateway/plugins/utils.py
@@ -655,9 +655,11 @@ def apply_attribute_mapping(attributes: dict, mapping: dict) -> dict:
     try:
         compiled_mappings, _ = compile_attribute_policy(mapping, [])
     except ValueError:
-        # Misconfigured mapping at runtime — fall back to exact-only behaviour
-        logger.debug("apply_attribute_mapping: compile_attribute_policy failed; falling back to exact match", exc_info=True)
-        compiled_mappings = [(True, None, src, dst) for src, dst in mapping.items()]
+        # Misconfigured mapping at runtime (e.g. otel.* destination, empty key, key > 256 chars).
+        # Fail-closed: return attributes unchanged rather than applying a partially-validated
+        # mapping that may have bypassed safety checks (e.g. reserved otel.* namespace).
+        logger.debug("apply_attribute_mapping: compile_attribute_policy failed; returning attributes unchanged", exc_info=True)
+        return dict(attributes)
 
     renamed_attributes: dict = {}
     for old_name, value in attributes.items():

--- a/mcpgateway/plugins/utils.py
+++ b/mcpgateway/plugins/utils.py
@@ -666,7 +666,12 @@ def apply_attribute_mapping(attributes: dict, mapping: dict) -> dict:
         return dict(attributes)
 
     try:
-        compiled_mappings, _ = _cached_compile_attribute_policy(tuple(sorted(mapping.items())), ())
+        # Preserve insertion order — sorting changes wildcard-rule precedence because the
+        # documented contract is "first matching wildcard wins" (compile_attribute_policy
+        # evaluates rules in the order they appear in the mapping dict).  Sorting would
+        # silently reorder rules and change which wildcard match is returned for overlapping
+        # patterns.  Using tuple(mapping.items()) keeps the caller's declared order.
+        compiled_mappings, _ = _cached_compile_attribute_policy(tuple(mapping.items()), ())
     except ValueError:
         # Misconfigured mapping at runtime (e.g. otel.* destination, empty key, key > 256 chars).
         # Fail-closed: return attributes unchanged rather than applying a partially-validated

--- a/mcpgateway/plugins/utils.py
+++ b/mcpgateway/plugins/utils.py
@@ -11,7 +11,7 @@ import itertools
 import logging
 import math
 import re
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 # Third-Party
 from cpex.framework.extensions import Extensions, RequestExtension
@@ -432,12 +432,207 @@ def build_request_extensions() -> Optional[Extensions]:
         return None
 
 
-def apply_attribute_mapping(attributes: dict[str, Any], mapping: dict[str, str]) -> dict[str, Any]:
+# ---------------------------------------------------------------------------
+# Wildcard-aware attribute policy helpers
+# ---------------------------------------------------------------------------
+#
+# Rules:
+#   - Exact keys (no ``*``) take precedence over wildcard rules.
+#   - ``*`` matches exactly one dot-delimited path segment.
+#   - No arbitrary user-supplied regular expressions (no catastrophic backtracking).
+#   - Mappings into reserved ``otel.*`` names are rejected at compile time.
+#   - Empty source / destination keys are rejected at compile time.
+#   - Rules are compiled once at startup (``_compile_wildcard_rule``), not per invocation.
+
+# Pre-compiled sentinel: a plain [^.]+ pattern replacing one ``*`` segment.
+_SEGMENT_PATTERN = r"[^.]+"
+
+
+def _compile_wildcard_rule(src: str) -> "re.Pattern[str]":
+    r"""Compile a single wildcard rule source key into a regex Pattern.
+
+    Only ``*`` is treated specially — it maps to ``[^.]+`` (one dot-delimited
+    segment).  All other regex metacharacters in the source key are escaped, so
+    there is no possibility of catastrophic backtracking from user-supplied
+    patterns.
+
+    Args:
+        src: Source attribute key with zero or more ``*`` segments
+             (e.g. ``"cpex.control.results.*.result.reason"``).
+
+    Returns:
+        A compiled regex that matches the full attribute key when the ``*``
+        positions contain exactly one non-dot segment.
+
+    Example:
+        >>> import re
+        >>> p = _compile_wildcard_rule("cpex.control.results.*.result.reason")
+        >>> bool(p.fullmatch("cpex.control.results.pii-guard.result.reason"))
+        True
+        >>> bool(p.fullmatch("cpex.control.results.a.b.result.reason"))
+        False
+    """
+    # Split on literal ``*``, escape surrounding parts, join with segment pattern.
+    parts = src.split("*")
+    regex = _SEGMENT_PATTERN.join(re.escape(p) for p in parts)
+    return re.compile(r"\A" + regex + r"\Z")
+
+
+def compile_attribute_policy(
+    mapping: Dict[str, str],
+    removals: List[str],
+) -> "Tuple[List[Tuple[bool, Any, str, str]], List[Tuple[bool, Any, str]]]":
+    """Compile attribute mapping and removal rules for efficient per-invocation use.
+
+    Rules are compiled **once** at startup (e.g. inside a plugin ``__init__``).
+    Calling this per-invocation is unnecessary and wasteful.
+
+    Rule precedence:
+    - Exact rules (no ``*``) take precedence over wildcard rules.
+    - Among wildcard rules, the first matching rule wins.
+    - Removal is evaluated after rename.
+
+    Safety:
+    - ``otel.*`` destination names are rejected.
+    - Empty source or destination keys are rejected.
+    - No user-supplied regular expressions (``*`` only).
+
+    Args:
+        mapping: Rename rules ``{source_key: dest_key}``.
+        removals: List of source keys to drop from attributes.
+
+    Returns:
+        A 2-tuple ``(compiled_mappings, compiled_removals)``.
+
+        Each mapping entry is a 4-tuple
+        ``(is_exact: bool, pattern: Optional[re.Pattern], src: str, dst: str)``.
+
+        Each removal entry is a 3-tuple
+        ``(is_exact: bool, pattern: Optional[re.Pattern], src: str)``.
+
+    Raises:
+        ValueError: On empty keys, reserved destinations, or invalid patterns.
+
+    Example:
+        >>> mappings, removals = compile_attribute_policy(
+        ...     {"cpex.control.result.allowed": "controls.result.allow"},
+        ...     ["cpex.control.config.keys"],
+        ... )
+        >>> len(mappings)
+        1
+        >>> len(removals)
+        1
+    """
+    compiled_mappings: List[Tuple[bool, Any, str, str]] = []
+    compiled_removals: List[Tuple[bool, Any, str]] = []
+
+    for src, dst in mapping.items():
+        if not src or not dst:
+            raise ValueError(f"Attribute mapping keys must be non-empty: {src!r} -> {dst!r}")
+        if dst.startswith("otel."):
+            raise ValueError(f"Mapping into reserved 'otel.*' namespace is not allowed: {dst!r}")
+        if len(src) > 256 or len(dst) > 256:
+            raise ValueError(f"Attribute mapping key exceeds 256 characters: {src!r} -> {dst!r}")
+        if "*" in src:
+            pattern = _compile_wildcard_rule(src)
+            compiled_mappings.append((False, pattern, src, dst))
+        else:
+            compiled_mappings.append((True, None, src, dst))
+
+    for src in removals:
+        if not src:
+            continue
+        if len(src) > 256:
+            raise ValueError(f"Remove-attribute key exceeds 256 characters: {src!r}")
+        if "*" in src:
+            pattern = _compile_wildcard_rule(src)
+            compiled_removals.append((False, pattern, src))
+        else:
+            compiled_removals.append((True, None, src))
+
+    return compiled_mappings, compiled_removals
+
+
+def _apply_one_mapping_rename(
+    key: str,
+    compiled_mappings: "List[Tuple[bool, Any, str, str]]",
+) -> str:
+    """Return the renamed key after applying compiled mapping rules.
+
+    Exact rules take precedence over wildcard rules.  The first matching
+    wildcard rule wins.  If no rule matches, the key is returned unchanged.
+
+    ``*`` captured segments are substituted into the destination template at
+    the same position.
+
+    Args:
+        key: Original attribute key.
+        compiled_mappings: Output of ``compile_attribute_policy``.
+
+    Returns:
+        Renamed key, or the original key when no rule matches.
+    """
+    # Pass 1: exact rules (is_exact=True)
+    for is_exact, _pattern, src, dst in compiled_mappings:
+        if is_exact and src == key:
+            return dst
+
+    # Pass 2: wildcard rules (is_exact=False)
+    for is_exact, pattern, src, dst in compiled_mappings:
+        if is_exact:
+            continue
+        m = pattern.fullmatch(key) if pattern else None
+        if m:
+            # Reconstruct destination by replacing ``*`` placeholders with the
+            # captured segments.  The number of ``*`` in src and dst must match;
+            # if they differ, skip silently (misconfiguration — already warned at
+            # compile time ideally; here we are defensive).
+            src_parts = src.split("*")
+            dst_parts = dst.split("*")
+            if len(src_parts) != len(dst_parts):
+                continue
+            # Extract captured segments: they are the substrings of key that
+            # correspond to the ``*`` slots.
+            key_remainder = key
+            captured: List[str] = []
+            for i, prefix in enumerate(src_parts[:-1]):
+                if not key_remainder.startswith(re.escape(prefix)):
+                    # Safety: let the regex result guide us but strip literal prefixes
+                    idx = len(prefix)
+                else:
+                    idx = len(prefix)
+                key_remainder = key_remainder[idx:]
+                # Find the end of the captured segment (next ``re.escape(src_parts[i+1])``)
+                suffix = src_parts[i + 1]
+                if suffix:
+                    cap_end = key_remainder.find(suffix)
+                    if cap_end < 0:
+                        break
+                    captured.append(key_remainder[:cap_end])
+                    key_remainder = key_remainder[cap_end:]
+                else:
+                    captured.append(key_remainder)
+                    key_remainder = ""
+            else:
+                # Build destination by interleaving dst_parts and captured
+                if len(captured) == len(dst_parts) - 1:
+                    result = dst_parts[0]
+                    for seg, dpart in zip(captured, dst_parts[1:]):
+                        result += seg + dpart
+                    return result
+    return key
+
+
+def apply_attribute_mapping(attributes: dict, mapping: dict) -> dict:
     """Apply attribute name mapping (renaming) to a dictionary of attributes.
+
+    Supports both exact key renames and single-``*`` wildcard renames.
+    Exact rules take precedence over wildcard rules.
 
     Args:
         attributes: Dictionary of attributes to rename.
         mapping: Dictionary mapping old attribute names to new names.
+                 Wildcard rules use ``*`` to match one dot-delimited segment.
 
     Returns:
         New dictionary with renamed attributes.
@@ -447,13 +642,26 @@ def apply_attribute_mapping(attributes: dict[str, Any], mapping: dict[str, str])
         >>> mapping = {"tool.name": "controls.artifact.name"}
         >>> apply_attribute_mapping(attrs, mapping)
         {'controls.artifact.name': 'weather', 'tool.version': '1.0'}
+
+        >>> attrs2 = {"cpex.control.results.pii.result.allowed": True}
+        >>> mapping2 = {"cpex.control.results.*.result.allowed": "controls.results.*.result.allowed"}
+        >>> result2 = apply_attribute_mapping(attrs2, mapping2)
+        >>> "controls.results.pii.result.allowed" in result2
+        True
     """
     if not mapping:
         return dict(attributes)
 
-    renamed_attributes = {}
+    try:
+        compiled_mappings, _ = compile_attribute_policy(mapping, [])
+    except ValueError:
+        # Misconfigured mapping at runtime — fall back to exact-only behaviour
+        logger.debug("apply_attribute_mapping: compile_attribute_policy failed; falling back to exact match", exc_info=True)
+        compiled_mappings = [(True, None, src, dst) for src, dst in mapping.items()]
+
+    renamed_attributes: dict = {}
     for old_name, value in attributes.items():
-        new_name = mapping.get(old_name, old_name)
+        new_name = _apply_one_mapping_rename(old_name, compiled_mappings)
         renamed_attributes[new_name] = value
 
     logger.debug("Applied %d attribute name mappings", len(mapping))

--- a/mcpgateway/plugins/utils.py
+++ b/mcpgateway/plugins/utils.py
@@ -7,6 +7,7 @@ Gateway-side plugin utilities.
 """
 
 # Standard
+import functools
 import itertools
 import logging
 import math
@@ -444,8 +445,30 @@ def build_request_extensions() -> Optional[Extensions]:
 #   - Empty source / destination keys are rejected at compile time.
 #   - Rules are compiled once at startup (``_compile_wildcard_rule``), not per invocation.
 
-# Pre-compiled sentinel: a plain [^.]+ pattern replacing one ``*`` segment.
-_SEGMENT_PATTERN = r"[^.]+"
+# Pre-compiled sentinel: a capturing [^.]+ group replacing one ``*`` segment.
+# Using a capturing group lets _apply_one_mapping_rename extract wildcard
+# segments directly via match.group(N) instead of a manual split-and-scan.
+_SEGMENT_PATTERN = r"([^.]+)"
+
+
+# Cache for compile_attribute_policy results, keyed on (mapping items, removals).
+# Populated lazily on first call; subsequent identical configs are O(1).
+@functools.lru_cache(maxsize=256)
+def _cached_compile_attribute_policy(mapping_items: tuple, removals_tuple: tuple) -> "Tuple[list, list]":
+    """Return a cached compile_attribute_policy result for the given frozen config.
+
+    Args:
+        mapping_items: Frozen tuple of (src, dst) pairs from the mapping dict.
+        removals_tuple: Frozen tuple of removal keys.
+
+    Returns:
+        2-tuple (compiled_mappings, compiled_removals) as produced by
+        ``compile_attribute_policy``.
+
+    Raises:
+        ValueError: Propagated from ``compile_attribute_policy`` on invalid config.
+    """
+    return compile_attribute_policy(dict(mapping_items), list(removals_tuple))
 
 
 def _compile_wildcard_rule(src: str) -> "re.Pattern[str]":
@@ -583,43 +606,18 @@ def _apply_one_mapping_rename(
             continue
         m = pattern.fullmatch(key) if pattern else None
         if m:
-            # Reconstruct destination by replacing ``*`` placeholders with the
-            # captured segments.  The number of ``*`` in src and dst must match;
-            # if they differ, skip silently (misconfiguration — already warned at
-            # compile time ideally; here we are defensive).
-            src_parts = src.split("*")
+            # _compile_wildcard_rule builds the pattern with one capturing group
+            # per ``*`` (``_SEGMENT_PATTERN = r"([^.]+)"``), so match.group(N)
+            # directly yields the captured segment — no manual split-and-scan needed.
             dst_parts = dst.split("*")
-            if len(src_parts) != len(dst_parts):
+            n_wildcards = dst.count("*")
+            if src.count("*") != n_wildcards:
+                # Mismatched wildcard counts — skip (misconfiguration)
                 continue
-            # Extract captured segments: they are the substrings of key that
-            # correspond to the ``*`` slots.
-            key_remainder = key
-            captured: List[str] = []
-            for i, prefix in enumerate(src_parts[:-1]):
-                if not key_remainder.startswith(re.escape(prefix)):
-                    # Safety: let the regex result guide us but strip literal prefixes
-                    idx = len(prefix)
-                else:
-                    idx = len(prefix)
-                key_remainder = key_remainder[idx:]
-                # Find the end of the captured segment (next ``re.escape(src_parts[i+1])``)
-                suffix = src_parts[i + 1]
-                if suffix:
-                    cap_end = key_remainder.find(suffix)
-                    if cap_end < 0:
-                        break
-                    captured.append(key_remainder[:cap_end])
-                    key_remainder = key_remainder[cap_end:]
-                else:
-                    captured.append(key_remainder)
-                    key_remainder = ""
-            else:
-                # Build destination by interleaving dst_parts and captured
-                if len(captured) == len(dst_parts) - 1:
-                    result = dst_parts[0]
-                    for seg, dpart in zip(captured, dst_parts[1:]):
-                        result += seg + dpart
-                    return result
+            result = dst_parts[0]
+            for i, dpart in enumerate(dst_parts[1:]):
+                result += m.group(i + 1) + dpart
+            return result
     return key
 
 
@@ -668,12 +666,13 @@ def apply_attribute_mapping(attributes: dict, mapping: dict) -> dict:
         return dict(attributes)
 
     try:
-        compiled_mappings, _ = compile_attribute_policy(mapping, [])
+        compiled_mappings, _ = _cached_compile_attribute_policy(tuple(sorted(mapping.items())), ())
     except ValueError:
         # Misconfigured mapping at runtime (e.g. otel.* destination, empty key, key > 256 chars).
         # Fail-closed: return attributes unchanged rather than applying a partially-validated
         # mapping that may have bypassed safety checks (e.g. reserved otel.* namespace).
-        logger.debug("apply_attribute_mapping: compile_attribute_policy failed; returning attributes unchanged", exc_info=True)
+        # Warn (not just debug) so operators discover bad config at test time, not in production.
+        logger.warning("apply_attribute_mapping: invalid mapping config; returning attributes unchanged", exc_info=True)
         return dict(attributes)
 
     renamed_attributes: dict = {}

--- a/mcpgateway/plugins/utils.py
+++ b/mcpgateway/plugins/utils.py
@@ -629,6 +629,21 @@ def apply_attribute_mapping(attributes: dict, mapping: dict) -> dict:
     Supports both exact key renames and single-``*`` wildcard renames.
     Exact rules take precedence over wildcard rules.
 
+    Collision behaviour (two source keys map to the same destination):
+    The last source key processed wins — ``dict`` assignment overwrites the
+    earlier value silently.  This is documented deterministic behaviour: since
+    exact rules are evaluated first and wildcard rules are evaluated in
+    insertion order, the outcome is predictable.  Compile-time collision
+    detection (rejecting ambiguous configs at startup) is planned for the
+    Phase 5 attribute-policy wiring.
+
+    Fallback on invalid mapping:
+    If ``compile_attribute_policy`` raises ``ValueError`` (e.g. ``otel.*``
+    destination, empty key, key > 256 chars), the function returns the
+    attributes **unchanged** rather than applying a partially-validated
+    mapping.  This is intentional fail-closed behaviour — no attribute will
+    ever be renamed into a reserved namespace on an invalid config.
+
     Args:
         attributes: Dictionary of attributes to rename.
         mapping: Dictionary mapping old attribute names to new names.

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -4669,6 +4669,7 @@ class ToolService(BaseService):
         global_context: Any,
         context_table: Any,
         plugin_manager: Any = None,
+        ctl_acc: Optional["ControlTelemetryAccumulator"] = None,
     ) -> None:
         """Invoke post-invoke plugins after a timeout and raise with retry signal if requested.
 
@@ -4684,6 +4685,9 @@ class ToolService(BaseService):
             global_context: Plugin global context for cross-hook state.
             context_table: Plugin local context table for per-plugin state.
             plugin_manager: Optional pre-fetched plugin manager to avoid redundant lookups.
+            ctl_acc: Optional invocation-local control-telemetry accumulator.  When provided,
+                the post-invoke hook's execution records are added here so they are included
+                in the telemetry emitted on the timeout path.
 
         Raises:
             ToolTimeoutError: When the retry plugin requests a delayed retry.
@@ -4703,6 +4707,8 @@ class ToolService(BaseService):
                 extensions=build_request_extensions(),
             )
             record_plugin_metrics(current_trace_id.get(), timeout_post_result.metadata if timeout_post_result else None)
+            if ctl_acc is not None:
+                ctl_acc.add(timeout_post_result, hook="post")
             if timeout_post_result and timeout_post_result.retry_delay_ms > 0:
                 raise ToolTimeoutError(f"Tool invocation timed out after {effective_timeout}s", retry_delay_ms=timeout_post_result.retry_delay_ms)
 
@@ -5627,7 +5633,7 @@ class ToolService(BaseService):
                                     exc_info=True,
                                 )
                             if plugin_manager:
-                                await self._run_timeout_post_invoke(name, effective_timeout, global_context, context_table, plugin_manager)
+                                await self._run_timeout_post_invoke(name, effective_timeout, global_context, context_table, plugin_manager, ctl_acc=_ctl_acc)
 
                             raise ToolTimeoutError(f"Tool invocation timed out after {effective_timeout}s")
                         try:
@@ -6256,7 +6262,7 @@ class ToolService(BaseService):
                                 )
 
                             if plugin_manager:
-                                await self._run_timeout_post_invoke(name, effective_timeout, global_context, context_table, plugin_manager)
+                                await self._run_timeout_post_invoke(name, effective_timeout, global_context, context_table, plugin_manager, ctl_acc=_ctl_acc)
 
                             raise ToolTimeoutError(f"Tool invocation timed out after {effective_timeout}s")
                         except asyncio.CancelledError:
@@ -6453,7 +6459,7 @@ class ToolService(BaseService):
 
                             # Trigger circuit breaker on timeout
                             if plugin_manager:
-                                await self._run_timeout_post_invoke(name, effective_timeout, global_context, context_table, plugin_manager)
+                                await self._run_timeout_post_invoke(name, effective_timeout, global_context, context_table, plugin_manager, ctl_acc=_ctl_acc)
 
                             raise ToolTimeoutError(f"Tool invocation timed out after {effective_timeout}s")
                         if status_code == 200:
@@ -6494,7 +6500,7 @@ class ToolService(BaseService):
                     except (asyncio.TimeoutError, ToolTimeoutError) as timeout_err:
                         logger.warning("gRPC tool invocation timed out for %s after %ss", tool_name_original, effective_timeout, exc_info=True)
                         if plugin_manager:
-                            await self._run_timeout_post_invoke(name, effective_timeout, global_context, context_table, plugin_manager)
+                            await self._run_timeout_post_invoke(name, effective_timeout, global_context, context_table, plugin_manager, ctl_acc=_ctl_acc)
                         raise ToolTimeoutError(f"Tool invocation timed out after {effective_timeout}s") from timeout_err
                     except Exception as grpc_err:
                         logger.error("gRPC tool invocation failed for %s: %s", tool_name_original, grpc_err, exc_info=True)
@@ -6573,6 +6579,14 @@ class ToolService(BaseService):
                 return tool_result
             except (PluginError, PluginViolationError):
                 # Emit partial telemetry even on pre-invoke deny (tool never executed).
+                # Note: when violations_as_exceptions=True, CPEX raises PluginViolationError
+                # *before* appending a ControlExecutionRecord for the denying plugin to the
+                # executions list (see cpex/framework/manager.py:680-682 — "propagate
+                # immediately, no record needed").  This means _ctl_acc may only contain
+                # records from earlier plugins in the chain that ran *before* the denial.
+                # The emitted summary span will reflect the partial pre-hook results; the
+                # effective_allow=False outcome is captured via accumulator.pre_denied.
+                # Upstream CPEX gap tracked in issue #5785 follow-on.
                 record_control_telemetry(
                     trace_id=current_trace_id.get(),
                     accumulator=_ctl_acc,

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -6638,10 +6638,11 @@ class ToolService(BaseService):
                 )
                 raise
             except PluginError:
-                # Plugin outage (crash/timeout/misconfiguration) — emit partial telemetry so the
-                # summary span is not silently lost, but do NOT treat this as a policy denial.
-                # effective_allowed remains True on the accumulator; downstream dashboards can
-                # distinguish plugin errors from enforcement decisions.
+                # Plugin outage (crash/timeout/misconfiguration) — mark the accumulator so
+                # the summary span carries cpex.control.plugin_error=True, emit partial
+                # telemetry (even when the accumulator is empty, e.g. first-plugin failure),
+                # and do NOT treat this as a policy denial (effective_allowed stays True).
+                _ctl_acc.mark_plugin_error()
                 record_control_telemetry(
                     trace_id=current_trace_id.get(),
                     accumulator=_ctl_acc,

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -5272,6 +5272,10 @@ class ToolService(BaseService):
         # Declared here (before the try/with block) so it survives into the
         # exception handlers and the finally block for partial pre-deny telemetry.
         _ctl_acc = ControlTelemetryAccumulator()
+        # Tracks which hook a PluginError propagated from so mark_plugin_error(hook=)
+        # can report the correct enforcement point even when no records were appended.
+        # Updated to "post" immediately before each post-hook invoke_hook call.
+        _ctl_last_hook: str = "pre"
 
         def _emit_ctl_telemetry() -> None:
             """Flush CPEX control-execution telemetry for this invocation (best-effort).
@@ -6560,6 +6564,7 @@ class ToolService(BaseService):
                     # Plugin hook: tool post-invoke
                     plugin_manager = await self._get_plugin_manager(plugin_context_id)
                     if plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_POST_INVOKE):
+                        _ctl_last_hook = "post"  # update hook tracker before the call
                         try:
                             post_result, _ = await plugin_manager.invoke_hook(
                                 ToolHookType.TOOL_POST_INVOKE,
@@ -6640,7 +6645,9 @@ class ToolService(BaseService):
                 # the summary span carries cpex.control.plugin_error=True, emit partial
                 # telemetry (even when the accumulator is empty, e.g. first-plugin failure),
                 # and do NOT treat this as a policy denial (effective_allowed stays True).
-                _ctl_acc.mark_plugin_error()
+                # hook= is derived from _ctl_last_hook which is "pre" by default and updated
+                # to "post" immediately before the post-hook invoke_hook call.
+                _ctl_acc.mark_plugin_error(hook=_ctl_last_hook)
                 _emit_ctl_telemetry()
                 raise
             except ToolTimeoutError as e:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -5273,6 +5273,25 @@ class ToolService(BaseService):
         # exception handlers and the finally block for partial pre-deny telemetry.
         _ctl_acc = ControlTelemetryAccumulator()
 
+        def _emit_ctl_telemetry() -> None:
+            """Flush CPEX control-execution telemetry for this invocation (best-effort).
+
+            Thin wrapper that captures the invocation-local ``_ctl_acc``, ``name``,
+            and identity fields so all five exit paths (normal return, PluginViolationError,
+            PluginError, ToolTimeoutError, BaseException) call a single canonical site.
+            Identity mapping is provisional — see issue #5785 follow-on for a dedicated
+            agent-identity model:
+              agent_id     = app_user_email ?? user_email  (authenticated caller email)
+              binding_name = gateway_name ?? server_id     (closest proxy for binding context)
+            """
+            record_control_telemetry(
+                trace_id=current_trace_id.get(),
+                accumulator=_ctl_acc,
+                tool_name=name,
+                agent_id=app_user_email or user_email or "",
+                binding_name=gateway_name or server_id or "",
+            )
+
         start_time = time.monotonic()
         success = False
         error_message = None
@@ -6601,25 +6620,10 @@ class ToolService(BaseService):
 
                 # Emit CPEX control-execution telemetry for this invocation (best-effort).
                 # Placed here on the normal-return path so both pre and post records are
-                # accumulated before emitting.  The PluginViolationError re-raise below
-                # also calls this so partial pre-deny telemetry is not lost.
-                #
-                # Identity mapping (provisional — see issue #5785 follow-on for a dedicated
-                # agent-identity model):
-                #   agent_id     = app_user_email ?? user_email — the authenticated caller email.
-                #                  This is a human identity field and is high-cardinality; avoid
-                #                  using it in metric aggregations or OTel cardinality-sensitive paths.
-                #                  GDPR/data-residency implications apply in regulated environments.
-                #   binding_name = gateway_name ?? server_id — the closest available proxy for a
-                #                  "control binding" context.  Gateway name is a registry concept,
-                #                  not a control-binding concept; interpretation may evolve.
-                record_control_telemetry(
-                    trace_id=current_trace_id.get(),
-                    accumulator=_ctl_acc,
-                    tool_name=name,
-                    agent_id=app_user_email or user_email or "",
-                    binding_name=gateway_name or server_id or "",
-                )
+                # accumulated before emitting.  Exception paths below also call this helper
+                # so partial pre-deny / error telemetry is never lost.
+                # Identity mapping rationale: see _emit_ctl_telemetry() docstring above.
+                _emit_ctl_telemetry()
                 return tool_result
             except PluginViolationError:
                 # Deliberate policy denial — emit partial telemetry so the summary span captures
@@ -6629,13 +6633,7 @@ class ToolService(BaseService):
                 # executions list (see cpex/framework/manager.py:680-682).  _ctl_acc therefore
                 # contains only records from plugins that ran before the denier.
                 # Upstream CPEX gap tracked in issue #5785 follow-on.
-                record_control_telemetry(  # identity mapping: see normal-return path comment above
-                    trace_id=current_trace_id.get(),
-                    accumulator=_ctl_acc,
-                    tool_name=name,
-                    agent_id=app_user_email or user_email or "",
-                    binding_name=gateway_name or server_id or "",
-                )
+                _emit_ctl_telemetry()
                 raise
             except PluginError:
                 # Plugin outage (crash/timeout/misconfiguration) — mark the accumulator so
@@ -6643,25 +6641,13 @@ class ToolService(BaseService):
                 # telemetry (even when the accumulator is empty, e.g. first-plugin failure),
                 # and do NOT treat this as a policy denial (effective_allowed stays True).
                 _ctl_acc.mark_plugin_error()
-                record_control_telemetry(
-                    trace_id=current_trace_id.get(),
-                    accumulator=_ctl_acc,
-                    tool_name=name,
-                    agent_id=app_user_email or user_email or "",
-                    binding_name=gateway_name or server_id or "",
-                )
+                _emit_ctl_telemetry()
                 raise
             except ToolTimeoutError as e:
                 # ToolTimeoutError is raised by timeout handlers which already called tool_post_invoke.
                 # Do NOT call post_invoke again — the retry_delay_ms signal is carried on the exception.
                 # Emit partial telemetry before retrying or re-raising so timeout records are not lost.
-                record_control_telemetry(  # identity mapping: see normal-return path comment above
-                    trace_id=current_trace_id.get(),
-                    accumulator=_ctl_acc,
-                    tool_name=name,
-                    agent_id=app_user_email or user_email or "",
-                    binding_name=gateway_name or server_id or "",
-                )
+                _emit_ctl_telemetry()
                 error_message = str(e)
                 if span:
                     set_span_error(span, error_message)
@@ -6729,13 +6715,7 @@ class ToolService(BaseService):
                         logger.debug("Failed to invoke post-invoke plugins on exception: %s", plugin_exc)
 
                 # Emit partial telemetry for unhandled exceptions (post-hook records already added above).
-                record_control_telemetry(  # identity mapping: see normal-return path comment above
-                    trace_id=current_trace_id.get(),
-                    accumulator=_ctl_acc,
-                    tool_name=name,
-                    agent_id=app_user_email or user_email or "",
-                    binding_name=gateway_name or server_id or "",
-                )
+                _emit_ctl_telemetry()
 
                 # Retry if the plugin requested a delayed retry and we haven't hit the ceiling.
                 # Same counting convention as the success path: retry_attempt is 0-based,

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -4464,6 +4464,14 @@ class ToolService(BaseService):
 
         # Run tool_pre_invoke hooks so that plugins (e.g. wxo_connections) can
         # inject credentials and clean arguments before the Rust direct call.
+        #
+        # NOTE: CPEX control-execution telemetry is intentionally not emitted from this
+        # path.  prepare_rust_mcp_tool_execution() builds an execution plan and returns
+        # before the actual tool invocation — there is no downstream flush point where
+        # record_control_telemetry() can be called.  When the Rust runtime falls back to
+        # the Python invoke_tool() path (e.g. post-invoke hooks configured, ineligible
+        # transport) the Python path's own accumulator will capture all telemetry.
+        # Tracked in the Phase 5 attribute-policy follow-on issue.
         modified_args = arguments
         if has_pre_invoke and arguments is not None:
             pre_invoke_headers = HttpHeaderPayload(root=dict(runtime_headers))
@@ -5389,14 +5397,21 @@ class ToolService(BaseService):
                         if tool_metadata:
                             global_context.metadata[TOOL_METADATA] = tool_metadata
                         pre_invoke_headers = HttpHeaderPayload(root=headers)
-                        pre_result, context_table = await plugin_manager.invoke_hook(
-                            ToolHookType.TOOL_PRE_INVOKE,
-                            payload=ToolPreInvokePayload(name=name, args=arguments, headers=pre_invoke_headers),
-                            global_context=global_context,
-                            local_contexts=context_table,  # Pass context from previous hooks
-                            violations_as_exceptions=True,
-                            extensions=build_request_extensions(),
-                        )
+                        try:
+                            pre_result, context_table = await plugin_manager.invoke_hook(
+                                ToolHookType.TOOL_PRE_INVOKE,
+                                payload=ToolPreInvokePayload(name=name, args=arguments, headers=pre_invoke_headers),
+                                global_context=global_context,
+                                local_contexts=context_table,  # Pass context from previous hooks
+                                violations_as_exceptions=True,
+                                extensions=build_request_extensions(),
+                            )
+                        except (PluginError, PluginViolationError):
+                            # violations_as_exceptions=True causes CPEX to raise before returning,
+                            # so add() is never called.  Mark the denial explicitly so telemetry
+                            # emits result.allowed=False rather than the incorrect True default.
+                            _ctl_acc.mark_denied(hook="pre")
+                            raise
                         record_plugin_metrics(current_trace_id.get(), pre_result.metadata)
                         _ctl_acc.add(pre_result, hook="pre")
                         _log_tool_pre_invoke_result(name, arguments, pre_invoke_headers, pre_result)
@@ -6075,7 +6090,7 @@ class ToolService(BaseService):
                                 )
 
                             if plugin_manager:
-                                await self._run_timeout_post_invoke(name, effective_timeout, global_context, context_table, plugin_manager)
+                                await self._run_timeout_post_invoke(name, effective_timeout, global_context, context_table, plugin_manager, ctl_acc=_ctl_acc)
 
                             raise ToolTimeoutError(f"Tool invocation timed out after {effective_timeout}s")
                         except asyncio.CancelledError:
@@ -6301,14 +6316,21 @@ class ToolService(BaseService):
                         if gateway_metadata:
                             global_context.metadata[GATEWAY_METADATA] = gateway_metadata
                         pre_invoke_headers = HttpHeaderPayload(root=headers)
-                        pre_result, context_table = await plugin_manager.invoke_hook(
-                            ToolHookType.TOOL_PRE_INVOKE,
-                            payload=ToolPreInvokePayload(name=name, args=arguments, headers=pre_invoke_headers),
-                            global_context=global_context,
-                            local_contexts=None,
-                            violations_as_exceptions=True,
-                            extensions=build_request_extensions(),
-                        )
+                        try:
+                            pre_result, context_table = await plugin_manager.invoke_hook(
+                                ToolHookType.TOOL_PRE_INVOKE,
+                                payload=ToolPreInvokePayload(name=name, args=arguments, headers=pre_invoke_headers),
+                                global_context=global_context,
+                                local_contexts=None,
+                                violations_as_exceptions=True,
+                                extensions=build_request_extensions(),
+                            )
+                        except (PluginError, PluginViolationError):
+                            # violations_as_exceptions=True causes CPEX to raise before returning,
+                            # so add() is never called.  Mark the denial explicitly so telemetry
+                            # emits result.allowed=False rather than the incorrect True default.
+                            _ctl_acc.mark_denied(hook="pre")
+                            raise
                         record_plugin_metrics(current_trace_id.get(), pre_result.metadata)
                         _ctl_acc.add(pre_result, hook="pre")
                         _log_tool_pre_invoke_result(name, arguments, pre_invoke_headers, pre_result)
@@ -6388,14 +6410,21 @@ class ToolService(BaseService):
                         if tool_metadata:
                             global_context.metadata[TOOL_METADATA] = tool_metadata
                         pre_invoke_headers = HttpHeaderPayload(root=plugin_headers)
-                        pre_result, context_table = await plugin_manager.invoke_hook(
-                            ToolHookType.TOOL_PRE_INVOKE,
-                            payload=ToolPreInvokePayload(name=name, args=arguments, headers=pre_invoke_headers),
-                            global_context=global_context,
-                            local_contexts=context_table,
-                            violations_as_exceptions=True,
-                            extensions=build_request_extensions(),
-                        )
+                        try:
+                            pre_result, context_table = await plugin_manager.invoke_hook(
+                                ToolHookType.TOOL_PRE_INVOKE,
+                                payload=ToolPreInvokePayload(name=name, args=arguments, headers=pre_invoke_headers),
+                                global_context=global_context,
+                                local_contexts=context_table,
+                                violations_as_exceptions=True,
+                                extensions=build_request_extensions(),
+                            )
+                        except (PluginError, PluginViolationError):
+                            # violations_as_exceptions=True causes CPEX to raise before returning,
+                            # so add() is never called.  Mark the denial explicitly so telemetry
+                            # emits result.allowed=False rather than the incorrect True default.
+                            _ctl_acc.mark_denied(hook="pre")
+                            raise
                         record_plugin_metrics(current_trace_id.get(), pre_result.metadata)
                         _ctl_acc.add(pre_result, hook="pre")
                         _log_tool_pre_invoke_result(name, arguments, pre_invoke_headers, pre_result)
@@ -6513,14 +6542,21 @@ class ToolService(BaseService):
                     # Plugin hook: tool post-invoke
                     plugin_manager = await self._get_plugin_manager(plugin_context_id)
                     if plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_POST_INVOKE):
-                        post_result, _ = await plugin_manager.invoke_hook(
-                            ToolHookType.TOOL_POST_INVOKE,
-                            payload=ToolPostInvokePayload(name=name, result=tool_result.model_dump(by_alias=True)),
-                            global_context=global_context,
-                            local_contexts=context_table,
-                            violations_as_exceptions=True,
-                            extensions=build_request_extensions(),
-                        )
+                        try:
+                            post_result, _ = await plugin_manager.invoke_hook(
+                                ToolHookType.TOOL_POST_INVOKE,
+                                payload=ToolPostInvokePayload(name=name, result=tool_result.model_dump(by_alias=True)),
+                                global_context=global_context,
+                                local_contexts=context_table,
+                                violations_as_exceptions=True,
+                                extensions=build_request_extensions(),
+                            )
+                        except (PluginError, PluginViolationError):
+                            # violations_as_exceptions=True: CPEX raises before returning,
+                            # so add() is never reached.  Mark the denial so telemetry
+                            # emits result.allowed=False correctly.
+                            _ctl_acc.mark_denied(hook="post")
+                            raise
                         record_plugin_metrics(current_trace_id.get(), post_result.metadata)
                         _ctl_acc.add(post_result, hook="post")
                         # Use modified payload if provided
@@ -6569,6 +6605,16 @@ class ToolService(BaseService):
                 # Placed here on the normal-return path so both pre and post records are
                 # accumulated before emitting.  The PluginViolationError re-raise below
                 # also calls this so partial pre-deny telemetry is not lost.
+                #
+                # Identity mapping (provisional — see issue #5785 follow-on for a dedicated
+                # agent-identity model):
+                #   agent_id     = app_user_email ?? user_email — the authenticated caller email.
+                #                  This is a human identity field and is high-cardinality; avoid
+                #                  using it in metric aggregations or OTel cardinality-sensitive paths.
+                #                  GDPR/data-residency implications apply in regulated environments.
+                #   binding_name = gateway_name ?? server_id — the closest available proxy for a
+                #                  "control binding" context.  Gateway name is a registry concept,
+                #                  not a control-binding concept; interpretation may evolve.
                 record_control_telemetry(
                     trace_id=current_trace_id.get(),
                     accumulator=_ctl_acc,
@@ -6587,7 +6633,7 @@ class ToolService(BaseService):
                 # The emitted summary span will reflect the partial pre-hook results; the
                 # effective_allow=False outcome is captured via accumulator.pre_denied.
                 # Upstream CPEX gap tracked in issue #5785 follow-on.
-                record_control_telemetry(
+                record_control_telemetry(  # identity mapping: see normal-return path comment above
                     trace_id=current_trace_id.get(),
                     accumulator=_ctl_acc,
                     tool_name=name,
@@ -6599,7 +6645,7 @@ class ToolService(BaseService):
                 # ToolTimeoutError is raised by timeout handlers which already called tool_post_invoke.
                 # Do NOT call post_invoke again — the retry_delay_ms signal is carried on the exception.
                 # Emit partial telemetry before retrying or re-raising so timeout records are not lost.
-                record_control_telemetry(
+                record_control_telemetry(  # identity mapping: see normal-return path comment above
                     trace_id=current_trace_id.get(),
                     accumulator=_ctl_acc,
                     tool_name=name,
@@ -6673,7 +6719,7 @@ class ToolService(BaseService):
                         logger.debug("Failed to invoke post-invoke plugins on exception: %s", plugin_exc)
 
                 # Emit partial telemetry for unhandled exceptions (post-hook records already added above).
-                record_control_telemetry(
+                record_control_telemetry(  # identity mapping: see normal-return path comment above
                     trace_id=current_trace_id.get(),
                     accumulator=_ctl_acc,
                     tool_name=name,

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -72,6 +72,7 @@ from mcpgateway.db import get_for_update, server_tool_association
 from mcpgateway.db import Tool as DbTool
 from mcpgateway.db import ToolMetric, ToolMetricsHourly
 from mcpgateway.observability import create_child_span, create_span, inject_trace_context_headers, otel_context_active, set_span_attribute, set_span_error
+from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, record_control_telemetry
 from mcpgateway.plugins.utils import build_request_extensions, record_plugin_metrics
 from mcpgateway.schemas import AuthenticationValues, ToolCreate, ToolMetrics, ToolRead, ToolUpdate, TopPerformer
 from mcpgateway.services.a2a_protocol import prepare_a2a_invocation
@@ -5253,6 +5254,11 @@ class ToolService(BaseService):
             content_type = request_headers.get("content-type") if request_headers else None
             global_context = GlobalContext(request_id=request_id, server_id=context_server_id, tenant_id=payload_tenant_id, user=app_user_email, content_type=content_type)
 
+        # Per-invocation accumulator for CPEX control-execution telemetry.
+        # Declared here (before the try/with block) so it survives into the
+        # exception handlers and the finally block for partial pre-deny telemetry.
+        _ctl_acc = ControlTelemetryAccumulator()
+
         start_time = time.monotonic()
         success = False
         error_message = None
@@ -5386,6 +5392,7 @@ class ToolService(BaseService):
                             extensions=build_request_extensions(),
                         )
                         record_plugin_metrics(current_trace_id.get(), pre_result.metadata)
+                        _ctl_acc.add(pre_result, hook="pre")
                         _log_tool_pre_invoke_result(name, arguments, pre_invoke_headers, pre_result)
                         if pre_result.modified_payload:
                             payload = pre_result.modified_payload
@@ -6297,6 +6304,7 @@ class ToolService(BaseService):
                             extensions=build_request_extensions(),
                         )
                         record_plugin_metrics(current_trace_id.get(), pre_result.metadata)
+                        _ctl_acc.add(pre_result, hook="pre")
                         _log_tool_pre_invoke_result(name, arguments, pre_invoke_headers, pre_result)
                         if pre_result.modified_payload:
                             payload = pre_result.modified_payload
@@ -6383,6 +6391,7 @@ class ToolService(BaseService):
                             extensions=build_request_extensions(),
                         )
                         record_plugin_metrics(current_trace_id.get(), pre_result.metadata)
+                        _ctl_acc.add(pre_result, hook="pre")
                         _log_tool_pre_invoke_result(name, arguments, pre_invoke_headers, pre_result)
                         if pre_result.modified_payload:
                             payload = pre_result.modified_payload
@@ -6507,6 +6516,7 @@ class ToolService(BaseService):
                             extensions=build_request_extensions(),
                         )
                         record_plugin_metrics(current_trace_id.get(), post_result.metadata)
+                        _ctl_acc.add(post_result, hook="post")
                         # Use modified payload if provided
                         if post_result.modified_payload:
                             # Reconstruct ToolResult from modified result
@@ -6549,12 +6559,39 @@ class ToolService(BaseService):
                             path_label="success",
                         )
 
+                # Emit CPEX control-execution telemetry for this invocation (best-effort).
+                # Placed here on the normal-return path so both pre and post records are
+                # accumulated before emitting.  The PluginViolationError re-raise below
+                # also calls this so partial pre-deny telemetry is not lost.
+                record_control_telemetry(
+                    trace_id=current_trace_id.get(),
+                    accumulator=_ctl_acc,
+                    tool_name=name,
+                    agent_id=app_user_email or user_email or "",
+                    binding_name=gateway_name or server_id or "",
+                )
                 return tool_result
             except (PluginError, PluginViolationError):
+                # Emit partial telemetry even on pre-invoke deny (tool never executed).
+                record_control_telemetry(
+                    trace_id=current_trace_id.get(),
+                    accumulator=_ctl_acc,
+                    tool_name=name,
+                    agent_id=app_user_email or user_email or "",
+                    binding_name=gateway_name or server_id or "",
+                )
                 raise
             except ToolTimeoutError as e:
                 # ToolTimeoutError is raised by timeout handlers which already called tool_post_invoke.
                 # Do NOT call post_invoke again — the retry_delay_ms signal is carried on the exception.
+                # Emit partial telemetry before retrying or re-raising so timeout records are not lost.
+                record_control_telemetry(
+                    trace_id=current_trace_id.get(),
+                    accumulator=_ctl_acc,
+                    tool_name=name,
+                    agent_id=app_user_email or user_email or "",
+                    binding_name=gateway_name or server_id or "",
+                )
                 error_message = str(e)
                 if span:
                     set_span_error(span, error_message)
@@ -6617,8 +6654,18 @@ class ToolService(BaseService):
                             extensions=build_request_extensions(),
                         )
                         record_plugin_metrics(current_trace_id.get(), exc_post_result.metadata if exc_post_result else None)
+                        _ctl_acc.add(exc_post_result, hook="post")
                     except Exception as plugin_exc:
                         logger.debug("Failed to invoke post-invoke plugins on exception: %s", plugin_exc)
+
+                # Emit partial telemetry for unhandled exceptions (post-hook records already added above).
+                record_control_telemetry(
+                    trace_id=current_trace_id.get(),
+                    accumulator=_ctl_acc,
+                    tool_name=name,
+                    agent_id=app_user_email or user_email or "",
+                    binding_name=gateway_name or server_id or "",
+                )
 
                 # Retry if the plugin requested a delayed retry and we haven't hit the ceiling.
                 # Same counting convention as the success path: retry_attempt is 0-based,

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -5406,10 +5406,11 @@ class ToolService(BaseService):
                                 violations_as_exceptions=True,
                                 extensions=build_request_extensions(),
                             )
-                        except (PluginError, PluginViolationError):
-                            # violations_as_exceptions=True causes CPEX to raise before returning,
-                            # so add() is never called.  Mark the denial explicitly so telemetry
-                            # emits result.allowed=False rather than the incorrect True default.
+                        except PluginViolationError:
+                            # Deliberate policy denial: mark so telemetry emits result.allowed=False.
+                            # PluginError (outage) is not caught here — it propagates to the outer
+                            # except PluginError handler without mark_denied(), keeping enforcement
+                            # denials and plugin crashes distinguishable in downstream dashboards.
                             _ctl_acc.mark_denied(hook="pre")
                             raise
                         record_plugin_metrics(current_trace_id.get(), pre_result.metadata)
@@ -6325,10 +6326,9 @@ class ToolService(BaseService):
                                 violations_as_exceptions=True,
                                 extensions=build_request_extensions(),
                             )
-                        except (PluginError, PluginViolationError):
-                            # violations_as_exceptions=True causes CPEX to raise before returning,
-                            # so add() is never called.  Mark the denial explicitly so telemetry
-                            # emits result.allowed=False rather than the incorrect True default.
+                        except PluginViolationError:
+                            # Deliberate policy denial: mark so telemetry emits result.allowed=False.
+                            # PluginError propagates to the outer handler without mark_denied().
                             _ctl_acc.mark_denied(hook="pre")
                             raise
                         record_plugin_metrics(current_trace_id.get(), pre_result.metadata)
@@ -6419,10 +6419,9 @@ class ToolService(BaseService):
                                 violations_as_exceptions=True,
                                 extensions=build_request_extensions(),
                             )
-                        except (PluginError, PluginViolationError):
-                            # violations_as_exceptions=True causes CPEX to raise before returning,
-                            # so add() is never called.  Mark the denial explicitly so telemetry
-                            # emits result.allowed=False rather than the incorrect True default.
+                        except PluginViolationError:
+                            # Deliberate policy denial: mark so telemetry emits result.allowed=False.
+                            # PluginError propagates to the outer handler without mark_denied().
                             _ctl_acc.mark_denied(hook="pre")
                             raise
                         record_plugin_metrics(current_trace_id.get(), pre_result.metadata)
@@ -6551,10 +6550,9 @@ class ToolService(BaseService):
                                 violations_as_exceptions=True,
                                 extensions=build_request_extensions(),
                             )
-                        except (PluginError, PluginViolationError):
-                            # violations_as_exceptions=True: CPEX raises before returning,
-                            # so add() is never reached.  Mark the denial so telemetry
-                            # emits result.allowed=False correctly.
+                        except PluginViolationError:
+                            # Deliberate policy denial: mark so telemetry emits result.allowed=False.
+                            # PluginError propagates to the outer handler without mark_denied().
                             _ctl_acc.mark_denied(hook="post")
                             raise
                         record_plugin_metrics(current_trace_id.get(), post_result.metadata)
@@ -6623,17 +6621,28 @@ class ToolService(BaseService):
                     binding_name=gateway_name or server_id or "",
                 )
                 return tool_result
-            except (PluginError, PluginViolationError):
-                # Emit partial telemetry even on pre-invoke deny (tool never executed).
+            except PluginViolationError:
+                # Deliberate policy denial — emit partial telemetry so the summary span captures
+                # result.allowed=False and any pre-denial execution records.
                 # Note: when violations_as_exceptions=True, CPEX raises PluginViolationError
                 # *before* appending a ControlExecutionRecord for the denying plugin to the
-                # executions list (see cpex/framework/manager.py:680-682 — "propagate
-                # immediately, no record needed").  This means _ctl_acc may only contain
-                # records from earlier plugins in the chain that ran *before* the denial.
-                # The emitted summary span will reflect the partial pre-hook results; the
-                # effective_allow=False outcome is captured via accumulator.pre_denied.
+                # executions list (see cpex/framework/manager.py:680-682).  _ctl_acc therefore
+                # contains only records from plugins that ran before the denier.
                 # Upstream CPEX gap tracked in issue #5785 follow-on.
                 record_control_telemetry(  # identity mapping: see normal-return path comment above
+                    trace_id=current_trace_id.get(),
+                    accumulator=_ctl_acc,
+                    tool_name=name,
+                    agent_id=app_user_email or user_email or "",
+                    binding_name=gateway_name or server_id or "",
+                )
+                raise
+            except PluginError:
+                # Plugin outage (crash/timeout/misconfiguration) — emit partial telemetry so the
+                # summary span is not silently lost, but do NOT treat this as a policy denial.
+                # effective_allowed remains True on the accumulator; downstream dashboards can
+                # distinguish plugin errors from enforcement decisions.
+                record_control_telemetry(
                     trace_id=current_trace_id.get(),
                     accumulator=_ctl_acc,
                     tool_name=name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,10 @@ build_py = "mcpgateway.tools.builder.build_hooks.BuildPyWithUI"
 exclude-newer = "10 days"
 
 [tool.uv.exclude-newer-package]
-cpex = "2026-07-27T23:59:59Z"
+cpex = "2026-07-30T23:59:59Z"
+# cpex 0.1.2 (2026-07-30T03:08:24Z) is the minimum required version for
+# ControlExecutionRecord support (issue #5785 / consume-cpex-executions).
+# Pinned past its publish timestamp so uv resolves it on Python 3.13 as well.
 # cpex-url-reputation pinned past its normal soak cutoff: 0.3.5 (2026-07-14) is the first
 # release that emits result.metadata["url_reputation"] for resource_pre_fetch, which
 # tests/integration/plugins/test_plugin_metrics_consumer_integration.py and
@@ -127,7 +130,7 @@ dependencies = [
     "base58>=2.1.1",
     "brotli>=1.2.0",
     "click>=8.4.2", # Transitive pin
-    "cpex>=0.1.1",
+    "cpex>=0.1.2",
     "cryptography>=50.0.0",
     "fastapi>=0.140.0",
     "filelock>=3.32.0,<3.33.0", # 3.30.0 added fork-safety guard that raises on pre-fork lock reuse; gateway_service.py:5351 rebuilds per-PID (fix from #5654). primary_worker.py and bootstrap_db.py create FileLock post-fork so are unaffected. Ceiling bumped to 3.32.x: 3.30.x–3.32.x have zero runtime changes (CI matrix, packaging, platform support only). Advance ceiling after verifying next minor release.

--- a/tests/e2e/test_otel_control_telemetry_e2e.py
+++ b/tests/e2e/test_otel_control_telemetry_e2e.py
@@ -1,0 +1,585 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/e2e/test_otel_control_telemetry_e2e.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+E2E test — CPEX control-execution telemetry (issue #5785).
+
+Proves, against a REAL gateway request pipeline (real FastAPI app, real
+ObservabilityMiddleware, real ToolService, real PluginManager, real
+ObservabilityService backed by a real temp SQLite database), that a genuinely
+traced HTTP ``tools/call`` request causes ``cpex.control.summary`` and
+``cpex.control.result`` DB spans to appear in
+``GET /observability/traces/{trace_id}``.
+
+Key insight: ``ControlExecutionRecord`` objects are populated by the CPEX
+**framework** (``cpex.framework.manager._make_execution_record``), not by
+individual plugins.  The framework builds one record per plugin evaluated,
+sourcing all identity/status/duration fields from trusted ``PluginRef`` config
+— plugins cannot forge them and do not need to emit them.  This means
+``PluginResult.executions`` is already non-empty whenever any plugin runs,
+even with the current pii_filter / secrets_detection / rate_limiter plugins
+that predate #5785.
+
+Chain under test:
+  1. Client sends ``POST /rpc`` (``tools/call``) with a W3C ``traceparent``
+     header carrying a trace_id we control.
+  2. ``ObservabilityMiddleware`` starts a trace using OUR trace_id and sets
+     ``current_trace_id`` context var.
+  3. ``ToolService.invoke_tool`` runs ``tool_pre_invoke`` / ``tool_post_invoke``
+     hooks via ``plugin_manager.invoke_hook``.  The CPEX framework appends
+     one ``ControlExecutionRecord`` per evaluated plugin to ``PluginResult.executions``.
+  4. ``ControlTelemetryAccumulator._ctl_acc.add(result, hook=…)`` collects
+     those records.
+  5. ``record_control_telemetry()`` writes:
+       - one ``cpex.control.summary`` DB span with aggregate attributes
+       - one ``cpex.control.result`` DB span per record
+     all rooted at our trace_id.
+  6. ``GET /observability/traces/{trace_id}`` returns those spans — this is
+     the concrete verification gate.
+
+Only the outbound HTTP call to the (fictitious) upstream REST tool backend is
+mocked.  Everything else runs real gateway code.
+
+Can be run standalone:
+    python -m pytest tests/e2e/test_otel_control_telemetry_e2e.py -v
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import os
+from pathlib import Path
+import secrets
+from unittest.mock import AsyncMock
+
+# Third-Party
+import yaml
+
+# Enable plugins + observability BEFORE mcpgateway.main is first imported.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+os.environ.setdefault("PLUGINS_ENABLED", "true")
+os.environ.setdefault("PLUGINS_CONFIG_FILE", str(_REPO_ROOT / "plugins" / "config.yaml"))
+os.environ.setdefault("OBSERVABILITY_ENABLED", "true")
+
+# First-Party — clear any settings caches populated before the env vars above were set.
+from mcpgateway.config import get_settings as _get_mcpgateway_settings  # noqa: E402
+
+_get_mcpgateway_settings.cache_clear()
+try:
+    from cpex.framework.settings import settings as _cpex_plugin_settings  # noqa: E402
+
+    _cpex_plugin_settings.cache_clear()
+except Exception:  # noqa: BLE001
+    pass
+
+# Third-Party
+from cpex.framework import PluginError, PluginViolationError, ToolHookType  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.exceptions import RequestValidationError  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+import httpx  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+import pytest  # noqa: E402
+import pytest_asyncio  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.exc import IntegrityError  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+# First-Party
+from mcpgateway.auth import get_current_user  # noqa: E402
+import mcpgateway.db as db_mod  # noqa: E402
+from mcpgateway.db import Base  # noqa: E402
+import mcpgateway.main as main_mod  # noqa: E402
+from mcpgateway.main import (  # noqa: E402
+    database_exception_handler,
+    get_db,
+    plugin_exception_handler,
+    plugin_violation_exception_handler,
+    request_validation_exception_handler,
+    tool_router,
+    unhandled_exception_handler,
+    utility_router,
+    validation_exception_handler,
+)
+from mcpgateway.middleware.observability_middleware import ObservabilityMiddleware  # noqa: E402
+from mcpgateway.middleware.rbac import get_current_user_with_permissions, get_permission_service  # noqa: E402
+from mcpgateway.plugins import (  # noqa: E402
+    enable_plugins,
+    get_plugin_manager,
+    init_plugin_manager_factory,
+    shutdown_plugin_manager_factory,
+)
+from mcpgateway.plugins.policy import HOOK_PAYLOAD_POLICIES  # noqa: E402
+from mcpgateway.routers.observability import router as observability_router  # noqa: E402
+from mcpgateway.services.observability_service import ObservabilityService  # noqa: E402
+from mcpgateway.services.tool_service import tool_service  # noqa: E402
+from mcpgateway.utils.create_jwt_token import get_jwt_token  # noqa: E402
+from mcpgateway.utils.verify_credentials import require_admin_auth, require_auth  # noqa: E402
+
+# Local
+from tests.helpers.auth import make_auth_headers, make_test_jwt  # noqa: E402
+from tests.utils.rbac_mocks import MockPermissionService, create_mock_email_user, create_mock_user_context  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ADMIN_EMAIL = "admin@example.com"
+CONTROL_TOOL_NAME = "control_telemetry_probe_tool"
+CONTROL_UPSTREAM_URL = "https://internal.e2e-fixture.invalid/control-echo"
+
+
+def _new_traceparent() -> tuple[str, str]:
+    """Build a W3C ``traceparent`` header with a trace_id we control.
+
+    Returns:
+        (trace_id, traceparent_header_value)
+    """
+    trace_id = secrets.token_hex(16)
+    parent_span_id = secrets.token_hex(8)
+    return trace_id, f"00-{trace_id}-{parent_span_id}-01"
+
+
+def _auth_headers() -> dict:
+    """Mint a real admin JWT and build an Authorization Bearer header.
+
+    Returns:
+        Dict with Authorization header.
+    """
+    token = make_test_jwt(ADMIN_EMAIL, is_admin=True)
+    return make_auth_headers(token)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def control_telemetry_app(monkeypatch, tmp_path):
+    """Wire a real temp-DB, dedicated FastAPI app with PIIFilter active.
+
+    Mirrors the ``traced_app`` fixture in ``test_otel_plugin_metadata_e2e.py``
+    exactly — real ObservabilityMiddleware, real ToolService, real PluginManager,
+    real ObservabilityService, in-memory SQLite DB, only the outbound HTTP call
+    mocked.
+
+    PIIFilter is used because:
+    - It hooks ``tool_post_invoke`` (so post-invoke records flow through the accumulator)
+    - It is always installed in the dev venv (``cpex-pii-filter``)
+    - Its ``block_on_detection=false`` shipped default means it never raises
+      ``PluginViolationError``, so both pre- and post-invoke complete normally
+
+    The CPEX framework itself creates one ``ControlExecutionRecord`` per plugin
+    evaluated — no plugin-side changes are needed.
+    """
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, expire_on_commit=False, bind=engine)
+
+    monkeypatch.setattr(db_mod, "engine", engine, raising=False)
+    monkeypatch.setattr(db_mod, "SessionLocal", TestSessionLocal, raising=False)
+    monkeypatch.setattr(main_mod, "SessionLocal", TestSessionLocal, raising=False)
+    monkeypatch.setattr("mcpgateway.services.observability_service.SessionLocal", TestSessionLocal, raising=False)
+    monkeypatch.setattr("mcpgateway.routers.observability.SessionLocal", TestSessionLocal, raising=False)
+    # Patch control_telemetry's SessionLocal so _emit_db_spans writes to the same DB
+    monkeypatch.setattr("mcpgateway.plugins.control_telemetry.SessionLocal", TestSessionLocal, raising=False)
+    for patch_target in (
+        "mcpgateway.middleware.auth_middleware.SessionLocal",
+        "mcpgateway.services.security_logger.SessionLocal",
+        "mcpgateway.services.audit_trail_service.SessionLocal",
+    ):
+        try:
+            monkeypatch.setattr(patch_target, TestSessionLocal, raising=False)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def override_get_db():
+        db = TestSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    # Force PIIFilter active (mode: sequential) — shipped default disables it.
+    real_config = yaml.safe_load((_REPO_ROOT / "plugins" / "config.yaml").read_text())
+    for plugin_entry in real_config.get("plugins", []):
+        if plugin_entry.get("name") == "PIIFilter":
+            plugin_entry["mode"] = "sequential"
+    patched_config_path = tmp_path / "plugins_config_control_telemetry_e2e.yaml"
+    patched_config_path.write_text(yaml.safe_dump(real_config, sort_keys=False))
+
+    await shutdown_plugin_manager_factory()
+    enable_plugins(True)
+    init_plugin_manager_factory(
+        yaml_path=str(patched_config_path),
+        timeout=30,
+        hook_policies=HOOK_PAYLOAD_POLICIES,
+        observability=None,
+        db_factory=TestSessionLocal,
+    )
+    plugin_manager = await get_plugin_manager()
+    assert plugin_manager is not None, "Plugin manager failed to initialize"
+    assert plugin_manager.has_hooks_for(ToolHookType.TOOL_POST_INVOKE), "PIIFilter not registered for tool_post_invoke"
+
+    observability_service = ObservabilityService()
+    test_app = FastAPI(title="control-telemetry-e2e")
+    test_app.add_middleware(ObservabilityMiddleware, enabled=True, service=observability_service)
+    test_app.include_router(tool_router)
+    test_app.include_router(utility_router)
+    test_app.include_router(observability_router)
+    test_app.add_exception_handler(Exception, unhandled_exception_handler)
+    test_app.add_exception_handler(RequestValidationError, request_validation_exception_handler)
+    test_app.add_exception_handler(ValidationError, validation_exception_handler)
+    test_app.add_exception_handler(IntegrityError, database_exception_handler)
+    test_app.add_exception_handler(PluginViolationError, plugin_violation_exception_handler)
+    test_app.add_exception_handler(PluginError, plugin_exception_handler)
+
+    test_app.dependency_overrides[get_db] = override_get_db
+
+    mock_email_user = create_mock_email_user(email=ADMIN_EMAIL, full_name="E2E Admin", is_admin=True, is_active=True)
+    admin_user_context = create_mock_user_context(email=ADMIN_EMAIL, full_name="E2E Admin", is_admin=True)
+
+    async def mock_get_current_user_with_permissions():
+        return admin_user_context
+
+    async def mock_require_admin_auth():
+        return ADMIN_EMAIL
+
+    async def mock_get_jwt_token():
+        return make_test_jwt(ADMIN_EMAIL, is_admin=True)
+
+    async def mock_require_auth():
+        return ADMIN_EMAIL
+
+    def mock_get_permission_service(*args, **kwargs):
+        return MockPermissionService(always_grant=True)
+
+    test_app.dependency_overrides[get_current_user] = lambda: mock_email_user
+    test_app.dependency_overrides[get_current_user_with_permissions] = mock_get_current_user_with_permissions
+    test_app.dependency_overrides[require_admin_auth] = mock_require_admin_auth
+    test_app.dependency_overrides[require_auth] = mock_require_auth
+    test_app.dependency_overrides[get_jwt_token] = mock_get_jwt_token
+    test_app.dependency_overrides[get_permission_service] = mock_get_permission_service
+
+    # Mock only the outbound HTTP call to the fictitious upstream tool backend.
+    upstream_response = httpx.Response(
+        200,
+        json={"content": [{"type": "text", "text": "hello from upstream"}], "isError": False},
+        request=httpx.Request("POST", CONTROL_UPSTREAM_URL),
+    )
+    monkeypatch.setattr(tool_service._http_client, "request", AsyncMock(return_value=upstream_response))
+
+    transport = ASGITransport(app=test_app)
+    async with AsyncClient(transport=transport, base_url="http://e2e-test") as client:
+        yield client
+
+    test_app.dependency_overrides.clear()
+    await shutdown_plugin_manager_factory()
+    enable_plugins(False)
+    engine.dispose()
+
+
+@pytest.fixture
+def otel_memory_exporter(monkeypatch):
+    """Install an in-memory OTel-SDK tracer (G2 sink seam).
+
+    Mirrors the identical fixture in ``test_otel_plugin_metadata_e2e.py``.
+    Skips cleanly when ``opentelemetry-sdk`` (the 'observability' extra) is absent.
+    """
+    try:
+        from opentelemetry.sdk.trace import TracerProvider  # pylint: disable=import-outside-toplevel
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor  # pylint: disable=import-outside-toplevel
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter  # pylint: disable=import-outside-toplevel
+    except ImportError as exc:
+        pytest.skip(f"opentelemetry-sdk not installed: {exc}")
+
+    import mcpgateway.observability as obs  # pylint: disable=import-outside-toplevel
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("test-control-telemetry-e2e")
+
+    monkeypatch.setattr(obs, "_TRACER", tracer)
+    monkeypatch.setattr(obs, "OTEL_AVAILABLE", True)
+    return exporter
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+async def _register_control_probe_tool(client: AsyncClient) -> str:
+    """Register a REST probe tool via a real POST /tools call.
+
+    Returns:
+        The gateway-assigned tool name for use in ``tools/call``.
+    """
+    payload = {
+        "tool": {
+            "name": CONTROL_TOOL_NAME,
+            "description": "E2E fixture: exercises control-execution telemetry via post_invoke.",
+            "integrationType": "REST",
+            "url": CONTROL_UPSTREAM_URL,
+            "requestType": "POST",
+            "visibility": "public",
+        },
+        "team_id": None,
+    }
+    resp = await client.post("/tools", json=payload, headers=_auth_headers())
+    assert resp.status_code == 200, f"Tool registration failed: {resp.status_code} {resp.text}"
+    return resp.json()["name"]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestControlTelemetryE2E:
+    """Full chain: traceparent -> tools/call -> CPEX records -> cpex.control.* DB spans."""
+
+    @pytest.mark.asyncio
+    async def test_control_summary_span_present_in_db(self, control_telemetry_app: AsyncClient):
+        """A traced tool call with PIIFilter active produces a cpex.control.summary DB span."""
+        client = control_telemetry_app
+        tool_name = await _register_control_probe_tool(client)
+
+        trace_id, traceparent = _new_traceparent()
+        headers = {**_auth_headers(), "traceparent": traceparent}
+
+        rpc_payload = {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": {}},
+            "id": 1,
+        }
+        rpc_resp = await client.post("/rpc", json=rpc_payload, headers=headers)
+        assert rpc_resp.status_code == 200, f"RPC call failed: {rpc_resp.status_code} {rpc_resp.text}"
+
+        # Give the best-effort DB write a moment to land (it is synchronous and inline,
+        # but allow one retry for any minor scheduling delay).
+        import asyncio  # noqa: PLC0415
+
+        await asyncio.sleep(0.05)
+
+        obs_resp = await client.get(f"/observability/traces/{trace_id}", headers=_auth_headers())
+        assert obs_resp.status_code == 200, f"Observability fetch failed: {obs_resp.status_code}"
+
+        trace_data = obs_resp.json()
+        spans = trace_data.get("spans", [])
+        span_names = [s.get("name") for s in spans]
+
+        assert "cpex.control.summary" in span_names, (
+            f"Expected cpex.control.summary span in trace {trace_id}. "
+            f"Found spans: {span_names}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_control_result_span_per_plugin_present_in_db(self, control_telemetry_app: AsyncClient):
+        """Each evaluated plugin produces a cpex.control.result child span."""
+        client = control_telemetry_app
+        tool_name = await _register_control_probe_tool(client)
+
+        trace_id, traceparent = _new_traceparent()
+        headers = {**_auth_headers(), "traceparent": traceparent}
+
+        rpc_payload = {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": {}},
+            "id": 2,
+        }
+        rpc_resp = await client.post("/rpc", json=rpc_payload, headers=headers)
+        assert rpc_resp.status_code == 200
+
+        import asyncio  # noqa: PLC0415
+
+        await asyncio.sleep(0.05)
+
+        obs_resp = await client.get(f"/observability/traces/{trace_id}", headers=_auth_headers())
+        assert obs_resp.status_code == 200
+
+        spans = obs_resp.json().get("spans", [])
+        result_spans = [s for s in spans if s.get("name") == "cpex.control.result"]
+
+        assert len(result_spans) >= 1, (
+            f"Expected at least one cpex.control.result span in trace {trace_id}. "
+            f"Found spans: {[s.get('name') for s in spans]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_control_summary_attributes_trusted_fields(self, control_telemetry_app: AsyncClient):
+        """cpex.control.summary span carries expected trusted aggregate attributes."""
+        client = control_telemetry_app
+        tool_name = await _register_control_probe_tool(client)
+
+        trace_id, traceparent = _new_traceparent()
+        headers = {**_auth_headers(), "traceparent": traceparent}
+
+        rpc_payload = {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": {}},
+            "id": 3,
+        }
+        await client.post("/rpc", json=rpc_payload, headers=headers)
+
+        import asyncio  # noqa: PLC0415
+
+        await asyncio.sleep(0.05)
+
+        obs_resp = await client.get(f"/observability/traces/{trace_id}", headers=_auth_headers())
+        assert obs_resp.status_code == 200
+
+        spans = obs_resp.json().get("spans", [])
+        summary = next((s for s in spans if s.get("name") == "cpex.control.summary"), None)
+        assert summary is not None, f"cpex.control.summary span not found in trace {trace_id}"
+
+        attrs = summary.get("attributes", {})
+        # Aggregate fields must be present
+        assert "cpex.control.invocation_count" in attrs, f"Missing invocation_count in {attrs}"
+        assert "cpex.control.result.allowed" in attrs, f"Missing result.allowed in {attrs}"
+        assert "cpex.control.type" in attrs, f"Missing type in {attrs}"
+        assert attrs["cpex.control.type"] == "tool", f"Expected type='tool', got {attrs['cpex.control.type']!r}"
+        assert attrs["cpex.control.invocation_count"] >= 1, f"invocation_count should be >= 1, got {attrs['cpex.control.invocation_count']}"
+
+    @pytest.mark.asyncio
+    async def test_control_result_span_has_per_control_fields(self, control_telemetry_app: AsyncClient):
+        """cpex.control.result spans carry per-control fixed-schema attributes."""
+        client = control_telemetry_app
+        tool_name = await _register_control_probe_tool(client)
+
+        trace_id, traceparent = _new_traceparent()
+        headers = {**_auth_headers(), "traceparent": traceparent}
+
+        rpc_payload = {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": {}},
+            "id": 4,
+        }
+        await client.post("/rpc", json=rpc_payload, headers=headers)
+
+        import asyncio  # noqa: PLC0415
+
+        await asyncio.sleep(0.05)
+
+        obs_resp = await client.get(f"/observability/traces/{trace_id}", headers=_auth_headers())
+        assert obs_resp.status_code == 200
+
+        spans = obs_resp.json().get("spans", [])
+        result_spans = [s for s in spans if s.get("name") == "cpex.control.result"]
+        assert result_spans, "No cpex.control.result spans found"
+
+        for span in result_spans:
+            attrs = span.get("attributes", {})
+            assert "cpex.control.name" in attrs, f"Missing cpex.control.name in {attrs}"
+            assert "cpex.control.status" in attrs, f"Missing cpex.control.status in {attrs}"
+            assert "cpex.control.result.allowed" in attrs, f"Missing result.allowed in {attrs}"
+            assert "cpex.control.enforcement_point" in attrs, f"Missing enforcement_point in {attrs}"
+            assert attrs["cpex.control.enforcement_point"] in {"pre", "post", "pre+post"}, (
+                f"Unexpected enforcement_point: {attrs['cpex.control.enforcement_point']!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_control_telemetry_does_not_leak_tool_arguments(self, control_telemetry_app: AsyncClient):
+        """Tool arguments must never appear in any cpex.control.* span attribute."""
+        client = control_telemetry_app
+        tool_name = await _register_control_probe_tool(client)
+
+        trace_id, traceparent = _new_traceparent()
+        headers = {**_auth_headers(), "traceparent": traceparent}
+
+        secret_marker = "SENTINEL_SHOULD_NOT_APPEAR_IN_TELEMETRY"
+        rpc_payload = {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": {"sensitive_input": secret_marker}},
+            "id": 5,
+        }
+        await client.post("/rpc", json=rpc_payload, headers=headers)
+
+        import asyncio  # noqa: PLC0415
+
+        await asyncio.sleep(0.05)
+
+        obs_resp = await client.get(f"/observability/traces/{trace_id}", headers=_auth_headers())
+        assert obs_resp.status_code == 200
+
+        raw_text = obs_resp.text
+        assert secret_marker not in raw_text, (
+            f"Tool argument sentinel {secret_marker!r} must not appear anywhere in observability output"
+        )
+
+    @pytest.mark.asyncio
+    async def test_control_telemetry_otel_sdk_spans(self, control_telemetry_app: AsyncClient, otel_memory_exporter):
+        """G2 sink: cpex.control.summary and cpex.control.result appear in the OTel in-memory exporter."""
+        client = control_telemetry_app
+        tool_name = await _register_control_probe_tool(client)
+
+        trace_id, traceparent = _new_traceparent()
+        headers = {**_auth_headers(), "traceparent": traceparent}
+
+        rpc_payload = {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": {}},
+            "id": 6,
+        }
+        await client.post("/rpc", json=rpc_payload, headers=headers)
+
+        import asyncio  # noqa: PLC0415
+
+        await asyncio.sleep(0.05)
+
+        finished = otel_memory_exporter.get_finished_spans()
+        otel_span_names = [s.name for s in finished]
+
+        assert "cpex.control.summary" in otel_span_names, (
+            f"cpex.control.summary not in OTel spans. Found: {otel_span_names}"
+        )
+        assert "cpex.control.result" in otel_span_names, (
+            f"cpex.control.result not in OTel spans. Found: {otel_span_names}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_db_and_otel_span_names_match(self, control_telemetry_app: AsyncClient, otel_memory_exporter):
+        """DB and OTel sinks emit the same canonical span names — parity check."""
+        client = control_telemetry_app
+        tool_name = await _register_control_probe_tool(client)
+
+        trace_id, traceparent = _new_traceparent()
+        headers = {**_auth_headers(), "traceparent": traceparent}
+
+        rpc_payload = {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": {}},
+            "id": 7,
+        }
+        await client.post("/rpc", json=rpc_payload, headers=headers)
+
+        import asyncio  # noqa: PLC0415
+
+        await asyncio.sleep(0.05)
+
+        # DB side
+        obs_resp = await client.get(f"/observability/traces/{trace_id}", headers=_auth_headers())
+        db_span_names = {s.get("name") for s in obs_resp.json().get("spans", [])}
+
+        # OTel side
+        otel_span_names = {s.name for s in otel_memory_exporter.get_finished_spans()}
+
+        for canonical in ("cpex.control.summary", "cpex.control.result"):
+            assert canonical in db_span_names, f"{canonical!r} missing from DB spans: {db_span_names}"
+            assert canonical in otel_span_names, f"{canonical!r} missing from OTel spans: {otel_span_names}"

--- a/tests/e2e/test_otel_control_telemetry_e2e.py
+++ b/tests/e2e/test_otel_control_telemetry_e2e.py
@@ -740,8 +740,12 @@ class TestDenialPathTelemetry:
             "id": 8,
         }
         resp = await client.post("/rpc", json=rpc_payload, headers=headers)
-        # Gateway returns an error (422 or 200 with isError) when denial happens — either is fine.
-        assert resp.status_code in {200, 400, 403, 422, 500}
+        # A pre-invoke denial must produce a 4xx error response, never a 5xx.
+        # 200 with isError is acceptable (JSON-RPC error envelope); 500 indicates
+        # an unhandled exception rather than a controlled denial.
+        assert resp.status_code in {200, 400, 403, 422}, (
+            f"Expected a denial error response (200/400/403/422), got {resp.status_code}"
+        )
 
         await asyncio.sleep(0.1)
 
@@ -751,9 +755,12 @@ class TestDenialPathTelemetry:
         spans = obs_resp.json().get("spans", [])
         summary_spans = [s for s in spans if s.get("name") == "cpex.control.summary"]
 
-        # If PIIFilter does not detect PII in this environment, skip gracefully.
-        if not summary_spans:
-            pytest.skip("PIIFilter did not produce a summary span — PII not detected in this environment")
+        # A live pre-invoke denial MUST produce a summary span.  Absence is a regression,
+        # not an environment variation — do not skip.
+        assert summary_spans, (
+            "Expected a cpex.control.summary span for the pre-invoke denial, but none was emitted. "
+            "This indicates denial telemetry is broken."
+        )
 
         summary = summary_spans[0]
         attrs = summary.get("attributes") or {}
@@ -761,8 +768,8 @@ class TestDenialPathTelemetry:
         assert attrs.get("cpex.control.result.allowed") is False, (
             f"Expected result.allowed=false on denial path, got: {attrs.get('cpex.control.result.allowed')!r}"
         )
-        assert attrs.get("cpex.control.enforcement_point") in {"pre", "none"}, (
-            f"Unexpected enforcement_point on pre-deny: {attrs.get('cpex.control.enforcement_point')!r}"
+        assert attrs.get("cpex.control.enforcement_point") == "pre", (
+            f"Expected enforcement_point=pre for a pre-invoke denial, got: {attrs.get('cpex.control.enforcement_point')!r}"
         )
 
     @pytest.mark.asyncio
@@ -795,8 +802,9 @@ class TestDenialPathTelemetry:
         spans = obs_resp.json().get("spans", [])
         summary_spans = [s for s in spans if s.get("name") == "cpex.control.summary"]
 
-        if not summary_spans:
-            pytest.skip("PIIFilter did not produce a summary span — PII not detected in this environment")
+        assert summary_spans, (
+            "Expected a cpex.control.summary span for the pre-invoke denial, but none was emitted."
+        )
 
         summary = summary_spans[0]
         attrs = summary.get("attributes") or {}

--- a/tests/e2e/test_otel_control_telemetry_e2e.py
+++ b/tests/e2e/test_otel_control_telemetry_e2e.py
@@ -62,6 +62,8 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 os.environ.setdefault("PLUGINS_ENABLED", "true")
 os.environ.setdefault("PLUGINS_CONFIG_FILE", str(_REPO_ROOT / "plugins" / "config.yaml"))
 os.environ.setdefault("OBSERVABILITY_ENABLED", "true")
+# Explicitly enable CPEX control telemetry for E2E tests (default is now false).
+os.environ.setdefault("CPEX_CONTROL_TELEMETRY_ENABLED", "true")
 
 # First-Party — clear any settings caches populated before the env vars above were set.
 from mcpgateway.config import get_settings as _get_mcpgateway_settings  # noqa: E402
@@ -583,3 +585,226 @@ class TestControlTelemetryE2E:
         for canonical in ("cpex.control.summary", "cpex.control.result"):
             assert canonical in db_span_names, f"{canonical!r} missing from DB spans: {db_span_names}"
             assert canonical in otel_span_names, f"{canonical!r} missing from OTel spans: {otel_span_names}"
+
+
+# ---------------------------------------------------------------------------
+# Denial-path fixture and tests (pre-invoke and post-invoke denial)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def denying_plugin_app(monkeypatch, tmp_path):
+    """Wire a real gateway app with a PIIFilter configured to BLOCK on detection.
+
+    PIIFilter with ``block_on_detection=true`` and ``enforcement_mode=pre_invoke``
+    will raise ``PluginViolationError`` when PII is detected in tool arguments,
+    exercising the pre-invoke denial path.  For post-invoke denial we use
+    ``enforcement_mode=post_invoke`` instead.
+    """
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, expire_on_commit=False, bind=engine)
+
+    monkeypatch.setattr(db_mod, "engine", engine, raising=False)
+    monkeypatch.setattr(db_mod, "SessionLocal", TestSessionLocal, raising=False)
+    monkeypatch.setattr(main_mod, "SessionLocal", TestSessionLocal, raising=False)
+    monkeypatch.setattr("mcpgateway.services.observability_service.SessionLocal", TestSessionLocal, raising=False)
+    monkeypatch.setattr("mcpgateway.routers.observability.SessionLocal", TestSessionLocal, raising=False)
+    monkeypatch.setattr("mcpgateway.plugins.control_telemetry.SessionLocal", TestSessionLocal, raising=False)
+    for patch_target in (
+        "mcpgateway.middleware.auth_middleware.SessionLocal",
+        "mcpgateway.services.security_logger.SessionLocal",
+        "mcpgateway.services.audit_trail_service.SessionLocal",
+    ):
+        try:
+            monkeypatch.setattr(patch_target, TestSessionLocal, raising=False)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def override_get_db():
+        db = TestSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    # Configure PIIFilter to block on detection in pre_invoke mode.
+    real_config = yaml.safe_load((_REPO_ROOT / "plugins" / "config.yaml").read_text())
+    for plugin_entry in real_config.get("plugins", []):
+        if plugin_entry.get("name") == "PIIFilter":
+            plugin_entry["mode"] = "sequential"
+            plugin_cfg = plugin_entry.setdefault("config", {})
+            plugin_cfg["block_on_detection"] = True
+            plugin_cfg["enforcement_mode"] = "pre_invoke"
+    patched_config_path = tmp_path / "plugins_config_denying_e2e.yaml"
+    patched_config_path.write_text(yaml.safe_dump(real_config, sort_keys=False))
+
+    await shutdown_plugin_manager_factory()
+    enable_plugins(True)
+    init_plugin_manager_factory(
+        yaml_path=str(patched_config_path),
+        timeout=30,
+        hook_policies=HOOK_PAYLOAD_POLICIES,
+        observability=None,
+        db_factory=TestSessionLocal,
+    )
+    plugin_manager = await get_plugin_manager()
+    assert plugin_manager is not None, "Plugin manager failed to initialize"
+
+    observability_service = ObservabilityService()
+    test_app = FastAPI(title="denying-plugin-e2e")
+    test_app.add_middleware(ObservabilityMiddleware, enabled=True, service=observability_service)
+    test_app.include_router(tool_router)
+    test_app.include_router(utility_router)
+    test_app.include_router(observability_router)
+    test_app.add_exception_handler(Exception, unhandled_exception_handler)
+    test_app.add_exception_handler(RequestValidationError, request_validation_exception_handler)
+    test_app.add_exception_handler(ValidationError, validation_exception_handler)
+    test_app.add_exception_handler(IntegrityError, database_exception_handler)
+    test_app.add_exception_handler(PluginViolationError, plugin_violation_exception_handler)
+    test_app.add_exception_handler(PluginError, plugin_exception_handler)
+
+    test_app.dependency_overrides[get_db] = override_get_db
+
+    mock_email_user = create_mock_email_user(email=ADMIN_EMAIL, full_name="E2E Admin", is_admin=True, is_active=True)
+    admin_user_context = create_mock_user_context(email=ADMIN_EMAIL, full_name="E2E Admin", is_admin=True)
+
+    async def mock_get_current_user_with_permissions():
+        return admin_user_context
+
+    async def mock_require_admin_auth():
+        return ADMIN_EMAIL
+
+    async def mock_get_jwt_token():
+        return make_test_jwt(ADMIN_EMAIL, is_admin=True)
+
+    async def mock_require_auth():
+        return ADMIN_EMAIL
+
+    def mock_get_permission_service(*args, **kwargs):
+        return MockPermissionService(always_grant=True)
+
+    test_app.dependency_overrides[get_current_user] = lambda: mock_email_user
+    test_app.dependency_overrides[get_current_user_with_permissions] = mock_get_current_user_with_permissions
+    test_app.dependency_overrides[require_admin_auth] = mock_require_admin_auth
+    test_app.dependency_overrides[require_auth] = mock_require_auth
+    test_app.dependency_overrides[get_jwt_token] = mock_get_jwt_token
+    test_app.dependency_overrides[get_permission_service] = mock_get_permission_service
+
+    upstream_response = httpx.Response(
+        200,
+        json={"content": [{"type": "text", "text": "hello"}], "isError": False},
+        request=httpx.Request("POST", CONTROL_UPSTREAM_URL),
+    )
+    monkeypatch.setattr(tool_service._http_client, "request", AsyncMock(return_value=upstream_response))
+
+    transport = ASGITransport(app=test_app)
+    async with AsyncClient(transport=transport, base_url="http://e2e-test") as client:
+        yield client
+
+    test_app.dependency_overrides.clear()
+    await shutdown_plugin_manager_factory()
+    enable_plugins(False)
+    engine.dispose()
+
+
+class TestDenialPathTelemetry:
+    """Verify cpex.control.summary spans are emitted correctly on denial paths."""
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_denial_summary_span_allowed_false(self, denying_plugin_app: AsyncClient):
+        """Pre-invoke denial: summary span has result.allowed=false and enforcement_point=pre.
+
+        When PIIFilter with block_on_detection=true detects PII in tool arguments on
+        the pre_invoke hook, it raises PluginViolationError.  ContextForge catches it,
+        calls mark_denied(hook="pre"), and still emits partial telemetry.  The summary
+        span must reflect the denial outcome even though the tool never executed.
+        """
+        import asyncio  # noqa: PLC0415
+
+        client = denying_plugin_app
+        tool_name = await _register_control_probe_tool(client)
+
+        trace_id, traceparent = _new_traceparent()
+        headers = {**_auth_headers(), "traceparent": traceparent}
+
+        # Send an argument value that PIIFilter will detect as PII (email address).
+        rpc_payload = {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": {"input": "user@example.com"}},
+            "id": 8,
+        }
+        resp = await client.post("/rpc", json=rpc_payload, headers=headers)
+        # Gateway returns an error (422 or 200 with isError) when denial happens — either is fine.
+        assert resp.status_code in {200, 400, 403, 422, 500}
+
+        await asyncio.sleep(0.1)
+
+        obs_resp = await client.get(f"/observability/traces/{trace_id}", headers=_auth_headers())
+        assert obs_resp.status_code == 200
+
+        spans = obs_resp.json().get("spans", [])
+        summary_spans = [s for s in spans if s.get("name") == "cpex.control.summary"]
+
+        # If PIIFilter does not detect PII in this environment, skip gracefully.
+        if not summary_spans:
+            pytest.skip("PIIFilter did not produce a summary span — PII not detected in this environment")
+
+        summary = summary_spans[0]
+        attrs = summary.get("attributes") or {}
+
+        assert attrs.get("cpex.control.result.allowed") is False, (
+            f"Expected result.allowed=false on denial path, got: {attrs.get('cpex.control.result.allowed')!r}"
+        )
+        assert attrs.get("cpex.control.enforcement_point") in {"pre", "none"}, (
+            f"Unexpected enforcement_point on pre-deny: {attrs.get('cpex.control.enforcement_point')!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_pre_invoke_denial_tool_never_executed(self, denying_plugin_app: AsyncClient):
+        """Pre-invoke denial: tool execution success is distinguishable from control denial.
+
+        The summary span's result.allowed=false must not be confused with a tool-side
+        error.  The cpex.control.type=tool attribute should be present to identify
+        the invocation context, but there must be no upstream tool response mixed into
+        the control telemetry attributes.
+        """
+        import asyncio  # noqa: PLC0415
+
+        client = denying_plugin_app
+        tool_name = await _register_control_probe_tool(client)
+
+        trace_id, traceparent = _new_traceparent()
+        headers = {**_auth_headers(), "traceparent": traceparent}
+
+        rpc_payload = {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": {"input": "user@example.com"}},
+            "id": 9,
+        }
+        await client.post("/rpc", json=rpc_payload, headers=headers)
+        await asyncio.sleep(0.1)
+
+        obs_resp = await client.get(f"/observability/traces/{trace_id}", headers=_auth_headers())
+        spans = obs_resp.json().get("spans", [])
+        summary_spans = [s for s in spans if s.get("name") == "cpex.control.summary"]
+
+        if not summary_spans:
+            pytest.skip("PIIFilter did not produce a summary span — PII not detected in this environment")
+
+        summary = summary_spans[0]
+        attrs = summary.get("attributes") or {}
+
+        # Control telemetry must not contain tool argument content.
+        import json  # noqa: PLC0415
+
+        raw = json.dumps(attrs)
+        assert "user@example.com" not in raw, "Tool argument value must not appear in control telemetry attributes"
+        # cpex.control.type should identify this as a tool-context span.
+        assert attrs.get("cpex.control.type") == "tool"

--- a/tests/unit/mcpgateway/plugins/test_control_telemetry.py
+++ b/tests/unit/mcpgateway/plugins/test_control_telemetry.py
@@ -41,12 +41,16 @@ from mcpgateway.plugins.control_telemetry import (
 def _make_rec(
     *,
     plugin_name: str = "pii-guard",
+    plugin_id: str = "pii-guard-001",
+    plugin_kind: str = "builtin",
     hook_name: str = "tool_pre_invoke",
     mode: str = "sequential",
     status: str = "completed",
     effective_allow: bool = True,
+    requested_allow: object = None,
     matched: object = True,
     applied: bool = False,
+    payload_modified: bool = False,
     duration_ns: int = 1000,
     reason: object = None,
     error_code: object = None,
@@ -55,12 +59,16 @@ def _make_rec(
     """Create a minimal ControlExecutionRecord mock."""
     rec = MagicMock()
     rec.plugin_name = plugin_name
+    rec.plugin_id = plugin_id
+    rec.plugin_kind = plugin_kind
     rec.hook_name = hook_name
     rec.mode = mode
     rec.status = status
     rec.effective_allow = effective_allow
+    rec.requested_allow = requested_allow
     rec.matched = matched
     rec.applied = applied
+    rec.payload_modified = payload_modified
     rec.duration_ns = duration_ns
     rec.reason = reason
     rec.error_code = error_code
@@ -96,7 +104,7 @@ class TestAccumulatorInit:
         assert agg["cpex.control.invocation_count"] == 0
         assert agg["cpex.control.matched_count"] == 0
         assert agg["cpex.control.applied_count"] == 0
-        assert agg["cpex.control.duration"] == 0
+        assert agg["cpex.control.duration_ns"] == 0
         assert agg["cpex.control.result.allowed"] is True
         assert agg["cpex.control.error_count"] == 0
         assert agg["cpex.control.timeout_count"] == 0
@@ -209,6 +217,17 @@ class TestAggregate:
         acc = self._make_acc_with_records([("pre", _make_rec()), ("pre", _make_rec())])
         assert acc.aggregate()["cpex.control.invocation_count"] == 2
 
+    def test_invocation_count_excludes_skipped_disabled_cancelled(self):
+        """invocation_count only counts completed/error/timeout — not skipped/disabled/cancelled."""
+        completed = _make_rec(status="completed")
+        skipped = _make_rec(status="skipped")
+        disabled = _make_rec(status="disabled")
+        cancelled = _make_rec(status="cancelled")
+        acc = self._make_acc_with_records([
+            ("pre", completed), ("pre", skipped), ("pre", disabled), ("pre", cancelled),
+        ])
+        assert acc.aggregate()["cpex.control.invocation_count"] == 1  # only completed counts
+
     def test_matched_count(self):
         r1 = _make_rec(matched=True)
         r2 = _make_rec(matched=False)
@@ -226,7 +245,7 @@ class TestAggregate:
         r1 = _make_rec(duration_ns=1000)
         r2 = _make_rec(duration_ns=2000)
         acc = self._make_acc_with_records([("pre", r1), ("post", r2)])
-        assert acc.aggregate()["cpex.control.duration"] == 3000
+        assert acc.aggregate()["cpex.control.duration_ns"] == 3000
 
     def test_error_count(self):
         r1 = _make_rec(status="error")
@@ -271,16 +290,22 @@ class TestAggregateExceptionPath:
     def test_record_raising_on_duration_ns_is_skipped(self):
         """Lines 192-193: record raising during aggregation is caught; others still counted."""
         acc = ControlTelemetryAccumulator()
+        # Make a record whose duration_ns property raises — status read is first, so it
+        # will increment invocation_count before raising.  Verify the exception is caught
+        # and the good sibling record still contributes its duration.
         bad = MagicMock()
         bad.matched = True
         bad.applied = False
+        bad.status = "completed"
         bad.duration_ns = property(lambda self: (_ for _ in ()).throw(ValueError("bad")))
-        good = _make_rec(duration_ns=100)
+        good = _make_rec(status="completed", duration_ns=100)
         acc._records.append(("pre", bad))   # pylint: disable=protected-access
         acc._records.append(("pre", good))  # pylint: disable=protected-access
         agg = acc.aggregate()
+        # bad record was counted (status read succeeded) but its duration is 0 (exception caught)
+        # good record adds its duration
         assert agg["cpex.control.invocation_count"] == 2
-        assert agg["cpex.control.duration"] == 100
+        assert agg["cpex.control.duration_ns"] == 100
 
 
 # ---------------------------------------------------------------------------
@@ -294,8 +319,14 @@ class TestPerControlAttributes:
         attrs = _per_control_attributes("pre", rec)
         assert attrs["cpex.control.status"] == "completed"
         assert attrs["cpex.control.result.allowed"] is True
-        assert attrs["cpex.control.duration"] == 500
+        assert attrs["cpex.control.duration_ns"] == 500
         assert attrs["cpex.control.enforcement_point"] == "pre"
+        # New fields added in review response
+        assert "cpex.control.plugin_id" in attrs
+        assert "cpex.control.plugin_kind" in attrs
+        assert "cpex.control.matched" in attrs
+        assert "cpex.control.applied" in attrs
+        assert "cpex.control.payload_modified" in attrs
 
     def test_completed_deny_with_reason(self):
         rec = _make_rec(effective_allow=False, reason="PII detected")
@@ -318,7 +349,7 @@ class TestPerControlAttributes:
         rec = _make_rec(mode="fire_and_forget", duration_ns=0)
         attrs = _per_control_attributes("post", rec)
         assert attrs["cpex.control.mode"] == "fire_and_forget"
-        assert attrs["cpex.control.duration"] == 0
+        assert attrs["cpex.control.duration_ns"] == 0
 
     def test_missing_optional_fields_omitted(self):
         rec = _make_rec(reason=None, error_code=None, config_keys=[])
@@ -352,6 +383,18 @@ class TestPerControlAttributes:
 class TestSafeStr:
     def test_within_limit_unchanged(self):
         assert _safe_str("hello", 10) == "hello"
+
+    def test_requested_allow_emitted_when_not_none(self):
+        rec = _make_rec()
+        rec.requested_allow = True
+        attrs = _per_control_attributes("pre", rec)
+        assert attrs.get("cpex.control.result.requested_allowed") is True
+
+    def test_requested_allow_omitted_when_none(self):
+        rec = _make_rec()
+        rec.requested_allow = None
+        attrs = _per_control_attributes("pre", rec)
+        assert "cpex.control.result.requested_allowed" not in attrs
 
     def test_truncated_with_ellipsis(self):
         result = _safe_str("a" * 100, 10)

--- a/tests/unit/mcpgateway/plugins/test_control_telemetry.py
+++ b/tests/unit/mcpgateway/plugins/test_control_telemetry.py
@@ -35,6 +35,7 @@ from mcpgateway.plugins.control_telemetry import (
     _get_max_results,
     _per_control_attributes,
     _safe_str,
+    _sanitize_config_key,
     record_control_telemetry,
 )
 
@@ -1129,8 +1130,11 @@ class TestMarkPluginError:
         # Summary span must be emitted and carry plugin_error=True
         assert captured_attributes, "Expected a summary span to be emitted for a first-plugin PluginError"
         assert captured_attributes.get("cpex.control.plugin_error") is True
-        # effective_allowed must remain True — this is not a policy denial
-        assert captured_attributes.get("cpex.control.result.allowed") is True
+        # result.allowed must be ABSENT — the decision is indeterminate when a PluginError
+        # fires with no denial flag set.  Dashboards must treat absence as "unknown".
+        assert "cpex.control.result.allowed" not in captured_attributes, (
+            "cpex.control.result.allowed must be absent when decision is indeterminate (PluginError, no denial)"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1157,4 +1161,140 @@ class TestEnforcementPointDenialFlags:
     def test_enforcement_point_none_no_records_no_flags(self):
         from mcpgateway.plugins.control_telemetry import _enforcement_point  # noqa: PLC0415
         acc = ControlTelemetryAccumulator()
+        assert _enforcement_point(acc) == "none"
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_config_key — charset validation and injection guards
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeConfigKey:
+    """_sanitize_config_key() rejects unsafe key names, passes safe ones."""
+
+    def test_valid_simple_key(self):
+        assert _sanitize_config_key("my_key") == "my_key"
+
+    def test_valid_key_with_dots_and_hyphens(self):
+        assert _sanitize_config_key("some.key-name") == "some.key-name"
+
+    def test_comma_rejected(self):
+        """Commas are the CSV delimiter — must be rejected."""
+        assert _sanitize_config_key("bad,key") is None
+
+    def test_lf_rejected(self):
+        """Newline is a log-injection vector."""
+        assert _sanitize_config_key("bad\nkey") is None
+
+    def test_cr_rejected(self):
+        assert _sanitize_config_key("bad\rkey") is None
+
+    def test_nul_rejected(self):
+        assert _sanitize_config_key("bad\x00key") is None
+
+    def test_tab_rejected(self):
+        assert _sanitize_config_key("bad\tkey") is None
+
+    def test_non_ascii_rejected(self):
+        """Non-ASCII characters (e.g. CJK) must be rejected."""
+        assert _sanitize_config_key("钥匙") is None
+
+    def test_secret_marker_equals_rejected(self):
+        """Secret-shaped keys like 'api_key=sk-abc123' contain '=' which is not in charset."""
+        assert _sanitize_config_key("api_key=sk-abc123") is None
+
+    def test_empty_string_rejected(self):
+        assert _sanitize_config_key("") is None
+
+    def test_oversized_key_rejected(self):
+        """Keys longer than 64 chars are rejected by the regex (not just the byte cap)."""
+        assert _sanitize_config_key("a" * 65) is None
+
+    def test_max_length_key_accepted(self):
+        """A key exactly 64 chars passes (the regex allows 1..64)."""
+        assert _sanitize_config_key("a" * 64) is not None
+
+    def test_per_control_attributes_drops_comma_key(self):
+        """_per_control_attributes must drop a key with a comma from config.keys."""
+        rec = _make_rec(plugin_name="ctrl")
+        rec.config_keys = ["good_key", "bad,key", "another_good"]
+        attrs = _per_control_attributes("pre", rec)
+        val = attrs.get("cpex.control.config.keys", "")
+        assert "bad,key" not in val
+        assert "good_key" in val
+        assert "another_good" in val
+
+    def test_per_control_attributes_drops_crlf_key(self):
+        """_per_control_attributes must drop keys with CR/LF."""
+        rec = _make_rec(plugin_name="ctrl")
+        rec.config_keys = ["safe_key", "inject\nkey"]
+        attrs = _per_control_attributes("pre", rec)
+        val = attrs.get("cpex.control.config.keys", "")
+        assert "inject" not in val
+        assert "safe_key" in val
+
+    def test_per_control_attributes_all_keys_unsafe_omits_attribute(self):
+        """When every key fails validation, config.keys must be absent."""
+        rec = _make_rec(plugin_name="ctrl")
+        rec.config_keys = ["bad,one", "bad\ntwo"]
+        attrs = _per_control_attributes("pre", rec)
+        assert "cpex.control.config.keys" not in attrs
+
+
+# ---------------------------------------------------------------------------
+# PluginError indeterminate decision semantics
+# ---------------------------------------------------------------------------
+
+
+class TestPluginErrorIndeterminate:
+    """mark_plugin_error() makes result.allowed indeterminate; aggregate() must omit it."""
+
+    def test_aggregate_omits_result_allowed_on_plugin_error(self):
+        """result.allowed must be absent when plugin_errored=True and no denial."""
+        acc = ControlTelemetryAccumulator()
+        acc.mark_plugin_error(hook="pre")
+        agg = acc.aggregate()
+        assert "cpex.control.result.allowed" not in agg
+
+    def test_aggregate_emits_result_allowed_false_when_also_denied(self):
+        """If a denial flag is also set, denial takes precedence: emit result.allowed=False."""
+        acc = ControlTelemetryAccumulator()
+        acc.mark_plugin_error(hook="pre")
+        acc.mark_denied(hook="pre")  # unusual but possible
+        agg = acc.aggregate()
+        assert agg.get("cpex.control.result.allowed") is False
+
+    def test_aggregate_emits_result_allowed_true_without_error(self):
+        """Normal (no error, no denial) still emits result.allowed=True."""
+        acc = ControlTelemetryAccumulator()
+        agg = acc.aggregate()
+        assert agg.get("cpex.control.result.allowed") is True
+
+    def test_mark_plugin_error_hook_tracked(self):
+        """mark_plugin_error(hook=) stores the hook for enforcement_point derivation."""
+        acc = ControlTelemetryAccumulator()
+        acc.mark_plugin_error(hook="post")
+        assert acc.plugin_error_hook == "post"
+
+    def test_mark_plugin_error_unknown_hook_stored_as_empty(self):
+        """Invalid hook values are silently ignored; plugin_error_hook stays empty."""
+        acc = ControlTelemetryAccumulator()
+        acc.mark_plugin_error(hook="unknown")
+        assert acc.plugin_error_hook == ""
+
+    def test_enforcement_point_uses_error_hook_pre(self):
+        """_enforcement_point falls back to plugin_error_hook when no records/denial."""
+        acc = ControlTelemetryAccumulator()
+        acc.mark_plugin_error(hook="pre")
+        assert _enforcement_point(acc) == "pre"
+
+    def test_enforcement_point_uses_error_hook_post(self):
+        acc = ControlTelemetryAccumulator()
+        acc.mark_plugin_error(hook="post")
+        assert _enforcement_point(acc) == "post"
+
+    def test_enforcement_point_none_when_error_hook_empty(self):
+        """When mark_plugin_error() called with no hook, enforcement_point is 'none'."""
+        acc = ControlTelemetryAccumulator()
+        acc.mark_plugin_error()
         assert _enforcement_point(acc) == "none"

--- a/tests/unit/mcpgateway/plugins/test_control_telemetry.py
+++ b/tests/unit/mcpgateway/plugins/test_control_telemetry.py
@@ -888,6 +888,26 @@ class TestExportCapTruncation:
 
         assert "cpex.control.truncated" not in captured_attributes
 
+    def test_mark_export_cap_dropped_is_idempotent(self):
+        """Calling mark_export_cap_dropped() more than once must not inflate truncated.
+
+        Regression guard for the idempotency bug where repeated calls on the same
+        accumulator (e.g. on a retry path) used += and doubled the count.
+        """
+        acc = ControlTelemetryAccumulator()
+        acc.mark_export_cap_dropped(7)
+        acc.mark_export_cap_dropped(7)  # second call must be a no-op
+        acc.mark_export_cap_dropped(7)  # third call must also be a no-op
+        assert acc.truncated == 7  # still 7, not 21
+
+    def test_mark_export_cap_dropped_zero_then_positive(self):
+        """Zero call does not lock the slot; a subsequent positive call must succeed."""
+        acc = ControlTelemetryAccumulator()
+        acc.mark_export_cap_dropped(0)  # no-op — must not consume the single-write slot
+        acc.mark_export_cap_dropped(4)  # first positive call — must succeed
+        acc.mark_export_cap_dropped(4)  # second call — must be a no-op
+        assert acc.truncated == 4
+
 
 # ---------------------------------------------------------------------------
 # Item 6/7 — records_received counter in aggregate()

--- a/tests/unit/mcpgateway/plugins/test_control_telemetry.py
+++ b/tests/unit/mcpgateway/plugins/test_control_telemetry.py
@@ -9,6 +9,7 @@ Covers:
   - ControlTelemetryAccumulator: empty init, add pre/post, caps, truncated, denied flags,
     effective_allowed, aggregate() semantics.
   - ControlTelemetryAccumulator.mark_denied(): pre/post explicit denial, effective_allowed.
+  - ControlTelemetryAccumulator.mark_export_cap_dropped(): tier-3 export-cap truncation.
   - add() per-hook cap contributes to truncated counter (item 4 / item 6 fix).
   - _per_control_attributes: completed allow/deny, error/timeout/faf, optional field omission,
     reason truncation, config_keys bounded, artifact_name/artifact_id fields.
@@ -17,6 +18,7 @@ Covers:
   - _build_flattened_attributes: basic (duration_ns key), collision, reason, error_code,
     bounded, artifact fields, config_keys field, name field, edge cases.
   - aggregate() exception path, _get_max_results exception path.
+  - record_control_telemetry(): tier-3 export-cap drops emitted in cpex.control.truncated.
 """
 
 # Standard
@@ -33,6 +35,7 @@ from mcpgateway.plugins.control_telemetry import (
     _get_max_results,
     _per_control_attributes,
     _safe_str,
+    record_control_telemetry,
 )
 
 
@@ -785,6 +788,105 @@ class TestPerHookTruncationCounter:
             acc.add(_make_result(extra_batch), hook="post")
         assert len(acc.records) == _MAX_RECORDS_PER_CALL
         assert acc.truncated == 10
+
+
+# ---------------------------------------------------------------------------
+# Item 7 — tier-3 export-cap truncation accounting
+# ---------------------------------------------------------------------------
+
+
+class TestExportCapTruncation:
+    """mark_export_cap_dropped() and record_control_telemetry() tier-3 drop accounting."""
+
+    def test_mark_export_cap_dropped_adds_to_truncated(self):
+        """mark_export_cap_dropped() must add to the truncated total."""
+        acc = ControlTelemetryAccumulator()
+        acc.mark_export_cap_dropped(5)
+        assert acc.truncated == 5
+
+    def test_mark_export_cap_dropped_zero_is_no_op(self):
+        """Calling mark_export_cap_dropped(0) must not change truncated."""
+        acc = ControlTelemetryAccumulator()
+        acc.mark_export_cap_dropped(0)
+        assert acc.truncated == 0
+
+    def test_truncated_combines_all_three_tiers(self):
+        """truncated = tier-1/2 accumulation drops + tier-3 export-cap drops."""
+        acc = ControlTelemetryAccumulator()
+        # Simulate tier-1/2 drops by directly incrementing the internal counter
+        acc._truncated = 3  # pylint: disable=protected-access
+        acc.mark_export_cap_dropped(4)
+        assert acc.truncated == 7
+
+    def test_record_control_telemetry_includes_export_cap_in_truncated(self):
+        """When records_received > max_results, cpex.control.truncated reflects the tier-3 drop."""
+        acc = ControlTelemetryAccumulator()
+        # Load 10 records into the accumulator directly (bypass add() to avoid cpex dependency)
+        for i in range(10):
+            acc._records.append(("pre", _make_rec(plugin_name=f"ctrl{i}")))  # pylint: disable=protected-access
+
+        captured_attributes: dict = {}
+
+        def fake_start_span(**kwargs):
+            if kwargs.get("name") == "cpex.control.summary":
+                captured_attributes.update(kwargs.get("attributes", {}))
+            return "span-id-123"
+
+        mock_service = MagicMock()
+        mock_service.start_span.side_effect = fake_start_span
+        mock_service.end_span.return_value = None
+
+        mock_settings = MagicMock()
+        mock_settings.cpex_control_telemetry_enabled = True
+        mock_settings.cpex_control_telemetry_db_enabled = True
+        mock_settings.cpex_control_telemetry_flatten_results = False
+        mock_settings.cpex_control_telemetry_max_results = 3  # cap at 3 out of 10
+
+        with (
+            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+            patch("mcpgateway.services.observability_service.ObservabilityService", return_value=mock_service),
+            patch("mcpgateway.db.SessionLocal"),
+            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+            patch("mcpgateway.config.settings", mock_settings),
+        ):
+            record_control_telemetry("trace-abc", acc, tool_name="my_tool", agent_id="u@e.com", binding_name="gw")
+
+        # 10 accumulated, 3 exported → 7 export-cap drops should be in truncated
+        assert captured_attributes.get("cpex.control.truncated") == 7
+
+    def test_no_truncated_attribute_when_no_drops(self):
+        """cpex.control.truncated must be absent when records_received <= max_results."""
+        acc = ControlTelemetryAccumulator()
+        for i in range(2):
+            acc._records.append(("pre", _make_rec(plugin_name=f"ctrl{i}")))  # pylint: disable=protected-access
+
+        captured_attributes: dict = {}
+
+        def fake_start_span(**kwargs):
+            if kwargs.get("name") == "cpex.control.summary":
+                captured_attributes.update(kwargs.get("attributes", {}))
+            return "span-id-456"
+
+        mock_service = MagicMock()
+        mock_service.start_span.side_effect = fake_start_span
+        mock_service.end_span.return_value = None
+
+        mock_settings = MagicMock()
+        mock_settings.cpex_control_telemetry_enabled = True
+        mock_settings.cpex_control_telemetry_db_enabled = True
+        mock_settings.cpex_control_telemetry_flatten_results = False
+        mock_settings.cpex_control_telemetry_max_results = 32
+
+        with (
+            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+            patch("mcpgateway.services.observability_service.ObservabilityService", return_value=mock_service),
+            patch("mcpgateway.db.SessionLocal"),
+            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+            patch("mcpgateway.config.settings", mock_settings),
+        ):
+            record_control_telemetry("trace-def", acc, tool_name="my_tool", agent_id="u@e.com", binding_name="gw")
+
+        assert "cpex.control.truncated" not in captured_attributes
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/plugins/test_control_telemetry.py
+++ b/tests/unit/mcpgateway/plugins/test_control_telemetry.py
@@ -12,10 +12,25 @@ Covers:
     reason truncation, config_keys bounded.
   - _safe_str: within-limit unchanged, truncated with ellipsis.
   - _enforcement_point: pre/post/pre+post/none.
+  - _build_flattened_attributes: basic, collision, reason, error_code, bounded, edge cases.
+  - aggregate() exception path, _get_max_results exception path.
 """
 
 # Standard
 from unittest.mock import MagicMock, patch
+
+# First-Party
+import mcpgateway.config as cfg_mod
+from mcpgateway.plugins.control_telemetry import (
+    _MAX_CONFIG_KEYS,
+    _MAX_RECORDS_PER_CALL,
+    ControlTelemetryAccumulator,
+    _build_flattened_attributes,
+    _enforcement_point,
+    _get_max_results,
+    _per_control_attributes,
+    _safe_str,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -68,8 +83,6 @@ def _make_result(records=None, *, continue_processing=True) -> MagicMock:
 
 class TestAccumulatorInit:
     def test_empty_on_init(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc = ControlTelemetryAccumulator()
         assert acc.records == []
         assert acc.truncated == 0
@@ -78,8 +91,6 @@ class TestAccumulatorInit:
         assert acc.effective_allowed is True
 
     def test_aggregate_all_zeros_when_empty(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc = ControlTelemetryAccumulator()
         agg = acc.aggregate()
         assert agg["cpex.control.invocation_count"] == 0
@@ -93,8 +104,6 @@ class TestAccumulatorInit:
 
 class TestAccumulatorAdd:
     def test_add_pre_only(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc = ControlTelemetryAccumulator()
         result = _make_result([_make_rec()])
         with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
@@ -103,8 +112,6 @@ class TestAccumulatorAdd:
         assert acc.records[0][0] == "pre"
 
     def test_add_post_only(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc = ControlTelemetryAccumulator()
         result = _make_result([_make_rec()])
         with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
@@ -113,8 +120,6 @@ class TestAccumulatorAdd:
         assert acc.records[0][0] == "post"
 
     def test_add_pre_and_post(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc = ControlTelemetryAccumulator()
         with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
             acc.add(_make_result([_make_rec()]), hook="pre")
@@ -122,16 +127,12 @@ class TestAccumulatorAdd:
         assert len(acc.records) == 2
 
     def test_noop_when_records_unsupported(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc = ControlTelemetryAccumulator()
         with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=False):
             acc.add(_make_result([_make_rec()]), hook="pre")
         assert acc.records == []
 
     def test_noop_on_none_result(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc = ControlTelemetryAccumulator()
         with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
             acc.add(None, hook="pre")
@@ -140,10 +141,7 @@ class TestAccumulatorAdd:
 
 class TestAccumulatorCap:
     def test_cap_enforced_at_max_records_per_call(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, _MAX_RECORDS_PER_CALL
-
         acc = ControlTelemetryAccumulator()
-        # Fill up to the cap with individual adds
         with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
             for _ in range(_MAX_RECORDS_PER_CALL + 5):
                 acc.add(_make_result([_make_rec()]), hook="pre")
@@ -151,8 +149,6 @@ class TestAccumulatorCap:
         assert acc.truncated == 5
 
     def test_truncated_counter(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, _MAX_RECORDS_PER_CALL
-
         acc = ControlTelemetryAccumulator()
         with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
             for _ in range(_MAX_RECORDS_PER_CALL + 3):
@@ -162,8 +158,6 @@ class TestAccumulatorCap:
 
 class TestAccumulatorDenied:
     def test_pre_denied_flag(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc = ControlTelemetryAccumulator()
         result = _make_result([], continue_processing=False)
         with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
@@ -172,8 +166,6 @@ class TestAccumulatorDenied:
         assert acc.post_denied is False
 
     def test_post_denied_flag(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc = ControlTelemetryAccumulator()
         result = _make_result([], continue_processing=False)
         with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
@@ -182,14 +174,10 @@ class TestAccumulatorDenied:
         assert acc.pre_denied is False
 
     def test_effective_allowed_when_neither_denied(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc = ControlTelemetryAccumulator()
         assert acc.effective_allowed is True
 
     def test_effective_allowed_false_when_pre_denied(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc = ControlTelemetryAccumulator()
         result = _make_result([], continue_processing=False)
         with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
@@ -197,8 +185,6 @@ class TestAccumulatorDenied:
         assert acc.effective_allowed is False
 
     def test_effective_allowed_false_when_post_denied(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc = ControlTelemetryAccumulator()
         result = _make_result([], continue_processing=False)
         with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
@@ -213,8 +199,6 @@ class TestAccumulatorDenied:
 
 class TestAggregate:
     def _make_acc_with_records(self, recs):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc = ControlTelemetryAccumulator()
         with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
             for hook, rec in recs:
@@ -257,16 +241,12 @@ class TestAggregate:
         assert acc.aggregate()["cpex.control.timeout_count"] == 1
 
     def test_result_allowed_false_when_pre_denied(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc = ControlTelemetryAccumulator()
         with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
             acc.add(_make_result([], continue_processing=False), hook="pre")
         assert acc.aggregate()["cpex.control.result.allowed"] is False
 
     def test_result_allowed_false_when_post_denied(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc = ControlTelemetryAccumulator()
         with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
             acc.add(_make_result([], continue_processing=False), hook="post")
@@ -274,16 +254,33 @@ class TestAggregate:
 
     def test_malformed_record_skipped_without_raising(self):
         """A bad record (raises on attribute access) should not abort aggregate()."""
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc = ControlTelemetryAccumulator()
         bad_rec = MagicMock()
         bad_rec.matched = property(lambda self: (_ for _ in ()).throw(RuntimeError("oops")))
-        # Manually inject so we bypass get_executions
         acc._records.append(("pre", bad_rec))  # pylint: disable=protected-access
-        # Should not raise
         agg = acc.aggregate()
         assert "cpex.control.invocation_count" in agg
+
+
+# ---------------------------------------------------------------------------
+# aggregate() — inner exception path (lines 192-193)
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateExceptionPath:
+    def test_record_raising_on_duration_ns_is_skipped(self):
+        """Lines 192-193: record raising during aggregation is caught; others still counted."""
+        acc = ControlTelemetryAccumulator()
+        bad = MagicMock()
+        bad.matched = True
+        bad.applied = False
+        bad.duration_ns = property(lambda self: (_ for _ in ()).throw(ValueError("bad")))
+        good = _make_rec(duration_ns=100)
+        acc._records.append(("pre", bad))   # pylint: disable=protected-access
+        acc._records.append(("pre", good))  # pylint: disable=protected-access
+        agg = acc.aggregate()
+        assert agg["cpex.control.invocation_count"] == 2
+        assert agg["cpex.control.duration"] == 100
 
 
 # ---------------------------------------------------------------------------
@@ -293,8 +290,6 @@ class TestAggregate:
 
 class TestPerControlAttributes:
     def test_completed_allow(self):
-        from mcpgateway.plugins.control_telemetry import _per_control_attributes
-
         rec = _make_rec(status="completed", effective_allow=True, duration_ns=500)
         attrs = _per_control_attributes("pre", rec)
         assert attrs["cpex.control.status"] == "completed"
@@ -303,39 +298,29 @@ class TestPerControlAttributes:
         assert attrs["cpex.control.enforcement_point"] == "pre"
 
     def test_completed_deny_with_reason(self):
-        from mcpgateway.plugins.control_telemetry import _per_control_attributes
-
         rec = _make_rec(effective_allow=False, reason="PII detected")
         attrs = _per_control_attributes("pre", rec)
         assert attrs["cpex.control.result.allowed"] is False
         assert attrs["cpex.control.result.reason"] == "PII detected"
 
     def test_error_status(self):
-        from mcpgateway.plugins.control_telemetry import _per_control_attributes
-
         rec = _make_rec(status="error", error_code="PLUGIN_ERROR")
         attrs = _per_control_attributes("pre", rec)
         assert attrs["cpex.control.status"] == "error"
         assert attrs["cpex.control.result.error_code"] == "PLUGIN_ERROR"
 
     def test_timeout_status(self):
-        from mcpgateway.plugins.control_telemetry import _per_control_attributes
-
         rec = _make_rec(status="timeout")
         attrs = _per_control_attributes("pre", rec)
         assert attrs["cpex.control.status"] == "timeout"
 
     def test_faf_mode(self):
-        from mcpgateway.plugins.control_telemetry import _per_control_attributes
-
         rec = _make_rec(mode="fire_and_forget", duration_ns=0)
         attrs = _per_control_attributes("post", rec)
         assert attrs["cpex.control.mode"] == "fire_and_forget"
         assert attrs["cpex.control.duration"] == 0
 
     def test_missing_optional_fields_omitted(self):
-        from mcpgateway.plugins.control_telemetry import _per_control_attributes
-
         rec = _make_rec(reason=None, error_code=None, config_keys=[])
         attrs = _per_control_attributes("pre", rec)
         assert "cpex.control.result.reason" not in attrs
@@ -343,24 +328,17 @@ class TestPerControlAttributes:
         assert "cpex.control.config.keys" not in attrs
 
     def test_reason_truncated_to_256(self):
-        from mcpgateway.plugins.control_telemetry import _per_control_attributes
-
         rec = _make_rec(reason="x" * 300)
         attrs = _per_control_attributes("pre", rec)
         assert len(attrs["cpex.control.result.reason"].encode("utf-8")) <= 256
 
     def test_config_keys_bounded(self):
-        from mcpgateway.plugins.control_telemetry import _per_control_attributes, _MAX_CONFIG_KEYS
-
         rec = _make_rec(config_keys=[f"key{i}" for i in range(_MAX_CONFIG_KEYS + 10)])
         attrs = _per_control_attributes("pre", rec)
-        # Joined keys — count commas+1
         parts = attrs["cpex.control.config.keys"].split(",")
         assert len(parts) == _MAX_CONFIG_KEYS
 
     def test_returns_empty_on_attribute_error(self):
-        from mcpgateway.plugins.control_telemetry import _per_control_attributes
-
         # rec missing plugin_name entirely
         attrs = _per_control_attributes("pre", MagicMock(spec=[]))
         assert attrs == {}
@@ -373,25 +351,17 @@ class TestPerControlAttributes:
 
 class TestSafeStr:
     def test_within_limit_unchanged(self):
-        from mcpgateway.plugins.control_telemetry import _safe_str
-
         assert _safe_str("hello", 10) == "hello"
 
     def test_truncated_with_ellipsis(self):
-        from mcpgateway.plugins.control_telemetry import _safe_str
-
         result = _safe_str("a" * 100, 10)
         assert result.endswith("...")
         assert len(result.encode("utf-8")) <= 10
 
     def test_non_string_coerced(self):
-        from mcpgateway.plugins.control_telemetry import _safe_str
-
         assert _safe_str(42, 20) == "42"
 
     def test_exact_limit_boundary(self):
-        from mcpgateway.plugins.control_telemetry import _safe_str
-
         s = "a" * 10
         assert _safe_str(s, 10) == s
 
@@ -403,34 +373,45 @@ class TestSafeStr:
 
 class TestEnforcementPoint:
     def _acc(self, pre: bool = False, post: bool = False):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc = ControlTelemetryAccumulator()
         if pre:
-            acc._records.append(("pre", _make_rec()))  # pylint: disable=protected-access
+            acc._records.append(("pre", _make_rec()))    # pylint: disable=protected-access
         if post:
-            acc._records.append(("post", _make_rec()))  # pylint: disable=protected-access
+            acc._records.append(("post", _make_rec()))   # pylint: disable=protected-access
         return acc
 
     def test_pre_only(self):
-        from mcpgateway.plugins.control_telemetry import _enforcement_point
-
         assert _enforcement_point(self._acc(pre=True)) == "pre"
 
     def test_post_only(self):
-        from mcpgateway.plugins.control_telemetry import _enforcement_point
-
         assert _enforcement_point(self._acc(post=True)) == "post"
 
     def test_pre_and_post(self):
-        from mcpgateway.plugins.control_telemetry import _enforcement_point
-
         assert _enforcement_point(self._acc(pre=True, post=True)) == "pre+post"
 
     def test_neither(self):
-        from mcpgateway.plugins.control_telemetry import _enforcement_point
-
         assert _enforcement_point(self._acc()) == "none"
+
+
+# ---------------------------------------------------------------------------
+# _get_max_results — exception path (lines 484-485)
+# ---------------------------------------------------------------------------
+
+
+class TestGetMaxResultsExceptionPath:
+    def test_returns_default_when_settings_raises(self):
+        """Lines 484-485: if settings access raises, _get_max_results returns 32."""
+        mock_settings = MagicMock()
+        # Make getattr(settings, "cpex_control_telemetry_max_results", 32) return an
+        # object that raises when int() is called on it — that hits the except branch.
+        mock_settings.cpex_control_telemetry_max_results = "not-an-int-\x00"
+        original = cfg_mod.settings
+        try:
+            cfg_mod.settings = mock_settings
+            result = _get_max_results()
+        finally:
+            cfg_mod.settings = original
+        assert result == 32
 
 
 # ---------------------------------------------------------------------------
@@ -440,12 +421,9 @@ class TestEnforcementPoint:
 
 class TestBuildFlattenedAttributes:
     def test_basic_flatten(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, _build_flattened_attributes
-
         acc = ControlTelemetryAccumulator()
         with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
             acc.add(_make_result([_make_rec(plugin_name="pii_guard", status="completed", effective_allow=True, duration_ns=1000)]), hook="pre")
-
         flat = _build_flattened_attributes(acc, 32)
         assert "cpex.control.results.pii_guard.status" in flat
         assert flat["cpex.control.results.pii_guard.status"] == "completed"
@@ -455,38 +433,27 @@ class TestBuildFlattenedAttributes:
 
     def test_invalid_name_skipped(self):
         """plugin_name with spaces/special chars is dropped from flattening."""
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, _build_flattened_attributes
-
         acc = ControlTelemetryAccumulator()
         acc._records.append(("pre", _make_rec(plugin_name="bad name!")))  # pylint: disable=protected-access
         flat = _build_flattened_attributes(acc, 32)
-        # no key should mention the bad name
         assert not any("bad" in k for k in flat)
 
     def test_collision_drops_both_and_emits_counter(self):
         """Two records with the same plugin_name cause both to be dropped."""
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, _build_flattened_attributes
-
         acc = ControlTelemetryAccumulator()
         acc._records.append(("pre", _make_rec(plugin_name="myctrl")))   # pylint: disable=protected-access
         acc._records.append(("post", _make_rec(plugin_name="myctrl")))  # pylint: disable=protected-access
         flat = _build_flattened_attributes(acc, 32)
-        # no flattened key for myctrl
         assert not any("cpex.control.results.myctrl." in k for k in flat)
-        # collision counter emitted
         assert flat.get("cpex.control.results._collision_count", 0) >= 1
 
     def test_reason_included_when_present(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, _build_flattened_attributes
-
         acc = ControlTelemetryAccumulator()
         acc._records.append(("pre", _make_rec(plugin_name="pii_guard", reason="PII found")))  # pylint: disable=protected-access
         flat = _build_flattened_attributes(acc, 32)
         assert flat.get("cpex.control.results.pii_guard.result.reason") == "PII found"
 
     def test_reason_omitted_when_none(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, _build_flattened_attributes
-
         acc = ControlTelemetryAccumulator()
         acc._records.append(("pre", _make_rec(plugin_name="pii_guard", reason=None)))  # pylint: disable=protected-access
         flat = _build_flattened_attributes(acc, 32)
@@ -494,18 +461,50 @@ class TestBuildFlattenedAttributes:
 
     def test_bounded_by_max_results(self):
         """Only up to max_results records are flattened."""
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, _build_flattened_attributes
-
         acc = ControlTelemetryAccumulator()
         for i in range(10):
             acc._records.append(("pre", _make_rec(plugin_name=f"ctrl{i}")))  # pylint: disable=protected-access
         flat = _build_flattened_attributes(acc, 3)
-        # Only ctrl0, ctrl1, ctrl2 flattened
         flattened_names = {k.split(".")[3] for k in flat if k.startswith("cpex.control.results.") and not k.endswith("_collision_count")}
         assert len(flattened_names) == 3
 
     def test_empty_accumulator_returns_empty(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, _build_flattened_attributes
-
         flat = _build_flattened_attributes(ControlTelemetryAccumulator(), 32)
         assert flat == {}
+
+
+# ---------------------------------------------------------------------------
+# _build_flattened_attributes — error_code branch + per-record except + outer except
+# (lines 553-555, 561-563)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFlattenedAttributesEdgeCases:
+    def test_error_code_included_when_present(self):
+        """Line 553: error_code branch emits the error_code attribute."""
+        acc = ControlTelemetryAccumulator()
+        acc._records.append(("pre", _make_rec(plugin_name="guard", error_code="TIMEOUT")))  # pylint: disable=protected-access
+        flat = _build_flattened_attributes(acc, 32)
+        assert flat.get("cpex.control.results.guard.result.error_code") == "TIMEOUT"
+
+    def test_per_record_exception_is_caught(self):
+        """Lines 554-555: exception inside per-record block is caught; other records continue."""
+        acc = ControlTelemetryAccumulator()
+        bad = MagicMock()
+        bad.plugin_name = property(lambda self: (_ for _ in ()).throw(RuntimeError("boom")))
+        good_rec = _make_rec(plugin_name="good_ctrl", status="completed")
+        acc._records.append(("pre", bad))        # pylint: disable=protected-access
+        acc._records.append(("pre", good_rec))   # pylint: disable=protected-access
+        flat = _build_flattened_attributes(acc, 32)
+        assert "cpex.control.results.good_ctrl.status" in flat
+
+    def test_outer_exception_returns_empty(self):
+        """Lines 561-563: if the outer try raises, returns {}."""
+
+        class ExplodingAcc:
+            @property
+            def records(self):
+                raise RuntimeError("outer explode")
+
+        result = _build_flattened_attributes(ExplodingAcc(), 32)  # type: ignore[arg-type]
+        assert result == {}

--- a/tests/unit/mcpgateway/plugins/test_control_telemetry.py
+++ b/tests/unit/mcpgateway/plugins/test_control_telemetry.py
@@ -1,0 +1,511 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for mcpgateway/plugins/control_telemetry.py.
+
+Location: ./tests/unit/mcpgateway/plugins/test_control_telemetry.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Covers:
+  - ControlTelemetryAccumulator: empty init, add pre/post, caps, truncated, denied flags,
+    effective_allowed, aggregate() semantics.
+  - _per_control_attributes: completed allow/deny, error/timeout/faf, optional field omission,
+    reason truncation, config_keys bounded.
+  - _safe_str: within-limit unchanged, truncated with ellipsis.
+  - _enforcement_point: pre/post/pre+post/none.
+"""
+
+# Standard
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_rec(
+    *,
+    plugin_name: str = "pii-guard",
+    hook_name: str = "tool_pre_invoke",
+    mode: str = "sequential",
+    status: str = "completed",
+    effective_allow: bool = True,
+    matched: object = True,
+    applied: bool = False,
+    duration_ns: int = 1000,
+    reason: object = None,
+    error_code: object = None,
+    config_keys: list = None,
+) -> MagicMock:
+    """Create a minimal ControlExecutionRecord mock."""
+    rec = MagicMock()
+    rec.plugin_name = plugin_name
+    rec.hook_name = hook_name
+    rec.mode = mode
+    rec.status = status
+    rec.effective_allow = effective_allow
+    rec.matched = matched
+    rec.applied = applied
+    rec.duration_ns = duration_ns
+    rec.reason = reason
+    rec.error_code = error_code
+    rec.config_keys = config_keys or []
+    return rec
+
+
+def _make_result(records=None, *, continue_processing=True) -> MagicMock:
+    """Create a minimal PluginResult mock."""
+    r = MagicMock()
+    r.executions = records or []
+    r.continue_processing = continue_processing
+    return r
+
+
+# ---------------------------------------------------------------------------
+# ControlTelemetryAccumulator — basic
+# ---------------------------------------------------------------------------
+
+
+class TestAccumulatorInit:
+    def test_empty_on_init(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc = ControlTelemetryAccumulator()
+        assert acc.records == []
+        assert acc.truncated == 0
+        assert acc.pre_denied is False
+        assert acc.post_denied is False
+        assert acc.effective_allowed is True
+
+    def test_aggregate_all_zeros_when_empty(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc = ControlTelemetryAccumulator()
+        agg = acc.aggregate()
+        assert agg["cpex.control.invocation_count"] == 0
+        assert agg["cpex.control.matched_count"] == 0
+        assert agg["cpex.control.applied_count"] == 0
+        assert agg["cpex.control.duration"] == 0
+        assert agg["cpex.control.result.allowed"] is True
+        assert agg["cpex.control.error_count"] == 0
+        assert agg["cpex.control.timeout_count"] == 0
+
+
+class TestAccumulatorAdd:
+    def test_add_pre_only(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc = ControlTelemetryAccumulator()
+        result = _make_result([_make_rec()])
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            acc.add(result, hook="pre")
+        assert len(acc.records) == 1
+        assert acc.records[0][0] == "pre"
+
+    def test_add_post_only(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc = ControlTelemetryAccumulator()
+        result = _make_result([_make_rec()])
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            acc.add(result, hook="post")
+        assert len(acc.records) == 1
+        assert acc.records[0][0] == "post"
+
+    def test_add_pre_and_post(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc = ControlTelemetryAccumulator()
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            acc.add(_make_result([_make_rec()]), hook="pre")
+            acc.add(_make_result([_make_rec()]), hook="post")
+        assert len(acc.records) == 2
+
+    def test_noop_when_records_unsupported(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc = ControlTelemetryAccumulator()
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=False):
+            acc.add(_make_result([_make_rec()]), hook="pre")
+        assert acc.records == []
+
+    def test_noop_on_none_result(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc = ControlTelemetryAccumulator()
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            acc.add(None, hook="pre")
+        assert acc.records == []
+
+
+class TestAccumulatorCap:
+    def test_cap_enforced_at_max_records_per_call(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, _MAX_RECORDS_PER_CALL
+
+        acc = ControlTelemetryAccumulator()
+        # Fill up to the cap with individual adds
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            for _ in range(_MAX_RECORDS_PER_CALL + 5):
+                acc.add(_make_result([_make_rec()]), hook="pre")
+        assert len(acc.records) == _MAX_RECORDS_PER_CALL
+        assert acc.truncated == 5
+
+    def test_truncated_counter(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, _MAX_RECORDS_PER_CALL
+
+        acc = ControlTelemetryAccumulator()
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            for _ in range(_MAX_RECORDS_PER_CALL + 3):
+                acc.add(_make_result([_make_rec()]), hook="pre")
+        assert acc.truncated == 3
+
+
+class TestAccumulatorDenied:
+    def test_pre_denied_flag(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc = ControlTelemetryAccumulator()
+        result = _make_result([], continue_processing=False)
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            acc.add(result, hook="pre")
+        assert acc.pre_denied is True
+        assert acc.post_denied is False
+
+    def test_post_denied_flag(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc = ControlTelemetryAccumulator()
+        result = _make_result([], continue_processing=False)
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            acc.add(result, hook="post")
+        assert acc.post_denied is True
+        assert acc.pre_denied is False
+
+    def test_effective_allowed_when_neither_denied(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc = ControlTelemetryAccumulator()
+        assert acc.effective_allowed is True
+
+    def test_effective_allowed_false_when_pre_denied(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc = ControlTelemetryAccumulator()
+        result = _make_result([], continue_processing=False)
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            acc.add(result, hook="pre")
+        assert acc.effective_allowed is False
+
+    def test_effective_allowed_false_when_post_denied(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc = ControlTelemetryAccumulator()
+        result = _make_result([], continue_processing=False)
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            acc.add(result, hook="post")
+        assert acc.effective_allowed is False
+
+
+# ---------------------------------------------------------------------------
+# ControlTelemetryAccumulator.aggregate()
+# ---------------------------------------------------------------------------
+
+
+class TestAggregate:
+    def _make_acc_with_records(self, recs):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc = ControlTelemetryAccumulator()
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            for hook, rec in recs:
+                acc.add(_make_result([rec]), hook=hook)
+        return acc
+
+    def test_invocation_count(self):
+        acc = self._make_acc_with_records([("pre", _make_rec()), ("pre", _make_rec())])
+        assert acc.aggregate()["cpex.control.invocation_count"] == 2
+
+    def test_matched_count(self):
+        r1 = _make_rec(matched=True)
+        r2 = _make_rec(matched=False)
+        r3 = _make_rec(matched=None)
+        acc = self._make_acc_with_records([("pre", r1), ("pre", r2), ("pre", r3)])
+        assert acc.aggregate()["cpex.control.matched_count"] == 1
+
+    def test_applied_count(self):
+        r1 = _make_rec(applied=True)
+        r2 = _make_rec(applied=False)
+        acc = self._make_acc_with_records([("pre", r1), ("pre", r2)])
+        assert acc.aggregate()["cpex.control.applied_count"] == 1
+
+    def test_duration_sum(self):
+        r1 = _make_rec(duration_ns=1000)
+        r2 = _make_rec(duration_ns=2000)
+        acc = self._make_acc_with_records([("pre", r1), ("post", r2)])
+        assert acc.aggregate()["cpex.control.duration"] == 3000
+
+    def test_error_count(self):
+        r1 = _make_rec(status="error")
+        r2 = _make_rec(status="completed")
+        acc = self._make_acc_with_records([("pre", r1), ("pre", r2)])
+        assert acc.aggregate()["cpex.control.error_count"] == 1
+
+    def test_timeout_count(self):
+        r1 = _make_rec(status="timeout")
+        r2 = _make_rec(status="completed")
+        acc = self._make_acc_with_records([("pre", r1), ("pre", r2)])
+        assert acc.aggregate()["cpex.control.timeout_count"] == 1
+
+    def test_result_allowed_false_when_pre_denied(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc = ControlTelemetryAccumulator()
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            acc.add(_make_result([], continue_processing=False), hook="pre")
+        assert acc.aggregate()["cpex.control.result.allowed"] is False
+
+    def test_result_allowed_false_when_post_denied(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc = ControlTelemetryAccumulator()
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            acc.add(_make_result([], continue_processing=False), hook="post")
+        assert acc.aggregate()["cpex.control.result.allowed"] is False
+
+    def test_malformed_record_skipped_without_raising(self):
+        """A bad record (raises on attribute access) should not abort aggregate()."""
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc = ControlTelemetryAccumulator()
+        bad_rec = MagicMock()
+        bad_rec.matched = property(lambda self: (_ for _ in ()).throw(RuntimeError("oops")))
+        # Manually inject so we bypass get_executions
+        acc._records.append(("pre", bad_rec))  # pylint: disable=protected-access
+        # Should not raise
+        agg = acc.aggregate()
+        assert "cpex.control.invocation_count" in agg
+
+
+# ---------------------------------------------------------------------------
+# _per_control_attributes
+# ---------------------------------------------------------------------------
+
+
+class TestPerControlAttributes:
+    def test_completed_allow(self):
+        from mcpgateway.plugins.control_telemetry import _per_control_attributes
+
+        rec = _make_rec(status="completed", effective_allow=True, duration_ns=500)
+        attrs = _per_control_attributes("pre", rec)
+        assert attrs["cpex.control.status"] == "completed"
+        assert attrs["cpex.control.result.allowed"] is True
+        assert attrs["cpex.control.duration"] == 500
+        assert attrs["cpex.control.enforcement_point"] == "pre"
+
+    def test_completed_deny_with_reason(self):
+        from mcpgateway.plugins.control_telemetry import _per_control_attributes
+
+        rec = _make_rec(effective_allow=False, reason="PII detected")
+        attrs = _per_control_attributes("pre", rec)
+        assert attrs["cpex.control.result.allowed"] is False
+        assert attrs["cpex.control.result.reason"] == "PII detected"
+
+    def test_error_status(self):
+        from mcpgateway.plugins.control_telemetry import _per_control_attributes
+
+        rec = _make_rec(status="error", error_code="PLUGIN_ERROR")
+        attrs = _per_control_attributes("pre", rec)
+        assert attrs["cpex.control.status"] == "error"
+        assert attrs["cpex.control.result.error_code"] == "PLUGIN_ERROR"
+
+    def test_timeout_status(self):
+        from mcpgateway.plugins.control_telemetry import _per_control_attributes
+
+        rec = _make_rec(status="timeout")
+        attrs = _per_control_attributes("pre", rec)
+        assert attrs["cpex.control.status"] == "timeout"
+
+    def test_faf_mode(self):
+        from mcpgateway.plugins.control_telemetry import _per_control_attributes
+
+        rec = _make_rec(mode="fire_and_forget", duration_ns=0)
+        attrs = _per_control_attributes("post", rec)
+        assert attrs["cpex.control.mode"] == "fire_and_forget"
+        assert attrs["cpex.control.duration"] == 0
+
+    def test_missing_optional_fields_omitted(self):
+        from mcpgateway.plugins.control_telemetry import _per_control_attributes
+
+        rec = _make_rec(reason=None, error_code=None, config_keys=[])
+        attrs = _per_control_attributes("pre", rec)
+        assert "cpex.control.result.reason" not in attrs
+        assert "cpex.control.result.error_code" not in attrs
+        assert "cpex.control.config.keys" not in attrs
+
+    def test_reason_truncated_to_256(self):
+        from mcpgateway.plugins.control_telemetry import _per_control_attributes
+
+        rec = _make_rec(reason="x" * 300)
+        attrs = _per_control_attributes("pre", rec)
+        assert len(attrs["cpex.control.result.reason"].encode("utf-8")) <= 256
+
+    def test_config_keys_bounded(self):
+        from mcpgateway.plugins.control_telemetry import _per_control_attributes, _MAX_CONFIG_KEYS
+
+        rec = _make_rec(config_keys=[f"key{i}" for i in range(_MAX_CONFIG_KEYS + 10)])
+        attrs = _per_control_attributes("pre", rec)
+        # Joined keys — count commas+1
+        parts = attrs["cpex.control.config.keys"].split(",")
+        assert len(parts) == _MAX_CONFIG_KEYS
+
+    def test_returns_empty_on_attribute_error(self):
+        from mcpgateway.plugins.control_telemetry import _per_control_attributes
+
+        # rec missing plugin_name entirely
+        attrs = _per_control_attributes("pre", MagicMock(spec=[]))
+        assert attrs == {}
+
+
+# ---------------------------------------------------------------------------
+# _safe_str
+# ---------------------------------------------------------------------------
+
+
+class TestSafeStr:
+    def test_within_limit_unchanged(self):
+        from mcpgateway.plugins.control_telemetry import _safe_str
+
+        assert _safe_str("hello", 10) == "hello"
+
+    def test_truncated_with_ellipsis(self):
+        from mcpgateway.plugins.control_telemetry import _safe_str
+
+        result = _safe_str("a" * 100, 10)
+        assert result.endswith("...")
+        assert len(result.encode("utf-8")) <= 10
+
+    def test_non_string_coerced(self):
+        from mcpgateway.plugins.control_telemetry import _safe_str
+
+        assert _safe_str(42, 20) == "42"
+
+    def test_exact_limit_boundary(self):
+        from mcpgateway.plugins.control_telemetry import _safe_str
+
+        s = "a" * 10
+        assert _safe_str(s, 10) == s
+
+
+# ---------------------------------------------------------------------------
+# _enforcement_point
+# ---------------------------------------------------------------------------
+
+
+class TestEnforcementPoint:
+    def _acc(self, pre: bool = False, post: bool = False):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc = ControlTelemetryAccumulator()
+        if pre:
+            acc._records.append(("pre", _make_rec()))  # pylint: disable=protected-access
+        if post:
+            acc._records.append(("post", _make_rec()))  # pylint: disable=protected-access
+        return acc
+
+    def test_pre_only(self):
+        from mcpgateway.plugins.control_telemetry import _enforcement_point
+
+        assert _enforcement_point(self._acc(pre=True)) == "pre"
+
+    def test_post_only(self):
+        from mcpgateway.plugins.control_telemetry import _enforcement_point
+
+        assert _enforcement_point(self._acc(post=True)) == "post"
+
+    def test_pre_and_post(self):
+        from mcpgateway.plugins.control_telemetry import _enforcement_point
+
+        assert _enforcement_point(self._acc(pre=True, post=True)) == "pre+post"
+
+    def test_neither(self):
+        from mcpgateway.plugins.control_telemetry import _enforcement_point
+
+        assert _enforcement_point(self._acc()) == "none"
+
+
+# ---------------------------------------------------------------------------
+# _build_flattened_attributes
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFlattenedAttributes:
+    def test_basic_flatten(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, _build_flattened_attributes
+
+        acc = ControlTelemetryAccumulator()
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            acc.add(_make_result([_make_rec(plugin_name="pii_guard", status="completed", effective_allow=True, duration_ns=1000)]), hook="pre")
+
+        flat = _build_flattened_attributes(acc, 32)
+        assert "cpex.control.results.pii_guard.status" in flat
+        assert flat["cpex.control.results.pii_guard.status"] == "completed"
+        assert flat["cpex.control.results.pii_guard.result.allowed"] is True
+        assert flat["cpex.control.results.pii_guard.duration"] == 1000
+        assert flat["cpex.control.results.pii_guard.enforcement_point"] == "pre"
+
+    def test_invalid_name_skipped(self):
+        """plugin_name with spaces/special chars is dropped from flattening."""
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, _build_flattened_attributes
+
+        acc = ControlTelemetryAccumulator()
+        acc._records.append(("pre", _make_rec(plugin_name="bad name!")))  # pylint: disable=protected-access
+        flat = _build_flattened_attributes(acc, 32)
+        # no key should mention the bad name
+        assert not any("bad" in k for k in flat)
+
+    def test_collision_drops_both_and_emits_counter(self):
+        """Two records with the same plugin_name cause both to be dropped."""
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, _build_flattened_attributes
+
+        acc = ControlTelemetryAccumulator()
+        acc._records.append(("pre", _make_rec(plugin_name="myctrl")))   # pylint: disable=protected-access
+        acc._records.append(("post", _make_rec(plugin_name="myctrl")))  # pylint: disable=protected-access
+        flat = _build_flattened_attributes(acc, 32)
+        # no flattened key for myctrl
+        assert not any("cpex.control.results.myctrl." in k for k in flat)
+        # collision counter emitted
+        assert flat.get("cpex.control.results._collision_count", 0) >= 1
+
+    def test_reason_included_when_present(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, _build_flattened_attributes
+
+        acc = ControlTelemetryAccumulator()
+        acc._records.append(("pre", _make_rec(plugin_name="pii_guard", reason="PII found")))  # pylint: disable=protected-access
+        flat = _build_flattened_attributes(acc, 32)
+        assert flat.get("cpex.control.results.pii_guard.result.reason") == "PII found"
+
+    def test_reason_omitted_when_none(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, _build_flattened_attributes
+
+        acc = ControlTelemetryAccumulator()
+        acc._records.append(("pre", _make_rec(plugin_name="pii_guard", reason=None)))  # pylint: disable=protected-access
+        flat = _build_flattened_attributes(acc, 32)
+        assert "cpex.control.results.pii_guard.result.reason" not in flat
+
+    def test_bounded_by_max_results(self):
+        """Only up to max_results records are flattened."""
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, _build_flattened_attributes
+
+        acc = ControlTelemetryAccumulator()
+        for i in range(10):
+            acc._records.append(("pre", _make_rec(plugin_name=f"ctrl{i}")))  # pylint: disable=protected-access
+        flat = _build_flattened_attributes(acc, 3)
+        # Only ctrl0, ctrl1, ctrl2 flattened
+        flattened_names = {k.split(".")[3] for k in flat if k.startswith("cpex.control.results.") and not k.endswith("_collision_count")}
+        assert len(flattened_names) == 3
+
+    def test_empty_accumulator_returns_empty(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, _build_flattened_attributes
+
+        flat = _build_flattened_attributes(ControlTelemetryAccumulator(), 32)
+        assert flat == {}

--- a/tests/unit/mcpgateway/plugins/test_control_telemetry.py
+++ b/tests/unit/mcpgateway/plugins/test_control_telemetry.py
@@ -1037,3 +1037,104 @@ class TestEmitReasonFlag:
         finally:
             cfg_mod.settings = original
         assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Fix 4 — mark_plugin_error() and cpex.control.plugin_error flag
+# ---------------------------------------------------------------------------
+
+
+class TestMarkPluginError:
+    """mark_plugin_error() sets the plugin_errored flag and bypasses the empty-accumulator guard."""
+
+    def test_plugin_errored_false_by_default(self):
+        acc = ControlTelemetryAccumulator()
+        assert acc.plugin_errored is False
+
+    def test_mark_plugin_error_sets_flag(self):
+        acc = ControlTelemetryAccumulator()
+        acc.mark_plugin_error()
+        assert acc.plugin_errored is True
+
+    def test_effective_allowed_unchanged_after_plugin_error(self):
+        """PluginError does NOT set effective_allowed=False — it stays True."""
+        acc = ControlTelemetryAccumulator()
+        acc.mark_plugin_error()
+        assert acc.effective_allowed is True
+
+    def test_aggregate_emits_plugin_error_true_when_flagged(self):
+        acc = ControlTelemetryAccumulator()
+        acc.mark_plugin_error()
+        agg = acc.aggregate()
+        assert agg.get("cpex.control.plugin_error") is True
+
+    def test_aggregate_omits_plugin_error_when_not_flagged(self):
+        acc = ControlTelemetryAccumulator()
+        agg = acc.aggregate()
+        assert "cpex.control.plugin_error" not in agg
+
+    def test_plugin_error_flag_bypasses_empty_accumulator_guard(self):
+        """record_control_telemetry() must emit a summary span even with an empty accumulator
+        when plugin_errored=True (first-plugin failure path)."""
+        acc = ControlTelemetryAccumulator()
+        acc.mark_plugin_error()
+        # No records, no denial — only the error flag
+
+        captured_attributes: dict = {}
+
+        def fake_start_span(**kwargs):
+            if kwargs.get("name") == "cpex.control.summary":
+                captured_attributes.update(kwargs.get("attributes", {}))
+            return "span-id-plugin-err"
+
+        mock_service = MagicMock()
+        mock_service.start_span.side_effect = fake_start_span
+        mock_service.end_span.return_value = None
+
+        mock_settings = MagicMock()
+        mock_settings.cpex_control_telemetry_enabled = True
+        mock_settings.cpex_control_telemetry_db_enabled = True
+        mock_settings.cpex_control_telemetry_flatten_results = False
+        mock_settings.cpex_control_telemetry_max_results = 32
+
+        with (
+            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+            patch("mcpgateway.services.observability_service.ObservabilityService", return_value=mock_service),
+            patch("mcpgateway.db.SessionLocal"),
+            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+            patch("mcpgateway.config.settings", mock_settings),
+        ):
+            record_control_telemetry("trace-plugin-err", acc, tool_name="my_tool", agent_id="u@e.com", binding_name="gw")
+
+        # Summary span must be emitted and carry plugin_error=True
+        assert captured_attributes, "Expected a summary span to be emitted for a first-plugin PluginError"
+        assert captured_attributes.get("cpex.control.plugin_error") is True
+        # effective_allowed must remain True — this is not a policy denial
+        assert captured_attributes.get("cpex.control.result.allowed") is True
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 — _enforcement_point uses denial flags when records are empty
+# ---------------------------------------------------------------------------
+
+
+class TestEnforcementPointDenialFlags:
+    """_enforcement_point() must use pre_denied/post_denied when no records exist."""
+
+    def test_enforcement_point_pre_from_flag_no_records(self):
+        """mark_denied(hook='pre') with no records should yield enforcement_point='pre'."""
+        from mcpgateway.plugins.control_telemetry import _enforcement_point  # noqa: PLC0415
+        acc = ControlTelemetryAccumulator()
+        acc.mark_denied(hook="pre")
+        assert _enforcement_point(acc) == "pre"
+
+    def test_enforcement_point_post_from_flag_no_records(self):
+        from mcpgateway.plugins.control_telemetry import _enforcement_point  # noqa: PLC0415
+        acc = ControlTelemetryAccumulator()
+        acc.mark_denied(hook="post")
+        assert _enforcement_point(acc) == "post"
+
+    def test_enforcement_point_none_no_records_no_flags(self):
+        from mcpgateway.plugins.control_telemetry import _enforcement_point  # noqa: PLC0415
+        acc = ControlTelemetryAccumulator()
+        assert _enforcement_point(acc) == "none"

--- a/tests/unit/mcpgateway/plugins/test_control_telemetry.py
+++ b/tests/unit/mcpgateway/plugins/test_control_telemetry.py
@@ -8,11 +8,14 @@ SPDX-License-Identifier: Apache-2.0
 Covers:
   - ControlTelemetryAccumulator: empty init, add pre/post, caps, truncated, denied flags,
     effective_allowed, aggregate() semantics.
+  - ControlTelemetryAccumulator.mark_denied(): pre/post explicit denial, effective_allowed.
+  - add() per-hook cap contributes to truncated counter (item 4 / item 6 fix).
   - _per_control_attributes: completed allow/deny, error/timeout/faf, optional field omission,
-    reason truncation, config_keys bounded.
+    reason truncation, config_keys bounded, artifact_name/artifact_id fields.
   - _safe_str: within-limit unchanged, truncated with ellipsis.
   - _enforcement_point: pre/post/pre+post/none.
-  - _build_flattened_attributes: basic, collision, reason, error_code, bounded, edge cases.
+  - _build_flattened_attributes: basic (duration_ns key), collision, reason, error_code,
+    bounded, artifact fields, config_keys field, name field, edge cases.
   - aggregate() exception path, _get_max_results exception path.
 """
 
@@ -330,13 +333,17 @@ class TestPerControlAttributes:
 
     def test_completed_deny_with_reason(self):
         rec = _make_rec(effective_allow=False, reason="PII detected")
-        attrs = _per_control_attributes("pre", rec)
+        # reason is only emitted when CPEX_CONTROL_TELEMETRY_EMIT_REASON=true
+        with patch("mcpgateway.plugins.control_telemetry._emit_reason_enabled", return_value=True):
+            attrs = _per_control_attributes("pre", rec)
         assert attrs["cpex.control.result.allowed"] is False
         assert attrs["cpex.control.result.reason"] == "PII detected"
 
     def test_error_status(self):
         rec = _make_rec(status="error", error_code="PLUGIN_ERROR")
-        attrs = _per_control_attributes("pre", rec)
+        # error_code is only emitted when CPEX_CONTROL_TELEMETRY_EMIT_REASON=true
+        with patch("mcpgateway.plugins.control_telemetry._emit_reason_enabled", return_value=True):
+            attrs = _per_control_attributes("pre", rec)
         assert attrs["cpex.control.status"] == "error"
         assert attrs["cpex.control.result.error_code"] == "PLUGIN_ERROR"
 
@@ -358,9 +365,18 @@ class TestPerControlAttributes:
         assert "cpex.control.result.error_code" not in attrs
         assert "cpex.control.config.keys" not in attrs
 
+    def test_reason_omitted_when_flag_disabled(self):
+        """reason is not emitted when emit_reason=False (default), even when present."""
+        rec = _make_rec(reason="sensitive", error_code="E01")
+        with patch("mcpgateway.plugins.control_telemetry._emit_reason_enabled", return_value=False):
+            attrs = _per_control_attributes("pre", rec)
+        assert "cpex.control.result.reason" not in attrs
+        assert "cpex.control.result.error_code" not in attrs
+
     def test_reason_truncated_to_256(self):
         rec = _make_rec(reason="x" * 300)
-        attrs = _per_control_attributes("pre", rec)
+        with patch("mcpgateway.plugins.control_telemetry._emit_reason_enabled", return_value=True):
+            attrs = _per_control_attributes("pre", rec)
         assert len(attrs["cpex.control.result.reason"].encode("utf-8")) <= 256
 
     def test_config_keys_bounded(self):
@@ -471,8 +487,13 @@ class TestBuildFlattenedAttributes:
         assert "cpex.control.results.pii_guard.status" in flat
         assert flat["cpex.control.results.pii_guard.status"] == "completed"
         assert flat["cpex.control.results.pii_guard.result.allowed"] is True
-        assert flat["cpex.control.results.pii_guard.duration"] == 1000
+        # duration key must use _ns suffix — item 3 fix
+        assert "cpex.control.results.pii_guard.duration_ns" in flat
+        assert flat["cpex.control.results.pii_guard.duration_ns"] == 1000
+        assert "cpex.control.results.pii_guard.duration" not in flat
         assert flat["cpex.control.results.pii_guard.enforcement_point"] == "pre"
+        # name field must be present — item 2 fix
+        assert flat["cpex.control.results.pii_guard.name"] == "pii_guard"
 
     def test_invalid_name_skipped(self):
         """plugin_name with spaces/special chars is dropped from flattening."""
@@ -493,7 +514,8 @@ class TestBuildFlattenedAttributes:
     def test_reason_included_when_present(self):
         acc = ControlTelemetryAccumulator()
         acc._records.append(("pre", _make_rec(plugin_name="pii_guard", reason="PII found")))  # pylint: disable=protected-access
-        flat = _build_flattened_attributes(acc, 32)
+        with patch("mcpgateway.plugins.control_telemetry._emit_reason_enabled", return_value=True):
+            flat = _build_flattened_attributes(acc, 32)
         assert flat.get("cpex.control.results.pii_guard.result.reason") == "PII found"
 
     def test_reason_omitted_when_none(self):
@@ -524,10 +546,11 @@ class TestBuildFlattenedAttributes:
 
 class TestBuildFlattenedAttributesEdgeCases:
     def test_error_code_included_when_present(self):
-        """Line 553: error_code branch emits the error_code attribute."""
+        """error_code branch emits the attribute when emit_reason=True."""
         acc = ControlTelemetryAccumulator()
         acc._records.append(("pre", _make_rec(plugin_name="guard", error_code="TIMEOUT")))  # pylint: disable=protected-access
-        flat = _build_flattened_attributes(acc, 32)
+        with patch("mcpgateway.plugins.control_telemetry._emit_reason_enabled", return_value=True):
+            flat = _build_flattened_attributes(acc, 32)
         assert flat.get("cpex.control.results.guard.result.error_code") == "TIMEOUT"
 
     def test_per_record_exception_is_caught(self):
@@ -551,3 +574,364 @@ class TestBuildFlattenedAttributesEdgeCases:
 
         result = _build_flattened_attributes(ExplodingAcc(), 32)  # type: ignore[arg-type]
         assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Item 2 — artifact fields in _per_control_attributes and flattened projection
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactFieldsInPerControlAttributes:
+    """_per_control_attributes emits cpex.control.artifact.* when the record has them."""
+
+    def test_artifact_name_emitted_when_present(self):
+        rec = _make_rec()
+        rec.artifact_name = "my-artifact"
+        rec.artifact_id = None
+        attrs = _per_control_attributes("pre", rec)
+        assert attrs.get("cpex.control.artifact.name") == "my-artifact"
+        assert "cpex.control.artifact.id" not in attrs
+
+    def test_artifact_id_emitted_when_present(self):
+        rec = _make_rec()
+        rec.artifact_name = None
+        rec.artifact_id = "artifact-123"
+        attrs = _per_control_attributes("pre", rec)
+        assert attrs.get("cpex.control.artifact.id") == "artifact-123"
+        assert "cpex.control.artifact.name" not in attrs
+
+    def test_both_artifact_fields_emitted(self):
+        rec = _make_rec()
+        rec.artifact_name = "svc-a"
+        rec.artifact_id = "id-xyz"
+        attrs = _per_control_attributes("pre", rec)
+        assert attrs["cpex.control.artifact.name"] == "svc-a"
+        assert attrs["cpex.control.artifact.id"] == "id-xyz"
+
+    def test_artifact_fields_absent_when_not_on_record(self):
+        """Records without artifact fields (older CPEX) must not emit artifact attrs."""
+        rec = _make_rec()
+        # Simulate a record that has no artifact_name / artifact_id attributes at all
+        del rec.artifact_name  # MagicMock deletion makes getattr return default
+        del rec.artifact_id
+        attrs = _per_control_attributes("pre", rec)
+        assert "cpex.control.artifact.name" not in attrs
+        assert "cpex.control.artifact.id" not in attrs
+
+    def test_artifact_name_truncated_to_128(self):
+        rec = _make_rec()
+        rec.artifact_name = "x" * 200
+        rec.artifact_id = None
+        attrs = _per_control_attributes("pre", rec)
+        assert len(attrs["cpex.control.artifact.name"].encode("utf-8")) <= 128
+
+
+class TestArtifactFieldsInFlattenedAttributes:
+    """_build_flattened_attributes emits artifact.name/id + config.keys + name fields."""
+
+    def test_artifact_name_in_flattened(self):
+        acc = ControlTelemetryAccumulator()
+        rec = _make_rec(plugin_name="guard")
+        rec.artifact_name = "my-svc"
+        rec.artifact_id = None
+        acc._records.append(("pre", rec))  # pylint: disable=protected-access
+        flat = _build_flattened_attributes(acc, 32)
+        assert flat.get("cpex.control.results.guard.artifact.name") == "my-svc"
+        assert "cpex.control.results.guard.artifact.id" not in flat
+
+    def test_artifact_id_in_flattened(self):
+        acc = ControlTelemetryAccumulator()
+        rec = _make_rec(plugin_name="guard")
+        rec.artifact_name = None
+        rec.artifact_id = "id-42"
+        acc._records.append(("pre", rec))  # pylint: disable=protected-access
+        flat = _build_flattened_attributes(acc, 32)
+        assert flat.get("cpex.control.results.guard.artifact.id") == "id-42"
+
+    def test_config_keys_in_flattened(self):
+        acc = ControlTelemetryAccumulator()
+        rec = _make_rec(plugin_name="guard", config_keys=["key1", "key2"])
+        rec.artifact_name = None
+        rec.artifact_id = None
+        acc._records.append(("pre", rec))  # pylint: disable=protected-access
+        flat = _build_flattened_attributes(acc, 32)
+        assert flat.get("cpex.control.results.guard.config.keys") == "key1,key2"
+
+    def test_name_field_in_flattened(self):
+        acc = ControlTelemetryAccumulator()
+        rec = _make_rec(plugin_name="rate_limit")
+        rec.artifact_name = None
+        rec.artifact_id = None
+        acc._records.append(("pre", rec))  # pylint: disable=protected-access
+        flat = _build_flattened_attributes(acc, 32)
+        assert flat.get("cpex.control.results.rate_limit.name") == "rate_limit"
+
+
+# ---------------------------------------------------------------------------
+# Item 3 — duration_ns key in flattened projection (no bare .duration key)
+# ---------------------------------------------------------------------------
+
+
+class TestFlattenedDurationKey:
+    """Flattened projection must use .duration_ns, never .duration."""
+
+    def test_duration_ns_key_present(self):
+        acc = ControlTelemetryAccumulator()
+        rec = _make_rec(plugin_name="ctrl", duration_ns=9876)
+        rec.artifact_name = None
+        rec.artifact_id = None
+        acc._records.append(("pre", rec))  # pylint: disable=protected-access
+        flat = _build_flattened_attributes(acc, 32)
+        assert flat["cpex.control.results.ctrl.duration_ns"] == 9876
+
+    def test_bare_duration_key_absent(self):
+        acc = ControlTelemetryAccumulator()
+        rec = _make_rec(plugin_name="ctrl")
+        rec.artifact_name = None
+        rec.artifact_id = None
+        acc._records.append(("pre", rec))  # pylint: disable=protected-access
+        flat = _build_flattened_attributes(acc, 32)
+        assert "cpex.control.results.ctrl.duration" not in flat
+
+
+# ---------------------------------------------------------------------------
+# Item 4 — mark_denied() and per-hook truncation counter
+# ---------------------------------------------------------------------------
+
+
+class TestMarkDenied:
+    """mark_denied() sets the correct denial flag without requiring add() to run."""
+
+    def test_mark_denied_pre_sets_pre_denied(self):
+        acc = ControlTelemetryAccumulator()
+        acc.mark_denied(hook="pre")
+        assert acc.pre_denied is True
+        assert acc.post_denied is False
+
+    def test_mark_denied_post_sets_post_denied(self):
+        acc = ControlTelemetryAccumulator()
+        acc.mark_denied(hook="post")
+        assert acc.post_denied is True
+        assert acc.pre_denied is False
+
+    def test_effective_allowed_false_after_pre_deny(self):
+        acc = ControlTelemetryAccumulator()
+        acc.mark_denied(hook="pre")
+        assert acc.effective_allowed is False
+
+    def test_effective_allowed_false_after_post_deny(self):
+        acc = ControlTelemetryAccumulator()
+        acc.mark_denied(hook="post")
+        assert acc.effective_allowed is False
+
+    def test_mark_denied_with_no_records_still_triggers_telemetry(self):
+        """Accumulator with no records but pre_denied=True is non-empty for telemetry gate."""
+        acc = ControlTelemetryAccumulator()
+        acc.mark_denied(hook="pre")
+        # record_control_telemetry gates on: not records AND not pre_denied AND not post_denied
+        assert acc.pre_denied is True  # telemetry will NOT be skipped
+
+    def test_mark_denied_then_add_still_works(self):
+        """mark_denied does not break subsequent add() calls for partial records."""
+        acc = ControlTelemetryAccumulator()
+        acc.mark_denied(hook="pre")
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            result = _make_result([_make_rec(status="completed")])
+            acc.add(result, hook="pre")
+        assert len(acc.records) == 1
+        assert acc.pre_denied is True
+
+    def test_aggregate_result_allowed_false_when_mark_denied(self):
+        """aggregate() must emit cpex.control.result.allowed=False after mark_denied."""
+        acc = ControlTelemetryAccumulator()
+        acc.mark_denied(hook="pre")
+        agg = acc.aggregate()
+        assert agg["cpex.control.result.allowed"] is False
+
+
+class TestPerHookTruncationCounter:
+    """add() must count records dropped at the per-hook cap (_MAX_RECORDS_PER_HOOK=64)."""
+
+    def test_per_hook_overflow_increments_truncated(self):
+        """Records beyond _MAX_RECORDS_PER_HOOK are counted in _truncated."""
+        acc = ControlTelemetryAccumulator()
+        # Build 70 records — 64 allowed per hook, 6 should be truncated
+        records = [_make_rec(plugin_name=f"ctrl{i}") for i in range(70)]
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            result = _make_result(records)
+            acc.add(result, hook="pre")
+        assert len(acc.records) == 64
+        assert acc.truncated == 6
+
+    def test_per_hook_exactly_at_cap_not_truncated(self):
+        """Exactly _MAX_RECORDS_PER_HOOK records — no truncation."""
+        acc = ControlTelemetryAccumulator()
+        records = [_make_rec(plugin_name=f"ctrl{i}") for i in range(64)]
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            acc.add(_make_result(records), hook="pre")
+        assert acc.truncated == 0
+        assert len(acc.records) == 64
+
+    def test_per_call_overflow_also_counted(self):
+        """Records beyond _MAX_RECORDS_PER_CALL are also counted in truncated."""
+        acc = ControlTelemetryAccumulator()
+        # Fill to cap via two hooks of 64 each = 128 accepted, then add more
+        first_batch = [_make_rec(plugin_name=f"pre{i}") for i in range(64)]
+        second_batch = [_make_rec(plugin_name=f"post{i}") for i in range(64)]
+        extra_batch = [_make_rec(plugin_name=f"extra{i}") for i in range(10)]
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            acc.add(_make_result(first_batch), hook="pre")
+            acc.add(_make_result(second_batch), hook="post")
+            acc.add(_make_result(extra_batch), hook="post")
+        assert len(acc.records) == _MAX_RECORDS_PER_CALL
+        assert acc.truncated == 10
+
+
+# ---------------------------------------------------------------------------
+# Item 6/7 — records_received counter in aggregate()
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateRecordsReceived:
+    """aggregate() must emit cpex.control.records_received — total before export cap."""
+
+    def _make_acc(self, n: int, status: str = "completed") -> ControlTelemetryAccumulator:
+        acc = ControlTelemetryAccumulator()
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            for i in range(n):
+                acc.add(_make_result([_make_rec(plugin_name=f"ctrl{i}", status=status)]), hook="pre")
+        return acc
+
+    def test_records_received_equals_accumulated_count(self):
+        acc = self._make_acc(5)
+        agg = acc.aggregate()
+        assert agg["cpex.control.records_received"] == 5
+
+    def test_records_received_zero_when_empty(self):
+        acc = ControlTelemetryAccumulator()
+        agg = acc.aggregate()
+        assert agg["cpex.control.records_received"] == 0
+
+    def test_records_received_includes_skipped_disabled_cancelled(self):
+        """records_received counts ALL accumulated records, including non-active statuses."""
+        acc = ControlTelemetryAccumulator()
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            acc.add(_make_result([
+                _make_rec(plugin_name="a", status="completed"),
+                _make_rec(plugin_name="b", status="skipped"),
+                _make_rec(plugin_name="c", status="disabled"),
+                _make_rec(plugin_name="d", status="cancelled"),
+            ]), hook="pre")
+        agg = acc.aggregate()
+        assert agg["cpex.control.records_received"] == 4
+        # invocation_count only counts active statuses
+        assert agg["cpex.control.invocation_count"] == 1
+
+    def test_results_count_capped_at_max_results(self):
+        """results_count = min(records_received, max_results)."""
+        import mcpgateway.config as cfg_mod  # noqa: PLC0415
+        mock_settings = MagicMock()
+        mock_settings.cpex_control_telemetry_max_results = 3
+        original = cfg_mod.settings
+        try:
+            cfg_mod.settings = mock_settings
+            acc = self._make_acc(10)
+            agg = acc.aggregate()
+        finally:
+            cfg_mod.settings = original
+        assert agg["cpex.control.records_received"] == 10
+        assert agg["cpex.control.results_count"] == 3
+
+    def test_records_received_present_in_aggregate_keys(self):
+        """records_received is always in the aggregate dict."""
+        agg = ControlTelemetryAccumulator().aggregate()
+        assert "cpex.control.records_received" in agg
+
+
+# ---------------------------------------------------------------------------
+# Item 9 — CPEX_CONTROL_TELEMETRY_EMIT_REASON gates reason/error_code
+# ---------------------------------------------------------------------------
+
+
+class TestEmitReasonFlag:
+    """result.reason and result.error_code are only emitted when emit_reason=True."""
+
+    def _attrs_with_reason_flag(self, flag: bool) -> dict:
+        rec = _make_rec(reason="PII found", error_code="DENY_001")
+        import mcpgateway.config as cfg_mod  # noqa: PLC0415
+        mock_settings = MagicMock()
+        mock_settings.cpex_control_telemetry_emit_reason = flag
+        original = cfg_mod.settings
+        try:
+            cfg_mod.settings = mock_settings
+            return _per_control_attributes("pre", rec)
+        finally:
+            cfg_mod.settings = original
+
+    def test_reason_absent_by_default(self):
+        """result.reason must not appear when emit_reason=False (default)."""
+        attrs = self._attrs_with_reason_flag(False)
+        assert "cpex.control.result.reason" not in attrs
+        assert "cpex.control.result.error_code" not in attrs
+
+    def test_reason_present_when_flag_enabled(self):
+        """result.reason and result.error_code appear when emit_reason=True."""
+        attrs = self._attrs_with_reason_flag(True)
+        assert attrs.get("cpex.control.result.reason") == "PII found"
+        assert attrs.get("cpex.control.result.error_code") == "DENY_001"
+
+    def test_reason_absent_from_flattened_by_default(self):
+        """Flattened projection also respects emit_reason=False."""
+        acc = ControlTelemetryAccumulator()
+        rec = _make_rec(plugin_name="guard", reason="sensitive text", error_code="E001")
+        rec.artifact_name = None
+        rec.artifact_id = None
+        acc._records.append(("pre", rec))  # pylint: disable=protected-access
+        import mcpgateway.config as cfg_mod  # noqa: PLC0415
+        mock_settings = MagicMock()
+        mock_settings.cpex_control_telemetry_emit_reason = False
+        original = cfg_mod.settings
+        try:
+            cfg_mod.settings = mock_settings
+            flat = _build_flattened_attributes(acc, 32)
+        finally:
+            cfg_mod.settings = original
+        assert "cpex.control.results.guard.result.reason" not in flat
+        assert "cpex.control.results.guard.result.error_code" not in flat
+
+    def test_reason_present_in_flattened_when_flag_enabled(self):
+        """Flattened projection emits reason/error_code when emit_reason=True."""
+        acc = ControlTelemetryAccumulator()
+        rec = _make_rec(plugin_name="guard", reason="deny reason", error_code="E002")
+        rec.artifact_name = None
+        rec.artifact_id = None
+        acc._records.append(("pre", rec))  # pylint: disable=protected-access
+        import mcpgateway.config as cfg_mod  # noqa: PLC0415
+        mock_settings = MagicMock()
+        mock_settings.cpex_control_telemetry_emit_reason = True
+        original = cfg_mod.settings
+        try:
+            cfg_mod.settings = mock_settings
+            flat = _build_flattened_attributes(acc, 32)
+        finally:
+            cfg_mod.settings = original
+        assert flat.get("cpex.control.results.guard.result.reason") == "deny reason"
+        assert flat.get("cpex.control.results.guard.result.error_code") == "E002"
+
+    def test_emit_reason_enabled_returns_bool(self):
+        """_emit_reason_enabled() always returns a plain bool."""
+        from mcpgateway.plugins.control_telemetry import _emit_reason_enabled  # noqa: PLC0415
+        assert isinstance(_emit_reason_enabled(), bool)
+
+    def test_emit_reason_enabled_default_false(self):
+        """Default value is False when setting is absent."""
+        from mcpgateway.plugins.control_telemetry import _emit_reason_enabled  # noqa: PLC0415
+        import mcpgateway.config as cfg_mod  # noqa: PLC0415
+        mock_settings = MagicMock(spec=[])  # no cpex_control_telemetry_emit_reason attr
+        original = cfg_mod.settings
+        try:
+            cfg_mod.settings = mock_settings
+            result = _emit_reason_enabled()
+        finally:
+            cfg_mod.settings = original
+        assert result is False

--- a/tests/unit/mcpgateway/plugins/test_cpex_compat.py
+++ b/tests/unit/mcpgateway/plugins/test_cpex_compat.py
@@ -10,6 +10,10 @@ SPDX-License-Identifier: Apache-2.0
 import sys
 from unittest.mock import MagicMock, patch
 
+# First-Party
+import mcpgateway.plugins.cpex_compat as cpex_compat_mod
+from mcpgateway.plugins.cpex_compat import execution_records_supported, get_executions
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -18,9 +22,7 @@ from unittest.mock import MagicMock, patch
 
 def _reset_cache():
     """Reset the module-level cache so each test starts clean."""
-    import mcpgateway.plugins.cpex_compat as mod
-
-    mod._EXECUTION_RECORDS_SUPPORTED = None  # pylint: disable=protected-access
+    cpex_compat_mod._EXECUTION_RECORDS_SUPPORTED = None  # pylint: disable=protected-access
 
 
 # ---------------------------------------------------------------------------
@@ -39,23 +41,16 @@ class TestExecutionRecordsSupported:
 
     def test_returns_true_when_cpex_available(self):
         """Returns True when cpex 0.1.2+ is installed (ControlExecutionRecord importable)."""
-        from mcpgateway.plugins.cpex_compat import execution_records_supported
-
-        # cpex 0.1.2 is installed in the venv; import must succeed
         result = execution_records_supported()
         assert result is True
 
     def test_result_is_bool(self):
         """Always returns a plain bool, not a truthy/falsy object."""
-        from mcpgateway.plugins.cpex_compat import execution_records_supported
-
         result = execution_records_supported()
         assert isinstance(result, bool)
 
     def test_result_is_cached(self):
         """Second call returns the cached result without re-importing."""
-        from mcpgateway.plugins.cpex_compat import execution_records_supported
-
         r1 = execution_records_supported()
         r2 = execution_records_supported()
         assert r1 is r2
@@ -63,20 +58,46 @@ class TestExecutionRecordsSupported:
     def test_returns_false_when_import_fails(self):
         """Returns False gracefully when cpex cannot be imported."""
         _reset_cache()
-        with patch.dict(sys.modules, {"cpex.framework": None}):
-            # Force re-evaluation by resetting cache
-            import mcpgateway.plugins.cpex_compat as mod
-
-            mod._EXECUTION_RECORDS_SUPPORTED = None  # pylint: disable=protected-access
-            with patch("builtins.__import__", side_effect=ImportError("cpex not found")):
-                # patch the from-import inside the function
-                pass
-        # After the patch, manually set False to verify behavior
-        import mcpgateway.plugins.cpex_compat as mod
-
-        mod._EXECUTION_RECORDS_SUPPORTED = False  # pylint: disable=protected-access
-        result = mod.execution_records_supported()
+        cpex_compat_mod._EXECUTION_RECORDS_SUPPORTED = False  # pylint: disable=protected-access
+        result = cpex_compat_mod.execution_records_supported()
         assert result is False
+
+
+# ---------------------------------------------------------------------------
+# execution_records_supported — actual ImportError branch (lines 51-52)
+# ---------------------------------------------------------------------------
+
+
+class TestExecutionRecordsSupportedImportError:
+    """Exercises the except ImportError branch by forcing the inner import to fail."""
+
+    def setup_method(self):
+        _reset_cache()
+
+    def teardown_method(self):
+        _reset_cache()
+
+    def test_returns_false_when_cpex_framework_import_error(self):
+        """Lines 51-52: ImportError branch sets cache to False and returns False."""
+        saved = sys.modules.pop("cpex.framework", None)
+        cpex_compat_mod._EXECUTION_RECORDS_SUPPORTED = None  # pylint: disable=protected-access
+        try:
+            original_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__  # type: ignore[attr-defined]
+
+            def _raise_on_cpex(name, *args, **kwargs):
+                if name == "cpex.framework":
+                    raise ImportError("simulated missing cpex")
+                return original_import(name, *args, **kwargs)
+
+            with patch("builtins.__import__", side_effect=_raise_on_cpex):
+                result = cpex_compat_mod.execution_records_supported()
+
+            assert result is False
+            assert cpex_compat_mod._EXECUTION_RECORDS_SUPPORTED is False  # pylint: disable=protected-access
+        finally:
+            if saved is not None:
+                sys.modules["cpex.framework"] = saved
+            _reset_cache()
 
 
 # ---------------------------------------------------------------------------
@@ -89,14 +110,10 @@ class TestGetExecutions:
 
     def test_returns_empty_on_none_result(self):
         """Returns [] when result is None."""
-        from mcpgateway.plugins.cpex_compat import get_executions
-
         assert get_executions(None) == []
 
     def test_returns_list_from_executions_field(self):
         """Returns a list copy of result.executions when present."""
-        from mcpgateway.plugins.cpex_compat import get_executions
-
         rec = MagicMock()
         result = MagicMock()
         result.executions = [rec]
@@ -105,22 +122,17 @@ class TestGetExecutions:
 
     def test_returns_empty_when_executions_field_absent(self):
         """Returns [] when the result object has no executions attribute."""
-        from mcpgateway.plugins.cpex_compat import get_executions
-
         result = MagicMock(spec=[])  # no 'executions' attr
         assert get_executions(result) == []
 
     def test_returns_empty_when_executions_is_none(self):
         """Returns [] when result.executions is None."""
-        from mcpgateway.plugins.cpex_compat import get_executions
-
         result = MagicMock()
         result.executions = None
         assert get_executions(result) == []
 
     def test_returns_empty_on_exception(self):
         """Returns [] without raising when getattr raises unexpectedly."""
-        from mcpgateway.plugins.cpex_compat import get_executions
 
         class Boom:
             @property
@@ -131,8 +143,6 @@ class TestGetExecutions:
 
     def test_returns_new_list_not_same_reference(self):
         """Always returns a new list, not the original executions list."""
-        from mcpgateway.plugins.cpex_compat import get_executions
-
         original = [MagicMock()]
         result = MagicMock()
         result.executions = original
@@ -142,8 +152,6 @@ class TestGetExecutions:
 
     def test_returns_empty_list_when_executions_empty(self):
         """Returns [] when result.executions is an empty list."""
-        from mcpgateway.plugins.cpex_compat import get_executions
-
         result = MagicMock()
         result.executions = []
         assert get_executions(result) == []

--- a/tests/unit/mcpgateway/plugins/test_cpex_compat.py
+++ b/tests/unit/mcpgateway/plugins/test_cpex_compat.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for mcpgateway/plugins/cpex_compat.py.
+
+Location: ./tests/unit/mcpgateway/plugins/test_cpex_compat.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+"""
+
+# Standard
+import sys
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _reset_cache():
+    """Reset the module-level cache so each test starts clean."""
+    import mcpgateway.plugins.cpex_compat as mod
+
+    mod._EXECUTION_RECORDS_SUPPORTED = None  # pylint: disable=protected-access
+
+
+# ---------------------------------------------------------------------------
+# execution_records_supported
+# ---------------------------------------------------------------------------
+
+
+class TestExecutionRecordsSupported:
+    """Tests for execution_records_supported()."""
+
+    def setup_method(self):
+        _reset_cache()
+
+    def teardown_method(self):
+        _reset_cache()
+
+    def test_returns_true_when_cpex_available(self):
+        """Returns True when cpex 0.1.2+ is installed (ControlExecutionRecord importable)."""
+        from mcpgateway.plugins.cpex_compat import execution_records_supported
+
+        # cpex 0.1.2 is installed in the venv; import must succeed
+        result = execution_records_supported()
+        assert result is True
+
+    def test_result_is_bool(self):
+        """Always returns a plain bool, not a truthy/falsy object."""
+        from mcpgateway.plugins.cpex_compat import execution_records_supported
+
+        result = execution_records_supported()
+        assert isinstance(result, bool)
+
+    def test_result_is_cached(self):
+        """Second call returns the cached result without re-importing."""
+        from mcpgateway.plugins.cpex_compat import execution_records_supported
+
+        r1 = execution_records_supported()
+        r2 = execution_records_supported()
+        assert r1 is r2
+
+    def test_returns_false_when_import_fails(self):
+        """Returns False gracefully when cpex cannot be imported."""
+        _reset_cache()
+        with patch.dict(sys.modules, {"cpex.framework": None}):
+            # Force re-evaluation by resetting cache
+            import mcpgateway.plugins.cpex_compat as mod
+
+            mod._EXECUTION_RECORDS_SUPPORTED = None  # pylint: disable=protected-access
+            with patch("builtins.__import__", side_effect=ImportError("cpex not found")):
+                # patch the from-import inside the function
+                pass
+        # After the patch, manually set False to verify behavior
+        import mcpgateway.plugins.cpex_compat as mod
+
+        mod._EXECUTION_RECORDS_SUPPORTED = False  # pylint: disable=protected-access
+        result = mod.execution_records_supported()
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# get_executions
+# ---------------------------------------------------------------------------
+
+
+class TestGetExecutions:
+    """Tests for get_executions()."""
+
+    def test_returns_empty_on_none_result(self):
+        """Returns [] when result is None."""
+        from mcpgateway.plugins.cpex_compat import get_executions
+
+        assert get_executions(None) == []
+
+    def test_returns_list_from_executions_field(self):
+        """Returns a list copy of result.executions when present."""
+        from mcpgateway.plugins.cpex_compat import get_executions
+
+        rec = MagicMock()
+        result = MagicMock()
+        result.executions = [rec]
+        output = get_executions(result)
+        assert output == [rec]
+
+    def test_returns_empty_when_executions_field_absent(self):
+        """Returns [] when the result object has no executions attribute."""
+        from mcpgateway.plugins.cpex_compat import get_executions
+
+        result = MagicMock(spec=[])  # no 'executions' attr
+        assert get_executions(result) == []
+
+    def test_returns_empty_when_executions_is_none(self):
+        """Returns [] when result.executions is None."""
+        from mcpgateway.plugins.cpex_compat import get_executions
+
+        result = MagicMock()
+        result.executions = None
+        assert get_executions(result) == []
+
+    def test_returns_empty_on_exception(self):
+        """Returns [] without raising when getattr raises unexpectedly."""
+        from mcpgateway.plugins.cpex_compat import get_executions
+
+        class Boom:
+            @property
+            def executions(self):
+                raise RuntimeError("unexpected error")
+
+        assert get_executions(Boom()) == []
+
+    def test_returns_new_list_not_same_reference(self):
+        """Always returns a new list, not the original executions list."""
+        from mcpgateway.plugins.cpex_compat import get_executions
+
+        original = [MagicMock()]
+        result = MagicMock()
+        result.executions = original
+        output = get_executions(result)
+        assert output is not original
+        assert output == original
+
+    def test_returns_empty_list_when_executions_empty(self):
+        """Returns [] when result.executions is an empty list."""
+        from mcpgateway.plugins.cpex_compat import get_executions
+
+        result = MagicMock()
+        result.executions = []
+        assert get_executions(result) == []

--- a/tests/unit/mcpgateway/plugins/test_record_control_telemetry.py
+++ b/tests/unit/mcpgateway/plugins/test_record_control_telemetry.py
@@ -153,7 +153,14 @@ class TestRecordControlTelemetryNoop:
 
 class TestRecordControlTelemetryTruncated:
     def test_truncated_attribute_present_when_accumulator_overflowed(self):
-        """Line 260: cpex.control.truncated is added when accumulator.truncated > 0."""
+        """cpex.control.truncated covers all three truncation tiers:
+        - Tier 1/2: records dropped at accumulation time (per-hook/per-call caps).
+        - Tier 3: records dropped at export time (cpex_control_telemetry_max_results cap).
+
+        With _MAX_RECORDS_PER_CALL=128 records accumulated and max_results=32 (default),
+        tier-1/2 drops = 2 (130 pushed, 128 accepted), tier-3 drops = 96 (128 - 32).
+        Total truncated = 98.
+        """
         from mcpgateway.plugins.control_telemetry import _MAX_RECORDS_PER_CALL  # noqa: PLC0415
 
         acc = ControlTelemetryAccumulator()
@@ -164,7 +171,8 @@ class TestRecordControlTelemetryTruncated:
                 r.continue_processing = True
                 acc.add(r, hook="pre")
 
-        assert acc.truncated == 2
+        # Tier-1/2 drops only at this point (export cap not yet applied)
+        assert acc._truncated == 2  # pylint: disable=protected-access
         captured: dict = {}
 
         def capture_db(service, trace_id, aggregate, accumulator):
@@ -177,7 +185,10 @@ class TestRecordControlTelemetryTruncated:
         ):
             record_control_telemetry("trace-trunc", acc)
 
-        assert captured.get("cpex.control.truncated") == 2
+        # After record_control_telemetry(): tier-3 export-cap drops (128 - 32 = 96) added.
+        # Total: 2 (tier-1/2) + 96 (tier-3) = 98
+        assert captured.get("cpex.control.truncated") == 98
+        assert acc.truncated == 98
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/plugins/test_record_control_telemetry.py
+++ b/tests/unit/mcpgateway/plugins/test_record_control_telemetry.py
@@ -650,3 +650,119 @@ class TestObservabilityServiceAPICompatibility:
         params = sig.parameters
         assert "commit" in params, "ObservabilityService.end_span missing 'commit' kwarg"
         assert "obs_db" in params, "ObservabilityService.end_span missing 'obs_db' kwarg"
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — wildcard insertion order preserved in apply_attribute_mapping cache
+# ---------------------------------------------------------------------------
+
+
+class TestWildcardInsertionOrderPreserved:
+    """apply_attribute_mapping() must respect insertion order for wildcard rule precedence."""
+
+    def test_first_wildcard_wins_over_later_wildcard(self):
+        """When two wildcard rules match the same key, the first declared rule must win."""
+        attrs = {"x.a": 1}
+        mapping = {
+            "x.*": "first.*",   # declared first — should win
+            "*.a": "second.*",  # declared second — must NOT win
+        }
+        result = apply_attribute_mapping(attrs, mapping)
+        # "x.*" matches "x.a" (captures "a") → "first.a"
+        assert "first.a" in result, (
+            f"Expected first declared wildcard rule to win, got keys: {list(result)}"
+        )
+        assert "second.x" not in result, "Second wildcard rule must not override first"
+
+    def test_reversed_order_changes_result(self):
+        """Reversing the rule order must change which rule wins — proving order is preserved."""
+        attrs = {"x.a": 1}
+        mapping_first_wins = {"x.*": "first.*", "*.a": "second.*"}
+        mapping_second_wins = {"*.a": "second.*", "x.*": "first.*"}
+        result_first = apply_attribute_mapping(attrs, mapping_first_wins)
+        result_second = apply_attribute_mapping(attrs, mapping_second_wins)
+        # Results must differ to prove order is actually preserved
+        assert list(result_first.keys()) != list(result_second.keys()), (
+            "Reversing rule order should change which wildcard fires first"
+        )
+
+    def test_exact_rule_still_beats_all_wildcards(self):
+        """Exact rules take precedence regardless of insertion order."""
+        attrs = {"x.a": 1}
+        mapping = {
+            "*.a": "wildcard_first.*",  # wildcard declared before exact
+            "x.a": "exact_dest",        # exact declared after wildcard
+        }
+        result = apply_attribute_mapping(attrs, mapping)
+        assert "exact_dest" in result
+        assert "wildcard_first.x" not in result
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — config_keys joined cap is byte-aware via _safe_str
+# ---------------------------------------------------------------------------
+
+
+class TestConfigKeysByteCapAware:
+    """config_keys joined cap must be byte-aware (not char-based) for multibyte keys."""
+
+    def _make_rec_with_keys(self, keys):
+        """Build a minimal ControlExecutionRecord mock with the given config_keys."""
+        from unittest.mock import MagicMock  # noqa: PLC0415
+        rec = MagicMock()
+        rec.plugin_name = "guard"
+        rec.plugin_id = "g-001"
+        rec.plugin_kind = "builtin"
+        rec.hook_name = "tool_pre_invoke"
+        rec.mode = "sequential"
+        rec.status = "completed"
+        rec.effective_allow = True
+        rec.requested_allow = None
+        rec.matched = True
+        rec.applied = False
+        rec.payload_modified = False
+        rec.duration_ns = 1000
+        rec.reason = None
+        rec.error_code = None
+        rec.config_keys = keys
+        rec.artifact_name = None
+        rec.artifact_id = None
+        return rec
+
+    def test_multibyte_key_does_not_exceed_byte_budget(self):
+        """A joined config_keys string with multibyte chars must not exceed _MAX_CONFIG_KEYS_JOINED_LEN bytes."""
+        from mcpgateway.plugins.control_telemetry import _MAX_CONFIG_KEYS_JOINED_LEN, _per_control_attributes  # noqa: PLC0415
+        import mcpgateway.config as cfg_mod_local  # noqa: PLC0415
+        # Use a key with multibyte chars (each '日' is 3 UTF-8 bytes)
+        multibyte_key = "日" * 40  # 40 chars, 120 bytes — under per-key 128-byte limit
+        keys = [multibyte_key] * 100  # many keys to trigger the joined cap
+        rec = self._make_rec_with_keys(keys)
+        mock_settings = MagicMock()
+        mock_settings.cpex_control_telemetry_emit_reason = False
+        original = cfg_mod_local.settings
+        try:
+            cfg_mod_local.settings = mock_settings
+            attrs = _per_control_attributes("pre", rec)
+        finally:
+            cfg_mod_local.settings = original
+        joined = attrs.get("cpex.control.config.keys", "")
+        # The byte length of the result must not exceed the cap
+        assert len(joined.encode("utf-8")) <= _MAX_CONFIG_KEYS_JOINED_LEN, (
+            f"config.keys byte length {len(joined.encode('utf-8'))} exceeds budget {_MAX_CONFIG_KEYS_JOINED_LEN}"
+        )
+
+    def test_ascii_keys_still_work(self):
+        """ASCII-only config_keys must be unaffected by the byte-aware cap."""
+        from mcpgateway.plugins.control_telemetry import _per_control_attributes  # noqa: PLC0415
+        import mcpgateway.config as cfg_mod_local  # noqa: PLC0415
+        keys = ["key_one", "key_two", "key_three"]
+        rec = self._make_rec_with_keys(keys)
+        mock_settings = MagicMock()
+        mock_settings.cpex_control_telemetry_emit_reason = False
+        original = cfg_mod_local.settings
+        try:
+            cfg_mod_local.settings = mock_settings
+            attrs = _per_control_attributes("pre", rec)
+        finally:
+            cfg_mod_local.settings = original
+        assert attrs.get("cpex.control.config.keys") == "key_one,key_two,key_three"

--- a/tests/unit/mcpgateway/plugins/test_record_control_telemetry.py
+++ b/tests/unit/mcpgateway/plugins/test_record_control_telemetry.py
@@ -98,6 +98,23 @@ def _acc_pre_denied():
     return acc
 
 
+def _enabled_settings(**kwargs):
+    """Build a MagicMock settings object with CPEX control telemetry enabled.
+
+    Merges any extra kwargs so individual tests can override specific fields.
+    """
+    s = MagicMock()
+    s.cpex_control_telemetry_enabled = True
+    s.cpex_control_telemetry_db_enabled = True
+    s.cpex_control_telemetry_flatten_results = False
+    s.cpex_control_telemetry_max_results = 32
+    s.cpex_control_telemetry_emit_reason = False
+    s.cpex_control_telemetry_emit_agent_id = False
+    for k, v in kwargs.items():
+        setattr(s, k, v)
+    return s
+
+
 # ---------------------------------------------------------------------------
 # record_control_telemetry — no-op scenarios
 # ---------------------------------------------------------------------------
@@ -178,12 +195,17 @@ class TestRecordControlTelemetryTruncated:
         def capture_db(service, trace_id, aggregate, accumulator):
             captured.update(aggregate)
 
-        with (
-            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
-            patch("mcpgateway.plugins.control_telemetry._emit_db_spans", side_effect=capture_db),
-            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
-        ):
-            record_control_telemetry("trace-trunc", acc)
+        original = cfg_mod.settings
+        try:
+            cfg_mod.settings = _enabled_settings()
+            with (
+                patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+                patch("mcpgateway.plugins.control_telemetry._emit_db_spans", side_effect=capture_db),
+                patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+            ):
+                record_control_telemetry("trace-trunc", acc)
+        finally:
+            cfg_mod.settings = original
 
         # After record_control_telemetry(): tier-3 export-cap drops (128 - 32 = 96) added.
         # Total: 2 (tier-1/2) + 96 (tier-3) = 98
@@ -239,46 +261,66 @@ class TestRecordControlTelemetryDB:
     def test_writes_summary_span_to_db(self):
         """DB sink is invoked when there are execution records."""
         acc = _acc_with_pre_records([_make_rec()])
-        with (
-            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
-            patch("mcpgateway.plugins.control_telemetry._emit_db_spans") as mock_db,
-            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
-        ):
-            record_control_telemetry("trace-123", acc, tool_name="my_tool")
-        mock_db.assert_called_once()
+        original = cfg_mod.settings
+        try:
+            cfg_mod.settings = _enabled_settings()
+            with (
+                patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+                patch("mcpgateway.plugins.control_telemetry._emit_db_spans") as mock_db,
+                patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+            ):
+                record_control_telemetry("trace-123", acc, tool_name="my_tool")
+            mock_db.assert_called_once()
+        finally:
+            cfg_mod.settings = original
 
     def test_writes_per_control_spans(self):
         """DB sink receives the accumulator with multiple records."""
         acc = _acc_with_pre_records([_make_rec(plugin_name="ctrl1"), _make_rec(plugin_name="ctrl2")])
-        with (
-            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
-            patch("mcpgateway.plugins.control_telemetry._emit_db_spans") as mock_db,
-            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
-        ):
-            record_control_telemetry("trace-123", acc)
-        mock_db.assert_called_once()
-        call_args = mock_db.call_args[0]
-        assert len(call_args[3].records) == 2
+        original = cfg_mod.settings
+        try:
+            cfg_mod.settings = _enabled_settings()
+            with (
+                patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+                patch("mcpgateway.plugins.control_telemetry._emit_db_spans") as mock_db,
+                patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+            ):
+                record_control_telemetry("trace-123", acc)
+            mock_db.assert_called_once()
+            call_args = mock_db.call_args[0]
+            assert len(call_args[3].records) == 2
+        finally:
+            cfg_mod.settings = original
 
     def test_db_failure_does_not_raise(self):
         """_emit_db_spans raising must not propagate into the request path."""
         acc = _acc_with_pre_records([_make_rec()])
-        with (
-            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
-            patch("mcpgateway.plugins.control_telemetry._emit_db_spans", side_effect=RuntimeError("DB is down")),
-            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
-        ):
-            record_control_telemetry("trace-123", acc)
+        original = cfg_mod.settings
+        try:
+            cfg_mod.settings = _enabled_settings()
+            with (
+                patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+                patch("mcpgateway.plugins.control_telemetry._emit_db_spans", side_effect=RuntimeError("DB is down")),
+                patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+            ):
+                record_control_telemetry("trace-123", acc)
+        finally:
+            cfg_mod.settings = original
 
     def test_otel_failure_does_not_raise(self):
         """_emit_otel_spans raising must not propagate."""
         acc = _acc_with_pre_records([_make_rec()])
-        with (
-            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
-            patch("mcpgateway.plugins.control_telemetry._emit_db_spans"),
-            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans", side_effect=RuntimeError("OTel explode")),
-        ):
-            record_control_telemetry("trace-123", acc)
+        original = cfg_mod.settings
+        try:
+            cfg_mod.settings = _enabled_settings()
+            with (
+                patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+                patch("mcpgateway.plugins.control_telemetry._emit_db_spans"),
+                patch("mcpgateway.plugins.control_telemetry._emit_otel_spans", side_effect=RuntimeError("OTel explode")),
+            ):
+                record_control_telemetry("trace-123", acc)
+        finally:
+            cfg_mod.settings = original
 
     def test_pre_deny_summary_has_result_allowed_false(self):
         """When pre-hook was denied, aggregate result.allowed must be False."""
@@ -288,12 +330,17 @@ class TestRecordControlTelemetryDB:
         def capture_db(service, trace_id, aggregate, accumulator):
             captured_aggregate.update(aggregate)
 
-        with (
-            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
-            patch("mcpgateway.plugins.control_telemetry._emit_db_spans", side_effect=capture_db),
-            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
-        ):
-            record_control_telemetry("trace-123", acc)
+        original = cfg_mod.settings
+        try:
+            cfg_mod.settings = _enabled_settings()
+            with (
+                patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+                patch("mcpgateway.plugins.control_telemetry._emit_db_spans", side_effect=capture_db),
+                patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+            ):
+                record_control_telemetry("trace-123", acc)
+        finally:
+            cfg_mod.settings = original
         assert captured_aggregate.get("cpex.control.result.allowed") is False
 
     def test_tool_name_in_attributes(self):
@@ -304,12 +351,17 @@ class TestRecordControlTelemetryDB:
         def capture_db(service, trace_id, aggregate, accumulator):
             captured.update(aggregate)
 
-        with (
-            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
-            patch("mcpgateway.plugins.control_telemetry._emit_db_spans", side_effect=capture_db),
-            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
-        ):
-            record_control_telemetry("trace-123", acc, tool_name="my_tool")
+        original = cfg_mod.settings
+        try:
+            cfg_mod.settings = _enabled_settings()
+            with (
+                patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+                patch("mcpgateway.plugins.control_telemetry._emit_db_spans", side_effect=capture_db),
+                patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+            ):
+                record_control_telemetry("trace-123", acc, tool_name="my_tool")
+        finally:
+            cfg_mod.settings = original
         assert captured.get("cpex.control.tool.name") == "my_tool"
 
     def test_capped_at_max_results(self):
@@ -320,13 +372,18 @@ class TestRecordControlTelemetryDB:
         def capture_db(service, trace_id, aggregate, accumulator):
             call_count_tracker.append(len(accumulator.records))
 
-        with (
-            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
-            patch("mcpgateway.plugins.control_telemetry._emit_db_spans", side_effect=capture_db),
-            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
-            patch("mcpgateway.plugins.control_telemetry._get_max_results", return_value=3),
-        ):
-            record_control_telemetry("trace-123", acc)
+        original = cfg_mod.settings
+        try:
+            cfg_mod.settings = _enabled_settings()
+            with (
+                patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+                patch("mcpgateway.plugins.control_telemetry._emit_db_spans", side_effect=capture_db),
+                patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+                patch("mcpgateway.plugins.control_telemetry._get_max_results", return_value=3),
+            ):
+                record_control_telemetry("trace-123", acc)
+        finally:
+            cfg_mod.settings = original
         assert call_count_tracker[0] == 10  # accumulator has all 10
 
 

--- a/tests/unit/mcpgateway/plugins/test_record_control_telemetry.py
+++ b/tests/unit/mcpgateway/plugins/test_record_control_telemetry.py
@@ -11,10 +11,27 @@ cap, and concurrency isolation.
 """
 
 # Standard
+import inspect
 from unittest.mock import MagicMock, patch
 
 # Third-Party
 import pytest
+
+# First-Party
+import mcpgateway.config as cfg_mod
+from mcpgateway.plugins.control_telemetry import (
+    ControlTelemetryAccumulator,
+    _emit_db_spans,
+    _emit_otel_spans,
+    _per_control_attributes,
+    record_control_telemetry,
+)
+from mcpgateway.plugins.utils import (
+    _compile_wildcard_rule,
+    apply_attribute_mapping,
+    compile_attribute_policy,
+)
+from mcpgateway.services.observability_service import ObservabilityService
 
 
 # ---------------------------------------------------------------------------
@@ -53,8 +70,6 @@ def _make_rec(
 
 def _acc_with_pre_records(recs):
     """Build a ControlTelemetryAccumulator with pre-hook records."""
-    from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
     acc = ControlTelemetryAccumulator()
     with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
         result = MagicMock()
@@ -66,8 +81,6 @@ def _acc_with_pre_records(recs):
 
 def _acc_pre_denied():
     """Build an accumulator where pre-hook was denied (no records)."""
-    from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
     acc = ControlTelemetryAccumulator()
     with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
         result = MagicMock()
@@ -84,18 +97,13 @@ def _acc_pre_denied():
 
 class TestRecordControlTelemetryNoop:
     def test_noop_when_no_trace_id(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, record_control_telemetry
-
         acc = ControlTelemetryAccumulator()
-        # Should not raise and not attempt any DB/OTel write
         with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
             with patch("mcpgateway.plugins.control_telemetry._emit_db_spans") as mock_db:
                 record_control_telemetry(None, acc)
                 mock_db.assert_not_called()
 
     def test_noop_when_cpex_records_unavailable(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, record_control_telemetry
-
         acc = ControlTelemetryAccumulator()
         with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=False):
             with patch("mcpgateway.plugins.control_telemetry._emit_db_spans") as mock_db:
@@ -103,8 +111,6 @@ class TestRecordControlTelemetryNoop:
                 mock_db.assert_not_called()
 
     def test_noop_when_accumulator_empty_and_not_denied(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, record_control_telemetry
-
         acc = ControlTelemetryAccumulator()
         with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
             with patch("mcpgateway.plugins.control_telemetry._emit_db_spans") as mock_db:
@@ -113,11 +119,7 @@ class TestRecordControlTelemetryNoop:
 
     def test_noop_when_feature_disabled(self):
         """Feature flag CPEX_CONTROL_TELEMETRY_ENABLED=false skips all emission."""
-        from mcpgateway.plugins.control_telemetry import record_control_telemetry
-
         acc = _acc_with_pre_records([_make_rec()])
-
-        # Patch settings with cpex_control_telemetry_enabled=False inside the lazy import
         mock_settings = MagicMock()
         mock_settings.cpex_control_telemetry_enabled = False
         mock_settings.cpex_control_telemetry_db_enabled = True
@@ -127,23 +129,84 @@ class TestRecordControlTelemetryNoop:
             patch("mcpgateway.plugins.control_telemetry._emit_db_spans") as mock_db,
             patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
         ):
-            # Patch the lazy import of settings inside the function
-            with patch("mcpgateway.plugins.control_telemetry.record_control_telemetry"):
-                # Simulate the feature-flag guard by calling the real implementation
-                # with patched settings; we verify _emit_db_spans is NOT called.
-                pass
-
-            # Call with feature disabled: settings loaded lazily — patch via sys.modules
-            import mcpgateway.config as cfg_mod  # noqa: PLC0415
-
             original_settings = cfg_mod.settings
             try:
                 cfg_mod.settings = mock_settings
                 record_control_telemetry("trace-1", acc)
             finally:
                 cfg_mod.settings = original_settings
-
             mock_db.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# record_control_telemetry — truncated flag (line 260)
+# ---------------------------------------------------------------------------
+
+
+class TestRecordControlTelemetryTruncated:
+    def test_truncated_attribute_present_when_accumulator_overflowed(self):
+        """Line 260: cpex.control.truncated is added when accumulator.truncated > 0."""
+        from mcpgateway.plugins.control_telemetry import _MAX_RECORDS_PER_CALL  # noqa: PLC0415
+
+        acc = ControlTelemetryAccumulator()
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            for i in range(_MAX_RECORDS_PER_CALL + 2):
+                r = MagicMock()
+                r.executions = [_make_rec(plugin_name=f"p{i}")]
+                r.continue_processing = True
+                acc.add(r, hook="pre")
+
+        assert acc.truncated == 2
+        captured: dict = {}
+
+        def capture_db(service, trace_id, aggregate, accumulator):
+            captured.update(aggregate)
+
+        with (
+            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+            patch("mcpgateway.plugins.control_telemetry._emit_db_spans", side_effect=capture_db),
+            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+        ):
+            record_control_telemetry("trace-trunc", acc)
+
+        assert captured.get("cpex.control.truncated") == 2
+
+
+# ---------------------------------------------------------------------------
+# record_control_telemetry — flatten_results branch (lines 267-268)
+# ---------------------------------------------------------------------------
+
+
+class TestRecordControlTelemetryFlatten:
+    def test_flatten_results_attributes_added_when_enabled(self):
+        """Lines 267-268: flattened attributes are merged into aggregate when enabled."""
+        acc = _acc_with_pre_records([_make_rec(plugin_name="pii_filter")])
+        mock_settings = MagicMock()
+        mock_settings.cpex_control_telemetry_enabled = True
+        mock_settings.cpex_control_telemetry_db_enabled = True
+        mock_settings.cpex_control_telemetry_flatten_results = True
+        mock_settings.cpex_control_telemetry_max_results = 32
+        captured: dict = {}
+
+        def capture_db(service, trace_id, aggregate, accumulator):
+            captured.update(aggregate)
+
+        original = cfg_mod.settings
+        try:
+            cfg_mod.settings = mock_settings
+            with (
+                patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+                patch("mcpgateway.plugins.control_telemetry._emit_db_spans", side_effect=capture_db),
+                patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+            ):
+                record_control_telemetry("trace-flat", acc)
+        finally:
+            cfg_mod.settings = original
+
+        # At least the base aggregate key must be present; flattened keys start with cpex.control.results.
+        assert any(k.startswith("cpex.control.results.") for k in captured), (
+            f"Expected flattened keys in aggregate, got: {list(captured)}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -152,70 +215,45 @@ class TestRecordControlTelemetryNoop:
 
 
 class TestRecordControlTelemetryDB:
-    """Tests that the DB sink helper is called correctly.
-
-    ObservabilityService and SessionLocal are imported lazily inside
-    record_control_telemetry() / _emit_db_spans(), so we patch the
-    functions themselves via the control_telemetry module rather than
-    trying to patch the lazily-imported classes.
-    """
+    """Tests that the DB sink helper is called correctly."""
 
     def test_writes_summary_span_to_db(self):
         """DB sink is invoked when there are execution records."""
-        from mcpgateway.plugins.control_telemetry import record_control_telemetry
-
         acc = _acc_with_pre_records([_make_rec()])
-
         with (
             patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
             patch("mcpgateway.plugins.control_telemetry._emit_db_spans") as mock_db,
             patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
         ):
             record_control_telemetry("trace-123", acc, tool_name="my_tool")
-
         mock_db.assert_called_once()
-        # First positional arg is service, second is trace_id, third is aggregate dict
-        assert mock_db.call_count == 1
 
     def test_writes_per_control_spans(self):
         """DB sink receives the accumulator with multiple records."""
-        from mcpgateway.plugins.control_telemetry import record_control_telemetry
-
         acc = _acc_with_pre_records([_make_rec(plugin_name="ctrl1"), _make_rec(plugin_name="ctrl2")])
-
         with (
             patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
             patch("mcpgateway.plugins.control_telemetry._emit_db_spans") as mock_db,
             patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
         ):
             record_control_telemetry("trace-123", acc)
-
         mock_db.assert_called_once()
-        # accumulator (4th positional arg) should have 2 records
         call_args = mock_db.call_args[0]
-        accumulator_arg = call_args[3]
-        assert len(accumulator_arg.records) == 2
+        assert len(call_args[3].records) == 2
 
     def test_db_failure_does_not_raise(self):
         """_emit_db_spans raising must not propagate into the request path."""
-        from mcpgateway.plugins.control_telemetry import record_control_telemetry
-
         acc = _acc_with_pre_records([_make_rec()])
-
         with (
             patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
             patch("mcpgateway.plugins.control_telemetry._emit_db_spans", side_effect=RuntimeError("DB is down")),
             patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
         ):
-            # Must not raise
             record_control_telemetry("trace-123", acc)
 
     def test_otel_failure_does_not_raise(self):
         """_emit_otel_spans raising must not propagate."""
-        from mcpgateway.plugins.control_telemetry import record_control_telemetry
-
         acc = _acc_with_pre_records([_make_rec()])
-
         with (
             patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
             patch("mcpgateway.plugins.control_telemetry._emit_db_spans"),
@@ -225,8 +263,6 @@ class TestRecordControlTelemetryDB:
 
     def test_pre_deny_summary_has_result_allowed_false(self):
         """When pre-hook was denied, aggregate result.allowed must be False."""
-        from mcpgateway.plugins.control_telemetry import record_control_telemetry
-
         acc = _acc_pre_denied()
         captured_aggregate: dict = {}
 
@@ -239,13 +275,10 @@ class TestRecordControlTelemetryDB:
             patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
         ):
             record_control_telemetry("trace-123", acc)
-
         assert captured_aggregate.get("cpex.control.result.allowed") is False
 
     def test_tool_name_in_attributes(self):
         """tool_name appears in the aggregate attributes."""
-        from mcpgateway.plugins.control_telemetry import record_control_telemetry
-
         acc = _acc_with_pre_records([_make_rec()])
         captured: dict = {}
 
@@ -258,18 +291,14 @@ class TestRecordControlTelemetryDB:
             patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
         ):
             record_control_telemetry("trace-123", acc, tool_name="my_tool")
-
         assert captured.get("cpex.control.tool.name") == "my_tool"
 
     def test_capped_at_max_results(self):
         """record_control_telemetry respects _get_max_results cap on per-control spans."""
-        from mcpgateway.plugins.control_telemetry import record_control_telemetry
-
         acc = _acc_with_pre_records([_make_rec(plugin_name=f"ctrl{i}") for i in range(10)])
         call_count_tracker: list = []
 
         def capture_db(service, trace_id, aggregate, accumulator):
-            # Count how many records the accumulator presents
             call_count_tracker.append(len(accumulator.records))
 
         with (
@@ -279,9 +308,87 @@ class TestRecordControlTelemetryDB:
             patch("mcpgateway.plugins.control_telemetry._get_max_results", return_value=3),
         ):
             record_control_telemetry("trace-123", acc)
-
-        # _emit_db_spans was called once with the full accumulator (capping happens inside)
         assert call_count_tracker[0] == 10  # accumulator has all 10
+
+
+# ---------------------------------------------------------------------------
+# _emit_db_spans — exception paths (lines 327, 342-348, 353-354)
+# ---------------------------------------------------------------------------
+
+
+class TestEmitDbSpansExceptionPaths:
+    def test_empty_attrs_record_is_skipped(self):
+        """Line 327: record whose _per_control_attributes returns {} is skipped (continue)."""
+        acc = ControlTelemetryAccumulator()
+        # Inject a record that will produce empty attrs
+        acc._records.append(("pre", MagicMock(spec=[])))  # pylint: disable=protected-access
+
+        with (
+            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+        ):
+            # Must not raise; the bad record is silently skipped
+            record_control_telemetry("trace-skip", acc)
+
+    def test_db_exception_triggers_rollback(self):
+        """Lines 342-348: start_span raising triggers rollback in the except block."""
+        acc = _acc_with_pre_records([_make_rec()])
+        mock_db = MagicMock()
+        mock_service = MagicMock()
+        mock_service.start_span.side_effect = RuntimeError("DB write failed")
+
+        # SessionLocal is a lazy import inside _emit_db_spans from mcpgateway.db
+        with patch("mcpgateway.db.SessionLocal", return_value=mock_db):
+            _emit_db_spans(mock_service, "trace-rollback", {}, acc)
+
+        mock_db.rollback.assert_called_once()
+        mock_db.close.assert_called_once()
+
+    def test_db_close_exception_in_finally_is_swallowed(self):
+        """Lines 353-354: db.close() raising in the finally block must not propagate."""
+        acc = _acc_with_pre_records([_make_rec()])
+        mock_db = MagicMock()
+        mock_db.close.side_effect = RuntimeError("close failed")
+        mock_service = MagicMock()
+        mock_service.start_span.return_value = "span-id-1"
+
+        with patch("mcpgateway.db.SessionLocal", return_value=mock_db):
+            # Must not raise despite close() failing
+            _emit_db_spans(mock_service, "trace-close", {}, acc)
+
+
+# ---------------------------------------------------------------------------
+# _emit_otel_spans — active OTel context path (lines 379-387)
+# ---------------------------------------------------------------------------
+
+
+class TestEmitOtelSpansActivePath:
+    def test_emits_spans_when_otel_active(self):
+        """Lines 379-387: OTel spans are emitted when tracing is enabled and context is active."""
+        acc = _acc_with_pre_records([_make_rec(plugin_name="pii_filter")])
+        spans_created: list = []
+
+        class _FakeSpan:
+            def __init__(self, name, attrs):
+                spans_created.append(name)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        with (
+            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+            patch("mcpgateway.plugins.control_telemetry._emit_db_spans"),
+            patch("mcpgateway.observability.otel_tracing_enabled", return_value=True),
+            patch("mcpgateway.observability.otel_context_active", return_value=True),
+            patch("mcpgateway.observability.create_span", side_effect=_FakeSpan),
+        ):
+            _emit_otel_spans({"cpex.control.type": "tool"}, acc)
+
+        assert "cpex.control.summary" in spans_created
+        assert "cpex.control.result" in spans_created
 
 
 # ---------------------------------------------------------------------------
@@ -292,8 +399,6 @@ class TestRecordControlTelemetryDB:
 class TestRecordControlTelemetryRemoveAttributes:
     def test_remove_attributes_applied(self):
         """cpex.control.config.keys is present when config_keys are provided."""
-        from mcpgateway.plugins.control_telemetry import _per_control_attributes
-
         rec = _make_rec(config_keys=["timeout_ms", "max_size"])
         attrs = _per_control_attributes("pre", rec)
         assert "cpex.control.config.keys" in attrs
@@ -301,22 +406,18 @@ class TestRecordControlTelemetryRemoveAttributes:
 
 
 # ---------------------------------------------------------------------------
-# Wildcard rules in apply_attribute_mapping
+# Wildcard rules in apply_attribute_mapping / compile_attribute_policy
 # ---------------------------------------------------------------------------
 
 
 class TestWildcardAttributeMapping:
     def test_exact_rename(self):
-        from mcpgateway.plugins.utils import apply_attribute_mapping
-
         attrs = {"cpex.control.result.allowed": True, "other": "val"}
         result = apply_attribute_mapping(attrs, {"cpex.control.result.allowed": "controls.result.allow"})
         assert "controls.result.allow" in result
         assert "cpex.control.result.allowed" not in result
 
     def test_wildcard_rename(self):
-        from mcpgateway.plugins.utils import apply_attribute_mapping
-
         attrs = {"cpex.control.results.pii.result.allowed": True}
         result = apply_attribute_mapping(
             attrs,
@@ -326,8 +427,6 @@ class TestWildcardAttributeMapping:
         assert "cpex.control.results.pii.result.allowed" not in result
 
     def test_exact_takes_precedence_over_wildcard(self):
-        from mcpgateway.plugins.utils import apply_attribute_mapping
-
         attrs = {"cpex.control.results.pii.result.allowed": True}
         result = apply_attribute_mapping(
             attrs,
@@ -339,37 +438,75 @@ class TestWildcardAttributeMapping:
         assert "exact.dest" in result
 
     def test_otel_destination_rejected(self):
-        from mcpgateway.plugins.utils import compile_attribute_policy
-
         with pytest.raises(ValueError, match="otel"):
             compile_attribute_policy({"cpex.control.result.allowed": "otel.reserved"}, [])
 
     def test_empty_source_rejected(self):
-        from mcpgateway.plugins.utils import compile_attribute_policy
-
         with pytest.raises(ValueError):
             compile_attribute_policy({"": "dest"}, [])
 
-    def test_wildcard_compile_matches_single_segment(self):
-        from mcpgateway.plugins.utils import _compile_wildcard_rule
+    def test_key_exceeding_256_chars_rejected(self):
+        """Line 535: mapping key > 256 chars raises ValueError."""
+        long_key = "a" * 257
+        with pytest.raises(ValueError, match="exceeds 256"):
+            compile_attribute_policy({long_key: "dest"}, [])
 
+    def test_removal_wildcard_compiled(self):
+        """Lines 547-549: wildcard removal rule is compiled correctly."""
+        _, removals = compile_attribute_policy({}, ["cpex.control.results.*.reason"])
+        assert len(removals) == 1
+        is_exact, pattern, src = removals[0]
+        assert not is_exact
+        assert pattern is not None
+        assert src == "cpex.control.results.*.reason"
+
+    def test_removal_exact_compiled(self):
+        """Line 551: exact removal rule (no wildcard) is compiled correctly."""
+        _, removals = compile_attribute_policy({}, ["cpex.control.type"])
+        assert len(removals) == 1
+        is_exact, pattern, src = removals[0]
+        assert is_exact
+        assert pattern is None
+
+    def test_removal_key_exceeding_256_chars_rejected(self):
+        """Line 546: removal key > 256 chars raises ValueError."""
+        with pytest.raises(ValueError, match="exceeds 256"):
+            compile_attribute_policy({}, ["b" * 257])
+
+    def test_wildcard_compile_matches_single_segment(self):
         p = _compile_wildcard_rule("cpex.control.results.*.result.reason")
         assert p.fullmatch("cpex.control.results.pii-guard.result.reason") is not None
         assert p.fullmatch("cpex.control.results.pii.guard.result.reason") is None
 
     def test_wildcard_compile_no_match_multiple_segments(self):
-        from mcpgateway.plugins.utils import _compile_wildcard_rule
-
         p = _compile_wildcard_rule("cpex.control.results.*.reason")
         assert p.fullmatch("cpex.control.results.a.b.reason") is None
 
     def test_no_mapping_returns_copy(self):
-        from mcpgateway.plugins.utils import apply_attribute_mapping
-
         attrs = {"a": 1, "b": 2}
         result = apply_attribute_mapping(attrs, {})
         assert result == attrs
         assert result is not attrs
+
+    def test_mismatched_wildcard_count_in_src_dst_skips(self):
+        """Line 593: src has 1 wildcard, dst has 2 — mismatch is silently skipped."""
+        attrs = {"cpex.control.results.pii.result.reason": "x"}
+        # src has 1 '*', dst has 2 '*' — mismatched, key returned unchanged
+        result = apply_attribute_mapping(
+            attrs,
+            {"cpex.control.results.*.result.reason": "new.*.result.*.reason"},
+        )
+        # Key must still be present (unchanged or renamed); must not raise
+        assert len(result) == 1
+
+    def test_apply_attribute_mapping_valueerror_fallback(self):
+        """Lines 657, 659-660: ValueError from compile falls back to exact-only matching."""
+        attrs = {"cpex.control.result.allowed": True, "other": "val"}
+        # otel.* destination triggers ValueError inside compile_attribute_policy
+        # apply_attribute_mapping catches it and falls back to exact matching
+        result = apply_attribute_mapping(attrs, {"cpex.control.result.allowed": "otel.reserved"})
+        # Fallback uses exact match — key is renamed despite the reserved namespace
+        assert "otel.reserved" in result or "cpex.control.result.allowed" in result
 
 
 # ---------------------------------------------------------------------------
@@ -379,8 +516,6 @@ class TestWildcardAttributeMapping:
 
 class TestConcurrencyIsolation:
     def test_two_accumulators_are_independent(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc1 = ControlTelemetryAccumulator()
         acc2 = ControlTelemetryAccumulator()
 
@@ -400,8 +535,6 @@ class TestConcurrencyIsolation:
         assert acc1.records[0][1].plugin_name == "alpha"
 
     def test_adding_to_one_does_not_affect_other(self):
-        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
-
         acc1 = ControlTelemetryAccumulator()
         acc2 = ControlTelemetryAccumulator()
 
@@ -424,30 +557,18 @@ class TestConcurrencyIsolation:
 class TestObservabilityServiceAPICompatibility:
     """Verify that ObservabilityService.start_span and end_span accept the
     ``commit`` and ``obs_db`` kwargs that _emit_db_spans relies on.
-
-    This is a compile-time/import-time guard: if a future refactor removes
-    these parameters the test fails loudly rather than silently swallowing
-    the error inside control_telemetry's best-effort catch-all.
     """
 
     def test_start_span_accepts_commit_and_obs_db_kwargs(self):
         """start_span signature must include commit and obs_db parameters."""
-        import inspect
-
-        from mcpgateway.services.observability_service import ObservabilityService
-
         sig = inspect.signature(ObservabilityService.start_span)
         params = sig.parameters
-        assert "commit" in params, "ObservabilityService.start_span missing 'commit' kwarg — _emit_db_spans will silently fail"
-        assert "obs_db" in params, "ObservabilityService.start_span missing 'obs_db' kwarg — _emit_db_spans will silently fail"
+        assert "commit" in params, "ObservabilityService.start_span missing 'commit' kwarg"
+        assert "obs_db" in params, "ObservabilityService.start_span missing 'obs_db' kwarg"
 
     def test_end_span_accepts_commit_and_obs_db_kwargs(self):
         """end_span signature must include commit and obs_db parameters."""
-        import inspect
-
-        from mcpgateway.services.observability_service import ObservabilityService
-
         sig = inspect.signature(ObservabilityService.end_span)
         params = sig.parameters
-        assert "commit" in params, "ObservabilityService.end_span missing 'commit' kwarg — _emit_db_spans will silently fail"
-        assert "obs_db" in params, "ObservabilityService.end_span missing 'obs_db' kwarg — _emit_db_spans will silently fail"
+        assert "commit" in params, "ObservabilityService.end_span missing 'commit' kwarg"
+        assert "obs_db" in params, "ObservabilityService.end_span missing 'obs_db' kwarg"

--- a/tests/unit/mcpgateway/plugins/test_record_control_telemetry.py
+++ b/tests/unit/mcpgateway/plugins/test_record_control_telemetry.py
@@ -42,12 +42,16 @@ from mcpgateway.services.observability_service import ObservabilityService
 def _make_rec(
     *,
     plugin_name: str = "pii-guard",
+    plugin_id: str = "pii-guard-001",
+    plugin_kind: str = "builtin",
     hook_name: str = "tool_pre_invoke",
     mode: str = "sequential",
     status: str = "completed",
     effective_allow: bool = True,
+    requested_allow: object = None,
     matched: object = True,
     applied: bool = False,
+    payload_modified: bool = False,
     duration_ns: int = 500,
     reason: object = None,
     error_code: object = None,
@@ -55,12 +59,16 @@ def _make_rec(
 ) -> MagicMock:
     rec = MagicMock()
     rec.plugin_name = plugin_name
+    rec.plugin_id = plugin_id
+    rec.plugin_kind = plugin_kind
     rec.hook_name = hook_name
     rec.mode = mode
     rec.status = status
     rec.effective_allow = effective_allow
+    rec.requested_allow = requested_allow
     rec.matched = matched
     rec.applied = applied
+    rec.payload_modified = payload_modified
     rec.duration_ns = duration_ns
     rec.reason = reason
     rec.error_code = error_code
@@ -500,13 +508,15 @@ class TestWildcardAttributeMapping:
         assert len(result) == 1
 
     def test_apply_attribute_mapping_valueerror_fallback(self):
-        """Lines 657, 659-660: ValueError from compile falls back to exact-only matching."""
+        """Lines 657-660: ValueError from compile_attribute_policy → fail-closed, attrs unchanged."""
         attrs = {"cpex.control.result.allowed": True, "other": "val"}
-        # otel.* destination triggers ValueError inside compile_attribute_policy
-        # apply_attribute_mapping catches it and falls back to exact matching
+        # otel.* destination triggers ValueError inside compile_attribute_policy.
+        # After the fix: apply_attribute_mapping returns attrs unchanged (fail-closed).
         result = apply_attribute_mapping(attrs, {"cpex.control.result.allowed": "otel.reserved"})
-        # Fallback uses exact match — key is renamed despite the reserved namespace
-        assert "otel.reserved" in result or "cpex.control.result.allowed" in result
+        # Fail-closed: original keys preserved, otel.reserved must NOT appear
+        assert "cpex.control.result.allowed" in result
+        assert "otel.reserved" not in result
+        assert result["cpex.control.result.allowed"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/plugins/test_record_control_telemetry.py
+++ b/tests/unit/mcpgateway/plugins/test_record_control_telemetry.py
@@ -1,0 +1,453 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for record_control_telemetry() and related helpers.
+
+Location: ./tests/unit/mcpgateway/plugins/test_record_control_telemetry.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Tests ``record_control_telemetry()`` end-to-end through the two sinks
+(DB + OTel), including no-op cases, attribute mapping, removal, max-results
+cap, and concurrency isolation.
+"""
+
+# Standard
+from unittest.mock import MagicMock, patch
+
+# Third-Party
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_rec(
+    *,
+    plugin_name: str = "pii-guard",
+    hook_name: str = "tool_pre_invoke",
+    mode: str = "sequential",
+    status: str = "completed",
+    effective_allow: bool = True,
+    matched: object = True,
+    applied: bool = False,
+    duration_ns: int = 500,
+    reason: object = None,
+    error_code: object = None,
+    config_keys: list = None,
+) -> MagicMock:
+    rec = MagicMock()
+    rec.plugin_name = plugin_name
+    rec.hook_name = hook_name
+    rec.mode = mode
+    rec.status = status
+    rec.effective_allow = effective_allow
+    rec.matched = matched
+    rec.applied = applied
+    rec.duration_ns = duration_ns
+    rec.reason = reason
+    rec.error_code = error_code
+    rec.config_keys = config_keys or []
+    return rec
+
+
+def _acc_with_pre_records(recs):
+    """Build a ControlTelemetryAccumulator with pre-hook records."""
+    from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+    acc = ControlTelemetryAccumulator()
+    with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+        result = MagicMock()
+        result.executions = recs
+        result.continue_processing = True
+        acc.add(result, hook="pre")
+    return acc
+
+
+def _acc_pre_denied():
+    """Build an accumulator where pre-hook was denied (no records)."""
+    from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+    acc = ControlTelemetryAccumulator()
+    with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+        result = MagicMock()
+        result.executions = []
+        result.continue_processing = False
+        acc.add(result, hook="pre")
+    return acc
+
+
+# ---------------------------------------------------------------------------
+# record_control_telemetry — no-op scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestRecordControlTelemetryNoop:
+    def test_noop_when_no_trace_id(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, record_control_telemetry
+
+        acc = ControlTelemetryAccumulator()
+        # Should not raise and not attempt any DB/OTel write
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            with patch("mcpgateway.plugins.control_telemetry._emit_db_spans") as mock_db:
+                record_control_telemetry(None, acc)
+                mock_db.assert_not_called()
+
+    def test_noop_when_cpex_records_unavailable(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, record_control_telemetry
+
+        acc = ControlTelemetryAccumulator()
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=False):
+            with patch("mcpgateway.plugins.control_telemetry._emit_db_spans") as mock_db:
+                record_control_telemetry("trace-1", acc)
+                mock_db.assert_not_called()
+
+    def test_noop_when_accumulator_empty_and_not_denied(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, record_control_telemetry
+
+        acc = ControlTelemetryAccumulator()
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            with patch("mcpgateway.plugins.control_telemetry._emit_db_spans") as mock_db:
+                record_control_telemetry("trace-1", acc)
+                mock_db.assert_not_called()
+
+    def test_noop_when_feature_disabled(self):
+        """Feature flag CPEX_CONTROL_TELEMETRY_ENABLED=false skips all emission."""
+        from mcpgateway.plugins.control_telemetry import record_control_telemetry
+
+        acc = _acc_with_pre_records([_make_rec()])
+
+        # Patch settings with cpex_control_telemetry_enabled=False inside the lazy import
+        mock_settings = MagicMock()
+        mock_settings.cpex_control_telemetry_enabled = False
+        mock_settings.cpex_control_telemetry_db_enabled = True
+
+        with (
+            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+            patch("mcpgateway.plugins.control_telemetry._emit_db_spans") as mock_db,
+            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+        ):
+            # Patch the lazy import of settings inside the function
+            with patch("mcpgateway.plugins.control_telemetry.record_control_telemetry"):
+                # Simulate the feature-flag guard by calling the real implementation
+                # with patched settings; we verify _emit_db_spans is NOT called.
+                pass
+
+            # Call with feature disabled: settings loaded lazily — patch via sys.modules
+            import mcpgateway.config as cfg_mod  # noqa: PLC0415
+
+            original_settings = cfg_mod.settings
+            try:
+                cfg_mod.settings = mock_settings
+                record_control_telemetry("trace-1", acc)
+            finally:
+                cfg_mod.settings = original_settings
+
+            mock_db.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# record_control_telemetry — writes to DB sink
+# ---------------------------------------------------------------------------
+
+
+class TestRecordControlTelemetryDB:
+    """Tests that the DB sink helper is called correctly.
+
+    ObservabilityService and SessionLocal are imported lazily inside
+    record_control_telemetry() / _emit_db_spans(), so we patch the
+    functions themselves via the control_telemetry module rather than
+    trying to patch the lazily-imported classes.
+    """
+
+    def test_writes_summary_span_to_db(self):
+        """DB sink is invoked when there are execution records."""
+        from mcpgateway.plugins.control_telemetry import record_control_telemetry
+
+        acc = _acc_with_pre_records([_make_rec()])
+
+        with (
+            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+            patch("mcpgateway.plugins.control_telemetry._emit_db_spans") as mock_db,
+            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+        ):
+            record_control_telemetry("trace-123", acc, tool_name="my_tool")
+
+        mock_db.assert_called_once()
+        # First positional arg is service, second is trace_id, third is aggregate dict
+        assert mock_db.call_count == 1
+
+    def test_writes_per_control_spans(self):
+        """DB sink receives the accumulator with multiple records."""
+        from mcpgateway.plugins.control_telemetry import record_control_telemetry
+
+        acc = _acc_with_pre_records([_make_rec(plugin_name="ctrl1"), _make_rec(plugin_name="ctrl2")])
+
+        with (
+            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+            patch("mcpgateway.plugins.control_telemetry._emit_db_spans") as mock_db,
+            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+        ):
+            record_control_telemetry("trace-123", acc)
+
+        mock_db.assert_called_once()
+        # accumulator (4th positional arg) should have 2 records
+        call_args = mock_db.call_args[0]
+        accumulator_arg = call_args[3]
+        assert len(accumulator_arg.records) == 2
+
+    def test_db_failure_does_not_raise(self):
+        """_emit_db_spans raising must not propagate into the request path."""
+        from mcpgateway.plugins.control_telemetry import record_control_telemetry
+
+        acc = _acc_with_pre_records([_make_rec()])
+
+        with (
+            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+            patch("mcpgateway.plugins.control_telemetry._emit_db_spans", side_effect=RuntimeError("DB is down")),
+            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+        ):
+            # Must not raise
+            record_control_telemetry("trace-123", acc)
+
+    def test_otel_failure_does_not_raise(self):
+        """_emit_otel_spans raising must not propagate."""
+        from mcpgateway.plugins.control_telemetry import record_control_telemetry
+
+        acc = _acc_with_pre_records([_make_rec()])
+
+        with (
+            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+            patch("mcpgateway.plugins.control_telemetry._emit_db_spans"),
+            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans", side_effect=RuntimeError("OTel explode")),
+        ):
+            record_control_telemetry("trace-123", acc)
+
+    def test_pre_deny_summary_has_result_allowed_false(self):
+        """When pre-hook was denied, aggregate result.allowed must be False."""
+        from mcpgateway.plugins.control_telemetry import record_control_telemetry
+
+        acc = _acc_pre_denied()
+        captured_aggregate: dict = {}
+
+        def capture_db(service, trace_id, aggregate, accumulator):
+            captured_aggregate.update(aggregate)
+
+        with (
+            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+            patch("mcpgateway.plugins.control_telemetry._emit_db_spans", side_effect=capture_db),
+            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+        ):
+            record_control_telemetry("trace-123", acc)
+
+        assert captured_aggregate.get("cpex.control.result.allowed") is False
+
+    def test_tool_name_in_attributes(self):
+        """tool_name appears in the aggregate attributes."""
+        from mcpgateway.plugins.control_telemetry import record_control_telemetry
+
+        acc = _acc_with_pre_records([_make_rec()])
+        captured: dict = {}
+
+        def capture_db(service, trace_id, aggregate, accumulator):
+            captured.update(aggregate)
+
+        with (
+            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+            patch("mcpgateway.plugins.control_telemetry._emit_db_spans", side_effect=capture_db),
+            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+        ):
+            record_control_telemetry("trace-123", acc, tool_name="my_tool")
+
+        assert captured.get("cpex.control.tool.name") == "my_tool"
+
+    def test_capped_at_max_results(self):
+        """record_control_telemetry respects _get_max_results cap on per-control spans."""
+        from mcpgateway.plugins.control_telemetry import record_control_telemetry
+
+        acc = _acc_with_pre_records([_make_rec(plugin_name=f"ctrl{i}") for i in range(10)])
+        call_count_tracker: list = []
+
+        def capture_db(service, trace_id, aggregate, accumulator):
+            # Count how many records the accumulator presents
+            call_count_tracker.append(len(accumulator.records))
+
+        with (
+            patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True),
+            patch("mcpgateway.plugins.control_telemetry._emit_db_spans", side_effect=capture_db),
+            patch("mcpgateway.plugins.control_telemetry._emit_otel_spans"),
+            patch("mcpgateway.plugins.control_telemetry._get_max_results", return_value=3),
+        ):
+            record_control_telemetry("trace-123", acc)
+
+        # _emit_db_spans was called once with the full accumulator (capping happens inside)
+        assert call_count_tracker[0] == 10  # accumulator has all 10
+
+
+# ---------------------------------------------------------------------------
+# Attribute policy — remove_attributes
+# ---------------------------------------------------------------------------
+
+
+class TestRecordControlTelemetryRemoveAttributes:
+    def test_remove_attributes_applied(self):
+        """cpex.control.config.keys is present when config_keys are provided."""
+        from mcpgateway.plugins.control_telemetry import _per_control_attributes
+
+        rec = _make_rec(config_keys=["timeout_ms", "max_size"])
+        attrs = _per_control_attributes("pre", rec)
+        assert "cpex.control.config.keys" in attrs
+        assert "timeout_ms" in attrs["cpex.control.config.keys"]
+
+
+# ---------------------------------------------------------------------------
+# Wildcard rules in apply_attribute_mapping
+# ---------------------------------------------------------------------------
+
+
+class TestWildcardAttributeMapping:
+    def test_exact_rename(self):
+        from mcpgateway.plugins.utils import apply_attribute_mapping
+
+        attrs = {"cpex.control.result.allowed": True, "other": "val"}
+        result = apply_attribute_mapping(attrs, {"cpex.control.result.allowed": "controls.result.allow"})
+        assert "controls.result.allow" in result
+        assert "cpex.control.result.allowed" not in result
+
+    def test_wildcard_rename(self):
+        from mcpgateway.plugins.utils import apply_attribute_mapping
+
+        attrs = {"cpex.control.results.pii.result.allowed": True}
+        result = apply_attribute_mapping(
+            attrs,
+            {"cpex.control.results.*.result.allowed": "controls.results.*.result.allowed"},
+        )
+        assert "controls.results.pii.result.allowed" in result
+        assert "cpex.control.results.pii.result.allowed" not in result
+
+    def test_exact_takes_precedence_over_wildcard(self):
+        from mcpgateway.plugins.utils import apply_attribute_mapping
+
+        attrs = {"cpex.control.results.pii.result.allowed": True}
+        result = apply_attribute_mapping(
+            attrs,
+            {
+                "cpex.control.results.pii.result.allowed": "exact.dest",
+                "cpex.control.results.*.result.allowed": "wildcard.dest.*.result.allowed",
+            },
+        )
+        assert "exact.dest" in result
+
+    def test_otel_destination_rejected(self):
+        from mcpgateway.plugins.utils import compile_attribute_policy
+
+        with pytest.raises(ValueError, match="otel"):
+            compile_attribute_policy({"cpex.control.result.allowed": "otel.reserved"}, [])
+
+    def test_empty_source_rejected(self):
+        from mcpgateway.plugins.utils import compile_attribute_policy
+
+        with pytest.raises(ValueError):
+            compile_attribute_policy({"": "dest"}, [])
+
+    def test_wildcard_compile_matches_single_segment(self):
+        from mcpgateway.plugins.utils import _compile_wildcard_rule
+
+        p = _compile_wildcard_rule("cpex.control.results.*.result.reason")
+        assert p.fullmatch("cpex.control.results.pii-guard.result.reason") is not None
+        assert p.fullmatch("cpex.control.results.pii.guard.result.reason") is None
+
+    def test_wildcard_compile_no_match_multiple_segments(self):
+        from mcpgateway.plugins.utils import _compile_wildcard_rule
+
+        p = _compile_wildcard_rule("cpex.control.results.*.reason")
+        assert p.fullmatch("cpex.control.results.a.b.reason") is None
+
+    def test_no_mapping_returns_copy(self):
+        from mcpgateway.plugins.utils import apply_attribute_mapping
+
+        attrs = {"a": 1, "b": 2}
+        result = apply_attribute_mapping(attrs, {})
+        assert result == attrs
+        assert result is not attrs
+
+
+# ---------------------------------------------------------------------------
+# Concurrency isolation
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrencyIsolation:
+    def test_two_accumulators_are_independent(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc1 = ControlTelemetryAccumulator()
+        acc2 = ControlTelemetryAccumulator()
+
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            r1 = MagicMock()
+            r1.executions = [_make_rec(plugin_name="alpha")]
+            r1.continue_processing = True
+            acc1.add(r1, hook="pre")
+
+            r2 = MagicMock()
+            r2.executions = [_make_rec(plugin_name="beta"), _make_rec(plugin_name="gamma")]
+            r2.continue_processing = True
+            acc2.add(r2, hook="post")
+
+        assert len(acc1.records) == 1
+        assert len(acc2.records) == 2
+        assert acc1.records[0][1].plugin_name == "alpha"
+
+    def test_adding_to_one_does_not_affect_other(self):
+        from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator
+
+        acc1 = ControlTelemetryAccumulator()
+        acc2 = ControlTelemetryAccumulator()
+
+        with patch("mcpgateway.plugins.control_telemetry.execution_records_supported", return_value=True):
+            r = MagicMock()
+            r.executions = [_make_rec()]
+            r.continue_processing = False
+            acc1.add(r, hook="pre")
+
+        assert acc1.pre_denied is True
+        assert acc2.pre_denied is False
+        assert acc2.records == []
+
+
+# ---------------------------------------------------------------------------
+# ObservabilityService API compatibility smoke test (F4)
+# ---------------------------------------------------------------------------
+
+
+class TestObservabilityServiceAPICompatibility:
+    """Verify that ObservabilityService.start_span and end_span accept the
+    ``commit`` and ``obs_db`` kwargs that _emit_db_spans relies on.
+
+    This is a compile-time/import-time guard: if a future refactor removes
+    these parameters the test fails loudly rather than silently swallowing
+    the error inside control_telemetry's best-effort catch-all.
+    """
+
+    def test_start_span_accepts_commit_and_obs_db_kwargs(self):
+        """start_span signature must include commit and obs_db parameters."""
+        import inspect
+
+        from mcpgateway.services.observability_service import ObservabilityService
+
+        sig = inspect.signature(ObservabilityService.start_span)
+        params = sig.parameters
+        assert "commit" in params, "ObservabilityService.start_span missing 'commit' kwarg — _emit_db_spans will silently fail"
+        assert "obs_db" in params, "ObservabilityService.start_span missing 'obs_db' kwarg — _emit_db_spans will silently fail"
+
+    def test_end_span_accepts_commit_and_obs_db_kwargs(self):
+        """end_span signature must include commit and obs_db parameters."""
+        import inspect
+
+        from mcpgateway.services.observability_service import ObservabilityService
+
+        sig = inspect.signature(ObservabilityService.end_span)
+        params = sig.parameters
+        assert "commit" in params, "ObservabilityService.end_span missing 'commit' kwarg — _emit_db_spans will silently fail"
+        assert "obs_db" in params, "ObservabilityService.end_span missing 'obs_db' kwarg — _emit_db_spans will silently fail"

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ exclude-newer-span = "P10D"
 [options.exclude-newer-package]
 langchain-core = "2026-07-27T23:59:59Z"
 sse-starlette = "2026-07-27T23:59:59Z"
-cpex = "2026-07-27T23:59:59Z"
+cpex = "2026-07-30T23:59:59Z"
 cpex-retry-with-backoff = "2026-07-27T23:59:59Z"
 grpcio-tools = "2026-07-27T23:59:59Z"
 cpex-pii-filter = "2026-07-27T23:59:59Z"
@@ -942,7 +942,7 @@ toml = [
 
 [[package]]
 name = "cpex"
-version = "0.1.1"
+version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastapi" },
@@ -960,9 +960,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/d5/f3961c8492e20c7f8988a5f041452ffae876878eb0e60a9c121be42e20c5/cpex-0.1.1.tar.gz", hash = "sha256:64ddfda6239f975bc5c0fa841e036e660ac478eb42f03225f7d3fe205680e049", size = 4658279, upload-time = "2026-06-04T19:00:52.486Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/f2/2a32438da74096a17bd317eb90b8661e5aa50861b32fe84ad04c93ff11a3/cpex-0.1.2.tar.gz", hash = "sha256:668e439ec32b46d5b7360312c63b081f9ff04a094e0ea7fe00ace43396e791f1", size = 2381420, upload-time = "2026-07-30T03:08:25.808Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/a7/a3f4f37291ba266a138dc72918a9d570fef68ccecb1397cb25d8307f9bb1/cpex-0.1.1-py3-none-any.whl", hash = "sha256:4b0c753979a8c52b0e5eea2269e67328ea96d3bef477da3f3ec200ff297bcddc", size = 272528, upload-time = "2026-06-04T19:00:50.721Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/51/98c3974d23526d8e6dfd3d2dbf8bf1d62cfe6a80b3da62bc166b71d886e8/cpex-0.1.2-py3-none-any.whl", hash = "sha256:6c6b354a51ba4f9bcc187369e4f635bb367715df0c041aa487777d352996fc99", size = 277592, upload-time = "2026-07-30T03:08:24.234Z" },
 ]
 
 [[package]]
@@ -3203,7 +3203,7 @@ requires-dist = [
     { name = "brotli", specifier = ">=1.2.0" },
     { name = "click", specifier = ">=8.4.2" },
     { name = "cookiecutter", marker = "extra == 'templating'", specifier = ">=2.7.1" },
-    { name = "cpex", specifier = ">=0.1.1" },
+    { name = "cpex", specifier = ">=0.1.2" },
     { name = "cpex-encoded-exfil-detection", marker = "extra == 'plugins'", specifier = ">=0.3.6" },
     { name = "cpex-pii-filter", marker = "extra == 'plugins'", specifier = ">=0.3.6" },
     { name = "cpex-rate-limiter", marker = "extra == 'plugins'", specifier = ">=0.1.7" },


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #5785

---

## 📝 Summary

Adds structured per-plugin enforcement observability on every tool invocation by consuming `ControlExecutionRecord` objects emitted by the CPEX framework (≥ 0.1.2).

On each traced `invoke_tool()` call the gateway now writes two new span types into `observability_spans` (and, when active, the OTel SDK sink):

- **`cpex.control.summary`** — one per tool call. Carries aggregate counters (`invocation_count`, `matched_count`, `applied_count`, `error_count`, `timeout_count`, `duration`), the overall `result.allowed` outcome, the `enforcement_point` tag, and calling identity (`tool.name`, `agent.id`, `binding.name`).
- **`cpex.control.result`** — one per plugin evaluated, nested under the summary span. Carries the per-plugin `name`, `hook_name`, `mode`, `status`, `result.allowed`, `duration`, and optional `result.reason`, `result.error_code`, and `config.keys` (key names only, never values).

All fields come from **trusted CPEX framework sources** (`ControlExecutionRecord`), never from untrusted plugin metadata. The feature is a complete no-op on CPEX < 0.1.2.

**Files changed:**

| File | Change |
|---|---|
| `mcpgateway/plugins/control_telemetry.py` | New — `ControlTelemetryAccumulator` + `record_control_telemetry()` + DB/OTel sinks |
| `mcpgateway/plugins/cpex_compat.py` | New — CPEX version feature-detection helpers |
| `mcpgateway/plugins/utils.py` | Wildcard-aware attribute policy: `compile_attribute_policy()`, `apply_attribute_mapping()` |
| `mcpgateway/services/tool_service.py` | Accumulator wired at all 5 pre/post hook sites and all 4 exit paths |
| `mcpgateway/config.py` | 5 new `CPEX_CONTROL_TELEMETRY_*` settings |
| `pyproject.toml` / `uv.lock` | `cpex>=0.1.2`; `exclude-newer-package` cutoff advanced |
| `.env.example` | New `CPEX_CONTROL_TELEMETRY_*` section with descriptions |
| `CHANGELOG.md` | Entry under `[Unreleased] → Added` |
| `tests/unit/…/test_cpex_compat.py` | 11 unit tests |
| `tests/unit/…/test_control_telemetry.py` | 47 unit tests |
| `tests/unit/…/test_record_control_telemetry.py` | 24 integration tests |
| `tests/e2e/test_otel_control_telemetry_e2e.py` | 7 E2E tests (real gateway + PIIFilter + in-memory SQLite) |

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Lint suite | `make ruff` | ✅ All clear |
| Unit tests (new files only) | `python -m pytest tests/unit/mcpgateway/plugins/test_cpex_compat.py tests/unit/mcpgateway/plugins/test_control_telemetry.py tests/unit/mcpgateway/plugins/test_record_control_telemetry.py -v` | ✅ 82/82 passed |
| E2E — DB spans present in real traced request | `OBSERVABILITY_ENABLED=true PLUGINS_ENABLED=true python -m pytest tests/e2e/test_otel_control_telemetry_e2e.py -v` | ✅ 5 passed, 2 skipped¹ |
| Full plugin unit suite | `python -m pytest tests/unit/mcpgateway/plugins/ -v` | ✅ 720 passed, 33 skipped |
| Observability service tests | `python -m pytest tests/unit/mcpgateway/services/test_observability_service.py -v` | ✅ 92/92 passed |

¹ The 2 OTel-SDK tests skip cleanly when `opentelemetry-sdk` (the `observability` extra) is absent — this is expected and documented in the test fixture.

### Manual validation

Ran an in-memory SQLite gateway with PIIFilter active (via `test_otel_control_telemetry_e2e.py::test_control_summary_span_present_in_db`) and verified via DB query that a traced `tools/call` request writes:
- One `cpex.control.summary` span with `cpex.control.invocation_count`, `cpex.control.result.allowed`, `cpex.control.tool.name` attributes
- One `cpex.control.result` span per plugin evaluated, with `cpex.control.name`, `cpex.control.status`, `cpex.control.result.allowed`, `cpex.control.enforcement_point`, and `parent_span_id` linking it to the summary span

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

### Known items (not blockers, documented for reviewer awareness)

1. **Phase 5 attribute policy not yet wired** — `compile_attribute_policy()` / `apply_attribute_mapping()` infrastructure is built and tested (see `mcpgateway/plugins/utils.py` lines 481–669 and `test_record_control_telemetry.py::TestWildcardAttributeMapping`), but `record_control_telemetry()` does not yet read `SpanAttributeCustomizer` plugin context state (`span_attribute_mapping` / `remove_span_attributes`) before emitting, so the wildcard rename/drop rules are ready but not consumed. Planned follow-on for Phase 5 wiring (same pattern as `start_span()` at `observability_service.py:520`).

2. **`cpex_control_telemetry_max_attributes` is informational only** — Not enforced gateway-side. Intended as a hint for external OTel-collector attribute-limit configuration (e.g. `transform/attributes` processor). The `config.py` description explicitly calls this out.

3. **OTel-SDK E2E tests skip in standard dev venv** — The 2 tests requiring `opentelemetry-sdk` (`observability` optional extra) skip cleanly when the package is absent. This is expected; the DB-side E2E tests (which are the primary verification gate) pass unconditionally.

4. **`_EXECUTION_RECORDS_SUPPORTED` cache is idempotent but has no mutex** — `cpex_compat.py:45` writes to the module-global cache without a `threading.Lock`. The write is idempotent (both concurrent writers set it to the same value) so there is no correctness risk — just a theoretical double-import race on the very first call from two threads. Low-priority follow-on.

### Architecture decisions

- **Best-effort telemetry (L4)**: `record_control_telemetry()` never raises into the request path; all exceptions are caught and logged at debug level. This mirrors `record_plugin_metrics()` in `utils.py`.
- **Separate DB sessions**: `_emit_db_spans()` opens its own `SessionLocal()` (issue #3883 pattern) so observability writes persist even when the main request fails.
- **Explicit per-control child spans rather than inlined plugin metadata**: Control-execution records are **trusted** CPEX framework output (sourced from framework-internal `PluginRef` config), not **untrusted** plugin-returned metadata. Recording them as first-class spans with a fixed schema makes queries/dashboards simpler and avoids the deny-by-default field-name allowlist required by plugin metadata (see `utils.py` `_SAFE_STRING_FIELD_NAMES` / `_SAFE_NUMERIC_FIELD_NAMES`).
- **Flattened attributes off by default**: `CPEX_CONTROL_TELEMETRY_FLATTEN_RESULTS=false` (default). Enabled only when downstream tooling requires dynamic key names; the fixed-schema `cpex.control.result` child spans remain the source of truth.

### Commits

- `370db9e11` feat: consume Cpex control execution records