### PR TITLE
feat(plugins): add invinoveritas Review plugin (independent pre-action verdict gate)

### DIFF
--- a/plugins/config.yaml
+++ b/plugins/config.yaml
@@ -1346,3 +1346,27 @@ plugins:
       detect_ssn: true
       block_on_detection: false
       log_detections: false
+
+  # invinoveritas Review — independent, signed pre-action verdict for tool_pre_invoke.
+  # Distinct from PDP/rule-based gates (unified_pdp, deny_filter, etc.): those decide
+  # eligibility deterministically (may this actor/tool/resource combination happen at
+  # all); this decides soundness for THIS specific payload (a judgment call a static
+  # rule can't make). See plugins/invinoveritas_review/README.md for the full design.
+  # Disabled by default, matching every other opt-in plugin here -- requires an
+  # IVV_API_KEY (free registration: POST https://api.babyblueviper.com/register).
+  - name: "InvinoveritasReviewPlugin"
+    kind: "plugins.invinoveritas_review.invinoveritas_review.InvinoveritasReviewPlugin"
+    description: "Gates tool_pre_invoke on an independent invinoveritas /review verdict."
+    version: "0.1.0"
+    author: "babyblueviper1"
+    hooks: ["tool_pre_invoke"]
+    tags: ["plugin", "safety", "review", "human-in-the-loop"]
+    mode: "disabled" # enforce | enforce_ignore_error | permissive | disabled
+    priority: 100
+    conditions: []
+    config:
+      base_url: "https://api.babyblueviper.com"
+      block_on_reject: true
+      sign: false
+      artifact_type: "general"
+      timeout_s: 15.0

