### PR TITLE
docs: update architecture roadmap and add release history

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
+    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-04T09:47:50Z",
+  "generated_at": "2026-08-04T12:52:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -910,7 +910,7 @@
         "hashed_secret": "32cedd1d512c32c41cf5aae15c03a74c806120d2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 16,
+        "line_number": 17,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/architecture/.pages
+++ b/docs/docs/architecture/.pages
@@ -2,6 +2,7 @@ nav:
   - Overview: index.md
   - Interactive Explorer: explorer.md
   - Roadmap: roadmap.md
+  - Release History: releases.md
   - Performance Architecture: performance-architecture.md
   - Rust MCP Runtime: rust-mcp-runtime.md
   - MCP Apps: mcp-apps.md

--- a/docs/docs/architecture/releases.md
+++ b/docs/docs/architecture/releases.md
@@ -1,0 +1,16 @@
+# Release History
+
+Every stable release since General Availability, with the three most
+impactful changes in each. For the complete list of changes, see the
+[CHANGELOG](https://github.com/IBM/mcp-context-forge/blob/main/CHANGELOG.md);
+for what's coming next, see the [ContextForge Roadmap](roadmap.md).
+
+| Release | Date | Changes |
+|---|---|---|
+| **1.0.6** | 2026-07-21 | <ul><li>**MCP Apps support** — interactive UI resources served by MCP servers and rendered securely in agent clients</li><li>**RFC 8693 OAuth token exchange** — on-behalf-of delegation for virtual servers, plus per-user Vault credential resolution</li><li>**Dataplane capability publishing** — resource URIs, capabilities, and original tool names published from the dataplane</li></ul> |
+| **1.0.5** | 2026-07-07 | <ul><li>**Versioned API** — all endpoints served under the `/v1` prefix, with OpenAPI-to-MCP tool schema generation</li><li>**Auth hardening** — environment-bound JWTs closing cross-environment token acceptance (GHSA-vgf8-3685-66j9)</li><li>**A2A compatibility** — JSON-RPC passthrough endpoints and sensitive-header forwarding controls</li></ul> |
+| **1.0.4** | 2026-06-23 | <ul><li>**Rust server migration** — Rust benchmark server and A2A echo agent replace earlier implementations</li><li>**SSO `client_secret_basic` token exchange** for providers that require confidential-client authentication</li><li>**HTTP compliance** — RFC 6585 status codes and HTTP 202 Accepted responses for async operations</li></ul> |
+| **1.0.3** | 2026-06-10 | <ul><li>**Auth & JWT cleanup** — OAuth `audience` parameter support and token-handling fixes</li><li>**FedRAMP/FIPS hardening** — opt-in FIPS compliance mode with parameterized base images</li><li>**PII redaction in logs** — sensitive data scrubbed from log output</li></ul> |
+| **1.0.2** | 2026-05-25 | <ul><li>**Admin UI rewrite** — virtual server management, tools page cards, user management, and OAuth popup authorization flow</li><li>**Database migrations** — Alembic-based schema migration chain replaces ad-hoc bootstrapping</li><li>**A2A plugin framework integration** — agents participate in plugin hooks, with an A2A protocol version selector</li></ul> |
+| **1.0.1** | 2026-05-13 | <ul><li>**Security hardening** — CSRF token validation, nonce-based CSP (no `unsafe-inline`), and a comprehensive password policy</li><li>**UAID cross-gateway auth forwarding** between federated gateways</li><li>**Operational tooling** — secrets-generation CLI and fail-closed environment-aware defaults</li></ul> |
+| **1.0.0** | 2026-05-01 | <ul><li>**General Availability** — the first stable release of the ContextForge gateway</li><li>**JWT security** — server-side token revocation, idle timeout, and logout</li><li>**Content security** — malicious-pattern detection, prompt-template validation, and ReDoS defense for pattern scanning</li></ul> |

--- a/docs/docs/architecture/roadmap.md
+++ b/docs/docs/architecture/roadmap.md
@@ -1,24 +1,76 @@
 # ContextForge Roadmap
 
-## Major upcoming features
+This page summarizes the major themes under active development. For detailed
+tracking, see the linked GitHub epics and issues. Dates are targets, not
+commitments; minor releases ship roughly every two weeks. For what has already
+shipped, see the [Release History](releases.md).
 
-- Support for MCP Protocol features
-    - MCP Apps
-    - MCP Tasks
-    - Elicitation
-    - Pagination
-    - Completion
-    - Cancellation
+## MCP Protocol Features (Q3 2026)
 
-## ContextForge 2.0 - Coming late Q3 2026
+First-class support for MCP 2025-11-25 and 2026-07-28 protocol capabilities:
 
-- MCP 2026-07-28 Protocol
-- Hand-crafted User Experience
-- Streamlined Authentication, Authorization and Access Control
+- **MCP Apps** — interactive UI elements (charts, forms, media) served as MCP
+  resources and rendered securely in the agent client. Implementation supports
+  both stateful and stateless MCP, with CSP, sandboxing, and permissions
+  policy enforcement. Tracked in
+  [#2527](https://github.com/IBM/mcp-context-forge/issues/2527) (Governed
+  Extension Framework).
+- **MCP Tasks** — asynchronous, long-running operations with polling,
+  mid-flight input, and durable handles, delivered as the official
+  `io.modelcontextprotocol/tasks` extension. Tracked in
+  [#5677](https://github.com/IBM/mcp-context-forge/issues/5677) and
+  [#5683](https://github.com/IBM/mcp-context-forge/issues/5683).
+- **Elicitation, Pagination, Completion, and Cancellation** — tracked in
+  [#5558](https://github.com/IBM/mcp-context-forge/issues/5558), with
+  protocol-compliance verification in
+  [#5557](https://github.com/IBM/mcp-context-forge/issues/5557).
+- **Trusted Token Security Pattern** — authorize from properly signed tokens
+  without local user storage. Tracked in
+  [#5885](https://github.com/IBM/mcp-context-forge/issues/5885).
+
+## ContextForge 2.0 (late Q3 2026)
+
+- **MCP 2026-07-28 (stateless) protocol**, integrated with RBAC/ABAC role
+  control, plugins, and the control plane — preview available now, GA targeted
+  for late September. Tracked in
+  [#5677](https://github.com/IBM/mcp-context-forge/issues/5677) and
+  [#5679](https://github.com/IBM/mcp-context-forge/issues/5679).
+- **New user experience** — a redesigned look and feel covering all core
+  functions, replacing the HTMX frontend with a modern React application.
+  Tracked in [#4093](https://github.com/IBM/mcp-context-forge/issues/4093).
+- **Streamlined authentication, authorization, and access control.**
 
 ## Coming Q4 2026
 
-- Agent-to-Agent (A2A) v1.0.0 support
-- LLM Gateway Proxies (_e.g._ Portkey, LiteLLM)
-- UX Playground
-- Update Plugins
+- **Agent-to-Agent (A2A) v1.0.0 support** — the open standard for agent
+  interoperability, integrated with RBAC/ABAC, the plugin framework, and the
+  control plane. Tracked in
+  [#5936](https://github.com/IBM/mcp-context-forge/issues/5936).
+- **LLM Gateway Proxies** — provider-agnostic adapter for external LLM
+  gateways (_e.g._ LiteLLM, Portkey, and a ContextForge-native lightweight
+  option), with new providers added through configuration. Tracked in
+  [#3131](https://github.com/IBM/mcp-context-forge/issues/3131).
+- **UX Playground** — a chat interface to exercise and experiment with your
+  current ContextForge configuration.
+  ([#4927](https://github.com/IBM/mcp-context-forge/issues/4927))
+- **ContextForge TUI and Skills** — a terminal UI with Skills available in
+  both TUI and CLI modalities from the same binary. Tracked in
+  [#5731](https://github.com/IBM/mcp-context-forge/issues/5731).
+
+## Plugin Library Upgrades (Q3–Q4 2026)
+
+Moving plugin detection logic onto maintained open-source libraries:
+
+- **PII Filter → Presidio** —
+  [#2553](https://github.com/IBM/mcp-context-forge/issues/2553)
+- **SQL Injection → libinjection** —
+  [#5937](https://github.com/IBM/mcp-context-forge/issues/5937)
+- **Secret Detection → detect-secrets** —
+  [#5938](https://github.com/IBM/mcp-context-forge/issues/5938)
+
+## Runtimes and Code Mode (ongoing)
+
+- **Secure runtimes** for remote server deployment and catalog integration —
+  [#2110](https://github.com/IBM/mcp-context-forge/issues/2110)
+- **MCP Code Mode** — secure code execution and a virtual tool filesystem —
+  [#2952](https://github.com/IBM/mcp-context-forge/issues/2952)


### PR DESCRIPTION
# 📚 Documentation PR

## 🔗 Related Issue / Epic

N/A — no tracking issue; this refreshes the published roadmap to match the current H2 2026 plan.

---

## 📝 Summary (1-2 sentences)

Rewrites `docs/docs/architecture/roadmap.md` around the H2 2026 plan, linking every theme to its tracking epic or issue, and adds a new `docs/docs/architecture/releases.md` page with a release-by-release table of the most impactful changes since 1.0.0.

The previous roadmap was a short bullet list with no dates, no context, and no links — readers had no way to check status or follow along. Both pages are now cross-linked (roadmap → release history for what shipped, release history → roadmap for what's next), and the release history also points at `CHANGELOG.md` for the full detail.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage` — N/A, no linked issue
- [x] Unrelated docs fixes or improvements are tracked in separate issues/PRs
- [x] Generated files are separated where that improves reviewability
- [x] If AI-assisted, I understand and can explain the generated changes

---

## ✏️ Type of Change

- [ ] Typo / formatting
- [x] Outdated or incorrect info
- [x] Missing explanation / example
- [ ] Unclear instructions
- [x] New page or major rewrite
- [ ] Other (describe)

---

## 📄 What changed

**`architecture/roadmap.md`** — restructured into dated themes, each linked to its tracking issue:

| Section | Content |
|---|---|
| MCP Protocol Features (Q3 2026) | MCP Apps (#2527), MCP Tasks (#5677, #5683), Elicitation/Pagination/Completion/Cancellation (#5558, #5557), Trusted Token Security Pattern (#5885) |
| ContextForge 2.0 (late Q3 2026) | MCP 2026-07-28 stateless protocol (#5677, #5679), React UI replacing HTMX (#4093), streamlined authn/authz |
| Coming Q4 2026 | A2A v1.0.0 (#5936), LLM gateway proxies (#3131), UX Playground (#4927), ContextForge TUI and Skills (#5731) |
| Plugin Library Upgrades (Q3–Q4 2026) | PII Filter → Presidio (#2553), SQL injection → libinjection (#5937), secret detection → detect-secrets (#5938) |
| Runtimes and Code Mode (ongoing) | Secure runtimes (#2110), MCP Code Mode (#2952) |

A leading note makes the caveat explicit: dates are targets rather than commitments, and minor releases ship roughly every two weeks.

**`architecture/releases.md`** (new) — a table covering 1.0.0 through 1.0.6, three highlights per release, with dates.

**`architecture/.pages`** — registers the new page as *Release History*, immediately after *Roadmap*, so it appears in the sidebar rather than being reachable only via the in-page link.

**`.secrets.baseline`** — regenerated by the `detect-secrets` pre-commit hook (timestamp plus one shifted line number). Not a deliberate change; included because the hook rewrites it on commit.

---

## 🧪 Verification

| Check | Command | Result |
|---|---|---|
| Pre-commit hooks | `pre-commit` (via `git commit`) | ✅ Passed, including `detect-secrets` |
| Nav file parses | `python3 -c "yaml.safe_load(open('docs/docs/architecture/.pages'))"` | ✅ 19 entries, *Release History* in position 4 |
| Markdown lint | `markdownlint-cli2 --config .markdownlint-cli2.yaml` | ⚠️ See note below |

**Markdown lint note:** `releases.md` trips `MD033/no-inline-html` because the table cells use `<ul><li>` to hold multiple bullets per release — Markdown tables can't express multi-line cells otherwise. `MD033` is not currently enforced in CI, and neighbouring pages (e.g. `multitenancy.md`, `security-features.md`) already carry unrelated violations. Happy to flatten the cells to `<br>`-separated lines if the inline HTML is unwanted.

**Not run:** `mkdocs build` — MkDocs isn't installed in this environment. The changes are Markdown content plus one nav entry, so the risk is limited to the nav rendering; worth a quick `cd docs && make serve` from a reviewer with the docs toolchain installed.

No code, tests, or runtime behaviour is touched, so `make test` / `make coverage` are not applicable.

---

## 🙏 Notes for reviewers

The issue numbers and target dates are the parts most worth a second pair of eyes — please flag anything that has since moved, been renumbered, or slipped.
