### PR TITLE
fix(admin): preserve OAuth credentials on edit

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -944,7 +944,13 @@ def _form_team_id(form: Any) -> Optional[str]:
     return str(raw).strip() or None
 
 
-async def _assemble_oauth_config_from_fields(fields: Any, *, encrypt_secret: bool, include_resource: bool = True) -> Optional[Dict[str, Any]]:
+async def _assemble_oauth_config_from_fields(
+    fields: Any,
+    *,
+    encrypt_secret: bool,
+    include_resource: bool = True,
+    existing_config: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
     """Assemble an ``oauth_config`` dict from individual OAuth form/JSON fields.
 
     Shared by all four admin OAuth form handlers (gateway create/edit, A2A
@@ -961,12 +967,15 @@ async def _assemble_oauth_config_from_fields(fields: Any, *, encrypt_secret: boo
     * ``encrypt_secret=True`` encrypts ``client_secret`` before storage
       (UI edit/add handlers); ``False`` stores it as submitted (the gateway
       create path, where encryption happens downstream in the service layer).
+    * On edit, ``existing_config`` preserves stored credentials when password
+      inputs are intentionally left blank rather than echoing secrets to the UI.
 
     Args:
         fields: Mapping with ``.get()`` (a form dict or parsed JSON body)
             containing the ``oauth_*`` keys.
         encrypt_secret: Whether to encrypt a submitted ``client_secret``.
         include_resource: Whether to read and emit ``oauth_resource``.
+        existing_config: Existing stored OAuth configuration for edit requests.
 
     Returns:
         Assembled ``oauth_config`` dict, or ``None`` when no meaningful OAuth
@@ -1007,10 +1016,14 @@ async def _assemble_oauth_config_from_fields(fields: Any, *, encrypt_secret: boo
             oauth_config["client_secret"] = await encryption.encrypt_secret_async(oauth_client_secret)
         else:
             oauth_config["client_secret"] = oauth_client_secret
+    elif existing_config and existing_config.get("client_secret"):
+        oauth_config["client_secret"] = existing_config["client_secret"]
     if oauth_username:
         oauth_config["username"] = oauth_username
     if oauth_password:
         oauth_config["password"] = oauth_password
+    elif oauth_grant_type == "password" and existing_config and existing_config.get("password"):
+        oauth_config["password"] = existing_config["password"]
     if oauth_audience:
         oauth_config["audience"] = oauth_audience
     if oauth_scopes_str:
@@ -13103,6 +13116,11 @@ async def admin_edit_gateway(
         else:
             passthrough_headers = None
 
+        existing_gateway = db.get(DbGateway, gateway_id)
+        existing_oauth_config = getattr(existing_gateway, "oauth_config", None)
+        if not isinstance(existing_oauth_config, dict):
+            existing_oauth_config = None
+
         # Parse OAuth configuration - support both JSON string and individual form fields
         oauth_config_json = str(form.get("oauth_config"))
         oauth_config: Optional[dict[str, Any]] = None
@@ -13121,7 +13139,7 @@ async def admin_edit_gateway(
 
         # Option 2: Assemble from individual UI form fields
         if not oauth_config:
-            oauth_config = await _assemble_oauth_config_from_fields(form, encrypt_secret=True)
+            oauth_config = await _assemble_oauth_config_from_fields(form, encrypt_secret=True, existing_config=existing_oauth_config)
             if oauth_config:
                 LOGGER.info(f"✅ Assembled OAuth config from UI form fields (edit): grant_type={oauth_config.get('grant_type')}, issuer={oauth_config.get('issuer')}")
 
@@ -13130,7 +13148,6 @@ async def admin_edit_gateway(
         # Without this guard, verify_team_for_user() falls back to the user's
         # personal team, silently reassigning the gateway on every edit.
         if not team_id:
-            existing_gateway = db.get(DbGateway, gateway_id)
             existing_team = getattr(existing_gateway, "team_id", None) if existing_gateway else None
             if isinstance(existing_team, str) and existing_team:
                 team_id = existing_team
@@ -16338,6 +16355,11 @@ async def admin_edit_a2a_agent(
         else:
             passthrough_headers = None
 
+        existing_agent = db.get(DbA2AAgent, agent_id)
+        existing_oauth_config = getattr(existing_agent, "oauth_config", None)
+        if not isinstance(existing_oauth_config, dict):
+            existing_oauth_config = None
+
         # Parse OAuth configuration - support both JSON string and individual form fields
         oauth_config_json = str(form.get("oauth_config"))
         oauth_config: Optional[dict[str, Any]] = None
@@ -16359,7 +16381,7 @@ async def admin_edit_a2a_agent(
         # (no per-user token storage / audience validation on the A2A path), so the
         # field is not offered on A2A forms and is not assembled here.
         if not oauth_config:
-            oauth_config = await _assemble_oauth_config_from_fields(form, encrypt_secret=True, include_resource=False)
+            oauth_config = await _assemble_oauth_config_from_fields(form, encrypt_secret=True, include_resource=False, existing_config=existing_oauth_config)
             if oauth_config:
                 LOGGER.info(f"✅ Assembled OAuth config from UI form fields (edit): grant_type={oauth_config.get('grant_type')}, issuer={oauth_config.get('issuer')}")
 
@@ -16369,7 +16391,6 @@ async def admin_edit_a2a_agent(
         # Without this guard, verify_team_for_user() falls back to the user's
         # personal team, silently reassigning the agent on every edit.
         if not team_id:
-            existing_agent = db.get(DbA2AAgent, agent_id)
             existing_team = getattr(existing_agent, "team_id", None) if existing_agent else None
             if isinstance(existing_team, str) and existing_team:
                 team_id = existing_team

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -7325,6 +7325,52 @@ class TestOAuthFunctionality:
         assert gateway_update.passthrough_headers == ["X-Req-Id", "X-Trace"]
 
     @patch.object(GatewayService, "update_gateway")
+    async def test_admin_edit_gateway_oauth_blank_credentials_preserve_existing(self, mock_update_gateway, mock_request, mock_db, monkeypatch):
+        """Blank edit-form credentials preserve the stored secret and password."""
+        form_data = FakeForm(
+            {
+                "name": "Edited_Gateway",
+                "url": "https://edited.example.com",
+                "oauth_grant_type": "password",
+                "oauth_client_id": "client-id",
+                "oauth_client_secret": "",
+                "oauth_username": "user",
+                "oauth_password": "",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+        mock_db.get.return_value = SimpleNamespace(
+            oauth_config={
+                "client_secret": "encrypted-client-secret",  # pragma: allowlist secret
+                "password": "stored-password",  # pragma: allowlist secret
+            },
+            team_id=None,
+        )
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value=None)
+        monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+        monkeypatch.setattr(
+            "mcpgateway.admin.MetadataCapture.extract_modification_metadata",
+            lambda *_args, **_kwargs: {"modified_by": "u", "modified_from_ip": None, "modified_via": "ui", "modified_user_agent": None, "version": 1},
+        )
+        encryption_factory = MagicMock()
+        monkeypatch.setattr("mcpgateway.admin.get_encryption_service", encryption_factory)
+
+        result = await admin_edit_gateway("gateway-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+
+        assert result.status_code == 200
+        gateway_update = mock_update_gateway.call_args.args[2]
+        assert gateway_update.oauth_config["client_secret"] == "encrypted-client-secret"
+        assert gateway_update.oauth_config["password"] == "stored-password"
+        encryption_factory.assert_not_called()
+
+        form_data["oauth_grant_type"] = "client_credentials"
+        await admin_edit_gateway("gateway-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        gateway_update = mock_update_gateway.call_args.args[2]
+        assert "password" not in gateway_update.oauth_config
+
+    @patch.object(GatewayService, "update_gateway")
     async def test_admin_edit_gateway_oauth_scopes_parse_empty(self, mock_update_gateway, mock_request, mock_db, monkeypatch):
         """Cover the empty-scopes (inner if) branch in admin_edit_gateway."""
         form_data = FakeForm(
@@ -14576,6 +14622,50 @@ class TestAdminAdditionalCoverage:
         agent_update = call_args[1].get("agent_data") or call_args[0][2]
         # UUID is normalized (dashes removed) by schema validation
         assert agent_update.team_id == existing_team_id.replace("-", "")
+
+    async def test_admin_edit_a2a_agent_oauth_blank_credentials_preserve_existing(self, monkeypatch, mock_request, mock_db):
+        """Blank A2A edit credentials preserve the stored OAuth values."""
+        mock_service = MagicMock()
+        mock_service.update_agent = AsyncMock()
+        monkeypatch.setattr("mcpgateway.admin.a2a_service", mock_service)
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value=None)
+        monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+        monkeypatch.setattr(
+            "mcpgateway.admin.MetadataCapture.extract_modification_metadata",
+            MagicMock(return_value={"modified_by": "user", "modified_from_ip": "127.0.0.1", "modified_via": "ui", "modified_user_agent": "test"}),
+        )
+        encryption_factory = MagicMock()
+        monkeypatch.setattr("mcpgateway.admin.get_encryption_service", encryption_factory)
+
+        form_data = FakeForm(
+            {
+                "name": "Agent Updated",
+                "endpoint_url": "http://example.com/agent",
+                "oauth_grant_type": "password",
+                "oauth_client_id": "client-id",
+                "oauth_client_secret": "",
+                "oauth_username": "user",
+                "oauth_password": "",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+        mock_db.get.return_value = SimpleNamespace(
+            oauth_config={
+                "client_secret": "encrypted-client-secret",  # pragma: allowlist secret
+                "password": "stored-password",  # pragma: allowlist secret
+            },
+            team_id=None,
+        )
+
+        response = await admin_edit_a2a_agent("agent-1", mock_request, mock_db, user={"email": "user@example.com", "db": mock_db})
+
+        assert response.status_code == 200
+        agent_update = mock_service.update_agent.call_args.kwargs["agent_data"]
+        assert agent_update.oauth_config["client_secret"] == "encrypted-client-secret"
+        assert agent_update.oauth_config["password"] == "stored-password"
+        encryption_factory.assert_not_called()
 
     async def test_admin_search_a2a_agents_access_filtering(self, monkeypatch, mock_db):
         """Search A2A agents with team access filters."""


### PR DESCRIPTION
## Summary

- preserve the stored OAuth `client_secret` when Gateway or A2A edit forms leave the password input blank
- preserve the stored resource-owner password only while the edited configuration remains on the password grant
- reuse the already-loaded entity for both OAuth credential preservation and team preservation, without decrypting or re-encrypting existing ciphertext
- keep full `oauth_config` JSON submissions unchanged so API callers retain an explicit way to clear credentials

## Testing

- `pytest tests/unit/mcpgateway/test_admin.py -k 'admin_edit_gateway or admin_edit_a2a_agent' -q` (22 passed)
- `ruff check mcpgateway/admin.py`
- `ruff format --check mcpgateway/admin.py tests/unit/mcpgateway/test_admin.py`
- `git diff --check`

Closes #6048

---
This change was developed with AI assistance (Claude); the code and tests were reviewed and verified locally before submission.