### PR TITLE
fix(ui): preserve delegated event arguments

### DIFF
--- a/mcpgateway/admin_ui/eventDelegation.js
+++ b/mcpgateway/admin_ui/eventDelegation.js
@@ -83,6 +83,7 @@ function parseDataAttributes(element) {
  * @param {string} action - The function name to call
  * @param {Array} args - Arguments to pass to the function
  * @param {Event} event - The original event object
+ * @param {boolean} eventFirst - Whether to pass the event before the declared arguments
  * @returns {*} - The return value of the called function
  */
 function executeAction(action, args, event, eventFirst = false) {
@@ -161,13 +162,14 @@ function handleDelegatedInput(event) {
 
   const action = target.dataset.actionInput;
   const args = parseDataAttributes(target);
+  const eventFirst = target.dataset.eventFirst === 'true';
 
-  // Add the input value as first argument if no args specified
-  if (args.length === 0) {
+  // Add the input value when the handler does not explicitly request the event first
+  if (args.length === 0 && !eventFirst) {
     args.push(target.value);
   }
 
-  executeAction(action, args, event);
+  executeAction(action, args, event, eventFirst);
 }
 
 /**
@@ -181,9 +183,10 @@ function handleDelegatedChange(event) {
 
   const action = target.dataset.actionChange;
   const args = parseDataAttributes(target);
+  const eventFirst = target.dataset.eventFirst === 'true';
 
-  // Add the changed value as first argument if no args specified
-  if (args.length === 0) {
+  // Add the changed value when the handler does not explicitly request the event first
+  if (args.length === 0 && !eventFirst) {
     if (target.type === 'checkbox') {
       args.push(target.checked);
     } else {
@@ -191,7 +194,7 @@ function handleDelegatedChange(event) {
     }
   }
 
-  executeAction(action, args, event);
+  executeAction(action, args, event, eventFirst);
 }
 
 /**

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -824,6 +824,7 @@
                     id="performance-aggregation-select"
                     class="px-3 py-2 block w-full border-gray-300 rounded-md shadow-sm dark:bg-gray-700 dark:border-gray-600 text-gray-700 dark:text-gray-300"
                     data-action-change="handlePerformanceAggregationChange"
+                    data-event-first="true"
                   >
                     <option value="5m">5 minutes</option>
                     <option value="24h">24 hours</option>
@@ -1738,7 +1739,8 @@
                       <textarea id="chat-input" rows="1"
                         placeholder="Type your message here... (Shift+Enter for new line)"
                         class="w-full rounded-lg border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-3 text-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500 dark:bg-gray-900 dark:text-gray-300 resize-none transition-all"
-                        data-action-keydown="handleChatInputKeydown" data-action-input="autoResizeTextarea" disabled></textarea>
+                        data-action-keydown="handleChatInputKeydown" data-action-input="autoResizeTextarea"
+                        data-event-first="true" disabled></textarea>
                       <div
                         class="absolute bottom-2 right-2 text-xs text-gray-400 dark:text-gray-500 pointer-events-none">
                         Press Enter to send
@@ -5862,6 +5864,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                 name="ca_certificates[]"
                 class="hidden"
                 data-action-change="validateCACertFiles"
+                data-event-first="true"
                 accept=".pem,.crt,.cer,.cert,application/x-x509-ca-certificate"
                 multiple
               />
@@ -6311,6 +6314,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                   {% if require_token_expiration %}required{% endif %}
                   {% if require_token_expiration %}
                   data-action-input="clearCustomValidity"
+                  data-event-first="true"
                   {% endif %}
                   class="mt-1 px-3 py-2 block w-full border border-gray-300 rounded-md shadow-sm bg-gray-100 dark:bg-gray-700 dark:border-gray-600 text-gray-700 dark:text-gray-300"
                   placeholder="30"

--- a/tests/unit/js/eventDelegation.test.js
+++ b/tests/unit/js/eventDelegation.test.js
@@ -191,6 +191,31 @@ describe("eventDelegation", () => {
 
       expect(mockAdminFunction).toHaveBeenCalledWith("explicit-value", expect.any(Event));
     });
+
+    it("passes the event first when requested", () => {
+      const input = document.createElement("textarea");
+      input.setAttribute("data-action-input", "testFunction");
+      input.setAttribute("data-event-first", "true");
+      container.appendChild(input);
+
+      input.value = "not passed as an argument";
+      const event = new Event("input", { bubbles: true });
+      input.dispatchEvent(event);
+
+      expect(mockAdminFunction).toHaveBeenCalledWith(event);
+    });
+
+    it("auto-resizes a textarea through delegated input", () => {
+      const input = document.createElement("textarea");
+      input.setAttribute("data-action-input", "autoResizeTextarea");
+      input.setAttribute("data-event-first", "true");
+      Object.defineProperty(input, "scrollHeight", { value: 84 });
+      container.appendChild(input);
+
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+
+      expect(input.style.height).toBe("84px");
+    });
   });
 
   describe("change events", () => {
@@ -230,6 +255,19 @@ describe("eventDelegation", () => {
       select.dispatchEvent(new Event("change", { bubbles: true }));
 
       expect(mockAdminFunction).toHaveBeenCalledWith("option1", expect.any(Event));
+    });
+
+    it("passes the event before explicit arguments when requested", () => {
+      const input = document.createElement("input");
+      input.setAttribute("data-action-change", "testFunction");
+      input.setAttribute("data-event-first", "true");
+      input.setAttribute("data-arg0", '"certificate"');
+      container.appendChild(input);
+
+      const event = new Event("change", { bubbles: true });
+      input.dispatchEvent(event);
+
+      expect(mockAdminFunction).toHaveBeenCalledWith(event, "certificate");
     });
   });
 


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #6001

## Summary

- Add an explicit `data-event-first` opt-in for delegated input and change actions.
- Mark the four handlers that consume the DOM event instead of an element value.
- Preserve automatic value/checked argument passing for existing value-based handlers.

## Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

## Verification

| Check | Command | Status |
|---|---|---|
| Focused JS tests | `vitest run tests/unit/js/eventDelegation.test.js` | 37 passed |
| Full JS tests | `vitest run` | 52 files, 2325 passed, 3 skipped |
| Patch whitespace | `git diff --check` | Passed |

## Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (not applicable; internal dispatch contract only)
- [x] No secrets or credentials committed

## Notes

PRs #4801 and #5045 each address one symptom of the argument shift. This change fixes the dispatch contract for all four known event-first bindings while leaving the other value-based input/change actions unchanged.

The repository-wide ESLint invocation still reports the pre-existing undefined `toggleBulkImportDropdown` reference in `eventDelegation.js:375`; this patch does not modify that path.