### PR TITLE
chore: improve support bundle redaction and settings secret typing (Release/v1.0.7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,7 +90,9 @@ BASIC_AUTH_PASSWORD=changeme  # pragma: allowlist secret
 # Enable CSRF protection (default: true)
 CSRF_ENABLED=true
 
-# Secret key for CSRF token generation (falls back to JWT_SECRET_KEY if empty)
+# Secret used to sign CSRF tokens. If left unset, the application reuses
+# JWT_SECRET_KEY for this purpose. Set it explicitly so that the two keys can
+# be rotated independently.
 CSRF_SECRET_KEY=
 
 # HTTP header name for CSRF token

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-05T13:33:20Z",
+  "generated_at": "2026-08-05T13:42:04Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-05T12:11:08Z",
+  "generated_at": "2026-08-05T13:33:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -89,10 +89,10 @@
     ],
     ".env.example": [
       {
-        "hashed_secret": "07d79dfd9ad52d9706b1dc4685d018fdbe522f68",
+        "hashed_secret": "15ab6d87c10ed359ba98e6a578764fa53954fdfc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 53,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -100,7 +100,7 @@
         "hashed_secret": "548a5cde15c93a9e50e12e4cba776b85f6befc83",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 132,
+        "line_number": 123,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -108,7 +108,7 @@
         "hashed_secret": "8e9a8667ded25c805ce3dc920a5f2343bd2d198f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 133,
+        "line_number": 124,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -116,7 +116,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 777,
+        "line_number": 768,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1022,
+        "line_number": 1013,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1321,
+        "line_number": 1312,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1358,
+        "line_number": 1347,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1447,
+        "line_number": 1436,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1452,
+        "line_number": 1441,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1457,
+        "line_number": 1446,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1463,
+        "line_number": 1452,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1475,
+        "line_number": 1464,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1493,
+        "line_number": 1482,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1554,
+        "line_number": 1543,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -206,7 +206,7 @@
         "hashed_secret": "5546721ffdfc2e5b0e4c0da38f10774f9ad50b09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 246,
+        "line_number": 242,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -258,7 +258,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2023,
+        "line_number": 1938,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2111,
+        "line_number": 2026,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2461,
+        "line_number": 2376,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3826,
+        "line_number": 3741,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3917,
+        "line_number": 3832,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3960,
+        "line_number": 3875,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3965,
+        "line_number": 3880,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3970,
+        "line_number": 3885,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -331,18 +331,10 @@
     ],
     "Makefile": [
       {
-        "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 335,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 577,
+        "line_number": 576,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +342,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1055,
+        "line_number": 1054,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +350,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1057,
+        "line_number": 1056,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +358,7 @@
         "hashed_secret": "db69d9215c29ae2f2e4ead587890a9f8455059dd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1131,
+        "line_number": 1130,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +366,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1711,
+        "line_number": 1710,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +374,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1930,
+        "line_number": 1929,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6064,
+        "line_number": 6063,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6561,
+        "line_number": 6560,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6573,
+        "line_number": 6572,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6645,
+        "line_number": 6644,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +414,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7061,
+        "line_number": 7060,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -430,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7752,
+        "line_number": 7751,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -606,7 +598,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 65,
+        "line_number": 61,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4667,16 +4659,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 7268,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_config.py": [
-      {
-        "hashed_secret": "15ab6d87c10ed359ba98e6a578764fa53954fdfc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1990,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -405,7 +405,10 @@ class Settings(BaseSettings):
 
     # CSRF Protection Configuration
     csrf_enabled: bool = Field(default=True, description="Enable CSRF protection for state-changing operations")
-    csrf_secret_key: str = Field(default="", description="Secret key for CSRF token generation (falls back to jwt_secret_key if empty)")
+    csrf_secret_key: SecretStr = Field(
+        default=SecretStr(""),
+        description="Secret key for CSRF token generation. Falls back to jwt_secret_key when unset; set explicitly so the two keys can be rotated independently.",
+    )
     csrf_token_name: str = Field(default="X-CSRF-Token", description="HTTP header name for CSRF token")
     csrf_cookie_name: str = Field(default="mcpgateway_csrf_token", description="Cookie name for CSRF token")
     csrf_token_expiry: int = Field(default=3600, description="CSRF token expiration time in seconds")
@@ -680,7 +683,7 @@ class Settings(BaseSettings):
         default=False,
         description="Sign propagated user claims with HMAC for verification",
     )
-    identity_claims_secret: Optional[str] = Field(
+    identity_claims_secret: Optional[SecretStr] = Field(
         default=None,
         description="Secret key for signing propagated identity claims (uses JWT_SECRET_KEY if unset)",
     )
@@ -1636,9 +1639,14 @@ class Settings(BaseSettings):
             if self.debug and not self.dev_mode:
                 logger.warning("🐛 SECURITY WARNING: Debug mode is enabled in non-dev mode. This may leak sensitive information! Set DEBUG=false for production.")
 
-        # CSRF secret key fallback to JWT secret key
-        if not self.csrf_secret_key:
-            self.csrf_secret_key = self.jwt_secret_key.get_secret_value()
+        # CSRF secret key fallback to JWT secret key.
+        # NOTE: SecretStr("") is truthy, so the emptiness check must go through
+        # get_secret_value(); `if not self.csrf_secret_key` would never fire and
+        # CSRF tokens would end up signed with an empty key. Settings does not
+        # set validate_assignment, so the assigned value is not coerced and has
+        # to be wrapped in SecretStr explicitly.
+        if not self.csrf_secret_key.get_secret_value():
+            self.csrf_secret_key = SecretStr(self.jwt_secret_key.get_secret_value())
 
         # CSRF_COOKIE_NAME / CSRF_TOKEN_NAME govern CSRFMiddleware only. Every
         # other consumer -- enforce_admin_csrf (admin.py), enforce_fetch_tools_csrf

--- a/mcpgateway/routers/auth.py
+++ b/mcpgateway/routers/auth.py
@@ -156,7 +156,7 @@ async def get_csrf_token(request: Request, current_user: "EmailUser" = Depends(g
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing session identifier")
 
         # Generate fresh CSRF token
-        csrf_token = generate_csrf_token(user_id=current_user.email, session_id=session_id, secret=settings.csrf_secret_key, expiry=settings.csrf_token_expiry)
+        csrf_token = generate_csrf_token(user_id=current_user.email, session_id=session_id, secret=settings.csrf_secret_key.get_secret_value(), expiry=settings.csrf_token_expiry)
 
         # Create response with CSRF cookie
         response = JSONResponse(content={"csrf_token": csrf_token})
@@ -239,7 +239,7 @@ async def login(login_request: LoginRequest, request: Request, db: Session = Dep
                 session_id = payload.get("jti", "")
 
                 # Generate CSRF token
-                csrf_token = generate_csrf_token(user_id=user.email, session_id=session_id, secret=settings.csrf_secret_key, expiry=settings.csrf_token_expiry)
+                csrf_token = generate_csrf_token(user_id=user.email, session_id=session_id, secret=settings.csrf_secret_key.get_secret_value(), expiry=settings.csrf_token_expiry)
 
                 auth_response = AuthenticationResponse(access_token=access_token, token_type="bearer", expires_in=expires_in, user=EmailUserResponse.from_email_user(user))  # nosec B106 - OAuth2 token type, not a password
                 response = JSONResponse(content=auth_response.model_dump(mode="json"))

--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -301,7 +301,7 @@ async def login(login_request: EmailLoginRequest, request: Request, db: Session 
             session_id = payload.get("jti", "")
 
             # Generate CSRF token
-            csrf_token = generate_csrf_token(user_id=user.email, session_id=session_id, secret=settings.csrf_secret_key, expiry=settings.csrf_token_expiry)
+            csrf_token = generate_csrf_token(user_id=user.email, session_id=session_id, secret=settings.csrf_secret_key.get_secret_value(), expiry=settings.csrf_token_expiry)
 
             auth_response = AuthenticationResponse(access_token=access_token, token_type="bearer", expires_in=expires_in, user=EmailUserResponse.from_email_user(user))  # nosec B106 - OAuth2 token type, not a password
             response = ORJSONResponse(content=auth_response.model_dump(mode="json"))

--- a/mcpgateway/services/csrf_service.py
+++ b/mcpgateway/services/csrf_service.py
@@ -348,4 +348,4 @@ def get_csrf_service() -> CSRFService:
     Returns:
         CSRFService instance
     """
-    return CSRFService(secret=app_settings.csrf_secret_key, expiry=app_settings.csrf_token_expiry)
+    return CSRFService(secret=app_settings.csrf_secret_key.get_secret_value(), expiry=app_settings.csrf_token_expiry)

--- a/mcpgateway/services/support_bundle_service.py
+++ b/mcpgateway/services/support_bundle_service.py
@@ -6,14 +6,18 @@ SPDX-License-Identifier: Apache-2.0
 Support Bundle Service - Generate diagnostic bundles for troubleshooting.
 
 This module provides functionality to create comprehensive support bundles containing
-system diagnostics, logs, configuration, and other debugging information with automatic
-sanitization of sensitive data (passwords, tokens, API keys).
+system diagnostics, logs, configuration, and other debugging information. Sensitive
+data is handled differently depending on where it appears: settings.json
+deterministically excludes every field the Settings model marks as a secret (see
+SupportBundleService._secret_field_names()); environment.json masks environment
+variables by name pattern; and logs/ apply best-effort regex redaction, which is not
+a guarantee against every possible secret shape.
 
 Features:
 - Version and system information collection
-- Log file collection with size limits and sanitization
-- Environment configuration with secret redaction
-- Database connection info (sanitized)
+- Log file collection with size limits and best-effort sanitization
+- Environment configuration with name-based secret masking
+- Database connection info (credentials stripped from URLs)
 - Platform and dependency information
 - ZIP archive generation with timestamped filenames
 
@@ -40,17 +44,37 @@ import platform
 import re
 import socket
 import tempfile
-from typing import Any, Dict, Optional
+from types import UnionType
+from typing import Any, Dict, get_args, get_origin, Optional, Union
 import zipfile
 
 # Third-Party
 import orjson
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SecretStr
 
 # First-Party
 from mcpgateway import __version__
 from mcpgateway.config import settings
 from mcpgateway.db import engine
+
+# Field names that indicate a secret when the setting is string-typed.
+#
+# Deliberately narrower than SupportBundleService._is_secret(): bare "token"
+# and "key" match ~60 harmless settings (token_expiry, password_min_length,
+# csrf_token_name, ...) and redacting those would gut the bundle's value for
+# the debugging it exists to support. _is_secret() can afford to be broad
+# because it inspects raw environment variables whose names are unknown;
+# here the field set is known and typed.
+#
+# This regex is a backstop, not the policy: new secret settings must be typed
+# SecretStr, which _secret_field_names() rule 1 always catches regardless of
+# name. The regex only catches the mistake of forgetting to do that, and it
+# fails open for a plausible name it doesn't match, e.g. webhook_signing_key,
+# encryption_salt, or hmac_pepper. Do not rely on it as the primary control.
+_SECRET_NAME_RE = re.compile(r"secret|password|passwd|credential|passphrase|private_key|api_key", re.IGNORECASE)
+
+# String settings matching _SECRET_NAME_RE that are not themselves secrets.
+_SAFE_STRING_FIELDS = frozenset({"jwt_private_key_path"})
 
 
 class SupportBundleConfig(BaseModel):
@@ -124,12 +148,20 @@ class SupportBundleService:
             True
             >>> service._is_secret("API_KEY")
             True
+            >>> service._is_secret("RATELIMITER_REDIS_URL")
+            True
             >>> service._is_secret("DEBUG")
             False
         """
         key_upper = key.upper()
         # Check for common secret keywords
         if any(tok in key_upper for tok in ("SECRET", "TOKEN", "PASS", "KEY")):
+            return True
+        # URL-shaped settings routinely carry inline credentials in their
+        # userinfo component; mask by name suffix rather than maintaining an
+        # exact-match entry per URL setting (see database_url / redis_url
+        # below, kept for variables whose names predate this rule).
+        if key_upper.endswith("_URL"):
             return True
         # Check for specific secret environment variables
         secret_vars = {
@@ -141,6 +173,88 @@ class SupportBundleService:
             "AUTH_ENCRYPTION_SECRET",
         }
         return key_upper in secret_vars
+
+    @staticmethod
+    def _is_string_annotation(annotation: Any) -> bool:
+        """Check whether a field annotation is ``str`` or ``Optional[str]``.
+
+        Container annotations such as ``Dict[str, str]`` are rejected so that
+        a mapping setting is never mistaken for a scalar secret.
+
+        Args:
+            annotation: The declared annotation of a Pydantic model field.
+
+        Returns:
+            bool: True if the annotation resolves to a plain or optional string.
+
+        Examples:
+            >>> from typing import Dict, Optional
+            >>> SupportBundleService._is_string_annotation(str)
+            True
+            >>> SupportBundleService._is_string_annotation(Optional[str])
+            True
+            >>> SupportBundleService._is_string_annotation(Dict[str, str])
+            False
+            >>> SupportBundleService._is_string_annotation(int)
+            False
+        """
+        if annotation is str:
+            return True
+        if get_origin(annotation) in (Union, UnionType):
+            return all(arg is str or arg is type(None) for arg in get_args(annotation))
+        return False
+
+    @classmethod
+    def _secret_field_names(cls, model: type[BaseModel] | None = None) -> set[str]:
+        """Compute the set of settings fields that must never reach the bundle.
+
+        A field is a secret when either:
+
+        1. ``SecretStr`` appears anywhere in its annotation — directly,
+           ``Optional[SecretStr]``, or nested in a container such as
+           ``Dict[str, SecretStr]`` or ``List[SecretStr]`` — the primary rule,
+           so any correctly typed secret added in future is covered without
+           touching this module; or
+        2. it is string-typed, its name matches :data:`_SECRET_NAME_RE`, and it
+           is not in :data:`_SAFE_STRING_FIELDS` — a backstop for plain-string
+           secrets that were not typed as ``SecretStr``. New secret settings
+           must be typed ``SecretStr``; that is the enforced rule. This name
+           regex only catches the mistake of forgetting to.
+
+        Args:
+            model: Pydantic model class to inspect. Defaults to the
+                application :class:`~mcpgateway.config.Settings` model;
+                overridable so the rule can be exercised against a throwaway
+                model in tests without depending on the real settings shape.
+
+        Returns:
+            set[str]: Field names to exclude from ``settings.json``.
+
+        Examples:
+            >>> names = SupportBundleService._secret_field_names()
+            >>> "jwt_secret_key" in names
+            True
+            >>> "csrf_secret_key" in names
+            True
+            >>> "token_expiry" in names
+            False
+        """
+        # First-Party
+        from mcpgateway.config import Settings  # pylint: disable=import-outside-toplevel
+
+        model = model or Settings
+
+        secret_names: set[str] = set()
+        for name, field in model.model_fields.items():
+            annotation = field.annotation
+            if annotation is SecretStr or SecretStr in get_args(annotation):
+                secret_names.add(name)
+                continue
+            if name in _SAFE_STRING_FIELDS:
+                continue
+            if _SECRET_NAME_RE.search(name) and cls._is_string_annotation(annotation):
+                secret_names.add(name)
+        return secret_names
 
     def _sanitize_url(self, url: Optional[str]) -> Optional[str]:
         """Redact credentials from URLs.
@@ -273,7 +387,7 @@ class SupportBundleService:
         return {k: "*****" if self._is_secret(k) else v for k, v in os.environ.items()}
 
     def _collect_settings(self) -> Dict[str, Any]:
-        """Collect application settings with secrets redacted.
+        """Collect application settings with secret fields excluded.
 
         Returns:
             Dict of application settings
@@ -284,27 +398,20 @@ class SupportBundleService:
             >>> 'host' in config
             True
         """
-        # Export settings as dict but exclude sensitive fields
-        exclude_fields = {
-            "basic_auth_password",
-            "jwt_secret_key",
-            "auth_encryption_secret",
-            "platform_admin_password",
-            "sso_github_client_secret",
-            "sso_google_client_secret",
-            "sso_ibm_verify_client_secret",
-            "sso_okta_client_secret",
-            "sso_keycloak_client_secret",
-            "sso_entra_client_secret",
-            "sso_generic_client_secret",
-        }
-        config = settings.model_dump(exclude=exclude_fields)
+        # Exclusions are computed from the Settings model rather than
+        # hand-maintained: a hardcoded list silently goes stale as new settings
+        # are added, so a field added later is omitted from it by default.
+        config = settings.model_dump(exclude=self._secret_field_names())
 
-        # Sanitize URLs
-        if "database_url" in config:
-            config["database_url"] = self._sanitize_url(config["database_url"])
-        if "redis_url" in config:
-            config["redis_url"] = self._sanitize_url(config["redis_url"])
+        # Sanitize every string-valued *_url setting (database_url, redis_url,
+        # ratelimiter_redis_url, elasticsearch_url, ...) generically rather
+        # than naming each one: these routinely carry inline credentials
+        # (redis://:password@host:6379) and the set of URL settings grows
+        # independently of this module. Iterate a snapshot of the keys since
+        # the loop mutates config in place.
+        for key in list(config.keys()):
+            if key.endswith("_url") and isinstance(config[key], str):
+                config[key] = self._sanitize_url(config[key])
 
         return config
 
@@ -459,20 +566,26 @@ This bundle contains diagnostic information for troubleshooting ContextForge iss
 - MANIFEST.json: Bundle metadata and generation info
 - version.json: Application and dependency versions
 - system_info.json: Platform and system metrics
-- settings.json: Application configuration (secrets redacted)
-- environment.json: Environment variables (secrets redacted)
-- logs/: Application logs (sanitized)
+- settings.json: Application configuration (secret fields excluded)
+- environment.json: Environment variables (credential-like names masked)
+- logs/: Application logs (known credential patterns redacted)
 
 ## Security Notice
 
-This bundle has been automatically sanitized to remove:
-- Passwords and authentication credentials
-- API keys and tokens
-- JWT secrets
-- Database connection passwords
-- Other sensitive configuration values
+This bundle applies different guarantees depending on the file:
 
-However, please review the contents before sharing with support or external parties.
+- settings.json: every field the application's configuration model marks as
+  a secret (passwords, tokens, API keys, JWT/CSRF/identity-claims signing
+  keys, and similar) is deterministically excluded, not just masked.
+- environment.json: variables whose names look credential-like are masked.
+  A secret exposed under an unexpected variable name could be missed.
+- logs/: known credential patterns (passwords, tokens, API keys, bearer
+  auth headers, JWTs, URL-embedded credentials) are redacted on a
+  best-effort basis. Free-form log messages can still contain sensitive
+  data that does not match any known pattern.
+
+Review the contents before sharing this bundle with support or external
+parties, especially the logs/ directory.
 
 ## Usage
 

--- a/mcpgateway/services/support_bundle_service.py
+++ b/mcpgateway/services/support_bundle_service.py
@@ -76,6 +76,17 @@ _SECRET_NAME_RE = re.compile(r"secret|password|passwd|credential|passphrase|priv
 # String settings matching _SECRET_NAME_RE that are not themselves secrets.
 _SAFE_STRING_FIELDS = frozenset({"jwt_private_key_path"})
 
+# Key names that indicate a secret when they appear *inside* a collection-typed
+# setting (a SIEM destination entry, a role mapping, ...). Deliberately broader
+# than _SECRET_NAME_RE: that one is narrow because it screens our own typed
+# settings, where "token" and "key" appear in benign names like token_expiry.
+# These keys come from operator-authored config with no such convention, and a
+# nested key called "token" is a credential far more often than it is not.
+_NESTED_SECRET_KEY_RE = re.compile(r"secret|password|passwd|credential|passphrase|token|key|auth", re.IGNORECASE)
+
+# Placeholder written in place of a redacted value inside a collection setting.
+REDACTED_VALUE = "*****"
+
 
 class SupportBundleConfig(BaseModel):
     """Configuration for support bundle generation.
@@ -122,8 +133,11 @@ class SupportBundleService:
         (re.compile(r'secret["\']?\s*[:=]\s*["\']?([^"\'\s,}]+)', re.IGNORECASE), r"secret: *****"),
         (re.compile(r"bearer\s+[A-Za-z0-9\-._~+/]+=*", re.IGNORECASE), r"bearer *****"),
         (re.compile(r'authorization:\s*["\']?([^"\'\s,}]+)', re.IGNORECASE), r"authorization: *****"),
-        # Database / service URLs (scheme-agnostic to catch legacy or misconfigured DSNs)
-        (re.compile(r"(\w[\w+.-]*)://([^:]+):([^@]+)@"), r"\1://\2:*****@"),
+        # Database / service URLs (scheme-agnostic to catch legacy or misconfigured DSNs).
+        # The userinfo username is optional: several clients accept a URL with an
+        # empty user (scheme://:password@host), so the username group must be
+        # allowed to match zero characters.
+        (re.compile(r"(\w[\w+.-]*)://([^:@]*):([^@]+)@"), r"\1://\2:*****@"),
         # JWT tokens (eyJ pattern)
         (re.compile(r"eyJ[A-Za-z0-9\-_]+\.eyJ[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+"), r"eyJ*****"),
     ]
@@ -403,17 +417,47 @@ class SupportBundleService:
         # are added, so a field added later is omitted from it by default.
         config = settings.model_dump(exclude=self._secret_field_names())
 
-        # Sanitize every string-valued *_url setting (database_url, redis_url,
-        # ratelimiter_redis_url, elasticsearch_url, ...) generically rather
-        # than naming each one: these routinely carry inline credentials
-        # (redis://:password@host:6379) and the set of URL settings grows
-        # independently of this module. Iterate a snapshot of the keys since
-        # the loop mutates config in place.
-        for key in list(config.keys()):
-            if key.endswith("_url") and isinstance(config[key], str):
-                config[key] = self._sanitize_url(config[key])
+        # Settings that survive exclusion can still carry a credential inside
+        # their value: a DSN with inline userinfo, an OTLP header blob holding a
+        # bearer token, a SIEM destination list whose entries hold per-endpoint
+        # tokens. Keying off the field name cannot find those — the name says
+        # nothing about the shape of the value — so every value is walked and
+        # sanitized on its content instead.
+        return {key: self._sanitize_config_value(value) for key, value in config.items()}
 
-        return config
+    def _sanitize_config_value(self, value: Any) -> Any:
+        """Recursively redact credentials from a settings value.
+
+        Strings are matched against :data:`SENSITIVE_PATTERNS`, the same
+        best-effort rules applied to log text. Lists and dicts are walked so
+        that collection-typed settings are covered too; inside a dict, a key
+        whose name looks like a secret has its value replaced outright, since
+        the value itself carries no pattern to match on.
+
+        Args:
+            value: A settings value of any type.
+
+        Returns:
+            Any: The value with any detected credentials redacted.
+
+        Examples:
+            >>> service = SupportBundleService()
+            >>> service._sanitize_config_value("redis://:hunter2@cache:6379")  # pragma: allowlist secret
+            'redis://:*****@cache:6379'
+            >>> service._sanitize_config_value([{"endpoint": "https://siem.example.com", "token": "abc123"}])
+            [{'endpoint': 'https://siem.example.com', 'token': '*****'}]
+            >>> service._sanitize_config_value(3600)
+            3600
+        """
+        if isinstance(value, str):
+            # Preserve "" rather than turning it into None: an empty setting and
+            # an unset one are different facts to whoever reads the bundle.
+            return self._sanitize_line(value) if value else value
+        if isinstance(value, dict):
+            return {key: REDACTED_VALUE if _NESTED_SECRET_KEY_RE.search(str(key)) else self._sanitize_config_value(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [self._sanitize_config_value(item) for item in value]
+        return value
 
     def _collect_logs(self, config: SupportBundleConfig) -> Dict[str, str]:
         """Collect log files with sanitization and size limits.

--- a/mcpgateway/templates/version_info_partial.html
+++ b/mcpgateway/templates/version_info_partial.html
@@ -454,9 +454,11 @@
           Troubleshooting Support
         </h3>
         <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
-          Download a comprehensive diagnostics bundle for troubleshooting. All
-          sensitive data (passwords, tokens, secrets) are automatically
-          redacted.
+          Download a comprehensive diagnostics bundle for troubleshooting.
+          Configuration secrets are omitted from the settings file,
+          environment variables with credential-like names are masked,
+          and known credential patterns are redacted from included logs.
+          Review the bundle before sharing it outside your organization.
         </p>
       </div>
     </div>

--- a/mcpgateway/utils/identity_propagation.py
+++ b/mcpgateway/utils/identity_propagation.py
@@ -60,7 +60,8 @@ def _sign_claims(payload: str) -> str:
     Returns:
         Hex-encoded HMAC signature.
     """
-    secret = settings.identity_claims_secret or (settings.jwt_secret_key.get_secret_value() if settings.jwt_secret_key else "")
+    configured = settings.identity_claims_secret.get_secret_value() if settings.identity_claims_secret else ""
+    secret = configured or (settings.jwt_secret_key.get_secret_value() if settings.jwt_secret_key else "")
     return hmac.new(secret.encode(), payload.encode(), hashlib.sha256).hexdigest()
 
 

--- a/tests/unit/mcpgateway/middleware/test_csrf_fixes.py
+++ b/tests/unit/mcpgateway/middleware/test_csrf_fixes.py
@@ -17,6 +17,7 @@ Tests for the 5 issues identified in the review:
 from unittest.mock import AsyncMock, Mock, patch
 
 # Third-Party
+from pydantic import SecretStr
 import pytest
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -39,7 +40,7 @@ def mock_settings():
         mock.csrf_trusted_origins = []
         mock.app_domain = "http://localhost:4444"
         mock.csrf_exempt_paths = ["/health"]
-        mock.csrf_secret_key = "test-secret-key"
+        mock.csrf_secret_key = SecretStr("test-secret-key")  # pragma: allowlist secret
         mock.csrf_token_expiry = 3600
         mock.csrf_cookie_httponly = False
         mock.csrf_cookie_secure = True
@@ -59,7 +60,7 @@ async def test_form_field_parsing_urlencoded(csrf_middleware, mock_settings):
     """Test Issue #1: Parse CSRF token from application/x-www-form-urlencoded form field."""
     user_id = "test@example.com"
     session_id = "test-session-123"
-    csrf_token = generate_csrf_token(user_id, session_id, mock_settings.csrf_secret_key, mock_settings.csrf_token_expiry)
+    csrf_token = generate_csrf_token(user_id, session_id, mock_settings.csrf_secret_key.get_secret_value(), mock_settings.csrf_token_expiry)
 
     # Create mock request with form data (no header)
     mock_request = Mock(spec=Request)
@@ -92,7 +93,7 @@ async def test_form_field_parsing_multipart(csrf_middleware, mock_settings):
     """Test Issue #1: Parse CSRF token from multipart/form-data form field."""
     user_id = "test@example.com"
     session_id = "test-session-123"
-    csrf_token = generate_csrf_token(user_id, session_id, mock_settings.csrf_secret_key, mock_settings.csrf_token_expiry)
+    csrf_token = generate_csrf_token(user_id, session_id, mock_settings.csrf_secret_key.get_secret_value(), mock_settings.csrf_token_expiry)
 
     # Create mock request with multipart form data
     mock_request = Mock(spec=Request)
@@ -130,7 +131,7 @@ async def test_double_submit_cookie_validation(csrf_middleware, mock_settings):
     """Test Issue #2: Validate both cookie and header/form tokens match."""
     user_id = "test@example.com"
     session_id = "test-session-123"
-    csrf_token = generate_csrf_token(user_id, session_id, mock_settings.csrf_secret_key, mock_settings.csrf_token_expiry)
+    csrf_token = generate_csrf_token(user_id, session_id, mock_settings.csrf_secret_key.get_secret_value(), mock_settings.csrf_token_expiry)
     wrong_token = "wrong-token-value"
 
     # Create mock request with mismatched tokens
@@ -160,7 +161,7 @@ async def test_double_submit_cookie_missing(csrf_middleware, mock_settings):
     """Test Issue #2: Reject when cookie is missing."""
     user_id = "test@example.com"
     session_id = "test-session-123"
-    csrf_token = generate_csrf_token(user_id, session_id, mock_settings.csrf_secret_key, mock_settings.csrf_token_expiry)
+    csrf_token = generate_csrf_token(user_id, session_id, mock_settings.csrf_secret_key.get_secret_value(), mock_settings.csrf_token_expiry)
 
     # Create mock request with header but no cookie
     mock_request = Mock(spec=Request)
@@ -222,7 +223,7 @@ async def test_referer_check_fail_closed_missing_header(csrf_middleware, mock_se
     """Test Issue #4: Reject when Referer/Origin header is missing (fail closed)."""
     user_id = "test@example.com"
     session_id = "test-session-123"
-    csrf_token = generate_csrf_token(user_id, session_id, mock_settings.csrf_secret_key, mock_settings.csrf_token_expiry)
+    csrf_token = generate_csrf_token(user_id, session_id, mock_settings.csrf_secret_key.get_secret_value(), mock_settings.csrf_token_expiry)
 
     # Create mock request without Referer/Origin header
     mock_request = Mock(spec=Request)
@@ -251,7 +252,7 @@ async def test_referer_check_fail_closed_invalid_origin(csrf_middleware, mock_se
     """Test Issue #4: Reject when Referer/Origin is not in allowed list."""
     user_id = "test@example.com"
     session_id = "test-session-123"
-    csrf_token = generate_csrf_token(user_id, session_id, mock_settings.csrf_secret_key, mock_settings.csrf_token_expiry)
+    csrf_token = generate_csrf_token(user_id, session_id, mock_settings.csrf_secret_key.get_secret_value(), mock_settings.csrf_token_expiry)
 
     # Create mock request with invalid origin
     mock_request = Mock(spec=Request)
@@ -300,7 +301,7 @@ async def test_token_rotation_on_login():
 
         # Setup mocks
         mock_settings.csrf_rotate_on_login = True
-        mock_settings.csrf_secret_key = "test-secret"
+        mock_settings.csrf_secret_key = SecretStr("test-secret")  # pragma: allowlist secret
         mock_settings.csrf_token_expiry = 3600
         mock_settings.sso_enabled = False
 

--- a/tests/unit/mcpgateway/routers/test_auth.py
+++ b/tests/unit/mcpgateway/routers/test_auth.py
@@ -11,8 +11,9 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
-import pytest
 from fastapi import HTTPException
+from pydantic import SecretStr
+import pytest
 
 # First-Party
 from mcpgateway.routers.auth import LoginRequest, get_csrf_token, get_db, login
@@ -265,7 +266,7 @@ class TestLogin:
             mock_create_token.return_value = ("test_token", 3600)
             mock_settings.sso_enabled = False
             mock_settings.csrf_rotate_on_login = True
-            mock_settings.csrf_secret_key = "secret"
+            mock_settings.csrf_secret_key = SecretStr("secret")  # pragma: allowlist secret
             mock_settings.csrf_token_expiry = 60
 
             login_request = LoginRequest(email="test@example.com", password="password123")  # pragma: allowlist secret
@@ -288,7 +289,7 @@ class TestLogin:
             patch("mcpgateway.services.csrf_service.generate_csrf_token", return_value="csrf-token-123") as mock_generate,
             patch("mcpgateway.services.csrf_service.set_csrf_cookie") as mock_set_cookie,
         ):
-            mock_settings.csrf_secret_key = "secret"
+            mock_settings.csrf_secret_key = SecretStr("secret")  # pragma: allowlist secret
             mock_settings.csrf_token_expiry = 60
 
             response = await get_csrf_token(request, current_user)
@@ -321,7 +322,7 @@ class TestLogin:
             patch("mcpgateway.routers.auth.settings") as mock_settings,
             patch("mcpgateway.services.csrf_service.generate_csrf_token", side_effect=Exception("boom")),
         ):
-            mock_settings.csrf_secret_key = "secret"
+            mock_settings.csrf_secret_key = SecretStr("secret")  # pragma: allowlist secret
             mock_settings.csrf_token_expiry = 60
 
             with pytest.raises(HTTPException) as exc_info:

--- a/tests/unit/mcpgateway/routers/test_email_auth_router.py
+++ b/tests/unit/mcpgateway/routers/test_email_auth_router.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 from fastapi import HTTPException, status, Response
+from pydantic import SecretStr
 import pytest
 
 # First-Party
@@ -224,7 +225,7 @@ class TestEmailAuthLoginPasswordChangeRequired:
                     mock_settings.jwt_issuer = "test-issuer"
                     mock_settings.jwt_audience = "test-audience"
                     mock_settings.csrf_rotate_on_login = True
-                    mock_settings.csrf_secret_key = "secret"
+                    mock_settings.csrf_secret_key = SecretStr("secret")  # pragma: allowlist secret
                     mock_settings.csrf_token_expiry = 60
                     mock_jwt_decode.return_value = {"jti": "session-123"}
 

--- a/tests/unit/mcpgateway/services/test_csrf_service.py
+++ b/tests/unit/mcpgateway/services/test_csrf_service.py
@@ -13,6 +13,7 @@ import time
 from unittest.mock import Mock, patch
 
 # Third-Party
+from pydantic import SecretStr
 import pytest
 
 # First-Party
@@ -348,7 +349,7 @@ class TestCSRFService:
 
 def test_get_csrf_service_uses_app_settings():
     with patch("mcpgateway.services.csrf_service.app_settings") as mock_settings:
-        mock_settings.csrf_secret_key = "secret"
+        mock_settings.csrf_secret_key = SecretStr("secret")  # pragma: allowlist secret
         mock_settings.csrf_token_expiry = 3600
 
         get_csrf_service.cache_clear()

--- a/tests/unit/mcpgateway/services/test_support_bundle_service.py
+++ b/tests/unit/mcpgateway/services/test_support_bundle_service.py
@@ -11,9 +11,11 @@ Tests bundle generation, sanitization, and file operations.
 import builtins
 from pathlib import Path
 import tempfile
+from typing import Dict, get_args
 import zipfile
 
 # Third-Party
+from pydantic import BaseModel, Field, SecretStr
 import pytest
 
 # First-Party
@@ -54,6 +56,29 @@ class TestSupportBundleService:
         assert not service._is_secret("PORT")
         assert not service._is_secret("HOSTNAME")
         assert not service._is_secret("LOG_LEVEL")
+
+    def test_is_secret_detection_url_suffix(self):
+        """Any *_URL environment variable is masked, not just the two named exact matches.
+
+        database_url / redis_url are also *_URL names and are already covered by the
+        SECRET/TOKEN/PASS/KEY substring check or the exact-match list; this test targets
+        URL settings that were previously missed entirely, such as ratelimiter_redis_url
+        and elasticsearch_url, both of which routinely carry inline credentials.
+        """
+        service = SupportBundleService()
+
+        assert service._is_secret("RATELIMITER_REDIS_URL")
+        assert service._is_secret("ELASTICSEARCH_URL")
+        assert service._is_secret("MEMCACHED_URL")
+
+        # Existing exact-match entries must still be caught (not narrowed).
+        assert service._is_secret("DATABASE_URL")
+        assert service._is_secret("REDIS_URL")
+
+        # Benign, non-URL names must not be swept up by the new suffix rule.
+        assert not service._is_secret("LOG_LEVEL")
+        assert not service._is_secret("HOSTNAME")
+        assert not service._is_secret("URL_PREFIX")
 
     def test_sanitize_url(self):
         """Test URL sanitization removes passwords."""
@@ -215,6 +240,33 @@ class TestSupportBundleService:
         assert "redis_url" in config
         assert "secret123" not in config["redis_url"]
         assert "database_url" not in config
+
+    def test_collect_settings_sanitizes_other_url_settings(self, monkeypatch: pytest.MonkeyPatch):
+        """URL settings beyond database_url/redis_url are sanitized generically.
+
+        Regression for the finding that ratelimiter_redis_url and elasticsearch_url
+        (and any future *_url setting) shipped credentials verbatim because only two
+        URL fields were special-cased.
+        """
+        service = SupportBundleService()
+
+        def fake_dump(*, exclude=None):  # noqa: ARG001
+            return {
+                "ratelimiter_redis_url": "redis://ratelimiter:hunter2@ratelimiter.example.com:6379/0",  # pragma: allowlist secret
+                "elasticsearch_url": "https://elastic:hunter2@es.example.com:9200",  # pragma: allowlist secret
+                "not_a_url_setting": "https://user:hunter2@example.com",  # pragma: allowlist secret
+            }
+
+        monkeypatch.setattr("mcpgateway.services.support_bundle_service.settings.model_dump", fake_dump)
+
+        config = service._collect_settings()
+        assert "hunter2" not in config["ratelimiter_redis_url"]
+        assert "*****" in config["ratelimiter_redis_url"]
+        assert "hunter2" not in config["elasticsearch_url"]
+        assert "*****" in config["elasticsearch_url"]
+        # A key that doesn't end in "_url" is left untouched by the loop, even
+        # though its value happens to look URL-shaped.
+        assert config["not_a_url_setting"] == "https://user:hunter2@example.com"  # pragma: allowlist secret
 
     def test_collect_logs_file_not_found(self):
         """Test log collection when file doesn't exist."""
@@ -423,6 +475,150 @@ class TestSupportBundleService:
         assert config.include_env is True
         assert config.include_system_info is True
         assert config.log_tail_lines == 1000
+
+    def test_secret_field_names_includes_known_secretstr_settings(self):
+        """The two settings that were previously plain-str secrets are detected.
+
+        Both csrf_secret_key and identity_claims_secret are now SecretStr-typed (see
+        test_secret_field_names_matches_secretstr_fields_exactly for the rule-2 backstop
+        they used to exercise), but pinning them by name is still valuable: neither may
+        slip out of the detected set, regardless of which rule catches it.
+        """
+        names = SupportBundleService._secret_field_names()
+
+        # csrf_secret_key derives from the JWT signing secret when unset.
+        assert "csrf_secret_key" in names
+        # identity_claims_secret derives from it the same way.
+        assert "identity_claims_secret" in names
+
+    def test_secret_field_names_matches_secretstr_fields_exactly(self):
+        """Every secret setting is SecretStr-typed; rule 2 currently adds nothing.
+
+        This test fails the day a contributor adds a plain-string secret with a
+        secret-ish name, forcing an explicit decision (retype it SecretStr, or
+        add it to _SAFE_STRING_FIELDS) rather than silently relying on the net.
+        """
+        # First-Party
+        from mcpgateway.config import Settings
+
+        secretstr_fields = {name for name, field in Settings.model_fields.items() if field.annotation is SecretStr or SecretStr in get_args(field.annotation)}
+
+        assert SupportBundleService._secret_field_names() == secretstr_fields
+
+    def test_secret_field_names_rule_2_backstop_on_throwaway_model(self):
+        """Rule 2 (name-regex fallback for plain strings) is directly exercised.
+
+        Against the real Settings model, rule 2 currently selects nothing (every
+        secret is SecretStr-typed), so this test builds a throwaway model to prove
+        the fallback still works on its own terms: it must catch a plain-string
+        secret-shaped name, ignore a benign string name, ignore a non-string
+        container annotation even with a secret-shaped name, and ignore a
+        non-string scalar annotation with a secret-shaped name.
+        """
+
+        class ThrowawayModel(BaseModel):
+            """Throwaway model exercising _secret_field_names() rule 2 in isolation."""
+
+            api_key: str = ""
+            notes: str = ""
+            mapping: Dict[str, str] = Field(default_factory=dict)
+            token_expiry: int = 0
+
+        names = SupportBundleService._secret_field_names(ThrowawayModel)
+
+        assert "api_key" in names
+        assert "notes" not in names
+        assert "mapping" not in names
+        assert "token_expiry" not in names
+
+    def test_secret_field_names_includes_every_secretstr_field(self):
+        """Every SecretStr-annotated setting is detected by type alone."""
+        # First-Party
+        from mcpgateway.config import Settings
+
+        names = SupportBundleService._secret_field_names()
+        for field_name, field in Settings.model_fields.items():
+            annotation = field.annotation
+            is_secret_type = annotation is SecretStr or SecretStr in get_args(annotation)
+            if is_secret_type:
+                assert field_name in names, f"SecretStr field {field_name} not detected as a secret"
+
+    def test_secret_field_names_excludes_benign_settings(self):
+        """Non-secret knobs whose names contain secret-ish words are kept."""
+        names = SupportBundleService._secret_field_names()
+
+        # int/bool knobs — redacting these would gut the bundle's usefulness
+        for benign in (
+            "token_expiry",
+            "password_min_length",
+            "password_policy_enabled",
+            "min_secret_length",
+            "require_strong_secrets",
+            "csrf_token_name",
+            "host",
+            "port",
+        ):
+            assert benign not in names, f"{benign} must not be redacted"
+
+        # A filesystem path, not a key
+        assert "jwt_private_key_path" not in names
+
+    def test_collect_settings_omits_csrf_secret_key(self):
+        """Neither JWT-derived signing key may appear in the collected settings."""
+        service = SupportBundleService()
+        config = service._collect_settings()
+
+        assert "csrf_secret_key" not in config
+        assert "identity_claims_secret" not in config
+
+    def test_collect_settings_keeps_benign_fields(self):
+        """The bundle stays useful: non-secret settings keep their real values."""
+        service = SupportBundleService()
+        config = service._collect_settings()
+
+        for benign in ("host", "port", "token_expiry", "password_min_length", "csrf_token_name"):
+            assert benign in config, f"{benign} was over-redacted"
+
+    def test_collect_settings_omits_every_detected_secret(self):
+        """Meta-test: every field _secret_field_names() flags is really gone.
+
+        A future secret setting that is neither SecretStr-typed nor name-matched
+        is caught by test_no_secret_leaks_into_bundle below; one that is detected
+        but somehow still emitted is caught here.
+        """
+        service = SupportBundleService()
+        config = service._collect_settings()
+
+        for name in SupportBundleService._secret_field_names():
+            assert name not in config, f"secret field {name} leaked into settings.json"
+
+    def test_no_secret_leaks_into_bundle(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """End-to-end: a sentinel JWT secret appears in no bundle member.
+
+        Byte-level rather than key-level, so the check still fires when the value
+        surfaces under some other key — a derived setting carrying a copy of the
+        signing secret would not be caught by a key-name assertion.
+        """
+        # First-Party
+        from mcpgateway.config import Settings
+
+        sentinel = "sentinel-jwt-canary-DO-NOT-USE-IN-PRODUCTION-0123456789"  # pragma: allowlist secret
+        sentinel_settings = Settings(
+            jwt_secret_key=sentinel,
+            database_url="sqlite:///:memory:",
+            environment="development",
+        )
+        # Sanity: the fallback under test really did copy the JWT secret across.
+        assert sentinel_settings.csrf_secret_key == sentinel or sentinel_settings.csrf_secret_key.get_secret_value() == sentinel
+
+        monkeypatch.setattr("mcpgateway.services.support_bundle_service.settings", sentinel_settings)
+
+        service = SupportBundleService()
+        bundle_path = service.generate_bundle(SupportBundleConfig(output_dir=tmp_path, include_logs=False))
+
+        with zipfile.ZipFile(bundle_path) as zf:
+            for member in zf.namelist():
+                assert sentinel.encode() not in zf.read(member), f"JWT secret leaked into {member}"
 
 
 if __name__ == "__main__":

--- a/tests/unit/mcpgateway/services/test_support_bundle_service.py
+++ b/tests/unit/mcpgateway/services/test_support_bundle_service.py
@@ -242,11 +242,12 @@ class TestSupportBundleService:
         assert "database_url" not in config
 
     def test_collect_settings_sanitizes_other_url_settings(self, monkeypatch: pytest.MonkeyPatch):
-        """URL settings beyond database_url/redis_url are sanitized generically.
+        """Credentials are redacted from any setting value, whatever the field is called.
 
-        Regression for the finding that ratelimiter_redis_url and elasticsearch_url
-        (and any future *_url setting) shipped credentials verbatim because only two
-        URL fields were special-cased.
+        Sanitization keys off the *content* of a value rather than the field name:
+        a name says nothing about the shape of what it holds, so ratelimiter_redis_url,
+        elasticsearch_url, and a URL-shaped value under a name with no url suffix are
+        all covered by the same pass.
         """
         service = SupportBundleService()
 
@@ -255,18 +256,68 @@ class TestSupportBundleService:
                 "ratelimiter_redis_url": "redis://ratelimiter:hunter2@ratelimiter.example.com:6379/0",  # pragma: allowlist secret
                 "elasticsearch_url": "https://elastic:hunter2@es.example.com:9200",  # pragma: allowlist secret
                 "not_a_url_setting": "https://user:hunter2@example.com",  # pragma: allowlist secret
+                "harmless_setting": "X-CSRF-Token",
             }
 
         monkeypatch.setattr("mcpgateway.services.support_bundle_service.settings.model_dump", fake_dump)
 
         config = service._collect_settings()
-        assert "hunter2" not in config["ratelimiter_redis_url"]
-        assert "*****" in config["ratelimiter_redis_url"]
-        assert "hunter2" not in config["elasticsearch_url"]
-        assert "*****" in config["elasticsearch_url"]
-        # A key that doesn't end in "_url" is left untouched by the loop, even
-        # though its value happens to look URL-shaped.
-        assert config["not_a_url_setting"] == "https://user:hunter2@example.com"  # pragma: allowlist secret
+        for key in ("ratelimiter_redis_url", "elasticsearch_url", "not_a_url_setting"):
+            assert "hunter2" not in config[key]
+            assert "*****" in config[key]
+        # Content-based sanitization must not chew through ordinary values.
+        assert config["harmless_setting"] == "X-CSRF-Token"
+
+    def test_sanitize_url_redacts_empty_username_credentials(self):
+        """A DSN with no username still has its password redacted.
+
+        Several clients accept scheme://:password@host. The userinfo pattern must
+        allow a zero-length username, or this common Redis form ships verbatim.
+        """
+        service = SupportBundleService()
+
+        sanitized = service._sanitize_url("redis://:hunter2@cache.example.com:6379/0")  # pragma: allowlist secret
+        assert "hunter2" not in sanitized
+        assert sanitized == "redis://:*****@cache.example.com:6379/0"
+
+        # A URL with no credentials at all is returned unchanged.
+        assert service._sanitize_url("redis://cache.example.com:6379/0") == "redis://cache.example.com:6379/0"
+
+    def test_sanitize_config_value_walks_collections(self):
+        """Collection-typed settings are sanitized element-wise, at any depth."""
+        service = SupportBundleService()
+
+        # List of strings: each element is sanitized on its content.
+        assert service._sanitize_config_value(["redis://:hunter2@h:6379", "10.0.0.0/8"]) == ["redis://:*****@h:6379", "10.0.0.0/8"]  # pragma: allowlist secret
+
+        # List of dicts: a secret-looking key has its value replaced outright,
+        # since the value itself carries no pattern to match on.
+        destinations = [{"endpoint": "https://siem.example.com", "token": "hunter2", "name": "prod"}]  # pragma: allowlist secret
+        assert service._sanitize_config_value(destinations) == [{"endpoint": "https://siem.example.com", "token": "*****", "name": "prod"}]
+
+        # Nested dicts are walked; benign mappings survive intact.
+        assert service._sanitize_config_value({"role_map": {"admin": "platform_admin"}}) == {"role_map": {"admin": "platform_admin"}}
+
+        # Non-string scalars pass through untouched.
+        assert service._sanitize_config_value(3600) == 3600
+        assert service._sanitize_config_value(None) is None
+        # An empty string stays empty rather than becoming None: "set but blank"
+        # and "unset" are different facts to whoever reads the bundle.
+        assert service._sanitize_config_value("") == ""
+
+    def test_sanitize_config_value_redacts_bearer_token_in_header_blob(self):
+        """A header blob carrying a bearer token is redacted.
+
+        otel_exporter_otlp_headers is a comma-separated key=value string that
+        conventionally holds an Authorization header. Its field name matches no
+        secret-name rule, so only content-based sanitization catches it.
+        """
+        service = SupportBundleService()
+
+        sanitized = service._sanitize_config_value("Authorization=Bearer eyJhbGci.eyJzdWIi.abc123,X-Env=prod")  # pragma: allowlist secret
+        assert "eyJhbGci" not in sanitized
+        assert "*****" in sanitized
+        assert "X-Env=prod" in sanitized
 
     def test_collect_logs_file_not_found(self):
         """Test log collection when file doesn't exist."""

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -2352,3 +2352,29 @@ def test_alembic_env_import_does_not_require_secrets():
             if val is not None:
                 os.environ[key] = val
         sys.modules.pop("mcpgateway.alembic.env", None)
+
+
+def test_csrf_secret_key_is_a_secret_and_falls_back_to_jwt_secret():
+    """CSRF key must be SecretStr, and must still inherit the JWT secret when unset."""
+    # Third-Party
+    from pydantic import SecretStr
+
+    # First-Party
+    from mcpgateway.config import Settings
+
+    jwt_value = "config-test-jwt-canary-DO-NOT-USE-IN-PRODUCTION-0123456789"  # pragma: allowlist secret
+    cfg = Settings(jwt_secret_key=jwt_value, database_url="sqlite:///:memory:", environment="development")
+
+    assert isinstance(cfg.csrf_secret_key, SecretStr)
+    # The fallback still fires: SecretStr("") is truthy, so a naive
+    # `if not self.csrf_secret_key` would silently leave the key empty.
+    assert cfg.csrf_secret_key.get_secret_value() == jwt_value
+
+    explicit = "config-test-csrf-canary-DO-NOT-USE-IN-PRODUCTION-0123456789"  # pragma: allowlist secret
+    cfg2 = Settings(
+        jwt_secret_key=jwt_value,
+        csrf_secret_key=explicit,
+        database_url="sqlite:///:memory:",
+        environment="development",
+    )
+    assert cfg2.csrf_secret_key.get_secret_value() == explicit

--- a/tests/unit/mcpgateway/test_identity_propagation.py
+++ b/tests/unit/mcpgateway/test_identity_propagation.py
@@ -155,7 +155,7 @@ class TestBuildIdentityHeaders:
         mock_settings.identity_propagation_mode = "both"
         mock_settings.identity_propagation_headers_prefix = "X-Forwarded-User"
         mock_settings.identity_sign_claims = True
-        mock_settings.identity_claims_secret = "test-secret"  # pragma: allowlist secret
+        mock_settings.identity_claims_secret = SecretStr("test-secret")  # pragma: allowlist secret
         mock_settings.identity_sensitive_attributes = []
         uc = UserContext(user_id="alice@co.com", email="alice@co.com")
         headers = build_identity_headers(uc)
@@ -491,9 +491,43 @@ class TestSignClaims:
 
     @patch("mcpgateway.utils.identity_propagation.settings")
     def test_uses_identity_claims_secret(self, mock_settings):
-        mock_settings.identity_claims_secret = "my-secret"  # pragma: allowlist secret
+        mock_settings.identity_claims_secret = SecretStr("my-secret")  # pragma: allowlist secret
         sig = _sign_claims("test-payload")
         assert len(sig) == 64  # SHA-256 hex
+
+    @patch("mcpgateway.utils.identity_propagation.settings")
+    def test_identity_claims_secret_actually_changes_the_signature(self, mock_settings):
+        """The configured secret must actually be used as the HMAC key, not merely present.
+
+        test_uses_identity_claims_secret and test_falls_back_to_empty_when_no_secrets only
+        assert len(sig) == 64, which would still pass even if identity_claims_secret were
+        silently ignored (HMAC-SHA256 always produces a 64-char hex digest, regardless of
+        key). Signing the same payload with a real secret and with no secret at all and
+        asserting the two signatures differ is what actually proves the secret is honored.
+        """
+        mock_settings.identity_claims_secret = SecretStr("my-secret")  # pragma: allowlist secret
+        mock_settings.jwt_secret_key = SecretStr("jwt-fallback-secret")  # pragma: allowlist secret
+        sig_with_secret = _sign_claims("test-payload")
+
+        mock_settings.identity_claims_secret = None
+        mock_settings.jwt_secret_key = None
+        sig_without_secret = _sign_claims("test-payload")
+
+        assert sig_with_secret != sig_without_secret
+
+    def test_identity_claims_secret_is_a_secret_type(self):
+        """The identity-claims signing key must not be a bare string."""
+        # Standard
+        from typing import get_args
+
+        # Third-Party
+        from pydantic import SecretStr
+
+        # First-Party
+        from mcpgateway.config import Settings
+
+        annotation = Settings.model_fields["identity_claims_secret"].annotation
+        assert SecretStr in get_args(annotation), "identity_claims_secret must be Optional[SecretStr]"
 
     @patch("mcpgateway.utils.identity_propagation.settings")
     def test_falls_back_to_jwt_secret(self, mock_settings):


### PR DESCRIPTION
Backport of #6080 to `Release/v1.0.7`. Same two commits, cherry-picked cleanly (only `.secrets.baseline` needed a line-number-driven regeneration).

Improves how the support bundle handles configuration values, and tightens the typing of two settings fields.

### Support bundle

- The set of settings fields excluded from a generated bundle is now derived from the `Settings` model rather than a hand-maintained list. A hardcoded list goes stale as settings are added; deriving it means a field declared with a secret type is covered without a second edit. A narrow name-based rule acts as a backstop for string-typed fields, with `SecretStr` typing remaining the enforced convention.
- Every settings value is sanitized on its content rather than by field name: strings are matched against the same patterns already applied to log text, and lists/dicts (SIEM destinations, webhook URL lists, header blobs) are walked element-wise so credentials are caught regardless of what the field happens to be called.
- Credentials are stripped from URL settings even when the username is empty (`scheme://:password@host`), a common Redis DSN shape the original pattern missed.

### Settings typing

- `csrf_secret_key` and `identity_claims_secret` are now `SecretStr`. Their fallback behaviour is unchanged: both still derive from `JWT_SECRET_KEY` when left unset.
- Worth knowing for anyone touching this area: `SecretStr("")` is truthy, so the emptiness checks guarding those fallbacks go through `get_secret_value()`, and the assignments wrap explicitly because `Settings` does not enable `validate_assignment`.

### Documentation

- The bundle README, the module docstring, and the Admin UI blurb now describe what each bundle member actually offers: deterministic exclusion for the settings file, name-based masking for environment variables, and best-effort pattern matching for logs. Each prompts the operator to review a bundle before sharing it.
- `CSRF_SECRET_KEY` is documented as reusing `JWT_SECRET_KEY` when unset, so the two can be set separately and rotated independently.

### Tracking

Internal: https://github.ibm.com/contextforge-org/internal_issues/issues/522