### PR TITLE
fix: gate admin event stream by RBAC permission

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -728,8 +728,8 @@ async def get_hidden_sections_for_user(
     return hidden
 
 
-# UI Action Permissions Mapping
-# Maps UI permission flags to required RBAC permissions
+# UI Permissions Mapping
+# Maps UI action and capability flags to required RBAC permissions
 UI_ACTION_PERMISSIONS = {
     # Create actions
     "can_create_team": "teams.create",
@@ -741,6 +741,8 @@ UI_ACTION_PERMISSIONS = {
     "can_create_user": "admin.user_management",
     "can_create_token": "tokens.read",  # Token creation uses tokens.read, setting nosec cause this is false positive as router uses this permission key.  # nosec B105
     "can_create_agent": "a2a.create",
+    # Page capabilities
+    "can_access_admin_events": "admin.events",
 }
 
 
@@ -750,9 +752,9 @@ async def get_user_action_permissions(
     is_admin: bool,
     token_teams: Optional[List[str]],
 ) -> Dict[str, bool]:
-    """Batch-check all UI action permissions for a user.
+    """Batch-check all UI permissions for a user.
 
-    Returns a dictionary mapping permission flags to boolean values.
+    Returns a dictionary mapping UI action and capability flags to boolean values.
     Platform admins with unrestricted tokens get all permissions.
 
     Args:

--- a/mcpgateway/admin_ui/monitoring.js
+++ b/mcpgateway/admin_ui/monitoring.js
@@ -11,7 +11,7 @@ import { safeGetElement } from  "./utils.js";
 
 
 export const initializeRealTimeMonitoring = function () {
-  if (!window.EventSource) {
+  if (!window.EventSource || window.CAN_ACCESS_ADMIN_EVENTS !== true) {
     return;
   }
 

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -12049,6 +12049,7 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       window.MCPGATEWAY_UI_TOOL_TEST_TIMEOUT = {{ mcpgateway_ui_tool_test_timeout | tojson }};
       window.CURRENT_USER = {{ current_user | tojson }};
       window.IS_ADMIN = {{ is_admin | tojson }};
+      window.CAN_ACCESS_ADMIN_EVENTS = {{ user_permissions.can_access_admin_events | tojson }};
       window.UI_HIDDEN_SECTIONS = {{ ui_hidden_sections | default([]) | tojson }};
       window.UI_HIDDEN_HEADER_ITEMS = {{ ui_hidden_header_items | default([]) | tojson }};
       window.UI_HIDDEN_TABS = {{ ui_hidden_tabs | default([]) | tojson }};

--- a/tests/unit/js/monitoring.test.js
+++ b/tests/unit/js/monitoring.test.js
@@ -3,7 +3,7 @@
  * Tests: initializeRealTimeMonitoring
  */
 
-import { describe, test, expect, vi, afterEach } from "vitest";
+import { describe, test, expect, vi, afterEach, beforeEach } from "vitest";
 
 import { initializeRealTimeMonitoring } from "../../../mcpgateway/admin_ui/monitoring.js";
 
@@ -14,10 +14,15 @@ vi.mock("../../../mcpgateway/admin_ui/utils.js", () => ({
   safeGetElement: vi.fn((id) => document.getElementById(id)),
 }));
 
+beforeEach(() => {
+  window.CAN_ACCESS_ADMIN_EVENTS = true;
+});
+
 afterEach(() => {
   document.body.innerHTML = "";
   delete window.ROOT_PATH;
   delete window.EventSource;
+  delete window.CAN_ACCESS_ADMIN_EVENTS;
 });
 
 // ---------------------------------------------------------------------------
@@ -27,6 +32,16 @@ describe("initializeRealTimeMonitoring", () => {
   test("does nothing when EventSource is not available", () => {
     delete window.EventSource;
     expect(() => initializeRealTimeMonitoring()).not.toThrow();
+  });
+
+  test("does not connect without admin events permission", () => {
+    const MockEventSource = vi.fn();
+    window.EventSource = MockEventSource;
+    window.CAN_ACCESS_ADMIN_EVENTS = false;
+
+    initializeRealTimeMonitoring();
+
+    expect(MockEventSource).not.toHaveBeenCalled();
   });
 
   test("creates EventSource when available", () => {

--- a/tests/unit/mcpgateway/test_admin_rbac_ui.py
+++ b/tests/unit/mcpgateway/test_admin_rbac_ui.py
@@ -23,7 +23,7 @@ class TestUIActionPermissions:
     def test_ui_action_permissions_structure(self):
         """UI_ACTION_PERMISSIONS should have correct structure."""
         assert isinstance(UI_ACTION_PERMISSIONS, dict)
-        assert len(UI_ACTION_PERMISSIONS) == 9  # Only create actions
+        assert len(UI_ACTION_PERMISSIONS) == 10
 
     def test_ui_action_permissions_keys(self):
         """UI_ACTION_PERMISSIONS should have expected keys."""
@@ -37,6 +37,7 @@ class TestUIActionPermissions:
             "can_create_user",
             "can_create_token",
             "can_create_agent",
+            "can_access_admin_events",
         }
         assert set(UI_ACTION_PERMISSIONS.keys()) == expected_keys
 
@@ -52,6 +53,7 @@ class TestUIActionPermissions:
             "can_create_user": "admin.user_management",
             "can_create_token": "tokens.read",
             "can_create_agent": "a2a.create",
+            "can_access_admin_events": "admin.events",
         }
         assert UI_ACTION_PERMISSIONS == expected_mappings
 
@@ -71,7 +73,7 @@ class TestGetUserActionPermissions:
         )
 
         # Should get all permissions
-        assert len(result) == 9
+        assert len(result) == 10
         assert all(result.values()), "All permissions should be True"
         assert result["can_create_team"] is True
         assert result["can_create_server"] is True
@@ -95,7 +97,7 @@ class TestGetUserActionPermissions:
             )
 
             # Should check permissions (not bypass)
-            assert mock_service.check_permission.call_count == 9
+            assert mock_service.check_permission.call_count == 10
             assert all(result.values())
 
     @pytest.mark.asyncio
@@ -115,9 +117,9 @@ class TestGetUserActionPermissions:
                 token_teams=["team1"],
             )
 
-            assert len(result) == 9
+            assert len(result) == 10
             assert all(result.values())
-            assert mock_service.check_permission.call_count == 9
+            assert mock_service.check_permission.call_count == 10
 
     @pytest.mark.asyncio
     async def test_regular_user_with_no_permissions(self):
@@ -136,7 +138,7 @@ class TestGetUserActionPermissions:
                 token_teams=["team1"],
             )
 
-            assert len(result) == 9
+            assert len(result) == 10
             assert not any(result.values()), "All permissions should be False"
             assert result["can_create_team"] is False
             assert result["can_create_server"] is False
@@ -185,7 +187,7 @@ class TestGetUserActionPermissions:
                 token_teams=[],  # Public-only
             )
 
-            assert len(result) == 9
+            assert len(result) == 10
             assert not any(result.values())
 
     @pytest.mark.asyncio
@@ -206,7 +208,7 @@ class TestGetUserActionPermissions:
             )
 
             # All permissions should be False due to errors
