### PR TITLE
migration-fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,10 +12,15 @@
 # REQUIRED SECRETS - Application will NOT start without these
 # =============================================================================
 #
-# ⚠️  SECURITY WARNING: JWT_SECRET_KEY and AUTH_ENCRYPTION_SECRET are REQUIRED
-#     in EVERY environment — including local development.
-#     The application will refuse to start if either value is a placeholder
-#     (__REPLACE_ME__) or a known-weak default.
+# ⚠️  SECURITY WARNING: JWT_SECRET_KEY is REQUIRED in every environment —
+#     including local development. The application will refuse to start if the
+#     value is a placeholder (__REPLACE_ME__), known-weak, too short, or low-entropy.
+#
+# ℹ️  AUTH_ENCRYPTION_SECRET follows the same rules in staging and production.
+#     In ENVIRONMENT=development it is relaxed: weak/short values emit a loud
+#     WARNING and startup continues, so local PoC workflows can use a simple
+#     value like AUTH_ENCRYPTION_SECRET=my-test-salt.
+#     The __REPLACE_ME__ placeholder is always rejected for both fields.
 #
 # Quickstart (fresh checkout):
 #   1. make install-dev          # installs Python deps — does NOT touch .env
@@ -48,18 +53,24 @@
 # Generate with: python3 -m mcpgateway.scripts.init_secrets
 JWT_SECRET_KEY=__REPLACE_ME__run_init-secrets_before_starting
 
-# Passphrase used to encrypt stored auth secrets (REQUIRED — all environments, including development)
-# Generate with: python3 -m mcpgateway.scripts.init_secrets
-AUTH_ENCRYPTION_SECRET=__REPLACE_ME__run_init-secrets_before_starting
+# Passphrase used to encrypt stored auth secrets.
+# REQUIRED in staging/production — must be strong (≥32 chars, non-weak, good entropy).
+# In ENVIRONMENT=development a short/weak vawlue is allowed (warns at startup).
+# The __REPLACE_ME__ placeholder is rejected in every environment.
+# Generate a strong value with: python3 -m mcpgateway.scripts.init_secrets
+AUTH_ENCRYPTION_SECRET=__REPLACE_ME__run_init-secrets_before_starting # pragma: allowlist secret
 
 # =============================================================================
 # Environment Mode
 # =============================================================================
-# Controls CORS, cookie security, and operational defaults — but NOT secret
-# enforcement. Placeholder/weak secrets are rejected in every environment.
-# - development: Relaxed CORS (localhost:3000/8080), insecure cookies, dev info
-# - staging: Production-like CORS and cookie defaults, staging domain
-# - production: Strict CORS (APP_DOMAIN only), secure cookies, no debug info
+# Controls CORS, cookie security, operational defaults, and secret enforcement:
+# - development: Relaxed CORS (localhost:3000/8080), insecure cookies, dev info.
+#                AUTH_ENCRYPTION_SECRET weak/short values warn instead of hard-failing.
+#                JWT_SECRET_KEY is still unconditionally enforced.
+# - staging:     Production-like CORS and cookie defaults, staging domain.
+#                Both secrets fully enforced.
+# - production:  Strict CORS (APP_DOMAIN only), secure cookies, no debug info.
+#                Both secrets fully enforced.
 # Default: development (if not set)
 ENVIRONMENT=development
 
@@ -1331,10 +1342,12 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 #   - Team membership validation is skipped (no JWT to extract teams from)
 #   - Use TRUST_PROXY_AUTH=true with a reverse proxy for user identification
 
-# Used to derive an AES encryption key for secure auth storage
-# Must be a non-empty string (e.g. passphrase or random secret)
-# Generate with: python3 -m mcpgateway.scripts.init_secrets
-# AUTH_ENCRYPTION_SECRET=
+# Used to derive an AES encryption key for secure auth storage.
+# In staging/production: must be strong (≥32 chars, non-weak, good entropy).
+# In ENVIRONMENT=development: weak/short values are allowed (emit a WARNING at startup).
+# The __REPLACE_ME__ placeholder is always rejected regardless of environment.
+# Generate a strong value with: python3 -m mcpgateway.scripts.init_secrets
+# AUTH_ENCRYPTION_SECRET=my-test-salt  # pragma: allowlist secret
 
 # Identity Propagation - forward end-user identity to upstream MCP servers
 # IDENTITY_PROPAGATION_ENABLED=false

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-05T11:24:02Z",
+  "generated_at": "2026-08-05T12:11:08Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4676,7 +4676,7 @@
         "hashed_secret": "15ab6d87c10ed359ba98e6a578764fa53954fdfc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1987,
