### PR TITLE
fix(oauth): preserve gateway catalog on empty fetch

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -2299,11 +2299,21 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 prompts=prompts,
                 created_via="oauth",
             )
+
+            skip_stale_cleanup = not tools and not resources and not prompts
+            if skip_stale_cleanup:
+                logger.warning("Empty catalog from auth_code gateway %s during OAuth fetch, preserving existing items", gateway.name)
+
+            # Only prune entries that came from MCP discovery. API/UI and legacy
+            # entries can share the gateway but are not authoritative upstream data.
+            mcp_created_via_values = {"MCP", "federation", "health_check", "manual_refresh", "oauth", "update"}
             reconcile_result = self._reconcile_gateway_catalog(
                 db,
                 gateway=gateway,
                 catalog_sync=catalog_sync,
                 log_context="gateway OAuth fetch",
+                stale_created_via_values=mcp_created_via_values,
+                skip_stale_cleanup=skip_stale_cleanup,
             )
 
             # Update gateway capabilities and last_seen

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 # Standard
 import asyncio
 from datetime import datetime, timedelta, timezone
+import logging
 import sys
 from types import SimpleNamespace
 from typing import TypeVar
@@ -4994,15 +4995,72 @@ async def test_fetch_tools_after_oauth_streamablehttp(gateway_service, monkeypat
 
 
 @pytest.mark.asyncio
+async def test_fetch_tools_after_oauth_empty_catalog_preserves_existing_items(gateway_service, monkeypatch, caplog):
+    gateway = MagicMock(spec=DbGateway)
+    gateway.id = "gw-1"
+    gateway.name = "gw"
+    gateway.oauth_config = {"grant_type": "authorization_code"}
+    gateway.transport = "streamablehttp"
+    gateway.tools = [SimpleNamespace(id=1, original_name="existing-tool", created_via="oauth")]
+    gateway.resources = [SimpleNamespace(id=2, uri="existing://resource", created_via="oauth")]
+    gateway.prompts = [SimpleNamespace(id=3, original_name="existing-prompt", created_via="oauth")]
+
+    db = MagicMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = gateway
+    db.execute.return_value = result
+
+    class DummyTokenStorage:
+        def __init__(self, _db):
+            self.db = _db
+
+        async def get_user_token(self, _gateway_id, _email):
+            return "token"
+
+        async def get_user_learned_audience(self, _gateway_id, _email):
+            return (None, None)
+
+    monkeypatch.setattr("mcpgateway.services.token_storage_service.TokenStorageService", DummyTokenStorage)
+    gateway_service.connect_to_streamablehttp_server = AsyncMock(return_value=({}, [], [], [], []))
+    gateway_service._update_or_create_tools = MagicMock(return_value=[])
+    gateway_service._update_or_create_resources = MagicMock(return_value=[])
+    gateway_service._update_or_create_prompts = MagicMock(return_value=[])
+
+    registry_cache = SimpleNamespace(
+        invalidate_tools=AsyncMock(),
+        invalidate_resources=AsyncMock(),
+        invalidate_prompts=AsyncMock(),
+    )
+    tool_lookup_cache = SimpleNamespace(invalidate_gateway=AsyncMock())
+    monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: registry_cache)
+    monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: tool_lookup_cache)
+    monkeypatch.setattr("mcpgateway.services.gateway_service.register_gateway_capabilities_for_notifications", MagicMock())
+    monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", SimpleNamespace(invalidate_tags=AsyncMock()))
+
+    with caplog.at_level(logging.WARNING):
+        await gateway_service.fetch_tools_after_oauth(db, "gw-1", "user@example.com")
+
+    assert gateway.tools[0].original_name == "existing-tool"
+    assert gateway.resources[0].uri == "existing://resource"
+    assert gateway.prompts[0].original_name == "existing-prompt"
+    assert db.execute.call_count == 1
+    assert "preserving existing items" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_fetch_tools_after_oauth_cleanup_and_adds_items(gateway_service, monkeypatch):
     gateway = MagicMock(spec=DbGateway)
     gateway.id = "gw-1"
     gateway.name = "gw"
     gateway.oauth_config = {"grant_type": "authorization_code"}
     gateway.transport = "sse"
-    gateway.tools = [SimpleNamespace(id=1, original_name="old-tool"), SimpleNamespace(id=2, original_name="keep-tool")]
-    gateway.resources = [SimpleNamespace(id=3, uri="old://res"), SimpleNamespace(id=4, uri="keep://res")]
-    gateway.prompts = [SimpleNamespace(id=5, original_name="old-prompt"), SimpleNamespace(id=6, original_name="keep-prompt")]
+    gateway.tools = [
+        SimpleNamespace(id=1, original_name="old-tool", created_via="oauth"),
+        SimpleNamespace(id=2, original_name="keep-tool", created_via="oauth"),
+        SimpleNamespace(id=7, original_name="ui-tool", created_via="ui"),
+    ]
+    gateway.resources = [SimpleNamespace(id=3, uri="old://res", created_via="oauth"), SimpleNamespace(id=4, uri="keep://res", created_via="oauth")]
+    gateway.prompts = [SimpleNamespace(id=5, original_name="old-prompt", created_via="oauth"), SimpleNamespace(id=6, original_name="keep-prompt", created_via="oauth")]
     gateway.capabilities = {}
     gateway.last_seen = None
 
@@ -5047,7 +5105,7 @@ async def test_fetch_tools_after_oauth_cleanup_and_adds_items(gateway_service, m
     result_data = await gateway_service.fetch_tools_after_oauth(db, "gw-1", "user@example.com")
 
     assert result_data["capabilities"]["resources"] is True
-    assert len(gateway.tools) == 1
+    assert {tool.original_name for tool in gateway.tools} == {"keep-tool", "ui-tool"}
     assert len(gateway.resources) == 1
     assert len(gateway.prompts) == 1
 


### PR DESCRIPTION
## Summary

- treat an empty catalog returned by the authorization-code OAuth fetch path as a probable authorization problem and preserve the gateway's existing tools, resources, prompts, metrics, and virtual-server associations
- restrict non-empty OAuth reconciliation to MCP-discovered entries so API/UI and legacy entries attached to the gateway are not pruned
- log a warning when the destructive cleanup guard is activated

## Testing

- `pytest tests/unit/mcpgateway/services/test_gateway_service.py -q` (full file passed, 1 existing skip)
- `pytest tests/unit/mcpgateway/services/test_gateway_service.py -k fetch_tools_after_oauth -q` (7 passed)
- `ruff check mcpgateway/services/gateway_service.py`
- `git diff --check`

Closes #6046

---
This change was developed with AI assistance (Claude); the code and tests were reviewed and verified locally before submission.