### PR TITLE
fix(ui): use v1 API for global search

### DIFF
--- a/client/e2e/global-search.spec.ts
+++ b/client/e2e/global-search.spec.ts
@@ -62,7 +62,7 @@ test.describe("Global search", () => {
         ]),
       });
     });
-    await page.route("**/admin/search?*", async (route) => {
+    await page.route("**/v1/search?*", async (route) => {
       searchRequestUrl = route.request().url();
       await route.fulfill({
         status: 200,
@@ -101,7 +101,7 @@ test.describe("Global search", () => {
     await searchBox.pressSequentially("eather");
 
     await expect(page.getByText("Weather Tool")).toBeVisible();
-    expect(searchRequestUrl).toContain("/admin/search?");
+    expect(searchRequestUrl).toContain("/v1/search?");
     expect(searchRequestUrl).toContain("q=weather");
     expect(searchRequestUrl).toContain("entity_types=");
 

--- a/client/src/api/search.test.ts
+++ b/client/src/api/search.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "./client";
-import { searchAdminEntities } from "./search";
+import { searchEntities } from "./search";
 
 vi.mock("./client", () => ({
   api: {
@@ -8,12 +8,12 @@ vi.mock("./client", () => ({
   },
 }));
 
-describe("searchAdminEntities", () => {
+describe("searchEntities", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("builds the /admin/search URL with entity types and per-type limit", async () => {
+  it("builds the /v1/search URL with entity types and per-type limit", async () => {
     const response = {
       query: "tool",
       entity_types: ["tools"],
@@ -25,14 +25,14 @@ describe("searchAdminEntities", () => {
     };
     vi.mocked(api.get).mockResolvedValue(response);
 
-    await searchAdminEntities({
+    await searchEntities({
       query: " tool ",
       entityTypes: ["tools", "resources"],
       limitPerType: 6,
     });
 
     expect(api.get).toHaveBeenCalledWith(
-      "/admin/search?q=tool&limit_per_type=6&entity_types=tools%2Cresources",
+      "/v1/search?q=tool&limit_per_type=6&entity_types=tools%2Cresources",
       undefined,
       undefined,
     );
@@ -50,7 +50,7 @@ describe("searchAdminEntities", () => {
       count: 0,
     });
 
-    await searchAdminEntities({
+    await searchEntities({
       query: "alpha",
       entityTypes: ["teams"],
       teamId: "team-123",
@@ -58,7 +58,7 @@ describe("searchAdminEntities", () => {
     });
 
     expect(api.get).toHaveBeenCalledWith(
-      "/admin/search?q=alpha&limit_per_type=8&entity_types=teams&team_id=team-123",
+      "/v1/search?q=alpha&limit_per_type=8&entity_types=teams&team_id=team-123",
       undefined,
       controller.signal,
     );

--- a/client/src/api/search.ts
+++ b/client/src/api/search.ts
@@ -45,7 +45,7 @@ export interface GlobalSearchParams {
   signal?: AbortSignal;
 }
 
-export function searchAdminEntities({
+export function searchEntities({
   query,
   entityTypes,
   limitPerType = 8,
@@ -61,5 +61,5 @@ export function searchAdminEntities({
     params.set("team_id", teamId);
   }
 
-  return api.get<GlobalSearchResponse>(`/admin/search?${params.toString()}`, undefined, signal);
+  return api.get<GlobalSearchResponse>(`/v1/search?${params.toString()}`, undefined, signal);
 }

--- a/client/src/components/layout/HeaderQuickNav.test.tsx
+++ b/client/src/components/layout/HeaderQuickNav.test.tsx
@@ -2,13 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { I18nProvider } from "@/i18n";
-import { searchAdminEntities } from "@/api/search";
+import { searchEntities } from "@/api/search";
 import { useAuthContext } from "@/auth/AuthContext";
 import { useRouter } from "@/router";
 import { HeaderQuickNav } from "./HeaderQuickNav";
 
 vi.mock("@/api/search", () => ({
-  searchAdminEntities: vi.fn(),
+  searchEntities: vi.fn(),
 }));
 
 vi.mock("@/auth/AuthContext", () => ({
@@ -56,7 +56,7 @@ beforeEach(() => {
     navigate: mockNavigate,
   });
   vi.mocked(useAuthContext).mockReturnValue(defaultAuthContext);
-  vi.mocked(searchAdminEntities).mockResolvedValue({
+  vi.mocked(searchEntities).mockResolvedValue({
     query: "server",
     entity_types: ["gateways"],
     limit_per_type: 8,
@@ -195,12 +195,12 @@ describe("HeaderQuickNav", () => {
     fireEvent.change(input, { target: { value: "s" } });
     vi.advanceTimersByTime(300);
 
-    expect(searchAdminEntities).not.toHaveBeenCalled();
+    expect(searchEntities).not.toHaveBeenCalled();
     expect(screen.getByText("Type at least 2 characters to search.")).toBeInTheDocument();
   });
 
-  it("searches /admin/search and renders grouped results", async () => {
-    vi.mocked(searchAdminEntities).mockResolvedValue({
+  it("searches /v1/search and renders grouped results", async () => {
+    vi.mocked(searchEntities).mockResolvedValue({
       query: "server",
       entity_types: ["gateways"],
       limit_per_type: 8,
@@ -229,7 +229,7 @@ describe("HeaderQuickNav", () => {
     fireEvent.change(input, { target: { value: "server" } });
 
     await waitFor(() => {
-      expect(searchAdminEntities).toHaveBeenCalledWith(
+      expect(searchEntities).toHaveBeenCalledWith(
         expect.objectContaining({
           query: "server",
           entityTypes: ["servers", "gateways", "tools", "resources", "prompts", "agents", "teams"],
@@ -245,7 +245,7 @@ describe("HeaderQuickNav", () => {
   });
 
   it("shows an error state when global search fails", async () => {
-    vi.mocked(searchAdminEntities).mockRejectedValue(new Error("Search failed"));
+    vi.mocked(searchEntities).mockRejectedValue(new Error("Search failed"));
 
     renderQuickNav();
 
@@ -270,7 +270,7 @@ describe("HeaderQuickNav", () => {
     fireEvent.change(input, { target: { value: "alice" } });
 
     await waitFor(() => {
-      expect(searchAdminEntities).toHaveBeenCalledWith(
+      expect(searchEntities).toHaveBeenCalledWith(
         expect.objectContaining({
           query: "alice",
           entityTypes: expect.arrayContaining(["users"]),
@@ -282,7 +282,7 @@ describe("HeaderQuickNav", () => {
 
   it("navigates to the owning page when a result is selected", async () => {
     const user = userEvent.setup();
-    vi.mocked(searchAdminEntities).mockResolvedValue({
+    vi.mocked(searchEntities).mockResolvedValue({
       query: "tool",
       entity_types: ["tools"],
       limit_per_type: 8,
@@ -309,7 +309,7 @@ describe("HeaderQuickNav", () => {
   });
 
   it("navigates to the first result when the form is submitted", async () => {
-    vi.mocked(searchAdminEntities).mockResolvedValue({
+    vi.mocked(searchEntities).mockResolvedValue({
       query: "resource",
       entity_types: ["resources"],
       limit_per_type: 8,
@@ -340,7 +340,7 @@ describe("HeaderQuickNav", () => {
   });
 
   it("navigates to the focused result with keyboard navigation", async () => {
-    vi.mocked(searchAdminEntities).mockResolvedValue({
+    vi.mocked(searchEntities).mockResolvedValue({
       query: "tool",
       entity_types: ["tools"],
       limit_per_type: 8,
@@ -379,7 +379,7 @@ describe("HeaderQuickNav", () => {
   });
 
   it("keeps keyboard focus inside result boundaries", async () => {
-    vi.mocked(searchAdminEntities).mockResolvedValue({
+    vi.mocked(searchEntities).mockResolvedValue({
       query: "tool",
       entity_types: ["tools"],
       limit_per_type: 8,
@@ -430,10 +430,10 @@ describe("HeaderQuickNav", () => {
     expect(await screen.findByText("No matching results.")).toBeInTheDocument();
   });
 
-  type SearchResult = Awaited<ReturnType<typeof searchAdminEntities>>;
+  type SearchResult = Awaited<ReturnType<typeof searchEntities>>;
 
   it("resolves result labels from fallback fields across multiple groups", async () => {
-    vi.mocked(searchAdminEntities).mockResolvedValue({
+    vi.mocked(searchEntities).mockResolvedValue({
       query: "q",
       entity_types: [],
       limit_per_type: 8,
@@ -468,7 +468,7 @@ describe("HeaderQuickNav", () => {
   });
 
   it("shows a searching state while the request is in flight", async () => {
-    vi.mocked(searchAdminEntities).mockReturnValue(new Promise<SearchResult>(() => {}));
+    vi.mocked(searchEntities).mockReturnValue(new Promise<SearchResult>(() => {}));
 
     renderQuickNav();
     const input = screen.getByRole("searchbox", { name: "Search" });
@@ -479,7 +479,7 @@ describe("HeaderQuickNav", () => {
   });
 
   it("ignores abort errors without showing an error state", async () => {
-    vi.mocked(searchAdminEntities).mockRejectedValue(new DOMException("aborted", "AbortError"));
+    vi.mocked(searchEntities).mockRejectedValue(new DOMException("aborted", "AbortError"));
 
     renderQuickNav();
     const input = screen.getByRole("searchbox", { name: "Search" });
@@ -487,12 +487,12 @@ describe("HeaderQuickNav", () => {
     fireEvent.change(input, { target: { value: "query" } });
 
     // The abort is swallowed, so no error message is rendered.
-    await waitFor(() => expect(searchAdminEntities).toHaveBeenCalled());
+    await waitFor(() => expect(searchEntities).toHaveBeenCalled());
     expect(screen.queryByText(/failed|error/i)).not.toBeInTheDocument();
   });
 
   it("closes the results popover on Escape", async () => {
-    vi.mocked(searchAdminEntities).mockResolvedValue({
+    vi.mocked(searchEntities).mockResolvedValue({
       query: "q",
       entity_types: [],
       limit_per_type: 8,

--- a/client/src/components/layout/HeaderQuickNav.tsx
+++ b/client/src/components/layout/HeaderQuickNav.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { FormEvent, KeyboardEvent as ReactKeyboardEvent } from "react";
 import { Search } from "lucide-react";
 import { useIntl } from "react-intl";
-import { searchAdminEntities } from "@/api/search";
+import { searchEntities } from "@/api/search";
 import type { GlobalSearchGroup, GlobalSearchItem, SearchEntityType } from "@/api/search";
 import { useAuthContext } from "@/auth/AuthContext";
 import { Badge } from "@/components/ui/badge";
@@ -228,7 +228,7 @@ export function HeaderQuickNav() {
     const controller = new AbortController();
     const timeoutId = window.setTimeout(() => {
       setStatus("loading");
-      searchAdminEntities({
+      searchEntities({
         query: trimmedQuery,
         entityTypes: searchEntityTypes,
         limitPerType: SEARCH_LIMIT_PER_TYPE,


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

N/A

---

## 📝 Summary

Updates React global search to use the stable, versioned `GET /v1/search` API instead of the admin-only `GET /admin/search` endpoint.

Renames the client helper from `searchAdminEntities` to `searchEntities` and updates unit and Playwright coverage. Response handling remains unchanged because `/v1/search` provides the same grouped search contract while enforcing authentication, per-entity RBAC, and token scoping without requiring `admin.dashboard`.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Focused unit tests | `npm run test:run -- src/api/search.test.ts src/components/layout/HeaderQuickNav.test.tsx` | Passed (25 tests) |
| Targeted lint | `npx eslint src/api/search.ts src/api/search.test.ts src/components/layout/HeaderQuickNav.tsx src/components/layout/HeaderQuickNav.test.tsx e2e/global-search.spec.ts` | Passed |
| Formatting | `npx prettier --check src/api/search.ts src/api/search.test.ts src/components/layout/HeaderQuickNav.tsx src/components/layout/HeaderQuickNav.test.tsx e2e/global-search.spec.ts` | Passed |
| TypeScript | `npx tsc -b --pretty false` | Passed |

---

## ✅ Checklist

- [x] Code formatted
- [x] Tests added/updated for changes
- [x] Documentation updated (not applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

Targets `epic/ui-rewrite`, where the React UI implementation lives.
