### PR TITLE
chore: added AUTH_ENCRYPTION_SECRET unconditional strength enforcement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,8 @@
 # ⚠️  SECURITY WARNING: JWT_SECRET_KEY and AUTH_ENCRYPTION_SECRET are REQUIRED
 #     in EVERY environment — including local development.
 #     The application will refuse to start if either value is a placeholder
-#     (__REPLACE_ME__) or a known-weak default.
+#     (__REPLACE_ME__), a known-weak default, shorter than 32 characters,
+#     or has low entropy. Both conditions are enforced in every environment.
 #
 # Quickstart (fresh checkout):
 #   1. make install-dev          # installs Python deps — does NOT touch .env
@@ -1334,8 +1335,8 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 #   - Use TRUST_PROXY_AUTH=true with a reverse proxy for user identification
 
 # Used to derive an AES encryption key for secure auth storage
-# Must be a non-empty string (e.g. passphrase or random secret)
-# Generate with: python3 -m mcpgateway.scripts.init_secrets
+# Must be at least 32 characters with high entropy — startup fails otherwise.
+# Generate with: make init-secrets-patch-env  (or python3 -m mcpgateway.scripts.init_secrets)
 # AUTH_ENCRYPTION_SECRET=
 
 # Identity Propagation - forward end-user identity to upstream MCP servers

--- a/.env.example
+++ b/.env.example
@@ -12,15 +12,10 @@
 # REQUIRED SECRETS - Application will NOT start without these
 # =============================================================================
 #
-# ⚠️  SECURITY WARNING: JWT_SECRET_KEY is REQUIRED in every environment —
-#     including local development. The application will refuse to start if the
-#     value is a placeholder (__REPLACE_ME__), known-weak, too short, or low-entropy.
-#
-# ℹ️  AUTH_ENCRYPTION_SECRET follows the same rules in staging and production.
-#     In ENVIRONMENT=development it is relaxed: weak/short values emit a loud
-#     WARNING and startup continues, so local PoC workflows can use a simple
-#     value like AUTH_ENCRYPTION_SECRET=my-test-salt.
-#     The __REPLACE_ME__ placeholder is always rejected for both fields.
+# ⚠️  SECURITY WARNING: JWT_SECRET_KEY and AUTH_ENCRYPTION_SECRET are REQUIRED
+#     in EVERY environment — including local development.
+#     The application will refuse to start if either value is a placeholder
+#     (__REPLACE_ME__) or a known-weak default.
 #
 # Quickstart (fresh checkout):
 #   1. make install-dev          # installs Python deps — does NOT touch .env
@@ -43,7 +38,7 @@
 #   make setup / make init-secrets-patch-env / --patch-env (in-place patch):
 #     - JWT_SECRET_KEY          (patched when placeholder or weak)
 #     - AUTH_ENCRYPTION_SECRET  (patched when placeholder or weak)
-#     - BASIC_AUTH_PASSWORD     (patched when "changeme" or placeholder)
+#     - BASIC_AUTH_PASSWORD     (patched when "changeme" or placeholder; 18 bytes → 24 chars)
 #     NOTE: PLATFORM_ADMIN_PASSWORD is NOT patched by this path — set it manually
 #           or via helm/k8s secrets before production deployment.
 #
@@ -53,24 +48,18 @@
 # Generate with: python3 -m mcpgateway.scripts.init_secrets
 JWT_SECRET_KEY=__REPLACE_ME__run_init-secrets_before_starting
 
-# Passphrase used to encrypt stored auth secrets.
-# REQUIRED in staging/production — must be strong (≥32 chars, non-weak, good entropy).
-# In ENVIRONMENT=development a short/weak vawlue is allowed (warns at startup).
-# The __REPLACE_ME__ placeholder is rejected in every environment.
-# Generate a strong value with: python3 -m mcpgateway.scripts.init_secrets
-AUTH_ENCRYPTION_SECRET=__REPLACE_ME__run_init-secrets_before_starting # pragma: allowlist secret
+# Passphrase used to encrypt stored auth secrets (REQUIRED — all environments, including development)
+# Generate with: python3 -m mcpgateway.scripts.init_secrets
+AUTH_ENCRYPTION_SECRET=__REPLACE_ME__run_init-secrets_before_starting
 
 # =============================================================================
 # Environment Mode
 # =============================================================================
-# Controls CORS, cookie security, operational defaults, and secret enforcement:
-# - development: Relaxed CORS (localhost:3000/8080), insecure cookies, dev info.
-#                AUTH_ENCRYPTION_SECRET weak/short values warn instead of hard-failing.
-#                JWT_SECRET_KEY is still unconditionally enforced.
-# - staging:     Production-like CORS and cookie defaults, staging domain.
-#                Both secrets fully enforced.
-# - production:  Strict CORS (APP_DOMAIN only), secure cookies, no debug info.
-#                Both secrets fully enforced.
+# Controls CORS, cookie security, and operational defaults — but NOT secret
+# enforcement. Placeholder/weak secrets are rejected in every environment.
+# - development: Relaxed CORS (localhost:3000/8080), insecure cookies, dev info
+# - staging: Production-like CORS and cookie defaults, staging domain
+# - production: Strict CORS (APP_DOMAIN only), secure cookies, no debug info
 # Default: development (if not set)
 ENVIRONMENT=development
 
@@ -1344,12 +1333,10 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 #   - Team membership validation is skipped (no JWT to extract teams from)
 #   - Use TRUST_PROXY_AUTH=true with a reverse proxy for user identification
 