--- a/plugins/invinoveritas_review/README.md
+++ b/plugins/invinoveritas_review/README.md
@@ -1,0 +1,77 @@
+# invinoveritas Review Plugin for ContextForge
+
+> Author: babyblueviper1
+> Version: 0.1.0
+
+Gates `tool_pre_invoke` on an independent, signed pre-action verdict from
+[invinoveritas](https://api.babyblueviper.com) — a judgment call about whether a
+specific tool invocation is sound, not a static rule. Grew out of
+[#5437](https://github.com/IBM/mcp-context-forge/issues/5437) (Human in the loop
+Approval for tool execution): a `risk_tier`/`gate.mode` rule engine can decide *whether*
+a human or policy needs to look at a call; it structurally cannot decide *whether this
+specific, novel action is actually sound* — that needs a judgment call, which is what
+`/review` does.
+
+## Features
+
+- Calls `POST /review` before every tool invocation with `{tool_name, arguments}` as the
+  artifact.
+- A `reject` verdict blocks the call by default (`block_on_reject: true`); set to `false`
+  for an advisory/observe-only rollout that never blocks, only annotates the result.
+- **Fails open** on any `/review`-side problem (network error, timeout, malformed
+  response, missing API key) — the tool call proceeds ungated rather than hanging or
+  crashing the gateway; `metadata["invinoveritas_review"] = "unavailable"` is set so this
+  is visible, not silent.
+- Optional `sign: true` attaches a portable, independently-verifiable signed proof
+  (verify at `https://api.babyblueviper.com/verify-proof`, free, no auth) to every
+  verdict.
+- Zero framework changes — a normal `Plugin` hooking `tool_pre_invoke`, same seam as
+  `unified_pdp` and the other example plugins in this directory.
+
+## Installation
+
+1. Register free, instant, no payment: `POST https://api.babyblueviper.com/register`
+2. Set `IVV_API_KEY` in your environment, or pass `api_key` directly in the plugin config
+   below (env var is preferred — don't commit a key to `config.yaml`).
+3. Add the plugin configuration to `plugins/config.yaml`:
+
+```yaml
+plugins:
+  - name: "InvinoveritasReviewPlugin"
+    kind: "plugins.invinoveritas_review.invinoveritas_review.InvinoveritasReviewPlugin"
+    description: "Gates tool_pre_invoke on an independent invinoveritas /review verdict."
+    version: "0.1.0"
+    author: "babyblueviper1"
+    hooks: ["tool_pre_invoke"]
+    tags: ["plugin", "safety", "review", "human-in-the-loop"]
+    mode: "enforce"  # enforce | permissive | disabled
+    priority: 100
+    config:
+      base_url: "https://api.babyblueviper.com"
+      block_on_reject: true
+      sign: false
+      artifact_type: "general"
+      timeout_s: 15.0
+```
+
+## Relationship to a rule-based PDP (e.g. `unified_pdp`)
+
+This plugin is deliberately **not** a replacement for a rule engine — it answers a
+different question. A PDP like `unified_pdp` decides *eligibility* (may this
+actor/tool/resource combination happen at all, per policy) deterministically and fast.
+`InvinoveritasReviewPlugin` decides *soundness for this specific payload* — the same
+tool call with different arguments can be fine or genuinely risky, which a static rule
+can't distinguish without an explosion of conditions. Run both: PDP first (cheap,
+deterministic, denies the clearly-disallowed), review second (judgment, for what the PDP
+lets through). Every `/review` verdict is independently checkable via
+`/verify-proof` — recompute it yourself, don't trust the plugin's word for it.
+
+## Testing
+
+```bash
+pytest plugins/invinoveritas_review/tests/test_invinoveritas_review.py -v
+```
+
+No live API key needed — all 6 tests run against `httpx.MockTransport`, covering
+reject-blocks, advisory-mode-never-blocks, approve-passes-through, fail-open-on-timeout,
+fail-open-on-malformed-response, and no-api-key-skips-the-call-entirely.

--- a/plugins/invinoveritas_review/invinoveritas_review.py
+++ b/plugins/invinoveritas_review/invinoveritas_review.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/invinoveritas_review/invinoveritas_review.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: babyblueviper1
+
+invinoveritas /review gate for tool_pre_invoke.
+
+Grew out of issue #5437 (Human in the loop Approval for tool execution): gates every
+tool invocation on an independent, signed pre-action verdict from invinoveritas
+(api.babyblueviper.com/review) BEFORE the tool runs, rather than a rule-based auto_approve
+boolean. A reject verdict blocks the call by default; approve/approve_with_concerns always
+lets it proceed unmodified.
+
+Design mirrors the same discipline used in the invinoveritas AutoGen GovernedWorkbench
+integration (integrations/autogen/governed_workbench.py):
+  - FAIL-OPEN on any /review-side problem (network error, timeout, malformed response,
+    missing key) -- the tool call proceeds as if ungated, never silently hangs or blocks
+    the gateway because our service had a bad moment. `review_unavailable` is set on the
+    result metadata so it's visible, not silent.
+  - GATES on a real reject verdict by default (block_on_reject=true in plugin config).
+    Set block_on_reject=false for an advisory/observe-only rollout that never blocks,
+    only annotates every ToolPreInvokeResult with the verdict.
+  - Optional sign=true attaches a portable, independently-verifiable signed proof
+    (verify at https://api.babyblueviper.com/verify-proof, free, no auth) to every
+    verdict, win or block.
+
+Configuration (inside plugins/config.yaml ``config:`` block), see PLUGIN_CONFIG below
+for every field and its default:
+
+    config:
+      api_key: null              # falls back to IVV_API_KEY env var
+      base_url: "https://api.babyblueviper.com"
+      block_on_reject: true
+      sign: false
+      artifact_type: "general"
+      timeout_s: 15.0
+"""
+
+# Standard
+import json
+import logging
+import os
+from typing import Any, Optional
+
+# Third-Party
+import httpx
+
+# First-Party
+from cpex.framework import Plugin, PluginContext, PluginResult, PluginViolation
+from cpex.framework.hooks.tools import ToolPreInvokePayload, ToolPreInvokeResult
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://api.babyblueviper.com"
+DEFAULT_TIMEOUT_S = 15.0
+_VALID_VERDICTS = ("approve", "approve_with_concerns", "reject")
+
+
+class InvinoveritasReviewPlugin(Plugin):
+    """Gates tool_pre_invoke on an invinoveritas /review verdict.
+
+    See module docstring for the full design discipline (fail-open, block_on_reject,
+    sign). Register free, instant, no payment: POST https://api.babyblueviper.com/register
+    """
+
+    async def initialize(self) -> None:
+        """Parse the plugin config block into local settings, once at startup."""
+        cfg = self._config.config or {}
+        self._api_key: Optional[str] = cfg.get("api_key") or os.environ.get("IVV_API_KEY")
+        self._base_url: str = cfg.get("base_url", DEFAULT_BASE_URL)
+        self._block_on_reject: bool = cfg.get("block_on_reject", True)
+        self._sign: bool = cfg.get("sign", False)
+        self._artifact_type: str = cfg.get("artifact_type", "general")
+        self._timeout_s: float = cfg.get("timeout_s", DEFAULT_TIMEOUT_S)
+        if not self._api_key:
+            logger.warning(
+                "InvinoveritasReviewPlugin: no IVV_API_KEY set (config.api_key or env var) -- "
+                "every tool call will proceed UNGATED (review_unavailable). Register free at "
+                "%s/register", self._base_url,
+            )
+
+    async def tool_pre_invoke(
+        self,
+        payload: ToolPreInvokePayload,
+        context: PluginContext,
+    ) -> ToolPreInvokeResult:
+        """Called before every tool invocation.
+
+        Args:
+            payload: contains the tool name and invocation arguments.
+            context: gateway-provided request context (unused directly here -- the
+                verdict is scoped to the tool call itself, not the caller identity;
+                a future revision could bind context.global_context.user into the
+                /review `context` field for a richer audit trail).
+
+        Returns:
+            A ToolPreInvokeResult -- pass-through (with the verdict attached as
+            metadata) or blocked with a PluginViolation on a reject verdict.
+        """
+        verdict = await self._review(payload, context)
+
+        if verdict is None:
+            # fail-open: either not configured, or the /review call itself failed
+            return PluginResult(continue_processing=True, metadata={"invinoveritas_review": "unavailable"})
+
+        if verdict.get("verdict") == "reject" and self._block_on_reject:
+            violation = PluginViolation(
+                reason="Independent invinoveritas /review verdict: reject",
+                description=verdict.get("summary", "Blocked by an independent pre-action verdict."),
+                code="IVV_REVIEW_REJECT",
+                details={
+                    "verdict": verdict.get("verdict"),
+                    "confidence": verdict.get("confidence"),
+                    "issues": verdict.get("issues"),
+                    "verify_url": f"{self._base_url}/verify-proof",
+                },
+            )
+            logger.warning(
+                "InvinoveritasReviewPlugin BLOCK tool_pre_invoke | tool=%s | confidence=%s",
+                payload.name, verdict.get("confidence"),
+            )
+            return PluginResult(continue_processing=False, violation=violation)
+
+        return PluginResult(continue_processing=True, metadata={"invinoveritas_review": verdict})
+
+    # ---- internals ----
+
+    async def _review(
+        self, payload: ToolPreInvokePayload, context: PluginContext
+    ) -> Optional[dict[str, Any]]:
+        """Returns the /review response dict, or None on any failure/misconfiguration
+        (fail-open -- the caller treats None exactly like an approve, just without a
+        verdict to attach)."""
+        if not self._api_key:
+            return None
+
+        artifact = json.dumps({"tool_name": payload.name, "arguments": dict(payload.args or {})}, default=str)
+        request_id = context.global_context.request_id if context.global_context else None
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout_s) as client:
+                resp = await client.post(
+                    f"{self._base_url}/review",
+                    headers={"Authorization": f"Bearer {self._api_key}", "Content-Type": "application/json"},
+                    json={
+                        "artifact": artifact,
+                        "artifact_type": self._artifact_type,
+                        "context": f"mcp-context-forge tool_pre_invoke, request_id={request_id}"
+                        if request_id else "mcp-context-forge tool_pre_invoke",
+                        "sign": self._sign,
+                    },
+                )
+            resp.raise_for_status()
+            data = resp.json()
+            if data.get("verdict") not in _VALID_VERDICTS:
+                logger.warning(
+                    "InvinoveritasReviewPlugin: malformed /review response for %r, failing open: %r",
+                    payload.name, data,
+                )
+                return None
+            logger.info(
+                "InvinoveritasReviewPlugin: %r -> %s (confidence=%s)",
+                payload.name, data.get("verdict"), data.get("confidence"),
+            )
+            return data
+        except Exception as e:  # noqa: BLE001 -- fail-open on ANY error, by design
+            logger.warning(
+                "InvinoveritasReviewPlugin: /review call failed for %r (%s), failing open (review_unavailable)",
+                payload.name, e,
+            )
+            return None

--- a/plugins/invinoveritas_review/plugin-manifest.yaml
+++ b/plugins/invinoveritas_review/plugin-manifest.yaml
@@ -1,0 +1,12 @@
+description: "invinoveritas /review pre-action verdict gate."
+author: "babyblueviper1"
+version: "0.1.0"
+available_hooks:
+  - "tool_pre_invoke"
+default_configs:
+  api_key: null
+  base_url: "https://api.babyblueviper.com"
+  block_on_reject: true
+  sign: false
+  artifact_type: "general"
+  timeout_s: 15.0

--- a/plugins/invinoveritas_review/tests/test_invinoveritas_review.py
+++ b/plugins/invinoveritas_review/tests/test_invinoveritas_review.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+"""Live-shaped tests for InvinoveritasReviewPlugin -- no network calls, real HTTP mocking
+via httpx.MockTransport (same pattern as invinoveritas's own AutoGen GovernedWorkbench
+tests). Run: pytest plugins/invinoveritas_review/tests/test_invinoveritas_review.py -v
+"""
+import json
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from cpex.framework import GlobalContext, PluginConfig, PluginContext  # noqa: E402
+from cpex.framework.hooks.tools import ToolPreInvokePayload  # noqa: E402
+
+from plugins.invinoveritas_review.invinoveritas_review import InvinoveritasReviewPlugin  # noqa: E402
+
+
+def _make_plugin(config: dict) -> InvinoveritasReviewPlugin:
+    pc = PluginConfig(
+        name="invinoveritas_review",
+        kind="plugins.invinoveritas_review.invinoveritas_review.InvinoveritasReviewPlugin",
+        version="0.1.0",
+        author="babyblueviper1",
+        hooks=["tool_pre_invoke"],
+        tags=["safety", "review"],
+        config=config,
+    )
+    return InvinoveritasReviewPlugin(pc)
+
+
+def _ctx() -> PluginContext:
+    return PluginContext(global_context=GlobalContext(request_id="req-test-1"))
+
+
+def _patch_httpx(monkeypatch, handler):
+    transport = httpx.MockTransport(handler)
+
+    class PatchedClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", PatchedClient)
+
+
+@pytest.mark.asyncio
+async def test_reject_blocks_by_default(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert body["artifact_type"] == "general"
+        assert json.loads(body["artifact"])["tool_name"] == "delete_prod_db"
+        return httpx.Response(200, json={"verdict": "reject", "confidence": 0.91, "summary": "Irreversible, no confirmation."})
+
+    _patch_httpx(monkeypatch, handler)
+    plugin = _make_plugin({"api_key": "test_key"})
+    await plugin.initialize()
+
+    payload = ToolPreInvokePayload(name="delete_prod_db", args={"table": "users"})
+    result = await plugin.tool_pre_invoke(payload, _ctx())
+
+    assert result.continue_processing is False
+    assert result.violation is not None
+    assert result.violation.code == "IVV_REVIEW_REJECT"
+
+
+@pytest.mark.asyncio
+async def test_reject_does_not_block_in_advisory_mode(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"verdict": "reject", "confidence": 0.9, "summary": "risky"})
+
+    _patch_httpx(monkeypatch, handler)
+    plugin = _make_plugin({"api_key": "test_key", "block_on_reject": False})
+    await plugin.initialize()
+
+    result = await plugin.tool_pre_invoke(ToolPreInvokePayload(name="risky_tool"), _ctx())
+
+    assert result.continue_processing is True
+    assert result.metadata["invinoveritas_review"]["verdict"] == "reject"
+
+
+@pytest.mark.asyncio
+async def test_approve_passes_through(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"verdict": "approve", "confidence": 0.97})
+
+    _patch_httpx(monkeypatch, handler)
+    plugin = _make_plugin({"api_key": "test_key"})
+    await plugin.initialize()
+
+    result = await plugin.tool_pre_invoke(ToolPreInvokePayload(name="read_file"), _ctx())
+
+    assert result.continue_processing is True
+    assert result.metadata["invinoveritas_review"]["verdict"] == "approve"
+
+
+@pytest.mark.asyncio
+async def test_fails_open_on_network_error(monkeypatch):
+    def raise_handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectTimeout("simulated timeout")
+
+    _patch_httpx(monkeypatch, raise_handler)
+    plugin = _make_plugin({"api_key": "test_key"})
+    await plugin.initialize()
+
+    result = await plugin.tool_pre_invoke(ToolPreInvokePayload(name="any_tool"), _ctx())
+
+    assert result.continue_processing is True
+    assert result.metadata["invinoveritas_review"] == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_fails_open_on_malformed_response(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"not_a_verdict_field": True})
+
+    _patch_httpx(monkeypatch, handler)
+    plugin = _make_plugin({"api_key": "test_key"})
+    await plugin.initialize()
+
+    result = await plugin.tool_pre_invoke(ToolPreInvokePayload(name="any_tool"), _ctx())
+
+    assert result.continue_processing is True
+    assert result.metadata["invinoveritas_review"] == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_no_api_key_fails_open_without_network_call(monkeypatch):
+    called = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        called["n"] += 1
+        return httpx.Response(200, json={"verdict": "reject"})
+
+    _patch_httpx(monkeypatch, handler)
+    plugin = _make_plugin({})  # no api_key, no IVV_API_KEY env var assumed absent
+    monkeypatch.delenv("IVV_API_KEY", raising=False)
+    await plugin.initialize()
+
+    result = await plugin.tool_pre_invoke(ToolPreInvokePayload(name="any_tool"), _ctx())
+
+    assert result.continue_processing is True
+    assert called["n"] == 0  # never even attempted the call


### PR DESCRIPTION
Grew out of #5437 (Human in the loop Approval for tool execution). Reading through the epic and hegu-1's proposal there, I noticed a real distinction worth making concrete as a plugin rather than just a comment: a `risk_tier`/`gate.mode` rule engine decides **eligibility** deterministically and fast (may this actor/tool/resource combination happen at all) — that's what `unified_pdp` and the other example plugins here already do well. It structurally cannot decide **soundness for this specific payload** — the same tool with different arguments can be fine or genuinely risky, which no finite rule set distinguishes without an explosion of conditions. That's a judgment call, which is what this plugin gates on.

## What it does

- Hooks `tool_pre_invoke`, calls `POST /review` (api.babyblueviper.com) with `{tool_name, arguments}` before the tool runs.
- A `reject` verdict blocks the call by default (`block_on_reject: true`). Set `false` for an advisory/observe-only rollout that only annotates the result, never blocks.
- **Fails open** on any `/review`-side problem (network error, timeout, malformed response, missing key) — never hangs or crashes the gateway on our service having a bad moment; `metadata["invinoveritas_review"] = "unavailable"` makes this visible rather than silent.
- Optional `sign: true` attaches a portable, independently-verifiable signed proof (`/verify-proof`, free, no auth) to every verdict.
- Disabled by default in `plugins/config.yaml`, matching every other opt-in plugin in this repo (e.g. the bundled `cpex-*` plugins).

## How it composes with a PDP

Not a replacement for `unified_pdp` or similar — the two answer different questions and are meant to run together: PDP first (cheap, deterministic, denies the clearly-disallowed), review second (judgment, for whatever the PDP lets through). Full rationale in `plugins/invinoveritas_review/README.md`.

## Testing

```
pytest plugins/invinoveritas_review/tests/test_invinoveritas_review.py -v
```

6/6 passing, real `httpx.MockTransport` (no live API key needed to run the suite) — covers reject-blocks, advisory-mode-never-blocks, approve-passes-through, fail-open-on-timeout, fail-open-on-malformed-response, and no-api-key-skips-the-call-entirely.

Happy to adjust naming/config shape/anything else — first PR to this repo, want to match the existing plugin conventions as closely as possible rather than introduce a new pattern.