### PR TITLE
fix(helm): set runAsUser so non-root containers can start

### DIFF
--- a/charts/mcp-stack/templates/deployment-mcp-fast-time-server.yaml
+++ b/charts/mcp-stack/templates/deployment-mcp-fast-time-server.yaml
@@ -54,6 +54,10 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            # The fast-time-server image declares no USER, so runAsNonRoot alone
+            # leaves kubelet with no non-root uid to use and it refuses the
+            # container. 1001 is the non-root uid used upstream.
+            runAsUser: 1001
             capabilities:
               drop:
                 - ALL

--- a/charts/mcp-stack/templates/deployment-postgres.yaml
+++ b/charts/mcp-stack/templates/deployment-postgres.yaml
@@ -171,6 +171,10 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            # The postgres image declares no USER, so runAsNonRoot alone leaves
+            # kubelet with no non-root uid to use and it refuses the container.
+            # 999 is the postgres uid built into the image.
+            runAsUser: 999
             capabilities:
               drop:
                 - ALL

--- a/charts/mcp-stack/templates/deployment-redis.yaml
+++ b/charts/mcp-stack/templates/deployment-redis.yaml
@@ -44,6 +44,10 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            # The redis image declares no USER, so runAsNonRoot alone leaves
+            # kubelet with no non-root uid to use and it refuses the container.
+            # 999 is the redis uid built into the image.
+            runAsUser: 999
             capabilities:
               drop:
                 - ALL

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -1027,7 +1027,7 @@ migration:
   # Use same image as mcpgateway
   image:
     repository: ghcr.io/ibm/mcp-context-forge
-    tag: "v1.0.6"                            # Should match mcpContextForge.image.tag
+    tag: "v1.0.7"                            # Should match mcpContextForge.image.tag
     pullPolicy: Always                      # Always pull to ensure latest security patches
 
   # Resource limits for the migration job


### PR DESCRIPTION
## 🔗 Related Issue

Closes #

---

## 📝 Summary

A default `helm install` of the `mcp-stack` chart at 1.0.7 does not come up — it lands at **0/6 pods**, with postgres, redis and fast-time-server all stuck in `CreateContainerConfigError`:

```
container has runAsNonRoot and image will run as root
```

These three containers set `runAsNonRoot: true` but never set `runAsUser`. None of the three images declare a `USER`, so kubelet has no non-root uid to run them as and refuses to start the container. This is a config rejection, not a crash — the containers never execute.

This PR sets the uid each image actually ships with:

| Container | uid | Source |
|---|---|---|
| postgres | 999 | `id postgres` in `postgres:17` → `uid=999(postgres)` |
| redis | 999 | `id redis` in `redis:8.0.0` → `uid=999(redis)` |
| fast-time-server | 1001 | `ghcr.io/ibm/fast-time-server:latest` declares `USER 1001:1001` |

**Two different bugs, same symptom.** Worth knowing when reviewing:

- **postgres / redis** — `runAsNonRoot` was newly added to these containers in `7a22fa442`, with no `runAsUser` alongside it. Straightforwardly incomplete.
- **fast-time-server** — this one already ran with `runAsNonRoot` at 1.0.5 and 1.0.6 and was fine, because it used the `:latest` tag, which declares `USER 1001:1001`. The same commit re-pinned it to `0.8.0`, an image built *without* a `USER`. So here the regression is the tag pin, not the security setting.

Both trace to `7a22fa442` (`fix(helm): resolve Helm chart linting issues`, 2026-07-22), which landed one day after 1.0.6 shipped (2026-07-21) and is not an ancestor of either the 1.0.5 or 1.0.6 release commit.

Worth calling out, because it explains how this reached a release branch: that commit is what drove **kube-linter from 14 findings → 0** and **checkov from 50 failures → 0**. On a static-gates-only view 1.0.7 looks like the cleanest release yet. The lint gates improved *because of* the same change that broke the runtime, so any verification that stopped at the lint table would have reported green.

### Also: `migration.image.tag`

Bumped `v1.0.6` → `v1.0.7` to satisfy its own comment ("Should match `mcpContextForge.image.tag`", which is already `v1.0.7`). The release bump in `11053fad7` updated the gateway tag and missed this one.

This is not cosmetic. 1.0.7 adds four Alembic migrations:

```
7ab59991e017_fix_oauth_tokens_unique_constraint.py
c9f8e7d6a4b3_add_learned_aud_and_iss_to_oauth_tokens.py
d21698ae4a19_add_rbac_unique_constraints_race_fix.py
e1a2b3c4d5f6_add_add_remove_headers_to_gateways.py
```

A migration job running the `v1.0.6` image does not contain these. It would upgrade the schema to 1.0.6's head, and the 1.0.7 gateway would then fail startup with `_SchemaNotAtHeadError: Schema not at head; migrations required before startup`.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

Chart-only change (4 YAML lines), so the Python suites below are not applicable. The chart-relevant gates from `release-management.md` §10 were run instead.

