### PR TITLE
fix(teams): scope admin team listings by token teams

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -1949,10 +1949,9 @@ async def _get_user_team_ids(user: dict, db: Session) -> list:
     if cached is not None:
         return cached
 
-    if "token_teams" in user:
-        team_ids = extract_token_team_ids(user)
-        if team_ids is not None:
-            return team_ids
+    team_ids = extract_token_team_ids(user)
+    if team_ids is not None:
+        return team_ids
 
     user_email = get_user_email(user)
     team_service = TeamManagementService(db)
@@ -1992,9 +1991,7 @@ def _is_explicit_token_team_scope(user: Any) -> bool:
     Returns:
         bool: True when ``token_teams`` is present and not ``None``.
     """
-    if not isinstance(user, dict):
-        return False
-    return "token_teams" in user and user.get("token_teams") is not None
+    return extract_token_team_ids(user) is not None
 
 
 def _owner_access_condition(owner_column, team_column, *, user_email: str, team_ids: list[str], user: Any):

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -68,6 +68,7 @@ from mcpgateway.auth import get_current_user, get_user_team_roles
 # Re-export canonical get_user_email from auth_context for backward compatibility.
 from mcpgateway.auth_context import (
     configuration_export_includes_roots,
+    extract_token_team_ids,
     get_scoped_resource_access_context,
     get_token_teams_from_request,
     get_user_email,
@@ -1949,16 +1950,8 @@ async def _get_user_team_ids(user: dict, db: Session) -> list:
         return cached
 
     if "token_teams" in user:
-        token_teams = user.get("token_teams")
-        if token_teams is not None:
-            team_ids: list[str] = []
-            for team in token_teams:
-                if isinstance(team, dict):
-                    team_id = team.get("id")
-                    if isinstance(team_id, str) and team_id:
-                        team_ids.append(team_id)
-                elif isinstance(team, str) and team:
-                    team_ids.append(team)
+        team_ids = extract_token_team_ids(user)
+        if team_ids is not None:
             return team_ids
 
     user_email = get_user_email(user)
@@ -5346,13 +5339,14 @@ async def change_password_required_handler(request: Request, db: Session = Depen
 # ============================================================================ #
 
 
-async def _generate_unified_teams_view(team_service, current_user, root_path):  # pylint: disable=unused-argument
+async def _generate_unified_teams_view(team_service, current_user, root_path, scoped_team_ids: Optional[list[str]] = None):  # pylint: disable=unused-argument
     """Generate unified team view with relationship badges.
 
     Args:
         team_service: Service for team operations
         current_user: Current authenticated user
         root_path: Application root path
+        scoped_team_ids: Explicit token team scope to apply to the generated list
 
     Returns:
         HTML string containing the unified teams view
@@ -5362,6 +5356,11 @@ async def _generate_unified_teams_view(team_service, current_user, root_path):  
 
     # Get public teams user can join
     public_teams = await team_service.discover_public_teams(current_user.email)
+
+    if scoped_team_ids is not None:
+        allowed_team_ids = set(scoped_team_ids)
+        user_teams = [team for team in user_teams if str(team.id) in allowed_team_ids]
+        public_teams = [team for team in public_teams if str(team.id) in allowed_team_ids]
 
     # Batch fetch ALL data upfront - 3 queries instead of 3N queries (N+1 elimination)
     user_team_ids = [str(t.id) for t in user_teams]
