### PR TITLE
fix(resources): proxy non-text templated resource reads (#5883)

### DIFF
--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -3978,7 +3978,6 @@ class ResourceService(BaseService):
         Raises:
             ResourceNotFoundError: If no matching template is found.
             ResourceError: For other template resolution errors.
-            NotImplementedError: If a binary template resource is encountered.
         """
         # Find matching template # DRT BREAKPOINT
         template = None
@@ -4010,14 +4009,19 @@ class ResourceService(BaseService):
             raise ResourceNotFoundError(f"No template matches URI: {uri}")
 
         try:
-            # Extract parameters
+            # Extract parameters and expand the concrete URI.
+            # The expanded URI is returned as placeholder text so read_resource()
+            # can proxy the concrete read to the template's owning upstream via
+            # invoke_resource() for any MIME type (not only text/*). See #5883.
             params = self._extract_template_params(uri, template.uri_template)
-            # Generate content
-            if template.mime_type and template.mime_type.startswith("text/"):
-                content = template.uri_template.format(**params)
-                return ResourceContent(type="resource", id=str(template.id) or None, uri=template.uri_template or None, mime_type=template.mime_type or None, text=content)
-            # # Handle binary template
-            raise NotImplementedError("Binary resource templates not yet supported")
+            concrete_uri = template.uri_template.format(**params)
+            return ResourceContent(
+                type="resource",
+                id=str(template.id) or None,
+                uri=template.uri_template or None,
+                mime_type=template.mime_type or None,
+                text=concrete_uri,
+            )
 
         except ResourceNotFoundError:
             raise

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -1934,13 +1934,14 @@ class TestResourceTemplates:
             assert "Failed to process template" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_read_template_resource_binary_not_supported(self):
-        """Test that binary template raises ResourceError with wrapped message."""
+    async def test_read_template_resource_non_text_mime_returns_placeholder(self):
+        """Non-text/* templates return a concrete URI placeholder for gateway proxy (#5883)."""
         # Third-Party
         from sqlalchemy.orm import Session
 
         # First-Party
-        from mcpgateway.services.resource_service import ResourceError, ResourceService
+        from mcpgateway.common.models import ResourceContent
+        from mcpgateway.services.resource_service import ResourceService
 
         # Arrange
         db = MagicMock(spec=Session)
@@ -1951,7 +1952,7 @@ class TestResourceTemplates:
         service = ResourceService()
         uri = "test://template/123"
 
-        # Binary MIME template
+        # Non-text MIME template (e.g. application/json federation templates)
         template = MagicMock()
         template.id = "39334ce0ed2644d79ede8913a66930c9"  # pragma: allowlist secret
         template.uri_template = "test://template/{id}"
@@ -1961,11 +1962,13 @@ class TestResourceTemplates:
         service._template_cache = {"binary": template}
 
         with patch.object(service, "_uri_matches_template", return_value=True), patch.object(service, "_extract_template_params", return_value={"id": "123"}):
-            with pytest.raises(ResourceError) as exc_info:
-                await service._read_template_resource(db, uri)
+            out = await service._read_template_resource(db, uri)
 
-            msg = str(exc_info.value)
-            assert "Failed to process template: Binary resource templates not yet supported" in msg
+        assert isinstance(out, ResourceContent)
+        assert out.id == template.id
+        assert out.uri == template.uri_template
+        assert out.mime_type == "application/octet-stream"
+        assert out.text == "test://template/123"
 
 
 # --------------------------------------------------------------------------- #
@@ -5981,6 +5984,53 @@ class TestReadResourceCoverageEdges:
         list_templates.assert_not_awaited()
         assert out.id == "cached-tmpl"
         assert out.text == '{"user_id":"7","name":"Cached User"}'
+
+    @pytest.mark.asyncio
+    async def test_read_resource_non_text_template_proxies_to_upstream(self):
+        """application/json resource templates resolve via gateway proxy (#5883)."""
+        # First-Party
+        from mcpgateway.common.models import ResourceTemplate
+        from mcpgateway.services.resource_service import ResourceService
+
+        svc = ResourceService()
+        json_template = ResourceTemplate(
+            id="json-tmpl",
+            uriTemplate="reference://users/{user_id}",
+            name="users",
+            description=None,
+            mime_type="application/json",
+        )
+        svc._template_cache = {"users": json_template}
+
+        db = MagicMock()
+        db.commit = MagicMock()
+
+        template_db = MagicMock()
+        template_db.id = "json-tmpl"
+        template_db.uri = "reference://users/{user_id}"
+        template_db.uri_template = "reference://users/{user_id}"
+        template_db.enabled = True
+        template_db.visibility = "public"
+        template_db.owner_email = None
+        template_db.team_id = None
+        template_db.gateway_id = "gateway-1"
+
+        # 1) URI lookup miss, 2) inactivity check miss, 3) template inactivity miss, 4) template access-check fetch
+        db.execute.return_value.scalar_one_or_none.side_effect = [None, None, None, template_db]
+        upstream_payload = '{"user_id":"7","name":"User 7"}'
+
+        with (
+            patch.object(svc, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch.object(svc, "invoke_resource", new_callable=AsyncMock, return_value=upstream_payload) as invoke,
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service", return_value=MagicMock()),
+        ):
+            out = await svc.read_resource(db, resource_uri="reference://users/7")
+
+        assert out.id == "json-tmpl"
+        assert out.mime_type == "application/json"
+        assert out.text == upstream_payload
+        invoke.assert_awaited_once()
+        assert invoke.await_args.kwargs["resource_template_uri"] == "reference://users/7"
 
     @pytest.mark.asyncio
     async def test_read_resource_template_proxy_none_response_raises(self):


### PR DESCRIPTION
# 🐛 Bug-Fix PR

## 🔗 Related Issue

Fixes #5883

---

## 📌 Summary

`resources/read` for a concrete URI that matches a federated resource template (e.g. `reference://users/7` vs `reference://users/{user_id}`) failed through the gateway when the template's MIME type was not `text/*` (e.g. `application/json`). The gateway reported `Resource not found` instead of proxying the concrete read to the upstream that owns the template.

## 🔁 Reproduction Steps

1. Federate a server that registers `reference://users/{user_id}` with `mime_type=application/json` (compliance reference server).
2. `list_resource_templates` succeeds (template is federated).
3. `read_resource("reference://users/7")` → `Resource not found: reference://users/7`.

Also exercised by:

`tests/live_gateway/protocol_compliance/test_resources.py::test_templated_resource_registered_and_resolves[gateway_proxy-http]`

## 🐞 Root Cause

`ResourceService._read_template_resource()` only expanded the URI template for `text/*` MIME types and raised `NotImplementedError("Binary resource templates not yet supported")` otherwise. That exception was wrapped as `ResourceNotFoundError` in `read_resource()`, so the gateway never reached the existing `invoke_resource()` proxy path.

The `text/*` branch did **not** produce final content locally — it only built a concrete URI placeholder so `read_resource()` could pass it as `resource_template_uri` to `invoke_resource()`.

## 💡 Fix Description

Always expand the concrete URI and return it as placeholder `ResourceContent.text` for **any** MIME type. `read_resource()` already loads the template's `DbResource` (including `gateway_id`) and proxies via `invoke_resource()`; non-text templates now take the same path as `text/*` ones.

No change to the upstream invocation or response handling.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

| Check | Command | Status |
|-------|---------|--------|
| Ruff (changed files) | `uv run ruff check mcpgateway/services/resource_service.py tests/unit/mcpgateway/services/test_resource_service.py` | ✅ passed |
| Template unit tests | `uv run pytest tests/unit/mcpgateway/services/test_resource_service.py -k "template_resource or non_text_template or binary or template_proxy or template_scoped or template_unscoped or template_none or template_access" -q` | ✅ 21 passed |
| New tests | `test_read_template_resource_non_text_mime_returns_placeholder`, `test_read_resource_non_text_template_proxies_to_upstream` | ✅ passed |
| Live protocol compliance | `make test-protocol-compliance K="test_templated_resource_registered_and_resolves"` | not run (requires `make testing-up` stack) |

## 📐 MCP Compliance

- [x] Matches current MCP spec (`resources/read` for template-expanded URIs)
- [x] No breaking change to MCP clients

## ✅ Checklist

- [x] Tests added/updated for changes
- [x] No secrets/credentials committed
- [x] DCO sign-off (`Signed-off-by: arimu1 <19286898+arimu1@users.noreply.github.com>`)

## 📓 Notes

- Related earlier work: #5569 fixed proxy placeholder / empty-response handling for templates that already reached `_read_template_resource` (text/*). This PR removes the MIME gate that blocked non-text templates from that path.
- Live compliance suite still xfails `gateway_virtual` under GAP-009 (virtual-server composition); this change targets the cache/federation proxy path described in #5883.