+        "line_number": 1990,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
+    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-04T17:51:11Z",
+  "generated_at": "2026-08-05T11:24:02Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -89,10 +89,10 @@
     ],
     ".env.example": [
       {
-        "hashed_secret": "15ab6d87c10ed359ba98e6a578764fa53954fdfc",
+        "hashed_secret": "07d79dfd9ad52d9706b1dc4685d018fdbe522f68",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 53,
+        "line_number": 22,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -100,7 +100,7 @@
         "hashed_secret": "548a5cde15c93a9e50e12e4cba776b85f6befc83",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 121,
+        "line_number": 132,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -108,7 +108,7 @@
         "hashed_secret": "8e9a8667ded25c805ce3dc920a5f2343bd2d198f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 122,
+        "line_number": 133,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -116,7 +116,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 766,
+        "line_number": 777,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1011,
+        "line_number": 1022,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1310,
+        "line_number": 1321,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1345,
+        "line_number": 1358,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1434,
+        "line_number": 1447,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1439,
+        "line_number": 1452,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1444,
+        "line_number": 1457,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1450,
+        "line_number": 1463,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1462,
+        "line_number": 1475,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1480,
+        "line_number": 1493,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1541,
+        "line_number": 1554,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -331,10 +331,18 @@
     ],
     "Makefile": [
       {
+        "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 335,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 576,
+        "line_number": 577,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -342,7 +350,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1054,
+        "line_number": 1055,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +358,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1056,
+        "line_number": 1057,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +366,7 @@
         "hashed_secret": "db69d9215c29ae2f2e4ead587890a9f8455059dd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1130,
+        "line_number": 1131,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +374,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1710,
+        "line_number": 1711,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +382,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1929,
+        "line_number": 1930,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +390,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6063,
+        "line_number": 6064,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +398,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6560,
+        "line_number": 6561,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +406,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6572,
+        "line_number": 6573,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +414,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6644,
+        "line_number": 6645,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +422,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7060,
+        "line_number": 7061,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +430,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7751,
+        "line_number": 7752,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -598,7 +606,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 61,
+        "line_number": 65,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4659,6 +4667,16 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 7268,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_config.py": [
+      {
+        "hashed_secret": "15ab6d87c10ed359ba98e6a578764fa53954fdfc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1987,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,8 @@ install-dev: venv
 	@echo "🔑  Next step — choose one:"
 	@echo "    make setup           # recommended: auto-creates .env and patches secrets in-place"
 	@echo "    make init-secrets    # writes secrets to .env.secrets so you can review before copying"
-	@echo "    The gateway will not start until JWT_SECRET_KEY and AUTH_ENCRYPTION_SECRET are set."
+	@echo "    JWT_SECRET_KEY must be strong in every environment."
+	@echo "    AUTH_ENCRYPTION_SECRET: weak values (e.g. my-test-salt) are allowed in ENVIRONMENT=development."
 
 # help: build-ui              - Build Admin UI CSS and JS bundles (requires npm; set SKIP_UI_BUILD=1 to bypass)
 .PHONY: build-ui
@@ -375,7 +376,7 @@ check-env-dev:
 
 # help: init-secrets          - Generate secrets → .env.secrets for manual review; copy values into .env when ready
 # help: init-secrets-force    - Regenerate .env.secrets unconditionally (no prompt)
-# help: init-secrets-patch-env - Write generated secrets directly into .env (in-place, preserves other values)
+# help: init-secrets-patch-env - Patch JWT_SECRET_KEY/BASIC_AUTH_PASSWORD into .env; AUTH_ENCRYPTION_SECRET written to .env.secrets only
 .PHONY: init-secrets init-secrets-force init-secrets-patch-env
 init-secrets:                   ## 🔑 Generate secrets → .env.secrets (prompts if file exists)
 	$(UV_BIN) run python3 -m mcpgateway.scripts.init_secrets
@@ -383,7 +384,7 @@ init-secrets:                   ## 🔑 Generate secrets → .env.secrets (promp
 init-secrets-force:             ## 🔑 Regenerate .env.secrets unconditionally (--force)
 	$(UV_BIN) run python3 -m mcpgateway.scripts.init_secrets --force
 
-init-secrets-patch-env:         ## 🔑 Patch weak/placeholder secrets directly into .env (--patch-env)
+init-secrets-patch-env:         ## 🔑 Patch JWT_SECRET_KEY into .env; AUTH_ENCRYPTION_SECRET written to .env.secrets only (--patch-env)
 	$(UV_BIN) run python3 -m mcpgateway.scripts.init_secrets --patch-env .env
 
 # First-time setup: works before make dev, make serve, and make compose-up.

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1537,10 +1537,13 @@ class Settings(BaseSettings):
                 is unset (placeholder), matches a known-weak value, is shorter than
                 ``min_secret_length`` characters, or has low per-character entropy.
         """
-        # client_mode is intentionally NOT exempted — secret-strength enforcement
-        # is always active regardless of deployment profile.
         weak_secrets = {v.lower() for v in self.WEAK_VALUES}
         env = str(self.environment).lower()
+        is_dev = env == "development"
+
+        # jwt_secret_key: unconditional hard-fail in every environment.
+        # auth_encryption_secret: weak/short/low-entropy values are downgraded to
+        # WARNING-only when ENVIRONMENT=development (PoC / local dev convenience).
         for field_name, secret_field in (
             ("jwt_secret_key", self.jwt_secret_key),
             ("auth_encryption_secret", self.auth_encryption_secret),
@@ -1548,19 +1551,40 @@ class Settings(BaseSettings):
             val = secret_field.get_secret_value()
 
             if not val.strip():
-                raise SecurityConfigurationError(f"{field_name}: secret is empty. Set a real value (run 'python -m mcpgateway.scripts.init_secrets').")
-
-            if len(val) < self.min_secret_length:
                 raise SecurityConfigurationError(
-                    f"{field_name}: too short ({len(val)} chars, minimum {self.min_secret_length}). "
-                    "Run 'python -m mcpgateway.scripts.init_secrets' to generate strong values, "
-                    "or use 'make init-secrets-patch-env' to write them directly into .env."
+                    f"{field_name}: secret is empty. "
+                    "To fix, choose one of:\n"
+                    "  make setup                  # recommended: auto-creates .env and patches secrets in-place\n"
+                    "  make init-secrets           # writes secrets to .env.secrets for review, then copy into .env\n"
+                    "  make init-secrets-patch-env # patches secrets directly into an existing .env"
                 )
 
             is_placeholder = val.lower().startswith("__replace_me__")
             is_weak = val.lower() in weak_secrets
             entropy = calculate_entropy(val)
             is_low_entropy = entropy < 3.5
+            is_too_short = len(val) < self.min_secret_length
+
+            # auth_encryption_secret in dev: warn instead of raising for weak/short/low-entropy.
+            # Placeholder is still rejected unconditionally (it has no runtime meaning).
+            if field_name == "auth_encryption_secret" and is_dev and not is_placeholder:
+                if is_too_short or is_weak or is_low_entropy:
+                    logger.warning(
+                        "🔓 DEV-MODE SECURITY WARNING - %s: weak/short/low-entropy secret detected "
+                        "(value allowed only because ENVIRONMENT=development). "
+                        "NEVER use this secret outside local development.",
+                        field_name,
+                    )
+                continue
+
+            if is_too_short:
+                raise SecurityConfigurationError(
+                    f"{field_name}: too short ({len(val)} chars, minimum {self.min_secret_length}). "
+                    "To fix, choose one of:\n"
+                    "  make setup                  # recommended: auto-creates .env and patches secrets in-place\n"
+                    "  make init-secrets           # writes secrets to .env.secrets for review, then copy into .env\n"
+                    "  make init-secrets-patch-env # patches secrets directly into an existing .env"
+                )
 
             if is_placeholder or is_weak or is_low_entropy:
                 if is_placeholder:

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1516,14 +1516,19 @@ class Settings(BaseSettings):
     def validate_security_combinations(self) -> Self:
         """Validate security setting combinations and raise on unsafe secrets.
 
-        Placeholder and weak/known secrets are rejected unconditionally in every
-        environment (development, staging, and production alike).  Some compose
-        sibling containers (e.g. ``register_fast_time``, ``prometheus_token``)
+        ``jwt_secret_key`` is rejected unconditionally in every environment
+        (development, staging, and production) when it is empty, a placeholder,
+        known-weak, too short, or low-entropy.  Some compose sibling containers
         sign tokens with the raw ``JWT_SECRET_KEY`` environment variable outside
         this validator, so per-process random generation cannot be used as a
         fallback — gateway and sibling containers must share the same secret.
-        The only safe option is an unconditional hard-fail that forces operators
-        to provide a real secret before the process will start.
+
+        ``auth_encryption_secret`` follows the same rules in staging and
+        production.  In ``ENVIRONMENT=development``, weak/short/low-entropy
+        values are downgraded to a loud WARNING so local PoC workflows can use
+        a simple value like ``AUTH_ENCRYPTION_SECRET=my-test-salt``.  The
+        ``__REPLACE_ME__`` placeholder is still rejected unconditionally for
+        both fields in every environment — it has no runtime meaning.
 
         Run ``python -m mcpgateway.scripts.init_secrets`` (or ``make init-secrets``
         for interactive use, ``make init-secrets-patch-env`` to write directly into
@@ -1533,17 +1538,21 @@ class Settings(BaseSettings):
             Itself.
 
         Raises:
-            SecurityConfigurationError: If jwt_secret_key or auth_encryption_secret
-                is unset (placeholder), matches a known-weak value, is shorter than
-                ``min_secret_length`` characters, or has low per-character entropy.
+            SecurityConfigurationError: If either secret is empty or is the
+                ``__REPLACE_ME__`` placeholder (both fields, all environments),
+                or if ``jwt_secret_key`` matches a known-weak value, is shorter
+                than ``min_secret_length`` characters, or has low per-character
+                entropy (``auth_encryption_secret`` only warns for these in
+                ``ENVIRONMENT=development``).
         """
         weak_secrets = {v.lower() for v in self.WEAK_VALUES}
         env = str(self.environment).lower()
         is_dev = env == "development"
 
-        # jwt_secret_key: unconditional hard-fail in every environment.
-        # auth_encryption_secret: weak/short/low-entropy values are downgraded to
-        # WARNING-only when ENVIRONMENT=development (PoC / local dev convenience).
+        # jwt_secret_key:          unconditional hard-fail in every environment.
+        # auth_encryption_secret:  same rules in staging/production; weak/short/
+        #                          low-entropy values are WARNING-only in development.
+        #                          The __REPLACE_ME__ placeholder is always rejected.
         for field_name, secret_field in (
             ("jwt_secret_key", self.jwt_secret_key),
             ("auth_encryption_secret", self.auth_encryption_secret),
@@ -1565,9 +1574,18 @@ class Settings(BaseSettings):
             is_low_entropy = entropy < 3.5
             is_too_short = len(val) < self.min_secret_length
 
-            # auth_encryption_secret in dev: warn instead of raising for weak/short/low-entropy.
-            # Placeholder is still rejected unconditionally (it has no runtime meaning).
-            if field_name == "auth_encryption_secret" and is_dev and not is_placeholder:
+            # Placeholder is always fatal — it has no usable runtime value.
+            if is_placeholder:
+                raise SecurityConfigurationError(
+                    f"{field_name}: unset placeholder (__REPLACE_ME__) rejected in every environment (including '{env}'). "
+                    "To fix, choose one of:\n"
+                    "  make setup                  # recommended: auto-creates .env and patches secrets in-place\n"
+                    "  make init-secrets           # writes secrets to .env.secrets for review, then copy into .env\n"
+                    "  make init-secrets-patch-env # patches secrets directly into an existing .env"
+                )
+
+            # auth_encryption_secret in development: downgrade weak/short/low-entropy to a warning.
+            if field_name == "auth_encryption_secret" and is_dev:
                 if is_too_short or is_weak or is_low_entropy:
                     logger.warning(
                         "🔓 DEV-MODE SECURITY WARNING - %s: weak/short/low-entropy secret detected "
@@ -1586,13 +1604,8 @@ class Settings(BaseSettings):
                     "  make init-secrets-patch-env # patches secrets directly into an existing .env"
                 )
 
-            if is_placeholder or is_weak or is_low_entropy:
-                if is_placeholder:
-                    reason = "unset placeholder (__REPLACE_ME__)"
-                elif is_weak:
-                    reason = "known-weak/default value"
-                else:
-                    reason = f"low entropy (score {entropy:.2f} < 3.5)"
+            if is_weak or is_low_entropy:
+                reason = "known-weak/default value" if is_weak else f"low entropy (score {entropy:.2f} < 3.5)"
                 raise SecurityConfigurationError(
                     f"{field_name}: {reason} rejected in every environment (including '{env}'). "
                     "Cross-process token consistency requires operators to supply a real secret before startup — "

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1538,21 +1538,24 @@ class Settings(BaseSettings):
             Itself.
 
         Raises:
-            SecurityConfigurationError: If either secret is empty or is the
-                ``__REPLACE_ME__`` placeholder (both fields, all environments),
-                or if ``jwt_secret_key`` matches a known-weak value, is shorter
-                than ``min_secret_length`` characters, or has low per-character
-                entropy (``auth_encryption_secret`` only warns for these in
-                ``ENVIRONMENT=development``).
+            SecurityConfigurationError: If either secret is empty (both fields,
+                all environments), or if ``jwt_secret_key`` is the
+                ``__REPLACE_ME__`` placeholder, known-weak, too short, or has
+                low per-character entropy (all environments).
+                ``auth_encryption_secret`` only warns for ALL of these in
+                ``ENVIRONMENT=development`` — including the placeholder.
+                Full enforcement applies to ``auth_encryption_secret`` in
+                staging and production.
         """
         weak_secrets = {v.lower() for v in self.WEAK_VALUES}
         env = str(self.environment).lower()
         is_dev = env == "development"
 
         # jwt_secret_key:          unconditional hard-fail in every environment.
-        # auth_encryption_secret:  same rules in staging/production; weak/short/
-        #                          low-entropy values are WARNING-only in development.
-        #                          The __REPLACE_ME__ placeholder is always rejected.
+        # auth_encryption_secret:  ALL non-compliant values (placeholder, insufficient
+        #                          length, known-default, low entropy) are WARNING-only
+        #                          in ENVIRONMENT=development. Full enforcement in
+        #                          staging and production.
         for field_name, secret_field in (
             ("jwt_secret_key", self.jwt_secret_key),
             ("auth_encryption_secret", self.auth_encryption_secret),
@@ -1574,7 +1577,24 @@ class Settings(BaseSettings):
             is_low_entropy = entropy < 3.5
             is_too_short = len(val) < self.min_secret_length
 
-            # Placeholder is always fatal — it has no usable runtime value.
+            # auth_encryption_secret in development: ALL non-compliant values are
+            # downgraded to a WARNING — including the __REPLACE_ME__ placeholder.
+            # Production and staging always enforce full cryptographic strength.
+            if field_name == "auth_encryption_secret" and is_dev:
+                if is_placeholder or is_too_short or is_weak or is_low_entropy:
+                    logger.warning(
+                        "🔓 SECURITY WARNING - %s: value does not meet minimum cryptographic "
+                        "strength requirements (placeholder, insufficient length, known-default, "
+                        "or low entropy). Permitted only in ENVIRONMENT=development for local "
+                        "PoC use. This configuration MUST NOT be used in staging or production "
+                        "— replace with a cryptographically secure value before any "
+                        "non-development deployment.",
+                        field_name,
+                    )
+                continue
+
+            # For jwt_secret_key and auth_encryption_secret outside development:
+            # placeholder, too-short, weak, and low-entropy all hard-fail.
             if is_placeholder:
                 raise SecurityConfigurationError(
                     f"{field_name}: unset placeholder (__REPLACE_ME__) rejected in every environment (including '{env}'). "
@@ -1583,17 +1603,6 @@ class Settings(BaseSettings):
                     "  make init-secrets           # writes secrets to .env.secrets for review, then copy into .env\n"
                     "  make init-secrets-patch-env # patches secrets directly into an existing .env"
                 )
-
-            # auth_encryption_secret in development: downgrade weak/short/low-entropy to a warning.
-            if field_name == "auth_encryption_secret" and is_dev:
-                if is_too_short or is_weak or is_low_entropy:
-                    logger.warning(
-                        "🔓 DEV-MODE SECURITY WARNING - %s: weak/short/low-entropy secret detected "
-                        "(value allowed only because ENVIRONMENT=development). "
-                        "NEVER use this secret outside local development.",
-                        field_name,
-                    )
-                continue
 
             if is_too_short:
                 raise SecurityConfigurationError(

--- a/mcpgateway/scripts/init_secrets.py
+++ b/mcpgateway/scripts/init_secrets.py
@@ -82,6 +82,13 @@ _SECRET_FIELDS: dict[str, int] = {
     "BASIC_AUTH_PASSWORD": 18,  # nosec B105 — patched when "changeme" or placeholder; 18 bytes → 24 chars
 }
 
+# Fields that are written to .env.secrets (--output / --stdout) but are NOT
+# patched into .env by --patch-env / ensure_env_file_secrets().
+# AUTH_ENCRYPTION_SECRET is intentionally excluded from auto-patching: in
+# ENVIRONMENT=development a weak value (e.g. my-test-salt) is allowed, so
+# operators should set it deliberately rather than having it silently replaced.
+_PATCH_ENV_SKIP_FIELDS: frozenset[str] = frozenset({"AUTH_ENCRYPTION_SECRET"})
+
 
 def _read_env_file(path: str) -> dict[str, str]:
     """Parse KEY=VALUE pairs from an env file, skipping comments and blank lines.
@@ -164,11 +171,16 @@ def ensure_env_file_secrets(
     env_file: str = ".env",
     weak_values: frozenset[str] | None = None,
 ) -> dict[str, str]:
-    """Check JWT_SECRET_KEY, AUTH_ENCRYPTION_SECRET, and BASIC_AUTH_PASSWORD for weak or placeholder values.
+    """Check JWT_SECRET_KEY and BASIC_AUTH_PASSWORD for weak or placeholder values.
 
     If weak values are detected, generates cryptographically strong replacements,
     merges them into *env_file* (creating the file if it does not exist), and
     patches ``os.environ`` so the running process picks them up without restart.
+
+    AUTH_ENCRYPTION_SECRET is intentionally NOT patched by this function.
+    In ENVIRONMENT=development a weak value (e.g. ``my-test-salt``) is allowed,
+    so operators should set it deliberately.  Strong values for it are still
+    written to .env.secrets by the --output / --stdout paths.
 
     Set ``MCPGATEWAY_AUTO_INIT_SECRETS=false`` to disable this behaviour (e.g.
     when secrets are injected via Vault or Kubernetes secrets and disk writes
@@ -190,6 +202,8 @@ def ensure_env_file_secrets(
     file_generated: dict[str, str] = {}
 
     for field, nbytes in _SECRET_FIELDS.items():
+        if field in _PATCH_ENV_SKIP_FIELDS:
+            continue  # never auto-patched into .env (see _PATCH_ENV_SKIP_FIELDS)
         # os.environ takes priority over .env (mirrors pydantic-settings behaviour)
         env_val = os.environ.get(field)
         current = env_val if env_val is not None else env_file_values.get(field, "changeme")
@@ -285,9 +299,11 @@ def main() -> None:
         metavar="ENV_FILE",
         default=None,
         help=(
-            "Patch an existing env file in-place: replace only the JWT_SECRET_KEY and "
-            "AUTH_ENCRYPTION_SECRET lines that still hold placeholder or weak values; "
-            "all other lines are preserved unchanged. No-ops if those keys are already strong."
+            "Patch an existing env file in-place: replace only the JWT_SECRET_KEY "
+            "and BASIC_AUTH_PASSWORD lines that still hold placeholder or weak values; "
+            "all other lines are preserved unchanged. No-ops if those keys are already strong. "
+            "AUTH_ENCRYPTION_SECRET is NOT patched — set it manually or use --stdout / "
+            "--output to get a strong value for .env.secrets."
         ),
     )
     args = parser.parse_args()

--- a/tests/scripts/test_init_secrets.py
+++ b/tests/scripts/test_init_secrets.py
@@ -228,9 +228,11 @@ class TestEnsureEnvFileSecrets:
 
         generated = ensure_env_file_secrets(env_file=str(env))
 
+        # JWT_SECRET_KEY is always auto-patched when weak.
         assert "JWT_SECRET_KEY" in generated
-        assert "AUTH_ENCRYPTION_SECRET" in generated
         assert len(generated["JWT_SECRET_KEY"]) == 43  # 32-byte token_urlsafe
+        # AUTH_ENCRYPTION_SECRET is intentionally NOT auto-patched (dev-mode leniency).
+        assert "AUTH_ENCRYPTION_SECRET" not in generated
 
     def test_ensure_patches_os_environ(self, tmp_path, monkeypatch):
         import os as _os
@@ -304,8 +306,10 @@ class TestEnsureEnvFileSecrets:
 
         generated = ensure_env_file_secrets(env_file=str(env))
 
+        # JWT_SECRET_KEY placeholder is always auto-patched.
         assert "JWT_SECRET_KEY" in generated
-        assert "AUTH_ENCRYPTION_SECRET" in generated
+        # AUTH_ENCRYPTION_SECRET is intentionally NOT auto-patched — operators set it manually.
+        assert "AUTH_ENCRYPTION_SECRET" not in generated
 
     def test_ensure_creates_env_file_when_missing(self, tmp_path, monkeypatch):
         env = tmp_path / ".env"

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -1968,10 +1968,14 @@ def test_primary_worker_heartbeat_warns_at_exact_boundary(caplog):
 
 
 def test_placeholder_secret_raises_in_development():
-    """__REPLACE_ME__ placeholder is rejected even in development — both fields."""
+    """__REPLACE_ME__ placeholder is rejected in development for jwt_secret_key.
+
+    For auth_encryption_secret the placeholder is permitted in development
+    (emits a WARNING) — consistent with all other non-compliant values.
+    """
     from mcpgateway.config import SecurityConfigurationError
 
-    # jwt_secret_key placeholder
+    # jwt_secret_key placeholder always hard-fails
     with pytest.raises(SecurityConfigurationError, match="unset placeholder"):
         Settings(
             jwt_secret_key="__REPLACE_ME__run_init-secrets_before_starting",
@@ -1979,15 +1983,15 @@ def test_placeholder_secret_raises_in_development():
             _env_file=None,
         )
 
-    # auth_encryption_secret placeholder — dev mode does NOT exempt the placeholder
+    # auth_encryption_secret placeholder in dev — warns and proceeds
     strong_jwt = "a-strong-jwt-secret-that-is-long-enough-and-unique-xxxx"  # nosec B105
-    with pytest.raises(SecurityConfigurationError, match="unset placeholder"):
-        Settings(
-            jwt_secret_key=strong_jwt,
-            auth_encryption_secret="__REPLACE_ME__run_init-secrets_before_starting",
-            environment="development",
-            _env_file=None,
-        )
+    s = Settings(
+        jwt_secret_key=strong_jwt,
+        auth_encryption_secret="__REPLACE_ME__run_init-secrets_before_starting",
+        environment="development",
+        _env_file=None,
+    )
+    assert s.auth_encryption_secret.get_secret_value() == "__REPLACE_ME__run_init-secrets_before_starting"
 
 
 def test_placeholder_secret_raises_in_staging():

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -1968,12 +1968,23 @@ def test_primary_worker_heartbeat_warns_at_exact_boundary(caplog):
 
 
 def test_placeholder_secret_raises_in_development():
-    """__REPLACE_ME__ placeholder is rejected even in development."""
+    """__REPLACE_ME__ placeholder is rejected even in development — both fields."""
     from mcpgateway.config import SecurityConfigurationError
 
+    # jwt_secret_key placeholder
     with pytest.raises(SecurityConfigurationError, match="unset placeholder"):
         Settings(
             jwt_secret_key="__REPLACE_ME__run_init-secrets_before_starting",
+            environment="development",
+            _env_file=None,
+        )
+
+    # auth_encryption_secret placeholder — dev mode does NOT exempt the placeholder
+    strong_jwt = "a-strong-jwt-secret-that-is-long-enough-and-unique-xxxx"  # nosec B105
+    with pytest.raises(SecurityConfigurationError, match="unset placeholder"):
+        Settings(
+            jwt_secret_key=strong_jwt,
+            auth_encryption_secret="__REPLACE_ME__run_init-secrets_before_starting",
             environment="development",
             _env_file=None,
         )
@@ -2038,6 +2049,29 @@ def test_weak_auth_encryption_secret_allowed_in_development():
     assert s.auth_encryption_secret.get_secret_value() == "my-test-salt"  # pragma: allowlist secret
 
 
+def test_weak_auth_encryption_secret_raises_outside_development():
+    """Known-weak auth_encryption_secret is still rejected in staging and production.
+
+    The dev-mode leniency must not bleed into non-development environments.
+    Uses a value that is long enough to pass the length floor so it reaches the
+    weak-value check rather than the too-short check.
+    """
+    from mcpgateway.config import SecurityConfigurationError
+
+    strong_jwt = "a-strong-jwt-secret-that-is-long-enough-and-unique-xxxx"  # nosec B105
+    # "my-test-key-but-now-longer-than-32-bytes" is in WEAK_VALUES and is ≥ 32 chars
+    weak_enc = "my-test-key-but-now-longer-than-32-bytes"  # nosec B106  # pragma: allowlist secret
+
+    for env in ("staging", "production"):
+        with pytest.raises(SecurityConfigurationError, match="known-weak"):
+            Settings(
+                jwt_secret_key=strong_jwt,
+                auth_encryption_secret=weak_enc,
+                environment=env,
+                _env_file=None,
+            )
+
+
 def test_strong_secrets_accepted_in_all_envs():
     """Strong, non-placeholder secrets pass validation in every environment."""
     strong_jwt = "a-strong-jwt-secret-that-is-long-enough-and-unique-xxxx"  # nosec B105
@@ -2067,7 +2101,13 @@ def test_empty_secret_raises():
 
 
 def test_init_secrets_patch_mode_writes_strong_values(tmp_path):
-    """init_secrets ensure_env_file_secrets replaces placeholder values with strong ones."""
+    """ensure_env_file_secrets patches JWT_SECRET_KEY but NOT AUTH_ENCRYPTION_SECRET.
+
+    AUTH_ENCRYPTION_SECRET is intentionally excluded from auto-patching so that
+    operators set it deliberately.  A weak value like my-test-salt is allowed
+    in ENVIRONMENT=development.  Strong values are still written to .env.secrets
+    by the --output / --stdout paths, just not auto-patched into .env.
+    """
     env_file = tmp_path / ".env"
     env_file.write_text(
         "JWT_SECRET_KEY=__REPLACE_ME__run_init-secrets_before_starting\n"
@@ -2078,7 +2118,7 @@ def test_init_secrets_patch_mode_writes_strong_values(tmp_path):
 
     from mcpgateway.scripts.init_secrets import ensure_env_file_secrets
 
-    # Patch os.environ to isolate the test
+    # Isolate from any real env vars
     env_backup_jwt = _os.environ.pop("JWT_SECRET_KEY", None)
     env_backup_enc = _os.environ.pop("AUTH_ENCRYPTION_SECRET", None)
     try:
@@ -2089,24 +2129,20 @@ def test_init_secrets_patch_mode_writes_strong_values(tmp_path):
         if env_backup_enc is not None:
             _os.environ["AUTH_ENCRYPTION_SECRET"] = env_backup_enc
 
+    # JWT_SECRET_KEY must be patched
     assert "JWT_SECRET_KEY" in generated
-    assert "AUTH_ENCRYPTION_SECRET" in generated
-
     new_jwt = generated["JWT_SECRET_KEY"]
-    new_enc = generated["AUTH_ENCRYPTION_SECRET"]
-
-    # Generated values must be non-trivially long (token_urlsafe(32) → 43 chars)
     assert len(new_jwt) >= 32
-    assert len(new_enc) >= 32
-
-    # Must not be placeholder or known-weak
     assert not new_jwt.lower().startswith("__replace_me__")
     assert new_jwt.lower() != "changeme"
 
-    # Running Settings() with the generated values must succeed
+    # AUTH_ENCRYPTION_SECRET must NOT be patched into .env
+    assert "AUTH_ENCRYPTION_SECRET" not in generated
+
+    # The generated JWT must work with Settings (using a dev-mode enc secret is fine)
     s = Settings(
         jwt_secret_key=new_jwt,
-        auth_encryption_secret=new_enc,
+        auth_encryption_secret="my-test-salt",  # nosec B106  # pragma: allowlist secret
         environment="development",
         _env_file=None,
     )

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -2019,22 +2019,23 @@ def test_weak_secret_raises_in_staging():
         )
 
 
-def test_weak_auth_encryption_secret_raises_in_development():
-    """Known-weak auth_encryption_secret is rejected unconditionally (including development).
+def test_weak_auth_encryption_secret_allowed_in_development():
+    """Known-weak auth_encryption_secret is downgraded to a warning in development mode.
 
-    ``"my-test-salt"`` is 12 chars — below the 32-char length floor — so ``"too short"``
-    fires before the weak-value check.  The test accepts either rejection reason.
+    When ENVIRONMENT=development, short/weak/low-entropy values for
+    auth_encryption_secret no longer raise SecurityConfigurationError — they
+    emit a logger.warning and startup proceeds.  This enables PoC / local-dev
+    convenience (e.g. AUTH_ENCRYPTION_SECRET=my-test-salt).
+    jwt_secret_key is NOT affected and still hard-fails unconditionally.
     """
-    from mcpgateway.config import SecurityConfigurationError
-
-    with pytest.raises(SecurityConfigurationError) as exc_info:
-        Settings(
-            auth_encryption_secret="my-test-salt",  # nosec B106  # pragma: allowlist secret
-            environment="development",
-            _env_file=None,
-        )
-    msg = str(exc_info.value)
-    assert "too short" in msg or "known-weak/default value" in msg
+    strong_jwt = "a-strong-jwt-secret-that-is-long-enough-and-unique-xxxx"  # nosec B105
+    s = Settings(
+        jwt_secret_key=strong_jwt,
+        auth_encryption_secret="my-test-salt",  # nosec B106  # pragma: allowlist secret
+        environment="development",
+        _env_file=None,
+    )
+    assert s.auth_encryption_secret.get_secret_value() == "my-test-salt"  # pragma: allowlist secret
 
 
 def test_strong_secrets_accepted_in_all_envs():


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->


## 🔗 Related Issue

relates to Release1.0.7

---

## 📝 Summary

Permits `AUTH_ENCRYPTION_SECRET` values that do not meet minimum cryptographic
strength requirements when `ENVIRONMENT=development`, reducing friction for
local PoC and first-run workflows without relaxing production security posture.

**Before:** Both `JWT_SECRET_KEY` and `AUTH_ENCRYPTION_SECRET` unconditionally
blocked startup in every environment when the configured value failed minimum
strength requirements (insufficient entropy, below 32 chars, or a known-default).

**After:**
- `JWT_SECRET_KEY` — behaviour unchanged; full cryptographic strength enforced
  unconditionally across all environments.
- `AUTH_ENCRYPTION_SECRET` — full enforcement in `staging` and `production`;
  in `ENVIRONMENT=development` values that do not meet minimum strength
  requirements emit a mandatory `WARNING` and startup proceeds. The
  `__REPLACE_ME__` placeholder is unconditionally rejected for both fields in
  every environment.
- `make setup` / `make init-secrets-patch-env` no longer silently overwrite
  `AUTH_ENCRYPTION_SECRET` in `.env` — operators must set it explicitly,
  making the choice deliberate and auditable. `make init-secrets` (`.env.secrets`)
  still generates a cryptographically secure value.

### Files changed

| File | Change |
|---|---|
| `mcpgateway/config.py` | Separated unconditional placeholder rejection from minimum-strength enforcement; `auth_encryption_secret` in development emits a mandatory `SECURITY WARNING` instead of blocking startup; docstring updated |
| `mcpgateway/scripts/init_secrets.py` | Introduced `_PATCH_ENV_SKIP_FIELDS`; `ensure_env_file_secrets` no longer auto-patches `AUTH_ENCRYPTION_SECRET` into `.env`; CLI help and docstrings updated |
| `Makefile` | Updated `init-secrets-patch-env` inline help; corrected `install-dev` advisory message |
| `.env.example` | All references to `AUTH_ENCRYPTION_SECRET` updated to use security-accurate language and reflect the two-tier enforcement model |
| `tests/unit/mcpgateway/test_config.py` | Renamed and corrected test; added `test_weak_auth_encryption_secret_allowed_in_development`, `test_weak_auth_encryption_secret_raises_outside_development`; extended `test_placeholder_secret_raises_in_development` to cover both fields |
| `tests/scripts/test_init_secrets.py` | Corrected two assertions: `AUTH_ENCRYPTION_SECRET` must NOT appear in `ensure_env_file_secrets` output |

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Lint suite | `make lint` | |
| Unit tests | `make test` | |
| Coverage ≥ 80% | `make coverage` | |
| Below-strength enc secret permits startup in dev | `ENVIRONMENT=development AUTH_ENCRYPTION_SECRET=my-test-salt JWT_SECRET_KEY=<compliant> make dev` | |
| Compliant enc secret accepted in all environments | `test_strong_secrets_accepted_in_all_envs` | |
| Non-compliant enc secret rejected outside development | `test_weak_auth_encryption_secret_raises_outside_development` | |
| Placeholder unconditionally rejected for both fields | `test_placeholder_secret_raises_in_development` | |
| `make setup` does not overwrite enc secret in `.env` | `test_init_secrets_patch_mode_writes_strong_values` | |

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

### Enforcement matrix

| Check | `jwt_secret_key` (all envs) | `auth_encryption_secret` staging/prod | `auth_encryption_secret` development |
|---|---|---|---|
| Empty / blank | REJECT | REJECT | REJECT |
| `__REPLACE_ME__` placeholder | REJECT | REJECT | REJECT |
| Below minimum length (< 32 chars) | REJECT | REJECT | WARNING + proceed |
| Known-default value | REJECT | REJECT | WARNING + proceed |
| Insufficient entropy | REJECT | REJECT | WARNING + proceed |

### Secret generation and patching behaviour

| Path | `JWT_SECRET_KEY` | `AUTH_ENCRYPTION_SECRET` |
|---|---|---|
| `make init-secrets` / `--output` / `--stdout` | Cryptographically secure value written to `.env.secrets` | Cryptographically secure value written to `.env.secrets` |
| `make setup` / `make init-secrets-patch-env` / `--patch-env` | Patched into `.env` when non-compliant or placeholder | **Not patched** — must be configured explicitly |

## 🔗 Related Issue

Closes #

---

## 📝 Summary

_What does this PR do and why?_

---

## 📏 Reviewability

- [ ] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [ ] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

_List exact commands, screenshots, videos, logs, reproduction steps, or manual validation. If evidence is not feasible, explain why._

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] No secrets or credentials committed

---

## 📓 Notes (optional)

_Screenshots, design decisions, or additional context._
