### PR TITLE
fix(ui): restore gateway selection when editing virtual servers

### DIFF
--- a/mcpgateway/admin_ui/events.js
+++ b/mcpgateway/admin_ui/events.js
@@ -707,6 +707,26 @@ import {
   // wire up the checkbox-pill UI.  Avoids new Function() / unsafe-eval.
   // ===================================================================
   const SELECTOR_SWAP_MAP = {
+    associatedGateways: () =>
+      initGatewaySelect(
+        "associatedGateways",
+        "selectedGatewayPills",
+        "selectedGatewayWarning",
+        12,
+        "selectAllGatewayBtn",
+        "clearAllGatewayBtn",
+        "searchGateways"
+      ),
+    associatedEditGateways: () =>
+      initGatewaySelect(
+        "associatedEditGateways",
+        "selectedEditGatewayPills",
+        "selectedEditGatewayWarning",
+        12,
+        "selectAllEditGatewayBtn",
+        "clearAllEditGatewayBtn",
+        "searchEditGateways"
+      ),
     associatedTools: () =>
       Admin.initToolSelect(
         "associatedTools",

--- a/mcpgateway/admin_ui/gateways.js
+++ b/mcpgateway/admin_ui/gateways.js
@@ -620,6 +620,55 @@ export const initGatewaySelect = function (
     return;
   }
 
+  const checkboxGatewayId = (checkbox) =>
+    checkbox.dataset?.gatewayNull === "true"
+      ? "null"
+      : String(checkbox.value);
+
+  const applyPersistedSelection = function () {
+    if (!container.dataset.selectedGatewayIds) return;
+
+    try {
+      const selectedIds = new Set(
+        JSON.parse(container.dataset.selectedGatewayIds).map(String)
+      );
+      container
+        .querySelectorAll('input[type="checkbox"]')
+        .forEach((checkbox) => {
+          checkbox.checked = selectedIds.has(checkboxGatewayId(checkbox));
+        });
+    } catch (error) {
+      console.error("Error restoring gateway selection:", error);
+    }
+  };
+
+  const persistSelection = function () {
+    const selectAllInput = container.querySelector(
+      'input[name="selectAllGateways"]'
+    );
+    const allIdsInput = container.querySelector(
+      'input[name="allGatewayIds"]'
+    );
+
+    if (selectAllInput?.value === "true" && allIdsInput) {
+      try {
+        container.dataset.selectedGatewayIds = JSON.stringify(
+          JSON.parse(allIdsInput.value).map(String)
+        );
+        return;
+      } catch (error) {
+        console.error("Error persisting all gateway IDs:", error);
+      }
+    }
+
+    const selectedIds = Array.from(
+      container.querySelectorAll('input[type="checkbox"]:checked')
+    ).map(checkboxGatewayId);
+    container.dataset.selectedGatewayIds = JSON.stringify(selectedIds);
+  };
+
+  applyPersistedSelection();
+
   const pillClasses =
     "inline-block bg-indigo-100 text-indigo-800 text-xs px-2 py-1 rounded-full dark:bg-indigo-900 dark:text-indigo-200";
 
@@ -779,6 +828,7 @@ export const initGatewaySelect = function (
         allIdsInput.remove();
       }
 
+      persistSelection();
       update();
 
       // Reload associated items after clearing selection
@@ -881,6 +931,7 @@ export const initGatewaySelect = function (
         }
         allIdsInput.value = JSON.stringify(allGatewayIds);
 
+        persistSelection();
         update();
 
         // Reload associated items after selecting all
@@ -952,6 +1003,7 @@ export const initGatewaySelect = function (
         // selected together with real gateways. Server-side filtering already
         // supports mixed lists like `gateway_id=abc,null`.
 
+        persistSelection();
         update();
 
         // Trigger reload of associated tools, resources, and prompts with selected gateway filter

--- a/mcpgateway/admin_ui/servers.js
+++ b/mcpgateway/admin_ui/servers.js
@@ -865,6 +865,15 @@ export const editServer = async function (serverId) {
     // Store server data for modal population
     window.Admin.currentEditingServer = server;
 
+    // Gateway selection is derived from the server's associated entities. Keep
+    // it on the stable HTMX container so swaps can restore the checked state.
+    const editGatewaysContainer = safeGetElement("associatedEditGateways");
+    if (editGatewaysContainer) {
+      editGatewaysContainer.dataset.selectedGatewayIds = JSON.stringify(
+        (server.associatedGateways || []).map(String)
+      );
+    }
+
     // Set associated tools data attribute on the container for reference by initToolSelect
     const editToolsContainer = safeGetElement("edit-server-tools");
     if (editToolsContainer && server.associatedTools) {

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -4703,7 +4703,7 @@ class ServerRead(BaseModelWithConfigDict):
 
     Includes all server fields plus:
     - Database ID
-    - Associated tool, resource, and prompt IDs
+    - Associated tool, resource, prompt, and gateway IDs
     - Creation/update timestamps
     - Active status
     - Metrics: Aggregated metrics for the server invocations.
@@ -4722,6 +4722,7 @@ class ServerRead(BaseModelWithConfigDict):
     associated_resources: List[str] = []
     associated_prompts: List[str] = []
     associated_a2a_agents: List[str] = []
+    associated_gateways: List[str] = []
     metrics: Optional[ServerMetrics] = Field(None, description="Server metrics (may be None in list operations)")
     tags: List[Dict[str, str]] = Field(default_factory=list, description="Tags for categorizing the server")
 

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -457,6 +457,18 @@ class ServerService(BaseService):
         server_dict["associated_prompts"] = [prompt.id for prompt in server.prompts if getattr(prompt, "enabled", True)] if server.prompts else []
         server_dict["associated_a2a_agents"] = [agent.id for agent in server.a2a_agents if getattr(agent, "enabled", True)] if server.a2a_agents else []
 
+        # Gateway selection is a UI filter rather than a persisted server relationship.
+        # Reconstruct it from the active entities that currently compose the server.
+        associated_gateway_ids: set[str] = set()
+        for entities in (server.tools, server.resources, server.prompts):
+            for entity in entities or []:
+                if getattr(entity, "enabled", True):
+                    gateway_id = getattr(entity, "gateway_id", None)
+                    associated_gateway_ids.add(str(gateway_id) if gateway_id is not None else "null")
+        if any(getattr(agent, "enabled", True) for agent in server.a2a_agents or []):
+            associated_gateway_ids.add("null")
+        server_dict["associated_gateways"] = sorted(associated_gateway_ids)
+
         # Team name is loaded via server.team property from email_team relationship
         server_dict["team"] = getattr(server, "team", None)
 

--- a/mcpgateway/templates/gateways_selector_items.html
+++ b/mcpgateway/templates/gateways_selector_items.html
@@ -23,7 +23,7 @@
 >
   <input
     type="checkbox"
-    name="associatedgateways"
+    name="associatedGateways"
     value="{{ gateway.id }}"
     data-gateway-name="{{ gateway_label }}"
     class="gateway-checkbox form-checkbox h-5 w-5 text-purple-600 dark:bg-gray-800 dark:border-gray-600"

--- a/tests/unit/js/events.test.js
+++ b/tests/unit/js/events.test.js
@@ -58,6 +58,50 @@ describe("events.js - Module Import", () => {
   test("events module can be imported without errors", async () => {
     await expect(import("../../../mcpgateway/admin_ui/events.js")).resolves.toBeDefined();
   });
+
+  test("reinitializes the edit gateway selector after an HTMX swap", async () => {
+    const { initGatewaySelect } = await import(
+      "../../../mcpgateway/admin_ui/gateways.js"
+    );
+    const target = document.createElement("div");
+    target.id = "associatedEditGateways";
+
+    document.dispatchEvent(
+      new CustomEvent("htmx:afterSwap", { detail: { target } })
+    );
+
+    expect(initGatewaySelect).toHaveBeenCalledWith(
+      "associatedEditGateways",
+      "selectedEditGatewayPills",
+      "selectedEditGatewayWarning",
+      12,
+      "selectAllEditGatewayBtn",
+      "clearAllEditGatewayBtn",
+      "searchEditGateways"
+    );
+  });
+
+  test("reinitializes the create gateway selector after an HTMX swap", async () => {
+    const { initGatewaySelect } = await import(
+      "../../../mcpgateway/admin_ui/gateways.js"
+    );
+    const target = document.createElement("div");
+    target.id = "associatedGateways";
+
+    document.dispatchEvent(
+      new CustomEvent("htmx:afterSwap", { detail: { target } })
+    );
+
+    expect(initGatewaySelect).toHaveBeenCalledWith(
+      "associatedGateways",
+      "selectedGatewayPills",
+      "selectedGatewayWarning",
+      12,
+      "selectAllGatewayBtn",
+      "clearAllGatewayBtn",
+      "searchGateways"
+    );
+  });
 });
 
 describe("events.js - DOMContentLoaded initialization", () => {

--- a/tests/unit/js/gateway.test.js
+++ b/tests/unit/js/gateway.test.js
@@ -75,6 +75,79 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+describe("initGatewaySelect persisted selection", () => {
+  test("restores real and local gateway selections and keeps later changes", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    document.body.innerHTML = `
+      <div id="edit-gateways" data-selected-gateway-ids='["gw-a","null"]'>
+        <label class="tool-item">
+          <input type="checkbox" value="gw-a" />
+          <span>Gateway A</span>
+        </label>
+        <label class="tool-item">
+          <input type="checkbox" value="gw-b" />
+          <span>Gateway B</span>
+        </label>
+        <label class="tool-item">
+          <input type="checkbox" value="" data-gateway-null="true" />
+          <span>REST/A2A</span>
+        </label>
+      </div>
+      <div id="edit-pills"></div>
+      <div id="edit-warning"></div>
+    `;
+
+    initGatewaySelect(
+      "edit-gateways",
+      "edit-pills",
+      "edit-warning",
+      12,
+      null,
+      null,
+      null
+    );
+
+    const [gatewayA, gatewayB, local] = document.querySelectorAll(
+      '#edit-gateways input[type="checkbox"]'
+    );
+    expect(gatewayA.checked).toBe(true);
+    expect(gatewayB.checked).toBe(false);
+    expect(local.checked).toBe(true);
+    expect(document.getElementById("edit-pills").children).toHaveLength(2);
+
+    gatewayA.checked = false;
+    gatewayA.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(
+      JSON.parse(
+        document.getElementById("edit-gateways").dataset.selectedGatewayIds
+      )
+    ).toEqual(["null"]);
+
+    const container = document.getElementById("edit-gateways");
+    container.innerHTML = `
+      <input type="checkbox" value="gw-a" />
+      <input type="checkbox" value="" data-gateway-null="true" />
+    `;
+    initGatewaySelect(
+      "edit-gateways",
+      "edit-pills",
+      "edit-warning",
+      12,
+      null,
+      null,
+      null
+    );
+
+    const [reloadedGateway, reloadedLocal] = container.querySelectorAll(
+      'input[type="checkbox"]'
+    );
+    expect(reloadedGateway.checked).toBe(false);
+    expect(reloadedLocal.checked).toBe(true);
+    consoleSpy.mockRestore();
+  });
+});
+
 // ---------------------------------------------------------------------------
 // viewGateway
 // ---------------------------------------------------------------------------

--- a/tests/unit/js/servers.test.js
+++ b/tests/unit/js/servers.test.js
@@ -15,6 +15,7 @@ import { fetchWithTimeout } from "../../../mcpgateway/admin_ui/utils";
 import { openModal } from "../../../mcpgateway/admin_ui/modals";
 import { AppState } from "../../../mcpgateway/admin_ui/appState.js";
 import { fetchWithAuth } from "../../../mcpgateway/admin_ui/tokens.js";
+import { initGatewaySelect } from "../../../mcpgateway/admin_ui/gateways.js";
 
 vi.mock("../../../mcpgateway/admin_ui/appState.js", () => ({
   AppState: {
@@ -216,6 +217,44 @@ describe("viewServer", () => {
 // editServer
 // ---------------------------------------------------------------------------
 describe("editServer", () => {
+  test("seeds gateway selection for the edit modal", async () => {
+    window.ROOT_PATH = "";
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    document.body.innerHTML = `
+      <form id="edit-server-form"></form>
+      <div id="associatedEditGateways"></div>
+    `;
+
+    fetchWithTimeout.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          id: "s1",
+          name: "test-server",
+          associatedGateways: ["gw-a", "gw-b"],
+        }),
+    });
+
+    await editServer("s1");
+
+    expect(
+      JSON.parse(
+        document.getElementById("associatedEditGateways").dataset
+          .selectedGatewayIds
+      )
+    ).toEqual(["gw-a", "gw-b"]);
+    expect(initGatewaySelect).toHaveBeenCalledWith(
+      "associatedEditGateways",
+      "selectedEditGatewayPills",
+      "selectedEditGatewayWarning",
+      12,
+      "selectAllEditGatewayBtn",
+      "clearAllEditGatewayBtn",
+      "searchEditGateways"
+    );
+    consoleSpy.mockRestore();
+  });
+
   test("fetches server data for editing", async () => {
     window.ROOT_PATH = "";
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});

--- a/tests/unit/mcpgateway/services/test_server_service.py
+++ b/tests/unit/mcpgateway/services/test_server_service.py
@@ -3579,6 +3579,37 @@ class TestConvertServerToReadAssociatedToolIds:
 
         assert result.associated_tool_ids == ["42"]
 
+    def test_associated_gateways_derived_from_active_entities(self, server_service):
+        """associated_gateways contains distinct gateway IDs across active entity types."""
+        # Standard
+        from types import SimpleNamespace
+
+        tools = [
+            SimpleNamespace(id="t1", name="Tool A", gateway_id="gw-b", enabled=True),
+            SimpleNamespace(id="t2", name="Tool B", gateway_id="gw-a", enabled=True),
+            SimpleNamespace(id="t3", name="Tool C", gateway_id="gw-disabled", enabled=False),
+        ]
+        resources = [SimpleNamespace(id="r1", gateway_id="gw-b", enabled=True)]
+        prompts = [SimpleNamespace(id="p1", gateway_id=None, enabled=True)]
+        server = self._make_server(tools=tools, resources=resources, prompts=prompts)
+
+        result = server_service.convert_server_to_read(server, include_metrics=False)
+
+        assert result.associated_gateways == ["gw-a", "gw-b", "null"]
+        assert result.model_dump(by_alias=True)["associatedGateways"] == ["gw-a", "gw-b", "null"]
+
+    def test_associated_gateways_includes_local_sentinel_for_a2a_agents(self, server_service):
+        """A server with an active A2A agent selects the shared local-entity entry."""
+        # Standard
+        from types import SimpleNamespace
+
+        server = self._make_server()
+        server.a2a_agents = [SimpleNamespace(id="agent-1", enabled=True)]
+
+        result = server_service.convert_server_to_read(server, include_metrics=False)
+
+        assert result.associated_gateways == ["null"]
+
     @pytest.mark.asyncio
     async def test_get_server_filters_deactivated_entities(self, server_service, test_db):
         """Test that get_server filters out deactivated tools, prompts, and resources."""


### PR DESCRIPTION
## Summary

- derive a virtual server's contributing gateway IDs from its active tools, resources, prompts, and A2A agents
- seed and persist the gateway checkbox state in the edit modal, including across HTMX swaps
- reinitialize both create and edit gateway selectors after partial reloads
- normalize the gateway checkbox field name to `associatedGateways`

The gateway rollup is read-only, so this does not add a migration or duplicate the existing entity associations.

## Testing

- `pytest tests/unit/mcpgateway/services/test_server_service.py -q` (123 passed)
- `pytest tests/unit/mcpgateway/test_schemas.py -q` (125 passed)
- `vitest run` (2326 passed, 3 skipped)
- `ruff check mcpgateway/schemas.py mcpgateway/services/server_service.py`
- `vite build`
- `git diff --check`

Closes #6042