-# Used to derive an AES encryption key for secure auth storage.
-# In staging/production: must be strong (≥32 chars, non-weak, good entropy).
-# In ENVIRONMENT=development: weak/short values are allowed (emit a WARNING at startup).
-# The __REPLACE_ME__ placeholder is always rejected regardless of environment.
-# Generate a strong value with: python3 -m mcpgateway.scripts.init_secrets
-# AUTH_ENCRYPTION_SECRET=my-test-salt  # pragma: allowlist secret
+# Used to derive an AES encryption key for secure auth storage
+# Must be a non-empty string (e.g. passphrase or random secret)
+# Generate with: python3 -m mcpgateway.scripts.init_secrets
+# AUTH_ENCRYPTION_SECRET=
 
 # Identity Propagation - forward end-user identity to upstream MCP servers
 # IDENTITY_PROPAGATION_ENABLED=false

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-12T15:30:22Z",
+  "generated_at": "2026-08-13T08:31:27Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -89,10 +89,10 @@
     ],
     ".env.example": [
       {
-        "hashed_secret": "07d79dfd9ad52d9706b1dc4685d018fdbe522f68",
+        "hashed_secret": "15ab6d87c10ed359ba98e6a578764fa53954fdfc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 54,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -100,7 +100,7 @@
         "hashed_secret": "548a5cde15c93a9e50e12e4cba776b85f6befc83",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 134,
+        "line_number": 124,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -108,7 +108,7 @@
         "hashed_secret": "8e9a8667ded25c805ce3dc920a5f2343bd2d198f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 135,
+        "line_number": 125,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -116,7 +116,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 779,
+        "line_number": 769,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1024,
+        "line_number": 1014,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1323,
+        "line_number": 1313,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1360,
+        "line_number": 1348,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1449,
+        "line_number": 1437,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1454,
+        "line_number": 1442,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1459,
+        "line_number": 1447,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1465,
+        "line_number": 1453,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1477,
+        "line_number": 1465,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1495,
+        "line_number": 1483,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1556,
+        "line_number": 1544,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -229,7 +229,7 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
+        "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
         "line_number": 304,
@@ -331,18 +331,10 @@
     ],
     "Makefile": [
       {
-        "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 335,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 577,
+        "line_number": 576,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +342,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1055,
+        "line_number": 1054,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +350,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1057,
+        "line_number": 1056,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +358,7 @@
         "hashed_secret": "db69d9215c29ae2f2e4ead587890a9f8455059dd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1131,
+        "line_number": 1130,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +366,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1711,
+        "line_number": 1710,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +374,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1930,
+        "line_number": 1929,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6079,
+        "line_number": 6078,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6576,
+        "line_number": 6575,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6588,
+        "line_number": 6587,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6660,
+        "line_number": 6659,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +414,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7076,
+        "line_number": 7075,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -430,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7767,
+        "line_number": 7766,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -622,14 +614,6 @@
       }
     ],
     "charts/mcp-stack/values.yaml": [
-      {
-        "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 824,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
       {
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
@@ -4641,6 +4625,24 @@
         "verified_result": null
       }
     ],
+    "tests/scripts/test_init_secrets.py": [
+      {
+        "hashed_secret": "61ae516fe556ac031cfa24a280de3822d9c4cdb9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 444,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c9ea447161081f3688e5360597ab2ae22ec43be6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 448,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
     "tests/unit/mcpgateway/services/test_mcp_client_chat_service_extended.py": [
       {
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
@@ -4673,10 +4675,10 @@
     ],
     "tests/unit/mcpgateway/test_config.py": [
       {
-        "hashed_secret": "15ab6d87c10ed359ba98e6a578764fa53954fdfc",
+        "hashed_secret": "a24a9eab46fcd2eb51c24d7e647a1e398c2c4b26",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2112,
+        "line_number": 2191,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-13T10:07:37Z",
+  "generated_at": "2026-08-13T12:51:52Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6087,
+        "line_number": 6086,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6584,
+        "line_number": 6583,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6596,
+        "line_number": 6595,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6668,
+        "line_number": 6667,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7084,
+        "line_number": 7083,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7775,
+        "line_number": 7774,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,7 +301,7 @@ JWT_SECRET_KEY=your-secret-key
 BASIC_AUTH_USER=admin
 BASIC_AUTH_PASSWORD=changeme
 AUTH_REQUIRED=true                   # Set false ONLY for development
-AUTH_ENCRYPTION_SECRET=my-test-salt  # For encrypting stored secrets
+AUTH_ENCRYPTION_SECRET=             # REQUIRED: generate with: make init-secrets-patch-env
 
 # Features
 MCPGATEWAY_UI_ENABLED=false          # .env.example sets true

--- a/Makefile
+++ b/Makefile
@@ -331,8 +331,7 @@ install-dev: venv
 	@echo "🔑  Next step — choose one:"
 	@echo "    make setup           # recommended: auto-creates .env and patches secrets in-place"
 	@echo "    make init-secrets    # writes secrets to .env.secrets so you can review before copying"
-	@echo "    JWT_SECRET_KEY must be strong in every environment."
-	@echo "    AUTH_ENCRYPTION_SECRET: weak values (e.g. my-test-salt) are allowed in ENVIRONMENT=development."
+	@echo "    The gateway will not start until JWT_SECRET_KEY and AUTH_ENCRYPTION_SECRET are set."
 
 # help: build-ui              - Build Admin UI CSS and JS bundles (requires npm; set SKIP_UI_BUILD=1 to bypass)
 .PHONY: build-ui
@@ -376,7 +375,7 @@ check-env-dev:
 
 # help: init-secrets          - Generate secrets → .env.secrets for manual review; copy values into .env when ready
 # help: init-secrets-force    - Regenerate .env.secrets unconditionally (no prompt)
-# help: init-secrets-patch-env - Patch JWT_SECRET_KEY/BASIC_AUTH_PASSWORD into .env; AUTH_ENCRYPTION_SECRET written to .env.secrets only
+# help: init-secrets-patch-env - Write generated secrets directly into .env (in-place, preserves other values)
 .PHONY: init-secrets init-secrets-force init-secrets-patch-env
 init-secrets:                   ## 🔑 Generate secrets → .env.secrets (prompts if file exists)
 	$(UV_BIN) run python3 -m mcpgateway.scripts.init_secrets
@@ -384,7 +383,7 @@ init-secrets:                   ## 🔑 Generate secrets → .env.secrets (promp
 init-secrets-force:             ## 🔑 Regenerate .env.secrets unconditionally (--force)
 	$(UV_BIN) run python3 -m mcpgateway.scripts.init_secrets --force
 
-init-secrets-patch-env:         ## 🔑 Patch JWT_SECRET_KEY into .env; AUTH_ENCRYPTION_SECRET written to .env.secrets only (--patch-env)
+init-secrets-patch-env:         ## 🔑 Patch weak/placeholder secrets directly into .env (--patch-env)
 	$(UV_BIN) run python3 -m mcpgateway.scripts.init_secrets --patch-env .env
 
 # First-time setup: works before make dev, make serve, and make compose-up.

--- a/charts/mcp-stack/README.md
+++ b/charts/mcp-stack/README.md
@@ -758,7 +758,7 @@ For detailed guidance on resource limits and process management, see `docs/docs/
 | mcpContextForge.secret.REQUIRE_TOKEN_EXPIRATION | string | `"true"` |  |
 | mcpContextForge.secret.REQUIRE_JTI | string | `"true"` |  |
 | mcpContextForge.secret.REQUIRE_USER_IN_DB | string | `"false"` |  |
-| mcpContextForge.secret.AUTH_ENCRYPTION_SECRET | string | `"my-test-salt"` |  |
+| mcpContextForge.secret.AUTH_ENCRYPTION_SECRET | string | `""` |  |
 | mcpContextForge.secret.EMAIL_AUTH_ENABLED | string | `"true"` |  |
 | mcpContextForge.secret.PROTECT_ALL_ADMINS | string | `"true"` |  |
 | mcpContextForge.secret.PLATFORM_ADMIN_EMAIL | string | `"admin@example.com"` |  |

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -821,7 +821,7 @@ mcpContextForge:
     REQUIRE_TOKEN_EXPIRATION: "true"       # require all JWT tokens to have expiration claims
     REQUIRE_JTI: "true"                    # require JTI (JWT ID) claim for revocation support
     REQUIRE_USER_IN_DB: "false"            # require all users to exist in database (disables platform admin bootstrap)
-    AUTH_ENCRYPTION_SECRET: my-test-salt   # passphrase to derive AES key for secure storage
+    AUTH_ENCRYPTION_SECRET: ""             # REQUIRED: passphrase to derive AES key for secure storage — must be set before deploying; generate with: make init-secrets-patch-env
     ALLOW_UNAUTHENTICATED_ADMIN: "false"  # DANGER: grants admin to unauthenticated requests when AUTH_REQUIRED=false
     TRUST_PROXY_AUTH_DANGEROUSLY: "false" # DANGER: trusts proxy identity headers without JWT verification
     PUBLIC_REGISTRATION_ENABLED: "false"  # disable public self-registration (admin must create accounts)

--- a/docs/docs/architecture/explorer.html
+++ b/docs/docs/architecture/explorer.html
@@ -4562,7 +4562,7 @@ var CONFIG_CATEGORIES = [
     { name:"BASIC_AUTH_USER", def:"admin", desc:"Admin UI HTTP Basic Auth username", req:true },
     { name:"BASIC_AUTH_PASSWORD", def:"changeme", desc:"Admin UI HTTP Basic Auth password", req:true },
     { name:"JWT_SECRET_KEY", def:"my-test-key-...", desc:"JWT signing secret (min 32 bytes)", req:true },
-    { name:"AUTH_ENCRYPTION_SECRET", def:"my-test-salt", desc:"AES passphrase for encrypting stored secrets", req:true },
+    { name:"AUTH_ENCRYPTION_SECRET", def:"", desc:"AES passphrase for encrypting stored secrets — must be set; generate with: make init-secrets-patch-env", req:true },
     { name:"PLATFORM_ADMIN_EMAIL", def:"admin@example.com", desc:"Bootstrap admin email (email auth)", req:true },
     { name:"PLATFORM_ADMIN_PASSWORD", def:"changeme", desc:"Bootstrap admin password", req:true },
     { name:"DEFAULT_USER_PASSWORD", def:"changeme", desc:"Default password for seeded users", req:true }

--- a/docs/docs/architecture/oauth-authorization-code-ui-design.md
+++ b/docs/docs/architecture/oauth-authorization-code-ui-design.md
@@ -298,7 +298,7 @@ For user authentication and RBAC configuration, see [RBAC Configuration](../mana
 | --- | --- | --- |
 | `OAUTH_REQUEST_TIMEOUT` | `30` | Timeout for OAuth HTTP requests |
 | `OAUTH_MAX_RETRIES` | `3` | Retry count for token exchanges |
-| `AUTH_ENCRYPTION_SECRET` | `my-test-salt` | Encrypts OAuth tokens and signs state |
+| `AUTH_ENCRYPTION_SECRET` | *(must be set — no default)* | Encrypts OAuth tokens and signs state; generate with `make init-secrets-patch-env` |
 | `CACHE_TYPE` | `database` | `redis`, `database`, `memory`, or `none` |
 | `REDIS_URL` | `redis://localhost:6379` | Required when `CACHE_TYPE=redis` |
 | `DATABASE_URL` | `sqlite:///./mcp.db` | Required when `CACHE_TYPE=database` |

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -470,7 +470,7 @@ These variables have insecure defaults and **must be changed** before production
 | Variable | Description | Default | Action Required |
 |----------|-------------|---------|-----------------|
 | `JWT_SECRET_KEY` | Secret key for signing JWT tokens (32+ chars) | `my-test-key-but-now-longer-than-32-bytes` | Generate with `openssl rand -hex 32` |
-| `AUTH_ENCRYPTION_SECRET` | Passphrase for encrypting stored credentials | `my-test-salt` | Generate with `openssl rand -hex 32` |
+| `AUTH_ENCRYPTION_SECRET` | Passphrase for encrypting stored credentials | *(must be set — no default)* | Generate with `make init-secrets-patch-env` or `openssl rand -hex 32` |
 | `BASIC_AUTH_USER` | Username for HTTP Basic auth | `admin` | Change for production |
 | `BASIC_AUTH_PASSWORD` | Password for HTTP Basic auth | `changeme` | Set a strong password |
 | `PLATFORM_ADMIN_EMAIL` | Email for bootstrap admin user | `admin@example.com` | Use real admin email |

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -130,7 +130,7 @@ ContextForge supports multiple database backends with full feature parity across
 | `REQUIRE_USER_IN_DB`        | Require all authenticated users to exist in the database                     | `false`             | bool        |
 | `EMBED_ENVIRONMENT_IN_TOKENS` | Embed environment claim in gateway-issued JWTs                             | `false`             | bool        |
 | `VALIDATE_TOKEN_ENVIRONMENT` | Reject tokens with mismatched environment claim                             | `false`             | bool        |
-| `AUTH_ENCRYPTION_SECRET`    | Passphrase used to derive AES key for encrypting tool auth headers           | `my-test-salt`      | string      |
+| `AUTH_ENCRYPTION_SECRET`    | Passphrase used to derive AES key for encrypting tool auth headers           | *(must be set)*     | string      |
 | `OAUTH_REQUEST_TIMEOUT`     | OAuth request timeout in seconds                                             | `30`                | int > 0     |
 | `OAUTH_MAX_RETRIES`         | Maximum retries for OAuth token requests                                     | `3`                 | int > 0     |
 | `INSECURE_ALLOW_QUERYPARAM_AUTH` | Enable query parameter authentication for gateways (see security warning) | `false`             | bool        |

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -10,8 +10,8 @@ These variables have insecure defaults and **must be changed** before production
 
 | Variable | Description | Default | Action Required |
 |----------|-------------|---------|-----------------|
-| `JWT_SECRET_KEY` | Secret key for signing JWT tokens | `my-test-key-but-now-longer-than-32-bytes` | Generate with `openssl rand -hex 32` |
-| `AUTH_ENCRYPTION_SECRET` | Passphrase for encrypting stored credentials | `my-test-salt` | Generate with `openssl rand -hex 32` |
+| `JWT_SECRET_KEY` | Secret key for signing JWT tokens | *(must be set — no default)* | Generate with `make init-secrets-patch-env` or `openssl rand -hex 32` |
+| `AUTH_ENCRYPTION_SECRET` | Passphrase for encrypting stored credentials | *(must be set — no default)* | Generate with `make init-secrets-patch-env` or `openssl rand -hex 32` |
 | `BASIC_AUTH_USER` | Username for HTTP Basic auth | `admin` | Change for production |
 | `BASIC_AUTH_PASSWORD` | Password for HTTP Basic auth | `changeme` | Set a strong password |
 | `PLATFORM_ADMIN_EMAIL` | Email for bootstrap admin user | `admin@example.com` | Use real admin email |

--- a/docs/docs/manage/oauth-troubleshooting.md
+++ b/docs/docs/manage/oauth-troubleshooting.md
@@ -507,7 +507,7 @@ DCR_METADATA_CACHE_TTL=3600
 | `CACHE_TYPE` | `database` | `database`, `redis`, `memory`, or `none` |
 | `REDIS_URL` | `redis://localhost:6379/0` | Redis connection string (when CACHE_TYPE=redis) |
 | `DATABASE_URL` | `sqlite:///./mcp.db` | Database for state storage |
-| `AUTH_ENCRYPTION_SECRET` | `my-test-salt` | Secret for HMAC signing states (change in production!) |
+| `AUTH_ENCRYPTION_SECRET` | *(must be set — no default)* | AES encryption key for OAuth tokens and state signatures; generate with `make init-secrets-patch-env` |
 | `OAUTH_REQUEST_TIMEOUT` | `30` | Timeout for OAuth requests (seconds) |
 | `OAUTH_MAX_RETRIES` | `3` | Max retries for token requests |
 | `LOG_LEVEL` | `INFO` | Set to `DEBUG` for troubleshooting |

--- a/mcpgateway/_security_constants.py
+++ b/mcpgateway/_security_constants.py
@@ -9,6 +9,28 @@ Must not import pydantic or any other mcpgateway module; init_secrets.py
 imports this before mcpgateway.config is loaded.
 """
 
+# Standard
+import math
+
+MIN_SECRET_LENGTH: int = 32
+MIN_ENTROPY: float = 3.5
+
+
+def calculate_entropy(text: str) -> float:
+    """Calculate Shannon entropy to detect low-randomness secrets.
+
+    Args:
+        text (str): The secret string to evaluate.
+
+    Returns:
+        float: The calculated entropy score.
+    """
+    if not text:
+        return 0.0
+    probabilities = [text.count(c) / len(text) for c in set(text)]
+    return -sum(p * math.log2(p) for p in probabilities)
+
+
 WEAK_VALUES: tuple[str, ...] = (
     "my-test-key",
     "my-test-key-but-now-longer-than-32-bytes",

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1535,9 +1535,10 @@ class Settings(BaseSettings):
             if not val.strip():
                 raise SecurityConfigurationError(f"{field_name}: secret is empty. Set a real value (run 'python -m mcpgateway.scripts.init_secrets').")
 
-            if len(val) < _MIN_SECRET_LENGTH:
+            effective_min = max(self.min_secret_length, _MIN_SECRET_LENGTH)
+            if len(val) < effective_min:
                 raise SecurityConfigurationError(
-                    f"{field_name}: too short ({len(val)} chars, minimum {_MIN_SECRET_LENGTH}). "
+                    f"{field_name}: too short ({len(val)} chars, minimum {effective_min}). "
                     "Run 'python -m mcpgateway.scripts.init_secrets' to generate strong values, "
                     "or use 'make init-secrets-patch-env' to write them directly into .env."
                 )

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -50,7 +50,6 @@ Examples:
 from functools import lru_cache
 from importlib.resources import files
 import logging
-import math
 import os
 from pathlib import Path, PurePosixPath
 import re
@@ -67,6 +66,7 @@ from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 # First-Party
 from mcpgateway._security_constants import WEAK_VALUES as _CANONICAL_WEAK_VALUES
+from mcpgateway._security_constants import calculate_entropy
 
 # Only configure basic logging if no handlers exist yet
 # This prevents conflicts with LoggingService while ensuring config logging works
@@ -168,22 +168,6 @@ UI_HIDE_SECTION_ALIASES = {
 
 class SecurityConfigurationError(Exception):
     """Exception for critical security configuration issues."""
-
-
-def calculate_entropy(text: str) -> float:
-    """
-    Calculate Shannon entropy to detect low-randomness secrets.
-
-    Args:
-        text (str): The secret string to evaluate.
-
-    Returns:
-        float: The calculated entropy score.
-    """
-    if not text:
-        return 0.0
-    probabilities = [text.count(c) / len(text) for c in set(text)]
-    return -sum(p * math.log2(p) for p in probabilities)
 
 
 class Settings(BaseSettings):

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -65,6 +65,8 @@ from pydantic import AliasChoices, Field, field_validator, HttpUrl, model_valida
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 # First-Party
+from mcpgateway._security_constants import MIN_ENTROPY as _MIN_ENTROPY
+from mcpgateway._security_constants import MIN_SECRET_LENGTH as _MIN_SECRET_LENGTH
 from mcpgateway._security_constants import WEAK_VALUES as _CANONICAL_WEAK_VALUES
 from mcpgateway._security_constants import calculate_entropy
 
@@ -1234,7 +1236,7 @@ class Settings(BaseSettings):
     }
 
     # Security validation thresholds
-    min_secret_length: int = 32
+    min_secret_length: int = Field(default=_MIN_SECRET_LENGTH, ge=_MIN_SECRET_LENGTH)
     min_password_length: int = 12
     require_strong_secrets: bool = Field(
         default=False,
@@ -1533,9 +1535,9 @@ class Settings(BaseSettings):
             if not val.strip():
                 raise SecurityConfigurationError(f"{field_name}: secret is empty. Set a real value (run 'python -m mcpgateway.scripts.init_secrets').")
 
-            if len(val) < self.min_secret_length:
+            if len(val) < _MIN_SECRET_LENGTH:
                 raise SecurityConfigurationError(
-                    f"{field_name}: too short ({len(val)} chars, minimum {self.min_secret_length}). "
+                    f"{field_name}: too short ({len(val)} chars, minimum {_MIN_SECRET_LENGTH}). "
                     "Run 'python -m mcpgateway.scripts.init_secrets' to generate strong values, "
                     "or use 'make init-secrets-patch-env' to write them directly into .env."
                 )
@@ -1543,7 +1545,7 @@ class Settings(BaseSettings):
             is_placeholder = val.lower().startswith("__replace_me__")
             is_weak = val.lower() in weak_secrets
             entropy = calculate_entropy(val)
-            is_low_entropy = entropy < 3.5
+            is_low_entropy = entropy < _MIN_ENTROPY
 
             if is_placeholder or is_weak or is_low_entropy:
                 if is_placeholder:
@@ -1551,7 +1553,7 @@ class Settings(BaseSettings):
                 elif is_weak:
                     reason = "known-weak/default value"
                 else:
-                    reason = f"low entropy (score {entropy:.2f} < 3.5)"
+                    reason = f"low entropy (score {entropy:.2f} < {_MIN_ENTROPY})"
                 raise SecurityConfigurationError(
                     f"{field_name}: {reason} rejected in every environment (including '{env}'). "
                     "Cross-process token consistency requires operators to supply a real secret before startup — "

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1515,19 +1515,14 @@ class Settings(BaseSettings):
     def validate_security_combinations(self) -> Self:
         """Validate security setting combinations and raise on unsafe secrets.
 
-        ``jwt_secret_key`` is rejected unconditionally in every environment
-        (development, staging, and production) when it is empty, a placeholder,
-        known-weak, too short, or low-entropy.  Some compose sibling containers
+        Placeholder and weak/known secrets are rejected unconditionally in every
+        environment (development, staging, and production alike).  Some compose
+        sibling containers (e.g. ``register_fast_time``, ``prometheus_token``)
         sign tokens with the raw ``JWT_SECRET_KEY`` environment variable outside
         this validator, so per-process random generation cannot be used as a
         fallback — gateway and sibling containers must share the same secret.
-
-        ``auth_encryption_secret`` follows the same rules in staging and
-        production.  In ``ENVIRONMENT=development``, weak/short/low-entropy
-        values are downgraded to a loud WARNING so local PoC workflows can use
-        a simple value like ``AUTH_ENCRYPTION_SECRET=my-test-salt``.  The
-        ``__REPLACE_ME__`` placeholder is still rejected unconditionally for
-        both fields in every environment — it has no runtime meaning.
+        The only safe option is an unconditional hard-fail that forces operators
+        to provide a real secret before the process will start.
 
         Run ``python -m mcpgateway.scripts.init_secrets`` (or ``make init-secrets``
         for interactive use, ``make init-secrets-patch-env`` to write directly into
@@ -1537,24 +1532,14 @@ class Settings(BaseSettings):
             Itself.
 
         Raises:
-            SecurityConfigurationError: If either secret is empty (both fields,
-                all environments), or if ``jwt_secret_key`` is the
-                ``__REPLACE_ME__`` placeholder, known-weak, too short, or has
-                low per-character entropy (all environments).
-                ``auth_encryption_secret`` only warns for ALL of these in
-                ``ENVIRONMENT=development`` — including the placeholder.
-                Full enforcement applies to ``auth_encryption_secret`` in
-                staging and production.
+            SecurityConfigurationError: If jwt_secret_key or auth_encryption_secret
+                is unset (placeholder), matches a known-weak value, is shorter than
+                ``min_secret_length`` characters, or has low per-character entropy.
         """
+        # client_mode is intentionally NOT exempted — secret-strength enforcement
+        # is always active regardless of deployment profile.
         weak_secrets = {v.lower() for v in self.WEAK_VALUES}
         env = str(self.environment).lower()
-        is_dev = env == "development"
-
-        # jwt_secret_key:          unconditional hard-fail in every environment.
-        # auth_encryption_secret:  ALL non-compliant values (placeholder, insufficient
-        #                          length, known-default, low entropy) are WARNING-only
-        #                          in ENVIRONMENT=development. Full enforcement in
-        #                          staging and production.
         for field_name, secret_field in (
             ("jwt_secret_key", self.jwt_secret_key),
             ("auth_encryption_secret", self.auth_encryption_secret),
@@ -1562,58 +1547,27 @@ class Settings(BaseSettings):
             val = secret_field.get_secret_value()
 
             if not val.strip():
+                raise SecurityConfigurationError(f"{field_name}: secret is empty. Set a real value (run 'python -m mcpgateway.scripts.init_secrets').")
+
+            if len(val) < self.min_secret_length:
                 raise SecurityConfigurationError(
-                    f"{field_name}: secret is empty. "
-                    "To fix, choose one of:\n"
-                    "  make setup                  # recommended: auto-creates .env and patches secrets in-place\n"
-                    "  make init-secrets           # writes secrets to .env.secrets for review, then copy into .env\n"
-                    "  make init-secrets-patch-env # patches secrets directly into an existing .env"
+                    f"{field_name}: too short ({len(val)} chars, minimum {self.min_secret_length}). "
+                    "Run 'python -m mcpgateway.scripts.init_secrets' to generate strong values, "
+                    "or use 'make init-secrets-patch-env' to write them directly into .env."
                 )
 
             is_placeholder = val.lower().startswith("__replace_me__")
             is_weak = val.lower() in weak_secrets
             entropy = calculate_entropy(val)
             is_low_entropy = entropy < 3.5
-            is_too_short = len(val) < self.min_secret_length
 
-            # auth_encryption_secret in development: ALL non-compliant values are
-            # downgraded to a WARNING — including the __REPLACE_ME__ placeholder.
-            # Production and staging always enforce full cryptographic strength.
-            if field_name == "auth_encryption_secret" and is_dev:
-                if is_placeholder or is_too_short or is_weak or is_low_entropy:
-                    logger.warning(
-                        "🔓 SECURITY WARNING - %s: value does not meet minimum cryptographic "
-                        "strength requirements (placeholder, insufficient length, known-default, "
-                        "or low entropy). Permitted only in ENVIRONMENT=development for local "
-                        "PoC use. This configuration MUST NOT be used in staging or production "
-                        "— replace with a cryptographically secure value before any "
-                        "non-development deployment.",
-                        field_name,
-                    )
-                continue
-
-            # For jwt_secret_key and auth_encryption_secret outside development:
-            # placeholder, too-short, weak, and low-entropy all hard-fail.
-            if is_placeholder:
-                raise SecurityConfigurationError(
-                    f"{field_name}: unset placeholder (__REPLACE_ME__) rejected in every environment (including '{env}'). "
-                    "To fix, choose one of:\n"
-                    "  make setup                  # recommended: auto-creates .env and patches secrets in-place\n"
-                    "  make init-secrets           # writes secrets to .env.secrets for review, then copy into .env\n"
-                    "  make init-secrets-patch-env # patches secrets directly into an existing .env"
-                )
-
-            if is_too_short:
-                raise SecurityConfigurationError(
-                    f"{field_name}: too short ({len(val)} chars, minimum {self.min_secret_length}). "
-                    "To fix, choose one of:\n"
-                    "  make setup                  # recommended: auto-creates .env and patches secrets in-place\n"
-                    "  make init-secrets           # writes secrets to .env.secrets for review, then copy into .env\n"
-                    "  make init-secrets-patch-env # patches secrets directly into an existing .env"
-                )
-
-            if is_weak or is_low_entropy:
-                reason = "known-weak/default value" if is_weak else f"low entropy (score {entropy:.2f} < 3.5)"
+            if is_placeholder or is_weak or is_low_entropy:
+                if is_placeholder:
+                    reason = "unset placeholder (__REPLACE_ME__)"
+                elif is_weak:
+                    reason = "known-weak/default value"
+                else:
+                    reason = f"low entropy (score {entropy:.2f} < 3.5)"
                 raise SecurityConfigurationError(
                     f"{field_name}: {reason} rejected in every environment (including '{env}'). "
                     "Cross-process token consistency requires operators to supply a real secret before startup — "

--- a/mcpgateway/scripts/init_secrets.py
+++ b/mcpgateway/scripts/init_secrets.py
@@ -115,11 +115,50 @@ def _is_strong_value(val: str, weak_values: frozenset[str]) -> bool:
     return True
 
 
+def _read_env_file(path: str) -> dict[str, str]:
+    """Parse KEY=VALUE pairs from an env file, skipping comments and blank lines.
+
+    Thin compatibility shim backed by ``dotenv_values`` so callers and tests
+    that import ``_read_env_file`` continue to work after the internal refactor
+    to ``dotenv_values``.  The returned dict uses the original key casing from
+    the file (i.e. uppercase-as-written), matching the previous hand-rolled
+    parser semantics.
+
+    Lines that do not contain an ``=`` sign (e.g. bare ``export FOO`` directives)
+    are skipped, preserving the behaviour of the original hand-rolled parser.
+
+    Args:
+        path: Path to the env file.
+
+    Returns:
+        dict: Parsed ``{KEY: value}`` mapping (original casing).  Empty dict
+        when the file does not exist.
+    """
+    try:
+        raw_lines = open(path, encoding="utf-8").readlines()
+    except FileNotFoundError:
+        return {}
+    keys_with_equals: set[str] = set()
+    for line in raw_lines:
+        stripped = line.strip()
+        if stripped.startswith("#") or not stripped:
+            continue
+        if "=" in stripped:
+            key = stripped.split("=", 1)[0].strip()
+            # Strip leading "export " so "export FOO=bar" registers as "FOO"
+            if key.lower().startswith("export "):
+                key = key[len("export ") :].strip()
+            keys_with_equals.add(key)
+    return {k: v for k, v in _dotenv_values(path).items() if k in keys_with_equals}
+
+
 def _merge_env_file(path: str, updates: dict[str, str]) -> None:
     """Merge key=value pairs into an env file.
 
-    Existing keys in *updates* are replaced in-place; new keys are appended.
-    All other content (comments, blanks, other keys) is preserved.
+    Existing keys in *updates* are replaced in-place (case-insensitive match
+    so ``auth_encryption_secret=weak`` is correctly replaced when the update
+    key is ``AUTH_ENCRYPTION_SECRET``); new keys are appended.  All other
+    content (comments, blanks, other keys) is preserved.
     File is written with owner-only permissions (0o600).
     """
     existing_lines: list[str] = []
@@ -129,15 +168,19 @@ def _merge_env_file(path: str, updates: dict[str, str]) -> None:
     except FileNotFoundError:
         pass
 
+    # Build a case-insensitive lookup: lowercase(update_key) → canonical update key
+    updates_ci: dict[str, str] = {k.lower(): k for k in updates}
+
     updated_keys: set[str] = set()
     new_lines: list[str] = []
     for line in existing_lines:
         stripped = line.strip()
         if stripped and not stripped.startswith("#") and "=" in stripped:
-            key = stripped.partition("=")[0].strip()
-            if key in updates:
-                new_lines.append(f"{key}={updates[key]}\n")
-                updated_keys.add(key)
+            file_key = stripped.partition("=")[0].strip()
+            canonical_key = updates_ci.get(file_key.lower())
+            if canonical_key is not None:
+                new_lines.append(f"{canonical_key}={updates[canonical_key]}\n")
+                updated_keys.add(canonical_key)
                 continue
         new_lines.append(line)
 
@@ -317,7 +360,11 @@ def main() -> None:
     # --patch-env: in-place update of an existing env file
     patch_target = args.patch_env
     if patch_target is not None:
-        generated = ensure_env_file_secrets(env_file=patch_target)
+        try:
+            generated = ensure_env_file_secrets(env_file=patch_target)
+        except ValueError as exc:
+            print(f"❌  {exc}", file=sys.stderr)
+            sys.exit(1)
         if generated:
             patched_keys = ", ".join(generated.keys())
             print(f"✅  Patched {patch_target}: generated strong values for {patched_keys}")

--- a/mcpgateway/scripts/init_secrets.py
+++ b/mcpgateway/scripts/init_secrets.py
@@ -237,13 +237,17 @@ def ensure_env_file_secrets(
 
     # Honour operator-raised MIN_SECRET_LENGTH floor (e.g. MIN_SECRET_LENGTH=64).
     # Precedence: os.environ > .env file > built-in constant — mirrors pydantic-settings.
-    # Using max() keeps the constant as the lower bound — never go below 32.
-    _min_raw = os.environ.get("MIN_SECRET_LENGTH") or _env_file_ci.get("min_secret_length") or str(_MIN_SECRET_LENGTH)
+    # Use is not None so that MIN_SECRET_LENGTH="" (unset in shell) correctly falls through
+    # to the .env value rather than being treated as an empty-string override.
+    _min_env = os.environ.get("MIN_SECRET_LENGTH")
+    _min_raw = _min_env if _min_env is not None else (_env_file_ci.get("min_secret_length") or str(_MIN_SECRET_LENGTH))
     try:
         configured_min: int = int(_min_raw)
     except ValueError:
         raise ValueError(f"MIN_SECRET_LENGTH={_min_raw!r} is not a valid integer. Set it to a whole number (e.g. MIN_SECRET_LENGTH=64).") from None
-    effective_min: int = max(configured_min, _MIN_SECRET_LENGTH)
+    if configured_min < _MIN_SECRET_LENGTH:
+        raise ValueError(f"MIN_SECRET_LENGTH={configured_min} is below the enforced minimum of {_MIN_SECRET_LENGTH}. Settings will reject it at startup — set it to {_MIN_SECRET_LENGTH} or higher.")
+    effective_min: int = configured_min
 
     for field, nbytes in _SECRET_FIELDS.items():
         # os.environ takes priority over .env (mirrors pydantic-settings behaviour)
@@ -259,9 +263,10 @@ def ensure_env_file_secrets(
             # always satisfies Settings.validate_security_combinations() on startup.
             token_bytes = max(nbytes, effective_min) if field in _STRONG_SECRET_FIELDS else nbytes
             new_val = generate_token(token_bytes)
-            if env_val is not None and field.lower() not in _env_file_ci:
-                # Weak value came from os.environ; patching environ is enough.
-                # Writing to .env would shadow subsequent env-var injections (Docker/K8s).
+            if env_val is not None and field.lower() not in _env_file_ci and field not in _STRONG_SECRET_FIELDS:
+                # Non-strong field (e.g. BASIC_AUTH_PASSWORD) with a weak value from
+                # os.environ only — patching environ is enough; writing to .env would
+                # shadow env-var injections in container setups.
                 env_only[field] = new_val
             elif env_val is not None and field in _ROTATION_GUARDED_FIELDS and _is_strong_value(_env_file_ci.get(field.lower(), ""), weak_values):
                 # The shell environment holds a weak value, but .env already contains a

--- a/mcpgateway/scripts/init_secrets.py
+++ b/mcpgateway/scripts/init_secrets.py
@@ -82,13 +82,6 @@ _SECRET_FIELDS: dict[str, int] = {
     "BASIC_AUTH_PASSWORD": 18,  # nosec B105 — patched when "changeme" or placeholder; 18 bytes → 24 chars
 }
 
-# Fields that are written to .env.secrets (--output / --stdout) but are NOT
-# patched into .env by --patch-env / ensure_env_file_secrets().
-# AUTH_ENCRYPTION_SECRET is intentionally excluded from auto-patching: in
-# ENVIRONMENT=development a weak value (e.g. my-test-salt) is allowed, so
-# operators should set it deliberately rather than having it silently replaced.
-_PATCH_ENV_SKIP_FIELDS: frozenset[str] = frozenset({"AUTH_ENCRYPTION_SECRET"})
-
 
 def _read_env_file(path: str) -> dict[str, str]:
     """Parse KEY=VALUE pairs from an env file, skipping comments and blank lines.
@@ -171,16 +164,11 @@ def ensure_env_file_secrets(
     env_file: str = ".env",
     weak_values: frozenset[str] | None = None,
 ) -> dict[str, str]:
-    """Check JWT_SECRET_KEY and BASIC_AUTH_PASSWORD for weak or placeholder values.
+    """Check JWT_SECRET_KEY, AUTH_ENCRYPTION_SECRET, and BASIC_AUTH_PASSWORD for weak or placeholder values.
 
     If weak values are detected, generates cryptographically strong replacements,
     merges them into *env_file* (creating the file if it does not exist), and
     patches ``os.environ`` so the running process picks them up without restart.
-
-    AUTH_ENCRYPTION_SECRET is intentionally NOT patched by this function.
-    In ENVIRONMENT=development a weak value (e.g. ``my-test-salt``) is allowed,
-    so operators should set it deliberately.  Strong values for it are still
-    written to .env.secrets by the --output / --stdout paths.
 
     Set ``MCPGATEWAY_AUTO_INIT_SECRETS=false`` to disable this behaviour (e.g.
     when secrets are injected via Vault or Kubernetes secrets and disk writes
@@ -202,8 +190,6 @@ def ensure_env_file_secrets(
     file_generated: dict[str, str] = {}
 
     for field, nbytes in _SECRET_FIELDS.items():
-        if field in _PATCH_ENV_SKIP_FIELDS:
-            continue  # never auto-patched into .env (see _PATCH_ENV_SKIP_FIELDS)
         # os.environ takes priority over .env (mirrors pydantic-settings behaviour)
         env_val = os.environ.get(field)
         current = env_val if env_val is not None else env_file_values.get(field, "changeme")
@@ -299,11 +285,9 @@ def main() -> None:
         metavar="ENV_FILE",
         default=None,
         help=(
-            "Patch an existing env file in-place: replace only the JWT_SECRET_KEY "
-            "and BASIC_AUTH_PASSWORD lines that still hold placeholder or weak values; "
-            "all other lines are preserved unchanged. No-ops if those keys are already strong. "
-            "AUTH_ENCRYPTION_SECRET is NOT patched — set it manually or use --stdout / "
-            "--output to get a strong value for .env.secrets."
+            "Patch an existing env file in-place: replace only the JWT_SECRET_KEY and "
+            "AUTH_ENCRYPTION_SECRET lines that still hold placeholder or weak values; "
+            "all other lines are preserved unchanged. No-ops if those keys are already strong."
         ),
     )
     args = parser.parse_args()

--- a/mcpgateway/scripts/init_secrets.py
+++ b/mcpgateway/scripts/init_secrets.py
@@ -236,8 +236,16 @@ def ensure_env_file_secrets(
     file_generated: dict[str, str] = {}
 
     # Honour operator-raised MIN_SECRET_LENGTH floor (e.g. MIN_SECRET_LENGTH=64).
-    # Using max() keeps the constant as the lower bound — never go below 32 bytes.
-    configured_min: int = int(os.environ.get("MIN_SECRET_LENGTH", _MIN_SECRET_LENGTH))
+    # Precedence: os.environ > .env file > built-in constant — mirrors pydantic-settings.
+    # Using max() keeps the constant as the lower bound — never go below 32.
+    _min_raw = os.environ.get("MIN_SECRET_LENGTH") or _env_file_ci.get("min_secret_length") or str(_MIN_SECRET_LENGTH)
+    try:
+        configured_min: int = int(_min_raw)
+    except ValueError:
+        raise ValueError(
+            f"MIN_SECRET_LENGTH={_min_raw!r} is not a valid integer. "
+            "Set it to a whole number (e.g. MIN_SECRET_LENGTH=64)."
+        ) from None
     effective_min: int = max(configured_min, _MIN_SECRET_LENGTH)
 
     for field, nbytes in _SECRET_FIELDS.items():

--- a/mcpgateway/scripts/init_secrets.py
+++ b/mcpgateway/scripts/init_secrets.py
@@ -235,6 +235,11 @@ def ensure_env_file_secrets(
     # Keys whose weak value came from .env (or was absent) — write to disk + environ.
     file_generated: dict[str, str] = {}
 
+    # Honour operator-raised MIN_SECRET_LENGTH floor (e.g. MIN_SECRET_LENGTH=64).
+    # Using max() keeps the constant as the lower bound — never go below 32 bytes.
+    configured_min: int = int(os.environ.get("MIN_SECRET_LENGTH", _MIN_SECRET_LENGTH))
+    effective_min: int = max(configured_min, _MIN_SECRET_LENGTH)
+
     for field, nbytes in _SECRET_FIELDS.items():
         # os.environ takes priority over .env (mirrors pydantic-settings behaviour)
         env_val = os.environ.get(field)
@@ -243,9 +248,12 @@ def ensure_env_file_secrets(
         is_non_compliant = not current.strip() or current.lower() in weak_values or current.lower().startswith("__replace_me__")
         # Length and entropy checks apply only to secrets that Settings hard-fails on startup.
         if not is_non_compliant and field in _STRONG_SECRET_FIELDS:
-            is_non_compliant = len(current) < _MIN_SECRET_LENGTH or calculate_entropy(current) < _MIN_ENTROPY
+            is_non_compliant = len(current) < effective_min or calculate_entropy(current) < _MIN_ENTROPY
         if is_non_compliant:
-            new_val = generate_token(nbytes)
+            # Size the generated token against the operator-configured floor so it
+            # always satisfies Settings.validate_security_combinations() on startup.
+            token_bytes = max(nbytes, effective_min) if field in _STRONG_SECRET_FIELDS else nbytes
+            new_val = generate_token(token_bytes)
             if env_val is not None and field.lower() not in _env_file_ci:
                 # Weak value came from os.environ; patching environ is enough.
                 # Writing to .env would shadow subsequent env-var injections (Docker/K8s).

--- a/mcpgateway/scripts/init_secrets.py
+++ b/mcpgateway/scripts/init_secrets.py
@@ -135,7 +135,8 @@ def _read_env_file(path: str) -> dict[str, str]:
         when the file does not exist.
     """
     try:
-        raw_lines = open(path, encoding="utf-8").readlines()
+        with open(path, encoding="utf-8") as fh:
+            raw_lines = fh.readlines()
     except FileNotFoundError:
         return {}
     keys_with_equals: set[str] = set()

--- a/mcpgateway/scripts/init_secrets.py
+++ b/mcpgateway/scripts/init_secrets.py
@@ -89,6 +89,28 @@ _SECRET_FIELDS: dict[str, int] = {
 # BASIC_AUTH_PASSWORD is excluded — Settings only warns on it, never hard-fails.
 _STRONG_SECRET_FIELDS: frozenset[str] = frozenset({"JWT_SECRET_KEY", "AUTH_ENCRYPTION_SECRET"})
 
+# Fields where auto-rotation without a data-migration is irreversible.
+# If the shell environment carries a weak value but .env already holds a strong
+# value for one of these fields, ensure_env_file_secrets() must NOT silently
+# overwrite the .env value — doing so rotates the AES key and makes all stored
+# encrypted credentials permanently unreadable.
+_ROTATION_GUARDED_FIELDS: frozenset[str] = frozenset({"AUTH_ENCRYPTION_SECRET"})
+
+
+def _is_strong_value(val: str, weak_values: frozenset[str]) -> bool:
+    """Return True when *val* passes all startup compliance checks.
+
+    Mirrors the predicate in :func:`ensure_env_file_secrets` so the rotation-guard
+    check uses identical criteria.
+    """
+    if not val.strip():
+        return False
+    if val.lower() in weak_values or val.lower().startswith("__replace_me__"):
+        return False
+    if len(val) < _MIN_SECRET_LENGTH or calculate_entropy(val) < _MIN_ENTROPY:
+        return False
+    return True
+
 
 def _read_env_file(path: str) -> dict[str, str]:
     """Parse KEY=VALUE pairs from an env file, skipping comments and blank lines.
@@ -211,6 +233,21 @@ def ensure_env_file_secrets(
                 # Weak value came from os.environ; patching environ is enough.
                 # Writing to .env would shadow subsequent env-var injections (Docker/K8s).
                 env_only[field] = new_val
+            elif env_val is not None and field in _ROTATION_GUARDED_FIELDS and _is_strong_value(env_file_values.get(field, ""), weak_values):
+                # The shell environment holds a weak value, but .env already contains a
+                # strong value for a rotation-guarded key (AUTH_ENCRYPTION_SECRET).
+                # Overwriting the .env value would silently rotate the AES encryption key
+                # and make all stored encrypted credentials permanently unreadable.
+                # Raise an actionable error instead of proceeding.
+                raise ValueError(
+                    f"{field}: shell environment holds a weak/non-compliant value that would "
+                    f"overwrite the strong value already present in {env_file!r}. "
+                    "Silently rotating this key would make all stored encrypted credentials "
+                    "permanently unreadable. To fix, choose one of:\n"
+                    f"  unset {field}           # let the strong .env value take effect\n"
+                    f"  export {field}=<strong> # set a strong value in your shell that matches {env_file!r}\n"
+                    "  run a migration-aware key rotation before changing this secret"
+                )
             else:
                 file_generated[field] = new_val
 

--- a/mcpgateway/scripts/init_secrets.py
+++ b/mcpgateway/scripts/init_secrets.py
@@ -32,7 +32,10 @@ import secrets
 import sys
 
 # First-Party
+from mcpgateway._security_constants import MIN_ENTROPY as _MIN_ENTROPY
+from mcpgateway._security_constants import MIN_SECRET_LENGTH as _MIN_SECRET_LENGTH
 from mcpgateway._security_constants import WEAK_VALUES as _CANONICAL_WEAK_VALUES
+from mcpgateway._security_constants import calculate_entropy
 
 
 def _secure_open_flags(force: bool) -> int:
@@ -189,11 +192,19 @@ def ensure_env_file_secrets(
     # Keys whose weak value came from .env (or was absent) — write to disk + environ.
     file_generated: dict[str, str] = {}
 
+    # Fields subject to the full compliance predicate (startup hard-fail): length + entropy enforced.
+    _STRONG_SECRET_FIELDS = {"JWT_SECRET_KEY", "AUTH_ENCRYPTION_SECRET"}
+
     for field, nbytes in _SECRET_FIELDS.items():
         # os.environ takes priority over .env (mirrors pydantic-settings behaviour)
         env_val = os.environ.get(field)
         current = env_val if env_val is not None else env_file_values.get(field, "changeme")
-        if current.lower() in weak_values or current.lower().startswith("__replace_me__"):
+        # Base checks apply to all fields: empty, known-weak name, placeholder.
+        is_non_compliant = not current.strip() or current.lower() in weak_values or current.lower().startswith("__replace_me__")
+        # Length and entropy checks apply only to secrets that Settings hard-fails on startup.
+        if not is_non_compliant and field in _STRONG_SECRET_FIELDS:
+            is_non_compliant = len(current) < _MIN_SECRET_LENGTH or calculate_entropy(current) < _MIN_ENTROPY
+        if is_non_compliant:
             new_val = generate_token(nbytes)
             if env_val is not None and field not in env_file_values:
                 # Weak value came from os.environ; patching environ is enough.

--- a/mcpgateway/scripts/init_secrets.py
+++ b/mcpgateway/scripts/init_secrets.py
@@ -85,6 +85,10 @@ _SECRET_FIELDS: dict[str, int] = {
     "BASIC_AUTH_PASSWORD": 18,  # nosec B105 — patched when "changeme" or placeholder; 18 bytes → 24 chars
 }
 
+# Fields subject to the full compliance predicate (startup hard-fail): length + entropy enforced.
+# BASIC_AUTH_PASSWORD is excluded — Settings only warns on it, never hard-fails.
+_STRONG_SECRET_FIELDS: frozenset[str] = frozenset({"JWT_SECRET_KEY", "AUTH_ENCRYPTION_SECRET"})
+
 
 def _read_env_file(path: str) -> dict[str, str]:
     """Parse KEY=VALUE pairs from an env file, skipping comments and blank lines.
@@ -191,9 +195,6 @@ def ensure_env_file_secrets(
     env_only: dict[str, str] = {}
     # Keys whose weak value came from .env (or was absent) — write to disk + environ.
     file_generated: dict[str, str] = {}
-
-    # Fields subject to the full compliance predicate (startup hard-fail): length + entropy enforced.
-    _STRONG_SECRET_FIELDS = {"JWT_SECRET_KEY", "AUTH_ENCRYPTION_SECRET"}
 
     for field, nbytes in _SECRET_FIELDS.items():
         # os.environ takes priority over .env (mirrors pydantic-settings behaviour)

--- a/mcpgateway/scripts/init_secrets.py
+++ b/mcpgateway/scripts/init_secrets.py
@@ -268,18 +268,20 @@ def ensure_env_file_secrets(
                 # os.environ only — patching environ is enough; writing to .env would
                 # shadow env-var injections in container setups.
                 env_only[field] = new_val
-            elif env_val is not None and field in _ROTATION_GUARDED_FIELDS and _is_strong_value(_env_file_ci.get(field.lower(), ""), weak_values):
-                # The shell environment holds a weak value, but .env already contains a
-                # strong value for a rotation-guarded key (AUTH_ENCRYPTION_SECRET).
-                # Overwriting the .env value would silently rotate the AES encryption key
-                # and make all stored encrypted credentials permanently unreadable.
-                # Raise an actionable error instead of proceeding.
+            elif env_val is not None and field in _ROTATION_GUARDED_FIELDS and (_env_file_ci.get(field.lower()) or "").strip():
+                # The shell environment holds a weak/non-compliant value, but .env already
+                # contains *any* pre-existing value for a rotation-guarded key
+                # (AUTH_ENCRYPTION_SECRET).  Overwriting it — even to replace a short value
+                # with a strong one — silently rotates the AES encryption key and makes all
+                # stored encrypted credentials permanently unreadable.  Raise an actionable
+                # error for every case, not just when the existing .env value is already
+                # strong.
                 raise ValueError(
                     f"{field}: shell environment holds a weak/non-compliant value that would "
-                    f"overwrite the strong value already present in {env_file!r}. "
+                    f"overwrite the value already present in {env_file!r}. "
                     "Silently rotating this key would make all stored encrypted credentials "
                     "permanently unreadable. To fix, choose one of:\n"
-                    f"  unset {field}           # let the strong .env value take effect\n"
+                    f"  unset {field}           # let the .env value take effect\n"
                     f"  export {field}=<strong> # set a strong value in your shell that matches {env_file!r}\n"
                     "  run a migration-aware key rotation before changing this secret"
                 )

--- a/mcpgateway/scripts/init_secrets.py
+++ b/mcpgateway/scripts/init_secrets.py
@@ -242,10 +242,7 @@ def ensure_env_file_secrets(
     try:
         configured_min: int = int(_min_raw)
     except ValueError:
-        raise ValueError(
-            f"MIN_SECRET_LENGTH={_min_raw!r} is not a valid integer. "
-            "Set it to a whole number (e.g. MIN_SECRET_LENGTH=64)."
-        ) from None
+        raise ValueError(f"MIN_SECRET_LENGTH={_min_raw!r} is not a valid integer. Set it to a whole number (e.g. MIN_SECRET_LENGTH=64).") from None
     effective_min: int = max(configured_min, _MIN_SECRET_LENGTH)
 
     for field, nbytes in _SECRET_FIELDS.items():

--- a/mcpgateway/scripts/init_secrets.py
+++ b/mcpgateway/scripts/init_secrets.py
@@ -31,6 +31,9 @@ import os
 import secrets
 import sys
 
+# Third-Party
+from dotenv import dotenv_values as _dotenv_values
+
 # First-Party
 from mcpgateway._security_constants import MIN_ENTROPY as _MIN_ENTROPY
 from mcpgateway._security_constants import MIN_SECRET_LENGTH as _MIN_SECRET_LENGTH
@@ -112,39 +115,6 @@ def _is_strong_value(val: str, weak_values: frozenset[str]) -> bool:
     return True
 
 
-def _read_env_file(path: str) -> dict[str, str]:
-    """Parse KEY=VALUE pairs from an env file, skipping comments and blank lines.
-
-    Handles: quoted values, ``export KEY=val`` prefix, inline ``# comments``,
-    and spaces around ``=``.  Matches python-dotenv parsing semantics so that
-    weak-value detection fires on the same string pydantic-settings would see.
-    """
-    result: dict[str, str] = {}
-    try:
-        with open(path, encoding="utf-8") as fh:
-            for line in fh:
-                line = line.strip()
-                if not line or line.startswith("#"):
-                    continue
-                if line.startswith("export "):
-                    line = line[len("export ") :]
-                if "=" not in line:
-                    continue
-                key, _, val = line.partition("=")
-                key = key.strip()
-                val = val.strip()
-                # Strip inline comment (space + #)
-                if " #" in val:
-                    val = val[: val.index(" #")].strip()
-                # Strip matching surrounding quotes
-                if len(val) >= 2 and val[0] == val[-1] and val[0] in ('"', "'"):
-                    val = val[1:-1]
-                result[key] = val
-    except FileNotFoundError:
-        pass
-    return result
-
-
 def _merge_env_file(path: str, updates: dict[str, str]) -> None:
     """Merge key=value pairs into an env file.
 
@@ -212,7 +182,10 @@ def ensure_env_file_secrets(
     if weak_values is None:
         weak_values = _WEAK_VALUES
 
-    env_file_values = _read_env_file(env_file)
+    env_file_values = dict(_dotenv_values(env_file))  # expands ${VAR} refs, matches pydantic-settings semantics
+    # Normalize keys for case-insensitive lookups — mirrors Settings case_sensitive=False so that
+    # 'auth_encryption_secret' and 'AUTH_ENCRYPTION_SECRET' in .env are treated as the same key.
+    _env_file_ci: dict[str, str] = {k.lower(): v for k, v in env_file_values.items()}
     # Keys whose weak value came from os.environ only — patch environ, skip disk write.
     env_only: dict[str, str] = {}
     # Keys whose weak value came from .env (or was absent) — write to disk + environ.
@@ -221,7 +194,7 @@ def ensure_env_file_secrets(
     for field, nbytes in _SECRET_FIELDS.items():
         # os.environ takes priority over .env (mirrors pydantic-settings behaviour)
         env_val = os.environ.get(field)
-        current = env_val if env_val is not None else env_file_values.get(field, "changeme")
+        current = env_val if env_val is not None else _env_file_ci.get(field.lower(), "changeme")
         # Base checks apply to all fields: empty, known-weak name, placeholder.
         is_non_compliant = not current.strip() or current.lower() in weak_values or current.lower().startswith("__replace_me__")
         # Length and entropy checks apply only to secrets that Settings hard-fails on startup.
@@ -229,11 +202,11 @@ def ensure_env_file_secrets(
             is_non_compliant = len(current) < _MIN_SECRET_LENGTH or calculate_entropy(current) < _MIN_ENTROPY
         if is_non_compliant:
             new_val = generate_token(nbytes)
-            if env_val is not None and field not in env_file_values:
+            if env_val is not None and field.lower() not in _env_file_ci:
                 # Weak value came from os.environ; patching environ is enough.
                 # Writing to .env would shadow subsequent env-var injections (Docker/K8s).
                 env_only[field] = new_val
-            elif env_val is not None and field in _ROTATION_GUARDED_FIELDS and _is_strong_value(env_file_values.get(field, ""), weak_values):
+            elif env_val is not None and field in _ROTATION_GUARDED_FIELDS and _is_strong_value(_env_file_ci.get(field.lower(), ""), weak_values):
                 # The shell environment holds a weak value, but .env already contains a
                 # strong value for a rotation-guarded key (AUTH_ENCRYPTION_SECRET).
                 # Overwriting the .env value would silently rotate the AES encryption key

--- a/mcpgateway/scripts/validate_env.py
+++ b/mcpgateway/scripts/validate_env.py
@@ -26,6 +26,10 @@ from typing import Optional
 from pydantic import SecretStr, ValidationError
 
 # First-Party
+from mcpgateway._security_constants import MIN_ENTROPY as _MIN_ENTROPY
+from mcpgateway._security_constants import MIN_SECRET_LENGTH as _MIN_SECRET_LENGTH
+from mcpgateway._security_constants import WEAK_VALUES as _WEAK_VALUES
+from mcpgateway._security_constants import calculate_entropy
 from mcpgateway.config import SecurityConfigurationError, Settings
 
 
@@ -148,26 +152,26 @@ def get_security_warnings(settings: Settings) -> list[str]:
 
     # --- JWT_SECRET_KEY ---
     jwt = settings.jwt_secret_key.get_secret_value() if isinstance(settings.jwt_secret_key, SecretStr) else settings.jwt_secret_key
-    weak_jwt = ["my-test-key", "my-test-key-but-now-longer-than-32-bytes", "changeme", "secret", "password"]
-    if jwt.lower() in weak_jwt:
+    _weak_set = frozenset(v.lower() for v in _WEAK_VALUES)
+    effective_min = max(getattr(settings, "min_secret_length", _MIN_SECRET_LENGTH), _MIN_SECRET_LENGTH)
+    if jwt.lower() in _weak_set or jwt.lower().startswith("__replace_me__"):
         warnings.append("JWT_SECRET_KEY: Default/weak secret detected! Please set a strong, unique value for production.")
 
-    if len(jwt) < 32:
-        warnings.append(f"JWT_SECRET_KEY: Secret should be at least 32 characters long. Current length: {len(jwt)}")
+    if len(jwt) < effective_min:
+        warnings.append(f"JWT_SECRET_KEY: Secret should be at least {effective_min} characters long. Current length: {len(jwt)}")
 
-    if len(set(jwt)) < 10:
+    if calculate_entropy(jwt) < _MIN_ENTROPY:
         warnings.append("JWT_SECRET_KEY: Secret has low entropy. Consider using a more random value.")
 
     # --- AUTH_ENCRYPTION_SECRET ---
     auth_secret = settings.auth_encryption_secret.get_secret_value() if isinstance(settings.auth_encryption_secret, SecretStr) else settings.auth_encryption_secret
-    weak_auth = ["my-test-salt", "changeme", "secret", "password"]
-    if auth_secret.lower() in weak_auth:
+    if auth_secret.lower() in _weak_set or auth_secret.lower().startswith("__replace_me__"):
         warnings.append("AUTH_ENCRYPTION_SECRET: Default/weak secret detected! Please set a strong, unique value for production.")
 
-    if len(auth_secret) < 32:
-        warnings.append(f"AUTH_ENCRYPTION_SECRET: Secret should be at least 32 characters long. Current length: {len(auth_secret)}")
+    if len(auth_secret) < effective_min:
+        warnings.append(f"AUTH_ENCRYPTION_SECRET: Secret should be at least {effective_min} characters long. Current length: {len(auth_secret)}")
 
-    if len(set(auth_secret)) < 10:
+    if calculate_entropy(auth_secret) < _MIN_ENTROPY:
         warnings.append("AUTH_ENCRYPTION_SECRET: Secret has low entropy. Consider using a more random value.")
 
     # --- URL Checks ---

--- a/tests/scripts/test_init_secrets.py
+++ b/tests/scripts/test_init_secrets.py
@@ -405,3 +405,34 @@ class TestEnsureEnvFileSecrets:
         env = tmp_path / ".env"
         env.write_text("JWT_SECRET_KEY=changeme # generated\n", encoding="utf-8")
         assert _read_env_file(str(env))["JWT_SECRET_KEY"] == "changeme"
+
+    def test_merge_env_file_case_insensitive_key_replaced_in_place(self, tmp_path):
+        """Regression: lowercase key in .env must be replaced in-place, not duplicated."""
+        env = tmp_path / ".env"
+        env.write_text("auth_encryption_secret=weak\nOTHER=keep\n", encoding="utf-8")
+        _merge_env_file(str(env), {"AUTH_ENCRYPTION_SECRET": "strong-new-value-here-long-enough"})
+        content = env.read_text(encoding="utf-8")
+        # The weak lowercase line must be gone; the strong value written with canonical casing
+        assert "weak" not in content
+        assert "AUTH_ENCRYPTION_SECRET=strong-new-value-here-long-enough" in content
+        # No duplication: key must appear exactly once
+        assert content.count("ENCRYPTION_SECRET=") == 1
+        assert "OTHER=keep" in content
+
+    def test_ensure_respects_min_secret_length_env_var(self, tmp_path, monkeypatch):
+        """Regression: MIN_SECRET_LENGTH=64 must result in a generated token >= 64 chars."""
+        env = tmp_path / ".env"
+        env.write_text("JWT_SECRET_KEY=changeme\nAUTH_ENCRYPTION_SECRET=changeme\n", encoding="utf-8")
+        monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+        monkeypatch.delenv("AUTH_ENCRYPTION_SECRET", raising=False)
+        monkeypatch.setenv("MCPGATEWAY_AUTO_INIT_SECRETS", "true")
+        monkeypatch.setenv("MIN_SECRET_LENGTH", "64")
+
+        generated = ensure_env_file_secrets(env_file=str(env))
+
+        assert "JWT_SECRET_KEY" in generated
+        assert len(generated["JWT_SECRET_KEY"]) >= 64, (
+            f"Expected token >= 64 chars with MIN_SECRET_LENGTH=64, got {len(generated['JWT_SECRET_KEY'])}"
+        )
+        assert "AUTH_ENCRYPTION_SECRET" in generated
+        assert len(generated["AUTH_ENCRYPTION_SECRET"]) >= 64

--- a/tests/scripts/test_init_secrets.py
+++ b/tests/scripts/test_init_secrets.py
@@ -228,11 +228,9 @@ class TestEnsureEnvFileSecrets:
 
         generated = ensure_env_file_secrets(env_file=str(env))
 
-        # JWT_SECRET_KEY is always auto-patched when weak.
         assert "JWT_SECRET_KEY" in generated
+        assert "AUTH_ENCRYPTION_SECRET" in generated
         assert len(generated["JWT_SECRET_KEY"]) == 43  # 32-byte token_urlsafe
-        # AUTH_ENCRYPTION_SECRET is intentionally NOT auto-patched (dev-mode leniency).
-        assert "AUTH_ENCRYPTION_SECRET" not in generated
 
     def test_ensure_patches_os_environ(self, tmp_path, monkeypatch):
         import os as _os
@@ -306,10 +304,8 @@ class TestEnsureEnvFileSecrets:
 
         generated = ensure_env_file_secrets(env_file=str(env))
 
-        # JWT_SECRET_KEY placeholder is always auto-patched.
         assert "JWT_SECRET_KEY" in generated
-        # AUTH_ENCRYPTION_SECRET is intentionally NOT auto-patched — operators set it manually.
-        assert "AUTH_ENCRYPTION_SECRET" not in generated
+        assert "AUTH_ENCRYPTION_SECRET" in generated
 
     def test_ensure_creates_env_file_when_missing(self, tmp_path, monkeypatch):
         env = tmp_path / ".env"

--- a/tests/scripts/test_init_secrets.py
+++ b/tests/scripts/test_init_secrets.py
@@ -18,8 +18,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 # First-Party
+from mcpgateway._security_constants import calculate_entropy
 from mcpgateway.scripts.init_secrets import (
     _WEAK_VALUES,
+    _is_strong_value,
     _merge_env_file,
     _read_env_file,
     ensure_env_file_secrets,
@@ -555,3 +557,80 @@ class TestMainPatchEnv:
         out = capsys.readouterr().out
         assert "ℹ️" in out
         assert env.read_text(encoding="utf-8") == original
+
+
+    def test_patch_env_value_error_exits_1(self, tmp_path, monkeypatch, capsys):
+        """--patch-env must exit 1 with a clean message when ensure_env_file_secrets raises ValueError.
+
+        Covers init_secrets.py lines 384-386: the except ValueError branch in the
+        --patch-env section of main().
+        """
+        env = tmp_path / ".env"
+        # A strong AUTH_ENCRYPTION_SECRET in .env with a weak value in os.environ
+        # triggers the rotation-guard ValueError inside ensure_env_file_secrets.
+        strong = "x3Kp_mQ8rZvN2wLsA5dYfB7cEjGhTuIo_X3K"  # pragma: allowlist secret
+        env.write_text(f"AUTH_ENCRYPTION_SECRET={strong}\n", encoding="utf-8")  # pragma: allowlist secret
+        monkeypatch.setenv("AUTH_ENCRYPTION_SECRET", "changeme")  # pragma: allowlist secret
+        monkeypatch.setenv("MCPGATEWAY_AUTO_INIT_SECRETS", "true")
+
+        with patch("argparse.ArgumentParser.parse_args") as mock_args:
+            mock_args.return_value = argparse.Namespace(
+                output=None, force=False, stdout=False, patch=None, patch_env=str(env)
+            )
+            with pytest.raises(SystemExit) as cm:
+                main()
+
+        assert cm.value.code == 1
+        err = capsys.readouterr().err
+        assert "AUTH_ENCRYPTION_SECRET" in err
+
+
+class TestIsStrongValue:
+    """Unit tests for the _is_strong_value helper (init_secrets.py lines 103-115)."""
+
+    def test_empty_string_is_not_strong(self):
+        """Empty / whitespace-only values must return False (line 109-110)."""
+        assert _is_strong_value("", _WEAK_VALUES) is False
+        assert _is_strong_value("   ", _WEAK_VALUES) is False
+
+    def test_known_weak_value_is_not_strong(self):
+        """Values in WEAK_VALUES must return False (line 111-112)."""
+        assert _is_strong_value("changeme", _WEAK_VALUES) is False
+
+    def test_replace_me_placeholder_is_not_strong(self):
+        """__REPLACE_ME__ prefixed values must return False (line 111-112)."""
+        assert _is_strong_value("__REPLACE_ME__init-secrets", _WEAK_VALUES) is False
+
+    def test_short_but_high_entropy_is_not_strong(self):
+        """Values shorter than MIN_SECRET_LENGTH must return False (line 113-114)."""
+        # 8 chars is below the 32-byte minimum; token_urlsafe(6) gives high entropy
+        import secrets as _secrets
+        short_val = _secrets.token_urlsafe(6)  # ~8 chars, high entropy
+        assert _is_strong_value(short_val, _WEAK_VALUES) is False
+
+    def test_long_low_entropy_is_not_strong(self):
+        """Values with entropy < MIN_ENTROPY must return False (line 113-114)."""
+        low_entropy = "a" * 40  # 40 chars but zero entropy
+        assert _is_strong_value(low_entropy, _WEAK_VALUES) is False
+
+    def test_strong_value_returns_true(self):
+        """A fully compliant value must return True (line 115)."""
+        import secrets as _secrets
+        strong = _secrets.token_urlsafe(32)  # 43 chars, high entropy
+        assert _is_strong_value(strong, _WEAK_VALUES) is True
+
+
+class TestCalculateEntropy:
+    """Tests for calculate_entropy in _security_constants.py."""
+
+    def test_empty_string_returns_zero(self):
+        """Empty string must return 0.0 (line 29 of _security_constants.py)."""
+        assert calculate_entropy("") == 0.0
+
+    def test_single_char_string_returns_zero(self):
+        """Single unique character has zero entropy."""
+        assert calculate_entropy("aaaa") == 0.0
+
+    def test_high_entropy_string(self):
+        """Mixed string should return a positive entropy value."""
+        assert calculate_entropy("aAbBcC123!@#") > 3.0

--- a/tests/scripts/test_init_secrets.py
+++ b/tests/scripts/test_init_secrets.py
@@ -436,3 +436,84 @@ class TestEnsureEnvFileSecrets:
         )
         assert "AUTH_ENCRYPTION_SECRET" in generated
         assert len(generated["AUTH_ENCRYPTION_SECRET"]) >= 64
+
+    def test_ensure_reads_min_secret_length_from_env_file(self, tmp_path, monkeypatch):
+        """Regression: MIN_SECRET_LENGTH=64 in .env (not os.environ) must size the token correctly."""
+        env = tmp_path / ".env"
+        env.write_text(
+            "JWT_SECRET_KEY=changeme\nAUTH_ENCRYPTION_SECRET=changeme\nMIN_SECRET_LENGTH=64\n",
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+        monkeypatch.delenv("AUTH_ENCRYPTION_SECRET", raising=False)
+        monkeypatch.delenv("MIN_SECRET_LENGTH", raising=False)
+        monkeypatch.setenv("MCPGATEWAY_AUTO_INIT_SECRETS", "true")
+
+        generated = ensure_env_file_secrets(env_file=str(env))
+
+        assert len(generated["JWT_SECRET_KEY"]) >= 64, (
+            f"Expected ≥64 chars with MIN_SECRET_LENGTH=64 in .env, got {len(generated['JWT_SECRET_KEY'])}"
+        )
+        assert len(generated["AUTH_ENCRYPTION_SECRET"]) >= 64
+
+    def test_ensure_invalid_min_secret_length_raises_value_error(self, tmp_path, monkeypatch):
+        """Non-numeric MIN_SECRET_LENGTH produces a clear ValueError, not a cryptic int() traceback."""
+        env = tmp_path / ".env"
+        env.write_text("JWT_SECRET_KEY=changeme\nMIN_SECRET_LENGTH=abc\n", encoding="utf-8")
+        monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+        monkeypatch.delenv("MIN_SECRET_LENGTH", raising=False)
+        monkeypatch.setenv("MCPGATEWAY_AUTO_INIT_SECRETS", "true")
+
+        with pytest.raises(ValueError, match="MIN_SECRET_LENGTH="):
+            ensure_env_file_secrets(env_file=str(env))
+
+
+class TestMainPatchEnv:
+    """Tests for the --patch-env branch of main()."""
+
+    def test_patch_env_generates_and_prints_success(self, tmp_path, monkeypatch, capsys):
+        """--patch-env with a weak .env prints a ✅ message and updates the file."""
+        env = tmp_path / ".env"
+        env.write_text("JWT_SECRET_KEY=changeme\nAUTH_ENCRYPTION_SECRET=changeme\n", encoding="utf-8")
+        monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+        monkeypatch.delenv("AUTH_ENCRYPTION_SECRET", raising=False)
+        monkeypatch.setenv("MCPGATEWAY_AUTO_INIT_SECRETS", "true")
+
+        with patch("argparse.ArgumentParser.parse_args") as mock_args:
+            mock_args.return_value = argparse.Namespace(
+                output=None, force=False, stdout=False, patch=None, patch_env=str(env)
+            )
+            main()
+
+        out = capsys.readouterr().out
+        assert "✅" in out
+        assert "JWT_SECRET_KEY" in out or "AUTH_ENCRYPTION_SECRET" in out
+        # The weak values must be gone from the file
+        content = env.read_text(encoding="utf-8")
+        assert "changeme" not in content
+
+    def test_patch_env_no_op_when_already_strong(self, tmp_path, monkeypatch, capsys):
+        """--patch-env with an already-strong .env prints ℹ️ and makes no changes."""
+        strong = "a" * 8 + "B" * 8 + "1" * 8 + "!" * 8  # 32 chars, mixed entropy
+        # Use a high-entropy value that passes the entropy gate
+        import secrets as _secrets
+        strong = _secrets.token_urlsafe(32)
+        env = tmp_path / ".env"
+        env.write_text(
+            f"JWT_SECRET_KEY={strong}\nAUTH_ENCRYPTION_SECRET={strong}\nBASIC_AUTH_PASSWORD={strong}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+        monkeypatch.delenv("AUTH_ENCRYPTION_SECRET", raising=False)
+        monkeypatch.setenv("MCPGATEWAY_AUTO_INIT_SECRETS", "true")
+        original = env.read_text(encoding="utf-8")
+
+        with patch("argparse.ArgumentParser.parse_args") as mock_args:
+            mock_args.return_value = argparse.Namespace(
+                output=None, force=False, stdout=False, patch=None, patch_env=str(env)
+            )
+            main()
+
+        out = capsys.readouterr().out
+        assert "ℹ️" in out
+        assert env.read_text(encoding="utf-8") == original

--- a/tests/scripts/test_init_secrets.py
+++ b/tests/scripts/test_init_secrets.py
@@ -308,6 +308,33 @@ class TestEnsureEnvFileSecrets:
         content = env.read_text(encoding="utf-8")
         assert strong in content
 
+    def test_weak_env_var_short_env_file_value_raises_for_rotation_guarded_field(self, tmp_path, monkeypatch):
+        """Weak shell var + ANY pre-existing .env value must raise for rotation-guarded fields.
+
+        Regression test for madhu's finding: the original guard only fired when the .env
+        value was *strong* (_is_strong_value returned True).  A short-but-non-default value
+        in .env (e.g. ``abcd`` — not in WEAK_VALUES, not a placeholder, but only 4 chars)
+        bypassed the guard and silently rotated the AES key.
+
+        The fixed condition is ``(_env_file_ci.get(field.lower()) or "").strip()`` — any
+        non-empty pre-existing .env value must block rotation.
+        """
+        # "abcd" is 4 chars — short, but NOT in WEAK_VALUES and NOT a placeholder.
+        # Under the old guard (_is_strong_value check) this would fall through to
+        # file_generated and silently overwrite the .env value.
+        short_non_default = "abcd"  # nosec B105  # pragma: allowlist secret
+        env = tmp_path / ".env"
+        env.write_text(f"AUTH_ENCRYPTION_SECRET={short_non_default}\n", encoding="utf-8")  # pragma: allowlist secret
+        monkeypatch.setenv("AUTH_ENCRYPTION_SECRET", "changeme")  # pragma: allowlist secret
+        monkeypatch.setenv("MCPGATEWAY_AUTO_INIT_SECRETS", "true")
+
+        with pytest.raises(ValueError, match="AUTH_ENCRYPTION_SECRET"):
+            ensure_env_file_secrets(env_file=str(env))
+
+        # The .env file must be unchanged — the short value must not have been rotated.
+        content = env.read_text(encoding="utf-8")
+        assert short_non_default in content
+
     def test_ensure_disabled_by_env_var(self, tmp_path, monkeypatch):
         env = tmp_path / ".env"
         env.write_text("JWT_SECRET_KEY=changeme\n", encoding="utf-8")

--- a/tests/scripts/test_init_secrets.py
+++ b/tests/scripts/test_init_secrets.py
@@ -282,6 +282,30 @@ class TestEnsureEnvFileSecrets:
 
         assert generated == {}
 
+    def test_weak_env_var_strong_env_file_raises_for_rotation_guarded_field(self, tmp_path, monkeypatch):
+        """Weak shell var + strong .env must raise, not silently overwrite AES key.
+
+        Regression test for the data-loss defect where ensure_env_file_secrets()
+        evaluated os.environ precedence first (current = env_val = weak), detected
+        is_non_compliant=True, then fell through to file_generated because
+        field IN env_file_values — silently overwriting the strong .env value with a
+        freshly generated key.  For AUTH_ENCRYPTION_SECRET that rotation makes every
+        stored encrypted credential permanently unreadable.
+        """
+        strong = "x3Kp_mQ8rZvN2wLsA5dYfB7cEjGhTuIo_X3K"  # pragma: allowlist secret
+        env = tmp_path / ".env"
+        env.write_text(f"AUTH_ENCRYPTION_SECRET={strong}\n", encoding="utf-8")  # pragma: allowlist secret
+        # Shell carries a weak / non-compliant value for the guarded field.
+        monkeypatch.setenv("AUTH_ENCRYPTION_SECRET", "changeme")  # pragma: allowlist secret
+        monkeypatch.setenv("MCPGATEWAY_AUTO_INIT_SECRETS", "true")
+
+        with pytest.raises(ValueError, match="AUTH_ENCRYPTION_SECRET"):
+            ensure_env_file_secrets(env_file=str(env))
+
+        # The .env file must be unchanged — the strong key must not have been rotated.
+        content = env.read_text(encoding="utf-8")
+        assert strong in content
+
     def test_ensure_disabled_by_env_var(self, tmp_path, monkeypatch):
         env = tmp_path / ".env"
         env.write_text("JWT_SECRET_KEY=changeme\n", encoding="utf-8")

--- a/tests/scripts/test_init_secrets.py
+++ b/tests/scripts/test_init_secrets.py
@@ -311,17 +311,11 @@ class TestEnsureEnvFileSecrets:
     def test_weak_env_var_short_env_file_value_raises_for_rotation_guarded_field(self, tmp_path, monkeypatch):
         """Weak shell var + ANY pre-existing .env value must raise for rotation-guarded fields.
 
-        Regression test for madhu's finding: the original guard only fired when the .env
-        value was *strong* (_is_strong_value returned True).  A short-but-non-default value
-        in .env (e.g. ``abcd`` — not in WEAK_VALUES, not a placeholder, but only 4 chars)
-        bypassed the guard and silently rotated the AES key.
-
-        The fixed condition is ``(_env_file_ci.get(field.lower()) or "").strip()`` — any
-        non-empty pre-existing .env value must block rotation.
+        A short-but-non-default value in .env (e.g. ``abcd`` — not in WEAK_VALUES, not a
+        placeholder, but only 4 chars) must still block rotation.  The guard condition is
+        ``(_env_file_ci.get(field.lower()) or "").strip()`` — any non-empty pre-existing
+        .env value blocks auto-rotation, not only values that pass the full strength predicate.
         """
-        # "abcd" is 4 chars — short, but NOT in WEAK_VALUES and NOT a placeholder.
-        # Under the old guard (_is_strong_value check) this would fall through to
-        # file_generated and silently overwrite the .env value.
         short_non_default = "abcd"  # nosec B105  # pragma: allowlist secret
         env = tmp_path / ".env"
         env.write_text(f"AUTH_ENCRYPTION_SECRET={short_non_default}\n", encoding="utf-8")  # pragma: allowlist secret

--- a/tests/scripts/test_init_secrets.py
+++ b/tests/scripts/test_init_secrets.py
@@ -381,7 +381,11 @@ class TestEnsureEnvFileSecrets:
 
     # --- F4 regression: os.environ-only weak values must not write to .env ---
 
-    def test_ensure_does_not_write_env_for_environ_only_weak(self, tmp_path, monkeypatch):
+    def test_ensure_writes_strong_fields_to_env_even_when_weak_value_from_environ(self, tmp_path, monkeypatch):
+        """Strong fields (JWT_SECRET_KEY, AUTH_ENCRYPTION_SECRET) with a weak value in os.environ
+        and absent from .env must be written to .env so the value survives process exit.
+        Only non-strong fields (BASIC_AUTH_PASSWORD) stay environ-only to avoid shadowing
+        container env-var injections."""
         env = tmp_path / ".env"
         env.write_text("OTHER=keep\n", encoding="utf-8")
         monkeypatch.setenv("JWT_SECRET_KEY", "changeme")
@@ -392,7 +396,11 @@ class TestEnsureEnvFileSecrets:
 
         assert "JWT_SECRET_KEY" in generated
         content = env.read_text(encoding="utf-8")
-        assert "JWT_SECRET_KEY" not in content
+        # Strong fields must be persisted — a CLI process exits after patching so
+        # an os.environ-only write would be silently lost.
+        assert f"JWT_SECRET_KEY={generated['JWT_SECRET_KEY']}" in content
+        assert f"AUTH_ENCRYPTION_SECRET={generated['AUTH_ENCRYPTION_SECRET']}" in content
+        assert "OTHER=keep" in content
 
     # --- F6 regression: parser edge cases ---
 
@@ -466,6 +474,36 @@ class TestEnsureEnvFileSecrets:
 
         with pytest.raises(ValueError, match="MIN_SECRET_LENGTH="):
             ensure_env_file_secrets(env_file=str(env))
+
+    def test_ensure_min_secret_length_below_floor_raises_value_error(self, tmp_path, monkeypatch):
+        """Regression: MIN_SECRET_LENGTH=0 must raise ValueError with an actionable message,
+        not silently clamp and produce a token that Settings() then rejects."""
+        env = tmp_path / ".env"
+        env.write_text("JWT_SECRET_KEY=changeme\nAUTH_ENCRYPTION_SECRET=changeme\nMIN_SECRET_LENGTH=0\n", encoding="utf-8")
+        monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+        monkeypatch.delenv("AUTH_ENCRYPTION_SECRET", raising=False)
+        monkeypatch.delenv("MIN_SECRET_LENGTH", raising=False)
+        monkeypatch.setenv("MCPGATEWAY_AUTO_INIT_SECRETS", "true")
+
+        with pytest.raises(ValueError, match="below the enforced minimum"):
+            ensure_env_file_secrets(env_file=str(env))
+
+    def test_ensure_strong_field_weak_in_environ_writes_to_env_file(self, tmp_path, monkeypatch):
+        """Regression: weak AUTH_ENCRYPTION_SECRET in os.environ (absent from .env) must be
+        written to .env, not discarded into the subprocess environ and silently lost."""
+        env = tmp_path / ".env"
+        # .env exists but does not contain AUTH_ENCRYPTION_SECRET
+        env.write_text("JWT_SECRET_KEY=changeme\n", encoding="utf-8")
+        monkeypatch.setenv("AUTH_ENCRYPTION_SECRET", "changeme")
+        monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+        monkeypatch.setenv("MCPGATEWAY_AUTO_INIT_SECRETS", "true")
+
+        generated = ensure_env_file_secrets(env_file=str(env))
+
+        assert "AUTH_ENCRYPTION_SECRET" in generated
+        # The value must be persisted to .env, not just os.environ
+        content = env.read_text(encoding="utf-8")
+        assert f"AUTH_ENCRYPTION_SECRET={generated['AUTH_ENCRYPTION_SECRET']}" in content
 
 
 class TestMainPatchEnv:

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -2090,30 +2090,15 @@ def test_primary_worker_heartbeat_warns_at_exact_boundary(caplog):
 
 
 def test_placeholder_secret_raises_in_development():
-    """__REPLACE_ME__ placeholder is rejected in development for jwt_secret_key.
-
-    For auth_encryption_secret the placeholder is permitted in development
-    (emits a WARNING) — consistent with all other non-compliant values.
-    """
+    """__REPLACE_ME__ placeholder is rejected even in development."""
     from mcpgateway.config import SecurityConfigurationError
 
-    # jwt_secret_key placeholder always hard-fails
     with pytest.raises(SecurityConfigurationError, match="unset placeholder"):
         Settings(
             jwt_secret_key="__REPLACE_ME__run_init-secrets_before_starting",
             environment="development",
             _env_file=None,
         )
-
-    # auth_encryption_secret placeholder in dev — warns and proceeds
-    strong_jwt = "a-strong-jwt-secret-that-is-long-enough-and-unique-xxxx"  # nosec B105
-    s = Settings(
-        jwt_secret_key=strong_jwt,
-        auth_encryption_secret="__REPLACE_ME__run_init-secrets_before_starting",
-        environment="development",
-        _env_file=None,
-    )
-    assert s.auth_encryption_secret.get_secret_value() == "__REPLACE_ME__run_init-secrets_before_starting"
 
 
 def test_placeholder_secret_raises_in_staging():
@@ -2156,46 +2141,22 @@ def test_weak_secret_raises_in_staging():
         )
 
 
-def test_weak_auth_encryption_secret_allowed_in_development():
-    """Known-weak auth_encryption_secret is downgraded to a warning in development mode.
+def test_weak_auth_encryption_secret_raises_in_development():
+    """Known-weak auth_encryption_secret is rejected unconditionally (including development).
 
-    When ENVIRONMENT=development, short/weak/low-entropy values for
-    auth_encryption_secret no longer raise SecurityConfigurationError — they
-    emit a logger.warning and startup proceeds.  This enables PoC / local-dev
-    convenience (e.g. AUTH_ENCRYPTION_SECRET=my-test-salt).
-    jwt_secret_key is NOT affected and still hard-fails unconditionally.
-    """
-    strong_jwt = "a-strong-jwt-secret-that-is-long-enough-and-unique-xxxx"  # nosec B105
-    s = Settings(
-        jwt_secret_key=strong_jwt,
-        auth_encryption_secret="my-test-salt",  # nosec B106  # pragma: allowlist secret
-        environment="development",
-        _env_file=None,
-    )
-    assert s.auth_encryption_secret.get_secret_value() == "my-test-salt"  # pragma: allowlist secret
-
-
-def test_weak_auth_encryption_secret_raises_outside_development():
-    """Known-weak auth_encryption_secret is still rejected in staging and production.
-
-    The dev-mode leniency must not bleed into non-development environments.
-    Uses a value that is long enough to pass the length floor so it reaches the
-    weak-value check rather than the too-short check.
+    ``"my-test-salt"`` is 12 chars — below the 32-char length floor — so ``"too short"``
+    fires before the weak-value check.  The test accepts either rejection reason.
     """
     from mcpgateway.config import SecurityConfigurationError
 
-    strong_jwt = "a-strong-jwt-secret-that-is-long-enough-and-unique-xxxx"  # nosec B105
-    # "my-test-key-but-now-longer-than-32-bytes" is in WEAK_VALUES and is ≥ 32 chars
-    weak_enc = "my-test-key-but-now-longer-than-32-bytes"  # nosec B106  # pragma: allowlist secret
-
-    for env in ("staging", "production"):
-        with pytest.raises(SecurityConfigurationError, match="known-weak"):
-            Settings(
-                jwt_secret_key=strong_jwt,
-                auth_encryption_secret=weak_enc,
-                environment=env,
-                _env_file=None,
-            )
+    with pytest.raises(SecurityConfigurationError) as exc_info:
+        Settings(
+            auth_encryption_secret="my-test-salt",  # nosec B106  # pragma: allowlist secret
+            environment="development",
+            _env_file=None,
+        )
+    msg = str(exc_info.value)
+    assert "too short" in msg or "known-weak/default value" in msg
 
 
 def test_strong_secrets_accepted_in_all_envs():
@@ -2227,13 +2188,7 @@ def test_empty_secret_raises():
 
 
 def test_init_secrets_patch_mode_writes_strong_values(tmp_path):
-    """ensure_env_file_secrets patches JWT_SECRET_KEY but NOT AUTH_ENCRYPTION_SECRET.
-
-    AUTH_ENCRYPTION_SECRET is intentionally excluded from auto-patching so that
-    operators set it deliberately.  A weak value like my-test-salt is allowed
-    in ENVIRONMENT=development.  Strong values are still written to .env.secrets
-    by the --output / --stdout paths, just not auto-patched into .env.
-    """
+    """init_secrets ensure_env_file_secrets replaces placeholder values with strong ones."""
     env_file = tmp_path / ".env"
     env_file.write_text(
         "JWT_SECRET_KEY=__REPLACE_ME__run_init-secrets_before_starting\n"
@@ -2244,7 +2199,7 @@ def test_init_secrets_patch_mode_writes_strong_values(tmp_path):
 
     from mcpgateway.scripts.init_secrets import ensure_env_file_secrets
 
-    # Isolate from any real env vars
+    # Patch os.environ to isolate the test
     env_backup_jwt = _os.environ.pop("JWT_SECRET_KEY", None)
     env_backup_enc = _os.environ.pop("AUTH_ENCRYPTION_SECRET", None)
     try:
@@ -2255,20 +2210,24 @@ def test_init_secrets_patch_mode_writes_strong_values(tmp_path):
         if env_backup_enc is not None:
             _os.environ["AUTH_ENCRYPTION_SECRET"] = env_backup_enc
 
-    # JWT_SECRET_KEY must be patched
     assert "JWT_SECRET_KEY" in generated
+    assert "AUTH_ENCRYPTION_SECRET" in generated
+
     new_jwt = generated["JWT_SECRET_KEY"]
+    new_enc = generated["AUTH_ENCRYPTION_SECRET"]
+
+    # Generated values must be non-trivially long (token_urlsafe(32) → 43 chars)
     assert len(new_jwt) >= 32
+    assert len(new_enc) >= 32
+
+    # Must not be placeholder or known-weak
     assert not new_jwt.lower().startswith("__replace_me__")
     assert new_jwt.lower() != "changeme"
 
-    # AUTH_ENCRYPTION_SECRET must NOT be patched into .env
-    assert "AUTH_ENCRYPTION_SECRET" not in generated
-
-    # The generated JWT must work with Settings (using a dev-mode enc secret is fine)
+    # Running Settings() with the generated values must succeed
     s = Settings(
         jwt_secret_key=new_jwt,
-        auth_encryption_secret="my-test-salt",  # nosec B106  # pragma: allowlist secret
+        auth_encryption_secret=new_enc,
         environment="development",
         _env_file=None,
     )

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -2337,3 +2337,35 @@ def test_csrf_secret_key_is_a_secret_and_falls_back_to_jwt_secret():
         environment="development",
     )
     assert cfg2.csrf_secret_key.get_secret_value() == explicit
+
+
+def test_min_secret_length_below_floor_raises_validation_error():
+    """Regression: MIN_SECRET_LENGTH=0 (or any value < 32) must raise ValidationError at
+    Settings() construction time, not silently pass through to validate_security_combinations().
+
+    The field uses Field(ge=_MIN_SECRET_LENGTH) so the guard lives at the Pydantic layer —
+    the error is ValidationError, not SecurityConfigurationError.
+    """
+    # Standard
+    import os
+
+    # Third-Party
+    from pydantic import ValidationError
+
+    # First-Party
+    from mcpgateway.config import Settings
+
+    strong = "a" * 8 + "B" * 8 + "1" * 8 + "!" * 8  # 32 chars, mixed entropy
+    import secrets as _secrets
+    strong = _secrets.token_urlsafe(32)
+
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(
+            jwt_secret_key=strong,
+            auth_encryption_secret=strong,
+            min_secret_length=0,
+            database_url="sqlite:///:memory:",
+            environment="development",
+        )
+    # Confirm the error is about min_secret_length, not some other field
+    assert "min_secret_length" in str(exc_info.value).lower() or "greater than or equal" in str(exc_info.value).lower()

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -2159,6 +2159,41 @@ def test_weak_auth_encryption_secret_raises_in_development():
     assert "too short" in msg or "known-weak/default value" in msg
 
 
+def test_weak_auth_encryption_secret_long_enough_raises_in_development():
+    """Known-weak auth_encryption_secret that is ≥32 chars is still rejected in development.
+
+    Exercises the ``is_weak`` branch of ``validate_security_combinations`` for
+    ``auth_encryption_secret``.  ``"my-test-key-but-now-longer-than-32-bytes"`` is in
+    ``WEAK_VALUES`` and is long enough to pass the length floor, so the rejection reason
+    must be ``"known-weak/default value"``, not ``"too short"``.
+    """
+    from mcpgateway.config import SecurityConfigurationError
+
+    with pytest.raises(SecurityConfigurationError, match="known-weak/default value"):
+        Settings(
+            auth_encryption_secret="my-test-key-but-now-longer-than-32-bytes",  # nosec B106  # pragma: allowlist secret
+            environment="development",
+            _env_file=None,
+        )
+
+
+def test_placeholder_auth_encryption_secret_raises_in_development():
+    """__REPLACE_ME__ placeholder on auth_encryption_secret is rejected in development.
+
+    Exercises the ``is_placeholder`` branch of ``validate_security_combinations`` for
+    ``auth_encryption_secret`` specifically.  Uses a value ≥32 chars so the length floor
+    is not hit first.
+    """
+    from mcpgateway.config import SecurityConfigurationError
+
+    with pytest.raises(SecurityConfigurationError, match="unset placeholder"):
+        Settings(
+            auth_encryption_secret="__REPLACE_ME__padding-to-reach-32-chars-x",  # nosec B106
+            environment="development",
+            _env_file=None,
+        )
+
+
 def test_strong_secrets_accepted_in_all_envs():
     """Strong, non-placeholder secrets pass validation in every environment."""
     strong_jwt = "a-strong-jwt-secret-that-is-long-enough-and-unique-xxxx"  # nosec B105

--- a/tests/unit/mcpgateway/test_validate_env.py
+++ b/tests/unit/mcpgateway/test_validate_env.py
@@ -158,3 +158,57 @@ def test_validate_env_warning_path_exit_on_warnings_true(tmp_path: Path) -> None
         code = ve.main(env_file=str(envfile), exit_on_warnings=True)
 
     assert code == 1
+
+
+def test_get_security_warnings_flags_short_jwt_secret() -> None:
+    """validate_env.py line 161: JWT_SECRET_KEY shorter than effective_min triggers a length warning.
+
+    Constructs a mock settings object where jwt_secret_key is 10 chars (not in WEAK_VALUES,
+    so the weak-name branch on line 157 does NOT fire) but below the 32-char floor
+    (line 160 condition is True).  This covers the previously-uncovered branch at line 161.
+    """
+    from pydantic import SecretStr  # already imported at module level, but explicit is fine
+
+    class _Settings:
+        port = 8080
+        password_min_length = 8
+        platform_admin_password = SecretStr("Str0ng!AdminPass")
+        basic_auth_password = SecretStr("Complex!Pass99")
+        # 10 chars, not in WEAK_VALUES (so not caught by line 157), but < 32 (line 160 fires)
+        jwt_secret_key = SecretStr("abcdefghij")  # nosec B106
+        auth_encryption_secret = SecretStr("Qr1!St2@Uv3#Wx4$Yz5%Aa6^Bb7&Cc8*")
+        app_domain = "https://example.com"
+        min_secret_length = 32
+
+    warnings = ve.get_security_warnings(_Settings())  # type: ignore[arg-type]
+
+    assert any("JWT_SECRET_KEY" in w and "at least" in w for w in warnings), (
+        f"Expected JWT length warning, got: {warnings}"
+    )
+
+
+def test_get_security_warnings_flags_short_auth_encryption_secret() -> None:
+    """validate_env.py line 172: AUTH_ENCRYPTION_SECRET shorter than effective_min triggers a length warning.
+
+    Constructs a mock settings object where auth_encryption_secret is 10 chars (not in
+    WEAK_VALUES, so line 168 does NOT fire) but below the 32-char floor (line 171 fires).
+    This covers the previously-uncovered branch at line 172.
+    """
+    from pydantic import SecretStr
+
+    class _Settings:
+        port = 8080
+        password_min_length = 8
+        platform_admin_password = SecretStr("Str0ng!AdminPass")
+        basic_auth_password = SecretStr("Complex!Pass99")
+        jwt_secret_key = SecretStr("a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p")  # nosec B106 # pragma: allowlist secret
+        # 10 chars, not in WEAK_VALUES (so line 168 does not fire), but < 32 (line 171 fires)
+        auth_encryption_secret = SecretStr("abcdefghij")  # nosec B106
+        app_domain = "https://example.com"
+        min_secret_length = 32
+
+    warnings = ve.get_security_warnings(_Settings())  # type: ignore[arg-type]
+
+    assert any("AUTH_ENCRYPTION_SECRET" in w and "at least" in w for w in warnings), (
+        f"Expected AUTH_ENCRYPTION_SECRET length warning, got: {warnings}"
+    )


### PR DESCRIPTION
## 🔗 Related Issue

Closes #6103 

---

## 📝 Summary


migration script for this issue is covered with a follow up PR Here - https://github.com/IBM/mcp-context-forge/issues/6113
Restores the unconditional `AUTH_ENCRYPTION_SECRET` cryptographic-strength guardrail
that was deliberately relaxed in PR #6073 for sprint testing and migration-script
preparation.

**Before (PR #6073 state):**
- `AUTH_ENCRYPTION_SECRET` with weak/short/low-entropy values emitted a `WARNING` in
  `ENVIRONMENT=development` and startup proceeded — enabling `my-test-salt` style values
  locally.
- `make init-secrets-patch-env` / `make setup` did **not** auto-patch
  `AUTH_ENCRYPTION_SECRET` into `.env`.

**After (this PR):**
- `AUTH_ENCRYPTION_SECRET` is enforced unconditionally in **every** environment
  (development, staging, production) — matching the pre-#6073 behaviour.
- Placeholder, known-weak, too-short, and low-entropy values all hard-fail at startup
  regardless of `ENVIRONMENT`.
- `make init-secrets-patch-env` / `make setup` auto-patches `AUTH_ENCRYPTION_SECRET`
  into `.env` again when the current value is non-compliant.

### Files changed

| File | Change |
|---|---|
| `mcpgateway/config.py` | Removed `is_dev` bypass branch for `auth_encryption_secret`; restored single-loop unconditional enforcement for both secrets; docstring reverted |
| `mcpgateway/scripts/init_secrets.py` | Removed `_PATCH_ENV_SKIP_FIELDS`; restored `AUTH_ENCRYPTION_SECRET` to `ensure_env_file_secrets()` auto-patching loop; `--patch-env` help text reverted |
| `Makefile` | Restored advisory message and `init-secrets-patch-env` help text to cover both secrets |
| `.env.example` | Restored original two-secret enforcement comment block; removed dev-relaxation language; reverted `ENVIRONMENT` section comment |
| `tests/unit/mcpgateway/test_config.py` | Removed `test_weak_auth_encryption_secret_allowed_in_development`; removed dev-placeholder pass-through assertion from `test_placeholder_secret_raises_in_development`; restored `test_weak_auth_encryption_secret_raises_in_development` (hard-fail); restored `test_init_secrets_patch_mode_writes_strong_values` to assert both secrets are generated |
| `tests/scripts/test_init_secrets.py` | Restored assertions that `AUTH_ENCRYPTION_SECRET` IS present in `ensure_env_file_secrets()` output for weak and placeholder inputs |

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Security config tests | `pytest tests/unit/mcpgateway/test_config.py -q` | 185 passed |
| Init secrets tests | `pytest tests/scripts/test_init_secrets.py -q` | 37 passed |
| Weak enc secret hard-fails in dev | `test_weak_auth_encryption_secret_raises_in_development` | ✅ |
| Placeholder hard-fails in dev | `test_placeholder_secret_raises_in_development` | ✅ |
| Patch mode generates both secrets | `test_init_secrets_patch_mode_writes_strong_values` | ✅ |
| Strong secrets still accepted | `test_strong_secrets_accepted_in_all_envs` | ✅ |

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed