### PR TITLE
fix(observability): honor granular feature flags

### DIFF
--- a/mcpgateway/middleware/observability_middleware.py
+++ b/mcpgateway/middleware/observability_middleware.py
@@ -99,7 +99,8 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
             service: Optional ObservabilityService instance
         """
         super().__init__(app)
-        self.enabled = enabled if enabled is not None else getattr(settings, "observability_enabled", False)
+        observability_enabled = enabled if enabled is not None else settings.observability_enabled
+        self.enabled = observability_enabled and settings.observability_trace_http_requests
         self.service = service or ObservabilityService()
         logger.info(f"Observability middleware initialized (enabled={self.enabled})")
 

--- a/mcpgateway/services/observability_service.py
+++ b/mcpgateway/services/observability_service.py
@@ -63,6 +63,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import joinedload, Session
 
 # First-Party
+from mcpgateway.config import settings
 from mcpgateway.db import ObservabilityEvent, ObservabilityMetric, ObservabilitySpan, ObservabilityTrace, SessionLocal
 
 logger = logging.getLogger(__name__)
@@ -885,6 +886,9 @@ class ObservabilityService:
             ...     message="Failed to connect to database"  # doctest: +SKIP
             ... )  # doctest: +SKIP
         """
+        if not settings.observability_events_enabled:
+            return 0
+
         # Use provided session or create new one
         obs_db, owned = (obs_db, False) if obs_db else _get_or_create_observability_session()
         try:
@@ -1351,6 +1355,9 @@ class ObservabilityService:
             ...     trace_id=trace_id  # doctest: +SKIP
             ... )  # doctest: +SKIP
         """
+        if not settings.observability_metrics_enabled:
+            return 0
+
         obs_db = None
         owned = False
         try:

--- a/tests/unit/mcpgateway/middleware/test_observability_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_observability_middleware.py
@@ -48,6 +48,19 @@ async def test_dispatch_disabled(mock_request, mock_call_next):
 
 
 @pytest.mark.asyncio
+async def test_dispatch_disabled_when_http_tracing_is_disabled(mock_request, mock_call_next):
+    service = MagicMock(spec=ObservabilityService)
+    with patch("mcpgateway.middleware.observability_middleware.settings") as mock_settings:
+        mock_settings.observability_trace_http_requests = False
+        middleware = ObservabilityMiddleware(app=None, enabled=True, service=service)
+
+    response = await middleware.dispatch(mock_request, mock_call_next)
+
+    assert response.status_code == 200
+    service.start_trace.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_dispatch_health_check_skipped(mock_request, mock_call_next):
     middleware = ObservabilityMiddleware(app=None, enabled=True)
     mock_request.url.path = "/health"

--- a/tests/unit/mcpgateway/services/test_observability_service.py
+++ b/tests/unit/mcpgateway/services/test_observability_service.py
@@ -92,6 +92,17 @@ def test_add_event_commits(mock_session_factory):
     assert eid is not None
 
 
+def test_add_event_skips_storage_when_events_disabled(mock_session_factory):
+    mock_factory, _mock_session = mock_session_factory
+    service = ObservabilityService()
+
+    with patch("mcpgateway.services.observability_service.settings") as mock_settings:
+        mock_settings.observability_events_enabled = False
+        assert service.add_event("span123", "evt") == 0
+
+    mock_factory.assert_not_called()
+
+
 @patch("mcpgateway.services.observability_service.current_trace_id")
 def test_record_token_usage_missing_trace(mock_ctid, mock_db):
     # Test that record_token_usage returns early when no trace is active
@@ -506,6 +517,17 @@ def test_record_metric_commit_failure_returns_zero(mock_session_factory):
     with patch.object(service, "_safe_commit", return_value=False):
         metric_id = service.record_metric(name="m", value=1.0, metric_type="counter", trace_id="tid")
     assert metric_id == 0
+
+
+def test_record_metric_skips_storage_when_metrics_disabled(mock_session_factory):
+    mock_factory, _mock_session = mock_session_factory
+    service = ObservabilityService()
+
+    with patch("mcpgateway.services.observability_service.settings") as mock_settings:
+        mock_settings.observability_metrics_enabled = False
+        assert service.record_metric(name="m", value=1.0) == 0
+
+    mock_factory.assert_not_called()
 
 
 def test_query_traces_applies_filters(mock_db):


### PR DESCRIPTION
## Related Issue

Closes #5849

## Summary

Make the three documented granular observability settings control their corresponding runtime behavior:

- `observability_metrics_enabled` prevents `record_metric()` from creating a database session or row when disabled.
- `observability_events_enabled` prevents `add_event()` from creating a database session or row when disabled.
- `observability_trace_http_requests` disables automatic request tracing while leaving other observability features available under the master switch.

All settings default to `true`, so existing deployments keep their current behavior unless an operator explicitly disables a feature.

## Root Cause

The settings were declared and documented, but none of the runtime entry points read them. Metric and event writes only relied on their callers, while `ObservabilityMiddleware` only received the master `observability_enabled` state.

## Fix Description

Gate metrics and events at the shared service methods so every caller gets consistent behavior, including plugin and transport instrumentation. Combine the middleware's enabled state with the HTTP tracing setting at initialization so disabling request tracing bypasses trace/span setup without disabling the observability service itself.

## Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage` (the issue currently retains that label)
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## Verification

| Check | Command | Status |
|---|---|---|
| Observability unit suites | `.venv/Scripts/python -m pytest tests/unit/mcpgateway/test_admin_observability_sql.py tests/unit/mcpgateway/test_observability.py tests/unit/mcpgateway/test_observability_baggage_exceptions.py tests/unit/mcpgateway/test_observability_coverage.py tests/unit/mcpgateway/middleware/test_observability_middleware.py tests/unit/mcpgateway/middleware/test_observability_middleware_transactions.py tests/unit/mcpgateway/services/test_observability_attribute_removal.py tests/unit/mcpgateway/services/test_observability_service.py -q` | 190 passed, 2 skipped |
| Production Ruff | `python -m uv tool run ruff check mcpgateway/services/observability_service.py mcpgateway/middleware/observability_middleware.py` | passed |
| Formatting | `python -m uv tool run ruff format --check <four changed files>` | passed |
| Whitespace | `git diff --check upstream/main...HEAD` | passed |

The two skips are existing environment-dependent tests (optional OpenTelemetry exporter and an integration-only middleware branch).

## Checklist

- [x] Code formatted
- [x] Tests added for each disabled path
- [x] No secrets or credentials committed
- [x] Commit signed off for DCO