-            assert len(result) == 9
+            assert len(result) == 10
             assert not any(result.values()), "Should fail closed on errors"
 
     @pytest.mark.asyncio
@@ -230,7 +232,7 @@ class TestGetUserActionPermissions:
             mock_service_class.assert_called_once_with(db, audit_enabled=False)
 
             # Verify check_permission calls
-            assert mock_service.check_permission.call_count == 9
+            assert mock_service.check_permission.call_count == 10
 
             # Check first call parameters
             first_call = mock_service.check_permission.call_args_list[0]
@@ -241,7 +243,7 @@ class TestGetUserActionPermissions:
 
     @pytest.mark.asyncio
     async def test_all_permission_flags_checked(self):
-        """All 9 permission flags should be checked."""
+        """All 10 permission flags should be checked."""
         db = Mock()
 
         with patch("mcpgateway.admin.PermissionService") as mock_service_class:
@@ -274,9 +276,10 @@ class TestGetUserActionPermissions:
                 "admin.user_management",
                 "tokens.read",
                 "a2a.create",
+                "admin.events",
             }
             assert set(checked_permissions) == expected_permissions
-            assert len(result) == 9
+            assert len(result) == 10
 
     @pytest.mark.asyncio
     async def test_mixed_permission_errors(self):
@@ -304,8 +307,8 @@ class TestGetUserActionPermissions:
                 token_teams=["team1"],
             )
 
-            # Should have results for all 9 permissions
-            assert len(result) == 9
+            # Should have results for all 10 permissions
+            assert len(result) == 10
             # Some should be True, some False (from errors)
             assert any(result.values()), "Some permissions should succeed"
             assert not all(result.values()), "Some permissions should fail"


### PR DESCRIPTION
## Related Issue

Closes #6064

## Summary

The admin shell currently initializes `/admin/events` for every signed-in role, even though the endpoint requires `admin.events`. Built-in team roles do not have that platform-level permission, so every page load produces a 403 and EventSource keeps retrying.

This change keeps the existing RBAC boundary intact and makes the UI permission-aware:

- include `admin.events` in the UI permission capability map
- expose the resolved boolean to the rendered admin shell
- skip real-time monitoring initialization when access is denied
- keep the connection enabled for unrestricted admins and custom roles that explicitly grant `admin.events`

No role gains a new permission and the SSE endpoint remains fail-closed.

## Reviewability

- [x] This PR has one clear purpose
- [x] Unrelated bugs or improvements are tracked separately
- [x] Tests are included with the code they validate

## Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

## Verification

| Check | Command | Status |
|---|---|---|
| Related Python tests | `pytest tests/unit/mcpgateway/test_admin_rbac_ui.py tests/unit/mcpgateway/test_admin_menu_visibility.py tests/unit/mcpgateway/test_admin_permission_helpers.py -q` | 56 passed |
| Frontend unit suite | `vitest run tests/unit/js` | 2323 passed, 3 skipped |
| Python lint and format | `ruff check ...` / `ruff format --check ...` | passed |
| Frontend lint | `eslint mcpgateway/admin_ui/monitoring.js tests/unit/js/monitoring.test.js` | passed |
| Production UI bundle | `vite build` | passed |
| Whitespace | `git diff --check` | passed |

## Checklist

- [x] Code formatted and linted
- [x] Tests added/updated for changes
- [x] Documentation updated (not applicable)
- [x] No secrets or credentials committed
- [x] Commit signed off for DCO