@@ -5646,10 +5645,7 @@ async def admin_search_teams(
         # the result. The scope is pushed into the query so it applies before
         # pagination (an allowed team must not be dropped for sorting past the
         # first page) and so an explicit scope no longer surfaces the personal team.
-        raw_token_teams = user.get("token_teams")
-        admin_scoped_team_ids: Optional[list[str]] = None
-        if raw_token_teams is not None:
-            admin_scoped_team_ids = [team["id"] if isinstance(team, dict) else team for team in raw_token_teams]
+        admin_scoped_team_ids = extract_token_team_ids(user)
         result = await team_service.list_teams(
             page=1,
             per_page=limit,
@@ -5749,6 +5745,8 @@ async def admin_teams_partial_html(
     if not current_user:
         return HTMLResponse(content='<div class="text-center py-8"><p class="text-red-500">User not found</p></div>', status_code=404)
 
+    scoped_team_ids = extract_token_team_ids(user)
+
     # Get user's teams and public teams for relationship info
     user_teams = await team_service.get_user_teams(user_email, include_personal=True)
     user_team_ids = {str(t.id) for t in user_teams}
@@ -5768,7 +5766,15 @@ async def admin_teams_partial_html(
     if current_user.is_admin and not relationship:
         # Admin sees all non-personal teams plus their own personal team (single query, correct pagination)
         paginated_result = await team_service.list_teams(
-            page=page, per_page=per_page, include_inactive=include_inactive, visibility_filter=visibility, base_url=base_url, include_personal=False, search_query=q, personal_owner_email=user_email
+            page=page,
+            per_page=per_page,
+            include_inactive=include_inactive,
+            visibility_filter=visibility,
+            base_url=base_url,
+            include_personal=False,
+            search_query=q,
+            personal_owner_email=user_email,
+            team_ids=scoped_team_ids,
         )
         data = paginated_result["data"]
         pagination = paginated_result["pagination"]
@@ -5789,6 +5795,10 @@ async def admin_teams_partial_html(
         else:
             # All teams: user's teams + public teams they can join
             all_teams = list(user_teams) + list(public_teams)
+
+        if scoped_team_ids is not None:
+            allowed_team_ids = set(scoped_team_ids)
+            all_teams = [t for t in all_teams if str(t.id) in allowed_team_ids]
 
         # Apply search filter
         if q:
@@ -5968,10 +5978,11 @@ async def admin_list_teams(
             return HTMLResponse(content='<div class="text-center py-8"><p class="text-red-500">User not found</p></div>', status_code=200)
 
         root_path = _resolve_root_path(request)
+        scoped_team_ids = extract_token_team_ids(user)
 
         if unified:
             # Generate unified team view
-            return await _generate_unified_teams_view(team_service, current_user, root_path)
+            return await _generate_unified_teams_view(team_service, current_user, root_path, scoped_team_ids=scoped_team_ids)
 
         # Traditional admin view refactored to use partial logic
         # We can reuse the logic by calling the service directly or redirecting?
@@ -5986,12 +5997,23 @@ async def admin_list_teams(
                 base_url += f"?q={urllib.parse.quote(q, safe='')}"
 
             # Admin sees all non-personal teams plus their own personal team (single query, correct pagination)
-            paginated_result = await team_service.list_teams(page=page, per_page=per_page, base_url=base_url, include_personal=False, search_query=q, personal_owner_email=user_email)
+            paginated_result = await team_service.list_teams(
+                page=page,
+                per_page=per_page,
+                base_url=base_url,
+                include_personal=False,
+                search_query=q,
+                personal_owner_email=user_email,
+                team_ids=scoped_team_ids,
+            )
             data = paginated_result["data"]
             pagination = paginated_result["pagination"]
             links = paginated_result["links"]
         else:
             all_teams = await team_service.get_user_teams(current_user.email, include_personal=True)
+            if scoped_team_ids is not None:
+                allowed_team_ids = set(scoped_team_ids)
+                all_teams = [team for team in all_teams if str(team.id) in allowed_team_ids]
             # Basic pagination for user view
             total = len(all_teams)
             start = (page - 1) * per_page

--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -71,6 +71,7 @@ The names below are the **module's public API**. Callers in ``main.py``,
         has_valid_internal_mcp_runtime_auth_header(request) -> bool
 
     Per-request JWT / scope resolution (the Layer-1 surface)
+        extract_token_team_ids(user_context) -> list[str] | None
         get_token_teams_from_request(request) -> list[str] | None
         get_rpc_filter_context(request, user) -> (email, teams, is_admin)
         get_request_identity(request, user) -> (email, is_admin)
@@ -114,7 +115,7 @@ policy. The key invariants that this module enforces:
 
 # Standard
 import base64
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from functools import lru_cache
 import hashlib
 import hmac
@@ -282,6 +283,52 @@ def normalize_token_teams(payload: Dict[str, Any]) -> Optional[List[str]]:
         elif isinstance(team, str):
             normalized.append(team)
     return normalized
+
+
+def extract_token_team_ids(user_context: Any) -> Optional[List[str]]:
+    """Extract explicit token team IDs from an authenticated user context.
+
+    This helper consumes the already-normalized ``token_teams`` value placed in
+    request/user context by auth middleware. It intentionally preserves context
+    key-presence semantics: a missing key is not the same thing as a JWT missing
+    its ``teams`` claim, because JWT normalization has already happened before
+    these endpoint helpers run.
+
+    Args:
+        user_context: Authenticated user context, normally a dict.
+
+    Returns:
+        ``None`` when no explicit endpoint-level narrowing should be applied,
+        or a list of normalized team IDs. An explicit empty list remains
+        ``[]`` and should match no teams.
+
+    Examples:
+        >>> extract_token_team_ids({})
+        >>> extract_token_team_ids({"token_teams": None})
+        >>> extract_token_team_ids({"token_teams": []})
+        []
+        >>> extract_token_team_ids({"token_teams": ["team-a", {"id": "team-b"}, {"id": ""}, 1]})
+        ['team-a', 'team-b']
+    """
+    if not isinstance(user_context, Mapping) or "token_teams" not in user_context:
+        return None
+
+    token_teams = user_context.get("token_teams")
+    if token_teams is None:
+        return None
+
+    if not isinstance(token_teams, list):
+        return []
+
+    team_ids: List[str] = []
+    for team in token_teams:
+        if isinstance(team, Mapping):
+            team_id = team.get("id")
+            if isinstance(team_id, str) and team_id:
+                team_ids.append(team_id)
+        elif isinstance(team, str) and team:
+            team_ids.append(team)
+    return team_ids
 
 
 def get_jwt_user_email_from_payload(payload: dict[str, Any]) -> str | None:

--- a/mcpgateway/routers/teams.py
+++ b/mcpgateway/routers/teams.py
@@ -26,6 +26,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 # First-Party
+from mcpgateway.auth_context import extract_token_team_ids
 from mcpgateway.common.query_params import QueryPaginationCursor, QueryPaginationCursorGeneric
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
@@ -195,6 +196,7 @@ async def list_teams(
         teams_data = []
         next_cursor = None
         total = 0
+        scoped_team_ids = extract_token_team_ids(current_user_ctx)
 
         # Check admin permissions using PermissionService (handles both is_admin flag and RBAC)
         permission_service = PermissionService(db)
@@ -216,15 +218,19 @@ async def list_teams(
                 offset=skip,
                 cursor=cursor,
                 personal_owner_email=current_user_ctx["email"],
+                team_ids=scoped_team_ids,
             )
             # Result is tuple (list, next_cursor)
             teams_data, next_cursor = result
 
             # Get accurate total count for API consumers
-            total = await service.get_teams_count(personal_owner_email=current_user_ctx["email"])
+            total = await service.get_teams_count(personal_owner_email=current_user_ctx["email"], team_ids=scoped_team_ids)
         else:
             # Fallback to user teams and apply pagination locally
             user_teams = await service.get_user_teams(current_user_ctx["email"], include_personal=True)
+            if scoped_team_ids is not None:
+                allowed_team_ids = set(scoped_team_ids)
+                user_teams = [team for team in user_teams if str(team.id) in allowed_team_ids]
             total = len(user_teams)
             teams_data = user_teams[skip : skip + limit]
 

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -1963,6 +1963,7 @@ class TeamManagementService:
         include_personal: bool = False,
         search_query: Optional[str] = None,
         personal_owner_email: Optional[str] = None,
+        team_ids: Optional[List[str]] = None,
     ) -> int:
         """Get total count of teams matching criteria.
 
@@ -1972,6 +1973,7 @@ class TeamManagementService:
             include_personal: Whether to include personal teams
             search_query: Search term for name/slug
             personal_owner_email: When set (and include_personal=False), includes this user's personal team in the count
+            team_ids: When set, restrict the count to these team IDs. An empty list matches no teams.
 
         Returns:
             int: Total count of matching teams
@@ -1984,6 +1986,9 @@ class TeamManagementService:
             search_query=search_query,
             personal_owner_email=personal_owner_email,
         )
+
+        if team_ids is not None:
+            query = query.where(EmailTeam.id.in_(team_ids))
 
         result = self.db.execute(query)
         count = result.scalar() or 0

--- a/tests/unit/mcpgateway/routers/test_teams.py
+++ b/tests/unit/mcpgateway/routers/test_teams.py
@@ -385,8 +385,54 @@ class TestTeamsRouter:
             assert len(result.teams) == 1
             assert result.teams[0].id == mock_team.id
             # personal_owner_email must be forwarded so an admin sees their own personal team (issue #5391)
-            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com")
-            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com")
+            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com", team_ids=None)
+            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com", team_ids=None)
+
+    @pytest.mark.asyncio
+    async def test_list_teams_scoped_admin_forwards_team_ids_to_query_and_count(self, mock_admin_context, mock_team, mock_db):
+        """A narrowed admin token scopes both the listed teams and the pagination total."""
+        scoped_context = {**mock_admin_context, "token_teams": ["team-b", {"id": "team-c"}]}
+        mock_team.id = "team-b"
+
+        with mock_permission_check(is_admin=True), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
+            mock_service = AsyncMock(spec=TeamManagementService)
+            mock_service.list_teams = AsyncMock(return_value=([mock_team], None))
+            mock_service.get_teams_count = AsyncMock(return_value=1)
+            mock_service.get_member_counts_batch_cached = AsyncMock(return_value={"team-b": 1})
+            MockService.return_value = mock_service
+
+            from mcpgateway.routers.teams import list_teams
+
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, current_user_ctx=scoped_context, db=mock_db)
+
+            assert len(result.teams) == 1
+            assert result.teams[0].id == "team-b"
+            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com", team_ids=["team-b", "team-c"])
+            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com", team_ids=["team-b", "team-c"])
+
+    @pytest.mark.asyncio
+    async def test_list_teams_public_only_admin_token_returns_no_fallback_teams(self, mock_admin_context, mock_team, mock_db):
+        """A public-only admin token falls through permission-wise but still sees zero teams."""
+        public_only_context = {**mock_admin_context, "token_teams": []}
+
+        with mock_permission_check(is_admin=False), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
+            mock_service = AsyncMock(spec=TeamManagementService)
+            mock_service.get_user_teams = AsyncMock(return_value=[mock_team])
+            mock_service.list_teams = AsyncMock()
+            mock_service.get_teams_count = AsyncMock()
+            mock_service.get_member_counts_batch_cached = AsyncMock(return_value={})
+            MockService.return_value = mock_service
+
+            from mcpgateway.routers.teams import list_teams
+
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, current_user_ctx=public_only_context, db=mock_db)
+
+            assert result.teams == []
+            assert result.total == 0
+            mock_service.get_user_teams.assert_called_once_with("admin@example.com", include_personal=True)
+            mock_service.list_teams.assert_not_called()
+            mock_service.get_teams_count.assert_not_called()
+            mock_service.get_member_counts_batch_cached.assert_called_once_with([])
 
     @pytest.mark.asyncio
     async def test_list_teams_admin_includes_own_personal_team(self, mock_admin_context, mock_team, mock_db):
@@ -413,8 +459,8 @@ class TestTeamsRouter:
             assert len(result.teams) == 1
             assert result.teams[0].id == personal_team.id
             assert result.total == 1
-            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com")
-            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com")
+            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com", team_ids=None)
+            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com", team_ids=None)
 
     @pytest.mark.asyncio
     async def test_list_teams_admin_with_cursor_pagination(self, mock_admin_context, mock_team, mock_db):
@@ -530,7 +576,7 @@ class TestTeamsRouter:
             # SSO platform_admin should see all teams (admin path)
             assert len(result.teams) == 1
             assert result.teams[0].id == mock_team.id
-            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="sso-admin@example.com")
+            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="sso-admin@example.com", team_ids=None)
             mock_perm_service.check_platform_admin_permission.assert_called_once_with(
                 mock_sso_platform_admin_context["email"],
                 token_teams=mock_sso_platform_admin_context.get("token_teams"),
@@ -583,8 +629,8 @@ class TestTeamsRouter:
 
             assert result.teams == []
             assert result.total == 0
-            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com")
-            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com")
+            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com", team_ids=None)
+            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com", team_ids=None)
 
     @pytest.mark.asyncio
     async def test_list_teams_sso_platform_admin_includes_own_personal_team(self, mock_sso_platform_admin_context, mock_team, mock_db):
@@ -616,8 +662,8 @@ class TestTeamsRouter:
             assert len(result.teams) == 1
             assert result.teams[0].id == personal_team.id
             # The caller's own email (not a client-supplied value) scopes the personal team.
-            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="sso-admin@example.com")
-            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="sso-admin@example.com")
+            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="sso-admin@example.com", team_ids=None)
+            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="sso-admin@example.com", team_ids=None)
 
     @pytest.mark.asyncio
     async def test_create_team_sso_platform_admin_bypass_limits(self, mock_sso_platform_admin_context, mock_team, mock_db):

--- a/tests/unit/mcpgateway/services/test_team_management_service.py
+++ b/tests/unit/mcpgateway/services/test_team_management_service.py
@@ -1085,10 +1085,12 @@ class TestTeamManagementService:
             svc = TeamManagementService(db)
             scoped, _ = await svc.list_teams(team_ids=["id-b"])
             scoped_names = {t.name for t in scoped}
+            empty, _ = await svc.list_teams(team_ids=[])
             unfiltered, _ = await svc.list_teams(team_ids=None)
             unfiltered_names = {t.name for t in unfiltered}
 
         assert scoped_names == {"Beta"}  # restricted to the given id
+        assert empty == []  # explicit empty scope matches no teams
         assert {"Alpha", "Beta"} <= unfiltered_names  # None = no filter
 
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/services/test_team_management_service.py
+++ b/tests/unit/mcpgateway/services/test_team_management_service.py
@@ -1166,6 +1166,34 @@ class TestTeamManagementService:
         assert result == 4
         mock_db.commit.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_get_teams_count_team_ids_filters_count(self):
+        """team_ids restricts the count; an explicit empty list matches no teams."""
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import Session as OrmSession
+
+        from mcpgateway.db import Base
+
+        engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+        Base.metadata.create_all(engine)
+        with OrmSession(engine) as db:
+            db.add_all(
+                [
+                    EmailTeam(id="id-a", name="Alpha", slug="alpha-count", created_by="o@example.com", is_personal=False),
+                    EmailTeam(id="id-b", name="Beta", slug="beta-count", created_by="o@example.com", is_personal=False),
+                ]
+            )
+            db.commit()
+
+            svc = TeamManagementService(db)
+            scoped_count = await svc.get_teams_count(team_ids=["id-b"])
+            empty_count = await svc.get_teams_count(team_ids=[])
+            unfiltered_count = await svc.get_teams_count(team_ids=None)
+
+        assert scoped_count == 1
+        assert empty_count == 0
+        assert unfiltered_count >= 2
+
     # =========================================================================
     # Discovery and Join Request Tests
     # =========================================================================

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -8964,6 +8964,39 @@ async def test_admin_list_teams_admin_view_forwards_scoped_team_ids(monkeypatch,
 
 
 @pytest.mark.asyncio
+async def test_admin_list_teams_admin_view_public_only_token_lists_no_teams(monkeypatch, mock_request, mock_db, allow_permission):
+    monkeypatch.setattr(settings, "email_auth_enabled", True)
+    current_user = SimpleNamespace(email="u@example.com", is_admin=True)
+    auth_service = MagicMock()
+    auth_service.get_user_by_email = AsyncMock(return_value=current_user)
+    monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
+
+    pagination = MagicMock()
+    pagination.model_dump.return_value = {"page": 1, "total_items": 0}
+    links = MagicMock()
+    links.model_dump.return_value = {"self": "/admin/teams?page=1"}
+
+    team_service = MagicMock()
+    team_service.list_teams = AsyncMock(return_value={"data": [], "pagination": pagination, "links": links})
+    team_service.get_member_counts_batch_cached = AsyncMock(return_value={})
+    monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+
+    response = await admin_list_teams(
+        request=mock_request,
+        page=1,
+        per_page=5,
+        q=None,
+        db=mock_db,
+        user={"email": "u@example.com", "db": mock_db, "token_teams": []},
+    )
+
+    assert isinstance(response, HTMLResponse)
+    assert team_service.list_teams.await_args.kwargs["team_ids"] == []
+    template_call = mock_request.app.state.templates.TemplateResponse.call_args
+    assert template_call[0][2]["data"] == []
+
+
+@pytest.mark.asyncio
 async def test_admin_list_teams_non_admin_view(monkeypatch, mock_request, mock_db, allow_permission):
     monkeypatch.setattr(settings, "email_auth_enabled", True)
     current_user = SimpleNamespace(email="u@example.com", is_admin=False)
@@ -10404,6 +10437,47 @@ async def test_admin_teams_partial_html_admin_forwards_scoped_team_ids(monkeypat
 
     assert isinstance(response, HTMLResponse)
     assert team_service.list_teams.await_args.kwargs["team_ids"] == ["team-2"]
+
+
+@pytest.mark.asyncio
+async def test_admin_teams_partial_html_admin_public_only_token_lists_no_teams(monkeypatch, mock_request, mock_db, allow_permission):
+    monkeypatch.setattr(settings, "email_auth_enabled", True)
+    current_user = SimpleNamespace(email="u@example.com", is_admin=True)
+    auth_service = MagicMock()
+    auth_service.get_user_by_email = AsyncMock(return_value=current_user)
+    monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
+
+    pagination = MagicMock()
+    pagination.model_dump.return_value = {"page": 1, "total_items": 0}
+    links = MagicMock()
+    links.model_dump.return_value = {"self": "/admin/teams/partial?page=1"}
+
+    team_service = MagicMock()
+    team_service.get_user_teams = AsyncMock(return_value=[])
+    team_service.get_user_roles_batch.return_value = {}
+    team_service.discover_public_teams = AsyncMock(return_value=[])
+    team_service.get_pending_join_requests_batch.return_value = {}
+    team_service.list_teams = AsyncMock(return_value={"data": [], "pagination": pagination, "links": links})
+    team_service.get_member_counts_batch_cached = AsyncMock(return_value={})
+    monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+
+    response = await admin_teams_partial_html(
+        request=mock_request,
+        page=1,
+        per_page=5,
+        include_inactive=False,
+        visibility=None,
+        render=None,
+        q=None,
+        relationship=None,
+        db=mock_db,
+        user={"email": "u@example.com", "db": mock_db, "token_teams": []},
+    )
+
+    assert isinstance(response, HTMLResponse)
+    assert team_service.list_teams.await_args.kwargs["team_ids"] == []
+    template_call = mock_request.app.state.templates.TemplateResponse.call_args
+    assert template_call[0][2]["data"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -8849,10 +8849,60 @@ async def test_admin_list_teams_unified(monkeypatch, mock_request, mock_db, allo
     auth_service = MagicMock()
     auth_service.get_user_by_email = AsyncMock(return_value=current_user)
     monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
-    monkeypatch.setattr("mcpgateway.admin._generate_unified_teams_view", AsyncMock(return_value=HTMLResponse("ok")))
+    generate_view = AsyncMock(return_value=HTMLResponse("ok"))
+    monkeypatch.setattr("mcpgateway.admin._generate_unified_teams_view", generate_view)
     response = await admin_list_teams(request=mock_request, page=1, per_page=5, q=None, db=mock_db, user={"email": "u@example.com", "db": mock_db}, unified=True)
     assert isinstance(response, HTMLResponse)
     assert response.body.decode() == "ok"
+    generate_view.assert_awaited_once()
+    assert generate_view.await_args.kwargs["scoped_team_ids"] is None
+
+
+@pytest.mark.asyncio
+async def test_admin_list_teams_unified_forwards_scoped_team_ids(monkeypatch, mock_request, mock_db, allow_permission):
+    monkeypatch.setattr(settings, "email_auth_enabled", True)
+    current_user = SimpleNamespace(email="u@example.com", is_admin=True)
+    auth_service = MagicMock()
+    auth_service.get_user_by_email = AsyncMock(return_value=current_user)
+    monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
+    generate_view = AsyncMock(return_value=HTMLResponse("ok"))
+    monkeypatch.setattr("mcpgateway.admin._generate_unified_teams_view", generate_view)
+
+    response = await admin_list_teams(
+        request=mock_request,
+        page=1,
+        per_page=5,
+        q=None,
+        db=mock_db,
+        user={"email": "u@example.com", "db": mock_db, "token_teams": ["team-1", {"id": "team-2"}]},
+        unified=True,
+    )
+
+    assert isinstance(response, HTMLResponse)
+    assert generate_view.await_args.kwargs["scoped_team_ids"] == ["team-1", "team-2"]
+
+
+@pytest.mark.asyncio
+async def test_generate_unified_teams_view_filters_scoped_team_ids():
+    current_user = SimpleNamespace(email="u@example.com")
+    alpha = SimpleNamespace(id="team-1", name="Alpha", is_personal=False, visibility="private", created_by="u@example.com", description="")
+    beta = SimpleNamespace(id="team-2", name="Beta", is_personal=False, visibility="private", created_by="u@example.com", description="")
+    gamma_public = SimpleNamespace(id="team-3", name="Gamma", is_personal=False, visibility="public", created_by="other@example.com", description="")
+
+    team_service = MagicMock()
+    team_service.get_user_teams = AsyncMock(return_value=[alpha, beta])
+    team_service.discover_public_teams = AsyncMock(return_value=[gamma_public])
+    team_service.get_member_counts_batch_cached = AsyncMock(return_value={"team-2": 1})
+    team_service.get_user_roles_batch.return_value = {"team-2": "member"}
+    team_service.get_pending_join_requests_batch.return_value = {}
+
+    response = await _generate_unified_teams_view(team_service, current_user, root_path="", scoped_team_ids=["team-2"])
+    body = response.body.decode()
+
+    assert "Beta" in body
+    assert "Alpha" not in body
+    assert "Gamma" not in body
+    team_service.get_member_counts_batch_cached.assert_awaited_once_with(["team-2"])
 
 
 @pytest.mark.asyncio
@@ -8878,6 +8928,39 @@ async def test_admin_list_teams_admin_view(monkeypatch, mock_request, mock_db, a
     response = await admin_list_teams(request=mock_request, page=1, per_page=5, q="t", db=mock_db, user={"email": "u@example.com", "db": mock_db})
     assert isinstance(response, HTMLResponse)
     assert team.member_count == 3
+    assert team_service.list_teams.await_args.kwargs["team_ids"] is None
+
+
+@pytest.mark.asyncio
+async def test_admin_list_teams_admin_view_forwards_scoped_team_ids(monkeypatch, mock_request, mock_db, allow_permission):
+    monkeypatch.setattr(settings, "email_auth_enabled", True)
+    current_user = SimpleNamespace(email="u@example.com", is_admin=True)
+    auth_service = MagicMock()
+    auth_service.get_user_by_email = AsyncMock(return_value=current_user)
+    monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
+
+    team = SimpleNamespace(id="team-2", name="Team Two")
+    pagination = MagicMock()
+    pagination.model_dump.return_value = {"page": 1}
+    links = MagicMock()
+    links.model_dump.return_value = {"self": "/admin/teams?page=1"}
+
+    team_service = MagicMock()
+    team_service.list_teams = AsyncMock(return_value={"data": [team], "pagination": pagination, "links": links})
+    team_service.get_member_counts_batch_cached = AsyncMock(return_value={"team-2": 1})
+    monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+
+    response = await admin_list_teams(
+        request=mock_request,
+        page=1,
+        per_page=5,
+        q=None,
+        db=mock_db,
+        user={"email": "u@example.com", "db": mock_db, "token_teams": ["team-2"]},
+    )
+
+    assert isinstance(response, HTMLResponse)
+    assert team_service.list_teams.await_args.kwargs["team_ids"] == ["team-2"]
 
 
 @pytest.mark.asyncio
@@ -10281,6 +10364,46 @@ async def test_admin_teams_partial_html_controls_admin(monkeypatch, mock_request
         user={"email": "u@example.com", "db": mock_db},
     )
     assert isinstance(response, HTMLResponse)
+    assert team_service.list_teams.await_args.kwargs["team_ids"] is None
+
+
+@pytest.mark.asyncio
+async def test_admin_teams_partial_html_admin_forwards_scoped_team_ids(monkeypatch, mock_request, mock_db, allow_permission):
+    monkeypatch.setattr(settings, "email_auth_enabled", True)
+    current_user = SimpleNamespace(email="u@example.com", is_admin=True)
+    auth_service = MagicMock()
+    auth_service.get_user_by_email = AsyncMock(return_value=current_user)
+    monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
+
+    team = SimpleNamespace(id="team-2", name="Team Two", slug="team-two", description="Desc", visibility="private", is_active=True)
+    pagination = MagicMock()
+    pagination.model_dump.return_value = {"page": 1}
+    links = MagicMock()
+    links.model_dump.return_value = {"self": "/admin/teams/partial?page=1"}
+
+    team_service = MagicMock()
+    team_service.get_user_teams = AsyncMock(return_value=[])
+    team_service.get_user_roles_batch.return_value = {}
+    team_service.discover_public_teams = AsyncMock(return_value=[])
+    team_service.get_pending_join_requests_batch.return_value = {}
+    team_service.list_teams = AsyncMock(return_value={"data": [team], "pagination": pagination, "links": links})
+    monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+
+    response = await admin_teams_partial_html(
+        request=mock_request,
+        page=1,
+        per_page=5,
+        include_inactive=False,
+        visibility=None,
+        render="controls",
+        q=None,
+        relationship=None,
+        db=mock_db,
+        user={"email": "u@example.com", "db": mock_db, "token_teams": ["team-2"]},
+    )
+
+    assert isinstance(response, HTMLResponse)
+    assert team_service.list_teams.await_args.kwargs["team_ids"] == ["team-2"]
 
 
 @pytest.mark.asyncio
@@ -10407,6 +10530,48 @@ async def test_admin_teams_partial_html_admin_relationship_none(monkeypatch, moc
     template_call = mock_request.app.state.templates.TemplateResponse.call_args
     data = template_call[0][2]["data"]
     assert data[0].relationship == "none"
+
+
+@pytest.mark.asyncio
+async def test_admin_teams_partial_html_relationship_branch_applies_token_scope(monkeypatch, mock_request, mock_db, allow_permission):
+    """A relationship filter skips the admin query branch, so the manual list must still be scoped."""
+    monkeypatch.setattr(settings, "email_auth_enabled", True)
+
+    current_user = SimpleNamespace(email="u@example.com", is_admin=True)
+    auth_service = MagicMock()
+    auth_service.get_user_by_email = AsyncMock(return_value=current_user)
+    monkeypatch.setattr("mcpgateway.admin.EmailAuthService", lambda db: auth_service)
+
+    alpha = SimpleNamespace(id="team-1", name="Alpha", slug="alpha", description="", visibility="private", is_active=True, is_personal=False)
+    beta = SimpleNamespace(id="team-2", name="Beta", slug="beta", description="", visibility="private", is_active=True, is_personal=False)
+
+    team_service = MagicMock()
+    team_service.get_user_teams = AsyncMock(return_value=[alpha, beta])
+    team_service.get_user_roles_batch.return_value = {"team-1": "member", "team-2": "member"}
+    team_service.discover_public_teams = AsyncMock(return_value=[])
+    team_service.get_pending_join_requests_batch.return_value = {}
+    team_service.get_member_counts_batch_cached = AsyncMock(return_value={"team-2": 1})
+    team_service.list_teams = AsyncMock()
+    monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+
+    response = await admin_teams_partial_html(
+        request=mock_request,
+        page=1,
+        per_page=5,
+        include_inactive=False,
+        visibility=None,
+        render=None,
+        q=None,
+        relationship="member",
+        db=mock_db,
+        user={"email": "u@example.com", "db": mock_db, "token_teams": ["team-2"]},
+    )
+
+    assert isinstance(response, HTMLResponse)
+    template_call = mock_request.app.state.templates.TemplateResponse.call_args
+    data = template_call[0][2]["data"]
+    assert [team.id for team in data] == ["team-2"]
+    team_service.list_teams.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_api_versioning_parity.py
+++ b/tests/unit/mcpgateway/test_api_versioning_parity.py
@@ -232,6 +232,19 @@ class TestPluginBindingsRoutePrefixes:
         assert not any(p.startswith("/v1") for p in paths), "Legacy mount must not contain /v1 paths"
 
 
+def test_teams_list_route_is_dual_mounted(monkeypatch):
+    """The teams list handler is served under canonical /v1 and legacy aliases."""
+    monkeypatch.setattr(settings, "email_auth_enabled", True)
+    v1_router = build_v1_router(settings, **_empty_router_kwargs())
+    legacy_router = build_legacy_router(settings, **_empty_router_kwargs())
+
+    v1_paths = [p for p, *_ in collect_routes(v1_router)]
+    legacy_paths = [p for p, *_ in collect_routes(legacy_router)]
+
+    assert "/v1/teams/" in v1_paths
+    assert "/teams/" in legacy_paths
+
+
 def test_llm_admin_router_csrf_dependency():
     """Verify llm_admin_router is mounted with enforce_admin_csrf dependency.
 

--- a/tests/unit/mcpgateway/test_token_scoping.py
+++ b/tests/unit/mcpgateway/test_token_scoping.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 # First-Party
 from mcpgateway.auth import normalize_token_teams
+from mcpgateway.auth_context import extract_token_team_ids
 
 # ---------------------------------------------------------------------------
 # D2.1: normalize_token_teams truth table
@@ -105,6 +106,26 @@ class TestNormalizeTokenTeams:
         """Dict with id=None is skipped."""
         result = normalize_token_teams({"teams": [{"id": None}]})
         assert result == []
+
+
+class TestExtractTokenTeamIds:
+    """Test endpoint-level extraction from already-normalized user contexts."""
+
+    def test_missing_token_teams_preserves_fallback(self):
+        """Missing context key is not re-normalized as public-only."""
+        assert extract_token_team_ids({"email": "admin@example.com"}) is None
+
+    def test_none_token_teams_preserves_admin_bypass(self):
+        """token_teams=None means no endpoint-level narrowing."""
+        assert extract_token_team_ids({"token_teams": None}) is None
+
+    def test_empty_token_teams_stays_empty(self):
+        """Explicit empty scope remains deny-all for team listings."""
+        assert extract_token_team_ids({"token_teams": []}) == []
+
+    def test_mixed_entries_extract_ids(self):
+        """String IDs and dict-shaped IDs are normalized to a list of strings."""
+        assert extract_token_team_ids({"token_teams": ["team-a", {"id": "team-b"}, {"id": ""}, 42]}) == ["team-a", "team-b"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #5812.

This fixes the three team-listing endpoints named by the issue so explicit token team scope constrains what an admin token can see:

- `GET /admin/teams/partial`
- `GET /admin/teams`
- `GET /v1/teams/` and its legacy alias `GET /teams/`

The change adds a shared endpoint-context helper for extracting `token_teams`, threads that scope into the affected listing queries and manual listing branches, and scopes the API pagination total through `TeamManagementService.get_teams_count(team_ids=...)`.

## Scope

This fix operates at Layer 1 visibility filtering and does not change Layer 2 RBAC/admin privilege semantics. `check_platform_admin_permission()` is unchanged by design: it answers whether the caller has platform-admin privileges and also gates team create/update/delete paths. Narrowing its return value for scoped tokens would revoke write privileges as a side effect of this read-visibility fix. Instead, explicit token scope is pushed into the listing query/result path so the affected lists return only what the token permits.

`admin_search_teams` now reuses the shared extraction helper instead of duplicating token-team parsing inline. That keeps #5668 behavior aligned with the same normalized scope semantics used by the three team-listing endpoints and drops malformed entries rather than raising on them.

## Deferred

Not addressed here: `GET /admin/teams/ids` still calls `get_all_team_ids()` without token scope. It is the same class of leak, but it is not one of the three endpoints named by #5812 and needs separate `team_ids` plumbing on `TeamManagementService.get_all_team_ids()`.

Documentation updates in `docs/docs/manage/rbac.md` and `docs/docs/architecture/multitenancy.md` are also deferred. The code change here is intentionally scoped to the three named endpoints plus the service plumbing those endpoints require.