### PR TITLE
test(plugins): isolate service plugin state

### DIFF
--- a/tests/unit/mcpgateway/services/conftest.py
+++ b/tests/unit/mcpgateway/services/conftest.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""Shared fixtures for service-layer tests."""
+
+import pytest
+from cpex.framework import PluginManager
+
+import mcpgateway.plugins as plugin_framework
+
+
+def _reset_plugin_state() -> None:
+    """Clear process-wide plugin state shared across service tests."""
+    PluginManager.reset()
+    plugin_framework.reset_plugin_manager_factory()
+    plugin_framework._invalidate_shared_enabled_cache()
+    plugin_framework._state.clear_local_mode_overrides()
+    plugin_framework._reset_factory_init_degraded_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def reset_plugin_manager_state():
+    """Keep plugin manager configuration isolated between service tests."""
+    _reset_plugin_state()
+    yield
+    _reset_plugin_state()


### PR DESCRIPTION
## Related Issue

Closes #5909

## Summary

Reset the process-wide plugin framework state before and after every service-layer test. This keeps service tests independent when pytest executes files in the same process and prevents a tool-service plugin configuration from leaking into prompt-service tests.

## Reproduction Steps

On `main`, run:

```bash
pytest tests/unit/mcpgateway/services/test_tool_service.py tests/unit/mcpgateway/services/test_prompt_service.py
```

The prompt post-hook policy test fails after the tool-service suite, while the prompt-service file passes by itself.

## Root Cause

CPEX `PluginManager` uses shared Borg state. The tool-service tests initialize it with `tool_headers_metadata_plugin.yaml`; a later construction in the prompt-service suite therefore retains that stale configuration instead of loading `plugin_parity_config.yaml`. The existing autouse reset fixture is scoped under `tests/unit/mcpgateway/plugins/`, so service tests do not receive it.

## Fix Description

Add a service-test `conftest.py` with an autouse fixture that resets both CPEX and MCP Gateway plugin factory/cache state before and after each test. The cleanup mirrors the established plugin-suite fixture and covers future service tests that instantiate a real plugin manager.

## Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage` (the issue currently retains that label)
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## Verification

| Check | Command | Status |
|---|---|---|
| Ordered regression | `.venv/Scripts/python -m pytest tests/unit/mcpgateway/services/test_tool_service.py tests/unit/mcpgateway/services/test_prompt_service.py -q` | 576 passed |
| Plugin service regression | `.venv/Scripts/python -m pytest tests/unit/mcpgateway/services/test_plugin_service.py -q` | 18 passed |
| Ruff | `python -m uv tool run ruff check tests/unit/mcpgateway/services/conftest.py` | passed |
| Ruff format | `python -m uv tool run ruff format --check tests/unit/mcpgateway/services/conftest.py` | passed |
| Whitespace | `git diff --check upstream/main...HEAD` | passed |

## Checklist

- [x] Code formatted
- [x] No secrets or credentials committed
- [x] Commit signed off for DCO