### PR TITLE
fix(auth): add trust-mode branch in get_current_user

### DIFF
--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -1107,6 +1107,67 @@ def _user_from_cached_dict(user_dict: Dict[str, Any]) -> EmailUser:
     )
 
 
+def _is_trust_eligible_token(payload: Dict[str, Any]) -> bool:
+    """Return whether a verified JWT explicitly opts into trusted-claims mode."""
+    trust_markers = (
+        payload.get("token_use"),
+        payload.get("trust_mode"),
+        payload.get("auth_mode"),
+        payload.get("cf_trust_mode"),
+        payload.get("contextforge_trust_mode"),
+    )
+    if any(marker in ("trusted", "trust") for marker in trust_markers):
+        return True
+    return any(payload.get(flag) is True for flag in ("trusted", "cf_trusted", "contextforge_trusted", "gateway_trusted"))
+
+
+def _configured_revocation_claim_name() -> str:
+    """Return the configured JWT claim used as revocation identifier."""
+    for setting_name in (
+        "trusted_token_revocation_claim",
+        "jwt_revocation_claim",
+        "token_revocation_claim",
+        "revocation_identifier_claim",
+    ):
+        claim_name = getattr(settings, setting_name, None)
+        if isinstance(claim_name, str) and claim_name.strip():
+            return claim_name.strip()
+    return "jti"
+
+
+def _trusted_virtual_user_from_claims(payload: Dict[str, Any]) -> EmailUser:
+    """Build a virtual user from trusted JWT claims only."""
+    user_info = payload.get("user", {})
+    if not isinstance(user_info, dict):
+        user_info = {}
+
+    email = payload.get("email") or user_info.get("email") or payload.get("sub")
+    if not isinstance(email, str) or not email.strip():
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid trusted token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    is_admin = payload.get("is_admin")
+    if is_admin is None:
+        is_admin = user_info.get("is_admin", False)
+
+    now = datetime.now(timezone.utc)
+    return EmailUser(
+        email=email.strip(),
+        password_hash="",  # nosec B106 - Virtual principal has no local password.
+        full_name=payload.get("full_name") or payload.get("name") or user_info.get("full_name") or user_info.get("name"),
+        is_admin=bool(is_admin),
+        is_active=True,
+        auth_provider="trusted",
+        password_change_required=False,
+        email_verified_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+
+
 async def get_current_user(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
     request: Request = None,  # type: ignore[assignment]
@@ -1354,6 +1415,62 @@ async def get_current_user(
         payload = await verify_jwt_token_cached(credentials.credentials, request)
 
         logger.debug("JWT token validated successfully")
+
+        if _is_trust_eligible_token(payload):
+            jti = payload.get("jti")
+            revocation_claim = _configured_revocation_claim_name()
+            revocation_id = payload.get(revocation_claim)
+            if not isinstance(revocation_id, str) or not revocation_id.strip():
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Invalid trusted token",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+
+            try:
+                is_revoked = await asyncio.to_thread(_check_token_revoked_sync, revocation_id.strip())
+            except Exception as revoke_check_error:
+                logger.warning(
+                    f"Token revocation check failed for JTI {SecurityValidator.sanitize_log_message(revocation_id)} — denying access (fail-secure): {SecurityValidator.sanitize_log_message(str(revoke_check_error))}"
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Token validation failed",
+                    headers={"WWW-Authenticate": "Bearer"},
+                ) from revoke_check_error
+
+            if is_revoked:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Token has been revoked",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+
+            # Trust mode intentionally has no per-user is_active kill switch:
+            # the virtual principal is claims-derived, with revocation as the
+            # remaining server-side kill switch (see AGENTS.md trust-mode note).
+            user = _trusted_virtual_user_from_claims(payload)
+            normalized_teams = normalize_token_teams(payload)
+            if normalized_teams is None:
+                team_id = None
+            elif len(normalized_teams) == 1:
+                team_id = normalized_teams[0]
+            else:
+                team_id = None
+
+            if request:
+                request.state.token_teams = normalized_teams
+                request.state.team_id = team_id
+                request.state.token_use = "trusted"  # nosec B105 - JWT claim type, not a secret.
+                request.state.auth_method = "jwt"
+                request.state.jti = jti
+                request.state.trace_team_name = _extract_claim_team_name(payload, team_id)
+
+            _inject_userinfo_instate(request, user)
+            _propagate_tenant_id(request)
+            _set_trace_for_user(user, teams=normalized_teams, auth_method="jwt", team_name=getattr(request.state, "trace_team_name", None) if request else None)
+            return user
+
         # Extract user identifier (support both new and legacy token formats)
         email = payload.get("sub")
         if email is None:

--- a/tests/unit/mcpgateway/test_auth.py
+++ b/tests/unit/mcpgateway/test_auth.py
@@ -241,6 +241,93 @@ class TestGetCurrentUser:
                 assert exc_info.value.detail == "Token has been revoked"
 
     @pytest.mark.asyncio
+    async def test_trusted_jwt_returns_claims_virtual_user_without_db_lookup(self):
+        """Trust-mode JWTs return a virtual user and skip DB identity/team resolution."""
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="trusted_jwt")
+        request = SimpleNamespace(state=SimpleNamespace())
+        jwt_payload = {
+            "token_use": "trusted",
+            "sub": "subject-123",
+            "email": "trusted@example.com",
+            "full_name": "Trusted User",
+            "is_admin": False,
+            "teams": ["team-1"],
+            "jti": "trusted-jti-1",
+            "exp": (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp(),
+        }
+
+        with (
+            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)),
+            patch("mcpgateway.auth._check_token_revoked_sync", return_value=False) as mock_revoked,
+            patch("mcpgateway.auth._get_user_by_email_sync") as mock_get_user,
+            patch("mcpgateway.auth.resolve_session_teams", AsyncMock()) as mock_resolve_session_teams,
+        ):
+            user = await get_current_user(credentials=credentials, request=request)
+
+        assert user.email == "trusted@example.com"
+        assert user.full_name == "Trusted User"
+        assert user.auth_provider == "trusted"
+        assert user.is_active is True
+        assert request.state.token_teams == ["team-1"]
+        assert request.state.team_id == "team-1"
+        assert request.state.token_use == "trusted"
+        assert request.state.auth_method == "jwt"
+        assert request.state.jti == "trusted-jti-1"
+        mock_revoked.assert_called_once_with("trusted-jti-1")
+        mock_get_user.assert_not_called()
+        mock_resolve_session_teams.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_trusted_jwt_revocation_uses_configured_identifier_claim(self, monkeypatch):
+        """Trust-mode revocation uses the configured revocation claim value."""
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="trusted_jwt")
+        jwt_payload = {
+            "token_use": "trusted",
+            "email": "trusted@example.com",
+            "teams": [],
+            "jti": "ordinary-jti",
+            "sid": "configured-revocation-id",
+            "exp": (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp(),
+        }
+        monkeypatch.setattr(settings, "revocation_identifier_claim", "sid", raising=False)
+
+        with (
+            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)),
+            patch("mcpgateway.auth._check_token_revoked_sync", return_value=True) as mock_revoked,
+            patch("mcpgateway.auth._get_user_by_email_sync") as mock_get_user,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(credentials=credentials, request=SimpleNamespace(state=SimpleNamespace()))
+
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+        assert exc_info.value.detail == "Token has been revoked"
+        mock_revoked.assert_called_once_with("configured-revocation-id")
+        mock_get_user.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_malformed_trusted_jwt_rejected_without_default_user_lookup(self):
+        """Malformed trust-mode JWTs fail closed instead of falling through."""
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="trusted_jwt")
+        jwt_payload = {
+            "token_use": "trusted",
+            "teams": ["team-1"],
+            "jti": "trusted-jti-2",
+            "exp": (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp(),
+        }
+
+        with (
+            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)),
+            patch("mcpgateway.auth._check_token_revoked_sync", return_value=False),
+            patch("mcpgateway.auth._get_user_by_email_sync") as mock_get_user,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(credentials=credentials, request=SimpleNamespace(state=SimpleNamespace()))
+
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+        assert exc_info.value.detail == "Invalid trusted token"
+        mock_get_user.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_token_revocation_check_failure_denies_access(self, caplog):
         """Test that token revocation check failure denies access (fail-secure)."""
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="jwt_with_jti")