| Check | Command | Status |
|---|---|---|
| Lint suite | `make lint` | ⬜ N/A — no Python/JS/MD changed |
| Unit tests | `make test` | ⬜ N/A — no application code changed |
| Coverage ≥ 80% | `make coverage` | ⬜ N/A — no application code changed |
| Helm lint | `make helm-lint` | ✅ 1 chart linted, 0 failed |
| Kubernetes lint | `make linting-security-kube-linter` | ✅ No lint errors found |
| IaC security scan | `checkov -d .` (skip-list per Makefile) | ✅ helm 424 / dockerfile 175 / actions 1474, **0 failures** |
| Chart package | `make helm-package` | ✅ `dist/mcp-stack-1.0.7.tgz` |
| Minikube deploy | `helm upgrade --install` | ✅ **6/6 pods 1/1 Running** |
| Smoke test | `curl` via port-forward | ✅ see below |
| Teardown | `helm uninstall` | ✅ clean |

### Before

```
NAME                                              READY   STATUS
mcp-stack-mcp-fast-time-server-5ff548b898-t6984   0/1     CreateContainerConfigError
mcp-stack-mcp-fast-time-server-5ff548b898-vnv4m   0/1     CreateContainerConfigError
mcp-stack-mcpgateway-56f4d99fb6-5njpz             0/1     ImagePullBackOff
mcp-stack-mcpgateway-56f4d99fb6-x66tl             0/1     ErrImagePull
mcp-stack-postgres-574d97c7b9-bds7l               0/1     CreateContainerConfigError
mcp-stack-redis-984b7cfcf-5bb52                   0/1     CreateContainerConfigError
```

### After

```
NAME                                             READY   STATUS    RESTARTS
mcp-stack-mcp-fast-time-server-78ccb664f-fdmgh   1/1     Running   0
mcp-stack-mcp-fast-time-server-78ccb664f-s2xkl   1/1     Running   0
mcp-stack-mcpgateway-7d6f7c7d79-lgqqk            1/1     Running   1
mcp-stack-mcpgateway-7d6f7c7d79-wvnws            1/1     Running   1
mcp-stack-postgres-57d49f7999-bwb7l              1/1     Running   0
mcp-stack-redis-5595f7774f-vzw2c                 1/1     Running   0
```

### Smoke test

```
/health    HTTP 200   {"status":"healthy", ...}
/ready     HTTP 200   {"status":"ready","status_items":[
                        {"name":"Database","status_code":200,"message":"Database Connection Successful"},
                        {"name":"Cache","status_code":200, ...}]}
/version   HTTP 401   {"detail":"Authentication required..."}   ← expected, auth required
```

### Confirming the fix is what's acting

```
postgres              id -u → 999
redis                 id -u → 999
mcp-fast-time-server  pod spec runAsUser → 1001   (distroless; no shell to exec)
```

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`) — N/A, YAML only; `helm lint` clean
- [ ] Tests added/updated for changes
- [x] Documentation updated (if applicable) — N/A; inline comments added at each `runAsUser`
- [x] No secrets or credentials committed

---

## 📓 Notes

### Verification caveats — please read before merging

1. **Deployed against the v1.0.6 image, not v1.0.7.** `ghcr.io/ibm/mcp-context-forge:v1.0.7` returns `manifest unknown` — CI has not published it. Both `mcpContextForge.image.tag` and `migration.image.tag` were overridden to `v1.0.6` for the run so the pair stayed consistent.

   This is fine for the securityContext fix, which kubelet evaluates from the pod spec *before* the image runs — the image contents cannot affect it. It is **not** fine as evidence for the `migration.image.tag` bump, which rests on the four migrations listed above rather than on an observed run. **The v1.0.7 image itself remains unverified.**

2. **Installed without `--wait`.** `make helm-deploy` uses `--wait`, which deadlocks against the `post-install` migration hook: Helm will not fire the hook until the gateway is Ready, and the gateway cannot be Ready until the hook has migrated the database. Result is `pending-install`, no Job, gateway crashlooping on `Schema not at head`. A plain `helm install` works. Out of scope here — see below.

3. **Secrets supplied at install.** The chart defaults ship `ENVIRONMENT: production` alongside placeholder secrets (`my-test-key…`, `my-test-salt`, `changeme`), which the app now rejects at startup. Strong values were passed via `--set`. Arguably intended, but it does mean the stock default install does not boot.


### Out of scope — worth separate issues

1. **`make helm-deploy` deadlocks** (see caveat 2). Fix is either `hookPhase: pre-install` on the migration job or dropping `--wait` from the Makefile target. Changes install semantics, so it wants a maintainer decision.
2. **`make linting-security-checkov` cannot run** on a machine without `python3-venv` — the target fails at venv creation (`ensurepip is not available`) rather than scanning. It exits non-zero, so it is not silently passing. Results above were obtained via `uv tool run` with the identical target and skip-list.
3. **Note on the checkov skip-list:** it currently suppresses every finding. Without it: 30 helm / 3 dockerfile / 7 secrets / 2 actions failures. The reported 0 reflects the skip-list, not an absence of findings.
4. **`release-management.md` §10.3 gap** — the step says `make minikube-image-load`, which loads `mcpgateway/mcpgateway:latest`, but `helm-deploy` pulls `ghcr.io/ibm/mcp-context-forge:<tag>`. The loaded image is never used unless the repository/tag are also overridden, which the doc does not mention. The procedure quietly assumes the release image is already published.
