### PR TITLE
fix(tools): preserve vendor REST error details

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -636,6 +636,59 @@ def _handle_json_parse_error(response, error, is_error_response: bool = False) -
     return {"response_text": text}
 
 
+def _format_rest_error_message(response: Any, result: object, fallback_message: Optional[str] = None) -> str:
+    """Return a useful, bounded message from a REST error response.
+
+    REST APIs use several common JSON error envelopes. Preserve those details
+    for tool callers and fall back to the raw response body for unknown or
+    non-object JSON values. The fallback is bounded by the same setting used
+    for non-JSON responses.
+
+    Args:
+        response: HTTP response with ``status_code`` and ``text`` attributes.
+        result: Parsed JSON body, or the fallback produced by
+            :func:`_handle_json_parse_error`.
+        fallback_message: Message to use when a non-JSON-compatible result
+            cannot be rendered.
+
+    Returns:
+        Error text suitable for a ``TextContent`` response.
+    """
+
+    if isinstance(result, Mapping):
+        for key in ("error", "errors", "message", "detail"):
+            value = result.get(key)
+            if value not in (None, "", [], {}):
+                return value if isinstance(value, str) else orjson.dumps(value).decode()
+
+        response_text = result.get("response_text")
+        if isinstance(response_text, str) and response_text:
+            return f"HTTP {response.status_code}: {response_text}"
+
+    if isinstance(result, str):
+        body = result
+    else:
+        response_text = getattr(response, "text", "")
+        if isinstance(response_text, str) and response_text:
+            body = response_text
+        else:
+            try:
+                body = orjson.dumps(result).decode()
+            except (TypeError, ValueError):
+                if fallback_message is not None:
+                    return fallback_message
+                body = _safe_text_repr(result, _safe_type_name(result))
+
+    if body:
+        max_length = settings.rest_response_text_max_length
+        if len(body) > max_length:
+            logger.warning("REST error response truncated from %s to %s characters.", len(body), max_length)
+            body = body[:max_length]
+        return f"HTTP {response.status_code}: {body}"
+
+    return f"HTTP {response.status_code}"
+
+
 @lru_cache(maxsize=256)
 def _compile_jq_filter(jq_filter: str):
     """Cache compiled jq filter program.
@@ -5683,14 +5736,9 @@ class ToolService(BaseService):
                                 result = response.json()
                             except (json.JSONDecodeError, orjson.JSONDecodeError, UnicodeDecodeError, AttributeError) as e:
                                 result = _handle_json_parse_error(response, e, is_error_response=True)
-                            if "error" in result:
-                                error_val = result["error"]
-                            elif "response_text" in result:
-                                error_val = f"HTTP {response.status_code}: {result['response_text']}"
-                            else:
-                                error_val = f"HTTP {response.status_code}"
+                            error_val = _format_rest_error_message(response, result)
                             tool_result = ToolResult(
-                                content=[TextContent(type="text", text=error_val if isinstance(error_val, str) else orjson.dumps(error_val).decode())],
+                                content=[TextContent(type="text", text=error_val)],
                                 is_error=True,
                                 structured_content={"status_code": response.status_code},
                             )
@@ -5708,9 +5756,9 @@ class ToolService(BaseService):
                                 result = response.json()
                             except (json.JSONDecodeError, orjson.JSONDecodeError, UnicodeDecodeError, AttributeError) as e:
                                 result = _handle_json_parse_error(response, e, is_error_response=True)
-                            error_val = result["error"] if "error" in result else "Tool error encountered"
+                            error_val = _format_rest_error_message(response, result, fallback_message="Tool error encountered")
                             tool_result = ToolResult(
-                                content=[TextContent(type="text", text=error_val if isinstance(error_val, str) else orjson.dumps(error_val).decode())],
+                                content=[TextContent(type="text", text=error_val)],
                                 is_error=True,
                             )
                             # Don't mark as successful for error responses - success remains False

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -6158,8 +6158,72 @@ class TestRestToolQueryParamHandling:
             assert params == {"q": "test"}
 
 
-class TestRestToolNonJsonResponses:
-    """Tests for handling non-JSON responses from REST tools (#3855)."""
+class TestRestToolErrorResponses:
+    """Tests for preserving error details from REST tool responses (#3855, #6027)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("body", "expected"),
+        [
+            ({"error": "Invalid zone identifier"}, "Invalid zone identifier"),
+            ({"errors": [{"code": 6003, "message": "Invalid zone identifier"}]}, '[{"code":6003,"message":"Invalid zone identifier"}]'),
+            ({"message": "Invalid zone identifier"}, "Invalid zone identifier"),
+            ({"detail": "Invalid zone identifier"}, "Invalid zone identifier"),
+            ({"reason": "Invalid zone identifier"}, 'HTTP 403: {"reason":"Invalid zone identifier"}'),
+            ([{"code": 6003, "message": "Invalid zone identifier"}], 'HTTP 403: [{"code":6003,"message":"Invalid zone identifier"}]'),
+            ("forbidden", "HTTP 403: forbidden"),
+            (None, "HTTP 403: null"),
+            (403, "HTTP 403: 403"),
+        ],
+    )
+    async def test_rest_tool_preserves_json_error_details(self, tool_service, mock_tool, mock_global_config_obj, test_db, body, expected):
+        """REST errors retain common vendor envelopes and arbitrary JSON bodies (#6027)."""
+        # Third-Party
+        import httpx
+
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "GET"
+        mock_tool.jsonpath_filter = ""
+        mock_tool.auth_value = None
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        response = Mock()
+        response.status_code = 403
+        response.text = orjson.dumps(body).decode()
+        response.json = Mock(return_value=body)
+        request = httpx.Request("GET", "https://api.example.com/test")
+        response.raise_for_status = Mock(side_effect=httpx.HTTPStatusError("Forbidden", request=request, response=response))
+        tool_service._http_client.get = AsyncMock(return_value=response)
+
+        with patch("mcpgateway.services.tool_service.metrics_buffer", Mock()):
+            result = await tool_service.invoke_tool(test_db, "test_tool", {}, request_headers=None)
+
+        assert result.is_error is True
+        assert result.structured_content == {"status_code": 403}
+        assert result.content[0].text == expected
+
+    @pytest.mark.asyncio
+    async def test_rest_tool_preserves_nonstandard_2xx_error_details(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """Non-standard 2xx errors use the same vendor error extraction (#6027)."""
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "GET"
+        mock_tool.jsonpath_filter = ""
+        mock_tool.auth_value = None
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        body = {"errors": [{"code": "partial_failure", "message": "One operation failed"}]}
+        response = Mock()
+        response.status_code = 207
+        response.text = orjson.dumps(body).decode()
+        response.json = Mock(return_value=body)
+        response.raise_for_status = Mock()
+        tool_service._http_client.get = AsyncMock(return_value=response)
+
+        with patch("mcpgateway.services.tool_service.metrics_buffer", Mock()):
+            result = await tool_service.invoke_tool(test_db, "test_tool", {}, request_headers=None)
+
+        assert result.is_error is True
+        assert result.content[0].text == '[{"code":"partial_failure","message":"One operation failed"}]'
 
     @pytest.mark.asyncio
     async def test_rest_tool_handles_html_error_response(self, tool_service, mock_tool, mock_global_config_obj, test_db, caplog):


### PR DESCRIPTION
## Summary

REST tools now preserve vendor error details instead of reducing most JSON error responses to a bare HTTP status.

- Supports the common `error`, `errors`, `message`, and `detail` envelopes.
- Preserves arbitrary JSON arrays, scalars, and unknown object shapes through a bounded raw-body fallback.
- Applies the same extraction logic to HTTP errors and non-standard 2xx error responses.
- Keeps the HTTP status in `structured_content` for retry and circuit-breaker consumers.

Closes #6027

## Reproduction Steps

A REST tool returning a Cloudflare-style `errors` array previously produced only `HTTP 403`. JSON strings, arrays, `null`, and numeric bodies could also trigger secondary exceptions while the error path inspected them as mappings.

## Root Cause

The error handler assumed every parsed JSON value was a mapping and only recognized a top-level `error` key. The `response_text` fallback was populated only for JSON parse failures, so valid JSON in every other shape was discarded.

## Fix Description

A shared formatter now:

1. extracts known error-envelope fields in a stable order;
2. serializes structured error values;
3. falls back to the original response body for unknown JSON shapes;
4. truncates fallback text using `REST_RESPONSE_TEXT_MAX_LENGTH`; and
5. preserves the previous generic fallback for non-JSON-compatible mock or adapter results.

Both REST error branches use this formatter. Parameterized regression coverage exercises nine JSON body shapes plus the non-standard 2xx path.

## Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated changes are excluded
- [x] Tests are included with the code they validate

## Verification

| Check | Command | Result |
|---|---|---|
| Focused regression | `pytest tests/unit/mcpgateway/services/test_tool_service.py -k rest_tool_preserves -q` | passed |
| Complete tool service module | `pytest tests/unit/mcpgateway/services/test_tool_service.py -q` | 409 passed |
| Ruff lint | `ruff check mcpgateway/services/tool_service.py tests/unit/mcpgateway/services/test_tool_service.py` | passed |
| Ruff format | `ruff format --check mcpgateway/services/tool_service.py tests/unit/mcpgateway/services/test_tool_service.py` | passed |
| Full repository suite | `make test` | not run locally; native Windows dev sync is blocked by `pytype` requiring MSVC |
