### PR TITLE
fix(tools): handle duplicate tool name conflicts on update

### DIFF
--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -6020,6 +6020,7 @@ def get_for_update(
     nowait: bool = False,
     lock_timeout_ms: Optional[int] = None,
     options: Optional[List] = None,
+    first_only: bool = False,
 ):
     """Get entity with row lock for update operations.
 
@@ -6028,6 +6029,9 @@ def get_for_update(
         model: ORM model class
         entity_id: Primary key value (optional if `where` provided)
         where: Optional SQLAlchemy WHERE clause to locate rows for conflict detection
+        first_only: Return the first matching row when the caller only needs to
+            establish that a conflict exists. This keeps the normal strict
+            single-row behavior for callers that expect uniqueness.
         skip_locked: If False (default), wait for locked rows. If True, skip locked
             rows (returns None if row is locked). Use False for conflict checks and
             entity updates to ensure consistency. Use True only for job-queue patterns.
@@ -6069,12 +6073,16 @@ def get_for_update(
     if options:
         stmt = stmt.options(*options)
 
+    if first_only:
+        stmt = stmt.limit(1)
+
     if dialect != "postgresql":
         # SQLite and others: no FOR UPDATE support
         # Use db.get optimization only when querying by primary key without loader options
         if not options and where is None and entity_id is not None:
             return db.get(model, entity_id)
-        return db.execute(stmt).scalar_one_or_none()
+        result = db.execute(stmt)
+        return result.scalars().first() if first_only else result.scalar_one_or_none()
 
     # PostgreSQL: set lock timeout if specified
     if lock_timeout_ms is not None:
@@ -6082,7 +6090,8 @@ def get_for_update(
 
     # PostgreSQL: apply FOR UPDATE with optional nowait
     stmt = stmt.with_for_update(skip_locked=skip_locked, nowait=nowait)
-    return db.execute(stmt).scalar_one_or_none()
+    result = db.execute(stmt)
+    return result.scalars().first() if first_only else result.scalar_one_or_none()
 
 
 # Using the existing get_db generator to create a context manager for fresh sessions

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -5956,6 +5956,13 @@ async def update_tool(
         if isinstance(ex, IntegrityError):
             logger.error(f"Integrity error while updating tool: {ex}")
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=ErrorFormatter.format_database_error(ex))
+        if isinstance(ex, ToolNameConflictError):
+            if not ex.enabled and ex.tool_id:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=f"Tool name already exists but is inactive. Consider activating it with ID: {ex.tool_id}",
+                )
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(ex))
         if isinstance(ex, ToolError):
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(ex))
         logger.error(f"Unexpected error while updating tool: {ex}")

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -6763,6 +6763,7 @@ class ToolService(BaseService):
                     DbTool.visibility == "public",
                     DbTool.id != tool_id,
                 ),
+                first_only=True,
             )
         elif visibility == "team" and team_id:
             existing_tool = get_for_update(
@@ -6774,6 +6775,7 @@ class ToolService(BaseService):
                     DbTool.team_id == team_id,
                     DbTool.id != tool_id,
                 ),
+                first_only=True,
             )
         elif visibility == "private" and owner_email:
             existing_tool = get_for_update(
@@ -6785,6 +6787,7 @@ class ToolService(BaseService):
                     DbTool.owner_email == owner_email,
                     DbTool.id != tool_id,
                 ),
+                first_only=True,
             )
         else:
             logger.warning("Skipping conflict check for tool %s: visibility=%r requires %s but none provided", tool_id, visibility, "team_id" if visibility == "team" else "owner_email")

--- a/tests/unit/mcpgateway/services/test_tool_name_conflict_regression.py
+++ b/tests/unit/mcpgateway/services/test_tool_name_conflict_regression.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Regression tests for tool custom-name conflict handling.
+Location: ./tests/unit/mcpgateway/services/test_tool_name_conflict_regression.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+"""
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.db import Tool as DbTool
+from mcpgateway.schemas import ToolUpdate
+from mcpgateway.services.tool_service import ToolNameConflictError, ToolService
+
+
+def _make_tool(tool_id: str, internal_name: str, visibility: str, owner_email: str | None = None) -> DbTool:
+    """Build a persisted tool with an intentionally shared custom name."""
+    return DbTool(
+        id=tool_id,
+        original_name=internal_name,
+        custom_name="execute_sql",
+        custom_name_slug=internal_name,
+        name=internal_name,
+        input_schema={},
+        owner_email=owner_email,
+        visibility=visibility,
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_tool_visibility_conflict_handles_duplicate_public_custom_names(test_db):
+    """Changing a private tool to public raises the domain conflict error, not a query cardinality error."""
+    test_db.add_all(
+        [
+            _make_tool("tool-a", "gateway-a-execute-sql", "public"),
+            _make_tool("tool-b", "gateway-b-execute-sql", "public"),
+            _make_tool("tool-c", "gateway-c-execute-sql", "private", owner_email="owner@example.com"),
+        ]
+    )
+    test_db.commit()
+
+    with pytest.raises(ToolNameConflictError):
+        await ToolService().update_tool(test_db, "tool-c", ToolUpdate(visibility="public"))

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -2005,6 +2005,7 @@ class TestToolService:
         # Mock DB query to check for name conflicts (returns None, so no pre-check conflict)
         mock_scalar = Mock()
         mock_scalar.scalar_one_or_none.return_value = None
+        mock_scalar.scalars.return_value.first.return_value = None
         test_db.execute = Mock(return_value=mock_scalar)
 
         # Mock commit to raise IntegrityError

--- a/tests/unit/mcpgateway/test_db.py
+++ b/tests/unit/mcpgateway/test_db.py
@@ -2364,6 +2364,39 @@ def test_get_for_update_postgresql_sets_lock_timeout_and_runs_query():
     assert any("SET LOCAL lock_timeout" in str(stmt) for stmt in calls)
 
 
+def test_get_for_update_first_only_returns_match_for_multiple_where_results(test_db):
+    """first_only should support existential conflict checks without cardinality errors."""
+    test_db.add_all(
+        [
+            db.Tool(id="first-only-a", original_name="first-only-a", custom_name="duplicate", custom_name_slug="first-only-a", name="first-only-a", input_schema={}, visibility="public"),
+            db.Tool(id="first-only-b", original_name="first-only-b", custom_name="duplicate", custom_name_slug="first-only-b", name="first-only-b", input_schema={}, visibility="public"),
+        ]
+    )
+    test_db.commit()
+
+    result = db.get_for_update(test_db, db.Tool, where=db.Tool.custom_name == "duplicate", first_only=True)
+
+    assert result is not None
+    assert result.id in {"first-only-a", "first-only-b"}
+
+
+def test_get_for_update_default_rejects_multiple_where_results(test_db):
+    """Default conflict lookups retain strict single-row cardinality semantics."""
+    # Third-Party
+    from sqlalchemy.exc import MultipleResultsFound
+
+    test_db.add_all(
+        [
+            db.Tool(id="strict-a", original_name="strict-a", custom_name="duplicate", custom_name_slug="strict-a", name="strict-a", input_schema={}, visibility="public"),
+            db.Tool(id="strict-b", original_name="strict-b", custom_name="duplicate", custom_name_slug="strict-b", name="strict-b", input_schema={}, visibility="public"),
+        ]
+    )
+    test_db.commit()
+
+    with pytest.raises(MultipleResultsFound):
+        db.get_for_update(test_db, db.Tool, where=db.Tool.custom_name == "duplicate")
+
+
 # --- Other slug listeners ---
 def test_set_grpc_service_slug_sets_slug(monkeypatch):
     class Target:

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -1172,6 +1172,18 @@ class TestToolEndpoints:
         response = test_client.put("/tools/1", json=req, headers=auth_headers)
         assert response.status_code == status_code
 
+    @patch("mcpgateway.main.tool_service.update_tool")
+    def test_update_tool_name_conflict_returns_409(self, mock_update, test_client, auth_headers):
+        """Tool name conflicts from updates are returned as HTTP 409."""
+        # First-Party
+        from mcpgateway.services.tool_service import ToolNameConflictError
+
+        mock_update.side_effect = ToolNameConflictError("existing_tool")
+
+        response = test_client.put("/tools/1", json={"description": "Updated description"}, headers=auth_headers)
+
+        assert response.status_code == 409
+
     @patch("mcpgateway.main.tool_service.set_tool_state")
     def test_set_tool_state(self, mock_toggle, test_client, auth_headers):
         """Test setting tool active/inactive state."""


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Fixes tool visibility updates that fail when multiple existing tools share the same `custom_name` in the target visibility scope.

## 🔁 Reproduction Steps

Closes #5995

1. Persist two public tools with the same `custom_name`.
2. Update a third private or team-scoped tool with that same `custom_name` to `visibility=public`.
3. Before this change, the conflict lookup raises `MultipleResultsFound` and is wrapped as a generic `ToolError` instead of returning a domain conflict.

## 🧠 Root Cause

`_check_tool_name_conflict()` used `get_for_update()` for an existence check. Its strict `scalar_one_or_none()` semantics assume at most one matching row, but duplicate public/team/private custom names can already exist.

## 🛠️ Fix Description

- Adds opt-in `first_only=True` support to `get_for_update()` while keeping the strict default behavior.
- Uses the existential lookup only for tool-name conflict checks.
- Maps update-time `ToolNameConflictError` to HTTP 409 before generic `ToolError` HTTP 400 handling.
- Adds DB-backed regression, helper, service mock, and route-level coverage.

## 🔎 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

| Check | Command / evidence | Status |
|---|---|---|
| DB-backed RED → GREEN regression | Baseline raises `MultipleResultsFound`; current code raises `ToolNameConflictError` | ✅ Passed |
| Focused regression, helper, and API coverage | #5995 focused suite | ✅ 5 passed |
| Unit tests | `make test` | ✅ 21,336 passed, 808 skipped, 2 xfailed |
| Coverage | `make coverage` | ✅ 98% |
| Patch validation | `git diff --check` | ✅ Passed |
| Lint suite | `make lint` | ⚠️ Not claimed as pass: its isort target mutates the working tree. Check-only validation found 33 Ruff diagnostics and one `main.py` isort finding reproduced on clean `a48826b`; no confirmed new lint regression from this PR. |

## 🔌 MCP Compliance

Not applicable: this is an internal persistence/conflict-handling and HTTP error mapping fix; it does not alter MCP protocol behavior or client compatibility.

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`) — not claimed because the repository lint target mutates the worktree and the remaining isort finding is reproduced on baseline
- [x] Tests added/updated for changes
- [x] No secrets/credentials committed

## 📝 Notes

- The DB-backed regression was exercised locally.
- Full tests passed in the available SQLite environment.
- Live PostgreSQL was not locally exercised; PostgreSQL `FOR UPDATE` behavior is preserved structurally and remains appropriate for upstream CI validation.