### PR TITLE
chore: clean up upstream error diagnostics

### DIFF
--- a/docs/docs/architecture/observability-otel.md
+++ b/docs/docs/architecture/observability-otel.md
@@ -656,7 +656,7 @@ the same baggage values are emitted as `tenant.id` and `user.id`.
 
 ### Overview
 
-When the upstream session registry is used (when a downstream `Mcp-Session-Id` header is present and tracing is inactive), ContextForge automatically categorizes upstream connection failures into 13 distinct error categories. This enhancement replaces generic "unhandled errors in a TaskGroup" messages with specific, actionable diagnostics that enable operators to quickly identify root causes.
+When the upstream session registry is used (when a downstream `Mcp-Session-Id` header is present and tracing is inactive), ContextForge automatically categorizes upstream connection failures into 14 distinct error categories. This enhancement replaces generic "unhandled errors in a TaskGroup" messages with specific, actionable diagnostics that enable operators to quickly identify root causes.
 
 ### Error Categories
 
@@ -757,7 +757,7 @@ This ensures operators see actionable error information without needing to parse
 
 ### Fallback Behavior
 
-When the upstream session registry is **not used** (no `Mcp-Session-Id` header, or tracing is active, or registry initialization failed), the per-call session path in `tool_service.py` performs its own ExceptionGroup unwrapping and error sanitization. Both paths provide consistent error diagnostics and credential redaction.
+When the upstream session registry is **not used** (no `Mcp-Session-Id` header, or tracing is active, or registry initialization failed), the per-call session path in `tool_service.py` performs its own ExceptionGroup unwrapping and error sanitization. Both paths preserve the root-cause message and redact credentials, but only the registry path currently adds the semantic error category described above.
 
 ### Observability Best Practices
 

--- a/mcpgateway/services/upstream_session_registry.py
+++ b/mcpgateway/services/upstream_session_registry.py
@@ -334,6 +334,7 @@ def _categorize_upstream_error(exc: BaseException, auth_query_params: Optional[d
             error_category = "connection_error"
     elif isinstance(root_cause, httpx.HTTPStatusError):
         status_code = getattr(root_cause.response, "status_code", None)
+        error_category = "http_error"
         if status_code is not None:
             if status_code == 401:
                 error_category = "auth_unauthorized"
@@ -343,10 +344,6 @@ def _categorize_upstream_error(exc: BaseException, auth_query_params: Optional[d
                 error_category = "not_found"
             elif 500 <= status_code < 600:
                 error_category = "upstream_server_error"
-            else:
-                error_category = "http_error"
-        else:
-            error_category = "http_error"
     elif isinstance(root_cause, McpError):
         # MCP protocol-level errors (failed session.initialize(), etc.)
         error_category = "mcp_protocol_error"

--- a/tests/unit/mcpgateway/services/test_upstream_session_error_categories.py
+++ b/tests/unit/mcpgateway/services/test_upstream_session_error_categories.py
@@ -424,9 +424,11 @@ async def test_structured_logger_exception_handling(monkeypatch):
     # Mock structured logger to raise an exception
     def fake_get_structured_logger():
         logger_called.append(True)
+
         class BrokenLogger:
             def log(self, *args, **kwargs):
                 raise RuntimeError("Structured logger is broken!")
+
         return BrokenLogger()
 
     monkeypatch.setattr(usr, "streamablehttp_client", fake_stream)
@@ -555,14 +557,8 @@ async def test_structured_logger_metadata_payload(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_cross_layer_error_message_consistency(monkeypatch):
-    """
-    Regression test for cross-layer consistency: verify that registry-created RuntimeError
-    surfaces the same categorized root-cause text through the tool_service consuming layer.
-
-    This ensures that the fix for the generic "unhandled errors in a TaskGroup" message
-    remains effective across the entire error propagation chain.
-    """
+async def test_registry_error_message_contains_categorized_root_cause(monkeypatch):
+    """Registry errors should surface categorized root-cause text."""
     # First-Party
     from mcpgateway.services import upstream_session_registry as usr
 
@@ -575,37 +571,16 @@ async def test_cross_layer_error_message_consistency(monkeypatch):
 
     req = _make_request()
 
-    # The registry creates a RuntimeError with categorized error information
-    try:
+    with pytest.raises(RuntimeError) as exc_info:
         await usr._default_session_factory(req)  # pylint: disable=protected-access
-        assert False, "Should have raised RuntimeError"
-    except RuntimeError as registry_error:
-        # Verify the registry error message contains:
-        # 1. Error category
-        # 2. Exception type
-        # 3. Original error message
-        error_msg = str(registry_error)
 
-        # Should NOT contain generic TaskGroup message
-        assert "unhandled errors in a TaskGroup" not in error_msg, \
-            "Generic TaskGroup message should be replaced with specific error"
-
-        # Should contain specific categorized error information
-        assert "[connection_refused]" in error_msg, \
-            "Error category should be present"
-        assert "ConnectionRefusedError" in error_msg, \
-            "Exception type should be present"
-        assert "Connection refused by server" in error_msg, \
-            "Original error message should be preserved"
-
-        # Verify format matches expected pattern:
-        # "Failed to create upstream MCP session for <url>: [<category>] <type>: <message>"
-        assert "Failed to create upstream MCP session for" in error_msg
-        assert "https://upstream.example.com/mcp" in error_msg
-
-        # This RuntimeError would be caught by tool_service.py which unwraps
-        # BaseExceptionGroup. Since we already unwrapped at registry level,
-        # the consuming layer receives a clean RuntimeError with actionable text.
+    error_msg = str(exc_info.value)
+    assert "unhandled errors in a TaskGroup" not in error_msg
+    assert "[connection_refused]" in error_msg
+    assert "ConnectionRefusedError" in error_msg
+    assert "Connection refused by server" in error_msg
+    assert "Failed to create upstream MCP session for" in error_msg
+    assert "https://upstream.example.com/mcp" in error_msg
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related Issue

Closes #6007

Follow-up technical debt is tracked separately in #6074, #6075, and #6076.

## Summary

Clean up the post-merge diagnostics work from #5631:

- Correct the documented error-category count from 13 to 14.
- Clarify that the per-call fallback path preserves and sanitizes root-cause messages but does not yet add registry-style semantic categories.
- Replace duplicated `HTTPStatusError` fallback branches with a single default assignment.
- Rename and simplify the misleading cross-layer test so it describes the registry behavior it actually exercises.
- Fix the nested-definition spacing warning in the same test module.

## Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated follow-up work is tracked in separate issues
- [x] Existing tests cover the preserved error-category behavior

## Verification

| Check | Command | Status |
|---|---|---|
| Upstream error category unit tests | `uv run --no-dev --with pytest --with pytest-asyncio pytest tests/unit/mcpgateway/services/test_upstream_session_error_categories.py -q` | 27 passed |
| Ruff | `uv tool run ruff check mcpgateway/services/upstream_session_registry.py tests/unit/mcpgateway/services/test_upstream_session_error_categories.py` | passed |
| Whitespace | `git diff --check` | passed |

## Checklist

- [x] No secrets or credentials committed
- [x] Commit signed off for DCO