### PR TITLE
fix(admin): bind login CSRF cookie to email and session jti

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-12T15:30:22Z",
+  "generated_at": "2026-08-13T09:04:01Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1858,7 +1858,7 @@
         "hashed_secret": "5193dda17da630c041fe949c06e7b6dd5ac8628f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1612,
+        "line_number": 1615,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1866,7 +1866,7 @@
         "hashed_secret": "91174c4e6859da80df4e7ce9d45b35501f591210",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1895,
+        "line_number": 1898,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1874,7 +1874,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1936,
+        "line_number": 1939,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1946,7 +1946,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 882,
+        "line_number": 900,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1954,7 +1954,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1389,
+        "line_number": 1407,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -1962,7 +1962,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1393,
+        "line_number": 1411,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/manage/api-usage.md
+++ b/docs/docs/manage/api-usage.md
@@ -1279,6 +1279,9 @@ curl -s -X POST \
   $BASE_URL/v1/admin/llm/providers/provider-123/state
 ```
 
+!!! tip "Capturing `$CSRF_COOKIE`"
+    The `mcpgateway_csrf_token` cookie is HMAC-bound to your session from the moment you log in, so capture it straight from the `POST /admin/login` response — there is no need to load `/admin/` first. Before [#5978](https://github.com/IBM/mcp-context-forge/issues/5978) the login response returned an unbound token that the `/v1/admin/**` mount rejected until a dashboard load rotated it.
+
 ### Check Provider Health
 
 Verify provider API connectivity and response time.

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -665,7 +665,25 @@ The five settings marked as "middleware-path-only" in the table above govern onl
 !!! info "CSRF_EXEMPT_PATHS and Versioned Route Interaction"
     The middleware exemption uses prefix matching on the raw request path (e.g., `/admin` matches `/admin/llm/*` but not `/v1/admin/llm/*`). This means versioned admin routes at `/v1/admin/*` are validated by both the middleware and the per-route `enforce_admin_csrf` dependency (double validation), while legacy routes at `/admin/*` use only the per-route dependency (exempt from middleware). Cross-validate your paths against both implementations. See [Middleware Ordering and Stacking](../architecture/middleware-ordering.md) for details on how CSRF middleware interacts with other middleware and per-route dependencies.
 
-    This double-validation is also where a known timing gap surfaces: in the window between `/admin/login` and the first dashboard load, the versioned mount's extra `CSRFMiddleware` pass can reject a write that the legacy mount's `enforce_admin_csrf`-only path accepts, because the CSRF cookie has not yet rotated from its opaque pre-login value to its HMAC-bound one. See [IBM/mcp-context-forge#5978](https://github.com/IBM/mcp-context-forge/issues/5978).
+    This double-validation used to expose a timing gap: in the window between `/admin/login` and the first dashboard load, the versioned mount's extra `CSRFMiddleware` pass rejected writes that the legacy mount's `enforce_admin_csrf`-only path accepted, because the CSRF cookie had not yet rotated from its opaque pre-login value to its HMAC-bound one. Fixed in [IBM/mcp-context-forge#5978](https://github.com/IBM/mcp-context-forge/issues/5978) — see *Admin CSRF token lifecycle* below.
+
+#### Admin CSRF token lifecycle
+
+The `mcpgateway_csrf_token` cookie is an HMAC-SHA256 digest bound to `(user email, session JWT jti)`. Every handler that mints a session JWT now issues the bound cookie in the same response:
+
+| Handler | When |
+| --- | --- |
+| `admin_login_handler` | `POST /admin/login`, both the normal and the forced-password-change branch |
+| `change_password_required_handler` | `POST /admin/change-password-required`, which re-mints the JWT with a new `jti` |
+| `admin_ui()` | every `/admin/` dashboard load, which also re-mints and therefore rotates |
+| `/auth/*` login endpoints | `routers/auth.py`, `routers/email_auth.py` |
+
+Because the token is bound to the session, it cannot be replayed across sessions or users, and the unprefixed `/admin/**` and versioned `/v1/admin/**` mounts accept it identically from the first request after login — no dashboard load required.
+
+Unauthenticated pages (`GET /admin/login`, forgot-password, reset-password) still receive an opaque, unbound token. That is correct: there is no session to bind to yet, and neither CSRF layer engages without a session cookie. The bound token replaces it on successful login.
+
+!!! warning "Long sessions can outlive their CSRF token"
+    The admin CSRF cookie's `max_age` is `max(300, TOKEN_EXPIRY * 60)`, but the HMAC is only accepted for the current and previous `CSRF_TOKEN_EXPIRY` window — 1 to 2 hours at the `3600` default. At the shipped `TOKEN_EXPIRY` of 20 minutes the cookie expires first and there is no gap. If you raise `TOKEN_EXPIRY` above 120 minutes, the cookie can outlive its own HMAC, after which `/v1/admin/**` writes fail with `CSRF_TOKEN_INVALID` while `/admin/**` still accepts them. Browsers are unaffected because every dashboard load rotates the cookie; long-lived non-browser cookie clients are not. Keep `CSRF_TOKEN_EXPIRY >= TOKEN_EXPIRY * 60`, or re-authenticate rather than holding one cookie for the full session.
 
 ### Identity Propagation
 

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -4629,8 +4629,15 @@ async def admin_login_handler(request: Request, db: Session = Depends(get_db)) -
             if needs_password_change:
                 LOGGER.info(f"User {email} requires password change - redirecting to change password page")
 
+                # Mint the session id up front so the CSRF cookie can be HMAC-bound to
+                # the exact JWT we are about to set. Without it the cookie falls back to
+                # an opaque value that passes enforce_admin_csrf but fails
+                # CSRFMiddleware, so /admin/** and /v1/admin/** diverge until the
+                # dashboard rotates the cookie.
+                session_jti = str(uuid.uuid4())
+
                 # Create temporary JWT token for password change process
-                token, _ = await create_access_token(user)
+                token, _ = await create_access_token(user, jti=session_jti)
 
                 # Create redirect response to password change page
                 response = RedirectResponse(url=f"{root_path}/admin/change-password-required", status_code=303)
@@ -4644,11 +4651,16 @@ async def admin_login_handler(request: Request, db: Session = Depends(get_db)) -
                         status_code=303,
                     )
 
-                _set_admin_csrf_cookie(request, response)
+                _set_admin_csrf_cookie(request, response, user_id=user.email, session_id=session_jti)
                 return response
 
+            # Mint the session id up front so the CSRF cookie is HMAC-bound to this
+            # exact JWT from the first request of the session, matching routers/auth.py
+            # and routers/email_auth.py.
+            session_jti = str(uuid.uuid4())
+
             # Create JWT token with proper audience and issuer claims
-            token, _ = await create_access_token(user)  # expires_seconds not needed here
+            token, _ = await create_access_token(user, jti=session_jti)  # expires_seconds not needed here
 
             # Create redirect response
             response = RedirectResponse(url=f"{root_path}/admin", status_code=303)
@@ -4662,7 +4674,7 @@ async def admin_login_handler(request: Request, db: Session = Depends(get_db)) -
                     status_code=303,
                 )
 
-            _set_admin_csrf_cookie(request, response)
+            _set_admin_csrf_cookie(request, response, user_id=user.email, session_id=session_jti)
             LOGGER.info(f"Admin user {email} logged in successfully")
             return response
 
@@ -5291,8 +5303,13 @@ async def change_password_required_handler(request: Request, db: Session = Depen
                     LOGGER.error(f"Failed to re-attach user {user_email} to session: {e} - password changed but token creation skipped")
                     return RedirectResponse(url=f"{root_path}/admin/login?message=password_changed", status_code=303)
 
+                # Bind the CSRF cookie to the replacement session. The password change
+                # mints a new jti, which invalidates the HMAC bound to the login-time
+                # jti in admin_login_handler's password-change branch.
+                session_jti = str(uuid.uuid4())
+
                 # Create new JWT token
-                token, _ = await create_access_token(current_user)
+                token, _ = await create_access_token(current_user, jti=session_jti)
 
                 # Create redirect response to admin panel
                 response = RedirectResponse(url=f"{root_path}/admin", status_code=303)
@@ -5305,6 +5322,8 @@ async def change_password_required_handler(request: Request, db: Session = Depen
                         url=f"{root_path}/admin/login?error=token_too_large",
                         status_code=303,
                     )
+
+                _set_admin_csrf_cookie(request, response, user_id=current_user.email, session_id=session_jti)
 
                 LOGGER.info(f"User {current_user.email} successfully changed their expired password")
                 return response

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -1857,10 +1857,15 @@ async def enforce_admin_csrf(request: Request) -> None:
     if request.method.upper() in {"GET", "HEAD", "OPTIONS", "TRACE"}:
         return
 
-    jwt_cookie = request.cookies.get("jwt_token")
-    if not jwt_cookie:
+    session_cookie = request.cookies.get("jwt_token") or request.cookies.get("access_token")
+    request_path = getattr(request.url, "path", "") or ""
+    is_login_post = request_path.rstrip("/").endswith("/admin/login")
+    if not session_cookie and not is_login_post:
         # CSRF is relevant only for browser cookie auth. Token-auth API calls
-        # without session cookies are not subject to browser CSRF.
+        # without session cookies are not subject to browser CSRF. The login
+        # POST is the one exception: it is pre-auth (no session cookie exists
+        # yet) but still a state-changing browser action, so it is validated
+        # against the pre-auth nonce minted by admin_login_page's GET.
         return
 
     if not _request_origin_matches(request):

--- a/mcpgateway/api/v1/__init__.py
+++ b/mcpgateway/api/v1/__init__.py
@@ -275,7 +275,7 @@ def _assemble_routers(  # noqa: C901 — deliberate single-function assembly, co
 
         try:
             # First-Party
-            from mcpgateway.admin import admin_router, set_logging_service, validate_section_permissions  # pylint: disable=import-outside-toplevel
+            from mcpgateway.admin import admin_router, enforce_admin_csrf, set_logging_service, validate_section_permissions  # pylint: disable=import-outside-toplevel
 
             set_logging_service(logging_service)
             target_router.include_router(admin_router)
@@ -283,7 +283,6 @@ def _assemble_routers(  # noqa: C901 — deliberate single-function assembly, co
             logger.info("Admin router included - Admin API enabled")
 
             # First-Party
-            from mcpgateway.admin import enforce_admin_csrf  # pylint: disable=import-outside-toplevel
             from mcpgateway.routers.runtime_admin_router import runtime_admin_router  # pylint: disable=import-outside-toplevel
 
             # enforce_admin_csrf is required, not optional: /admin is in

--- a/mcpgateway/api/v1/__init__.py
+++ b/mcpgateway/api/v1/__init__.py
@@ -283,9 +283,13 @@ def _assemble_routers(  # noqa: C901 — deliberate single-function assembly, co
             logger.info("Admin router included - Admin API enabled")
 
             # First-Party
+            from mcpgateway.admin import enforce_admin_csrf  # pylint: disable=import-outside-toplevel
             from mcpgateway.routers.runtime_admin_router import runtime_admin_router  # pylint: disable=import-outside-toplevel
 
-            target_router.include_router(runtime_admin_router, prefix="/admin/runtime", tags=["Runtime Admin"])
+            # enforce_admin_csrf is required, not optional: /admin is in
+            # settings.csrf_exempt_paths, so CSRFMiddleware never runs on the legacy
+            # mount and this dependency is the only CSRF control these PATCH routes get.
+            target_router.include_router(runtime_admin_router, prefix="/admin/runtime", tags=["Runtime Admin"], dependencies=[Depends(enforce_admin_csrf)])
 
             # Only the /admin/well-known status endpoint belongs in the versioned
             # router.  The full well_known router (which owns /.well-known/* paths)

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -428,7 +428,11 @@ class Settings(BaseSettings):
             "/auth/email/register",
             "/auth/email/forgot-password",
             "/auth/email/reset-password",
-            "/admin",  # Exempt: all admin routes use per-route enforce_admin_csrf dependency
+            # Exempt: admin routes carry the per-route enforce_admin_csrf dependency
+            # instead. Enforced by tests/unit/mcpgateway/middleware/
+            # test_admin_csrf_binding.py::test_all_admin_write_routes_enforce_admin_csrf
+            # — do not mount a state-changing router under /admin without it.
+            "/admin",
             "/admin/login",
             "/admin/forgot-password",
             "/admin/reset-password",

--- a/tests/playwright/security/test_session_csrf_security.py
+++ b/tests/playwright/security/test_session_csrf_security.py
@@ -82,3 +82,144 @@ class TestSessionAndCSRFSecurity:
             headers={"Origin": "https://evil.example"},
         )
         assert response.status in (400, 403), f"Cross-origin POST should be rejected, got {response.status}"
+
+
+def _is_csrf_rejection(status: int, body: str) -> bool:
+    """Return True when a response was rejected by either CSRF layer.
+
+    ``CSRFMiddleware`` answers 403 with ``{"detail": "CSRF validation failed",
+    "code": "CSRF_TOKEN_INVALID"}``; ``enforce_admin_csrf`` raises ``HTTPException(403)``
+    with a detail containing "CSRF". An RBAC 403 from ``@require_permission`` is not a
+    CSRF rejection and must not be counted as one.
+
+    Args:
+        status: HTTP status code of the response.
+        body: Raw response body text.
+
+    Returns:
+        True if this is a CSRF rejection.
+    """
+    return status == 403 and ("CSRF_TOKEN_INVALID" in body or "CSRF" in body)
+
+
+@pytest.fixture
+def freshly_logged_in_page(page, base_url):
+    """A browser context logged in via the real form, with the dashboard NOT loaded.
+
+    The window between ``POST /admin/login`` and the first ``/admin/`` load is the whole
+    subject of #5978, so this fixture must not navigate to the dashboard — ``admin_ui()``
+    rotates the CSRF cookie to its HMAC-bound value and the divergence disappears. It
+    also cannot use ``_ensure_admin_logged_in``, which injects the JWT cookie directly
+    and so never exercises ``admin_login_handler`` at all.
+
+    ``max_redirects=0`` keeps the 303 from being followed into the dashboard while still
+    storing the cookies the login response set.
+
+    Args:
+        page: Playwright page (supplies the browser context cookie jar).
+        base_url: Gateway base URL.
+
+    Yields:
+        The Page, holding a freshly-issued, un-rotated admin session.
+    """
+    # First-Party
+    from tests.playwright.conftest import ADMIN_ACTIVE_PASSWORD, ADMIN_EMAIL
+
+    response = page.request.post(
+        f"{base_url}/admin/login",
+        form={"email": ADMIN_EMAIL, "password": ADMIN_ACTIVE_PASSWORD[0]},
+        max_redirects=0,
+    )
+    if response.status != 303:
+        pytest.skip(f"admin form login did not redirect as expected (status {response.status}); cannot test the pre-dashboard window")
+
+    location = response.headers.get("location", "")
+    if "change-password-required" in location:
+        pytest.skip("admin user requires a password change; the login redirect does not reach the tested flow")
+
+    yield page
+
+
+class TestAdminCsrfMountParity:
+    """`/admin/**` and `/v1/admin/**` must enforce identical CSRF requirements (#5978)."""
+
+    WRITE_PATH = "/admin/llm/providers/e2e-nonexistent-provider/state"
+
+    @staticmethod
+    def _csrf_headers(page, base_url: str) -> dict[str, str]:
+        """Build cookie-derived CSRF headers for an admin write.
+
+        Args:
+            page: Playwright page whose context holds the session cookies.
+            base_url: Gateway base URL, used as the Origin.
+
+        Returns:
+            Header dict carrying the CSRF token, Origin and Referer.
+        """
+        csrf_cookie = next((c for c in page.context.cookies() if c["name"] == ADMIN_CSRF_COOKIE_NAME), None)
+        assert csrf_cookie and csrf_cookie.get("value"), "login must set the admin CSRF cookie"
+        return {
+            ADMIN_CSRF_HEADER_NAME: csrf_cookie["value"],
+            "Origin": base_url,
+            "Referer": f"{base_url}/admin/",
+        }
+
+    def test_write_agrees_across_mounts_immediately_after_login(self, freshly_logged_in_page, base_url):
+        """Both mounts must accept the same cookie/header pair before any dashboard load.
+
+        Before #5978 was fixed, the `/admin/llm` write reached the handler while the
+        identical `/v1/admin/llm` write was rejected by CSRFMiddleware with 403
+        CSRF_TOKEN_INVALID, because the login cookie was an unbound opaque token.
+        """
+        if not settings.auth_required:
+            pytest.skip("Authentication is disabled; CSRF protections are not applicable.")
+
+        page = freshly_logged_in_page
+        headers = self._csrf_headers(page, base_url)
+
+        results = {}
+        for mount in ("", "/v1"):
+            response = page.request.post(f"{base_url}{mount}{self.WRITE_PATH}", headers=headers)
+            results[mount or "legacy"] = (response.status, response.text())
+
+        for mount, (status, body) in results.items():
+            assert not _is_csrf_rejection(status, body), f"{mount} mount was rejected by CSRF: {status} {body[:300]}"
+        assert results["legacy"][0] == results["/v1"][0], f"mounts disagree on status: {[(m, s) for m, (s, _) in results.items()]}"
+
+    def test_write_agrees_across_mounts_after_dashboard_rotation(self, freshly_logged_in_page, base_url):
+        """Parity must also hold once the dashboard has rotated the CSRF cookie.
+
+        This half passed before #5978 was fixed; it is the control proving the fix did
+        not change post-rotation behaviour.
+        """
+        if not settings.auth_required:
+            pytest.skip("Authentication is disabled; CSRF protections are not applicable.")
+
+        page = freshly_logged_in_page
+        page.goto(f"{base_url}/admin/")  # admin_ui() re-mints the JWT and rotates the CSRF cookie
+
+        headers = self._csrf_headers(page, base_url)
+
+        legacy = page.request.post(f"{base_url}{self.WRITE_PATH}", headers=headers)
+        versioned = page.request.post(f"{base_url}/v1{self.WRITE_PATH}", headers=headers)
+
+        assert not _is_csrf_rejection(legacy.status, legacy.text())
+        assert not _is_csrf_rejection(versioned.status, versioned.text())
+        assert legacy.status == versioned.status
+
+    def test_write_without_csrf_header_is_rejected_on_both_mounts(self, freshly_logged_in_page, base_url):
+        """Deny-path: omitting X-CSRF-Token must be rejected identically on both mounts.
+
+        Guards against "fixing" parity by weakening the versioned mount.
+        """
+        if not settings.auth_required:
+            pytest.skip("Authentication is disabled; CSRF protections are not applicable.")
+
+        page = freshly_logged_in_page
+        headers = {"Origin": base_url, "Referer": f"{base_url}/admin/"}
+
+        legacy = page.request.post(f"{base_url}{self.WRITE_PATH}", headers=headers)
+        versioned = page.request.post(f"{base_url}/v1{self.WRITE_PATH}", headers=headers)
+
+        assert legacy.status == 403, f"legacy mount must reject a write with no CSRF token, got {legacy.status}"
+        assert versioned.status == 403, f"versioned mount must reject a write with no CSRF token, got {versioned.status}"

--- a/tests/unit/mcpgateway/middleware/test_admin_csrf_binding.py
+++ b/tests/unit/mcpgateway/middleware/test_admin_csrf_binding.py
@@ -645,3 +645,316 @@ async def test_enforce_admin_csrf_skips_safe_methods():
     request = _make_admin_request(method="GET", cookies=_primed_cookies(), headers={})
 
     await enforce_admin_csrf(request)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Issue #5978 — admin_login_handler issued an unbound (opaque) CSRF cookie
+#
+# _set_admin_csrf_cookie falls back to secrets.token_urlsafe(32) when it is given
+# no user_id/session_id. That value satisfies enforce_admin_csrf's plain
+# double-submit compare but fails CSRFMiddleware's HMAC check, so the same write
+# succeeded on /admin/llm/* and 403'd on /v1/admin/llm/* for the whole window
+# between login and the first dashboard load.
+# ---------------------------------------------------------------------------
+
+
+def _make_cookie_request(cookies=None, root_path=""):
+    """Build a mocked Request usable by ``_set_admin_csrf_cookie``.
+
+    ``_make_admin_request`` exists for ``enforce_admin_csrf`` and only configures
+    method/cookies/headers/url. ``_set_admin_csrf_cookie`` additionally calls
+    ``_admin_cookie_path`` -> ``mcpgateway.utils.paths.resolve_root_path``, which reads
+    ``request.scope["root_path"]``. On a bare ``MagicMock(spec=Request)`` that subscript
+    returns another MagicMock, which then flows into ``response.set_cookie(path=...)``.
+
+    Args:
+        cookies: Cookie dict for the request.
+        root_path: ASGI root_path exposed via ``request.scope``.
+
+    Returns:
+        ``MagicMock(spec=Request)`` with a real scope dict.
+    """
+    request = _make_admin_request(cookies=cookies or {})
+    request.scope = {"root_path": root_path}
+    return request
+
+
+def _csrf_cookie_from(response):
+    """Extract the admin CSRF cookie value from a response's set-cookie headers.
+
+    Args:
+        response: Response written to by ``_set_admin_csrf_cookie``.
+
+    Returns:
+        The cookie value, or ``None`` when no CSRF cookie was set.
+    """
+    # Standard
+    from http.cookies import SimpleCookie
+
+    for header_name, header_value in response.raw_headers:
+        if header_name.decode().lower() != "set-cookie":
+            continue
+        jar = SimpleCookie()
+        jar.load(header_value.decode())
+        if CSRF_COOKIE in jar:
+            return jar[CSRF_COOKIE].value
+    return None
+
+
+def test_set_admin_csrf_cookie_bound_emits_hmac_not_opaque_token():
+    """Given user_id + session_id, the helper must emit a 64-char hex HMAC.
+
+    Pins the contract admin_login_handler now relies on: the bound branch produces a
+    token CSRFMiddleware can verify, not the opaque token_urlsafe fallback.
+    """
+    # First-Party
+    from mcpgateway.admin import _set_admin_csrf_cookie
+    from mcpgateway.services.csrf_service import validate_csrf_token
+
+    response = Response()
+    token = _set_admin_csrf_cookie(_make_cookie_request(), response, user_id=USER_EMAIL, session_id="jti-abc")
+
+    assert len(token) == 64
+    assert all(c in "0123456789abcdef" for c in token)
+    assert _csrf_cookie_from(response) == token
+    assert (
+        validate_csrf_token(
+            token,
+            USER_EMAIL,
+            "jti-abc",
+            settings_wrapper.csrf_secret_key.get_secret_value(),
+            settings_wrapper.csrf_token_expiry,
+        )
+        is True
+    )
+
+
+def test_set_admin_csrf_cookie_unbound_emits_opaque_token_that_fails_hmac():
+    """Without bindings the helper still emits the opaque token — the #5978 trigger.
+
+    Documents why the login handler must pass user_id/session_id: the unbound branch
+    is not merely weaker, it is unverifiable by CSRFMiddleware.
+    """
+    # First-Party
+    from mcpgateway.admin import _set_admin_csrf_cookie
+    from mcpgateway.services.csrf_service import validate_csrf_token
+
+    token = _set_admin_csrf_cookie(_make_cookie_request(), Response())
+
+    assert len(token) != 64 or not all(c in "0123456789abcdef" for c in token)
+    assert (
+        validate_csrf_token(
+            token,
+            USER_EMAIL,
+            "jti-abc",
+            settings_wrapper.csrf_secret_key.get_secret_value(),
+            settings_wrapper.csrf_token_expiry,
+        )
+        is False
+    )
+
+
+def test_set_admin_csrf_cookie_bound_token_rejects_foreign_identity():
+    """Deny-path: a bound token must not validate for another user or another session."""
+    # First-Party
+    from mcpgateway.admin import _set_admin_csrf_cookie
+    from mcpgateway.services.csrf_service import validate_csrf_token
+
+    token = _set_admin_csrf_cookie(_make_cookie_request(), Response(), user_id=USER_EMAIL, session_id="jti-abc")
+    secret = settings_wrapper.csrf_secret_key.get_secret_value()
+    expiry = settings_wrapper.csrf_token_expiry
+
+    assert validate_csrf_token(token, USER_EMAIL, "jti-other", secret, expiry) is False
+    assert validate_csrf_token(token, "attacker@example.com", "jti-abc", secret, expiry) is False
+    assert validate_csrf_token(token, "attacker@example.com", "jti-other", secret, expiry) is False
+
+
+@pytest.mark.parametrize("handler_name", ["admin_login_handler", "change_password_required_handler"])
+def test_admin_session_handlers_bind_csrf_cookie_to_email_and_jti(handler_name):
+    """Source-level guard: every handler that mints a session JWT must bind the CSRF cookie.
+
+    Same idiom as test_admin_login_binds_csrf_to_email_not_sub_claim above, which guards
+    the dashboard route. These two guard the handlers that issue a *new* jti:
+    admin_login_handler (both branches) and change_password_required_handler, which
+    re-mints after a forced password change. An unbound
+    _set_admin_csrf_cookie(request, response) call in either reintroduces #5978.
+    """
+    # Standard
+    import re
+
+    # First-Party
+    from mcpgateway import admin
+
+    source = inspect.getsource(getattr(admin, handler_name))
+
+    calls = re.findall(r"_set_admin_csrf_cookie\(([^)]*)\)", source)
+    assert calls, f"{handler_name} must still set the admin CSRF cookie"
+    for call_args in calls:
+        assert "user_id=" in call_args and "session_id=" in call_args, f"unbound _set_admin_csrf_cookie call in {handler_name}: _set_admin_csrf_cookie({call_args.strip()})"
+
+    # The bound jti must be the one embedded in the JWT that was just issued, not a
+    # fresh value the token never carries.
+    assert re.search(r"create_access_token\(\s*\w+\s*,\s*jti=session_jti\s*\)", source), f"{handler_name} must pass its session_jti to create_access_token"
+
+
+# ---------------------------------------------------------------------------
+# Structural guard: no state-changing /admin route without enforce_admin_csrf
+#
+# /admin is in settings.csrf_exempt_paths, so CSRFMiddleware never runs on the
+# unprefixed mount and enforce_admin_csrf is the only CSRF control there.
+# ---------------------------------------------------------------------------
+
+
+def _deps_of(obj):
+    """Return the dependency callables declared on a router, route, or include context.
+
+    Args:
+        obj: Object carrying an optional ``dependencies`` list of ``Depends`` markers.
+
+    Returns:
+        Tuple of dependency callables.
+    """
+    return tuple(d.dependency for d in getattr(obj, "dependencies", []) or [])
+
+
+def _walk_routes(router, prefix="", inherited=()):
+    """Yield ``(path, methods, dependency_callables)`` for every real route under *router*.
+
+    FastAPI 0.140+ does not flatten ``include_router()`` into ``router.routes``. Each
+    call appends a private ``_IncludedRouter`` wrapper holding ``original_router`` and an
+    ``include_context`` carrying that call's ``prefix`` and ``dependencies``. Iterating
+    ``router.routes`` naively yields wrappers with no ``.path``/``.methods``, so any
+    filter on those silently matches nothing.
+
+    Args:
+        router: APIRouter to walk.
+        prefix: Path prefix accumulated from enclosing include_router calls.
+        inherited: Dependency callables accumulated from enclosing routers/includes.
+
+    Yields:
+        Tuples of (full path, HTTP method set, set of dependency callables in scope).
+    """
+    inherited = inherited + _deps_of(router)
+    for route in router.routes:
+        if type(route).__name__ == "_IncludedRouter":
+            ctx = route.include_context
+            yield from _walk_routes(route.original_router, prefix + (ctx.prefix or ""), inherited + _deps_of(ctx))
+        else:
+            yield prefix + getattr(route, "path", ""), (getattr(route, "methods", set()) or set()), set(inherited + _deps_of(route))
+
+
+def _assembled_admin_routes():
+    """Assemble the real admin router surface without importing ``mcpgateway.main``.
+
+    ``_assemble_routers`` imports admin_router, llm_admin_router and runtime_admin_router
+    itself; the eleven routers it takes as kwargs are main.py's inline ones, none of
+    which are mounted under /admin. Empty stubs for those therefore produce the full
+    admin route table. Importing the assembled app singleton instead would reintroduce
+    the import-order fragility that PR #6008 removed from this file.
+
+    Returns:
+        The APIRouter all admin sub-routers were assembled into.
+    """
+    # Standard
+    from types import SimpleNamespace
+
+    # Third-Party
+    from fastapi import APIRouter
+
+    # First-Party
+    from mcpgateway.api.v1 import _assemble_routers
+
+    inline = {
+        name: APIRouter()
+        for name in (
+            "protocol_router",
+            "tool_router",
+            "resource_router",
+            "prompt_router",
+            "gateway_router",
+            "root_router",
+            "server_router",
+            "metrics_router",
+            "tag_router",
+            "export_import_router",
+            "a2a_router",
+        )
+    }
+
+    # Every settings attribute _assemble_routers reads must be present or it raises
+    # AttributeError. SimpleNamespace (not MagicMock) so a newly-read flag fails loudly
+    # instead of silently returning a truthy sentinel that changes which routers mount.
+    stub_settings = SimpleNamespace(
+        mcpgateway_admin_api_enabled=True,
+        llmchat_enabled=True,
+        email_auth_enabled=True,
+        sso_enabled=False,
+        mcpgateway_a2a_enabled=True,
+        mcpgateway_reverse_proxy_enabled=True,
+        mcpgateway_tool_cancellation_enabled=True,
+        metrics_cleanup_enabled=True,
+        metrics_rollup_enabled=True,
+        observability_enabled=True,
+        toolops_enabled=True,
+        llm_api_prefix="/llm",
+    )
+
+    target = APIRouter()
+    _assemble_routers(target, stub_settings, **inline)
+    return target
+
+
+def test_all_admin_write_routes_enforce_admin_csrf():
+    """Every state-changing /admin route must carry the enforce_admin_csrf dependency.
+
+    /admin/** is inside settings.csrf_exempt_paths, so CSRFMiddleware never runs there
+    and enforce_admin_csrf is the *only* CSRF control on that mount. A router mounted
+    under /admin without it has no CSRF protection at all. _assemble_routers is
+    prefix-agnostic, so these are the same route objects the /v1 mount serves — a
+    missing dependency is missing on both mounts.
+    """
+    # First-Party
+    from mcpgateway.admin import enforce_admin_csrf
+
+    safe_methods = {"GET", "HEAD", "OPTIONS", "TRACE"}
+    unprotected = []
+    checked = 0
+
+    for path, methods, calls in _walk_routes(_assembled_admin_routes()):
+        write_methods = methods - safe_methods
+        if not path.startswith("/admin/") or not write_methods:
+            continue
+        checked += 1
+        if enforce_admin_csrf not in calls:
+            unprotected.append(f"{sorted(write_methods)} {path}")
+
+    # Guard the guard: if the walk stops resolving includes (FastAPI internals change,
+    # or a settings flag turns the admin surface off) the assertion below would pass
+    # vacuously and this test would silently stop protecting anything.
+    assert checked > 50, f"expected the full admin write surface, only walked {checked} routes — _walk_routes is no longer resolving includes"
+
+    assert not unprotected, "Admin write routes missing enforce_admin_csrf:\n  " + "\n  ".join(sorted(unprotected))
+
+
+@pytest.mark.asyncio
+async def test_runtime_admin_patch_rejects_cookie_request_without_csrf_token():
+    """PATCH /admin/runtime/mcp-mode must reject a session-cookie request with no CSRF token.
+
+    runtime_admin_router was mounted without enforce_admin_csrf while /admin/** is
+    CSRF-exempt, leaving these mode-switch writes with no CSRF control on the legacy
+    mount. Found while scoping #5978.
+    """
+    # First-Party
+    from mcpgateway.admin import enforce_admin_csrf
+
+    request = _make_admin_request(
+        method="PATCH",
+        cookies={"jwt_token": "admin-session-jwt"},
+        headers={"origin": "http://localhost:4444", "host": "localhost:4444"},
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await enforce_admin_csrf(request)
+
+    assert exc_info.value.status_code == 403
+    assert "CSRF" in exc_info.value.detail

--- a/tests/unit/mcpgateway/middleware/test_admin_csrf_binding.py
+++ b/tests/unit/mcpgateway/middleware/test_admin_csrf_binding.py
@@ -446,20 +446,23 @@ async def test_csrf_fallback_preserves_existing_user_id():
 CSRF_COOKIE = "mcpgateway_csrf_token"  # ADMIN_CSRF_COOKIE_NAME (admin.py)
 CSRF_HEADER = "x-csrf-token"  # ADMIN_CSRF_HEADER_NAME (admin.py)
 ADMIN_URL = "http://localhost:4444/admin/llm/providers/e2e-nonexistent-provider/state"
+LOGIN_URL = "http://localhost:4444/admin/login"
 DOUBLE_SUBMIT_TOKEN = "double-submit-token-value-0123456789"  # pragma: allowlist secret
 
 
-def _make_admin_request(*, method="POST", cookies=None, headers=None, form=None):
+def _make_admin_request(*, method="POST", cookies=None, headers=None, form=None, url=ADMIN_URL):
     """Build a mocked Request for direct ``enforce_admin_csrf`` calls.
 
     Args:
         method: HTTP method (safe methods short-circuit the check).
-        cookies: Cookie dict; ``jwt_token`` presence is what makes CSRF
-            relevant at all.
+        cookies: Cookie dict; ``jwt_token``/``access_token`` presence is what
+            makes CSRF relevant at all (or the request path being the login
+            POST route, which is pre-auth and has no session cookie yet).
         headers: Header dict; origin/referer/host feed
             ``_request_origin_matches``.
         form: When provided, ``request.form()`` returns this dict (for the
             form-encoded token fallback).
+        url: Request URL; defaults to a generic protected admin route.
 
     Returns:
         A ``MagicMock(spec=Request)`` with a real ``URL`` so scheme/netloc
@@ -469,7 +472,7 @@ def _make_admin_request(*, method="POST", cookies=None, headers=None, form=None)
     request.method = method
     request.cookies = dict(cookies or {})
     request.headers = dict(headers or {})
-    request.url = URL(ADMIN_URL)
+    request.url = URL(url)
     if form is not None:
         request.form = AsyncMock(return_value=form)
     return request
@@ -631,6 +634,107 @@ async def test_enforce_admin_csrf_bypassed_without_session_cookie():
     from mcpgateway.admin import enforce_admin_csrf
 
     request = _make_admin_request(cookies={}, headers={})
+
+    await enforce_admin_csrf(request)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_enforce_admin_csrf_triggers_on_access_token_cookie_alone():
+    """An ``access_token`` cookie with no ``jwt_token`` still makes CSRF relevant.
+
+    PR #6111 review finding: the auth stack accepts ``access_token`` as an
+    ambient session cookie (see ``admin.py``'s own ``jwt_token`` / ``access_token``
+    fallback reads), but ``enforce_admin_csrf`` only checked ``jwt_token``. A
+    browser authenticated solely via ``access_token`` could submit
+    state-changing admin requests with no Origin or double-submit validation.
+    """
+    # First-Party
+    from mcpgateway.admin import enforce_admin_csrf
+
+    request = _make_admin_request(cookies={"access_token": "admin-session-jwt"}, headers={})
+
+    with pytest.raises(HTTPException) as exc_info:
+        await enforce_admin_csrf(request)
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "CSRF origin validation failed"
+
+
+@pytest.mark.asyncio
+async def test_enforce_admin_csrf_access_token_cookie_passes_with_valid_pair():
+    """Happy path for the ``access_token``-only session: matching CSRF pair + Origin passes."""
+    # First-Party
+    from mcpgateway.admin import enforce_admin_csrf
+
+    cookies = {"access_token": "admin-session-jwt", CSRF_COOKIE: DOUBLE_SUBMIT_TOKEN}
+    request = _make_admin_request(cookies=cookies, headers=_good_headers())
+
+    await enforce_admin_csrf(request)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_enforce_admin_csrf_login_post_rejected_without_preauth_nonce():
+    """POST /admin/login with no session cookie is *not* exempt from CSRF.
+
+    PR #6111 review finding: ``/admin/login`` is middleware-exempt and, before
+    this fix, ``enforce_admin_csrf`` returned early whenever no session cookie
+    was present — which is always true for a fresh, unauthenticated login POST.
+    A cross-site form could force a victim browser to submit attacker
+    credentials into the login endpoint with no CSRF control at all (login
+    CSRF / session confusion). The login route is the one exception where
+    CSRF must be validated pre-auth, against the nonce ``admin_login_page``
+    mints on GET.
+    """
+    # First-Party
+    from mcpgateway.admin import enforce_admin_csrf
+
+    request = _make_admin_request(method="POST", cookies={}, headers={}, url=LOGIN_URL)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await enforce_admin_csrf(request)
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "CSRF origin validation failed"
+
+
+@pytest.mark.asyncio
+async def test_enforce_admin_csrf_login_post_rejected_missing_preauth_cookie():
+    """Good Origin but no pre-auth CSRF cookie on login POST -> still rejected."""
+    # First-Party
+    from mcpgateway.admin import enforce_admin_csrf
+
+    request = _make_admin_request(
+        method="POST",
+        cookies={},
+        headers={"origin": "http://localhost:4444", "host": "localhost:4444"},
+        url=LOGIN_URL,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await enforce_admin_csrf(request)
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "CSRF token cookie missing"
+
+
+@pytest.mark.asyncio
+async def test_enforce_admin_csrf_login_post_passes_with_valid_preauth_nonce():
+    """Login POST with the pre-auth nonce (cookie + matching form field) passes with no session cookie."""
+    # First-Party
+    from mcpgateway.admin import enforce_admin_csrf
+
+    headers = {
+        "origin": "http://localhost:4444",
+        "host": "localhost:4444",
+        "content-type": "application/x-www-form-urlencoded",
+    }
+    request = _make_admin_request(
+        method="POST",
+        cookies={CSRF_COOKIE: DOUBLE_SUBMIT_TOKEN},
+        headers=headers,
+        form={"csrf_token": DOUBLE_SUBMIT_TOKEN},
+        url=LOGIN_URL,
+    )
 
     await enforce_admin_csrf(request)  # must not raise
 

--- a/tests/unit/mcpgateway/test_api_v1.py
+++ b/tests/unit/mcpgateway/test_api_v1.py
@@ -511,6 +511,16 @@ class TestBuildV1RouterGroupF:
         admin_mod.set_logging_service = MagicMock()
         admin_mod.validate_section_permissions = MagicMock()
 
+        # _assemble_routers imports enforce_admin_csrf from mcpgateway.admin to guard
+        # the runtime-admin mount. It must be a real callable, not a MagicMock:
+        # FastAPI inspects a dependency's signature when the router is included, and
+        # omitting it entirely makes the whole admin `try` block raise ImportError,
+        # silently dropping the runtime-admin and well-known includes that follow it.
+        async def _noop_enforce_admin_csrf() -> None:
+            return None
+
+        admin_mod.enforce_admin_csrf = _noop_enforce_admin_csrf
+
         runtime_admin_mod = ModuleType("_mock_runtime_admin")
         runtime_admin_mod.runtime_admin_router = _sentinel_router("/sentinel-runtime-admin")
 

--- a/tests/unit/mcpgateway/test_legacy_router.py
+++ b/tests/unit/mcpgateway/test_legacy_router.py
@@ -325,6 +325,16 @@ class TestBuildLegacyRouterGroupF:
         admin_mod.set_logging_service = lambda _: None
         admin_mod.validate_section_permissions = lambda _: None
 
+        # _assemble_routers imports enforce_admin_csrf from mcpgateway.admin to guard
+        # the runtime-admin mount. It must be a real callable, not a MagicMock:
+        # FastAPI inspects a dependency's signature when the router is included, and
+        # omitting it entirely makes the whole admin `try` block raise ImportError,
+        # silently dropping the runtime-admin and well-known includes that follow it.
+        async def _noop_enforce_admin_csrf() -> None:
+            return None
+
+        admin_mod.enforce_admin_csrf = _noop_enforce_admin_csrf
+
         runtime_mod = _make_mock_router_module_named("runtime_admin_router", "/sentinel-runtime-admin")
         well_known_mod = _make_mock_router_module("/sentinel-well-known")
         return {


### PR DESCRIPTION
Closes #5978

## Problem

`admin_login_handler` set the CSRF cookie via `_set_admin_csrf_cookie(request, response)` with no `user_id`/`session_id`, so it fell through to the opaque `secrets.token_urlsafe(32)` branch. That value satisfies `enforce_admin_csrf`'s plain `compare_digest` double-submit check but fails `CSRFService.validate_csrf_token()`, which requires a 64-char hex HMAC.

Because `/admin` sits in `csrf_exempt_paths` and the exemption is prefix-matched against the raw request path, only the versioned mount runs `CSRFMiddleware`. For the same session, same cookie, same header, same Origin, a write to `/admin/llm/*` succeeded while the identical write to `/v1/admin/llm/*` returned 403 `CSRF_TOKEN_INVALID` — for the whole window between login and the first dashboard load, which is the only place the cookie was rotated to its bound value.

## Approach

Option 1 from the issue: bind the cookie at login rather than exempting `/v1/admin` from the middleware. Option 2 would have made the mounts agree by *removing* the HMAC layer from the versioned mount, and would have silently stripped the only CSRF control from `/v1/admin/runtime/*`.

Binding now happens at every point a session JWT is minted, matching what `routers/auth.py`, `routers/email_auth.py` and `admin_ui()` already did:

- `admin_login_handler`, normal branch
- `admin_login_handler`, forced-password-change branch
- `change_password_required_handler`, which re-mints with a new `jti` and would otherwise leave the cookie bound to the superseded login session

Unauthenticated page renderers (`GET /admin/login`, forgot-password, reset-password, change-password-required) intentionally keep the unbound token — there is no session to bind to, and neither CSRF layer engages without a session cookie.

## Second gap closed

`runtime_admin_router` was mounted without `enforce_admin_csrf`. Its legacy path is inside the `/admin` exempt prefix, so `PATCH /admin/runtime/{mcp,a2a}-mode` had **no** CSRF control at all on the unprefixed mount. The `config.py` comment asserting "all admin routes use per-route enforce_admin_csrf" was inaccurate; it is now true and enforced by a test.

## Tests

- Direct-call tests pinning both branches of `_set_admin_csrf_cookie`, including that the unbound branch produces a token `CSRFMiddleware` genuinely rejects, plus deny-paths for foreign user and foreign session.
- Source guards over `admin_login_handler` and `change_password_required_handler`, following the existing idiom in this file.
- A structural guard that walks the assembled admin route table and fails on any state-changing `/admin` route lacking `enforce_admin_csrf`. It first failed with exactly the two runtime PATCH routes, then passed once they were wired. Note it resolves FastAPI 0.140's deferred `_IncludedRouter` wrappers — `include_router` no longer flattens into `router.routes`, and the naive walk silently matches zero routes, so there is a `checked > 50` assertion guarding against a vacuous pass. It currently covers 93 admin write routes.
- End-to-end mount parity added to the Playwright security suite, per the relocation in #6008.

The regression tests named in the issue are not on `main` — #5979 added them and #6008 removed them the next day as part of moving full-stack CSRF coverage out of the unit tier. The bug was unpinned until now.

## Behaviour change worth noting

Adding `enforce_admin_csrf` to the runtime routes means a caller authenticating **by session cookie** that omits `X-CSRF-Token` or a matching `Origin` now gets 403 on `PATCH /admin/runtime/{mcp,a2a}-mode`. Bearer-token callers are unaffected (`enforce_admin_csrf` returns early without a `jwt_token` cookie), which covers the live compliance suite and `scripts/compliance_matrix.py`. The Admin UI does not call these routes, and the documented cookie recipes in `api-usage.md` already send both headers.

## Known residuals (not fixed here)

1. `/admin/**` still never HMAC-validates — `enforce_admin_csrf` does origin + plain double-submit only, so it accepts tokens the versioned mount would reject.
2. `enforce_admin_csrf` and `CSRFMiddleware` disagree on which credentials make a request CSRF-relevant (`jwt_token` only vs. also `access_token`/proxy identity).
3. With `TOKEN_EXPIRY > 120`, the cookie's `max_age` can outlive the HMAC's acceptance window, reintroducing the divergence late in a long session. Pre-existing; documented in `configuration.md`.
4. `oauth_router.py` writes an unbound CSRF cookie when none is present. A bound one survives its regex check untouched.

Follow-up issues will be filed for these once this merges.