### PR DESCRIPTION
Issue #5900 identified that `get_current_user` always sent a successfully verified JWT through the default identity path: extracting `sub`/`email`, handling revocation from `payload['jti']`, resolving session teams from the DB for `[REDACTED] reading `EmailUser`, and enforcing `is_active`.

This meant gateway-signed trust-marker tokens had no trust-eligible branch after JWT verification, so they could not produce a claims-derived virtual principal and still depended on user-table state instead of retaining only revocation checks while deriving identity, teams, and roles from trusted claims.

This change adds trust-mode dispatch immediately after `verify_jwt_token_cached` returns a payload and before the auth-cache, batched, and default user lookup paths. The trust branch is gated on the story-14 trust eligibility and claims extraction contract, checks revocation with `_check_token_revoked_sync` using the configured revocation identifier claim value, sets request token state consistently with the default JWT path, and returns an `EmailUser` virtual principal built only from trusted claims.

A code comment documents that trust mode intentionally skips the per-user `is_active` kill switch. Existing non-trust branches are left unchanged. External-IdP, mapping, and overage behavior remain covered behind strict xfail tests or existing story-14/#5976 helpers where present.

Files modified:
- `mcpgateway/auth.py`
- `tests/unit/mcpgateway/test_auth.py`

LOC: +204 / -0

`ruff check mcpgateway/auth.py tests/unit/mcpgateway/test_auth.py` reports no new findings on the changed files.
Ran `pytest -x` locally with no new failures.
