### PR TITLE
fix: make dist no longer wipes venv; MANIFEST.in toml glob breaks make verify

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-07T15:28:06Z",
+  "generated_at": "2026-08-10T12:45:48Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1894,7 +1894,7 @@
         "hashed_secret": "1a6222d0fd7cf8ec9f3da30d4369f45b30e81afb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 489,
+        "line_number": 507,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-07T14:56:50Z",
+  "generated_at": "2026-08-07T15:28:06Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -390,7 +390,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6064,
+        "line_number": 6065,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6561,
+        "line_number": 6562,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6573,
+        "line_number": 6574,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6645,
+        "line_number": 6646,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7061,
+        "line_number": 7062,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -430,7 +430,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7752,
+        "line_number": 7753,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1894,7 +1894,7 @@
         "hashed_secret": "1a6222d0fd7cf8ec9f3da30d4369f45b30e81afb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 507,
+        "line_number": 489,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,7 +22,11 @@ include *.py
 include *.md
 include *.example
 include *.properties
-include *.toml
+# Root *.toml files are listed explicitly: a blanket glob also sweeps untracked
+# local tool configs into the sdist, which breaks `make verify` (check-manifest).
+include deny.toml
+include fly.toml
+include license-policy.toml
 include *.yaml
 include *.yml
 include *.json

--- a/Makefile
+++ b/Makefile
@@ -4784,8 +4784,9 @@ deps-update:
 # =============================================================================
 .PHONY: dist wheel sdist verify publish publish-testpypi
 
-dist: clean uv               ## Build wheel + sdist into ./dist (optionally includes Rust)
+dist: uv                     ## Build wheel + sdist into ./dist (optionally includes Rust)
 	@echo "📦 Building Python package..."
+	@rm -rf dist build *.egg-info
 	@BUILD_UI_ASSETS=true $(UV_BIN) build
 	@if [ "$(ENABLE_RUST_BUILD)" = "1" ]; then \
 		echo "🦀 Building Rust..."; \


### PR DESCRIPTION
## 📌 Summary

Fixes two packaging bugs that made `make dist` destructive and `make verify` fail on developer machines.

Closes #6092

## 🐞 Root Cause

1. **`make dist`** had `clean` as a prerequisite. `clean` removes `$(VENV_DIR)`, `.ruff_cache`, `.mypy_cache`, `htmlcov`, and the rest of `DIRS_TO_CLEAN`/`FILES_TO_CLEAN` — so every build wiped the virtualenv and required a full re-install before `make dev`/`make test`. The build only needs stale `dist/`, `build/`, and `*.egg-info` gone to stay reproducible.

2. **`make verify`** runs `uvx check-manifest`, which resolves `MANIFEST.in` globs against the working tree, not the git index. `include *.toml` therefore matched any untracked root-level `.toml` (local tool configs, scratch files) and `check-manifest` exited non-zero.

## 💡 Fix Description

- `Makefile`: drop `clean` from `dist`'s prerequisites; scope cleanup to `@rm -rf dist build *.egg-info` inline.
- `MANIFEST.in`: replace `include *.toml` with explicit `deny.toml`, `fly.toml`, `license-policy.toml`. `pyproject.toml`, `Cargo.toml`, and `rust-toolchain.toml` were already listed explicitly and are untouched, so sdist contents are unchanged.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] No secrets/credentials committed

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Build no longer wipes venv/caches | `make dist` | ✅ |
| Packaging validation passes | `make verify` | ✅ |

Build-tooling change only — no runtime code paths touched, so no unit tests are added.
