### PR TITLE
feat(admin-ui): expose per-gateway direct proxy mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - **Startup secret validation** - `JWT_SECRET_KEY`, `AUTH_ENCRYPTION_SECRET`, and `BASIC_AUTH_PASSWORD` are validated at startup with a minimum 32-byte length requirement and a comprehensive blocklist of known-weak values. Weak secrets previously only rejected in non-development environments now fail unconditionally across all environments.
 - **Hardened Helm chart defaults** - `JWT_SECRET_KEY` in `charts/mcp-stack/values.yaml` now defaults to an empty string with deployment guidance, rather than shipping a sample weak key.
 - **Docker Compose and entrypoint hardening** - Compose `:?` variable guards and entrypoint secret checks updated to match the new enforcement policy.
+- **`gateway_mode` silently dropped by the Admin UI edit endpoint** ([#6012](https://github.com/IBM/mcp-context-forge/issues/6012)) - `POST /admin/gateways/{id}/edit` assembled `GatewayUpdate` from an explicit field list that omitted `gateway_mode`, so a submitted value was discarded and the stored mode never changed. The field is now forwarded, and left unset when absent so the stored mode is preserved.
 
 ### Added
 
@@ -35,6 +36,7 @@
 - **`mcpgateway/scripts/init_secrets.py`** - Script backing both Makefile targets; generates secrets using `secrets.token_hex(32)` and rewrites the relevant lines in `.env` without touching unrelated configuration.
 - **`mcpgateway/scripts/validate_env.py`** - Startup validation script invoked by the container entrypoint and `make check-env` that enforces the secret strength policy and surfaces clear remediation guidance.
 - **Popup-Based OAuth Authorization Flow** ([#5660](https://github.com/IBM/mcp-context-forge/issues/5660)) - `GET /oauth/authorize/{gateway_id}` accepts an optional `popup` query parameter that prefixes the generated state token with `popup.`. `GET /oauth/callback` detects the prefix and, for both success and every error path (provider error, missing code, invalid state, `OAuthError`, unexpected exception), responds with a minimal CSP-nonce'd `postMessage` script instead of the full HTML admin page, so a React UI can drive the flow in a popup window without a parent-page navigation. Non-popup flows keep the existing full HTML response unchanged.
+- **Gateway Mode selector in the Admin UI** ([#6012](https://github.com/IBM/mcp-context-forge/issues/6012)) - When `MCPGATEWAY_DIRECT_PROXY_ENABLED=true`, the add and edit gateway forms expose a Gateway Mode selector (`cache` / `direct_proxy`), so a single upstream can be put into pass-through mode without a JSON API call or a manual `UPDATE gateways`. The gateway detail view now reports the stored mode regardless of the flag. The selector is not rendered while the feature is disabled, in which case the form submits no `gateway_mode` and a gateway already stored as `direct_proxy` keeps its mode.
 
 ### Removed
 

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -246,6 +246,8 @@ capacity has been sized for more frequent snapshots.
 
 **Usage:** Register a gateway with `"gateway_mode": "direct_proxy"`, then send requests with the `X-Context-Forge-Gateway-Id` header set to the gateway's ID. All MCP operations (tools/list, tools/call, resources/list, resources/read) will be proxied directly to the remote server.
 
+**Admin UI:** When `MCPGATEWAY_DIRECT_PROXY_ENABLED=true`, the Gateways tab shows a **Gateway Mode** selector on the add and edit gateway forms, and the gateway detail view reports the current mode. The selector is hidden while the feature is disabled; a gateway already set to `direct_proxy` keeps that mode and is not rewritten by editing it from the UI.
+
 ### ToolOps
 
 ToolOps streamlines the entire workflow by enabling seamless tool enrichment, automated test case generation, and comprehensive tool validation.

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -4217,6 +4217,7 @@ async def admin_ui(
             "a2a_enabled": settings.mcpgateway_a2a_enabled,
             "grpc_enabled": GRPC_AVAILABLE and settings.mcpgateway_grpc_enabled,
             "catalog_enabled": settings.mcpgateway_catalog_enabled,
+            "direct_proxy_enabled": settings.mcpgateway_direct_proxy_enabled,
             "llmchat_enabled": getattr(settings, "llmchat_enabled", False),
             "toolops_enabled": getattr(settings, "toolops_enabled", False),
             "observability_enabled": getattr(settings, "observability_enabled", False),
@@ -13155,6 +13156,8 @@ async def admin_edit_gateway(
             url=str(form["url"]),
             description=str(form.get("description")),
             transport=str(form.get("transport", "SSE")),
+            # Omitted by the UI when direct proxy is disabled; None leaves the stored mode alone.
+            gateway_mode=str(form.get("gateway_mode", "")) or None,
             tags=tags,
             auth_type=auth_type_from_form,
             auth_username=str(form.get("auth_username", "")),

--- a/mcpgateway/admin_ui/gateways.js
+++ b/mcpgateway/admin_ui/gateways.js
@@ -71,6 +71,7 @@ export const viewGateway = async function (gatewayId) {
           value: decodeHtml(gateway.description) || "N/A",
         },
         { label: "Visibility", value: gateway.visibility || "private" },
+        { label: "Gateway Mode", value: gateway.gatewayMode || "cache" },
       ];
 
       // Add tags field with special handling
@@ -283,6 +284,9 @@ export const editGateway = async function (gatewayId) {
     const descField = safeGetElement("edit-gateway-description");
 
     const transportField = safeGetElement("edit-gateway-transport");
+    // Absent when MCPGATEWAY_DIRECT_PROXY_ENABLED is false: the template omits
+    // the field, so the form submits no gateway_mode and the stored mode stands.
+    const gatewayModeField = safeGetElement("edit-gateway-mode");
 
     if (nameField && nameValidation.valid) {
       nameField.value = nameValidation.value;
@@ -353,6 +357,10 @@ export const editGateway = async function (gatewayId) {
 
     if (transportField) {
       transportField.value = gateway.transport || "SSE"; // falls back to Admin.SSE(default)
+    }
+
+    if (gatewayModeField) {
+      gatewayModeField.value = gateway.gatewayMode || "cache"; // falls back to cache(default)
     }
 
     const authTypeField = safeGetElement("auth-type-gw-edit");

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -5335,6 +5335,29 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                   <option value="STREAMABLEHTTP">Streamable HTTP</option>
                 </select>
               </div>
+              {% if direct_proxy_enabled %}
+              <div>
+                <label
+                  for="gateway-mode"
+                  class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                  >Gateway Mode</label
+                >
+                <small class="text-gray-500 dark:text-gray-400 block mb-2">
+                  Cache serves tools and resources from the gateway database.
+                  Direct proxy forwards each MCP call to the remote server and
+                  returns the live result; clients opt in per request with the
+                  X-Context-Forge-Gateway-Id header.
+                </small>
+                <select
+                  name="gateway_mode"
+                  id="gateway-mode"
+                  class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                >
+                  <option value="cache" selected>Cache (default)</option>
+                  <option value="direct_proxy">Direct proxy</option>
+                </select>
+              </div>
+              {% endif %}
               <div>
                 <label
                   class="block text-sm font-medium text-gray-700 dark:text-gray-400"
@@ -9874,6 +9897,30 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                         <option value="STREAMABLEHTTP">Streamable HTTP</option>
                       </select>
                     </div>
+                    {% if direct_proxy_enabled %}
+                    <div>
+                      <label
+                        for="edit-gateway-mode"
+                        class="block text-sm font-medium text-gray-700"
+                        >Gateway Mode</label
+                      >
+                      <small class="text-gray-500 dark:text-gray-400 block mb-2">
+                        Cache serves tools and resources from the gateway
+                        database. Direct proxy forwards each MCP call to the
+                        remote server and returns the live result; clients opt
+                        in per request with the X-Context-Forge-Gateway-Id
+                        header.
+                      </small>
+                      <select
+                        name="gateway_mode"
+                        id="edit-gateway-mode"
+                        class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                      >
+                        <option value="cache">Cache (default)</option>
+                        <option value="direct_proxy">Direct proxy</option>
+                      </select>
+                    </div>
+                    {% endif %}
                     <div>
                       <label class="block text-sm font-medium text-gray-700"
                         >Authentication Type</label

--- a/tests/unit/js/gateway.test.js
+++ b/tests/unit/js/gateway.test.js
@@ -265,6 +265,147 @@ describe("editGateway", () => {
 });
 
 // ---------------------------------------------------------------------------
+// gateway mode (cache / direct_proxy)
+// ---------------------------------------------------------------------------
+describe("gateway mode", () => {
+  const MODE_SELECT_HTML =
+    '<select id="edit-gateway-mode">' +
+    '<option value="cache">Cache (default)</option>' +
+    '<option value="direct_proxy">Direct proxy</option>' +
+    "</select>";
+
+  function gatewayModeEditHTML({ withModeSelect = true } = {}) {
+    return `
+      <form id="edit-gateway-form"></form>
+      <input id="edit-gateway-name" />
+      <input id="edit-gateway-url" />
+      <textarea id="edit-gateway-description"></textarea>
+      <input id="edit-gateway-tags" />
+      <select id="edit-gateway-transport"><option value="SSE">SSE</option></select>
+      ${withModeSelect ? MODE_SELECT_HTML : ""}
+      <select id="auth-type-gw-edit"><option value="">None</option></select>
+      <input id="edit-gateway-passthrough-headers" />
+      <div id="gateway-edit-modal" class="hidden"></div>
+    `;
+  }
+
+  function mockGateway(gateway) {
+    fetchWithTimeout.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(gateway),
+    });
+  }
+
+  test("viewGateway displays the gateway mode", async () => {
+    window.ROOT_PATH = "";
+    document.body.innerHTML = `
+      <div id="gateway-details"></div>
+      <div id="gateway-modal" class="hidden"></div>
+    `;
+
+    mockGateway({
+      name: "Direct GW",
+      url: "http://localhost:8080",
+      visibility: "team",
+      gatewayMode: "direct_proxy",
+      enabled: true,
+      reachable: true,
+      tags: [],
+    });
+
+    await viewGateway("gw-direct");
+
+    expect(document.getElementById("gateway-details").textContent).toContain(
+      "Gateway Mode: direct_proxy"
+    );
+  });
+
+  test("viewGateway falls back to cache when the mode is absent", async () => {
+    window.ROOT_PATH = "";
+    document.body.innerHTML = `
+      <div id="gateway-details"></div>
+      <div id="gateway-modal" class="hidden"></div>
+    `;
+
+    mockGateway({
+      name: "Legacy GW",
+      url: "http://localhost:8080",
+      visibility: "team",
+      enabled: true,
+      reachable: true,
+      tags: [],
+    });
+
+    await viewGateway("gw-legacy");
+
+    expect(document.getElementById("gateway-details").textContent).toContain(
+      "Gateway Mode: cache"
+    );
+  });
+
+  test("editGateway selects the stored mode", async () => {
+    window.ROOT_PATH = "";
+    document.body.innerHTML = gatewayModeEditHTML();
+
+    mockGateway({
+      name: "Direct GW",
+      url: "http://localhost:8080",
+      visibility: "team",
+      transport: "SSE",
+      authType: "",
+      gatewayMode: "direct_proxy",
+      tags: [],
+    });
+
+    await editGateway("gw-direct");
+
+    expect(document.getElementById("edit-gateway-mode").value).toBe(
+      "direct_proxy"
+    );
+  });
+
+  test("editGateway falls back to cache when the mode is absent", async () => {
+    window.ROOT_PATH = "";
+    document.body.innerHTML = gatewayModeEditHTML();
+    // Stale value left by a previously edited gateway.
+    document.getElementById("edit-gateway-mode").value = "direct_proxy";
+
+    mockGateway({
+      name: "Legacy GW",
+      url: "http://localhost:8080",
+      visibility: "team",
+      transport: "SSE",
+      authType: "",
+      tags: [],
+    });
+
+    await editGateway("gw-legacy");
+
+    expect(document.getElementById("edit-gateway-mode").value).toBe("cache");
+  });
+
+  test("editGateway succeeds when the mode select is not rendered", async () => {
+    window.ROOT_PATH = "";
+    document.body.innerHTML = gatewayModeEditHTML({ withModeSelect: false });
+
+    mockGateway({
+      name: "Direct GW",
+      url: "http://localhost:8080",
+      visibility: "team",
+      transport: "SSE",
+      authType: "",
+      gatewayMode: "direct_proxy",
+      tags: [],
+    });
+
+    await editGateway("gw-direct");
+
+    expect(showErrorMessage).not.toHaveBeenCalled();
+    expect(openModal).toHaveBeenCalledWith("gateway-edit-modal");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // initGatewaySelect
 // ---------------------------------------------------------------------------
 describe("initGatewaySelect", () => {

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -3615,6 +3615,45 @@ class TestAdminGatewayRoutes:
         gateway_update = call_args[1].get("gateway") or call_args[0][2]
         assert gateway_update.team_id == existing_team_id
 
+    @pytest.mark.parametrize(
+        ("form_extra", "expected_mode"),
+        [
+            ({"gateway_mode": "direct_proxy"}, "direct_proxy"),
+            ({"gateway_mode": "cache"}, "cache"),
+            # Field omitted (direct proxy disabled): leave the stored mode alone.
+            ({}, None),
+        ],
+    )
+    @patch.object(GatewayService, "update_gateway")
+    async def test_admin_edit_gateway_forwards_gateway_mode(self, mock_update_gateway, mock_request, mock_db, monkeypatch, form_extra, expected_mode):
+        """The gateway mode selector must reach GatewayUpdate, and stay unset when absent."""
+        form_data = FakeForm(
+            {
+                "name": "Updated_Gateway",
+                "url": "http://example.com:9000/sse",
+                "transport": "STREAMABLEHTTP",
+                "visibility": "public",
+                **form_extra,
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(side_effect=lambda email, tid: tid)
+        monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+        monkeypatch.setattr(
+            "mcpgateway.admin.MetadataCapture.extract_modification_metadata",
+            lambda *_args, **_kwargs: {"modified_by": "u", "modified_from_ip": None, "modified_via": "ui", "modified_user_agent": None, "version": 1},
+        )
+        mock_update_gateway.return_value = None
+
+        result = await admin_edit_gateway("gateway-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+
+        assert result.status_code == 200
+        call_args = mock_update_gateway.call_args
+        gateway_update = call_args[1].get("gateway") or call_args[0][2]
+        assert gateway_update.gateway_mode == expected_mode
+
     @patch.object(GatewayService, "set_gateway_state")
     async def test_admin_set_gateway_state_concurrent_calls(self, mock_toggle_status, mock_request, mock_db):
         """Test setting gateway state with simulated concurrent calls."""
@@ -4839,6 +4878,47 @@ class TestAdminUIRoute:
             assert "prompts" in context
             assert "gateways" in context
             assert "roots" in context
+
+    @pytest.mark.parametrize("direct_proxy_enabled", [True, False])
+    @patch.object(ServerService, "list_servers", new_callable=AsyncMock)
+    @patch.object(ToolService, "list_tools", new_callable=AsyncMock)
+    @patch.object(ResourceService, "list_resources", new_callable=AsyncMock)
+    @patch.object(PromptService, "list_prompts", new_callable=AsyncMock)
+    @patch.object(GatewayService, "list_gateways", new_callable=AsyncMock)
+    @patch.object(RootService, "list_roots", new_callable=AsyncMock)
+    async def test_admin_ui_exposes_direct_proxy_flag(
+        self,
+        mock_roots,
+        mock_gateways,
+        mock_prompts,
+        mock_resources,
+        mock_tools,
+        mock_servers,
+        mock_request,
+        mock_db,
+        monkeypatch,
+        direct_proxy_enabled,
+    ):
+        """The gateway mode selector is rendered only when direct proxy is enabled."""
+        mock_servers.return_value = []
+        mock_tools.return_value = ([], None)
+        mock_resources.return_value = []
+        mock_prompts.return_value = []
+        mock_gateways.return_value = []
+        mock_roots.return_value = []
+
+        monkeypatch.setattr(settings, "mcpgateway_direct_proxy_enabled", direct_proxy_enabled)
+
+        await admin_ui(
+            request=mock_request,
+            team_id=None,
+            include_inactive=False,
+            db=mock_db,
+            user={"email": "admin", "db": mock_db},
+        )
+
+        context = mock_request.app.state.templates.TemplateResponse.call_args[0][2]
+        assert context["direct_proxy_enabled"] is direct_proxy_enabled
 
     @patch.object(ServerService, "list_servers", new_callable=AsyncMock)
     @patch.object(ToolService, "list_tools", new_callable=AsyncMock)


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue

Closes #6012

---

## 🚀 Summary (1-2 sentences)

`gateway_mode` already ships end to end — the `gateways.gateway_mode` column (migration `207d8bbddd61`), `GatewayCreate` / `GatewayUpdate` / `GatewayRead`, the `MCPGATEWAY_DIRECT_PROXY_ENABLED` flag, and the pass-through paths in `tool_service`, `resource_service` and `streamablehttp_transport` — but the Admin UI never exposed it, so opting one upstream into direct proxy meant a JSON API call or a manual `UPDATE gateways SET gateway_mode='direct_proxy'`. This adds a **Gateway Mode** selector to the add and edit gateway forms (rendered only when the feature flag is on), reports the stored mode in the gateway detail view, and forwards `gateway_mode` out of `admin_edit_gateway`, which was silently dropping it.

---

## What changed

| File | Change |
| --- | --- |
| `mcpgateway/admin.py` | Pass `direct_proxy_enabled` into the admin template context. Add `gateway_mode` to the `GatewayUpdate` built by `admin_edit_gateway`. |
| `mcpgateway/templates/admin.html` | **Gateway Mode** `<select name="gateway_mode">` on the add and edit gateway forms, immediately after Transport Type, behind `{% if direct_proxy_enabled %}`. |
| `mcpgateway/admin_ui/gateways.js` | `editGateway` preselects the stored mode; `viewGateway` shows a **Gateway Mode** row. |
| `docs/`, `CHANGELOG.md` | Document the selector and the flag-off behaviour. |
| `tests/unit/js/gateway.test.js`, `tests/unit/mcpgateway/test_admin.py` | 10 new cases (below). |

No change was needed on the add path: `_parse_gateway_data_from_request` already forwards every form field into `GatewayCreate`. The edit path builds `GatewayUpdate` from an explicit field list that omitted `gateway_mode`, so the posted value was discarded and the stored mode never changed — the same shape as #5180. That one-line fix is in this PR rather than a separate one because the edit selector is inert without it.

Backend enforcement is unchanged and still authoritative: `GatewayService._prepare_gateway_registration` and `GatewayService.update_gateway` both reject `direct_proxy` when the flag is off, so the template gate is presentation only.

---

## 📸 Screenshots

**Add gateway form, `MCPGATEWAY_DIRECT_PROXY_ENABLED=true`**

![Add gateway form with Gateway Mode selector](https://raw.githubusercontent.com/PhilipAD/mcp-context-forge/pr-assets/gateway-mode/.assets/01-add-form.png)

**Edit gateway form — the stored mode is preselected**

![Edit gateway form showing Direct proxy selected](https://raw.githubusercontent.com/PhilipAD/mcp-context-forge/pr-assets/gateway-mode/.assets/03-edit.png)

**Gateway detail view**

![Gateway detail view showing Gateway Mode: direct_proxy](https://raw.githubusercontent.com/PhilipAD/mcp-context-forge/pr-assets/gateway-mode/.assets/02-detail.png)

**Same form with the feature disabled — no selector, Transport Type runs straight into Authentication Type**

![Add gateway form with the Gateway Mode selector absent](https://raw.githubusercontent.com/PhilipAD/mcp-context-forge/pr-assets/gateway-mode/.assets/04-add-form-flag-off.png)

<details>
<summary>Dark mode</summary>

![Add gateway form in dark mode](https://raw.githubusercontent.com/PhilipAD/mcp-context-forge/pr-assets/gateway-mode/.assets/01b-add-form-dark.png)

</details>

---

## Behaviour when `MCPGATEWAY_DIRECT_PROXY_ENABLED=false`

The field is not rendered at all, so the form submits no `gateway_mode`:

- **Add** — `GatewayCreate` applies its `cache` default.
- **Edit** — `admin_edit_gateway` passes `gateway_mode=None`, and `update_gateway` only writes a non-`None` mode. A gateway already stored as `direct_proxy` therefore keeps its mode instead of being silently downgraded when an operator edits something unrelated.

The detail view reports the mode regardless of the flag, so that stored value stays visible and explains why a gateway is serving live results.

I went with omitting the field rather than rendering it disabled: a disabled `<select>` is excluded from `FormData`, so it would look like a setting you could read but would quietly contribute nothing on submit. Happy to switch to a read-only indicator on the edit form if you would rather the mode were visible there too.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage` — #6012 was opened with the template's default `triage` label; happy to hold until it is scoped.
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

---

## 🧪 Checks

**New tests** — `tests/unit/mcpgateway/test_admin.py`

- `test_admin_ui_exposes_direct_proxy_flag[True|False]` — the context flag tracks the setting.
- `test_admin_edit_gateway_forwards_gateway_mode[direct_proxy|cache|omitted]` — the selector reaches `GatewayUpdate`, and stays `None` when the field is absent.

**New tests** — `tests/unit/js/gateway.test.js`

- `viewGateway` renders the mode, and falls back to `cache` for a gateway that has none.
- `editGateway` preselects the stored mode, resets a stale `direct_proxy` selection back to `cache`, and still opens the modal when the selector is not rendered.

Each new case was confirmed to fail against the unmodified source before the change (4/5 JS, 4/5 Python; the remainder are absent-element guards).

```
$ python -m pytest tests/unit/mcpgateway/test_admin.py
1221 passed                                    # exit 0

$ npx vitest run
Test Files  52 passed (52)
Tests       2325 passed | 3 skipped (2328)

$ uv tool run --with-editable . --with pylint-pydantic==0.3.5 pylint==3.3.9 --rcfile=.pylintrc mcpgateway/admin.py
Your code has been rated at 10.00/10

$ npx eslint mcpgateway/admin_ui/gateways.js tests/unit/js/gateway.test.js
# clean apart from one pre-existing no-unused-vars in gateway.test.js, present on main

$ npx htmlhint mcpgateway/templates/admin.html
Scanned 1 files, no errors found

$ uv tool run ruff==0.15.20 check mcpgateway/admin.py tests/unit/mcpgateway/test_admin.py
$ uv tool run ruff==0.15.20 format --check mcpgateway/admin.py tests/unit/mcpgateway/test_admin.py
2 files already formatted
# ruff check reports the same 3 findings as unmodified main; no new ones
```

`prettier --check` already reports `admin.html`, `gateways.js` and `gateway.test.js` as unformatted on a clean `main`, so I left formatting alone rather than adding an unrelated reformat to the diff.

**Manual verification** against a live gateway (`make build-ui`, `npm run build:css`, gateway on `:4455`, a local streamable-HTTP MCP server on `:9123`):

1. `MCPGATEWAY_DIRECT_PROXY_ENABLED=true`, registered a gateway through the Add form with **Direct proxy** selected → row persisted with `gateway_mode='direct_proxy'`.
2. Reopened it in the Edit form → selector preselected **Direct proxy**; changed to **Cache**, saved → row updated to `cache`. Changed back → `direct_proxy`. Before the `admin_edit_gateway` fix this same save returned HTTP 200 and left the row unchanged.
3. Detail view reported `Gateway Mode: direct_proxy`.
4. Restarted with the flag unset → neither form renders the selector, and the seeded `direct_proxy` gateway kept its mode.

- [x] Linters clean — ruff, pylint, eslint and htmlhint run over the changed files, with every finding diffed against unmodified `main`; no new ones. I ran these per-file rather than the whole-repo `make lint`/`make test`, since both report pre-existing findings and failures in modules this PR does not touch; CI covers the full sweep.
- [x] Tests pass — full `tests/unit/mcpgateway/test_admin.py` and the full `vitest` suite, results above.
- [x] CHANGELOG updated

---

## 📓 Notes

I deliberately left the gateways table alone — it already carries eleven columns, and the mode is a per-gateway attribute most deployments never change. If you would rather it were visible at a glance in the list, a column or badge is a small follow-up.
