### PR TITLE
fix(catalog): preserve caller identity during registration

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -159,7 +159,7 @@ from mcpgateway.services.a2a_agent_plugin_binding_service import A2AAgentPluginB
 from mcpgateway.services.a2a_service import A2AAgentError, A2AAgentNameConflictError, A2AAgentNotFoundError, A2AAgentService
 from mcpgateway.services.argon2_service import Argon2PasswordService
 from mcpgateway.services.audit_trail_service import get_audit_trail_service
-from mcpgateway.services.catalog_service import catalog_service
+from mcpgateway.services.catalog_service import CatalogRegistrationContext, catalog_service
 from mcpgateway.services.content_security import ContentSizeError, ContentTypeError, TemplateValidationError
 from mcpgateway.services.csrf_service import get_csrf_service
 from mcpgateway.services.email_auth_service import AuthenticationError, EmailAuthService, PasswordValidationError
@@ -17904,6 +17904,22 @@ async def list_catalog_servers(
     return await catalog_service.get_catalog_servers(catalog_request, db)
 
 
+async def _catalog_registration_context(request: Request, user: Any, db: Session) -> CatalogRegistrationContext:
+    """Build gateway ownership and audit metadata for catalog registration."""
+    user_email = get_user_email(user)
+    verified_team_id = await TeamManagementService(db).verify_team_for_user(user_email)
+    metadata = MetadataCapture.extract_creation_metadata(request, user)
+
+    return CatalogRegistrationContext(
+        created_by=metadata["created_by"] or user_email,
+        owner_email=user_email,
+        created_from_ip=metadata["created_from_ip"],
+        created_via=metadata["created_via"],
+        created_user_agent=metadata["created_user_agent"],
+        team_id=verified_team_id if isinstance(verified_team_id, str) else None,
+    )
+
+
 @admin_router.post("/mcp-registry/{server_id}/register", response_model=CatalogServerRegisterResponse)
 @require_permission("servers.create", allow_admin_bypass=False)
 async def register_catalog_server(
@@ -17931,7 +17947,8 @@ async def register_catalog_server(
     if not settings.mcpgateway_catalog_enabled:
         raise HTTPException(status_code=404, detail="Catalog feature is disabled")
 
-    result = await catalog_service.register_catalog_server(catalog_id=server_id, request=request, db=db)
+    registration_context = await _catalog_registration_context(http_request, _user, db)
+    result = await catalog_service.register_catalog_server(catalog_id=server_id, request=request, db=db, context=registration_context)
 
     # Check if this is an HTMX request
     is_htmx = http_request.headers.get("HX-Request") == "true"
@@ -18035,6 +18052,7 @@ async def check_catalog_server_status(
 @require_permission("servers.create", allow_admin_bypass=False)
 async def bulk_register_catalog_servers(
     request: CatalogBulkRegisterRequest,
+    http_request: Request,
     db: Session = Depends(get_db),
     _user=Depends(get_current_user_with_permissions),
 ) -> CatalogBulkRegisterResponse:
@@ -18042,6 +18060,7 @@ async def bulk_register_catalog_servers(
 
     Args:
         request: Bulk registration request with server IDs
+        http_request: FastAPI request used to capture caller metadata
         db: Database session
         _user: Authenticated user
 
@@ -18054,7 +18073,8 @@ async def bulk_register_catalog_servers(
     if not settings.mcpgateway_catalog_enabled:
         raise HTTPException(status_code=404, detail="Catalog feature is disabled")
 
-    return await catalog_service.bulk_register_servers(request, db)
+    registration_context = await _catalog_registration_context(http_request, _user, db)
+    return await catalog_service.bulk_register_servers(request, db, context=registration_context)
 
 
 @admin_router.get("/mcp-registry/partial")

--- a/mcpgateway/services/catalog_service.py
+++ b/mcpgateway/services/catalog_service.py
@@ -11,6 +11,7 @@ easily registered with one-click from the admin UI.
 
 # Standard
 import asyncio
+from dataclasses import dataclass
 from datetime import datetime, timezone
 import logging
 from pathlib import Path
@@ -35,11 +36,24 @@ from mcpgateway.schemas import (
     CatalogServerRegisterResponse,
     CatalogServerStatusResponse,
 )
+from mcpgateway.services.audit_trail_service import get_audit_trail_service
 from mcpgateway.services.gateway_service import GatewayService
 from mcpgateway.utils.create_slug import slugify
 from mcpgateway.validation.tags import validate_tags_field
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CatalogRegistrationContext:
+    """Authenticated ownership and audit context for catalog registration."""
+
+    created_by: str
+    owner_email: str
+    created_from_ip: Optional[str] = None
+    created_via: Optional[str] = "catalog"
+    created_user_agent: Optional[str] = None
+    team_id: Optional[str] = None
 
 
 class CatalogService:
@@ -50,6 +64,7 @@ class CatalogService:
         self._catalog_cache: Optional[Dict[str, Any]] = None
         self._cache_timestamp: float = 0
         self._gateway_service = GatewayService()
+        self._audit_trail = get_audit_trail_service()
 
     async def load_catalog(self, force_reload: bool = False) -> Dict[str, Any]:
         """Load catalog from YAML file.
@@ -278,13 +293,21 @@ class CatalogService:
 
         return False
 
-    async def register_catalog_server(self, catalog_id: str, request: Optional[CatalogServerRegisterRequest], db: Session) -> CatalogServerRegisterResponse:
+    async def register_catalog_server(
+        self,
+        catalog_id: str,
+        request: Optional[CatalogServerRegisterRequest],
+        db: Session,
+        *,
+        context: CatalogRegistrationContext,
+    ) -> CatalogServerRegisterResponse:
         """Register a catalog server as a gateway.
 
         Args:
             catalog_id: Catalog server ID
             request: Registration request with optional overrides
             db: Database session
+            context: Authenticated ownership and audit context
 
         Returns:
             Registration response
@@ -399,7 +422,12 @@ class CatalogService:
                     capabilities={},
                     auth_type="oauth",  # Mark as OAuth so it can be identified after page refresh
                     enabled=False,  # Disabled until OAuth is configured
-                    created_via="catalog",
+                    created_by=context.created_by,
+                    created_from_ip=context.created_from_ip,
+                    created_via=context.created_via,
+                    created_user_agent=context.created_user_agent,
+                    team_id=context.team_id,
+                    owner_email=context.owner_email,
                     visibility="public",
                     version=1,
                 )
@@ -407,6 +435,28 @@ class CatalogService:
                 db.add(db_gateway)
                 db.commit()
                 db.refresh(db_gateway)
+
+                self._audit_trail.log_action(
+                    user_id=context.created_by,
+                    action="create_gateway",
+                    resource_type="gateway",
+                    resource_id=str(db_gateway.id),
+                    resource_name=db_gateway.name,
+                    user_email=context.owner_email,
+                    team_id=context.team_id,
+                    client_ip=context.created_from_ip,
+                    user_agent=context.created_user_agent,
+                    new_values={
+                        "name": db_gateway.name,
+                        "url": db_gateway.url,
+                        "visibility": db_gateway.visibility,
+                        "transport": db_gateway.transport,
+                        "tools_count": 0,
+                        "resources_count": 0,
+                        "prompts_count": 0,
+                    },
+                    context={"created_via": context.created_via},
+                )
 
                 # First-Party
                 from mcpgateway.schemas import GatewayRead  # pylint: disable=import-outside-toplevel
@@ -443,6 +493,10 @@ class CatalogService:
                     "version": db_gateway.version,
                     "team_id": db_gateway.team_id,
                     "owner_email": db_gateway.owner_email,
+                    "created_by": db_gateway.created_by,
+                    "created_from_ip": db_gateway.created_from_ip,
+                    "created_via": db_gateway.created_via,
+                    "created_user_agent": db_gateway.created_user_agent,
                 }
 
                 gateway_read = GatewayRead.model_validate(gateway_dict)
@@ -466,7 +520,12 @@ class CatalogService:
             gateway_read = await self._gateway_service.register_gateway(
                 db=db,
                 gateway=gateway_create,
-                created_via="catalog",
+                created_by=context.created_by,
+                created_from_ip=context.created_from_ip,
+                created_via=context.created_via,
+                created_user_agent=context.created_user_agent,
+                team_id=context.team_id,
+                owner_email=context.owner_email,
                 visibility="public",  # Catalog servers should be public
                 initialize_timeout=settings.httpx_admin_read_timeout,
             )
@@ -577,12 +636,19 @@ class CatalogService:
             logger.error("Failed to check server status for %s: %s", catalog_id, e)
             return CatalogServerStatusResponse(server_id=catalog_id, is_available=False, is_registered=False, error=str(e))
 
-    async def bulk_register_servers(self, request: CatalogBulkRegisterRequest, db: Session) -> CatalogBulkRegisterResponse:
+    async def bulk_register_servers(
+        self,
+        request: CatalogBulkRegisterRequest,
+        db: Session,
+        *,
+        context: CatalogRegistrationContext,
+    ) -> CatalogBulkRegisterResponse:
         """Register multiple catalog servers.
 
         Args:
             request: Bulk registration request
             db: Database session
+            context: Authenticated ownership and audit context
 
         Returns:
             Bulk registration response
@@ -592,7 +658,12 @@ class CatalogService:
 
         for server_id in request.server_ids:
             try:
-                response = await self.register_catalog_server(catalog_id=server_id, request=None, db=db)
+                response = await self.register_catalog_server(
+                    catalog_id=server_id,
+                    request=None,
+                    db=db,
+                    context=context,
+                )
 
                 if response.success:
                     successful.append(server_id)

--- a/tests/unit/mcpgateway/services/test_catalog_service.py
+++ b/tests/unit/mcpgateway/services/test_catalog_service.py
@@ -19,7 +19,10 @@ from mcpgateway.schemas import (
     CatalogListRequest,
     CatalogServerRegisterRequest,
 )
-from mcpgateway.services.catalog_service import CatalogService
+from mcpgateway.services.catalog_service import CatalogRegistrationContext, CatalogService
+
+
+REGISTRATION_CONTEXT = CatalogRegistrationContext(created_by="caller@example.com", owner_email="caller@example.com")
 
 
 @pytest.fixture
@@ -163,7 +166,7 @@ async def test_get_catalog_servers_requires_oauth_config_enabled(service):
 async def test_register_catalog_server_not_found(service):
     with patch.object(service, "load_catalog", AsyncMock(return_value={"catalog_servers": []})):
         db = MagicMock()
-        result = await service.register_catalog_server("missing", None, db)
+        result = await service.register_catalog_server("missing", None, db, context=REGISTRATION_CONTEXT)
         assert not result.success
         assert "not found" in result.message
 
@@ -175,7 +178,7 @@ async def test_register_catalog_server_already_registered(service):
         db = MagicMock()
         db.execute.return_value.scalar_one_or_none.return_value = MagicMock(id=123)
         with patch("mcpgateway.services.catalog_service.select"):
-            result = await service.register_catalog_server("1", None, db)
+            result = await service.register_catalog_server("1", None, db, context=REGISTRATION_CONTEXT)
             assert not result.success
             assert "already registered" in result.message
 
@@ -186,10 +189,27 @@ async def test_register_catalog_server_success(service):
     with patch.object(service, "load_catalog", AsyncMock(return_value=fake_catalog)):
         db = MagicMock()
         db.execute.return_value.scalar_one_or_none.return_value = None
-        with patch("mcpgateway.services.catalog_service.select"), patch.object(service._gateway_service, "register_gateway", AsyncMock(return_value=MagicMock(id=1, name="srv"))):
-            result = await service.register_catalog_server("1", None, db)
+        register_gateway = AsyncMock(return_value=MagicMock(id=1, name="srv"))
+        with patch("mcpgateway.services.catalog_service.select"), patch.object(service._gateway_service, "register_gateway", register_gateway):
+            context = CatalogRegistrationContext(
+                created_by="caller@example.com",
+                owner_email="caller@example.com",
+                created_from_ip="192.0.2.10",
+                created_via="api",
+                created_user_agent="test-agent",
+                team_id="team-1",
+            )
+            result = await service.register_catalog_server("1", None, db, context=context)
             assert result.success
             assert "Successfully" in result.message
+            register_gateway.assert_awaited_once()
+            call_kwargs = register_gateway.await_args.kwargs
+            assert call_kwargs["created_by"] == "caller@example.com"
+            assert call_kwargs["created_from_ip"] == "192.0.2.10"
+            assert call_kwargs["created_via"] == "api"
+            assert call_kwargs["created_user_agent"] == "test-agent"
+            assert call_kwargs["team_id"] == "team-1"
+            assert call_kwargs["owner_email"] == "caller@example.com"
 
 
 @pytest.mark.asyncio
@@ -199,7 +219,7 @@ async def test_register_catalog_server_ipv6(service):
         db = MagicMock()
         db.execute.return_value.scalar_one_or_none.return_value = None
         with patch("mcpgateway.services.catalog_service.select"):
-            result = await service.register_catalog_server("1", None, db)
+            result = await service.register_catalog_server("1", None, db, context=REGISTRATION_CONTEXT)
             assert not result.success
             assert "IPv6" in result.error
 
@@ -211,7 +231,7 @@ async def test_register_catalog_server_exception_mapping(service):
         db = MagicMock()
         db.execute.return_value.scalar_one_or_none.return_value = None
         with patch("mcpgateway.services.catalog_service.select"), patch.object(service._gateway_service, "register_gateway", AsyncMock(side_effect=Exception("Connection refused"))):
-            result = await service.register_catalog_server("1", None, db)
+            result = await service.register_catalog_server("1", None, db, context=REGISTRATION_CONTEXT)
             assert "offline" in result.message
 
 
@@ -247,11 +267,15 @@ async def test_check_server_availability_exception(service):
 @pytest.mark.asyncio
 async def test_bulk_register_servers_success_and_failure(service):
     fake_request = CatalogBulkRegisterRequest(server_ids=["1", "2"], skip_errors=False)
-    with patch.object(service, "register_catalog_server", AsyncMock(side_effect=[MagicMock(success=True), MagicMock(success=False, error="fail")])):
+    register_catalog_server = AsyncMock(side_effect=[MagicMock(success=True), MagicMock(success=False, error="fail")])
+    with patch.object(service, "register_catalog_server", register_catalog_server):
         db = MagicMock()
-        result = await service.bulk_register_servers(fake_request, db)
+        context = CatalogRegistrationContext(created_by="caller@example.com", owner_email="caller@example.com", team_id="team-1")
+        result = await service.bulk_register_servers(fake_request, db, context=context)
         assert result.total_attempted == 2
         assert len(result.failed) == 1
+        for call in register_catalog_server.await_args_list:
+            assert call.kwargs["context"] == context
 
 
 @pytest.mark.asyncio
@@ -262,7 +286,7 @@ async def test_auth_type_api_key_and_oauth(service):
         db = MagicMock()
         db.execute.return_value.scalar_one_or_none.return_value = None
         with patch("mcpgateway.services.catalog_service.select"), patch.object(service._gateway_service, "register_gateway", AsyncMock(return_value=MagicMock(id=1, name="srv"))):
-            result = await service.register_catalog_server("1", req, db)
+            result = await service.register_catalog_server("1", req, db, context=REGISTRATION_CONTEXT)
             assert result.success
 
     fake_catalog["catalog_servers"][0]["auth_type"] = "OAuth2.1 & API Key"
@@ -270,7 +294,7 @@ async def test_auth_type_api_key_and_oauth(service):
         db = MagicMock()
         db.execute.return_value.scalar_one_or_none.return_value = None
         with patch("mcpgateway.services.catalog_service.select"), patch.object(service._gateway_service, "register_gateway", AsyncMock(return_value=MagicMock(id=1, name="srv"))):
-            result = await service.register_catalog_server("1", req, db)
+            result = await service.register_catalog_server("1", req, db, context=REGISTRATION_CONTEXT)
             assert result.success
 
 
@@ -279,7 +303,7 @@ async def test_bulk_register_servers_skip_errors(service):
     fake_request = CatalogBulkRegisterRequest(server_ids=["1", "2"], skip_errors=True)
     with patch.object(service, "register_catalog_server", AsyncMock(side_effect=[MagicMock(success=False, error="fail"), MagicMock(success=True)])):
         db = MagicMock()
-        result = await service.bulk_register_servers(fake_request, db)
+        result = await service.bulk_register_servers(fake_request, db, context=REGISTRATION_CONTEXT)
         assert result.total_attempted == 2
         assert len(result.failed) == 1
 
@@ -312,7 +336,7 @@ async def test_register_catalog_server_with_tags(service, test_db):
         # Use real database session instead of MagicMock
         # No existing gateway
         with patch("mcpgateway.services.catalog_service.select"):
-            result = await service.register_catalog_server("github", None, test_db)
+            result = await service.register_catalog_server("github", None, test_db, context=REGISTRATION_CONTEXT)
 
             # Verify registration succeeded
             assert result.success, f"Registration failed: {result.error}"
@@ -370,8 +394,7 @@ async def test_register_catalog_server_tags_validation_error_handling(service):
             return MagicMock(id="test-id", name="Test Server", tags=[])
 
         with patch("mcpgateway.services.catalog_service.select"), patch.object(service._gateway_service, "register_gateway", mock_register_gateway):
-
-            result = await service.register_catalog_server("test-server", None, db)
+            result = await service.register_catalog_server("test-server", None, db, context=REGISTRATION_CONTEXT)
 
             # Registration should succeed even with some invalid tags
             assert result.success, f"Registration failed: {result.error}"
@@ -416,14 +439,22 @@ async def test_register_catalog_server_oauth_without_credentials(service):
             obj.reachable = False
 
         db.refresh = MagicMock(side_effect=mock_refresh)
+        service._audit_trail = MagicMock()
 
         with (
             patch("mcpgateway.services.catalog_service.select"),
             patch("mcpgateway.services.catalog_service.slugify", return_value="oauth-server"),
             patch("mcpgateway.services.catalog_service.validate_tags_field", return_value=[{"id": "oauth", "label": "oauth"}]),
         ):
-
-            result = await service.register_catalog_server("oauth-server", None, db)
+            context = CatalogRegistrationContext(
+                created_by="caller@example.com",
+                owner_email="caller@example.com",
+                created_from_ip="192.0.2.10",
+                created_via="ui",
+                created_user_agent="test-agent",
+                team_id="team-1",
+            )
+            result = await service.register_catalog_server("oauth-server", None, db, context=context)
 
             # Verify OAuth server was registered successfully but requires configuration
             assert result.success, f"Registration failed: {result.error}"
@@ -435,6 +466,34 @@ async def test_register_catalog_server_oauth_without_credentials(service):
             db.add.assert_called_once()
             db.commit.assert_called_once()
             db.refresh.assert_called_once()
+            db_gateway = db.add.call_args.args[0]
+            assert db_gateway.created_by == "caller@example.com"
+            assert db_gateway.created_from_ip == "192.0.2.10"
+            assert db_gateway.created_via == "ui"
+            assert db_gateway.created_user_agent == "test-agent"
+            assert db_gateway.team_id == "team-1"
+            assert db_gateway.owner_email == "caller@example.com"
+            service._audit_trail.log_action.assert_called_once_with(
+                user_id="caller@example.com",
+                action="create_gateway",
+                resource_type="gateway",
+                resource_id="test-id",
+                resource_name="OAuth Server",
+                user_email="caller@example.com",
+                team_id="team-1",
+                client_ip="192.0.2.10",
+                user_agent="test-agent",
+                new_values={
+                    "name": "OAuth Server",
+                    "url": "https://oauth.example.com/mcp",
+                    "visibility": "public",
+                    "transport": "STREAMABLEHTTP",
+                    "tools_count": 0,
+                    "resources_count": 0,
+                    "prompts_count": 0,
+                },
+                context={"created_via": "ui"},
+            )
 
 
 # ---------- Exception mapping in register_catalog_server ----------
@@ -459,7 +518,7 @@ async def test_register_exception_mapping_parametrized(service, error_msg, expec
         db = MagicMock()
         db.execute.return_value.scalar_one_or_none.return_value = None
         with patch("mcpgateway.services.catalog_service.select"), patch.object(service._gateway_service, "register_gateway", AsyncMock(side_effect=Exception(error_msg))):
-            result = await service.register_catalog_server("1", None, db)
+            result = await service.register_catalog_server("1", None, db, context=REGISTRATION_CONTEXT)
             assert not result.success
             assert expected_keyword in result.message
 
@@ -494,7 +553,7 @@ async def test_transport_auto_detection(service, url, expected_result):
         db = MagicMock()
         db.execute.return_value.scalar_one_or_none.return_value = None
         with patch("mcpgateway.services.catalog_service.select"), patch.object(service._gateway_service, "register_gateway", mock_register):
-            result = await service.register_catalog_server("1", None, db)
+            result = await service.register_catalog_server("1", None, db, context=REGISTRATION_CONTEXT)
             if expected_result is False:
                 # WebSocket URLs should fail validation
                 assert not result.success, f"Expected registration to fail for {url}"
@@ -659,7 +718,7 @@ async def test_register_with_custom_auth_type(service):
         db = MagicMock()
         db.execute.return_value.scalar_one_or_none.return_value = None
         with patch("mcpgateway.services.catalog_service.select"), patch.object(service._gateway_service, "register_gateway", mock_register):
-            result = await service.register_catalog_server("1", req, db)
+            result = await service.register_catalog_server("1", req, db, context=REGISTRATION_CONTEXT)
             assert result.success
             assert captured_data["auth_type"] == "authheaders"
 
@@ -678,7 +737,7 @@ async def test_register_with_explicit_transport(service):
         db = MagicMock()
         db.execute.return_value.scalar_one_or_none.return_value = None
         with patch("mcpgateway.services.catalog_service.select"), patch.object(service._gateway_service, "register_gateway", mock_register):
-            result = await service.register_catalog_server("1", None, db)
+            result = await service.register_catalog_server("1", None, db, context=REGISTRATION_CONTEXT)
             assert result.success
             assert captured_data["transport"] == "STREAMABLEHTTP"
 
@@ -693,7 +752,7 @@ async def test_register_with_tool_count(service):
         mock_tools = [MagicMock(), MagicMock(), MagicMock()]
         db.execute.return_value.scalars.return_value.all.return_value = mock_tools
         with patch("mcpgateway.services.catalog_service.select"), patch.object(service._gateway_service, "register_gateway", AsyncMock(return_value=MagicMock(id=1, name="srv"))):
-            result = await service.register_catalog_server("1", None, db)
+            result = await service.register_catalog_server("1", None, db, context=REGISTRATION_CONTEXT)
             assert result.success
             assert "3 tools" in result.message
 
@@ -706,7 +765,7 @@ async def test_register_check_existing_exception(service):
         db = MagicMock()
         db.execute.return_value.scalar_one_or_none.side_effect = Exception("DB error")
         with patch("mcpgateway.services.catalog_service.select"), patch.object(service._gateway_service, "register_gateway", AsyncMock(return_value=MagicMock(id=1, name="srv"))):
-            result = await service.register_catalog_server("1", None, db)
+            result = await service.register_catalog_server("1", None, db, context=REGISTRATION_CONTEXT)
             assert result.success
 
 
@@ -716,7 +775,7 @@ async def test_bulk_register_exception_per_server(service):
     fake_request = CatalogBulkRegisterRequest(server_ids=["1", "2"], skip_errors=True)
     with patch.object(service, "register_catalog_server", AsyncMock(side_effect=[Exception("boom"), MagicMock(success=True)])):
         db = MagicMock()
-        result = await service.bulk_register_servers(fake_request, db)
+        result = await service.bulk_register_servers(fake_request, db, context=REGISTRATION_CONTEXT)
         assert result.total_attempted == 2
         assert len(result.failed) == 1
         assert result.total_successful == 1
@@ -760,7 +819,7 @@ async def test_register_catalog_server_match_not_first_skips_tool_query_and_cach
         db = MagicMock()
         db.execute.return_value.scalar_one_or_none.return_value = None
         with patch("mcpgateway.services.catalog_service.select"), patch.object(service._gateway_service, "register_gateway", AsyncMock(return_value=MagicMock(id=None, name="srv"))):
-            result = await service.register_catalog_server("target", None, db)
+            result = await service.register_catalog_server("target", None, db, context=REGISTRATION_CONTEXT)
     assert result.success
 
 
@@ -797,7 +856,7 @@ async def test_register_catalog_server_oauth_without_credentials_tags_dict_forma
         db.refresh = MagicMock(side_effect=mock_refresh)
 
         with patch("mcpgateway.services.catalog_service.select"), patch("mcpgateway.services.catalog_service.slugify", return_value="oauth-server"):
-            result = await service.register_catalog_server("oauth-server", None, db)
+            result = await service.register_catalog_server("oauth-server", None, db, context=REGISTRATION_CONTEXT)
 
     assert result.success
     assert result.oauth_required is True
@@ -836,7 +895,7 @@ async def test_register_catalog_server_oauth_without_credentials_tags_empty(serv
         db.refresh = MagicMock(side_effect=mock_refresh)
 
         with patch("mcpgateway.services.catalog_service.select"), patch("mcpgateway.services.catalog_service.slugify", return_value="oauth-server"):
-            result = await service.register_catalog_server("oauth-server", None, db)
+            result = await service.register_catalog_server("oauth-server", None, db, context=REGISTRATION_CONTEXT)
 
     assert result.success
     assert result.oauth_required is True
@@ -870,5 +929,5 @@ async def test_bulk_register_breaks_on_exception_when_not_skipping_errors(servic
     fake_request = CatalogBulkRegisterRequest(server_ids=["1", "2"], skip_errors=False)
     with patch.object(service, "register_catalog_server", AsyncMock(side_effect=Exception("boom"))):
         db = MagicMock()
-        result = await service.bulk_register_servers(fake_request, db)
+        result = await service.bulk_register_servers(fake_request, db, context=REGISTRATION_CONTEXT)
     assert result.failed and result.failed[0]["error"] == "boom"

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -274,6 +274,7 @@ from mcpgateway.schemas import (
     ToolMetrics,
 )
 from mcpgateway.services.a2a_service import A2AAgentError, A2AAgentNameConflictError, A2AAgentNotFoundError, A2AAgentService
+from mcpgateway.services.catalog_service import CatalogRegistrationContext
 from mcpgateway.services.export_service import ExportError, ExportService
 from mcpgateway.services.gateway_service import GatewayConnectionError, GatewayLookupConflictError, GatewayNotFoundError, GatewayService
 from mcpgateway.services.import_service import ImportError as ImportServiceError
@@ -20283,12 +20284,41 @@ class TestCatalogEndpoints:
     async def test_register_catalog_server_json_response(self, monkeypatch, allow_permission, mock_db):
         monkeypatch.setattr("mcpgateway.admin.settings.mcpgateway_catalog_enabled", True, raising=False)
         reg_result = SimpleNamespace(success=True, message="Registered", oauth_required=False, error=None)
-        monkeypatch.setattr("mcpgateway.admin.catalog_service.register_catalog_server", AsyncMock(return_value=reg_result))
+        register_catalog_server_mock = AsyncMock(return_value=reg_result)
+        monkeypatch.setattr("mcpgateway.admin.catalog_service.register_catalog_server", register_catalog_server_mock)
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value="personal-team")
+        monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda _db: team_service)
+        monkeypatch.setattr(
+            "mcpgateway.admin.MetadataCapture.extract_creation_metadata",
+            MagicMock(
+                return_value={
+                    "created_by": "admin@test.com",
+                    "created_from_ip": "192.0.2.20",
+                    "created_via": "ui",
+                    "created_user_agent": "test-agent",
+                }
+            ),
+        )
 
         request = MagicMock(spec=Request)
         request.headers = {}
         result = await register_catalog_server("srv-1", request, db=mock_db, _user={"email": "admin@test.com"})
         assert result == reg_result
+        register_catalog_server_mock.assert_awaited_once()
+        call_kwargs = register_catalog_server_mock.await_args.kwargs
+        assert call_kwargs["catalog_id"] == "srv-1"
+        assert call_kwargs["request"] is None
+        assert call_kwargs["db"] is mock_db
+        context = call_kwargs["context"]
+        assert context == CatalogRegistrationContext(
+            created_by="admin@test.com",
+            owner_email="admin@test.com",
+            created_from_ip="192.0.2.20",
+            created_via="ui",
+            created_user_agent="test-agent",
+            team_id="personal-team",
+        )
 
     @pytest.mark.asyncio
     async def test_register_catalog_server_htmx_success(self, monkeypatch, allow_permission, mock_db):
@@ -20325,8 +20355,9 @@ class TestCatalogEndpoints:
         from mcpgateway.schemas import CatalogBulkRegisterRequest
 
         req = CatalogBulkRegisterRequest(server_ids=["a", "b"])
+        http_request = MagicMock(spec=Request)
         with pytest.raises(HTTPException) as exc_info:
-            await bulk_register_catalog_servers(req, db=mock_db, _user={"email": "admin@test.com"})
+            await bulk_register_catalog_servers(req, http_request, db=mock_db, _user={"email": "admin@test.com"})
         assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
@@ -20339,7 +20370,8 @@ class TestCatalogEndpoints:
         from mcpgateway.schemas import CatalogBulkRegisterRequest
 
         req = CatalogBulkRegisterRequest(server_ids=["a", "b"])
-        result = await bulk_register_catalog_servers(req, db=mock_db, _user={"email": "admin@test.com"})
+        http_request = MagicMock(spec=Request)
+        result = await bulk_register_catalog_servers(req, http_request, db=mock_db, _user={"email": "admin@test.com"})
         assert result == bulk_result
 
 


### PR DESCRIPTION
## Summary

- capture the authenticated caller's owner, personal-team, and request metadata for admin catalog registration
- require an explicit `CatalogRegistrationContext` through both single and bulk service paths
- preserve the same ownership metadata and emit the gateway creation audit event for OAuth catalog entries that bypass `GatewayService.register_gateway`

## Testing

- `pytest tests/unit/mcpgateway/services/test_catalog_service.py -q` (59 passed)
- `pytest tests/unit/mcpgateway/test_admin.py -k catalog -q` (11 passed)
- `pytest tests/unit/mcpgateway/test_admin_catalog_htmx.py -q` (7 passed)
- `ruff check mcpgateway/admin.py mcpgateway/services/catalog_service.py tests/unit/mcpgateway/services/test_catalog_service.py`
- `ruff format --check mcpgateway/admin.py mcpgateway/services/catalog_service.py tests/unit/mcpgateway/services/test_catalog_service.py tests/unit/mcpgateway/test_admin.py`

Closes #6036