### PR TITLE
fix: warn at startup when CSRF cookie or header names are overridden

### DIFF
--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1601,12 +1601,19 @@ class Settings(BaseSettings):
         # setting desynchronizes the middleware from all of them, which surfaces as
         # intermittent 403 CSRF_TOKEN_INVALID on non-/admin browser writes rather
         # than as an obvious failure. Warn loudly at startup instead.
+        #
+        # Comparison is asymmetric by design. HTTP header names are
+        # case-insensitive (RFC 7230) and Starlette normalizes them, so
+        # CSRF_TOKEN_NAME=x-csrf-token is functionally identical to the default
+        # and must not warn. Cookie names are case-sensitive (RFC 6265), so a
+        # cookie name differing only in case is a genuine desync and must warn.
         if self.csrf_enabled:
-            for setting_name, configured, default in (
-                ("CSRF_COOKIE_NAME", self.csrf_cookie_name, "mcpgateway_csrf_token"),
-                ("CSRF_TOKEN_NAME", self.csrf_token_name, "X-CSRF-Token"),
+            for setting_name, configured, default, case_sensitive in (
+                ("CSRF_COOKIE_NAME", self.csrf_cookie_name, "mcpgateway_csrf_token", True),
+                ("CSRF_TOKEN_NAME", self.csrf_token_name, "X-CSRF-Token", False),
             ):
-                if configured != default:
+                differs = configured != default if case_sensitive else configured.casefold() != default.casefold()
+                if differs:
                     logger.warning(
                         "⚠️  CSRF CONFIGURATION WARNING: %s is set to %r but the Admin UI and the "
                         "per-route CSRF dependencies hardcode %r. Browser-based writes outside /admin "

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1594,6 +1594,31 @@ class Settings(BaseSettings):
         if not self.csrf_secret_key:
             self.csrf_secret_key = self.jwt_secret_key.get_secret_value()
 
+        # CSRF_COOKIE_NAME / CSRF_TOKEN_NAME govern CSRFMiddleware only. Every
+        # other consumer -- enforce_admin_csrf (admin.py), enforce_fetch_tools_csrf
+        # (routers/oauth_router.py), the Admin UI JavaScript, and the server-rendered
+        # login/password templates -- hardcodes the default names. Overriding either
+        # setting desynchronizes the middleware from all of them, which surfaces as
+        # intermittent 403 CSRF_TOKEN_INVALID on non-/admin browser writes rather
+        # than as an obvious failure. Warn loudly at startup instead.
+        if self.csrf_enabled:
+            for setting_name, configured, default in (
+                ("CSRF_COOKIE_NAME", self.csrf_cookie_name, "mcpgateway_csrf_token"),
+                ("CSRF_TOKEN_NAME", self.csrf_token_name, "X-CSRF-Token"),
+            ):
+                if configured != default:
+                    logger.warning(
+                        "⚠️  CSRF CONFIGURATION WARNING: %s is set to %r but the Admin UI and the "
+                        "per-route CSRF dependencies hardcode %r. Browser-based writes outside /admin "
+                        "will intermittently fail with 403 CSRF_TOKEN_INVALID. Set %s=%s (or unset it) "
+                        "unless you have verified every client sends the custom name.",
+                        setting_name,
+                        configured,
+                        default,
+                        setting_name,
+                        default,
+                    )
+
         # Validate header passthrough feature flag dependencies
         # Fail if sensitive passthrough is enabled without base feature
         if self.enable_sensitive_header_passthrough and not self.enable_header_passthrough:

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -152,6 +152,53 @@ def test_oauth_router_csrf_cookie_name_matches_config_default():
         assert oauth_router.ADMIN_CSRF_COOKIE_NAME == s.csrf_cookie_name, f"oauth_router.ADMIN_CSRF_COOKIE_NAME={oauth_router.ADMIN_CSRF_COOKIE_NAME!r} does not match config.py default={s.csrf_cookie_name!r}"
 
 
+def _csrf_warnings(caplog):
+    """Collect CSRF configuration warnings emitted during Settings construction.
+
+    Args:
+        caplog: pytest caplog fixture.
+
+    Returns:
+        List of formatted warning messages mentioning the CSRF name mismatch.
+    """
+    return [rec.getMessage() for rec in caplog.records if "CSRF CONFIGURATION WARNING" in rec.getMessage()]
+
+
+def test_csrf_name_override_warns_at_startup(caplog):
+    """Overriding CSRF_COOKIE_NAME/CSRF_TOKEN_NAME must warn loudly at startup.
+
+    Both settings govern CSRFMiddleware only; the Admin UI JS and the per-route
+    CSRF dependencies hardcode the defaults. An override desynchronizes them,
+    which shows up as intermittent 403 CSRF_TOKEN_INVALID on non-/admin browser
+    writes rather than an obvious failure. Fail loudly at boot instead.
+    """
+    caplog.set_level("WARNING", logger="mcpgateway.config")
+
+    Settings(csrf_cookie_name="csrf_token", csrf_token_name="X-Probe-Csrf", environment="development", _env_file=None)
+
+    warnings = _csrf_warnings(caplog)
+    assert any("CSRF_COOKIE_NAME" in msg and "csrf_token" in msg for msg in warnings), warnings
+    assert any("CSRF_TOKEN_NAME" in msg and "X-Probe-Csrf" in msg for msg in warnings), warnings
+
+
+def test_csrf_default_names_do_not_warn(caplog):
+    """The default (and only supported) names must not produce startup noise."""
+    caplog.set_level("WARNING", logger="mcpgateway.config")
+
+    Settings(environment="development", _env_file=None)
+
+    assert _csrf_warnings(caplog) == []
+
+
+def test_csrf_name_override_silent_when_csrf_disabled(caplog):
+    """With CSRF_ENABLED=false the names are inert, so the warning is noise."""
+    caplog.set_level("WARNING", logger="mcpgateway.config")
+
+    Settings(csrf_enabled=False, csrf_cookie_name="csrf_token", environment="development", _env_file=None)
+
+    assert _csrf_warnings(caplog) == []
+
+
 def test_ratelimiter_redis_url_set():
     """Test rate limiter Redis URL can be configured."""
     s = Settings(

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -152,6 +152,51 @@ def test_oauth_router_csrf_cookie_name_matches_config_default():
         assert oauth_router.ADMIN_CSRF_COOKIE_NAME == s.csrf_cookie_name, f"oauth_router.ADMIN_CSRF_COOKIE_NAME={oauth_router.ADMIN_CSRF_COOKIE_NAME!r} does not match config.py default={s.csrf_cookie_name!r}"
 
 
+def test_admin_csrf_header_name_matches_config_default():
+    """ADMIN_CSRF_HEADER_NAME in admin.py must equal config.py's csrf_token_name default.
+
+    ``enforce_admin_csrf`` reads the submitted token via this module-level
+    constant rather than settings.csrf_token_name, so it does not track
+    operator overrides of CSRF_TOKEN_NAME -- the symmetrical gap to the cookie
+    constants pinned above. Compared case-insensitively because HTTP header
+    names are case-insensitive (RFC 7230) and the constant is deliberately
+    lowercased for ``request.headers.get``.
+    """
+    # First-Party
+    from mcpgateway import admin
+
+    dummy_env = {
+        "JWT_SECRET_KEY": _TEST_JWT_SECRET,
+        "AUTH_ENCRYPTION_SECRET": _TEST_ENC_SECRET,
+    }
+
+    with patch.dict(os.environ, dummy_env, clear=True):
+        s = Settings(_env_file=None)
+        assert admin.ADMIN_CSRF_HEADER_NAME.casefold() == s.csrf_token_name.casefold(), f"admin.ADMIN_CSRF_HEADER_NAME={admin.ADMIN_CSRF_HEADER_NAME!r} does not match config.py default={s.csrf_token_name!r}"
+
+
+def test_oauth_router_csrf_header_name_matches_config_default():
+    """ADMIN_CSRF_HEADER_NAME in routers/oauth_router.py must equal config.py's csrf_token_name default.
+
+    oauth_router.py duplicates the constant independently of admin.py (see
+    test_admin_csrf_header_name_matches_config_default). Both copies must stay
+    pinned to the settings default. Case-insensitive for the same reason.
+    """
+    # First-Party
+    from mcpgateway.routers import oauth_router
+
+    dummy_env = {
+        "JWT_SECRET_KEY": _TEST_JWT_SECRET,
+        "AUTH_ENCRYPTION_SECRET": _TEST_ENC_SECRET,
+    }
+
+    with patch.dict(os.environ, dummy_env, clear=True):
+        s = Settings(_env_file=None)
+        assert (
+            oauth_router.ADMIN_CSRF_HEADER_NAME.casefold() == s.csrf_token_name.casefold()
+        ), f"oauth_router.ADMIN_CSRF_HEADER_NAME={oauth_router.ADMIN_CSRF_HEADER_NAME!r} does not match config.py default={s.csrf_token_name!r}"
+
+
 def _csrf_warnings(caplog):
     """Collect CSRF configuration warnings emitted during Settings construction.
 
@@ -188,6 +233,36 @@ def test_csrf_default_names_do_not_warn(caplog):
     Settings(environment="development", _env_file=None)
 
     assert _csrf_warnings(caplog) == []
+
+
+def test_csrf_token_name_case_variant_does_not_warn(caplog):
+    """A header name differing only in case is functionally identical, so must not warn.
+
+    HTTP header names are case-insensitive (RFC 7230) and Starlette normalizes
+    them, so CSRF_TOKEN_NAME=x-csrf-token behaves exactly like the default.
+    admin.py and oauth_router.py in fact hardcode the lowercase spelling.
+    """
+    caplog.set_level("WARNING", logger="mcpgateway.config")
+
+    Settings(csrf_token_name="x-csrf-token", environment="development", _env_file=None)
+
+    assert _csrf_warnings(caplog) == []
+
+
+def test_csrf_cookie_name_case_variant_warns(caplog):
+    """A cookie name differing only in case is a real desync, so must warn.
+
+    Cookie names are case-sensitive (RFC 6265): the browser would hold
+    MCPGateway_CSRF_Token and mcpgateway_csrf_token as two distinct cookies.
+    This pins the asymmetry against a well-meaning blanket casefold that would
+    silence a genuine mismatch.
+    """
+    caplog.set_level("WARNING", logger="mcpgateway.config")
+
+    Settings(csrf_cookie_name="MCPGateway_CSRF_Token", environment="development", _env_file=None)
+
+    warnings = _csrf_warnings(caplog)
+    assert any("CSRF_COOKIE_NAME" in msg for msg in warnings), warnings
 
 
 def test_csrf_name_override_silent_when_csrf_disabled(caplog):


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes [#523](https://github.ibm.com/contextforge-org/internal_issues/issues/523)
---

## 📝 Summary

`CSRF_COOKIE_NAME` and `CSRF_TOKEN_NAME` govern `CSRFMiddleware` only. Every other
CSRF consumer hardcodes the default names independently:

- `enforce_admin_csrf` (`mcpgateway/admin.py`)
- `enforce_fetch_tools_csrf` (`mcpgateway/routers/oauth_router.py`)
- the Admin UI JavaScript (`mcpgateway/admin_ui/{utils,auth,formHandlers,llmModels}.js`)
- the server-rendered login / password / admin templates

Overriding either setting therefore desynchronizes the middleware from every client,
and the resulting failure is easy to miss. CSRF tokens are a deterministic HMAC over
`{email}:{jti}:{time_window}`, so the cookie written at login and the one written by
the admin page normally hold the *same* value and writes succeed. They diverge at a
token-window boundary, at which point browser writes outside `/admin` begin returning
`403 CSRF_TOKEN_INVALID` intermittently. The operator sees a flaky UI, not a
misconfiguration.

This PR emits a startup warning naming both the offending setting and the symptom, so
the mismatch is visible at boot instead of at request time. The check is gated on
`CSRF_ENABLED` so deployments with CSRF disabled stay quiet.

**Scope note — this is a stopgap, not the root-cause fix.** It makes an unsupported
configuration fail loudly; it does not make the setting work. The durable fix is to
have the Admin UI and the per-route CSRF dependencies read the configured names
instead of hardcoding them, which requires client-side changes plus a Vite bundle
rebuild and is intentionally deferred to a separate PR.

**This is not a CSRF bypass.** Every enforcement path fails closed —
`csrf_middleware.py:182-191`, `admin.py:1868-1884`, and `oauth_router.py:100-105` all
return 403 on a missing or mismatched cookie. `/admin` is unaffected because `admin.py`
both sets and validates under the same constant, so it is internally self-consistent.
Cross-origin JavaScript cannot read any cookie, so renaming it neither adds nor removes
protection against a forged request. The impact is configuration integrity and
availability, not a weakening of CSRF defenses.

**Default deployments are unaffected** — `csrf_cookie_name` defaults to exactly the
hardcoded literal, and existing tests already pin that (`test_config.py:75-153`).

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage` — _no public issue linked; see above_
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

**Changed files:** `mcpgateway/config.py` (+25), `tests/unit/mcpgateway/test_config.py` (+47)

| Check | Command | Status |
|---|---|---|
| Lint suite | `make lint` | ⬜ Not run — see targeted lint below |
| Unit tests | `make test` | ⬜ Not run — see targeted suites below |
| Coverage ≥ 80% | `make coverage` | ⬜ Not run |

Targeted runs that **were** executed:

| Check | Command | Status |
|---|---|---|
| Config + CSRF middleware | `pytest tests/unit/mcpgateway/test_config.py tests/unit/mcpgateway/middleware/test_csrf_middleware.py tests/unit/mcpgateway/middleware/test_admin_csrf_binding.py` | ✅ 256 passed |
| OAuth router CSRF | `pytest tests/unit/mcpgateway/routers/test_oauth_router.py` | ✅ 175 passed |
| CSRF service | `pytest tests/unit/mcpgateway/services/test_csrf_service.py` | ✅ 34 passed |
| New tests only | `pytest tests/unit/mcpgateway/test_config.py -k csrf` | ✅ 6 passed |
| Ruff | `ruff check mcpgateway/config.py tests/unit/mcpgateway/test_config.py` | ✅ No new findings |

**Ruff detail:** two `too-many-blank-lines` findings are reported in `test_config.py`.
Both are pre-existing at `HEAD` and in code this PR does not touch (verified by running
ruff against the `HEAD` versions of both files). No new findings are introduced.

**Manual verification** of the warning behavior across all three branches:

```python
Settings(_env_file=None)
# → no CSRF warning

Settings(_env_file=None, csrf_cookie_name="csrf_token", csrf_token_name="X-Probe")
# → ⚠️  CSRF CONFIGURATION WARNING: CSRF_COOKIE_NAME is set to 'csrf_token' but the
#    Admin UI and the per-route CSRF dependencies hardcode 'mcpgateway_csrf_token'.
#    Browser-based writes outside /admin will intermittently fail with 403
#    CSRF_TOKEN_INVALID. Set CSRF_COOKIE_NAME=mcpgateway_csrf_token (or unset it)
#    unless you have verified every client sends the custom name.
# → ⚠️  CSRF CONFIGURATION WARNING: CSRF_TOKEN_NAME is set to 'X-Probe' ...

Settings(_env_file=None, csrf_enabled=False, csrf_cookie_name="csrf_token")
# → no CSRF warning
```

Each of those three cases is covered by a test:

- `test_csrf_name_override_warns_at_startup`
- `test_csrf_default_names_do_not_warn`
- `test_csrf_name_override_silent_when_csrf_disabled`

**Regression risk:** the warning only fires when the names are non-default, which no
existing test configures. `tests/unit/mcpgateway/services/test_csrf_service.py` passes
`csrf_cookie_name="csrf_token"`, but via `Mock` objects rather than real `Settings`
instances, so the validator never runs there — confirmed passing.

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`) — _not run; `ruff check` and `ruff format --check` were run on the changed files and report no new findings_
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable) — _no change needed; see Notes_
- [x] No secrets or credentials committed

---

## 📓 Notes