### PR TITLE
Bff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # ========================================
 .env
 .env.*
+!**/.env.example
 .envrc
 .ica.env
 .htpasswd

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ eggs/
 lib/
 lib64/
 !client/src/lib/
+!client/server/src/lib/
 parts/
 sdist/
 var/

--- a/client/e2e/README.md
+++ b/client/e2e/README.md
@@ -58,7 +58,7 @@ Import the `test` and `expect` helpers from the fixture that matches your needs:
 // Unauthenticated / public flows
 import { test, expect } from "../fixtures/api-mock";
 
-// Authenticated flows (/app/auth/me mocked as a valid cookie session)
+// Authenticated flows (/auth/session mocked as a valid BFF session)
 import { test, expect } from "../fixtures/auth";
 ```
 
@@ -95,5 +95,7 @@ PRs and pushes to `main` / `epic/ui-rewrite` that touch `client/**`.
 - **Tests that pass locally but flake in CI** — add a `page.waitForLoadState`,
   tighten the mock's payload, or widen the retry count in the config for the
   specific test. Do not add arbitrary `waitForTimeout` calls.
-- **Mock not firing** — `page.route()` patterns use glob syntax. `"**/app/auth/me"`
-  is the supported form; a leading `/` anchors to the origin only.
+- **Mock not firing** — `page.route()` patterns use glob syntax. `"**/auth/session"`
+  is the supported form; a leading `/` anchors to the origin only. `**` spans
+  path segments, so it matches regardless of the `/api/*` prefix the BFF
+  proxy adds to non-auth calls (see `client/src/api/client.ts`).

--- a/client/e2e/auth/forgot-password.spec.ts
+++ b/client/e2e/auth/forgot-password.spec.ts
@@ -3,7 +3,7 @@ import { APP, TOKEN_STORAGE_KEY } from "../utils/paths";
 
 test.describe("Forgot password navigation", () => {
   test.beforeEach(async ({ page, apiMock }) => {
-    await apiMock.mockMe({ status: 401 });
+    await apiMock.mockSession({ authenticated: false });
     await page.addInitScript((key) => {
       window.sessionStorage.removeItem(key);
     }, TOKEN_STORAGE_KEY);

--- a/client/e2e/auth/login-flow.spec.ts
+++ b/client/e2e/auth/login-flow.spec.ts
@@ -3,7 +3,7 @@ import { APP, TOKEN_STORAGE_KEY } from "../utils/paths";
 
 test.describe("Login flow", () => {
   test.beforeEach(async ({ page, apiMock }) => {
-    await apiMock.mockMe({ status: 401 });
+    await apiMock.mockSession({ authenticated: false });
     await page.addInitScript((key) => {
       window.sessionStorage.removeItem(key);
     }, TOKEN_STORAGE_KEY);
@@ -57,7 +57,7 @@ test.describe("Login flow", () => {
 
   test("submit button shows loading state during request", async ({ page }) => {
     // Delay the response so the loading state is observable.
-    await page.route("**/app/auth/login", async (route) => {
+    await page.route("**/auth/login", async (route) => {
       await new Promise((resolve) => setTimeout(resolve, 500));
       await route.fulfill({
         status: 200,
@@ -72,7 +72,7 @@ test.describe("Login flow", () => {
             email_verified: true,
             password_change_required: false,
           },
-          mcpgateway_csrf_token: "mock-csrf-token",
+          csrfToken: "mock-csrf-token",
         }),
       });
     });

--- a/client/e2e/fixtures/api-mock.ts
+++ b/client/e2e/fixtures/api-mock.ts
@@ -2,10 +2,11 @@
  * Playwright fixture that exposes a typed API mock helper.
  *
  * Uses `page.route()` so tests run without a live backend. The payload
- * shapes mirror `client/src/auth/AuthContext.tsx` (`User`, `LoginResponse`).
+ * shapes mirror the BFF's auth routes (client/server/src/routes/auth/) and
+ * `client/src/auth/AuthContext.tsx` (`User`, `LoginResponse`, `SessionResponse`).
  */
 
-import { test as base, expect, type Page, type Route } from "@playwright/test";
+import { test as base, expect, type Page } from "@playwright/test";
 
 export interface MockUser {
   email: string;
@@ -31,7 +32,14 @@ export const MOCK_CSRF_TOKEN = "mock-csrf-token";
 
 export interface ApiMock {
   mockLogin(options?: { user?: MockUser; status?: number; detail?: string }): Promise<void>;
-  mockMe(options?: { user?: MockUser; status?: number }): Promise<void>;
+  /**
+   * Mocks GET /auth/session, the SPA's bootstrap probe. Unlike the old
+   * cookie-auth /app/auth/me, the BFF's /auth/session never 401s — it
+   * always returns 200 with an `authenticated` flag. Pass
+   * `authenticated: false` for the logged-out case; a bare call defaults to
+   * a logged-in DEFAULT_TEST_USER.
+   */
+  mockSession(options?: { user?: MockUser; authenticated?: boolean }): Promise<void>;
   mockUnauthorized(urlPattern: string | RegExp): Promise<void>;
 }
 
@@ -42,14 +50,14 @@ export function createApiMock(page: Page): ApiMock {
       status = 200,
       detail = "Invalid credentials",
     } = {}) {
-      await page.route("**/app/auth/login", async (route) => {
+      await page.route("**/auth/login", async (route) => {
         if (status === 200) {
           await route.fulfill({
             status,
             contentType: "application/json",
             body: JSON.stringify({
               user,
-              mcpgateway_csrf_token: MOCK_CSRF_TOKEN,
+              csrfToken: MOCK_CSRF_TOKEN,
             }),
           });
           return;
@@ -57,31 +65,23 @@ export function createApiMock(page: Page): ApiMock {
         await route.fulfill({
           status,
           contentType: "application/json",
-          body: JSON.stringify({ detail }),
+          body: JSON.stringify({ error: "login_failed", detail }),
         });
       });
     },
 
-    async mockMe({ user = DEFAULT_TEST_USER, status = 200 } = {}) {
-      const fulfillUser = async (route: Route) => {
-        if (status === 200) {
-          await route.fulfill({
-            status,
-            contentType: "application/json",
-            body: JSON.stringify(user),
-          });
-          return;
-        }
+    async mockSession({ user = DEFAULT_TEST_USER, authenticated = true } = {}) {
+      await page.route("**/auth/session", async (route) => {
         await route.fulfill({
-          status,
+          status: 200,
           contentType: "application/json",
-          body: JSON.stringify({ detail: "Unauthorized" }),
+          body: JSON.stringify(
+            authenticated
+              ? { authenticated: true, user, csrfToken: MOCK_CSRF_TOKEN }
+              : { authenticated: false },
+          ),
         });
-      };
-
-      await page.route("**/app/auth/me", fulfillUser);
-      await page.route("**/auth/email/me", fulfillUser);
-      await page.route("**/auth/me", fulfillUser);
+      });
     },
 
     async mockUnauthorized(urlPattern) {

--- a/client/e2e/fixtures/auth.ts
+++ b/client/e2e/fixtures/auth.ts
@@ -2,7 +2,7 @@
  * Authenticated-page fixture.
  *
  * Extends the base Playwright test with:
- *   - an `apiMock` with `/app/auth/me` + `/app/auth/login` pre-stubbed.
+ *   - an `apiMock` with `/auth/session` + `/auth/login` pre-stubbed.
  *
  * Tests import from here when they need to skip the login form and land
  * directly on an authenticated route.
@@ -18,13 +18,13 @@ type AuthFixtures = {
 export const test = base.extend<AuthFixtures>({
   page: async ({ page }, use) => {
     const mock = createApiMock(page);
-    await mock.mockMe();
+    await mock.mockSession();
     await mock.mockLogin();
     await use(page);
   },
   apiMock: async ({ page }, use) => {
     const mock = createApiMock(page);
-    await mock.mockMe();
+    await mock.mockSession();
     await mock.mockLogin();
     await use(mock);
   },

--- a/client/e2e/global-search.spec.ts
+++ b/client/e2e/global-search.spec.ts
@@ -3,7 +3,7 @@ import { APP } from "./utils/paths";
 
 test.describe("Global search", () => {
   test.beforeEach(async ({ apiMock }) => {
-    await apiMock.mockMe();
+    await apiMock.mockSession();
   });
 
   test("searches globally from the header and navigates to the selected result", async ({

--- a/client/e2e/prompts.spec.ts
+++ b/client/e2e/prompts.spec.ts
@@ -43,7 +43,7 @@ function makePrompt(id: string, gatewaySlug: string, overrides: Partial<Prompt> 
 
 test.describe("Prompts page", () => {
   test.beforeEach(async ({ page, apiMock }) => {
-    await apiMock.mockMe();
+    await apiMock.mockSession();
     await page.addInitScript(() => {
       sessionStorage.setItem("mcpgateway_token", "mock-token-12345");
     });

--- a/client/e2e/resources.spec.ts
+++ b/client/e2e/resources.spec.ts
@@ -30,7 +30,7 @@ const RESOURCE_B1 = makeResource("readme-md", "slack-server");
 test.describe("Resources page", () => {
   test.beforeEach(async ({ page, apiMock }) => {
     // Mock authentication
-    await apiMock.mockMe();
+    await apiMock.mockSession();
 
     // Set auth token in sessionStorage
     await page.addInitScript(() => {

--- a/client/e2e/servers.spec.ts
+++ b/client/e2e/servers.spec.ts
@@ -38,7 +38,7 @@ const MOCK_SERVER_2: MCPServer = {
 
 test.describe("MCP Servers page", () => {
   test.beforeEach(async ({ page, apiMock }) => {
-    await apiMock.mockMe();
+    await apiMock.mockSession();
 
     await page.addInitScript(() => {
       sessionStorage.setItem("mcpgateway_token", "mock-token-12345");

--- a/client/e2e/smoke/app-loads.spec.ts
+++ b/client/e2e/smoke/app-loads.spec.ts
@@ -3,9 +3,9 @@ import { APP } from "../utils/paths";
 
 test.describe("App loading (smoke)", () => {
   test("loads /app without JavaScript errors", async ({ page, apiMock }) => {
-    // Unauthenticated entry point: auth guard checks /app/auth/me and then
-    // redirects to /app/login when no cookie session exists.
-    await apiMock.mockMe({ status: 401 });
+    // Unauthenticated entry point: auth guard checks /auth/session and then
+    // redirects to /app/login when no session cookie exists.
+    await apiMock.mockSession({ authenticated: false });
 
     const consoleErrors: string[] = [];
     const pageErrors: string[] = [];
@@ -28,7 +28,7 @@ test.describe("App loading (smoke)", () => {
   });
 
   test("bare /app redirects into /app/ then to /app/login", async ({ page, apiMock }) => {
-    await apiMock.mockMe({ status: 401 });
+    await apiMock.mockSession({ authenticated: false });
 
     await page.goto("/app");
     await expect(page).toHaveURL(/\/app\/login\?next=%2Fapp%2F$/);

--- a/client/e2e/smoke/auth-redirect.spec.ts
+++ b/client/e2e/smoke/auth-redirect.spec.ts
@@ -3,7 +3,7 @@ import { APP, TOKEN_STORAGE_KEY } from "../utils/paths";
 
 test.describe("Unauthenticated access (smoke)", () => {
   test.beforeEach(async ({ page, apiMock }) => {
-    await apiMock.mockMe({ status: 401 });
+    await apiMock.mockSession({ authenticated: false });
     await page.addInitScript((key) => {
       window.sessionStorage.removeItem(key);
     }, TOKEN_STORAGE_KEY);

--- a/client/e2e/smoke/static-assets.spec.ts
+++ b/client/e2e/smoke/static-assets.spec.ts
@@ -9,7 +9,7 @@ import { APP } from "../utils/paths";
  */
 test.describe("Static assets (smoke)", () => {
   test("no 4xx/5xx for JS, CSS, or fonts on initial load", async ({ page, apiMock }) => {
-    await apiMock.mockMe({ status: 401 });
+    await apiMock.mockSession({ authenticated: false });
 
     const failures: string[] = [];
     page.on("response", (response) => {

--- a/client/e2e/smoke/team-switcher.spec.ts
+++ b/client/e2e/smoke/team-switcher.spec.ts
@@ -4,7 +4,7 @@ import { APP } from "../utils/paths";
 test.describe("TeamSwitcher component (smoke)", () => {
   test("renders and displays teams from API", async ({ page, apiMock }) => {
     // Mock authenticated user
-    await apiMock.mockMe();
+    await apiMock.mockSession();
 
     // Mock /teams endpoint
     await page.route("**/teams", async (route) => {
@@ -41,7 +41,7 @@ test.describe("TeamSwitcher component (smoke)", () => {
 
   test("displays error message when teams fail to load", async ({ page, apiMock }) => {
     // Mock authenticated user
-    await apiMock.mockMe();
+    await apiMock.mockSession();
 
     // Mock /teams endpoint with error
     await page.route("**/teams", async (route) => {

--- a/client/e2e/teams.spec.ts
+++ b/client/e2e/teams.spec.ts
@@ -91,7 +91,7 @@ async function pickComboboxOption(
 
 test.describe("Teams page", () => {
   test.beforeEach(async ({ page, apiMock }) => {
-    await apiMock.mockMe();
+    await apiMock.mockSession();
 
     await page.addInitScript(() => {
       sessionStorage.setItem("mcpgateway_token", "mock-token-12345");

--- a/client/e2e/tools.spec.ts
+++ b/client/e2e/tools.spec.ts
@@ -75,7 +75,7 @@ const TOOL_B1 = makeTool("send_message", "slack-server");
 
 test.describe("Tools page", () => {
   test.beforeEach(async ({ page, apiMock }) => {
-    await apiMock.mockMe();
+    await apiMock.mockSession();
 
     await page.addInitScript(() => {
       sessionStorage.setItem("mcpgateway_token", "mock-token-12345");
@@ -721,13 +721,13 @@ test.describe("Tools page", () => {
   const authScenarios: Array<{
     label: string;
     authLabelFor: string | null;
-    fillCreds: (page: Page) => Promise<void>;
-    expectAuth: (tool: Record<string, unknown>) => void;
+    fillCreds: (page: Page) => Promise<void>; // pragma: allowlist secret
+    expectAuth: (tool: Record<string, unknown>) => void; // pragma: allowlist secret
   }> = [
     {
       label: "no authentication",
       authLabelFor: null,
-      fillCreds: async () => {},
+      fillCreds: async () => {}, // pragma: allowlist secret
       expectAuth: (tool) => {
         expect(tool.auth_type).toBeUndefined();
       },
@@ -735,7 +735,8 @@ test.describe("Tools page", () => {
     {
       label: "basic authentication",
       authLabelFor: "auth-basic",
-      fillCreds: async (page) => {
+      // prettier-ignore
+      fillCreds: async (page) => { // pragma: allowlist secret
         await page.locator("#basic-auth-username").fill("api_user");
         await page.locator("#basic-auth-password").fill("s3cret_pass");
       },
@@ -748,7 +749,8 @@ test.describe("Tools page", () => {
     {
       label: "bearer token authentication",
       authLabelFor: "auth-bearer",
-      fillCreds: async (page) => {
+      // prettier-ignore
+      fillCreds: async (page) => { // pragma: allowlist secret
         await page.locator("#bearer-token").fill("tok_abc123");
       },
       expectAuth: (tool) => {
@@ -759,7 +761,8 @@ test.describe("Tools page", () => {
     {
       label: "custom header authentication",
       authLabelFor: "auth-custom",
-      fillCreds: async (page) => {
+      // prettier-ignore
+      fillCreds: async (page) => { // pragma: allowlist secret
         await page.getByRole("button", { name: "Add header" }).click();
         await page.locator("#header-key-0").fill("X-API-Key");
         await page.locator("#header-value-0").fill("key_value_123");

--- a/client/e2e/users.spec.ts
+++ b/client/e2e/users.spec.ts
@@ -39,7 +39,7 @@ const MOCK_USER_ROUTE = `**/auth/email/admin/users/${encodeURIComponent(MOCK_USE
 
 test.describe("Users page", () => {
   test.beforeEach(async ({ page, apiMock }) => {
-    await apiMock.mockMe();
+    await apiMock.mockSession();
 
     await page.addInitScript(() => {
       sessionStorage.setItem("mcpgateway_token", "mock-token-12345");

--- a/client/e2e/utils/paths.ts
+++ b/client/e2e/utils/paths.ts
@@ -32,12 +32,14 @@ export const APP = {
 } as const;
 
 /**
- * API endpoints consumed by the client. Patterns use Playwright's glob syntax
- * so they match regardless of origin (dev vs. reverse-proxied gateway).
+ * BFF-owned auth endpoints consumed by the client (client/server/src/routes/auth/).
+ * Patterns use Playwright's glob syntax so they match regardless of origin
+ * (dev vs. reverse-proxied gateway) — everything else the client calls goes
+ * through the BFF's /api/* proxy instead (see client/src/api/client.ts).
  */
 export const API = {
-  LOGIN: "**/app/auth/login",
-  ME: "**/app/auth/me",
+  LOGIN: "**/auth/login",
+  SESSION: "**/auth/session",
 } as const;
 
 /**

--- a/client/e2e/virtual-servers.spec.ts
+++ b/client/e2e/virtual-servers.spec.ts
@@ -75,7 +75,7 @@ const MOCK_MCP_SERVER_2 = {
 test.describe("Virtual Servers page", () => {
   test.beforeEach(async ({ page, apiMock }) => {
     // Mock authentication
-    await apiMock.mockMe();
+    await apiMock.mockSession();
 
     // Set auth token in sessionStorage
     await page.addInitScript(() => {

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "dev:e2e": "vite --base=/ --port 5173 --strictPort",
     "build": "npm run generate && tsc -b && vite build",
     "build:watch": "vite build --watch",
+    "build:bff": "npm run generate && tsc -b && vite build --config vite.bff.config.ts",
     "preview": "vite preview",
     "lint": "eslint src e2e",
     "lint:fix": "eslint src e2e --fix",

--- a/client/server/.env.example
+++ b/client/server/.env.example
@@ -1,0 +1,28 @@
+# BFF server config. Copy to .env and adjust for your environment.
+
+PORT=3000
+HOST=0.0.0.0
+
+# Upstream ContextForge API (FastAPI). Server-to-server only.
+FASTAPI_URL=http://127.0.0.1:4444
+
+# memory:// = in-process store, no Redis process needed (dev only — state is
+# lost on restart, not shared across instances). Use a real redis:// URL for
+# anything beyond a single local dev process, e.g. redis://localhost:6379/0.
+REDIS_URL=memory://
+
+# Opaque session_id -> bearer token TTL in Redis, seconds.
+SESSION_TTL_SECONDS=86400
+
+# Leave unset for a host-only cookie (recommended unless the BFF and its
+# subdomains genuinely need to share the session cookie).
+COOKIE_DOMAIN=
+# Set to "false" only for local HTTP development. Must be "true" (default) in prod.
+COOKIE_SECURE=true
+
+# How often an open SSE connection re-checks Redis for session revocation,
+# as a fallback to the pub/sub-based instant revocation. See
+# agent-output/bff-proxy-and-sse-plan.md.
+SSE_SESSION_RECHECK_SECONDS=15
+
+LOG_LEVEL=info

--- a/client/server/package.json
+++ b/client/server/package.json
@@ -5,15 +5,16 @@
   "type": "module",
   "description": "Backend For Frontend: session/CSRF boundary between the browser and the ContextForge API, keeping the API JWT off the browser.",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx watch --env-file-if-exists=.env src/index.ts",
     "build": "tsc -p tsconfig.json",
-    "start": "node dist/index.js",
+    "start": "node --env-file-if-exists=.env dist/index.js",
     "test": "vitest",
     "test:run": "vitest run",
     "lint": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "@fastify/cookie": "^11.1.2",
+    "@fastify/static": "^10.1.2",
     "@fastify/csrf-protection": "^8.0.1",
     "@fastify/redis": "^8.0.0",
     "@fastify/reply-from": "^12.6.4",

--- a/client/server/package.json
+++ b/client/server/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "mcp-context-forge-bff",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Backend For Frontend: session/CSRF boundary between the browser and the ContextForge API, keeping the API JWT off the browser.",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "lint": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@fastify/cookie": "^11.1.2",
+    "@fastify/csrf-protection": "^8.0.1",
+    "@fastify/redis": "^8.0.0",
+    "@fastify/reply-from": "^12.6.4",
+    "fastify": "^5.11.2",
+    "fastify-plugin": "^6.0.0",
+    "ioredis": "^5.11.1",
+    "undici": "^8.10.0"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.2",
+    "tsx": "^4.23.7",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.10"
+  }
+}

--- a/client/server/src/config.ts
+++ b/client/server/src/config.ts
@@ -18,7 +18,10 @@ export const config = {
   // server-to-server only — the browser never talks to this origin directly.
   fastapiUrl: optional("FASTAPI_URL", "http://127.0.0.1:4444"),
 
-  redisUrl: optional("REDIS_URL", "redis://localhost:6379/0"),
+  // memory:// (default) = in-process store, no Redis needed — dev only.
+  // See lib/memory-redis.ts. Use a real redis:// URL beyond a single
+  // local dev process.
+  redisUrl: optional("REDIS_URL", "memory://"),
 
   // Opaque session_id -> { bearerToken, user } TTL in Redis. Independent of
   // the upstream JWT's own expiry; the BFF just stops trusting a stale
@@ -28,6 +31,12 @@ export const config = {
   cookieDomain: process.env.COOKIE_DOMAIN, // undefined = host-only cookie
   cookieSecure: optional("COOKIE_SECURE", "true") === "true",
 
+  // SPA build directory (see plugins/static.ts). undefined = default,
+  // computed relative to that plugin's own file location
+  // (`cd client && npm run build:bff` -> client/server/public/). Override
+  // for a non-standard layout, or to point at a temp dir in tests.
+  publicDir: process.env.PUBLIC_DIR,
+
   // Session-revocation re-check cadence for long-lived SSE connections
   // (Option A from agent-output/bff-proxy-and-sse-plan.md — bounded staleness,
   // no pub/sub required). Revisit if instant revocation becomes a hard requirement.
@@ -35,3 +44,7 @@ export const config = {
 
   logLevel: optional("LOG_LEVEL", "info"),
 } as const;
+
+if (process.env.NODE_ENV === "production" && config.redisUrl.startsWith("memory://")) {
+  throw new Error("REDIS_URL=memory:// is dev-only — set a real redis:// URL in production");
+}

--- a/client/server/src/config.ts
+++ b/client/server/src/config.ts
@@ -1,0 +1,37 @@
+// Location: ./client/server/src/config.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// Env-driven config for the BFF. All values have dev-safe defaults; override
+// via env in every non-local deployment (COOKIE_SECURE and FASTAPI_URL in
+// particular).
+
+function optional(name: string, fallback: string): string {
+  return process.env[name] ?? fallback;
+}
+
+export const config = {
+  port: Number(optional("PORT", "3000")),
+  host: optional("HOST", "0.0.0.0"),
+
+  // Upstream ContextForge API (FastAPI). All bearer-token traffic goes here,
+  // server-to-server only — the browser never talks to this origin directly.
+  fastapiUrl: optional("FASTAPI_URL", "http://127.0.0.1:4444"),
+
+  redisUrl: optional("REDIS_URL", "redis://localhost:6379/0"),
+
+  // Opaque session_id -> { bearerToken, user } TTL in Redis. Independent of
+  // the upstream JWT's own expiry; the BFF just stops trusting a stale
+  // session key once this elapses.
+  sessionTtlSeconds: Number(optional("SESSION_TTL_SECONDS", "86400")),
+
+  cookieDomain: process.env.COOKIE_DOMAIN, // undefined = host-only cookie
+  cookieSecure: optional("COOKIE_SECURE", "true") === "true",
+
+  // Session-revocation re-check cadence for long-lived SSE connections
+  // (Option A from agent-output/bff-proxy-and-sse-plan.md — bounded staleness,
+  // no pub/sub required). Revisit if instant revocation becomes a hard requirement.
+  sseSessionRecheckSeconds: Number(optional("SSE_SESSION_RECHECK_SECONDS", "15")),
+
+  logLevel: optional("LOG_LEVEL", "info"),
+} as const;

--- a/client/server/src/index.ts
+++ b/client/server/src/index.ts
@@ -14,6 +14,8 @@ import cookiePlugin from "./plugins/cookie.js";
 import csrfPlugin from "./plugins/csrf.js";
 import redisPlugin from "./plugins/redis.js";
 import sessionPlugin from "./plugins/session.js";
+import staticPlugin from "./plugins/static.js";
+import appRoute from "./routes/app.js";
 import loginRoute from "./routes/auth/login.js";
 import logoutRoute from "./routes/auth/logout.js";
 import sessionRoute from "./routes/auth/session.js";
@@ -27,6 +29,7 @@ await fastify.register(cookiePlugin);
 await fastify.register(redisPlugin);
 await fastify.register(sessionPlugin);
 await fastify.register(csrfPlugin);
+await fastify.register(staticPlugin);
 
 fastify.get("/healthz", async () => ({ ok: true }));
 
@@ -35,6 +38,7 @@ await fastify.register(logoutRoute);
 await fastify.register(sessionRoute);
 await fastify.register(sseRoutes);
 await fastify.register(catchAllProxyRoute);
+await fastify.register(appRoute);
 
 const revocationSubscriber = startRevocationSubscriber();
 fastify.addHook("onClose", async () => {

--- a/client/server/src/index.ts
+++ b/client/server/src/index.ts
@@ -1,0 +1,49 @@
+// Location: ./client/server/src/index.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// BFF entrypoint. Plugin order matters: cookie -> redis -> session -> csrf,
+// then routes. Session/CSRF are decorators applied per-route (see
+// plugins/session.ts, plugins/csrf.ts), not global onRequest hooks, since
+// SSE routes need different CSRF treatment than the /api/* catch-all.
+
+import Fastify from "fastify";
+
+import { config } from "./config.js";
+import cookiePlugin from "./plugins/cookie.js";
+import csrfPlugin from "./plugins/csrf.js";
+import redisPlugin from "./plugins/redis.js";
+import sessionPlugin from "./plugins/session.js";
+import loginRoute from "./routes/auth/login.js";
+import logoutRoute from "./routes/auth/logout.js";
+import sessionRoute from "./routes/auth/session.js";
+import catchAllProxyRoute from "./routes/proxy/catch-all.js";
+import { startRevocationSubscriber } from "./routes/sse/revocation-subscriber.js";
+import sseRoutes from "./routes/sse/routes.js";
+
+const fastify = Fastify({ logger: { level: config.logLevel } });
+
+await fastify.register(cookiePlugin);
+await fastify.register(redisPlugin);
+await fastify.register(sessionPlugin);
+await fastify.register(csrfPlugin);
+
+fastify.get("/healthz", async () => ({ ok: true }));
+
+await fastify.register(loginRoute);
+await fastify.register(logoutRoute);
+await fastify.register(sessionRoute);
+await fastify.register(sseRoutes);
+await fastify.register(catchAllProxyRoute);
+
+const revocationSubscriber = startRevocationSubscriber();
+fastify.addHook("onClose", async () => {
+  await revocationSubscriber.quit();
+});
+
+try {
+  await fastify.listen({ port: config.port, host: config.host });
+} catch (err) {
+  fastify.log.error(err);
+  process.exit(1);
+}

--- a/client/server/src/lib/memory-redis.ts
+++ b/client/server/src/lib/memory-redis.ts
@@ -1,0 +1,92 @@
+// Location: ./client/server/src/lib/memory-redis.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// Zero-dependency in-process stand-in for ioredis, selected when
+// REDIS_URL=memory:// — dev-only convenience so `pnpm dev` needs nothing
+// running beyond FastAPI, same spirit as sqlite for `make dev`. Never use
+// in production: state is lost on restart and isn't shared across
+// processes, which defeats both session revocation and horizontal scaling.
+//
+// Store and pub/sub bus are module-level singletons so every MemoryRedis
+// instance in this process (the command client in plugins/redis.ts and the
+// dedicated subscriber in routes/sse/revocation-subscriber.ts) sees the
+// other's writes/publishes, exactly like two connections to one real Redis.
+
+import { EventEmitter } from "node:events";
+
+export const MEMORY_REDIS_URL_PREFIX = "memory://";
+
+export function isMemoryRedisUrl(url: string): boolean {
+  return url.startsWith(MEMORY_REDIS_URL_PREFIX);
+}
+
+interface StoredValue {
+  value: string;
+  expiresAt: number | null;
+}
+
+const store = new Map<string, StoredValue>();
+const bus = new EventEmitter();
+bus.setMaxListeners(0);
+
+function isExpired(entry: StoredValue): boolean {
+  return entry.expiresAt !== null && entry.expiresAt <= Date.now();
+}
+
+function globToRegExp(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+  return new RegExp(`^${escaped}$`);
+}
+
+export class MemoryRedis extends EventEmitter {
+  async get(key: string): Promise<string | null> {
+    const entry = store.get(key);
+    if (!entry || isExpired(entry)) {
+      if (entry) store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async setex(key: string, ttlSeconds: number, value: string): Promise<"OK"> {
+    store.set(key, { value, expiresAt: Date.now() + ttlSeconds * 1000 });
+    return "OK";
+  }
+
+  async del(key: string): Promise<number> {
+    return store.delete(key) ? 1 : 0;
+  }
+
+  async publish(channel: string, message: string): Promise<number> {
+    const before = bus.listenerCount("publish");
+    bus.emit("publish", channel, message);
+    return before;
+  }
+
+  // Mirrors ioredis's variadic signature: one or more patterns, optional
+  // trailing (err, count) callback.
+  async psubscribe(
+    ...args: Array<string | ((err: Error | null, count?: number) => void)>
+  ): Promise<number> {
+    const patterns = args.filter((a): a is string => typeof a === "string");
+    const callback = args.find(
+      (a): a is (err: Error | null, count?: number) => void => typeof a === "function",
+    );
+
+    for (const pattern of patterns) {
+      const regex = globToRegExp(pattern);
+      bus.on("publish", (channel: string, message: string) => {
+        if (regex.test(channel)) this.emit("pmessage", pattern, channel, message);
+      });
+    }
+
+    callback?.(null, patterns.length);
+    return patterns.length;
+  }
+
+  async quit(): Promise<"OK"> {
+    this.removeAllListeners();
+    return "OK";
+  }
+}

--- a/client/server/src/lib/session-store.ts
+++ b/client/server/src/lib/session-store.ts
@@ -1,0 +1,109 @@
+// Location: ./client/server/src/lib/session-store.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// Opaque session_id -> { bearerToken, user } in Redis. The browser only ever
+// sees the session_id (HttpOnly cookie); the bearer token never leaves the BFF.
+
+import { randomUUID } from "node:crypto";
+
+import type { FastifyReply } from "fastify";
+
+import { config } from "../config.js";
+
+export const SESSION_COOKIE_NAME = "bff_sid";
+
+// Structural subset of the ioredis client this module actually calls.
+// Avoids coupling to @fastify/redis's decorated instance type (which wraps
+// ioredis with its own generics) and lets tests pass an in-memory fake.
+export interface RedisLike {
+  get(key: string): Promise<string | null>;
+  setex(key: string, ttlSeconds: number, value: string): Promise<unknown>;
+  del(key: string): Promise<unknown>;
+  publish(channel: string, message: string): Promise<unknown>;
+}
+
+// Passthrough of the upstream API's user object (EmailUserResponse — email,
+// full_name, is_admin, is_active, auth_provider, email_verified,
+// password_change_required, ...). The BFF doesn't interpret these fields —
+// it stores and echoes back whatever FastAPI returned, snake_case included,
+// so the SPA's User type (client/src/auth/AuthContext.tsx) matches without
+// a translation layer that would drift as the upstream schema evolves.
+export interface SessionUser {
+  email: string;
+  [key: string]: unknown;
+}
+
+export interface SessionRecord {
+  bearerToken: string;
+  user: SessionUser;
+}
+
+export function sessionRedisKey(sessionId: string): string {
+  return `bff:session:${sessionId}`;
+}
+
+/** Publish channel for cross-instance revocation (see routes/sse/revocation-subscriber.ts). */
+export function sessionRevokedChannel(sessionId: string): string {
+  return `bff:session:revoked:${sessionId}`;
+}
+
+// TTL defaults to config.sessionTtlSeconds, but callers should pass the
+// upstream token's real expires_in (see routes/auth/login.ts) — the BFF
+// session and cookie must not outlive the bearer token they wrap. A session
+// that looks valid for 24h while the JWT died in 20 minutes just means
+// every call in between silently 401s until the proxy's own revoke-on-401
+// catches it (see routes/proxy/catch-all.ts); matching the TTL up front
+// avoids that window entirely.
+export async function createSession(
+  redis: RedisLike,
+  record: SessionRecord,
+  ttlSeconds: number = config.sessionTtlSeconds,
+): Promise<string> {
+  const sessionId = randomUUID();
+  await redis.setex(sessionRedisKey(sessionId), ttlSeconds, JSON.stringify(record));
+  return sessionId;
+}
+
+export async function getSession(
+  redis: RedisLike,
+  sessionId: string,
+): Promise<SessionRecord | null> {
+  const raw = await redis.get(sessionRedisKey(sessionId));
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as SessionRecord;
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteSession(redis: RedisLike, sessionId: string): Promise<void> {
+  await redis.del(sessionRedisKey(sessionId));
+  // Best-effort fan-out so any BFF instance holding an open SSE socket for
+  // this session aborts it promptly. No subscribers = no-op; not required
+  // for correctness (see Option A staleness re-check in the SSE proxy).
+  await redis.publish(sessionRevokedChannel(sessionId), "1");
+}
+
+export function setSessionCookie(
+  reply: FastifyReply,
+  sessionId: string,
+  maxAgeSeconds: number = config.sessionTtlSeconds,
+): void {
+  reply.setCookie(SESSION_COOKIE_NAME, sessionId, {
+    httpOnly: true,
+    secure: config.cookieSecure,
+    sameSite: "lax",
+    path: "/",
+    domain: config.cookieDomain,
+    maxAge: maxAgeSeconds,
+  });
+}
+
+export function clearSessionCookie(reply: FastifyReply): void {
+  reply.clearCookie(SESSION_COOKIE_NAME, {
+    path: "/",
+    domain: config.cookieDomain,
+  });
+}

--- a/client/server/src/lib/sse-headers.ts
+++ b/client/server/src/lib/sse-headers.ts
@@ -1,0 +1,20 @@
+// Location: ./client/server/src/lib/sse-headers.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// Response headers for a hijacked SSE passthrough. Replicates what
+// infra/nginx/nginx.conf's SSE location blocks do for the browser<->nginx
+// hop (no buffering, no compression, indefinite keep-alive) — there's no
+// nginx sitting between the BFF and FastAPI, so the BFF has to do it itself.
+
+import type { ServerResponse } from "node:http";
+
+export function writeSseHeaders(res: ServerResponse): void {
+  res.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-cache",
+    connection: "keep-alive",
+    "x-accel-buffering": "no", // belt-and-suspenders if nginx ever ends up in front of the BFF too
+  });
+  res.flushHeaders?.();
+}

--- a/client/server/src/lib/upstream-http-client.ts
+++ b/client/server/src/lib/upstream-http-client.ts
@@ -1,0 +1,18 @@
+// Location: ./client/server/src/lib/upstream-http-client.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// Dedicated undici pool for long-lived SSE upstream connections, separate
+// from @fastify/reply-from's pool (used by the generic /api/* catch-all).
+// SSE needs headersTimeout/bodyTimeout disabled; that must not leak into the
+// pool used for normal short-lived request/response calls.
+// See agent-output/bff-proxy-and-sse-plan.md, "Why hand-rolled ... for SSE".
+
+import { Pool } from "undici";
+
+import { config } from "../config.js";
+
+export const sseUpstreamPool = new Pool(config.fastapiUrl, {
+  headersTimeout: 0,
+  bodyTimeout: 0,
+});

--- a/client/server/src/plugins/cookie.ts
+++ b/client/server/src/plugins/cookie.ts
@@ -1,0 +1,14 @@
+// Location: ./client/server/src/plugins/cookie.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+
+import fastifyCookie from "@fastify/cookie";
+import type { FastifyInstance } from "fastify";
+import fp from "fastify-plugin";
+
+export default fp(
+  async function cookiePlugin(fastify: FastifyInstance) {
+    await fastify.register(fastifyCookie);
+  },
+  { name: "cookiePlugin" },
+);

--- a/client/server/src/plugins/csrf.ts
+++ b/client/server/src/plugins/csrf.ts
@@ -1,0 +1,45 @@
+// Location: ./client/server/src/plugins/csrf.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// Double-submit CSRF, browser<->BFF boundary only (BFF<->API is a
+// server-to-server bearer token, no CSRF needed there). Cookie-mode
+// (backed by @fastify/cookie, no server session store) since the BFF's own
+// session plugin is hand-rolled, not @fastify/session.
+//
+// The cookie this plugin sets (bff_csrf) holds a *secret*, not the token —
+// it stays HttpOnly. The actual token (`reply.generateCsrf()`'s return
+// value) is handed to the SPA in the JSON body of /auth/login and
+// /auth/session and must be echoed back in the X-CSRF-Token header on
+// mutating requests. This differs from the pre-BFF pattern of reading the
+// CSRF cookie straight off `document.cookie` (mcpgateway_csrf_token was the
+// token itself, not a secret) — that pattern doesn't fit this library's
+// secret/token split.
+//
+// Registered as a decorator (fastify.csrfProtection), applied per-route via
+// preHandler — not globally — so SSE routes (which can't send custom
+// headers) can opt out. See agent-output/bff-proxy-and-sse-plan.md Risk #2.
+
+import fastifyCsrf from "@fastify/csrf-protection";
+import type { FastifyInstance } from "fastify";
+import fp from "fastify-plugin";
+
+import { config } from "../config.js";
+
+export const CSRF_COOKIE_NAME = "bff_csrf";
+
+export default fp(
+  async function csrfPlugin(fastify: FastifyInstance) {
+    await fastify.register(fastifyCsrf, {
+      cookieKey: CSRF_COOKIE_NAME,
+      cookieOpts: {
+        httpOnly: true,
+        secure: config.cookieSecure,
+        sameSite: "strict",
+        path: "/",
+        domain: config.cookieDomain,
+      },
+    });
+  },
+  { name: "csrfPlugin", dependencies: ["cookiePlugin"] },
+);

--- a/client/server/src/plugins/redis.ts
+++ b/client/server/src/plugins/redis.ts
@@ -6,15 +6,31 @@
 // storage, PUBLISH for revocation). The dedicated subscriber connection used
 // by SSE revocation lives separately in routes/sse/revocation-subscriber.ts —
 // ioredis connections in subscribe mode can't issue normal commands.
+//
+// REDIS_URL=memory:// swaps in an in-process store (lib/memory-redis.ts) —
+// dev-only, no Redis process required, same spirit as sqlite for `make dev`.
 
 import fastifyRedis from "@fastify/redis";
 import type { FastifyInstance } from "fastify";
 import fp from "fastify-plugin";
 
 import { config } from "../config.js";
+import { isMemoryRedisUrl, MemoryRedis } from "../lib/memory-redis.js";
 
 export default fp(
   async function redisPlugin(fastify: FastifyInstance) {
+    if (isMemoryRedisUrl(config.redisUrl)) {
+      fastify.log.warn(
+        "REDIS_URL=memory:// — using an in-process session store. Dev only: state is lost on restart and not shared across instances.",
+      );
+      const memoryRedis = new MemoryRedis();
+      fastify.decorate("redis", memoryRedis as unknown as FastifyInstance["redis"]);
+      fastify.addHook("onClose", async () => {
+        await memoryRedis.quit();
+      });
+      return;
+    }
+
     await fastify.register(fastifyRedis, {
       url: config.redisUrl,
       closeClient: true,

--- a/client/server/src/plugins/redis.ts
+++ b/client/server/src/plugins/redis.ts
@@ -1,0 +1,24 @@
+// Location: ./client/server/src/plugins/redis.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// Decorates fastify.redis with a command client (GET/SETEX/DEL for session
+// storage, PUBLISH for revocation). The dedicated subscriber connection used
+// by SSE revocation lives separately in routes/sse/revocation-subscriber.ts —
+// ioredis connections in subscribe mode can't issue normal commands.
+
+import fastifyRedis from "@fastify/redis";
+import type { FastifyInstance } from "fastify";
+import fp from "fastify-plugin";
+
+import { config } from "../config.js";
+
+export default fp(
+  async function redisPlugin(fastify: FastifyInstance) {
+    await fastify.register(fastifyRedis, {
+      url: config.redisUrl,
+      closeClient: true,
+    });
+  },
+  { name: "redisPlugin" },
+);

--- a/client/server/src/plugins/session.ts
+++ b/client/server/src/plugins/session.ts
@@ -1,0 +1,43 @@
+// Location: ./client/server/src/plugins/session.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// Decorates fastify with `sessionAuth`, a preHandler that resolves the
+// session_id cookie against Redis and populates request.session. Applied
+// per-route (proxy/auth/SSE), not globally — SSE routes need different CSRF
+// treatment, and /healthz and /auth/login must stay unauthenticated.
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import fp from "fastify-plugin";
+
+import { getSession, SESSION_COOKIE_NAME } from "../lib/session-store.js";
+
+async function sessionAuth(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+  const sessionId = request.cookies[SESSION_COOKIE_NAME];
+  if (!sessionId) {
+    reply.code(401).send({ error: "unauthenticated" });
+    return;
+  }
+
+  const record = await getSession(request.server.redis, sessionId);
+
+  if (!record) {
+    reply.code(401).send({ error: "session_expired" });
+    return;
+  }
+
+  request.session = { sessionId, bearerToken: record.bearerToken, user: record.user };
+}
+
+export default fp(
+  async function sessionPlugin(fastify: FastifyInstance) {
+    fastify.decorate("sessionAuth", sessionAuth);
+  },
+  { name: "sessionPlugin" },
+);
+
+declare module "fastify" {
+  interface FastifyInstance {
+    sessionAuth: typeof sessionAuth;
+  }
+}

--- a/client/server/src/plugins/static.ts
+++ b/client/server/src/plugins/static.ts
@@ -1,0 +1,60 @@
+// Location: ./client/server/src/plugins/static.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// Serves the SPA build (`cd client && npm run build:bff` -> client/server/public/)
+// and owns the SPA-fallback 404: any GET that isn't a real static asset or an
+// already-registered API/auth/SSE route gets the app shell, so client-side
+// routing survives a hard refresh on a deep link (/app/login, /app/tools, ...).
+// Registered with fastify-plugin so both the `sendFile` decorator and the
+// not-found handler apply at the true root, not just this plugin's own
+// encapsulated context — routes/app.ts's GET / relies on `sendFile` too.
+//
+// The auth-aware '/' redirect itself lives in routes/app.ts, not here: this
+// plugin's fallback always serves index.html unconditionally for anything
+// under /app/*, deferring to the client router's own AuthGuard.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import fastifyStatic from "@fastify/static";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import fp from "fastify-plugin";
+
+import { config } from "../config.js";
+
+const DEFAULT_PUBLIC_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "../../public");
+const PUBLIC_DIR = config.publicDir ?? DEFAULT_PUBLIC_DIR;
+
+export default fp(
+  async function staticPlugin(fastify: FastifyInstance) {
+    await fastify.register(fastifyStatic, {
+      root: PUBLIC_DIR,
+      prefix: "/",
+      index: false, // '/' is handled explicitly by routes/app.ts, for the auth check
+    });
+
+    fastify.setNotFoundHandler((request: FastifyRequest, reply: FastifyReply) => {
+      const pathname = request.url.split("?")[0] ?? request.url;
+      // A missing asset (has a file extension, e.g. /assets/nope.js) is a
+      // real 404, not a client route — only extension-less paths (client
+      // router paths like /login, /tools/123) get the SPA fallback.
+      const looksLikeAsset = /\.[a-zA-Z0-9]+$/.test(pathname);
+
+      if (
+        request.method !== "GET" ||
+        pathname.startsWith("/api/") ||
+        pathname.startsWith("/auth/") ||
+        looksLikeAsset
+      ) {
+        return reply.code(404).send({
+          message: `Route ${request.method}:${request.url} not found`,
+          error: "Not Found",
+          statusCode: 404,
+        });
+      }
+      return reply.sendFile("index.html");
+    });
+  },
+  { name: "staticPlugin" },
+);

--- a/client/server/src/routes/app.ts
+++ b/client/server/src/routes/app.ts
@@ -1,0 +1,30 @@
+// Location: ./client/server/src/routes/app.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// The one route where the BFF decides server-side instead of leaving it to
+// client-side routing: GET / redirects to the dashboard for an authenticated
+// visitor, and to the login screen for everyone else, before any app JS
+// loads. Both targets are under /app/ because the client router
+// (client/src/router/index.tsx) hardcodes that prefix and only ever renders
+// /app/* paths — a bare '/' matches none of its routes and would render a
+// blank page if served directly instead of redirected. /app/* itself (and
+// every other deep client route) falls through to plugins/static.ts's
+// unconditional SPA-fallback 404 handler, where the client router's own
+// AuthGuard takes over.
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+
+import { getSession, SESSION_COOKIE_NAME } from "../lib/session-store.js";
+
+const HOME_PATH = "/app/";
+const LOGIN_PATH = "/app/login";
+
+export default async function appRoute(fastify: FastifyInstance): Promise<void> {
+  fastify.get("/", async (request: FastifyRequest, reply: FastifyReply) => {
+    const sessionId = request.cookies[SESSION_COOKIE_NAME];
+    const record = sessionId ? await getSession(fastify.redis, sessionId) : null;
+
+    return reply.redirect(record ? HOME_PATH : LOGIN_PATH);
+  });
+}

--- a/client/server/src/routes/auth/login.ts
+++ b/client/server/src/routes/auth/login.ts
@@ -10,21 +10,20 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 
 import { config } from "../../config.js";
-import { createSession, setSessionCookie } from "../../lib/session-store.js";
+import { createSession, setSessionCookie, type SessionUser } from "../../lib/session-store.js";
 
 interface LoginBody {
   email: string;
   password: string;
 }
 
-// Mirrors mcpgateway.schemas.AuthenticationResponse — only the fields the
-// BFF actually needs are declared.
+// Mirrors mcpgateway.schemas.AuthenticationResponse. `user` is forwarded to
+// the browser verbatim (see SessionUser) — the BFF only needs access_token
+// and expires_in.
 interface UpstreamAuthenticationResponse {
   access_token: string;
-  user: {
-    email: string;
-    is_admin: boolean;
-  };
+  expires_in: number;
+  user: SessionUser;
 }
 
 export default async function loginRoute(fastify: FastifyInstance): Promise<void> {
@@ -49,14 +48,26 @@ export default async function loginRoute(fastify: FastifyInstance): Promise<void
         return reply.code(upstreamResponse.status).send({ error: "login_failed", detail });
       }
 
-      const auth = (await upstreamResponse.json()) as UpstreamAuthenticationResponse;
+      const auth = (await upstreamResponse.json()) as UpstreamAuthenticationResponse;  // pragma: allowlist secret
 
-      const sessionId = await createSession(fastify.redis, {
-        bearerToken: auth.access_token,
-        user: { email: auth.user.email, isAdmin: auth.user.is_admin },
-      });
+      // The BFF session/cookie must not outlive the bearer token it wraps —
+      // use the upstream JWT's own lifetime, not a fixed BFF-side default.
+      // See createSession's comment in lib/session-store.ts.
+      const ttlSeconds =
+        Number.isFinite(auth.expires_in) && auth.expires_in > 0
+          ? auth.expires_in
+          : config.sessionTtlSeconds;
 
-      setSessionCookie(reply, sessionId);
+      const sessionId = await createSession(
+        fastify.redis,
+        {
+          bearerToken: auth.access_token,
+          user: auth.user,
+        },
+        ttlSeconds,
+      );
+
+      setSessionCookie(reply, sessionId, ttlSeconds);
       // Cookie holds the CSRF secret (HttpOnly); the SPA needs the derived
       // token itself to echo back via X-CSRF-Token — see plugins/csrf.ts.
       const csrfToken = await reply.generateCsrf();

--- a/client/server/src/routes/auth/login.ts
+++ b/client/server/src/routes/auth/login.ts
@@ -1,0 +1,67 @@
+// Location: ./client/server/src/routes/auth/login.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// POST /auth/login: browser -> BFF only. The BFF makes its own
+// server-to-server call to the upstream FastAPI login endpoint and never
+// forwards the resulting access_token to the browser — only an opaque
+// session_id cookie goes back. See agent-output/microfrontend-bff-auth-architecture.md.
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+
+import { config } from "../../config.js";
+import { createSession, setSessionCookie } from "../../lib/session-store.js";
+
+interface LoginBody {
+  email: string;
+  password: string;
+}
+
+// Mirrors mcpgateway.schemas.AuthenticationResponse — only the fields the
+// BFF actually needs are declared.
+interface UpstreamAuthenticationResponse {
+  access_token: string;
+  user: {
+    email: string;
+    is_admin: boolean;
+  };
+}
+
+export default async function loginRoute(fastify: FastifyInstance): Promise<void> {
+  fastify.post<{ Body: LoginBody }>(
+    "/auth/login",
+    async (request: FastifyRequest<{ Body: LoginBody }>, reply: FastifyReply) => {
+      const { email, password } = request.body ?? {};
+      if (!email || !password) {
+        return reply.code(400).send({ error: "email and password are required" });
+      }
+
+      const upstreamResponse = await fetch(`${config.fastapiUrl}/auth/email/login`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+
+      if (!upstreamResponse.ok) {
+        // Upstream 401/403/429 pass through as-is; body may carry rate-limit or
+        // lockout detail the SPA's login form wants to show.
+        const detail = await upstreamResponse.text();
+        return reply.code(upstreamResponse.status).send({ error: "login_failed", detail });
+      }
+
+      const auth = (await upstreamResponse.json()) as UpstreamAuthenticationResponse;
+
+      const sessionId = await createSession(fastify.redis, {
+        bearerToken: auth.access_token,
+        user: { email: auth.user.email, isAdmin: auth.user.is_admin },
+      });
+
+      setSessionCookie(reply, sessionId);
+      // Cookie holds the CSRF secret (HttpOnly); the SPA needs the derived
+      // token itself to echo back via X-CSRF-Token — see plugins/csrf.ts.
+      const csrfToken = await reply.generateCsrf();
+
+      return reply.send({ user: auth.user, csrfToken });
+    },
+  );
+}

--- a/client/server/src/routes/auth/login.ts
+++ b/client/server/src/routes/auth/login.ts
@@ -48,7 +48,7 @@ export default async function loginRoute(fastify: FastifyInstance): Promise<void
         return reply.code(upstreamResponse.status).send({ error: "login_failed", detail });
       }
 
-      const auth = (await upstreamResponse.json()) as UpstreamAuthenticationResponse;  // pragma: allowlist secret
+      const auth = (await upstreamResponse.json()) as UpstreamAuthenticationResponse; // pragma: allowlist secret
 
       // The BFF session/cookie must not outlive the bearer token it wraps —
       // use the upstream JWT's own lifetime, not a fixed BFF-side default.

--- a/client/server/src/routes/auth/logout.ts
+++ b/client/server/src/routes/auth/logout.ts
@@ -7,11 +7,42 @@
 // drops the Redis session even if session_id is already missing/expired
 // (double-click or retry), as long as the caller still holds a valid CSRF
 // cookie/token pair.
+//
+// Also revokes the upstream JWT itself via FastAPI's bearer-token logout
+// (mcpgateway/routers/auth.py POST /auth/logout, blocklist-backed —
+// DB or Redis depending on deployment). Without this, dropping the BFF's
+// own session/cookie only makes the token unreachable from the browser;
+// the JWT stays cryptographically valid until its natural TOKEN_EXPIRY.
+// Best-effort: an upstream failure (network blip, already-revoked token)
+// must not block the BFF-side logout the user is waiting on.
 
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 
-import { clearSessionCookie, deleteSession, SESSION_COOKIE_NAME } from "../../lib/session-store.js";
+import { config } from "../../config.js";
+import {
+  clearSessionCookie,
+  deleteSession,
+  getSession,
+  SESSION_COOKIE_NAME,
+} from "../../lib/session-store.js";
 import { CSRF_COOKIE_NAME } from "../../plugins/csrf.js";
+
+async function revokeUpstreamToken(request: FastifyRequest, bearerToken: string): Promise<void> {
+  try {
+    const response = await fetch(`${config.fastapiUrl}/auth/logout`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${bearerToken}` },
+    });
+    if (!response.ok) {
+      request.log.warn(
+        { status: response.status },
+        "upstream token revocation returned a non-2xx status",
+      );
+    }
+  } catch (err) {
+    request.log.warn({ err }, "upstream token revocation failed");
+  }
+}
 
 export default async function logoutRoute(fastify: FastifyInstance): Promise<void> {
   fastify.post(
@@ -20,6 +51,10 @@ export default async function logoutRoute(fastify: FastifyInstance): Promise<voi
     async (request: FastifyRequest, reply: FastifyReply) => {
       const sessionId = request.cookies[SESSION_COOKIE_NAME];
       if (sessionId) {
+        const record = await getSession(fastify.redis, sessionId);
+        if (record) {
+          await revokeUpstreamToken(request, record.bearerToken);
+        }
         await deleteSession(fastify.redis, sessionId);
       }
 

--- a/client/server/src/routes/auth/logout.ts
+++ b/client/server/src/routes/auth/logout.ts
@@ -1,0 +1,32 @@
+// Location: ./client/server/src/routes/auth/logout.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// POST /auth/logout: CSRF-protected like any other state-changing
+// browser->BFF call. Idempotent w.r.t. session state — clears cookies and
+// drops the Redis session even if session_id is already missing/expired
+// (double-click or retry), as long as the caller still holds a valid CSRF
+// cookie/token pair.
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+
+import { clearSessionCookie, deleteSession, SESSION_COOKIE_NAME } from "../../lib/session-store.js";
+import { CSRF_COOKIE_NAME } from "../../plugins/csrf.js";
+
+export default async function logoutRoute(fastify: FastifyInstance): Promise<void> {
+  fastify.post(
+    "/auth/logout",
+    { preHandler: [fastify.csrfProtection] },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const sessionId = request.cookies[SESSION_COOKIE_NAME];
+      if (sessionId) {
+        await deleteSession(fastify.redis, sessionId);
+      }
+
+      clearSessionCookie(reply);
+      reply.clearCookie(CSRF_COOKIE_NAME, { path: "/" });
+
+      return reply.send({ ok: true });
+    },
+  );
+}

--- a/client/server/src/routes/auth/session.ts
+++ b/client/server/src/routes/auth/session.ts
@@ -1,0 +1,27 @@
+// Location: ./client/server/src/routes/auth/session.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// GET /auth/session: SPA bootstrap probe. Never 401s past the network layer
+// with a body the app can't use — returns { authenticated: false } for an
+// anonymous visitor so the SPA can render a login screen without treating it
+// as an error. Also (re)seeds the CSRF cookie, since a page reload needs one
+// even mid-session.
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+
+import { getSession, SESSION_COOKIE_NAME } from "../../lib/session-store.js";
+
+export default async function sessionRoute(fastify: FastifyInstance): Promise<void> {
+  fastify.get("/auth/session", async (request: FastifyRequest, reply: FastifyReply) => {
+    const sessionId = request.cookies[SESSION_COOKIE_NAME];
+    const record = sessionId ? await getSession(fastify.redis, sessionId) : null;
+
+    if (!record) {
+      return reply.send({ authenticated: false });
+    }
+
+    const csrfToken = await reply.generateCsrf();
+    return reply.send({ authenticated: true, user: record.user, csrfToken });
+  });
+}

--- a/client/server/src/routes/proxy/catch-all.ts
+++ b/client/server/src/routes/proxy/catch-all.ts
@@ -1,0 +1,59 @@
+// Location: ./client/server/src/routes/proxy/catch-all.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// Generic `/api/*` -> FastAPI proxy. Covers the bulk of the API surface
+// without mirroring routes: session lookup -> inject Authorization header ->
+// forward via @fastify/reply-from. Only BFF-owned auth routes and SSE routes
+// (registered separately, see routes/sse/) are excluded — find-my-way
+// resolves their static paths before this wildcard regardless of
+// registration order, so there's no risk of this route swallowing them.
+//
+// SAFE_METHODS mirrors mcpgateway/middleware/csrf_middleware.py so the
+// browser<->BFF CSRF boundary matches the same-origin behavior it replaces.
+
+import replyFrom from "@fastify/reply-from";
+import type {
+  FastifyInstance,
+  FastifyReply,
+  FastifyRequest,
+  HookHandlerDoneFunction,
+} from "fastify";
+
+import { config } from "../../config.js";
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS", "TRACE"]);
+
+// fastify.csrfProtection is callback-style (request, reply, done), not
+// promise-returning — mirror that shape rather than mixing async/await with it.
+function csrfIfUnsafe(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  done: HookHandlerDoneFunction,
+): void {
+  if (SAFE_METHODS.has(request.method)) return done();
+  request.server.csrfProtection(request, reply, done);
+}
+
+export default async function catchAllProxyRoute(fastify: FastifyInstance): Promise<void> {
+  await fastify.register(replyFrom, { base: config.fastapiUrl });
+
+  fastify.all(
+    "/api/*",
+    { preHandler: [fastify.sessionAuth, csrfIfUnsafe] },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      // Wildcard capture excludes the leading '/api/'; FastAPI routes are
+      // mounted at root, so reattach a single leading slash.
+      const wildcard = (request.params as Record<string, string>)["*"] ?? "";
+      const upstreamPath = `/${wildcard}`;
+      const bearerToken = request.session!.bearerToken;
+
+      return reply.from(upstreamPath, {
+        rewriteRequestHeaders: (_req, headers) => ({
+          ...headers,
+          authorization: `Bearer ${bearerToken}`,
+        }),
+      });
+    },
+  );
+}

--- a/client/server/src/routes/proxy/catch-all.ts
+++ b/client/server/src/routes/proxy/catch-all.ts
@@ -21,8 +21,26 @@ import type {
 } from "fastify";
 
 import { config } from "../../config.js";
+import { clearSessionCookie, deleteSession } from "../../lib/session-store.js";
 
 const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS", "TRACE"]);
+
+// FastAPI/Starlette 307s bare "/teams" -> "/teams/" (redirect_slashes) with an
+// absolute Location built from its own host:port. Passed through unmodified,
+// the browser would follow it straight to FastAPI — leaking the upstream
+// origin and losing the BFF session (FastAPI has no bearer token or
+// understanding of the bff_sid cookie). Rewrite it back to a same-origin
+// /api/* path so every hop stays behind the BFF.
+function rewriteUpstreamLocation(
+  headers: Record<string, string | string[] | undefined>,
+): typeof headers {
+  const location = headers.location;
+  if (typeof location !== "string" || !location.startsWith(config.fastapiUrl)) {
+    return headers;
+  }
+  const upstreamPath = location.slice(config.fastapiUrl.length);
+  return { ...headers, location: `/api${upstreamPath}` };
+}
 
 // fastify.csrfProtection is callback-style (request, reply, done), not
 // promise-returning — mirror that shape rather than mixing async/await with it.
@@ -38,6 +56,33 @@ function csrfIfUnsafe(
 export default async function catchAllProxyRoute(fastify: FastifyInstance): Promise<void> {
   await fastify.register(replyFrom, { base: config.fastapiUrl });
 
+  // Fastify's default JSON parser throws FST_ERR_CTP_EMPTY_JSON_BODY on an
+  // empty body with Content-Type: application/json — before preHandler, so
+  // before this route (or even sessionAuth) ever runs. Several real calls
+  // (e.g. the tool/gateway activate-state toggle) send that header with no
+  // body at all.
+  //
+  // This must still produce a real parsed object for a non-empty body, not
+  // a raw Buffer passthrough: @fastify/reply-from unconditionally
+  // JSON.stringify()s request.body whenever Content-Type is
+  // application/json (contentTypesToEncode always includes it, with no way
+  // to opt out — see its index.js). A raw Buffer JSON.stringifies to
+  // `{"type":"Buffer","data":[...]}`, corrupting every JSON body sent
+  // through the proxy. So: parse for real (letting reply-from's re-encode
+  // round-trip correctly), just don't throw on empty.
+  fastify.addContentTypeParser("application/json", { parseAs: "string" }, (_req, rawBody, done) => {
+    const body = rawBody.toString();
+    if (!body) {
+      done(null, undefined);
+      return;
+    }
+    try {
+      done(null, JSON.parse(body));
+    } catch (err) {
+      done(err as Error, undefined);
+    }
+  });
+
   fastify.all(
     "/api/*",
     { preHandler: [fastify.sessionAuth, csrfIfUnsafe] },
@@ -48,11 +93,32 @@ export default async function catchAllProxyRoute(fastify: FastifyInstance): Prom
       const upstreamPath = `/${wildcard}`;
       const bearerToken = request.session!.bearerToken;
 
+      const sessionId = request.session!.sessionId;
+
       return reply.from(upstreamPath, {
         rewriteRequestHeaders: (_req, headers) => ({
           ...headers,
           authorization: `Bearer ${bearerToken}`,
         }),
+        rewriteHeaders: rewriteUpstreamLocation,
+        onResponse: (req, res, upstreamResponse) => {
+          // 401 from upstream means the bearer token itself is dead
+          // (expired/invalid) — not a permissions problem (that's 403,
+          // left alone; a valid session can still get 403s). Drop the BFF
+          // session and clear cookies now rather than let the browser keep
+          // retrying with a token that will never become valid again;
+          // its next call 401s from sessionAuth and the SPA's existing
+          // redirect-to-login handles the rest.
+          if (upstreamResponse.statusCode === 401) {
+            deleteSession(fastify.redis, sessionId).catch((err) =>
+              req.log.warn({ err, sessionId }, "failed to revoke session after upstream 401"),
+            );
+            // reply-from's onResponse types `res` generically enough (HTTP/2 union)
+            // to not structurally match FastifyReply; this app never runs HTTP/2.
+            clearSessionCookie(res as unknown as FastifyReply);
+          }
+          res.send(upstreamResponse.stream);
+        },
       });
     },
   );

--- a/client/server/src/routes/sse/proxy-sse.ts
+++ b/client/server/src/routes/sse/proxy-sse.ts
@@ -1,0 +1,110 @@
+// Location: ./client/server/src/routes/sse/proxy-sse.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// Generic SSE proxy route factory. Concrete registrations live in routes.ts.
+// Hand-rolled (reply.hijack() + a dedicated undici pool) rather than
+// @fastify/reply-from — see "Why hand-rolled ... for SSE" in
+// agent-output/bff-proxy-and-sse-plan.md: SSE needs a pool with no
+// headers/body timeouts, which must not leak into the shared catch-all pool,
+// and a first-class AbortController to register for cleanup.
+//
+// CSRF is intentionally not applied here: EventSource can't set custom
+// headers, so double-submit CSRF doesn't work for SSE. These routes are
+// GET/read-only; defense in depth is the SameSite session cookie + this
+// route never being state-changing. See Risk #2 in the plan doc.
+
+import { pipeline } from "node:stream/promises";
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+
+import { config } from "../../config.js";
+import { getSession } from "../../lib/session-store.js";
+import { sseUpstreamPool } from "../../lib/upstream-http-client.js";
+import { writeSseHeaders } from "../../lib/sse-headers.js";
+import { register, unregister } from "./registry.js";
+
+export interface SseProxyRouteOptions {
+  /** Browser-facing path, e.g. '/api/resources/subscribe'. Always GET (EventSource). */
+  browserPath: string;
+  /** Upstream FastAPI path, e.g. '/resources/subscribe'. */
+  upstreamPath: string;
+  /** Upstream verb — independent of the browser's GET, since e.g. /resources/subscribe is POST-only upstream. */
+  upstreamMethod: "GET" | "POST";
+  /** Optional upstream request body builder, for POST upstreams that take subscription params. */
+  buildUpstreamBody?: (request: FastifyRequest) => unknown;
+}
+
+export function registerSseProxyRoute(fastify: FastifyInstance, opts: SseProxyRouteOptions): void {
+  fastify.get(
+    opts.browserPath,
+    { preHandler: [fastify.sessionAuth] },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const session = request.session!;
+      const controller = new AbortController();
+
+      const body = opts.buildUpstreamBody
+        ? JSON.stringify(opts.buildUpstreamBody(request))
+        : undefined;
+
+      let upstream;
+      try {
+        upstream = await sseUpstreamPool.request({
+          path: opts.upstreamPath,
+          method: opts.upstreamMethod,
+          headers: {
+            authorization: `Bearer ${session.bearerToken}`,
+            accept: "text/event-stream",
+            ...(body ? { "content-type": "application/json" } : {}),
+          },
+          body,
+          signal: controller.signal,
+        });
+      } catch (err) {
+        request.log.error({ err, path: opts.upstreamPath }, "sse upstream connect failed");
+        return reply.code(502).send({ error: "upstream_unavailable" });
+      }
+
+      if (upstream.statusCode >= 400) {
+        const detail = await upstream.body.text().catch(() => "");
+        return reply.code(upstream.statusCode).send({ error: "upstream_error", detail });
+      }
+
+      reply.hijack();
+      writeSseHeaders(reply.raw);
+      register(session.sessionId, controller);
+
+      let closed = false;
+      const cleanup = (): void => {
+        if (closed) return;
+        closed = true;
+        clearInterval(recheckTimer);
+        unregister(session.sessionId, controller);
+        controller.abort();
+      };
+
+      request.raw.on("close", cleanup);
+
+      // Option A (bounded-staleness): re-check the Redis session periodically
+      // and abort if it's gone, in case pub/sub revocation (Option B, see
+      // revocation-subscriber.ts) is missed for any reason.
+      const recheckTimer = setInterval(() => {
+        getSession(fastify.redis, session.sessionId)
+          .then((record) => {
+            if (!record) cleanup();
+          })
+          .catch((err) => request.log.warn({ err }, "sse session recheck failed"));
+      }, config.sseSessionRecheckSeconds * 1000);
+
+      try {
+        // pipeline() handles backpressure and tears down both streams on
+        // error/abort — no manual write()/drain() loop needed.
+        await pipeline(upstream.body, reply.raw, { signal: controller.signal });
+      } catch (err) {
+        if (!closed) request.log.debug({ err }, "sse stream ended");
+      } finally {
+        cleanup();
+      }
+    },
+  );
+}

--- a/client/server/src/routes/sse/registry.ts
+++ b/client/server/src/routes/sse/registry.ts
@@ -1,0 +1,42 @@
+// Location: ./client/server/src/routes/sse/registry.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tracks live upstream SSE sockets per session on this BFF instance, so
+// logout / revocation can abort them and browser disconnect can unregister
+// them. Keyed by a Set, not a single controller — one session can have
+// multiple concurrent SSE subscriptions open (resources, future db-records).
+// Revocation must abort all of them. This registry is process-local by
+// design: session state lives in Redis, sockets live on whichever BFF
+// instance the browser's long-lived connection landed on.
+
+const sessionSockets = new Map<string, Set<AbortController>>();
+
+export function register(sessionId: string, controller: AbortController): void {
+  let sockets = sessionSockets.get(sessionId);
+  if (!sockets) {
+    sockets = new Set();
+    sessionSockets.set(sessionId, sockets);
+  }
+  sockets.add(controller);
+}
+
+export function unregister(sessionId: string, controller: AbortController): void {
+  const sockets = sessionSockets.get(sessionId);
+  if (!sockets) return;
+  sockets.delete(controller);
+  if (sockets.size === 0) sessionSockets.delete(sessionId);
+}
+
+/** Abort every open SSE socket for a session (logout / revocation). */
+export function abortAll(sessionId: string): void {
+  const sockets = sessionSockets.get(sessionId);
+  if (!sockets) return;
+  for (const controller of sockets) controller.abort();
+  sessionSockets.delete(sessionId);
+}
+
+/** Test-only: count of currently-registered sockets for a session. */
+export function socketCount(sessionId: string): number {
+  return sessionSockets.get(sessionId)?.size ?? 0;
+}

--- a/client/server/src/routes/sse/revocation-subscriber.ts
+++ b/client/server/src/routes/sse/revocation-subscriber.ts
@@ -1,0 +1,33 @@
+// Location: ./client/server/src/routes/sse/revocation-subscriber.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// Cross-instance SSE revocation (Option B from agent-output/bff-proxy-and-sse-plan.md,
+// layered on top of Option A's periodic re-check). A dedicated ioredis
+// connection in subscribe mode — the command client decorated by
+// plugins/redis.ts can't issue normal commands once subscribed, hence the
+// separate connection here.
+
+import { Redis } from "ioredis";
+
+import { config } from "../../config.js";
+import { abortAll } from "./registry.js";
+
+const REVOKED_PATTERN = "bff:session:revoked:*";
+
+export function startRevocationSubscriber(): Redis {
+  const subscriber = new Redis(config.redisUrl);
+
+  subscriber.psubscribe(REVOKED_PATTERN, (err) => {
+    if (err) {
+      subscriber.emit("error", err);
+    }
+  });
+
+  subscriber.on("pmessage", (_pattern: string, channel: string) => {
+    const sessionId = channel.slice("bff:session:revoked:".length);
+    if (sessionId) abortAll(sessionId);
+  });
+
+  return subscriber;
+}

--- a/client/server/src/routes/sse/revocation-subscriber.ts
+++ b/client/server/src/routes/sse/revocation-subscriber.ts
@@ -6,17 +6,27 @@
 // layered on top of Option A's periodic re-check). A dedicated ioredis
 // connection in subscribe mode — the command client decorated by
 // plugins/redis.ts can't issue normal commands once subscribed, hence the
-// separate connection here.
+// separate connection here. REDIS_URL=memory:// swaps in the in-process
+// MemoryRedis (see plugins/redis.ts) instead — irrelevant for a single dev
+// process, but kept symmetric with the command client's mode.
 
 import { Redis } from "ioredis";
 
 import { config } from "../../config.js";
+import { isMemoryRedisUrl, MemoryRedis } from "../../lib/memory-redis.js";
 import { abortAll } from "./registry.js";
 
 const REVOKED_PATTERN = "bff:session:revoked:*";
 
-export function startRevocationSubscriber(): Redis {
-  const subscriber = new Redis(config.redisUrl);
+function onPmessage(_pattern: string, channel: string): void {
+  const sessionId = channel.slice("bff:session:revoked:".length);
+  if (sessionId) abortAll(sessionId);
+}
+
+export function startRevocationSubscriber(): Redis | MemoryRedis {
+  const subscriber = isMemoryRedisUrl(config.redisUrl)
+    ? new MemoryRedis()
+    : new Redis(config.redisUrl);
 
   subscriber.psubscribe(REVOKED_PATTERN, (err) => {
     if (err) {
@@ -24,10 +34,7 @@ export function startRevocationSubscriber(): Redis {
     }
   });
 
-  subscriber.on("pmessage", (_pattern: string, channel: string) => {
-    const sessionId = channel.slice("bff:session:revoked:".length);
-    if (sessionId) abortAll(sessionId);
-  });
+  subscriber.on("pmessage", onPmessage);
 
   return subscriber;
 }

--- a/client/server/src/routes/sse/routes.ts
+++ b/client/server/src/routes/sse/routes.ts
@@ -1,0 +1,27 @@
+// Location: ./client/server/src/routes/sse/routes.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// Concrete SSE route registrations. Both go through the same
+// registerSseProxyRoute factory despite the upstream method mismatch
+// (resources/subscribe is POST-only upstream, roots/changes is GET) —
+// proof the factory is genuinely generic, not a one-off for that mismatch.
+// Add future SSE streams (e.g. a db-records subscription) here.
+
+import type { FastifyInstance } from "fastify";
+
+import { registerSseProxyRoute } from "./proxy-sse.js";
+
+export default async function sseRoutes(fastify: FastifyInstance): Promise<void> {
+  registerSseProxyRoute(fastify, {
+    browserPath: "/api/resources/subscribe",
+    upstreamPath: "/resources/subscribe",
+    upstreamMethod: "POST",
+  });
+
+  registerSseProxyRoute(fastify, {
+    browserPath: "/api/roots/changes",
+    upstreamPath: "/roots/changes",
+    upstreamMethod: "GET",
+  });
+}

--- a/client/server/src/types/fastify.d.ts
+++ b/client/server/src/types/fastify.d.ts
@@ -4,13 +4,12 @@
 
 import "fastify";
 
+import type { SessionUser } from "../lib/session-store.js";
+
 export interface BffSession {
   sessionId: string;
   bearerToken: string;
-  user: {
-    email: string;
-    isAdmin: boolean;
-  };
+  user: SessionUser;
 }
 
 declare module "fastify" {

--- a/client/server/src/types/fastify.d.ts
+++ b/client/server/src/types/fastify.d.ts
@@ -1,0 +1,21 @@
+// Location: ./client/server/src/types/fastify.d.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+
+import "fastify";
+
+export interface BffSession {
+  sessionId: string;
+  bearerToken: string;
+  user: {
+    email: string;
+    isAdmin: boolean;
+  };
+}
+
+declare module "fastify" {
+  interface FastifyRequest {
+    /** Populated by the session preHandler. Absent on unauthenticated routes. */
+    session?: BffSession;
+  }
+}

--- a/client/server/test/app.test.ts
+++ b/client/server/test/app.test.ts
@@ -1,0 +1,122 @@
+// Location: ./client/server/test/app.test.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// PUBLIC_DIR must be set before src/config.ts (and plugins/static.ts,
+// transitively) is first evaluated — same env-ordering constraint as
+// proxy.test.ts/sse.test.ts — so a temp SPA build dir is created and
+// process.env.PUBLIC_DIR set in beforeAll, with modules under test
+// dynamic-imported afterwards.
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import Fastify, { type FastifyInstance } from "fastify";
+import type { Redis } from "ioredis";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+let publicDir: string;
+
+beforeAll(async () => {
+  publicDir = await mkdtemp(path.join(tmpdir(), "bff-public-"));
+  await writeFile(
+    path.join(publicDir, "index.html"),
+    "<!doctype html><title>spa-shell-marker</title>",
+  );
+  process.env.PUBLIC_DIR = publicDir;
+});
+
+afterAll(() => rm(publicDir, { recursive: true, force: true }));
+
+async function buildApp(): Promise<{
+  fastify: FastifyInstance;
+  redis: import("./helpers/build-app.js").FakeRedis;
+}> {
+  const { FakeRedis } = await import("./helpers/build-app.js");
+  const cookiePlugin = (await import("../src/plugins/cookie.js")).default;
+  const sessionPlugin = (await import("../src/plugins/session.js")).default;
+  const staticPlugin = (await import("../src/plugins/static.js")).default;
+  const appRoute = (await import("../src/routes/app.js")).default;
+  const catchAllProxyRoute = (await import("../src/routes/proxy/catch-all.js")).default;
+
+  const fastify = Fastify();
+  const redis = new FakeRedis();
+  fastify.decorate("redis", redis as unknown as Redis);
+  await fastify.register(cookiePlugin);
+  await fastify.register(sessionPlugin);
+  await fastify.register(staticPlugin);
+  await fastify.register(catchAllProxyRoute); // registered alongside app/static to prove /api/* isn't swallowed by the SPA fallback
+  await fastify.register(appRoute);
+
+  return { fastify, redis };
+}
+
+let app: Awaited<ReturnType<typeof buildApp>>;
+
+afterEach(async () => {
+  await app?.fastify.close();
+});
+
+describe("GET /", () => {
+  it("redirects an anonymous visitor to /app/login", async () => {
+    app = await buildApp();
+    const response = await app.fastify.inject({ method: "GET", url: "/" });
+
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe("/app/login");
+  });
+
+  it("redirects an authenticated visitor to /app/", async () => {
+    app = await buildApp();
+    const { createSession } = await import("../src/lib/session-store.js");
+    const sessionId = await createSession(app.redis as never, {
+      bearerToken: "test-bearer-token", // pragma: allowlist secret
+      user: { email: "user@example.com", isAdmin: false },
+    });
+
+    const response = await app.fastify.inject({
+      method: "GET",
+      url: "/",
+      headers: { cookie: `bff_sid=${sessionId}` },
+    });
+
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe("/app/");
+  });
+});
+
+describe("SPA fallback (404 handler)", () => {
+  it("serves the app shell for /app/login (the client router's own auth screen)", async () => {
+    app = await buildApp();
+    const response = await app.fastify.inject({ method: "GET", url: "/app/login" });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toContain("spa-shell-marker");
+  });
+
+  it("serves the app shell for a deep client-side route", async () => {
+    app = await buildApp();
+    const response = await app.fastify.inject({ method: "GET", url: "/app/tools" });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toContain("spa-shell-marker");
+  });
+
+  it("404s a missing asset instead of serving the app shell", async () => {
+    app = await buildApp();
+    const response = await app.fastify.inject({ method: "GET", url: "/assets/does-not-exist.js" });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.body).not.toContain("spa-shell-marker");
+  });
+
+  it("does not swallow /api/* into the SPA fallback", async () => {
+    app = await buildApp();
+    const response = await app.fastify.inject({ method: "GET", url: "/api/tools" });
+
+    // 401 (no session) proves the catch-all's own auth check ran, not the fallback.
+    expect(response.statusCode).toBe(401);
+    expect(response.body).not.toContain("spa-shell-marker");
+  });
+});

--- a/client/server/test/auth.test.ts
+++ b/client/server/test/auth.test.ts
@@ -62,6 +62,41 @@ describe("POST /auth/login", () => {
     expect(setCookieNames).toContain("bff_csrf");
   });
 
+  it("sets the session cookie's maxAge to the upstream token's own expires_in, not a fixed BFF default", async () => {
+    const app = await buildTestApp();
+    mockUpstreamLogin(true, {
+      access_token: "upstream-jwt", // pragma: allowlist secret
+      expires_in: 1200, // 20 minutes — FastAPI's default TOKEN_EXPIRY
+      user: { email: "user@example.com", is_admin: false },
+    });
+
+    const response = await app.fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: { email: "user@example.com", password: "secret" }, // pragma: allowlist secret
+    });
+
+    const sessionCookie = response.cookies.find((c) => c.name === "bff_sid");
+    expect(sessionCookie?.maxAge).toBe(1200);
+  });
+
+  it("falls back to the BFF's default TTL if the upstream response omits expires_in", async () => {
+    const app = await buildTestApp();
+    mockUpstreamLogin(true, {
+      access_token: "upstream-jwt", // pragma: allowlist secret
+      user: { email: "user@example.com", is_admin: false },
+    });
+
+    const response = await app.fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: { email: "user@example.com", password: "secret" }, // pragma: allowlist secret
+    });
+
+    const sessionCookie = response.cookies.find((c) => c.name === "bff_sid");
+    expect(sessionCookie?.maxAge).toBeGreaterThan(1200); // sanity: not accidentally near-zero
+  });
+
   it("passes through upstream failure status without leaking a session", async () => {
     const app = await buildTestApp();
     mockUpstreamLogin(false, { detail: "Invalid email or password" }, 401);

--- a/client/server/test/auth.test.ts
+++ b/client/server/test/auth.test.ts
@@ -1,0 +1,173 @@
+// Location: ./client/server/test/auth.test.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { buildTestApp, type TestApp } from "./helpers/build-app.js";
+
+function mockUpstreamLogin(ok: boolean, body: unknown, status = ok ? 200 : 401): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok,
+      status,
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    })),
+  );
+}
+
+async function login(app: TestApp): Promise<{ cookies: string[]; csrfToken: string }> {
+  mockUpstreamLogin(true, {
+    access_token: "upstream-jwt", // pragma: allowlist secret
+    user: { email: "user@example.com", is_admin: false },
+  });
+
+  const response = await app.fastify.inject({
+    method: "POST",
+    url: "/auth/login",
+    payload: { email: "user@example.com", password: "secret" }, // pragma: allowlist secret
+  });
+
+  expect(response.statusCode).toBe(200);
+  const cookies = response.cookies.map((c) => `${c.name}=${c.value}`);
+  const csrfToken = response.json().csrfToken as string;
+  expect(csrfToken).toBeTruthy();
+  return { cookies, csrfToken };
+}
+
+describe("POST /auth/login", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("never returns the upstream access_token to the browser", async () => {
+    const app = await buildTestApp();
+    mockUpstreamLogin(true, {
+      access_token: "upstream-jwt", // pragma: allowlist secret
+      user: { email: "user@example.com", is_admin: false },
+    });
+
+    const response = await app.fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: { email: "user@example.com", password: "secret" }, // pragma: allowlist secret
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.stringify(response.json())).not.toContain("upstream-jwt");
+    const setCookieNames = response.cookies.map((c) => c.name);
+    expect(setCookieNames).toContain("bff_sid");
+    expect(setCookieNames).toContain("bff_csrf");
+  });
+
+  it("passes through upstream failure status without leaking a session", async () => {
+    const app = await buildTestApp();
+    mockUpstreamLogin(false, { detail: "Invalid email or password" }, 401);
+
+    const response = await app.fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: { email: "user@example.com", password: "wrong" }, // pragma: allowlist secret
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.cookies.map((c) => c.name)).not.toContain("bff_sid");
+  });
+
+  it("rejects a request missing credentials before calling upstream", async () => {
+    const app = await buildTestApp();
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const response = await app.fastify.inject({
+      method: "POST",
+      url: "/auth/login",
+      payload: { email: "a@b.com" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /auth/session", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("reports unauthenticated with no error for an anonymous visitor", async () => {
+    const app = await buildTestApp();
+    const response = await app.fastify.inject({ method: "GET", url: "/auth/session" });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ authenticated: false });
+  });
+
+  it("reports the session user and a fresh csrfToken once logged in", async () => {
+    const app = await buildTestApp();
+    const { cookies } = await login(app);
+
+    const response = await app.fastify.inject({
+      method: "GET",
+      url: "/auth/session",
+      headers: { cookie: cookies.join("; ") },
+    });
+
+    const payload = response.json();
+    expect(payload.authenticated).toBe(true);
+    expect(payload.user.email).toBe("user@example.com");
+    expect(payload.csrfToken).toBeTruthy();
+  });
+});
+
+describe("POST /auth/logout", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("rejects without a valid CSRF token", async () => {
+    const app = await buildTestApp();
+    const { cookies } = await login(app);
+
+    const response = await app.fastify.inject({
+      method: "POST",
+      url: "/auth/logout",
+      headers: { cookie: cookies.join("; ") }, // no X-CSRF-Token
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+
+  it("clears cookies and drops the Redis session given a valid CSRF token", async () => {
+    const app = await buildTestApp();
+    const { cookies, csrfToken } = await login(app);
+
+    const response = await app.fastify.inject({
+      method: "POST",
+      url: "/auth/logout",
+      headers: { cookie: cookies.join("; "), "x-csrf-token": csrfToken },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const cleared = response.cookies.find((c) => c.name === "bff_sid");
+    expect(cleared?.value).toBe("");
+
+    // Session is really gone, not just the cookie cleared client-side.
+    const followUp = await app.fastify.inject({
+      method: "GET",
+      url: "/auth/session",
+      headers: { cookie: cookies.join("; ") },
+    });
+    expect(followUp.json()).toEqual({ authenticated: false });
+  });
+
+  it("is safe to call twice (idempotent) given a still-valid CSRF pair", async () => {
+    const app = await buildTestApp();
+    const { cookies, csrfToken } = await login(app);
+    const headers = { cookie: cookies.join("; "), "x-csrf-token": csrfToken };
+
+    const first = await app.fastify.inject({ method: "POST", url: "/auth/logout", headers });
+    const second = await app.fastify.inject({ method: "POST", url: "/auth/logout", headers });
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(200);
+  });
+});

--- a/client/server/test/auth.test.ts
+++ b/client/server/test/auth.test.ts
@@ -4,6 +4,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { config } from "../src/config.js";
 import { buildTestApp, type TestApp } from "./helpers/build-app.js";
 
 function mockUpstreamLogin(ok: boolean, body: unknown, status = ok ? 200 : 401): void {
@@ -204,5 +205,61 @@ describe("POST /auth/logout", () => {
 
     expect(first.statusCode).toBe(200);
     expect(second.statusCode).toBe(200);
+  });
+
+  it("revokes the upstream JWT via FastAPI's bearer-token logout, not just the BFF session", async () => {
+    const app = await buildTestApp();
+    const { cookies, csrfToken } = await login(app);
+
+    const fetchCalls: Array<{ url: string; authorization: string | undefined }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        const headers = init?.headers as Record<string, string> | undefined;
+        fetchCalls.push({ url: String(url), authorization: headers?.authorization });
+        return { ok: true, status: 200, json: async () => ({}), text: async () => "" };
+      }),
+    );
+
+    const response = await app.fastify.inject({
+      method: "POST",
+      url: "/auth/logout",
+      headers: { cookie: cookies.join("; "), "x-csrf-token": csrfToken },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const revokeCall = fetchCalls.find((call) => call.url === `${config.fastapiUrl}/auth/logout`);
+    expect(revokeCall).toBeTruthy();
+    // The stored bearer token, minted at login — never a session/cookie value.
+    expect(revokeCall?.authorization).toBe("Bearer upstream-jwt");
+  });
+
+  it("still clears the BFF session even when upstream token revocation fails", async () => {
+    const app = await buildTestApp();
+    const { cookies, csrfToken } = await login(app);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("upstream unreachable");
+      }),
+    );
+
+    const response = await app.fastify.inject({
+      method: "POST",
+      url: "/auth/logout",
+      headers: { cookie: cookies.join("; "), "x-csrf-token": csrfToken },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const cleared = response.cookies.find((c) => c.name === "bff_sid");
+    expect(cleared?.value).toBe("");
+
+    const followUp = await app.fastify.inject({
+      method: "GET",
+      url: "/auth/session",
+      headers: { cookie: cookies.join("; ") },
+    });
+    expect(followUp.json()).toEqual({ authenticated: false });
   });
 });

--- a/client/server/test/helpers/build-app.ts
+++ b/client/server/test/helpers/build-app.ts
@@ -1,0 +1,73 @@
+// Location: ./client/server/test/helpers/build-app.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// Test fixture: a Fastify instance wired the same way as src/index.ts, but
+// with an in-memory fake in place of plugins/redis.ts so tests don't need a
+// real Redis instance. Only the ioredis surface the app actually touches
+// (get/setex/del/publish) is implemented.
+
+import Fastify, { type FastifyInstance } from "fastify";
+import { type Redis } from "ioredis";
+
+import cookiePlugin from "../../src/plugins/cookie.js";
+import csrfPlugin from "../../src/plugins/csrf.js";
+import sessionPlugin from "../../src/plugins/session.js";
+import loginRoute from "../../src/routes/auth/login.js";
+import logoutRoute from "../../src/routes/auth/logout.js";
+import sessionRoute from "../../src/routes/auth/session.js";
+import catchAllProxyRoute from "../../src/routes/proxy/catch-all.js";
+
+export class FakeRedis {
+  private store = new Map<string, string>();
+  public published: Array<{ channel: string; message: string }> = [];
+
+  async get(key: string): Promise<string | null> {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  async setex(key: string, _ttlSeconds: number, value: string): Promise<"OK"> {
+    this.store.set(key, value);
+    return "OK";
+  }
+
+  async del(key: string): Promise<number> {
+    return this.store.delete(key) ? 1 : 0;
+  }
+
+  async publish(channel: string, message: string): Promise<number> {
+    this.published.push({ channel, message });
+    return 0;
+  }
+}
+
+export interface TestApp {
+  fastify: FastifyInstance;
+  redis: FakeRedis;
+}
+
+export async function buildTestApp(opts: { withProxy?: boolean } = {}): Promise<TestApp> {
+  const fastify = Fastify();
+  const redis = new FakeRedis();
+  fastify.decorate("redis", redis as unknown as Redis);
+
+  await fastify.register(cookiePlugin);
+  await fastify.register(sessionPlugin);
+  await fastify.register(csrfPlugin);
+
+  await fastify.register(loginRoute);
+  await fastify.register(logoutRoute);
+  await fastify.register(sessionRoute);
+
+  if (opts.withProxy) {
+    await fastify.register(catchAllProxyRoute);
+  }
+
+  await fastify.ready();
+  return { fastify, redis };
+}
+
+/** Parse `Set-Cookie` response headers into a `name=value; name2=value2` request Cookie header. */
+export function cookieHeaderFrom(setCookieHeaders: string[] | undefined): string {
+  return (setCookieHeaders ?? []).map((raw) => raw.split(";")[0]).join("; ");
+}

--- a/client/server/test/memory-redis.test.ts
+++ b/client/server/test/memory-redis.test.ts
@@ -1,0 +1,51 @@
+// Location: ./client/server/test/memory-redis.test.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { MemoryRedis } from "../src/lib/memory-redis.js";
+
+describe("MemoryRedis", () => {
+  it("round-trips get/setex/del", async () => {
+    const redis = new MemoryRedis();
+    expect(await redis.get("k")).toBeNull();
+
+    await redis.setex("k", 60, "v");
+    expect(await redis.get("k")).toBe("v");
+
+    expect(await redis.del("k")).toBe(1);
+    expect(await redis.get("k")).toBeNull();
+    expect(await redis.del("k")).toBe(0);
+  });
+
+  it("expires keys after their TTL", async () => {
+    vi.useFakeTimers();
+    try {
+      const redis = new MemoryRedis();
+      await redis.setex("k", 1, "v");
+      expect(await redis.get("k")).toBe("v");
+
+      vi.advanceTimersByTime(1001);
+      expect(await redis.get("k")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("delivers publish() to a matching psubscribe() pattern across instances", async () => {
+    const subscriber = new MemoryRedis();
+    const publisher = new MemoryRedis();
+    const received: Array<[string, string, string]> = [];
+
+    await subscriber.psubscribe("bff:session:revoked:*");
+    subscriber.on("pmessage", (pattern: string, channel: string, message: string) => {
+      received.push([pattern, channel, message]);
+    });
+
+    await publisher.publish("bff:session:revoked:abc123", "1");
+    await publisher.publish("some:other:channel", "ignored");
+
+    expect(received).toEqual([["bff:session:revoked:*", "bff:session:revoked:abc123", "1"]]);
+  });
+});

--- a/client/server/test/proxy.test.ts
+++ b/client/server/test/proxy.test.ts
@@ -13,21 +13,51 @@ import type { AddressInfo } from "node:net";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 let upstream: Server;
-let lastRequest: { path: string; authorization: string | undefined; method: string } | undefined;
+let upstreamOrigin: string;
+let lastRequest:
+  | { path: string; authorization: string | undefined; method: string; body: string }
+  | undefined;
 
 beforeAll(async () => {
   upstream = createServer((req: IncomingMessage, res) => {
-    lastRequest = {
-      path: req.url ?? "",
-      authorization: req.headers.authorization,
-      method: req.method ?? "",
-    };
-    res.writeHead(200, { "content-type": "application/json" });
-    res.end(JSON.stringify({ ok: true }));
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      lastRequest = {
+        path: req.url ?? "",
+        authorization: req.headers.authorization,
+        method: req.method ?? "",
+        body: Buffer.concat(chunks).toString("utf8"),
+      };
+      // Mirrors Starlette's redirect_slashes: bare "/teams" -> "/teams/"
+      // with an absolute Location built from the upstream's own host:port.
+      if (req.url === "/teams") {
+        res.writeHead(307, { location: `${upstreamOrigin}/teams/` });
+        res.end();
+        return;
+      }
+      // Simulates an expired/invalid bearer token — FastAPI's real
+      // rbac middleware rejects with 401 here.
+      if (req.url === "/expired") {
+        res.writeHead(401, { "content-type": "application/json" });
+        res.end(JSON.stringify({ detail: "Token has expired" }));
+        return;
+      }
+      // Simulates a valid session with insufficient RBAC permissions —
+      // must not be treated the same as an expired token.
+      if (req.url === "/forbidden") {
+        res.writeHead(403, { "content-type": "application/json" });
+        res.end(JSON.stringify({ detail: "Insufficient permissions" }));
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
   });
   await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", () => resolve()));
   const { port } = upstream.address() as AddressInfo;
-  process.env.FASTAPI_URL = `http://127.0.0.1:${port}`;
+  upstreamOrigin = `http://127.0.0.1:${port}`;
+  process.env.FASTAPI_URL = upstreamOrigin;
 });
 
 afterAll(() => new Promise<void>((resolve) => upstream.close(() => resolve())));
@@ -109,7 +139,7 @@ describe("ALL /api/*", () => {
     expect(response.statusCode).toBe(403);
   });
 
-  it("forwards a state-changing request given a valid CSRF token", async () => {
+  it("forwards a state-changing request given a valid CSRF token, with the JSON body intact", async () => {
     const app = await buildApp();
     const { cookie, csrfToken } = await seedSession(app);
 
@@ -122,5 +152,87 @@ describe("ALL /api/*", () => {
 
     expect(response.statusCode).toBe(200);
     expect(lastRequest?.method).toBe("POST");
+    // @fastify/reply-from always JSON.stringify()s request.body for
+    // Content-Type: application/json (no way to opt out — see catch-all.ts).
+    // A naive raw-Buffer passthrough JSON.stringifies to
+    // {"type":"Buffer","data":[...]}; must round-trip as real JSON instead.
+    expect(JSON.parse(lastRequest!.body)).toEqual({ name: "x" });
+  });
+
+  it("forwards a state-changing request with Content-Type: application/json but no body (e.g. an activate/deactivate toggle)", async () => {
+    const app = await buildApp();
+    const { cookie, csrfToken } = await seedSession(app);
+
+    const response = await app.fastify.inject({
+      method: "POST",
+      url: "/api/gateways/gw-1/state?activate=false",
+      headers: { cookie, "x-csrf-token": csrfToken, "content-type": "application/json" },
+    });
+
+    // Fastify's default JSON parser 400s an empty body under this
+    // Content-Type before the request ever reaches this route — must not
+    // regress to that (see catch-all.ts's addContentTypeParser override).
+    expect(response.statusCode).toBe(200);
+    expect(lastRequest?.method).toBe("POST");
+    expect(lastRequest?.body).toBe("");
+  });
+
+  it("rewrites an upstream redirect's absolute Location back to a same-origin /api/* path", async () => {
+    const app = await buildApp();
+    const { cookie } = await seedSession(app);
+
+    const response = await app.fastify.inject({
+      method: "GET",
+      url: "/api/teams",
+      headers: { cookie },
+    });
+
+    expect(response.statusCode).toBe(307);
+    // Must never leak the upstream host:port to the browser, or the
+    // redirect would leave the BFF and drop the session entirely.
+    expect(response.headers.location).toBe("/api/teams/");
+  });
+
+  it("revokes the BFF session when upstream returns 401 (expired/invalid bearer token)", async () => {
+    const app = await buildApp();
+    const { cookie } = await seedSession(app);
+
+    const response = await app.fastify.inject({
+      method: "GET",
+      url: "/api/expired",
+      headers: { cookie },
+    });
+
+    expect(response.statusCode).toBe(401);
+    const clearedCookie = response.cookies.find((c) => c.name === "bff_sid");
+    expect(clearedCookie?.value).toBe("");
+
+    // Not just the cookie cleared client-side — the session is really gone,
+    // so a follow-up request can't keep retrying with a dead token.
+    const followUp = await app.fastify.inject({
+      method: "GET",
+      url: "/auth/session",
+      headers: { cookie },
+    });
+    expect(followUp.json()).toEqual({ authenticated: false });
+  });
+
+  it("does not revoke the session on a plain 403 (valid session, insufficient permissions)", async () => {
+    const app = await buildApp();
+    const { cookie } = await seedSession(app);
+
+    const response = await app.fastify.inject({
+      method: "GET",
+      url: "/api/forbidden",
+      headers: { cookie },
+    });
+    expect(response.statusCode).toBe(403);
+
+    const followUp = await app.fastify.inject({
+      method: "GET",
+      url: "/auth/session",
+      headers: { cookie },
+    });
+    expect(followUp.json().authenticated).toBe(true);
   });
 });

--- a/client/server/test/proxy.test.ts
+++ b/client/server/test/proxy.test.ts
@@ -1,0 +1,126 @@
+// Location: ./client/server/test/proxy.test.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// FASTAPI_URL must be set before src/config.ts (and anything importing it)
+// is first evaluated, so the fake upstream server is spun up and
+// process.env.FASTAPI_URL set in beforeAll, with every module under test
+// dynamic-imported afterwards rather than statically at the top of the file.
+
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+let upstream: Server;
+let lastRequest: { path: string; authorization: string | undefined; method: string } | undefined;
+
+beforeAll(async () => {
+  upstream = createServer((req: IncomingMessage, res) => {
+    lastRequest = {
+      path: req.url ?? "",
+      authorization: req.headers.authorization,
+      method: req.method ?? "",
+    };
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+  });
+  await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", () => resolve()));
+  const { port } = upstream.address() as AddressInfo;
+  process.env.FASTAPI_URL = `http://127.0.0.1:${port}`;
+});
+
+afterAll(() => new Promise<void>((resolve) => upstream.close(() => resolve())));
+
+async function buildApp() {
+  const { buildTestApp } = await import("./helpers/build-app.js");
+  return buildTestApp({ withProxy: true });
+}
+
+async function seedSession(app: Awaited<ReturnType<typeof buildApp>>) {
+  const { createSession } = await import("../src/lib/session-store.js");
+  const sessionId = await createSession(app.redis as never, {
+    bearerToken: "test-bearer-token", // pragma: allowlist secret
+    user: { email: "user@example.com", isAdmin: false },
+  });
+
+  // Round-trip through /auth/session to get a real CSRF cookie + token pair
+  // tied to this Fastify instance, the same way the SPA would.
+  const sessionProbe = await app.fastify.inject({
+    method: "GET",
+    url: "/auth/session",
+    headers: { cookie: `bff_sid=${sessionId}` },
+  });
+  const csrfCookie = sessionProbe.cookies.find((c) => c.name === "bff_csrf");
+  const csrfToken = sessionProbe.json().csrfToken as string;
+
+  return {
+    cookie: `bff_sid=${sessionId}; bff_csrf=${csrfCookie?.value}`,
+    csrfToken,
+  };
+}
+
+describe("ALL /api/*", () => {
+  it("401s without a session cookie", async () => {
+    const app = await buildApp();
+    const response = await app.fastify.inject({ method: "GET", url: "/api/tools" });
+    expect(response.statusCode).toBe(401);
+  });
+
+  it("strips the /api prefix and injects Authorization for an authenticated GET", async () => {
+    const app = await buildApp();
+    const { cookie } = await seedSession(app);
+
+    const response = await app.fastify.inject({
+      method: "GET",
+      url: "/api/tools?limit=5",
+      headers: { cookie },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(lastRequest?.path).toBe("/tools?limit=5");
+    expect(lastRequest?.authorization).toBe("Bearer test-bearer-token");
+  });
+
+  it("never lets the browser override the injected Authorization header", async () => {
+    const app = await buildApp();
+    const { cookie } = await seedSession(app);
+
+    await app.fastify.inject({
+      method: "GET",
+      url: "/api/tools",
+      headers: { cookie, authorization: "Bearer attacker-supplied-token" }, // pragma: allowlist secret
+    });
+
+    expect(lastRequest?.authorization).toBe("Bearer test-bearer-token");
+  });
+
+  it("rejects a state-changing request without a CSRF token", async () => {
+    const app = await buildApp();
+    const { cookie } = await seedSession(app);
+
+    const response = await app.fastify.inject({
+      method: "POST",
+      url: "/api/tools",
+      headers: { cookie },
+      payload: { name: "x" },
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+
+  it("forwards a state-changing request given a valid CSRF token", async () => {
+    const app = await buildApp();
+    const { cookie, csrfToken } = await seedSession(app);
+
+    const response = await app.fastify.inject({
+      method: "POST",
+      url: "/api/tools",
+      headers: { cookie, "x-csrf-token": csrfToken },
+      payload: { name: "x" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(lastRequest?.method).toBe("POST");
+  });
+});

--- a/client/server/test/sse.test.ts
+++ b/client/server/test/sse.test.ts
@@ -1,0 +1,131 @@
+// Location: ./client/server/test/sse.test.ts
+// Copyright contributors to the MCP-CONTEXT-FORGE project
+// SPDX-License-Identifier: Apache-2.0
+//
+// Exercises the real network path (fastify.listen + fetch), not
+// fastify.inject(), because reply.hijack() takes the response out of
+// Fastify/light-my-request's normal capture path — inject() would hang
+// waiting for a stream that's designed to live indefinitely.
+//
+// Same env-ordering constraint as proxy.test.ts: FASTAPI_URL must be set
+// before anything importing src/config.ts (transitively, the SSE upstream
+// pool) is first evaluated, so every module under test is dynamic-imported
+// after the fake upstream server is listening.
+
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import Fastify, { type FastifyInstance } from "fastify";
+import type { Redis } from "ioredis";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+let upstream: Server;
+let upstreamSocketCount = 0;
+
+beforeAll(async () => {
+  upstream = createServer((req, res) => {
+    if (req.url === "/roots/changes") {
+      upstreamSocketCount += 1;
+      res.on("close", () => {
+        upstreamSocketCount -= 1;
+      });
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write("data: hello\n\n");
+      // Deliberately never ends — mirrors FastAPI's indefinite SSE stream.
+      return;
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: true, path: req.url }));
+  });
+  await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", () => resolve()));
+  const { port } = upstream.address() as AddressInfo;
+  process.env.FASTAPI_URL = `http://127.0.0.1:${port}`;
+  process.env.SSE_SESSION_RECHECK_SECONDS = "3600"; // keep the recheck timer out of the way of these tests
+});
+
+afterAll(() => new Promise<void>((resolve) => upstream.close(() => resolve())));
+
+interface App {
+  fastify: FastifyInstance;
+  redis: import("./helpers/build-app.js").FakeRedis;
+  baseUrl: string;
+}
+
+async function buildRunningApp(): Promise<App> {
+  const { FakeRedis } = await import("./helpers/build-app.js");
+  const cookiePlugin = (await import("../src/plugins/cookie.js")).default;
+  const sessionPlugin = (await import("../src/plugins/session.js")).default;
+  const sseRoutes = (await import("../src/routes/sse/routes.js")).default;
+  const catchAllProxyRoute = (await import("../src/routes/proxy/catch-all.js")).default;
+
+  const fastify = Fastify();
+  const redis = new FakeRedis();
+  fastify.decorate("redis", redis as unknown as Redis);
+  await fastify.register(cookiePlugin);
+  await fastify.register(sessionPlugin);
+  await fastify.register(sseRoutes);
+  await fastify.register(catchAllProxyRoute); // registered alongside SSE routes to prove routing precedence
+
+  await fastify.listen({ port: 0, host: "127.0.0.1" });
+  const address = fastify.server.address() as AddressInfo;
+  return { fastify, redis, baseUrl: `http://127.0.0.1:${address.port}` };
+}
+
+async function seedSessionCookie(app: App): Promise<string> {
+  const { createSession } = await import("../src/lib/session-store.js");
+  const sessionId = await createSession(app.redis as never, {
+    bearerToken: "test-bearer-token", // pragma: allowlist secret
+    user: { email: "user@example.com", isAdmin: false },
+  });
+  return `bff_sid=${sessionId}`;
+}
+
+describe("SSE proxy", () => {
+  it("routes /api/roots/changes to the SSE handler, not the /api/* catch-all", async () => {
+    const app = await buildRunningApp();
+    try {
+      const cookie = await seedSessionCookie(app);
+      const response = await fetch(`${app.baseUrl}/api/roots/changes`, { headers: { cookie } });
+      expect(response.headers.get("content-type")).toContain("text/event-stream");
+      await response.body?.cancel();
+    } finally {
+      await app.fastify.close();
+    }
+  });
+
+  it("streams upstream events through to the client", async () => {
+    const app = await buildRunningApp();
+    try {
+      const cookie = await seedSessionCookie(app);
+      const response = await fetch(`${app.baseUrl}/api/roots/changes`, { headers: { cookie } });
+      const reader = response.body!.getReader();
+      const { value } = await reader.read();
+      expect(new TextDecoder().decode(value)).toContain("data: hello");
+      await reader.cancel();
+    } finally {
+      await app.fastify.close();
+    }
+  });
+
+  it("aborts the upstream socket when the client disconnects", async () => {
+    const app = await buildRunningApp();
+    try {
+      const cookie = await seedSessionCookie(app);
+      const controller = new AbortController();
+      const response = await fetch(`${app.baseUrl}/api/roots/changes`, {
+        headers: { cookie },
+        signal: controller.signal,
+      });
+      const reader = response.body!.getReader();
+      await reader.read(); // make sure the stream is actually flowing first
+      expect(upstreamSocketCount).toBe(1);
+
+      controller.abort();
+      await new Promise((resolve) => setTimeout(resolve, 100)); // let close events propagate
+
+      expect(upstreamSocketCount).toBe(0);
+    } finally {
+      await app.fastify.close();
+    }
+  });
+});

--- a/client/server/tsconfig.json
+++ b/client/server/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}

--- a/client/server/vitest.config.ts
+++ b/client/server/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+// Standalone config so this package isn't swept up by client/vitest.config.ts
+// (React/jsdom setup for the SPA) when vitest searches up the directory tree.
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    globals: false,
+  },
+});

--- a/client/src/api/client.test.ts
+++ b/client/src/api/client.test.ts
@@ -417,7 +417,7 @@ describe("api client", () => {
       expect(requestUrl).not.toContain("/api/api/tools");
     });
 
-    it("leaves /auth/* paths unprefixed (BFF-owned, not proxied)", async () => {
+    it("leaves the BFF's own auth routes unprefixed (login/logout/session)", async () => {
       let requestUrl: string | null = null;
       server.use(
         http.get("*/auth/session", ({ request }) => {
@@ -430,6 +430,23 @@ describe("api client", () => {
 
       expect(requestUrl).not.toContain("/api/auth");
       expect(requestUrl).toContain("/auth/session");
+    });
+
+    it("prefixes /auth/email/admin/users — a real FastAPI endpoint, not a BFF-owned auth route", async () => {
+      // Regression: an earlier version exempted anything starting with
+      // "/auth/" from prefixing, which silently broke user management
+      // (FastAPI mounts admin user endpoints under /auth/email/admin/*).
+      let requestUrl: string | null = null;
+      server.use(
+        http.get("*/api/auth/email/admin/users", ({ request }) => {
+          requestUrl = request.url;
+          return HttpResponse.json({ users: [] });
+        }),
+      );
+
+      await api.get("/auth/email/admin/users");
+
+      expect(requestUrl).toContain("/api/auth/email/admin/users");
     });
   });
 

--- a/client/src/api/client.test.ts
+++ b/client/src/api/client.test.ts
@@ -1,26 +1,21 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
-import { api, ApiError, getToken, setToken, clearToken } from "./client";
+import { api, ApiError, getToken, setToken, clearToken, setCsrfToken } from "./client";
 import { server } from "@/test/mocks/server";
-
-function clearCookie(name: string) {
-  document.cookie = `${name}=; Max-Age=0; path=/`;
-}
 
 describe("api client", () => {
   afterEach(() => {
-    clearCookie("mcpgateway_csrf_token");
-    clearCookie("csrf_token");
+    setCsrfToken(null);
     vi.clearAllMocks();
   });
 
   describe("CSRF Token Handling", () => {
-    it("sends X-CSRF-Token from the configured mcpgateway CSRF cookie", async () => {
-      document.cookie = "mcpgateway_csrf_token=new-token; path=/";
+    it("sends X-CSRF-Token from the in-memory token set after login/session-check", async () => {
+      setCsrfToken("new-token");
 
       let csrfHeader: string | null = null;
       server.use(
-        http.post("*/csrf-check", ({ request }) => {
+        http.post("*/api/csrf-check", ({ request }) => {
           csrfHeader = request.headers.get("X-CSRF-Token");
           return HttpResponse.json({ ok: true });
         }),
@@ -31,12 +26,10 @@ describe("api client", () => {
       expect(csrfHeader).toBe("new-token");
     });
 
-    it("does not use legacy csrf_token cookies", async () => {
-      document.cookie = "csrf_token=legacy-token; path=/";
-
+    it("does not send a CSRF header when no token has been set", async () => {
       let csrfHeader: string | null = null;
       server.use(
-        http.post("*/csrf-check", ({ request }) => {
+        http.post("*/api/csrf-check", ({ request }) => {
           csrfHeader = request.headers.get("X-CSRF-Token");
           return HttpResponse.json({ ok: true });
         }),
@@ -48,7 +41,7 @@ describe("api client", () => {
     });
 
     it("does not send CSRF token for GET requests", async () => {
-      document.cookie = "mcpgateway_csrf_token=token; path=/";
+      setCsrfToken("token");
 
       let csrfHeader: string | null = null;
       server.use(
@@ -64,7 +57,7 @@ describe("api client", () => {
     });
 
     it("sends CSRF token for PATCH requests", async () => {
-      document.cookie = "mcpgateway_csrf_token=patch-token; path=/";
+      setCsrfToken("patch-token");
 
       let csrfHeader: string | null = null;
       server.use(
@@ -80,7 +73,7 @@ describe("api client", () => {
     });
 
     it("sends CSRF token for PUT requests", async () => {
-      document.cookie = "mcpgateway_csrf_token=put-token; path=/";
+      setCsrfToken("put-token");
 
       let csrfHeader: string | null = null;
       server.use(
@@ -96,7 +89,7 @@ describe("api client", () => {
     });
 
     it("sends CSRF token for DELETE requests", async () => {
-      document.cookie = "mcpgateway_csrf_token=delete-token; path=/";
+      setCsrfToken("delete-token");
 
       let csrfHeader: string | null = null;
       server.use(
@@ -337,10 +330,10 @@ describe("api client", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       window.location = { ...originalLocation, replace: mockReplace } as any;
 
-      server.use(http.get("*/app/auth/me", () => new HttpResponse(null, { status: 401 })));
+      server.use(http.get("*/auth/session", () => new HttpResponse(null, { status: 401 })));
 
       try {
-        await api.get("/app/auth/me");
+        await api.get("/auth/session");
       } catch {
         // expected
       }
@@ -394,6 +387,49 @@ describe("api client", () => {
       await api.get("/api/data");
 
       expect(requestUrl).toContain("/api/data");
+    });
+
+    it("prepends /api to a bare path so it routes through the BFF proxy", async () => {
+      let requestUrl: string | null = null;
+      server.use(
+        http.get("*/api/tools", ({ request }) => {
+          requestUrl = request.url;
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      await api.get("/tools");
+
+      expect(requestUrl).toContain("/api/tools");
+    });
+
+    it("does not double-prefix a path that already starts with /api", async () => {
+      let requestUrl: string | null = null;
+      server.use(
+        http.get("*/api/tools", ({ request }) => {
+          requestUrl = request.url;
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      await api.get("/api/tools");
+
+      expect(requestUrl).not.toContain("/api/api/tools");
+    });
+
+    it("leaves /auth/* paths unprefixed (BFF-owned, not proxied)", async () => {
+      let requestUrl: string | null = null;
+      server.use(
+        http.get("*/auth/session", ({ request }) => {
+          requestUrl = request.url;
+          return HttpResponse.json({ authenticated: false });
+        }),
+      );
+
+      await api.get("/auth/session");
+
+      expect(requestUrl).not.toContain("/api/auth");
+      expect(requestUrl).toContain("/auth/session");
     });
   });
 
@@ -452,7 +488,7 @@ describe("api client", () => {
     });
 
     it("accepts authenticated option in api.post", async () => {
-      document.cookie = "mcpgateway_csrf_token=csrf; path=/";
+      setCsrfToken("csrf");
 
       let csrfHeader: string | null = null;
       server.use(

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -1,15 +1,25 @@
 /**
- * API client — typed fetch wrapper.
+ * API client — typed fetch wrapper for the BFF (client/server).
  *
  * Security guarantees:
- *  - Authentication uses same-origin httpOnly cookies; JWTs are never stored in web storage.
- *  - CSRF tokens are read from the non-httpOnly CSRF cookie and sent on mutating requests.
+ *  - Authentication uses a same-origin HttpOnly session cookie set by the BFF;
+ *    the API JWT never reaches the browser.
+ *  - The BFF's CSRF cookie is HttpOnly (it holds a secret, not the token) —
+ *    the token itself is handed to us in the JSON body of /auth/login and
+ *    /auth/session and kept in memory here (setCsrfToken), then echoed back
+ *    via X-CSRF-Token on mutating requests. See client/server/src/plugins/csrf.ts.
+ *  - Every path except /auth/* is routed through the BFF's /api/* proxy —
+ *    resolveApiPath prepends /api automatically, so callers keep writing
+ *    bare paths like "/tools" or "/servers/:id".
  *  - Content-Type and X-Requested-With are always set on JSON requests.
  *  - Non-2xx responses throw a typed ApiError; callers never handle raw text.
  *  - Protected 401 responses redirect to /app/login.
  */
 
 const LOGIN_PATH = "/app/login";
+const API_PREFIX = "/api";
+const AUTH_PREFIX = "/auth/";
+const SESSION_CHECK_PATH = "/auth/session";
 
 export class ApiError extends Error {
   constructor(
@@ -31,22 +41,32 @@ export function setToken(): void {
 }
 
 export function clearToken(): void {
-  // Kept for backward-compatible imports; cookies are cleared by /app/auth/logout.
+  // Kept for backward-compatible imports; cookies are cleared by /auth/logout.
 }
 
-function getCookie(name: string): string | null {
-  const prefix = `${encodeURIComponent(name)}=`;
-  const cookie = document.cookie
-    .split(";")
-    .map((part) => part.trim())
-    .find((part) => part.startsWith(prefix));
+// In-memory CSRF token, set by AuthContext after login/session-check succeeds
+// and cleared on logout. Not persisted anywhere — a full page reload always
+// re-derives it from a fresh /auth/session call.
+let currentCsrfToken: string | null = null;
 
-  if (!cookie) return null;
-  return decodeURIComponent(cookie.slice(prefix.length));
+export function setCsrfToken(token: string | null): void {
+  currentCsrfToken = token;
+}
+
+function isAbsoluteUrl(path: string): boolean {
+  return /^https?:\/\//i.test(path);
+}
+
+/** Bare paths get /api/* (BFF proxy to the API); /auth/* and absolute URLs pass through untouched. */
+function resolveApiPath(path: string): string {
+  if (isAbsoluteUrl(path)) return path;
+  if (path === "/auth" || path.startsWith(AUTH_PREFIX)) return path;
+  if (path === API_PREFIX || path.startsWith(`${API_PREFIX}/`)) return path;
+  return path.startsWith("/") ? `${API_PREFIX}${path}` : `${API_PREFIX}/${path}`;
 }
 
 function getRequestUrl(path: string): string {
-  if (/^https?:\/\//i.test(path)) {
+  if (isAbsoluteUrl(path)) {
     return path;
   }
 
@@ -110,14 +130,12 @@ async function requestWithMeta<T>(
     ...extraHeaders,
   };
 
-  if (method !== "GET" && authenticated) {
-    const csrfToken = getCookie("mcpgateway_csrf_token");
-    if (csrfToken) {
-      headers["X-CSRF-Token"] = csrfToken;
-    }
+  if (method !== "GET" && authenticated && currentCsrfToken) {
+    headers["X-CSRF-Token"] = currentCsrfToken;
   }
 
-  const requestUrl = getRequestUrl(path);
+  const resolvedPath = resolveApiPath(path);
+  const requestUrl = getRequestUrl(resolvedPath);
   const requestOptions: RequestInit = {
     method,
     headers,
@@ -132,7 +150,7 @@ async function requestWithMeta<T>(
   const response = await fetch(requestUrl, requestOptions);
 
   if (response.status === 401) {
-    if (authenticated && path !== "/app/auth/me") {
+    if (authenticated && resolvedPath !== SESSION_CHECK_PATH) {
       // replace() rather than href= so the failed page is not added to history
       // (the user can't hit Back into an unauthenticated state).
       // Preserve the current page so login can return the user to it; built

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -8,9 +8,13 @@
  *    the token itself is handed to us in the JSON body of /auth/login and
  *    /auth/session and kept in memory here (setCsrfToken), then echoed back
  *    via X-CSRF-Token on mutating requests. See client/server/src/plugins/csrf.ts.
- *  - Every path except /auth/* is routed through the BFF's /api/* proxy —
- *    resolveApiPath prepends /api automatically, so callers keep writing
- *    bare paths like "/tools" or "/servers/:id".
+ *  - Every path except the three BFF-owned auth routes is routed through the
+ *    BFF's /api/* proxy — resolveApiPath prepends /api automatically, so
+ *    callers keep writing bare paths like "/tools" or "/servers/:id". This
+ *    must be an exact-match set, not a "/auth/*" prefix check: FastAPI's own
+ *    user-management endpoints live under /auth/email/admin/users and need
+ *    the /api prefix like everything else — only login/logout/session are
+ *    the BFF's own routes.
  *  - Content-Type and X-Requested-With are always set on JSON requests.
  *  - Non-2xx responses throw a typed ApiError; callers never handle raw text.
  *  - Protected 401 responses redirect to /app/login.
@@ -18,8 +22,8 @@
 
 const LOGIN_PATH = "/app/login";
 const API_PREFIX = "/api";
-const AUTH_PREFIX = "/auth/";
 const SESSION_CHECK_PATH = "/auth/session";
+const BFF_OWNED_AUTH_PATHS = new Set(["/auth/login", "/auth/logout", SESSION_CHECK_PATH]);
 
 export class ApiError extends Error {
   constructor(
@@ -57,10 +61,10 @@ function isAbsoluteUrl(path: string): boolean {
   return /^https?:\/\//i.test(path);
 }
 
-/** Bare paths get /api/* (BFF proxy to the API); /auth/* and absolute URLs pass through untouched. */
+/** Bare paths get /api/* (BFF proxy to the API); the BFF's own auth routes and absolute URLs pass through untouched. */
 function resolveApiPath(path: string): string {
   if (isAbsoluteUrl(path)) return path;
-  if (path === "/auth" || path.startsWith(AUTH_PREFIX)) return path;
+  if (BFF_OWNED_AUTH_PATHS.has(path)) return path;
   if (path === API_PREFIX || path.startsWith(`${API_PREFIX}/`)) return path;
   return path.startsWith("/") ? `${API_PREFIX}${path}` : `${API_PREFIX}/${path}`;
 }

--- a/client/src/api/prompts.test.ts
+++ b/client/src/api/prompts.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { promptsApi } from "./prompts";
+import { setCsrfToken } from "./client";
 
 describe("promptsApi", () => {
   const mockFetch = vi.fn();
@@ -7,13 +8,11 @@ describe("promptsApi", () => {
   beforeEach(() => {
     global.fetch = mockFetch;
     vi.clearAllMocks();
-    Object.defineProperty(document, "cookie", {
-      writable: true,
-      value: "mcpgateway_csrf_token=test-csrf-token",
-    });
+    setCsrfToken("test-csrf-token");
   });
 
   afterEach(() => {
+    setCsrfToken(null);
     vi.restoreAllMocks();
   });
 

--- a/client/src/api/resources.test.ts
+++ b/client/src/api/resources.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { resourcesApi } from "./resources";
+import { setCsrfToken } from "./client";
 
 describe("resourcesApi", () => {
   const mockFetch = vi.fn();
@@ -7,13 +8,11 @@ describe("resourcesApi", () => {
   beforeEach(() => {
     global.fetch = mockFetch;
     vi.clearAllMocks();
-    Object.defineProperty(document, "cookie", {
-      writable: true,
-      value: "mcpgateway_csrf_token=test-csrf-token",
-    });
+    setCsrfToken("test-csrf-token");
   });
 
   afterEach(() => {
+    setCsrfToken(null);
     vi.restoreAllMocks();
   });
 

--- a/client/src/api/servers.test.ts
+++ b/client/src/api/servers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { serversApi } from "./servers";
+import { setCsrfToken } from "./client";
 import type { GatewayTestRequest } from "@/generated/types";
 
 describe("serversApi", () => {
@@ -9,14 +10,11 @@ describe("serversApi", () => {
     // Mock fetch globally
     global.fetch = mockFetch;
     vi.clearAllMocks();
-    // Mock document.cookie for CSRF token
-    Object.defineProperty(document, "cookie", {
-      writable: true,
-      value: "mcpgateway_csrf_token=test-csrf-token",
-    });
+    setCsrfToken("test-csrf-token");
   });
 
   afterEach(() => {
+    setCsrfToken(null);
     vi.restoreAllMocks();
   });
 

--- a/client/src/api/tools.test.ts
+++ b/client/src/api/tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { toolsApi } from "./tools";
+import { setCsrfToken } from "./client";
 
 describe("toolsApi", () => {
   const mockFetch = vi.fn();
@@ -7,13 +8,11 @@ describe("toolsApi", () => {
   beforeEach(() => {
     global.fetch = mockFetch;
     vi.clearAllMocks();
-    Object.defineProperty(document, "cookie", {
-      writable: true,
-      value: "mcpgateway_csrf_token=test-csrf-token",
-    });
+    setCsrfToken("test-csrf-token");
   });
 
   afterEach(() => {
+    setCsrfToken(null);
     vi.restoreAllMocks();
   });
 

--- a/client/src/auth/AuthContext.test.tsx
+++ b/client/src/auth/AuthContext.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { screen, render, waitFor } from "@testing-library/react";
-import { AuthProvider, useAuthContext, ApiError } from "./AuthContext";
+import { AuthProvider, useAuthContext } from "./AuthContext";
 import { useAuth } from "./useAuth";
-import { api } from "../api/client";
+import { api, setCsrfToken } from "../api/client";
 import { permissionsApi } from "../api/permissions";
 
 // Mock the API client
@@ -21,6 +21,7 @@ vi.mock("../api/client", () => {
       post: vi.fn(),
     },
     ApiError: MockApiError,
+    setCsrfToken: vi.fn(),
   };
 });
 
@@ -29,6 +30,16 @@ vi.mock("../api/client", () => {
 vi.mock("../api/permissions", () => ({
   permissionsApi: { listMine: vi.fn().mockResolvedValue([]) },
 }));
+
+const mockUser = {
+  email: "user@example.com",
+  full_name: "Test User",
+  is_admin: false,
+  is_active: true,
+  auth_provider: "local",
+  email_verified: true,
+  password_change_required: false,
+};
 
 // Helper component to test context values
 function TestComponent() {
@@ -90,17 +101,11 @@ describe("AuthContext", () => {
   });
 
   it("handles successful initial authentication", async () => {
-    const mockUser = {
-      email: "user@example.com",
-      full_name: "Test User",
-      is_admin: true,
-      is_active: true,
-      auth_provider: "local",
-      email_verified: true,
-      password_change_required: false,
-    };
-
-    vi.mocked(api.get).mockResolvedValueOnce(mockUser);
+    vi.mocked(api.get).mockResolvedValueOnce({
+      authenticated: true,
+      user: mockUser,
+      csrfToken: "session-csrf-token",
+    });
 
     render(
       <AuthProvider>
@@ -116,12 +121,12 @@ describe("AuthContext", () => {
 
     expect(screen.getByTestId("auth-status")).toHaveTextContent("authenticated");
     expect(screen.getByTestId("user-email")).toHaveTextContent("user@example.com");
-    expect(api.get).toHaveBeenCalledWith("/app/auth/me");
+    expect(api.get).toHaveBeenCalledWith("/auth/session");
+    expect(setCsrfToken).toHaveBeenCalledWith("session-csrf-token");
   });
 
-  it("handles failed initial authentication (401)", async () => {
-    const error = new ApiError(401, "Unauthorized", "");
-    vi.mocked(api.get).mockRejectedValueOnce(error);
+  it("handles an unauthenticated initial session check", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({ authenticated: false });
 
     render(
       <AuthProvider>
@@ -137,7 +142,7 @@ describe("AuthContext", () => {
     expect(screen.queryByTestId("user-email")).not.toBeInTheDocument();
   });
 
-  it("handles failed initial authentication (generic error)", async () => {
+  it("handles failed initial authentication (network/generic error)", async () => {
     vi.mocked(api.get).mockRejectedValueOnce(new Error("Network Failure"));
 
     render(
@@ -154,7 +159,7 @@ describe("AuthContext", () => {
   });
 
   it("handles successful login", async () => {
-    vi.mocked(api.get).mockRejectedValueOnce(new ApiError(401, "Unauthorized", ""));
+    vi.mocked(api.get).mockResolvedValueOnce({ authenticated: false });
 
     render(
       <AuthProvider>
@@ -166,19 +171,9 @@ describe("AuthContext", () => {
       expect(screen.queryByTestId("loading")).not.toBeInTheDocument();
     });
 
-    const mockUser = {
-      email: "user@example.com",
-      full_name: "Test User",
-      is_admin: false,
-      is_active: true,
-      auth_provider: "local",
-      email_verified: true,
-      password_change_required: false,
-    };
-
     vi.mocked(api.post).mockResolvedValueOnce({
       user: mockUser,
-      csrf_token: "csrf-token-123",
+      csrfToken: "csrf-token-123",
     });
 
     screen.getByText("Login").click();
@@ -189,24 +184,19 @@ describe("AuthContext", () => {
     });
 
     expect(api.post).toHaveBeenCalledWith(
-      "/app/auth/login",
+      "/auth/login",
       { email: "test@example.com", password: "pass" },
       { authenticated: false },
     );
+    expect(setCsrfToken).toHaveBeenCalledWith("csrf-token-123");
   });
 
   it("handles successful logout", async () => {
-    const mockUser = {
-      email: "user@example.com",
-      full_name: "Test User",
-      is_admin: false,
-      is_active: true,
-      auth_provider: "local",
-      email_verified: true,
-      password_change_required: false,
-    };
-
-    vi.mocked(api.get).mockResolvedValueOnce(mockUser);
+    vi.mocked(api.get).mockResolvedValueOnce({
+      authenticated: true,
+      user: mockUser,
+      csrfToken: "t",
+    });
 
     render(
       <AuthProvider>
@@ -218,7 +208,7 @@ describe("AuthContext", () => {
       expect(screen.queryByTestId("loading")).not.toBeInTheDocument();
     });
 
-    vi.mocked(api.post).mockResolvedValueOnce({ message: "logged out" });
+    vi.mocked(api.post).mockResolvedValueOnce({ ok: true });
 
     screen.getByText("Logout").click();
 
@@ -227,21 +217,16 @@ describe("AuthContext", () => {
       expect(window.location.href).toBe("/app/login");
     });
 
-    expect(api.post).toHaveBeenCalledWith("/app/auth/logout");
+    expect(api.post).toHaveBeenCalledWith("/auth/logout");
+    expect(setCsrfToken).toHaveBeenCalledWith(null);
   });
 
   it("handles logout server failure gracefully", async () => {
-    const mockUser = {
-      email: "user@example.com",
-      full_name: "Test User",
-      is_admin: false,
-      is_active: true,
-      auth_provider: "local",
-      email_verified: true,
-      password_change_required: false,
-    };
-
-    vi.mocked(api.get).mockResolvedValueOnce(mockUser);
+    vi.mocked(api.get).mockResolvedValueOnce({
+      authenticated: true,
+      user: mockUser,
+      csrfToken: "t",
+    });
 
     render(
       <AuthProvider>
@@ -300,13 +285,9 @@ describe("AuthContext", () => {
 
   it("re-exports useAuth correctly", async () => {
     vi.mocked(api.get).mockResolvedValueOnce({
-      email: "user@example.com",
-      full_name: "Test User",
-      is_admin: false,
-      is_active: true,
-      auth_provider: "local",
-      email_verified: true,
-      password_change_required: false,
+      authenticated: true,
+      user: mockUser,
+      csrfToken: "t",
     });
 
     render(

--- a/client/src/auth/AuthContext.tsx
+++ b/client/src/auth/AuthContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useState, useEffect, useRef } from "react";
 import type { ReactNode } from "react";
-import { api, ApiError } from "../api/client";
+import { api, ApiError, setCsrfToken } from "../api/client";
 import { permissionsApi } from "../api/permissions";
 
 // ---------------------------------------------------------------------------
@@ -17,9 +17,16 @@ export interface User {
   password_change_required: boolean;
 }
 
+// BFF's GET /auth/session — always 200, never 401 (see client/server/src/routes/auth/session.ts).
+interface SessionResponse {
+  authenticated: boolean;
+  user?: User;
+  csrfToken?: string;
+}
+
 interface LoginResponse {
   user: User;
-  mcpgateway_csrf_token: string;
+  csrfToken: string;
 }
 
 interface AuthState {
@@ -83,23 +90,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const version = authVersion.current;
 
     api
-      .get<User>("/app/auth/me")
-      .then((user) => {
-        if (!cancelled && version === authVersion.current) {
-          setState({ user, isAuthenticated: true, isLoading: false, selectedTeamId: null });
+      .get<SessionResponse>("/auth/session")
+      .then((data) => {
+        if (cancelled || version !== authVersion.current) return;
+        setCsrfToken(data.csrfToken ?? null);
+        if (data.authenticated && data.user) {
+          setState({
+            user: data.user,
+            isAuthenticated: true,
+            isLoading: false,
+            selectedTeamId: null,
+          });
+        } else {
+          setState({ user: null, isAuthenticated: false, isLoading: false, selectedTeamId: null });
         }
       })
-      .catch((err) => {
+      .catch(() => {
         if (!cancelled && version === authVersion.current) {
-          if (err instanceof ApiError && err.status === 401) {
-            setState({
-              user: null,
-              isAuthenticated: false,
-              isLoading: false,
-              selectedTeamId: null,
-            });
-            return;
-          }
           setState({ user: null, isAuthenticated: false, isLoading: false, selectedTeamId: null });
         }
       });
@@ -115,11 +122,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       password: string, // pragma: allowlist secret
     ): Promise<void> => {
       const data = await api.post<LoginResponse>(
-        "/app/auth/login",
+        "/auth/login",
         { email, password },
         { authenticated: false },
       );
 
+      setCsrfToken(data.csrfToken);
       authVersion.current += 1;
       setState({ user: data.user, isAuthenticated: true, isLoading: false, selectedTeamId: null });
     },
@@ -128,11 +136,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = useCallback(async (): Promise<void> => {
     try {
-      await api.post<{ message: string }>("/app/auth/logout");
+      await api.post<{ ok: boolean }>("/auth/logout");
     } catch {
       // Client-side logout should still complete if the server-side session is already gone
-      // or the CSRF cookie has expired.
+      // or the CSRF token has expired.
     } finally {
+      setCsrfToken(null);
       authVersion.current += 1;
       setState({ user: null, isAuthenticated: false, isLoading: false, selectedTeamId: null });
       window.location.href = "/app/login";

--- a/client/src/components/gateways/ExposeComponentsForm.test.tsx
+++ b/client/src/components/gateways/ExposeComponentsForm.test.tsx
@@ -28,7 +28,7 @@ const mockPrompts = [
 
 // MSW server setup
 const server = setupServer(
-  http.get("/tools", ({ request }) => {
+  http.get("/api/tools", ({ request }) => {
     const url = new URL(request.url);
     const gatewayId = url.searchParams.get("gateway_id");
     if (gatewayId === "test-gateway-123") {
@@ -36,7 +36,7 @@ const server = setupServer(
     }
     return HttpResponse.json([]);
   }),
-  http.get("/resources", ({ request }) => {
+  http.get("/api/resources", ({ request }) => {
     const url = new URL(request.url);
     const gatewayId = url.searchParams.get("gateway_id");
     if (gatewayId === "test-gateway-123") {
@@ -44,7 +44,7 @@ const server = setupServer(
     }
     return HttpResponse.json([]);
   }),
-  http.get("/prompts", ({ request }) => {
+  http.get("/api/prompts", ({ request }) => {
     const url = new URL(request.url);
     const gatewayId = url.searchParams.get("gateway_id");
     if (gatewayId === "test-gateway-123") {
@@ -52,7 +52,7 @@ const server = setupServer(
     }
     return HttpResponse.json([]);
   }),
-  http.post("/servers", () => {
+  http.post("/api/servers", () => {
     return HttpResponse.json({ id: "virtual-server-456" });
   }),
 );
@@ -380,7 +380,7 @@ describe("ExposeComponentsForm", () => {
     it("should disable submit button while creating", async () => {
       // Delay the server response to test the loading state
       server.use(
-        http.post("/servers", async () => {
+        http.post("/api/servers", async () => {
           await new Promise((resolve) => setTimeout(resolve, 100));
           return HttpResponse.json({ id: "virtual-server-456" });
         }),
@@ -404,7 +404,7 @@ describe("ExposeComponentsForm", () => {
 
     it("should show error message on creation failure", async () => {
       server.use(
-        http.post("/servers", () => {
+        http.post("/api/servers", () => {
           return HttpResponse.json({ error: "Failed to create server" }, { status: 500 });
         }),
       );
@@ -553,7 +553,7 @@ describe("ExposeComponentsForm", () => {
   describe("Empty State", () => {
     it("should handle empty tools list", async () => {
       server.use(
-        http.get("/tools", () => {
+        http.get("/api/tools", () => {
           return HttpResponse.json([]);
         }),
       );
@@ -567,7 +567,7 @@ describe("ExposeComponentsForm", () => {
 
     it("should handle empty resources list", async () => {
       server.use(
-        http.get("/resources", () => {
+        http.get("/api/resources", () => {
           return HttpResponse.json([]);
         }),
       );
@@ -581,7 +581,7 @@ describe("ExposeComponentsForm", () => {
 
     it("should handle empty prompts list", async () => {
       server.use(
-        http.get("/prompts", () => {
+        http.get("/api/prompts", () => {
           return HttpResponse.json([]);
         }),
       );

--- a/client/src/components/mcp-servers/MCPServerForm.test.tsx
+++ b/client/src/components/mcp-servers/MCPServerForm.test.tsx
@@ -31,15 +31,15 @@ vi.mock("@/hooks/useMCPServerForm", async (importOriginal) => {
 
 // Mock API responses for ExposeComponentsForm and gateway creation
 const server = setupServer(
-  http.get("/app/auth/me", () => {
-    return HttpResponse.json({ detail: "Unauthorized" }, { status: 401 });
+  http.get("/auth/session", () => {
+    return HttpResponse.json({ authenticated: false });
   }),
   // Mock gateway creation
-  http.post("/gateways", () => {
+  http.post("/api/gateways", () => {
     return HttpResponse.json({ id: "test-gateway-123", name: "Test Server" });
   }),
   // Mock single gateway fetch (used in edit mode)
-  http.get("/gateways/:id", ({ params }) => {
+  http.get("/api/gateways/:id", ({ params }) => {
     return HttpResponse.json({
       id: params.id,
       name: "Test Server",
@@ -50,13 +50,13 @@ const server = setupServer(
     });
   }),
   // Mock ExposeComponentsForm API calls
-  http.get("/tools", () => {
+  http.get("/api/tools", () => {
     return HttpResponse.json([]);
   }),
-  http.get("/resources", () => {
+  http.get("/api/resources", () => {
     return HttpResponse.json([]);
   }),
-  http.get("/prompts", () => {
+  http.get("/api/prompts", () => {
     return HttpResponse.json([]);
   }),
 );

--- a/client/src/hooks/useMCPServerForm.test.ts
+++ b/client/src/hooks/useMCPServerForm.test.ts
@@ -881,7 +881,7 @@ describe("useMCPServerForm", () => {
   describe("Edit Mode - Form Population from API", () => {
     it("maps 'authheaders' from API response to 'custom' auth type", async () => {
       server.use(
-        http.get("/gateways/gw-1", () =>
+        http.get("/api/gateways/gw-1", () =>
           HttpResponse.json({
             name: "My Server",
             url: "http://localhost:3000",
@@ -898,7 +898,7 @@ describe("useMCPServerForm", () => {
 
     it("maps 'query_param' from API response to 'query' auth type", async () => {
       server.use(
-        http.get("/gateways/gw-2", () =>
+        http.get("/api/gateways/gw-2", () =>
           HttpResponse.json({
             name: "My Server",
             url: "http://localhost:3000",
@@ -918,7 +918,7 @@ describe("useMCPServerForm", () => {
 
     it("populates advanced settings and OAuth config from the API", async () => {
       server.use(
-        http.get("/gateways/gw-adv", () =>
+        http.get("/api/gateways/gw-adv", () =>
           HttpResponse.json({
             name: "Advanced Server",
             url: "http://localhost:3000",
@@ -959,7 +959,7 @@ describe("useMCPServerForm", () => {
 
     it("accepts OAuth scopes provided as a plain string", async () => {
       server.use(
-        http.get("/gateways/gw-scopes", () =>
+        http.get("/api/gateways/gw-scopes", () =>
           HttpResponse.json({
             name: "Scopes Server",
             url: "http://localhost:3000",
@@ -975,7 +975,7 @@ describe("useMCPServerForm", () => {
 
     it("populates basic auth username and masked password from API", async () => {
       server.use(
-        http.get("/gateways/gw-3", () =>
+        http.get("/api/gateways/gw-3", () =>
           HttpResponse.json({
             name: "My Server",
             url: "http://localhost:3000",
@@ -995,7 +995,7 @@ describe("useMCPServerForm", () => {
 
     it("populates bearer token from API response", async () => {
       server.use(
-        http.get("/gateways/gw-4", () =>
+        http.get("/api/gateways/gw-4", () =>
           HttpResponse.json({
             name: "My Server",
             url: "http://localhost:3000",
@@ -1013,7 +1013,7 @@ describe("useMCPServerForm", () => {
 
     it("populates multiple custom headers from API response", async () => {
       server.use(
-        http.get("/gateways/gw-5", () =>
+        http.get("/api/gateways/gw-5", () =>
           HttpResponse.json({
             name: "My Server",
             url: "http://localhost:3000",
@@ -1035,7 +1035,7 @@ describe("useMCPServerForm", () => {
 
     it("populates oauth store_tokens and auto_refresh as true from API", async () => {
       server.use(
-        http.get("/gateways/gw-6", () =>
+        http.get("/api/gateways/gw-6", () =>
           HttpResponse.json({
             name: "My Server",
             url: "http://localhost:3000",
@@ -1058,7 +1058,7 @@ describe("useMCPServerForm", () => {
 
     it("populates oauth store_tokens and auto_refresh as false from API", async () => {
       server.use(
-        http.get("/gateways/gw-7", () =>
+        http.get("/api/gateways/gw-7", () =>
           HttpResponse.json({
             name: "My Server",
             url: "http://localhost:3000",
@@ -1081,7 +1081,7 @@ describe("useMCPServerForm", () => {
 
     it("defaults oauth store_tokens and auto_refresh to false when absent from API response", async () => {
       server.use(
-        http.get("/gateways/gw-8", () =>
+        http.get("/api/gateways/gw-8", () =>
           HttpResponse.json({
             name: "My Server",
             url: "http://localhost:3000",
@@ -1100,7 +1100,7 @@ describe("useMCPServerForm", () => {
 
     it("opens the advanced panel when server has auth configured", async () => {
       server.use(
-        http.get("/gateways/gw-9", () =>
+        http.get("/api/gateways/gw-9", () =>
           HttpResponse.json({
             name: "My Server",
             url: "http://localhost:3000",
@@ -1131,7 +1131,7 @@ describe("useMCPServerForm", () => {
 
       it("should trigger OAuth authorization after successful gateway creation with OAuth auth type", async () => {
         server.use(
-          http.post("/gateways", () => {
+          http.post("/api/gateways", () => {
             return HttpResponse.json({
               id: "new-gateway-123",
               name: "Test OAuth Gateway",
@@ -1184,7 +1184,7 @@ describe("useMCPServerForm", () => {
 
       it("should trigger OAuth authorization after successful gateway update with OAuth auth type", async () => {
         server.use(
-          http.get("/gateways/existing-gateway", () => {
+          http.get("/api/gateways/existing-gateway", () => {
             return HttpResponse.json({
               id: "existing-gateway",
               name: "Existing Gateway",
@@ -1199,7 +1199,7 @@ describe("useMCPServerForm", () => {
               authType: "oauth",
             });
           }),
-          http.put("/gateways/existing-gateway", () => {
+          http.put("/api/gateways/existing-gateway", () => {
             return HttpResponse.json({
               id: "existing-gateway",
               name: "Updated OAuth Gateway",
@@ -1254,7 +1254,7 @@ describe("useMCPServerForm", () => {
 
       it("should not trigger OAuth authorization for non-OAuth auth types", async () => {
         server.use(
-          http.post("/gateways", () => {
+          http.post("/api/gateways", () => {
             return HttpResponse.json({
               id: "new-gateway-456",
               name: "Test Basic Auth Gateway",
@@ -1295,7 +1295,7 @@ describe("useMCPServerForm", () => {
       it("reuses the created gateway ID on OAuth retry to prevent duplicate gateway creation", async () => {
         let createCallCount = 0;
         server.use(
-          http.post("/gateways", () => {
+          http.post("/api/gateways", () => {
             createCallCount++;
             return HttpResponse.json({ id: "gateway-retry-test" });
           }),
@@ -1351,7 +1351,9 @@ describe("useMCPServerForm", () => {
       it("delays onSuccess by 2 s after OAuth success so the notification is visible", async () => {
         vi.useFakeTimers();
 
-        server.use(http.post("/gateways", () => HttpResponse.json({ id: "gateway-delay-test" })));
+        server.use(
+          http.post("/api/gateways", () => HttpResponse.json({ id: "gateway-delay-test" })),
+        );
 
         const triggerOAuthMock = vi
           .spyOn(serversApi, "triggerOAuthAuthorization")
@@ -1411,7 +1413,7 @@ describe("useMCPServerForm", () => {
     });
 
     it("sets fetchToolsNotification to success after OAuth + successful tool fetch", async () => {
-      server.use(http.post("/gateways", () => HttpResponse.json({ id: "gw-ft-success" })));
+      server.use(http.post("/api/gateways", () => HttpResponse.json({ id: "gw-ft-success" })));
 
       vi.spyOn(serversApi, "triggerOAuthAuthorization").mockResolvedValueOnce({
         type: "oauth_callback",
@@ -1449,7 +1451,7 @@ describe("useMCPServerForm", () => {
     });
 
     it("sets fetchToolsNotification to error with nested detail.message when fetch-tools fails", async () => {
-      server.use(http.post("/gateways", () => HttpResponse.json({ id: "gw-ft-err" })));
+      server.use(http.post("/api/gateways", () => HttpResponse.json({ id: "gw-ft-err" })));
 
       vi.spyOn(serversApi, "triggerOAuthAuthorization").mockResolvedValueOnce({
         type: "oauth_callback",
@@ -1491,7 +1493,7 @@ describe("useMCPServerForm", () => {
     });
 
     it("sets fetchToolsNotification to error with plain detail string when fetch-tools fails", async () => {
-      server.use(http.post("/gateways", () => HttpResponse.json({ id: "gw-ft-str-err" })));
+      server.use(http.post("/api/gateways", () => HttpResponse.json({ id: "gw-ft-str-err" })));
 
       vi.spyOn(serversApi, "triggerOAuthAuthorization").mockResolvedValueOnce({
         type: "oauth_callback",
@@ -1532,7 +1534,7 @@ describe("useMCPServerForm", () => {
     });
 
     it("clearFetchToolsNotification resets fetchToolsNotification to null", async () => {
-      server.use(http.post("/gateways", () => HttpResponse.json({ id: "gw-clear-test" })));
+      server.use(http.post("/api/gateways", () => HttpResponse.json({ id: "gw-clear-test" })));
 
       vi.spyOn(serversApi, "triggerOAuthAuthorization").mockResolvedValueOnce({
         type: "oauth_callback",
@@ -1568,7 +1570,7 @@ describe("useMCPServerForm", () => {
   describe("handleSubmit error parsing", () => {
     it("extracts nested detail.message from API error on create failure", async () => {
       server.use(
-        http.post("/gateways", () =>
+        http.post("/api/gateways", () =>
           HttpResponse.json(
             { detail: { message: "A server with this name already exists", success: false } },
             { status: 400 },
@@ -1595,10 +1597,10 @@ describe("useMCPServerForm", () => {
 
     it("extracts plain detail string from API error on update failure", async () => {
       server.use(
-        http.get("/gateways/edit-gw", () =>
+        http.get("/api/gateways/edit-gw", () =>
           HttpResponse.json({ name: "My Server", url: "http://localhost:3000" }),
         ),
-        http.put("/gateways/edit-gw", () =>
+        http.put("/api/gateways/edit-gw", () =>
           HttpResponse.json({ detail: "Gateway not found" }, { status: 404 }),
         ),
       );
@@ -1618,7 +1620,9 @@ describe("useMCPServerForm", () => {
     });
 
     it("logs error and continues if activation fails during OAuth", async () => {
-      server.use(http.post("/gateways", () => HttpResponse.json({ id: "gw-oauth-activate-fail" })));
+      server.use(
+        http.post("/api/gateways", () => HttpResponse.json({ id: "gw-oauth-activate-fail" })),
+      );
 
       vi.spyOn(serversApi, "triggerOAuthAuthorization").mockResolvedValueOnce({
         type: "oauth_callback",
@@ -1645,7 +1649,7 @@ describe("useMCPServerForm", () => {
       });
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "Failed to activate gateway after OAuth:",
+        "Failed to activate gateway after OAuth:", // pragma: allowlist secret
         "An error occurred. Please try again.",
       );
     });

--- a/client/src/hooks/useQuery.test.ts
+++ b/client/src/hooks/useQuery.test.ts
@@ -7,9 +7,9 @@ import { useQuery } from "./useQuery";
 describe("useQuery", () => {
   describe("refetch stability", () => {
     it("returns the same refetch reference across re-renders", async () => {
-      server.use(http.get("/test-stable", () => HttpResponse.json({ value: 1 })));
+      server.use(http.get("/api/test-stable", () => HttpResponse.json({ value: 1 })));
 
-      const { result, rerender } = renderHook(() => useQuery("/test-stable"));
+      const { result, rerender } = renderHook(() => useQuery("/api/test-stable"));
 
       await waitFor(() => expect(result.current.data).toBeDefined());
 
@@ -23,9 +23,9 @@ describe("useQuery", () => {
 
   describe("GET request", () => {
     it("fetches data and sets it on success", async () => {
-      server.use(http.get("/test-get", () => HttpResponse.json({ hello: "world" })));
+      server.use(http.get("/api/test-get", () => HttpResponse.json({ hello: "world" })));
 
-      const { result } = renderHook(() => useQuery<{ hello: string }>("/test-get"));
+      const { result } = renderHook(() => useQuery<{ hello: string }>("/api/test-get"));
 
       await waitFor(() => expect(result.current.data).toEqual({ hello: "world" }));
       expect(result.current.error).toBeNull();
@@ -34,10 +34,12 @@ describe("useQuery", () => {
 
     it("sets error state on non-2xx response", async () => {
       server.use(
-        http.get("/test-error", () => HttpResponse.json({ detail: "Not found" }, { status: 404 })),
+        http.get("/api/test-error", () =>
+          HttpResponse.json({ detail: "Not found" }, { status: 404 }),
+        ),
       );
 
-      const { result } = renderHook(() => useQuery("/test-error"));
+      const { result } = renderHook(() => useQuery("/api/test-error"));
 
       await waitFor(() => expect(result.current.error).not.toBeNull());
       expect(result.current.error?.message).toBe("HTTP 404");
@@ -45,7 +47,7 @@ describe("useQuery", () => {
     });
 
     it("does not fetch when enabled is false", () => {
-      const { result } = renderHook(() => useQuery("/test-disabled", { enabled: false }));
+      const { result } = renderHook(() => useQuery("/api/test-disabled", { enabled: false }));
 
       expect(result.current.isLoading).toBe(false);
       expect(result.current.data).toBeUndefined();
@@ -62,10 +64,10 @@ describe("useQuery", () => {
 
   describe("manual execute (POST with enabled: false)", () => {
     it("does not run on mount and resolves when execute is called", async () => {
-      server.use(http.post("/test-post", () => HttpResponse.json({ created: true })));
+      server.use(http.post("/api/test-post", () => HttpResponse.json({ created: true })));
 
       const { result } = renderHook(() =>
-        useQuery<{ created: boolean }, { name: string }>("/test-post", {
+        useQuery<{ created: boolean }, { name: string }>("/api/test-post", {
           method: "POST",
           enabled: false,
         }),
@@ -115,10 +117,10 @@ describe("useQuery", () => {
 
   describe("PUT, PATCH, DELETE methods", () => {
     it("executes a PUT request", async () => {
-      server.use(http.put("/test-put", () => HttpResponse.json({ updated: true })));
+      server.use(http.put("/api/test-put", () => HttpResponse.json({ updated: true })));
 
       const { result } = renderHook(() =>
-        useQuery<{ updated: boolean }, { name: string }>("/test-put", {
+        useQuery<{ updated: boolean }, { name: string }>("/api/test-put", {
           method: "PUT",
           enabled: false,
         }),
@@ -131,10 +133,10 @@ describe("useQuery", () => {
     });
 
     it("executes a PATCH request", async () => {
-      server.use(http.patch("/test-patch", () => HttpResponse.json({ patched: true })));
+      server.use(http.patch("/api/test-patch", () => HttpResponse.json({ patched: true })));
 
       const { result } = renderHook(() =>
-        useQuery<{ patched: boolean }, { field: string }>("/test-patch", {
+        useQuery<{ patched: boolean }, { field: string }>("/api/test-patch", {
           method: "PATCH",
           enabled: false,
         }),
@@ -147,10 +149,10 @@ describe("useQuery", () => {
     });
 
     it("executes a DELETE request", async () => {
-      server.use(http.delete("/test-delete", () => HttpResponse.json({ deleted: true })));
+      server.use(http.delete("/api/test-delete", () => HttpResponse.json({ deleted: true })));
 
       const { result } = renderHook(() =>
-        useQuery<{ deleted: boolean }>("/test-delete", {
+        useQuery<{ deleted: boolean }>("/api/test-delete", {
           method: "DELETE",
           enabled: false,
         }),
@@ -166,7 +168,7 @@ describe("useQuery", () => {
   describe("initialData option", () => {
     it("starts with initialData and does not set isLoading", () => {
       const { result } = renderHook(() =>
-        useQuery("/test-init", { initialData: { value: "preset" } }),
+        useQuery("/api/test-init", { initialData: { value: "preset" } }),
       );
       // With initialData provided, isLoading should be false immediately
       expect(result.current.data).toEqual({ value: "preset" });
@@ -176,10 +178,10 @@ describe("useQuery", () => {
 
   describe("headers option", () => {
     it("sends custom headers", async () => {
-      server.use(http.get("/test-headers", () => HttpResponse.json({ ok: true })));
+      server.use(http.get("/api/test-headers", () => HttpResponse.json({ ok: true })));
 
       const { result } = renderHook(() =>
-        useQuery("/test-headers", {
+        useQuery("/api/test-headers", {
           headers: { "X-Custom-Header": "value" },
         }),
       );
@@ -192,13 +194,13 @@ describe("useQuery", () => {
   describe("execute error handling", () => {
     it("sets error state when execute fails", async () => {
       server.use(
-        http.post("/test-exec-error", () =>
+        http.post("/api/test-exec-error", () =>
           HttpResponse.json({ detail: "Server error" }, { status: 500 }),
         ),
       );
 
       const { result } = renderHook(() =>
-        useQuery("/test-exec-error", { method: "POST", enabled: false }),
+        useQuery("/api/test-exec-error", { method: "POST", enabled: false }),
       );
 
       await act(async () => {
@@ -211,16 +213,16 @@ describe("useQuery", () => {
 
   describe("immediate option", () => {
     it("does not auto-fetch when immediate is false and method is GET", () => {
-      const { result } = renderHook(() => useQuery("/test-no-immediate", { immediate: false }));
+      const { result } = renderHook(() => useQuery("/api/test-no-immediate", { immediate: false }));
       expect(result.current.isLoading).toBe(false);
       expect(result.current.data).toBeUndefined();
     });
 
     it("auto-fetches when immediate is true for non-GET method", async () => {
-      server.use(http.post("/test-immediate-post", () => HttpResponse.json({ posted: true })));
+      server.use(http.post("/api/test-immediate-post", () => HttpResponse.json({ posted: true })));
 
       const { result } = renderHook(() =>
-        useQuery("/test-immediate-post", { method: "POST", immediate: true }),
+        useQuery("/api/test-immediate-post", { method: "POST", immediate: true }),
       );
 
       await waitFor(() => expect(result.current.data).toBeDefined());
@@ -232,13 +234,13 @@ describe("useQuery", () => {
     it("re-fetches data when refetch is called", async () => {
       let callCount = 0;
       server.use(
-        http.get("/test-refetch", () => {
+        http.get("/api/test-refetch", () => {
           callCount++;
           return HttpResponse.json({ count: callCount });
         }),
       );
 
-      const { result } = renderHook(() => useQuery<{ count: number }>("/test-refetch"));
+      const { result } = renderHook(() => useQuery<{ count: number }>("/api/test-refetch"));
 
       await waitFor(() => expect(result.current.data).toBeDefined());
       expect(result.current.data?.count).toBe(1);
@@ -255,14 +257,14 @@ describe("useQuery", () => {
     it("sends overrideBody instead of default body", async () => {
       let receivedBody: unknown;
       server.use(
-        http.post("/test-override-body", async ({ request }) => {
+        http.post("/api/test-override-body", async ({ request }) => {
           receivedBody = await request.json();
           return HttpResponse.json({ ok: true });
         }),
       );
 
       const { result } = renderHook(() =>
-        useQuery<{ ok: boolean }, { name: string }>("/test-override-body", {
+        useQuery<{ ok: boolean }, { name: string }>("/api/test-override-body", {
           method: "POST",
           enabled: false,
           body: { name: "default" },

--- a/client/src/pages/Prompts.test.tsx
+++ b/client/src/pages/Prompts.test.tsx
@@ -52,7 +52,7 @@ describe("Prompts", () => {
   });
 
   it("renders the add prompts card", async () => {
-    server.use(http.get("/prompts", () => HttpResponse.json([])));
+    server.use(http.get("/api/prompts", () => HttpResponse.json([])));
 
     renderWithProviders(<Prompts />);
 
@@ -67,7 +67,7 @@ describe("Prompts", () => {
   });
 
   it("renders the add prompts card when the response object has no prompts", async () => {
-    server.use(http.get("/prompts", () => HttpResponse.json({})));
+    server.use(http.get("/api/prompts", () => HttpResponse.json({})));
 
     renderWithProviders(<Prompts />);
 
@@ -77,7 +77,7 @@ describe("Prompts", () => {
 
   it("shows the prompt form when the add card is clicked", async () => {
     const user = userEvent.setup();
-    server.use(http.get("/prompts", () => HttpResponse.json([])));
+    server.use(http.get("/api/prompts", () => HttpResponse.json([])));
 
     renderWithProviders(<Prompts />);
 
@@ -92,7 +92,7 @@ describe("Prompts", () => {
 
   it("shows the prompt form when the add card is activated by keyboard", async () => {
     const user = userEvent.setup();
-    server.use(http.get("/prompts", () => HttpResponse.json([])));
+    server.use(http.get("/api/prompts", () => HttpResponse.json([])));
 
     renderWithProviders(<Prompts />);
 
@@ -108,7 +108,7 @@ describe("Prompts", () => {
 
   it("ignores non-activation keys on the add prompts card", async () => {
     const user = userEvent.setup();
-    server.use(http.get("/prompts", () => HttpResponse.json([])));
+    server.use(http.get("/api/prompts", () => HttpResponse.json([])));
 
     renderWithProviders(<Prompts />);
 
@@ -122,7 +122,7 @@ describe("Prompts", () => {
 
   it("returns to the prompt grid when the form is canceled", async () => {
     const user = userEvent.setup();
-    server.use(http.get("/prompts", () => HttpResponse.json([])));
+    server.use(http.get("/api/prompts", () => HttpResponse.json([])));
 
     renderWithProviders(<Prompts />);
 
@@ -140,11 +140,11 @@ describe("Prompts", () => {
     const user = userEvent.setup();
     let promptListRequests = 0;
     server.use(
-      http.get("/prompts", () => {
+      http.get("/api/prompts", () => {
         promptListRequests += 1;
         return HttpResponse.json([]);
       }),
-      http.post("/prompts", () =>
+      http.post("/api/prompts", () =>
         HttpResponse.json({
           id: "prompt-1",
           name: "Greeting prompt",
@@ -175,7 +175,7 @@ describe("Prompts", () => {
 
   it("renders array prompt responses as REST prompt badges with description tooltips", async () => {
     server.use(
-      http.get("/prompts", () =>
+      http.get("/api/prompts", () =>
         HttpResponse.json([
           {
             id: "prompt-1",
@@ -209,7 +209,7 @@ describe("Prompts", () => {
 
   it("renders loading state", () => {
     server.use(
-      http.get("/prompts", async () => {
+      http.get("/api/prompts", async () => {
         await new Promise(() => {});
         return HttpResponse.json([]);
       }),
@@ -242,7 +242,7 @@ describe("Prompts", () => {
       }),
     ];
 
-    server.use(http.get("/prompts", () => HttpResponse.json(prompts)));
+    server.use(http.get("/api/prompts", () => HttpResponse.json(prompts)));
 
     renderWithProviders(<Prompts />);
 
@@ -274,7 +274,7 @@ describe("Prompts", () => {
       }),
     ];
 
-    server.use(http.get("/prompts", () => HttpResponse.json(prompts)));
+    server.use(http.get("/api/prompts", () => HttpResponse.json(prompts)));
 
     renderWithProviders(<Prompts />);
 
@@ -312,8 +312,8 @@ describe("Prompts", () => {
       return HttpResponse.json({ status: "success" });
     });
     server.use(
-      http.get("/prompts", () => HttpResponse.json(remaining)),
-      http.delete("/prompts/prompt-1", deleteSpy),
+      http.get("/api/prompts", () => HttpResponse.json(remaining)),
+      http.delete("/api/prompts/prompt-1", deleteSpy),
     );
 
     renderWithProviders(<Prompts />);
@@ -373,8 +373,8 @@ describe("Prompts", () => {
     ];
 
     server.use(
-      http.get("/prompts", () => HttpResponse.json(remaining)),
-      http.delete("/prompts/prompt-1", () => {
+      http.get("/api/prompts", () => HttpResponse.json(remaining)),
+      http.delete("/api/prompts/prompt-1", () => {
         remaining = remaining.filter((p) => p.id !== "prompt-1");
         return HttpResponse.json({ status: "success" });
       }),
@@ -428,8 +428,8 @@ describe("Prompts", () => {
     // failure), so the post-failure refetch still returns it and the row
     // reappears.
     server.use(
-      http.get("/prompts", () => HttpResponse.json(prompts)),
-      http.delete("/prompts/prompt-1", () =>
+      http.get("/api/prompts", () => HttpResponse.json(prompts)),
+      http.delete("/api/prompts/prompt-1", () =>
         HttpResponse.json({ detail: "Prompt is in use" }, { status: 409 }),
       ),
     );
@@ -483,8 +483,8 @@ describe("Prompts", () => {
     ];
 
     server.use(
-      http.get("/prompts", () => HttpResponse.json(remaining)),
-      http.delete("/prompts/prompt-1", () => {
+      http.get("/api/prompts", () => HttpResponse.json(remaining)),
+      http.delete("/api/prompts/prompt-1", () => {
         // Row is committed as deleted, but the request still errors out.
         remaining = remaining.filter((p) => p.id !== "prompt-1");
         return HttpResponse.json({ detail: "Post-commit hook failed" }, { status: 500 });
@@ -531,7 +531,7 @@ describe("Prompts", () => {
       }),
     ];
 
-    server.use(http.get("/prompts", () => HttpResponse.json(prompts)));
+    server.use(http.get("/api/prompts", () => HttpResponse.json(prompts)));
 
     renderWithProviders(<Prompts />);
 
@@ -582,7 +582,7 @@ describe("Prompts", () => {
       }),
     ];
 
-    server.use(http.get("/prompts", () => HttpResponse.json(prompts)));
+    server.use(http.get("/api/prompts", () => HttpResponse.json(prompts)));
 
     renderWithProviders(<Prompts />);
 
@@ -613,7 +613,7 @@ describe("Prompts", () => {
       }),
     );
 
-    server.use(http.get("/prompts", () => HttpResponse.json(prompts)));
+    server.use(http.get("/api/prompts", () => HttpResponse.json(prompts)));
 
     renderWithProviders(<Prompts />);
 
@@ -644,7 +644,9 @@ describe("Prompts", () => {
   });
 
   it("renders error state when prompts fail to load", async () => {
-    server.use(http.get("/prompts", () => HttpResponse.json({ detail: "Nope" }, { status: 500 })));
+    server.use(
+      http.get("/api/prompts", () => HttpResponse.json({ detail: "Nope" }, { status: 500 })),
+    );
 
     renderWithProviders(<Prompts />);
 
@@ -666,11 +668,11 @@ describe("Prompts", () => {
 
     let promptsListCalls = 0;
     server.use(
-      http.get("/prompts", () => {
+      http.get("/api/prompts", () => {
         promptsListCalls += 1;
         return HttpResponse.json([prompt]);
       }),
-      http.put("/prompts/:id", () =>
+      http.put("/api/prompts/:id", () =>
         HttpResponse.json({
           ...prompt,
           tags: [
@@ -717,8 +719,8 @@ describe("Prompts", () => {
     });
     // Object-shaped response ({ prompts: [...] }) exercises the non-array cache patch.
     server.use(
-      http.get("/prompts", () => HttpResponse.json({ prompts: [prompt] })),
-      http.put("/prompts/:id", () =>
+      http.get("/api/prompts", () => HttpResponse.json({ prompts: [prompt] })),
+      http.put("/api/prompts/:id", () =>
         HttpResponse.json({
           ...prompt,
           tags: [
@@ -754,8 +756,8 @@ describe("Prompts", () => {
       tags: [{ id: "summary", label: "summary" }],
     });
     server.use(
-      http.get("/prompts", () => HttpResponse.json([prompt])),
-      http.put("/prompts/:id", () => HttpResponse.json({ detail: "nope" }, { status: 500 })),
+      http.get("/api/prompts", () => HttpResponse.json([prompt])),
+      http.put("/api/prompts/:id", () => HttpResponse.json({ detail: "nope" }, { status: 500 })),
     );
 
     renderWithProviders(<Prompts />);
@@ -787,8 +789,8 @@ describe("Prompts", () => {
       tags: [{ id: "summary", label: "summary" }],
     });
     server.use(
-      http.get("/prompts", () => HttpResponse.json([prompt])),
-      http.put("/prompts/:id", () => HttpResponse.json(null)),
+      http.get("/api/prompts", () => HttpResponse.json([prompt])),
+      http.put("/api/prompts/:id", () => HttpResponse.json(null)),
     );
 
     renderWithProviders(<Prompts />);
@@ -815,7 +817,7 @@ describe("Prompts", () => {
   it("closes the details drawer when the close button is clicked", async () => {
     const user = userEvent.setup();
     const prompt = createMockPrompt({ id: "prompt-1", gatewaySlug: "gh-repo-tasks" });
-    server.use(http.get("/prompts", () => HttpResponse.json([prompt])));
+    server.use(http.get("/api/prompts", () => HttpResponse.json([prompt])));
 
     renderWithProviders(<Prompts />);
     await waitFor(() => expect(screen.getByText("Summarize document")).toBeInTheDocument());

--- a/client/src/pages/Resources.test.tsx
+++ b/client/src/pages/Resources.test.tsx
@@ -94,7 +94,7 @@ describe("Resources", () => {
     });
 
     server.use(
-      http.get("/resources", async () => {
+      http.get("/api/resources", async () => {
         await requestGate;
         return HttpResponse.json([]);
       }),
@@ -112,7 +112,7 @@ describe("Resources", () => {
   });
 
   it("renders Add resources card", async () => {
-    server.use(http.get("/resources", () => HttpResponse.json([])));
+    server.use(http.get("/api/resources", () => HttpResponse.json([])));
 
     renderWithRouter(<Resources />);
 
@@ -127,7 +127,7 @@ describe("Resources", () => {
 
   it("handles Add resources card click", async () => {
     const user = userEvent.setup();
-    server.use(http.get("/resources", () => HttpResponse.json([])));
+    server.use(http.get("/api/resources", () => HttpResponse.json([])));
 
     renderWithRouter(<Resources />);
 
@@ -148,7 +148,7 @@ describe("Resources", () => {
 
   it("handles Add resources card keyboard activation", async () => {
     const user = userEvent.setup();
-    server.use(http.get("/resources", () => HttpResponse.json([])));
+    server.use(http.get("/api/resources", () => HttpResponse.json([])));
 
     renderWithRouter(<Resources />);
 
@@ -169,7 +169,7 @@ describe("Resources", () => {
 
   it("displays error message when API call fails", async () => {
     server.use(
-      http.get("/resources", () => {
+      http.get("/api/resources", () => {
         return HttpResponse.json({ detail: "Failed to fetch resources" }, { status: 500 });
       }),
     );
@@ -192,7 +192,7 @@ describe("Resources", () => {
       createMockResource(5, "gateway-b"),
     ];
 
-    server.use(http.get("/resources", () => HttpResponse.json(mockResources)));
+    server.use(http.get("/api/resources", () => HttpResponse.json(mockResources)));
 
     renderWithRouter(<Resources />);
 
@@ -208,7 +208,7 @@ describe("Resources", () => {
   it("groups resources without a gateway into the REST resources bucket", async () => {
     const mockResources: Resource[] = [createMockResource(1, null)];
 
-    server.use(http.get("/resources", () => HttpResponse.json(mockResources)));
+    server.use(http.get("/api/resources", () => HttpResponse.json(mockResources)));
 
     renderWithRouter(<Resources />);
 
@@ -226,7 +226,7 @@ describe("Resources", () => {
       createMockResource(3, "multi-resource-gateway"),
     ];
 
-    server.use(http.get("/resources", () => HttpResponse.json(mockResources)));
+    server.use(http.get("/api/resources", () => HttpResponse.json(mockResources)));
 
     renderWithRouter(<Resources />);
 
@@ -243,7 +243,7 @@ describe("Resources", () => {
       createMockResource(2, "inactive-gateway", false),
     ];
 
-    server.use(http.get("/resources", () => HttpResponse.json(mockResources)));
+    server.use(http.get("/api/resources", () => HttpResponse.json(mockResources)));
 
     renderWithRouter(<Resources />);
 
@@ -260,7 +260,7 @@ describe("Resources", () => {
   it("displays resource descriptions as tooltips", async () => {
     const mockResources: Resource[] = [createMockResource(1, "server-1")];
 
-    server.use(http.get("/resources", () => HttpResponse.json(mockResources)));
+    server.use(http.get("/api/resources", () => HttpResponse.json(mockResources)));
 
     renderWithRouter(<Resources />);
 
@@ -285,7 +285,7 @@ describe("Resources", () => {
       createMockResource(2, "server-2"),
     ];
 
-    server.use(http.get("/resources", () => HttpResponse.json(mockResources)));
+    server.use(http.get("/api/resources", () => HttpResponse.json(mockResources)));
 
     renderWithRouter(<Resources />);
 
@@ -300,7 +300,7 @@ describe("Resources", () => {
   });
 
   it("handles empty resources list", async () => {
-    server.use(http.get("/resources", () => HttpResponse.json([])));
+    server.use(http.get("/api/resources", () => HttpResponse.json([])));
 
     renderWithRouter(<Resources />);
 
@@ -313,7 +313,7 @@ describe("Resources", () => {
   });
 
   it("uses correct grid layout classes", async () => {
-    server.use(http.get("/resources", () => HttpResponse.json([])));
+    server.use(http.get("/api/resources", () => HttpResponse.json([])));
 
     renderWithRouter(<Resources />);
 
@@ -334,7 +334,7 @@ describe("Resources", () => {
 
   it("handles network errors gracefully", async () => {
     server.use(
-      http.get("/resources", () => {
+      http.get("/api/resources", () => {
         return HttpResponse.error();
       }),
     );
@@ -353,7 +353,7 @@ describe("Resources", () => {
       createMockResource(i + 1, "gateway-with-many-resources"),
     );
 
-    server.use(http.get("/resources", () => HttpResponse.json(mockResources)));
+    server.use(http.get("/api/resources", () => HttpResponse.json(mockResources)));
 
     renderWithRouter(<Resources />);
 
@@ -387,7 +387,7 @@ describe("Resources", () => {
       createMockResource(i + 1, "gateway-with-eight-resources"),
     );
 
-    server.use(http.get("/resources", () => HttpResponse.json(mockResources)));
+    server.use(http.get("/api/resources", () => HttpResponse.json(mockResources)));
 
     renderWithRouter(<Resources />);
 
@@ -406,7 +406,7 @@ describe("Resources", () => {
       createMockResource(i + 1, "gateway-with-nine-resources"),
     );
 
-    server.use(http.get("/resources", () => HttpResponse.json(mockResources)));
+    server.use(http.get("/api/resources", () => HttpResponse.json(mockResources)));
 
     renderWithRouter(<Resources />);
 
@@ -434,7 +434,7 @@ describe("Resources", () => {
       const user = userEvent.setup();
       const mockResources: Resource[] = [createMockResource(1, "test-gateway")];
 
-      server.use(http.get("/resources", () => HttpResponse.json(mockResources)));
+      server.use(http.get("/api/resources", () => HttpResponse.json(mockResources)));
 
       renderWithRouter(<Resources />);
 
@@ -457,7 +457,7 @@ describe("Resources", () => {
         createMockResource(2, "test-gateway"),
       ];
 
-      server.use(http.get("/resources", () => HttpResponse.json(mockResources)));
+      server.use(http.get("/api/resources", () => HttpResponse.json(mockResources)));
 
       renderWithRouter(<Resources />);
 
@@ -484,7 +484,7 @@ describe("Resources", () => {
       const user = userEvent.setup();
       const mockResources: Resource[] = [createMockResource(1, "test-gateway")];
 
-      server.use(http.get("/resources", () => HttpResponse.json(mockResources)));
+      server.use(http.get("/api/resources", () => HttpResponse.json(mockResources)));
 
       renderWithRouter(<Resources />);
 
@@ -517,7 +517,7 @@ describe("Resources", () => {
       const user = userEvent.setup();
       const mockResources: Resource[] = [createMockResource(1, "test-gateway")];
 
-      server.use(http.get("/resources", () => HttpResponse.json(mockResources)));
+      server.use(http.get("/api/resources", () => HttpResponse.json(mockResources)));
 
       renderWithRouter(<Resources />);
 
@@ -553,7 +553,7 @@ describe("Resources", () => {
         createMockResource(3, "multi-resource-gateway"),
       ];
 
-      server.use(http.get("/resources", () => HttpResponse.json(mockResources)));
+      server.use(http.get("/api/resources", () => HttpResponse.json(mockResources)));
 
       renderWithRouter(<Resources />);
 
@@ -585,7 +585,7 @@ describe("Resources", () => {
         createMockResource(2, "gateway-b"),
       ];
 
-      server.use(http.get("/resources", () => HttpResponse.json(mockResources)));
+      server.use(http.get("/api/resources", () => HttpResponse.json(mockResources)));
 
       renderWithRouter(<Resources />);
 
@@ -652,8 +652,8 @@ describe("Resources", () => {
       const mockResources: Resource[] = [createMockResource(1, "test-gateway")];
 
       server.use(
-        http.get("/resources", () => HttpResponse.json(mockResources)),
-        http.get("/resources/resource-1", () => HttpResponse.json({ text: "resource body" })),
+        http.get("/api/resources", () => HttpResponse.json(mockResources)),
+        http.get("/api/resources/resource-1", () => HttpResponse.json({ text: "resource body" })),
       );
 
       renderWithRouter(<Resources />);
@@ -672,12 +672,12 @@ describe("Resources", () => {
       let getResourcesCallCount = 0;
 
       server.use(
-        http.get("/resources", () => {
+        http.get("/api/resources", () => {
           getResourcesCallCount += 1;
           return HttpResponse.json(mockResources);
         }),
-        http.get("/resources/resource-1", () => HttpResponse.json({ text: "resource body" })),
-        http.put("/resources/resource-1", () =>
+        http.get("/api/resources/resource-1", () => HttpResponse.json({ text: "resource body" })),
+        http.put("/api/resources/resource-1", () =>
           HttpResponse.json({ id: "resource-1" }, { status: 200 }),
         ),
       );
@@ -707,8 +707,8 @@ describe("Resources", () => {
       const user = userEvent.setup();
       const mockResources: Resource[] = [createMockResource(1, "test-gateway")];
       server.use(
-        http.get("/resources", () => HttpResponse.json(mockResources)),
-        http.get("/resources/resource-1", () =>
+        http.get("/api/resources", () => HttpResponse.json(mockResources)),
+        http.get("/api/resources/resource-1", () =>
           HttpResponse.json({ detail: "boom" }, { status: 500 }),
         ),
       );
@@ -728,9 +728,9 @@ describe("Resources", () => {
       const user = userEvent.setup();
       const mockResources: Resource[] = [createMockResource(1, "test-gateway")];
       server.use(
-        http.get("/resources", () => HttpResponse.json(mockResources)),
+        http.get("/api/resources", () => HttpResponse.json(mockResources)),
         // Never resolves, so the content stays in its loading state.
-        http.get("/resources/resource-1", () => new Promise(() => {})),
+        http.get("/api/resources/resource-1", () => new Promise(() => {})),
       );
 
       renderWithRouter(<Resources />);
@@ -748,9 +748,9 @@ describe("Resources", () => {
       const mockResources: Resource[] = [createMockResource(1, "test-gateway")];
 
       server.use(
-        http.get("/resources", () => HttpResponse.json(mockResources)),
-        http.get("/resources/resource-1", () => HttpResponse.json({ text: "resource body" })),
-        http.put("/resources/resource-1", () =>
+        http.get("/api/resources", () => HttpResponse.json(mockResources)),
+        http.get("/api/resources/resource-1", () => HttpResponse.json({ text: "resource body" })),
+        http.put("/api/resources/resource-1", () =>
           HttpResponse.json({ detail: "Update failed" }, { status: 500 }),
         ),
       );
@@ -788,15 +788,15 @@ describe("Resources", () => {
       let refetchCount = 0;
 
       server.use(
-        http.get("/resources", () => {
+        http.get("/api/resources", () => {
           refetchCount += 1;
           if (refetchCount === 1) return HttpResponse.json([]);
           return HttpResponse.json([createMockResource(99, "test-gw")]);
         }),
-        http.get("/gateways", () =>
+        http.get("/api/gateways", () =>
           HttpResponse.json({ gateways: [], next_cursor: null, total: 0 }),
         ),
-        http.post("/resources", () => HttpResponse.json({ id: "res-99" }, { status: 201 })),
+        http.post("/api/resources", () => HttpResponse.json({ id: "res-99" }, { status: 201 })),
       );
 
       renderWithRouter(<Resources />);
@@ -814,11 +814,11 @@ describe("Resources", () => {
       const user = userEvent.setup();
 
       server.use(
-        http.get("/resources", () => HttpResponse.json([])),
-        http.get("/gateways", () =>
+        http.get("/api/resources", () => HttpResponse.json([])),
+        http.get("/api/gateways", () =>
           HttpResponse.json({ gateways: [], next_cursor: null, total: 0 }),
         ),
-        http.post("/resources", () =>
+        http.post("/api/resources", () =>
           HttpResponse.json({ detail: "URI already in use" }, { status: 409 }),
         ),
       );
@@ -838,7 +838,7 @@ describe("Resources", () => {
   describe("ResourceForm Toggle", () => {
     it("closes form when Cancel clicked", async () => {
       const user = userEvent.setup();
-      server.use(http.get("/resources", () => HttpResponse.json([])));
+      server.use(http.get("/api/resources", () => HttpResponse.json([])));
 
       renderWithRouter(<Resources />);
 
@@ -863,7 +863,7 @@ describe("Resources", () => {
 
   describe("Optimistic delete", () => {
     async function setup(mockResources: Resource[], gatewaySlug: string) {
-      server.use(http.get("/resources", () => HttpResponse.json(mockResources)));
+      server.use(http.get("/api/resources", () => HttpResponse.json(mockResources)));
       renderWithRouter(<Resources />);
       await waitFor(() => expect(screen.getByText(gatewaySlug)).toBeInTheDocument());
 
@@ -889,9 +889,9 @@ describe("Resources", () => {
 
       let resolveDelete!: () => void;
       server.use(
-        http.get("/resources", () => HttpResponse.json(mockResources)),
+        http.get("/api/resources", () => HttpResponse.json(mockResources)),
         http.delete(
-          "/resources/resource-1",
+          "/api/resources/resource-1",
           () =>
             new Promise<Response>((resolve) => {
               resolveDelete = () => resolve(new Response(null, { status: 204 }));
@@ -931,8 +931,8 @@ describe("Resources", () => {
     it("rolls back: resource badge reappears in card grid when delete API fails", async () => {
       const mockResources = [createMockResource(1, "rollback-gateway")];
       server.use(
-        http.get("/resources", () => HttpResponse.json(mockResources)),
-        http.delete("/resources/resource-1", () =>
+        http.get("/api/resources", () => HttpResponse.json(mockResources)),
+        http.delete("/api/resources/resource-1", () =>
           HttpResponse.json({ detail: "Server error" }, { status: 500 }),
         ),
       );
@@ -966,8 +966,8 @@ describe("Resources", () => {
     it("details panel closes immediately when the only resource in a group is deleted", async () => {
       const mockResources = [createMockResource(1, "solo-gateway")];
       server.use(
-        http.get("/resources", () => HttpResponse.json(mockResources)),
-        http.delete("/resources/resource-1", () => new HttpResponse(null, { status: 204 })),
+        http.get("/api/resources", () => HttpResponse.json(mockResources)),
+        http.delete("/api/resources/resource-1", () => new HttpResponse(null, { status: 204 })),
       );
 
       const { user } = await setup(mockResources, "solo-gateway");
@@ -990,8 +990,8 @@ describe("Resources", () => {
         createMockResource(2, "multi-gateway"),
       ];
       server.use(
-        http.get("/resources", () => HttpResponse.json(mockResources)),
-        http.delete("/resources/resource-1", () => new HttpResponse(null, { status: 204 })),
+        http.get("/api/resources", () => HttpResponse.json(mockResources)),
+        http.delete("/api/resources/resource-1", () => new HttpResponse(null, { status: 204 })),
       );
 
       const { user } = await setup(mockResources, "multi-gateway");
@@ -1021,9 +1021,9 @@ describe("Resources", () => {
 
       let resolveDelete!: () => void;
       server.use(
-        http.get("/resources", () => HttpResponse.json(mockResources)),
+        http.get("/api/resources", () => HttpResponse.json(mockResources)),
         http.delete(
-          "/resources/resource-1",
+          "/api/resources/resource-1",
           () =>
             new Promise<Response>((resolve) => {
               resolveDelete = () => resolve(new Response(null, { status: 204 }));
@@ -1061,8 +1061,8 @@ describe("Resources", () => {
         createMockResource(2, "reopen-gateway"),
       ];
       server.use(
-        http.get("/resources", () => HttpResponse.json(mockResources)),
-        http.delete("/resources/resource-1", () =>
+        http.get("/api/resources", () => HttpResponse.json(mockResources)),
+        http.delete("/api/resources/resource-1", () =>
           HttpResponse.json({ detail: "Forbidden" }, { status: 403 }),
         ),
       );
@@ -1091,8 +1091,8 @@ describe("Resources", () => {
     it("shows generic error toast when delete returns no detail field", async () => {
       const mockResources = [createMockResource(1, "err-gateway")];
       server.use(
-        http.get("/resources", () => HttpResponse.json(mockResources)),
-        http.delete("/resources/resource-1", () =>
+        http.get("/api/resources", () => HttpResponse.json(mockResources)),
+        http.delete("/api/resources/resource-1", () =>
           HttpResponse.json({ message: "Unexpected error" }, { status: 500 }),
         ),
       );
@@ -1114,9 +1114,9 @@ describe("Resources", () => {
     it("rolls back with a generic error toast when delete fails at the network level", async () => {
       const mockResources = [createMockResource(1, "net-gateway")];
       server.use(
-        http.get("/resources", () => HttpResponse.json(mockResources)),
+        http.get("/api/resources", () => HttpResponse.json(mockResources)),
         // A network-level failure surfaces as a non-ApiError Error in the rollback.
-        http.delete("/resources/resource-1", () => HttpResponse.error()),
+        http.delete("/api/resources/resource-1", () => HttpResponse.error()),
       );
 
       const { user } = await setup(mockResources, "net-gateway");
@@ -1141,7 +1141,7 @@ describe("Resources", () => {
       const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       server.use(
-        http.get("/resources", () => {
+        http.get("/api/resources", () => {
           throw new Error("Simulated rendering error");
         }),
       );
@@ -1163,11 +1163,11 @@ describe("Resources", () => {
 
       let resourcesListCalls = 0;
       server.use(
-        http.get("/resources", () => {
+        http.get("/api/resources", () => {
           resourcesListCalls += 1;
           return HttpResponse.json([resource]);
         }),
-        http.put("/resources/:id", () =>
+        http.put("/api/resources/:id", () =>
           HttpResponse.json({ ...resource, tags: ["tag1", "alerts"] }),
         ),
       );
@@ -1198,8 +1198,10 @@ describe("Resources", () => {
       const user = userEvent.setup();
       const resource: Resource = { ...createMockResource(1, "test-gateway"), tags: ["tag1"] };
       server.use(
-        http.get("/resources", () => HttpResponse.json([resource])),
-        http.put("/resources/:id", () => HttpResponse.json({ detail: "nope" }, { status: 500 })),
+        http.get("/api/resources", () => HttpResponse.json([resource])),
+        http.put("/api/resources/:id", () =>
+          HttpResponse.json({ detail: "nope" }, { status: 500 }),
+        ),
       );
 
       renderWithRouter(<Resources />);
@@ -1237,8 +1239,8 @@ describe("Resources", () => {
       const mockResources = [createMockResource(1, "toggle-gateway", false)];
 
       server.use(
-        http.get("/resources", () => HttpResponse.json(mockResources)),
-        http.post("/resources/resource-1/state", () =>
+        http.get("/api/resources", () => HttpResponse.json(mockResources)),
+        http.post("/api/resources/resource-1/state", () =>
           HttpResponse.json({
             status: "success",
             message: "activated",
@@ -1267,8 +1269,8 @@ describe("Resources", () => {
       const mockResources = [createMockResource(1, "toggle-gateway", true)];
 
       server.use(
-        http.get("/resources", () => HttpResponse.json(mockResources)),
-        http.post("/resources/resource-1/state", () =>
+        http.get("/api/resources", () => HttpResponse.json(mockResources)),
+        http.post("/api/resources/resource-1/state", () =>
           HttpResponse.json({
             status: "success",
             message: "deactivated",
@@ -1298,9 +1300,9 @@ describe("Resources", () => {
 
       let resolveState!: () => void;
       server.use(
-        http.get("/resources", () => HttpResponse.json(mockResources)),
+        http.get("/api/resources", () => HttpResponse.json(mockResources)),
         http.post(
-          "/resources/resource-1/state",
+          "/api/resources/resource-1/state",
           () =>
             new Promise<Response>((resolve) => {
               resolveState = () =>
@@ -1340,8 +1342,8 @@ describe("Resources", () => {
       const mockResources = [createMockResource(1, "fail-toggle-gateway", false)];
 
       server.use(
-        http.get("/resources", () => HttpResponse.json(mockResources)),
-        http.post("/resources/resource-1/state", () =>
+        http.get("/api/resources", () => HttpResponse.json(mockResources)),
+        http.post("/api/resources/resource-1/state", () =>
           HttpResponse.json({ detail: "Cannot activate" }, { status: 400 }),
         ),
       );
@@ -1367,9 +1369,9 @@ describe("Resources", () => {
       let resolveState!: () => void;
       let callCount = 0;
       server.use(
-        http.get("/resources", () => HttpResponse.json(mockResources)),
+        http.get("/api/resources", () => HttpResponse.json(mockResources)),
         http.post(
-          "/resources/resource-1/state",
+          "/api/resources/resource-1/state",
           () =>
             new Promise<Response>((resolve) => {
               callCount += 1;
@@ -1411,8 +1413,8 @@ describe("Resources", () => {
     it("labels a resource group using the gateway name from the gateways list", async () => {
       const resource = createMockResource(1, "gw-1");
       server.use(
-        http.get("/resources", () => HttpResponse.json([resource])),
-        http.get("/gateways", () =>
+        http.get("/api/resources", () => HttpResponse.json([resource])),
+        http.get("/api/gateways", () =>
           HttpResponse.json({
             gateways: [{ id: "gw-1", slug: "gh-repo-tasks", name: "GH Repo" }],
           }),

--- a/client/src/pages/Tools.test.tsx
+++ b/client/src/pages/Tools.test.tsx
@@ -73,7 +73,7 @@ describe("Tools", () => {
   it("renders loading state initially", () => {
     // Mock a delayed response
     server.use(
-      http.get("/tools", async () => {
+      http.get("/api/tools", async () => {
         await new Promise(() => {}); // Never resolves
         return HttpResponse.json([]);
       }),
@@ -92,7 +92,7 @@ describe("Tools", () => {
       createMockTool(3, "server-2"),
     ];
 
-    server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+    server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
     renderWithRouter(<Tools />);
 
@@ -117,7 +117,7 @@ describe("Tools", () => {
   it("requests the tool list with include_inactive=true so deactivated tools stay listed", async () => {
     let requestUrl: URL | null = null;
     server.use(
-      http.get("/tools", ({ request }) => {
+      http.get("/api/tools", ({ request }) => {
         requestUrl = new URL(request.url);
         return HttpResponse.json([]);
       }),
@@ -136,7 +136,7 @@ describe("Tools", () => {
   it("lists inactive tools and shows their 'Inactive' status in the details panel", async () => {
     // A gateway whose only tool is deactivated — it must still appear so it can be re-activated.
     const mockTools: Tool[] = [createMockTool(1, "inactive-gateway", false, true)];
-    server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+    server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
     const user = userEvent.setup();
     renderWithRouter(<Tools />);
@@ -161,8 +161,8 @@ describe("Tools", () => {
   it("shows the gateway description in the tool details panel", async () => {
     const mockTools: Tool[] = [createMockTool(1, "described-gateway")];
     server.use(
-      http.get("/tools", () => HttpResponse.json(mockTools)),
-      http.get("/gateways", () =>
+      http.get("/api/tools", () => HttpResponse.json(mockTools)),
+      http.get("/api/gateways", () =>
         HttpResponse.json({
           gateways: [
             {
@@ -188,7 +188,7 @@ describe("Tools", () => {
   });
 
   it("renders Add tools card", async () => {
-    server.use(http.get("/tools", () => HttpResponse.json([])));
+    server.use(http.get("/api/tools", () => HttpResponse.json([])));
 
     renderWithRouter(<Tools />);
 
@@ -203,7 +203,7 @@ describe("Tools", () => {
 
   it("handles Add tools card click", async () => {
     const user = userEvent.setup();
-    server.use(http.get("/tools", () => HttpResponse.json([])));
+    server.use(http.get("/api/tools", () => HttpResponse.json([])));
 
     renderWithRouter(<Tools />);
 
@@ -222,7 +222,7 @@ describe("Tools", () => {
 
   it("handles Add tools card keyboard activation", async () => {
     const user = userEvent.setup();
-    server.use(http.get("/tools", () => HttpResponse.json([])));
+    server.use(http.get("/api/tools", () => HttpResponse.json([])));
 
     renderWithRouter(<Tools />);
 
@@ -242,7 +242,7 @@ describe("Tools", () => {
 
   it("clicking Add tools card opens the ToolForm", async () => {
     const user = userEvent.setup();
-    server.use(http.get("/tools", () => HttpResponse.json([])));
+    server.use(http.get("/api/tools", () => HttpResponse.json([])));
 
     renderWithRouter(<Tools />);
 
@@ -262,7 +262,7 @@ describe("Tools", () => {
 
   it("ToolForm Cancel button closes the form and shows the tools list again", async () => {
     const user = userEvent.setup();
-    server.use(http.get("/tools", () => HttpResponse.json([])));
+    server.use(http.get("/api/tools", () => HttpResponse.json([])));
 
     renderWithRouter(<Tools />);
 
@@ -286,7 +286,7 @@ describe("Tools", () => {
 
   it("displays error message when API call fails", async () => {
     server.use(
-      http.get("/tools", () => {
+      http.get("/api/tools", () => {
         return HttpResponse.json({ detail: "Failed to fetch tools" }, { status: 500 });
       }),
     );
@@ -309,7 +309,7 @@ describe("Tools", () => {
       createMockTool(5, "gateway-b"),
     ];
 
-    server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+    server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
     renderWithRouter(<Tools />);
 
@@ -328,7 +328,7 @@ describe("Tools", () => {
       createMockTool(2, "inactive-gateway", false, false),
     ];
 
-    server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+    server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
     renderWithRouter(<Tools />);
 
@@ -349,7 +349,7 @@ describe("Tools", () => {
   it("displays tool descriptions as tooltips", async () => {
     const mockTools: Tool[] = [createMockTool(1, "server-1")];
 
-    server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+    server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
     renderWithRouter(<Tools />);
 
@@ -367,7 +367,7 @@ describe("Tools", () => {
   it("renders more options button for each tool group", async () => {
     const mockTools: Tool[] = [createMockTool(1, "server-1"), createMockTool(2, "server-2")];
 
-    server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+    server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
     renderWithRouter(<Tools />);
 
@@ -382,7 +382,7 @@ describe("Tools", () => {
   });
 
   it("handles empty tools list", async () => {
-    server.use(http.get("/tools", () => HttpResponse.json([])));
+    server.use(http.get("/api/tools", () => HttpResponse.json([])));
 
     renderWithRouter(<Tools />);
 
@@ -396,7 +396,7 @@ describe("Tools", () => {
   });
 
   it("uses correct grid layout classes", async () => {
-    server.use(http.get("/tools", () => HttpResponse.json([])));
+    server.use(http.get("/api/tools", () => HttpResponse.json([])));
 
     renderWithRouter(<Tools />);
 
@@ -425,7 +425,7 @@ describe("Tools", () => {
       },
     ];
 
-    server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+    server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
     renderWithRouter(<Tools />);
 
@@ -443,7 +443,7 @@ describe("Tools", () => {
       createMockTool(3, "multi-tool-gateway"),
     ];
 
-    server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+    server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
     renderWithRouter(<Tools />);
 
@@ -465,7 +465,7 @@ describe("Tools", () => {
       createMockTool(7, "gateway-3"),
     ];
 
-    server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+    server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
     renderWithRouter(<Tools />);
 
@@ -485,7 +485,7 @@ describe("Tools", () => {
       createMockTool(3, "mixed-gateway", true, false), // Inactive (unreachable)
     ];
 
-    server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+    server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
     renderWithRouter(<Tools />);
 
@@ -499,7 +499,7 @@ describe("Tools", () => {
 
   it("handles network errors gracefully", async () => {
     server.use(
-      http.get("/tools", () => {
+      http.get("/api/tools", () => {
         return HttpResponse.error();
       }),
     );
@@ -519,7 +519,7 @@ describe("Tools", () => {
       createMockTool(i + 1, "gateway-with-many-tools"),
     );
 
-    server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+    server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
     renderWithRouter(<Tools />);
 
@@ -555,7 +555,7 @@ describe("Tools", () => {
       createMockTool(i + 1, "gateway-with-eight-tools"),
     );
 
-    server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+    server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
     renderWithRouter(<Tools />);
 
@@ -576,7 +576,7 @@ describe("Tools", () => {
       createMockTool(i + 1, "gateway-with-nine-tools"),
     );
 
-    server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+    server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
     renderWithRouter(<Tools />);
 
@@ -601,7 +601,7 @@ describe("Tools", () => {
       ...Array.from({ length: 20 }, (_, i) => createMockTool(i + 16, "gateway-large")),
     ];
 
-    server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+    server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
     renderWithRouter(<Tools />);
 
@@ -634,7 +634,7 @@ describe("Tools", () => {
       const user = userEvent.setup();
       const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
 
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
       renderWithRouter(<Tools />);
 
@@ -658,7 +658,7 @@ describe("Tools", () => {
         createMockTool(2, "test-gateway"),
       ];
 
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
       renderWithRouter(<Tools />);
 
@@ -687,7 +687,7 @@ describe("Tools", () => {
       const user = userEvent.setup();
       const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
 
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
       renderWithRouter(<Tools />);
 
@@ -722,7 +722,7 @@ describe("Tools", () => {
       const user = userEvent.setup();
       const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
 
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
       renderWithRouter(<Tools />);
 
@@ -760,7 +760,7 @@ describe("Tools", () => {
         createMockTool(3, "multi-tool-gateway"),
       ];
 
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
       renderWithRouter(<Tools />);
 
@@ -797,7 +797,7 @@ describe("Tools", () => {
         },
       ];
 
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
       renderWithRouter(<Tools />);
 
@@ -821,7 +821,7 @@ describe("Tools", () => {
       const user = userEvent.setup();
       const mockTools: Tool[] = [createMockTool(1, "gateway-a"), createMockTool(2, "gateway-b")];
 
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
       renderWithRouter(<Tools />);
 
@@ -878,8 +878,8 @@ describe("Tools", () => {
     it("shows Edit option in the tool row dropdown when panel is open", async () => {
       const mockTools: Tool[] = [createMockTool(1, "test-gateway", true, true)];
       server.use(
-        http.get("/tools", () => HttpResponse.json(mockTools)),
-        http.get("/tools/tool-1", () => HttpResponse.json(mockTools[0])),
+        http.get("/api/tools", () => HttpResponse.json(mockTools)),
+        http.get("/api/tools/tool-1", () => HttpResponse.json(mockTools[0])),
       );
       renderWithRouter(<Tools />);
       await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
@@ -893,8 +893,8 @@ describe("Tools", () => {
     it("opens the edit form when Edit is clicked", async () => {
       const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
       server.use(
-        http.get("/tools", () => HttpResponse.json(mockTools)),
-        http.get("/tools/tool-1", () => HttpResponse.json(mockTools[0])),
+        http.get("/api/tools", () => HttpResponse.json(mockTools)),
+        http.get("/api/tools/tool-1", () => HttpResponse.json(mockTools[0])),
       );
       renderWithRouter(<Tools />);
       await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
@@ -911,8 +911,8 @@ describe("Tools", () => {
     it("pre-populates the form with the tool's URL", async () => {
       const mockTool = createMockTool(1, "test-gateway");
       server.use(
-        http.get("/tools", () => HttpResponse.json([mockTool])),
-        http.get("/tools/tool-1", () => HttpResponse.json(mockTool)),
+        http.get("/api/tools", () => HttpResponse.json([mockTool])),
+        http.get("/api/tools/tool-1", () => HttpResponse.json(mockTool)),
       );
       renderWithRouter(<Tools />);
       await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
@@ -940,9 +940,9 @@ describe("Tools", () => {
 
       let putCalled = false;
       server.use(
-        http.get("/tools", () => HttpResponse.json([putCalled ? updatedTool : originalTool])),
-        http.get("/tools/tool-1", () => HttpResponse.json(originalTool)),
-        http.put("/tools/tool-1", () => {
+        http.get("/api/tools", () => HttpResponse.json([putCalled ? updatedTool : originalTool])),
+        http.get("/api/tools/tool-1", () => HttpResponse.json(originalTool)),
+        http.put("/api/tools/tool-1", () => {
           putCalled = true;
           return HttpResponse.json(updatedTool);
         }),
@@ -981,8 +981,8 @@ describe("Tools", () => {
     it("shows Edit above Delete in the dropdown when both are available", async () => {
       const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
       server.use(
-        http.get("/tools", () => HttpResponse.json(mockTools)),
-        http.get("/tools/tool-1", () => HttpResponse.json(mockTools[0])),
+        http.get("/api/tools", () => HttpResponse.json(mockTools)),
+        http.get("/api/tools/tool-1", () => HttpResponse.json(mockTools[0])),
       );
       renderWithRouter(<Tools />);
       await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
@@ -1019,7 +1019,7 @@ describe("Tools", () => {
 
     it("shows Delete option in the tool row dropdown when panel is open", async () => {
       const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
       renderWithRouter(<Tools />);
       await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
 
@@ -1034,7 +1034,7 @@ describe("Tools", () => {
 
     it("opens a confirm dialog with the tool name when Delete is clicked", async () => {
       const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
       renderWithRouter(<Tools />);
       await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
 
@@ -1056,9 +1056,9 @@ describe("Tools", () => {
 
     it("does not call the API when the confirm dialog is cancelled", async () => {
       const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
       const deleteSpy = vi.fn(() => HttpResponse.json(null, { status: 204 }));
-      server.use(http.delete("/tools/:id", deleteSpy));
+      server.use(http.delete("/api/tools/:id", deleteSpy));
 
       renderWithRouter(<Tools />);
       await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
@@ -1079,8 +1079,8 @@ describe("Tools", () => {
     it("calls the delete API, shows success toast, and closes the panel on confirm", async () => {
       const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
       server.use(
-        http.get("/tools", () => HttpResponse.json(mockTools)),
-        http.delete("/tools/tool-1", () => new HttpResponse(null, { status: 204 })),
+        http.get("/api/tools", () => HttpResponse.json(mockTools)),
+        http.delete("/api/tools/tool-1", () => new HttpResponse(null, { status: 204 })),
       );
 
       renderWithRouter(<Tools />);
@@ -1108,8 +1108,8 @@ describe("Tools", () => {
     it("shows an error toast when the delete API returns a string detail", async () => {
       const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
       server.use(
-        http.get("/tools", () => HttpResponse.json(mockTools)),
-        http.delete("/tools/tool-1", () =>
+        http.get("/api/tools", () => HttpResponse.json(mockTools)),
+        http.delete("/api/tools/tool-1", () =>
           HttpResponse.json({ detail: "Cannot delete: tool is in use" }, { status: 409 }),
         ),
       );
@@ -1132,8 +1132,8 @@ describe("Tools", () => {
     it("shows a generic error toast when the delete API returns no detail", async () => {
       const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
       server.use(
-        http.get("/tools", () => HttpResponse.json(mockTools)),
-        http.delete("/tools/tool-1", () =>
+        http.get("/api/tools", () => HttpResponse.json(mockTools)),
+        http.delete("/api/tools/tool-1", () =>
           HttpResponse.json({ message: "Something went wrong" }, { status: 500 }),
         ),
       );
@@ -1156,8 +1156,8 @@ describe("Tools", () => {
     it("shows an error toast when the delete API throws a standard Error", async () => {
       const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
       server.use(
-        http.get("/tools", () => HttpResponse.json(mockTools)),
-        http.delete("/tools/tool-1", () => {
+        http.get("/api/tools", () => HttpResponse.json(mockTools)),
+        http.delete("/api/tools/tool-1", () => {
           return HttpResponse.error();
         }),
       );
@@ -1181,7 +1181,7 @@ describe("Tools", () => {
       const mockTools: Tool[] = [
         { ...createMockTool(1, "test-gateway"), displayName: "My Custom Tool" },
       ];
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
       renderWithRouter(<Tools />);
       await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
@@ -1196,7 +1196,7 @@ describe("Tools", () => {
 
     it("falls back to name in the dialog description when displayName is absent", async () => {
       const mockTools: Tool[] = [{ ...createMockTool(1, "test-gateway"), displayName: undefined }];
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
       renderWithRouter(<Tools />);
       await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
@@ -1233,7 +1233,7 @@ describe("Tools", () => {
 
     it("shows Deactivate for an enabled tool and Edit, Deactivate, Delete in order", async () => {
       const mockTools: Tool[] = [createMockTool(1, "test-gateway", true, true)];
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
       renderWithRouter(<Tools />);
       await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
 
@@ -1251,16 +1251,16 @@ describe("Tools", () => {
       let listFetches = 0;
       server.use(
         // The list is fetched once on mount; the toggle must NOT trigger another list fetch.
-        http.get("/tools", () => {
+        http.get("/api/tools", () => {
           listFetches += 1;
           return HttpResponse.json([activeTool]);
         }),
-        http.post("/tools/tool-1/state", ({ request }) => {
+        http.post("/api/tools/tool-1/state", ({ request }) => {
           expect(new URL(request.url).searchParams.get("activate")).toBe("false");
           return HttpResponse.json({ status: "success", tool: inactiveTool });
         }),
         // Only the affected tool is re-fetched and patched into the list.
-        http.get("/tools/tool-1", () => HttpResponse.json(inactiveTool)),
+        http.get("/api/tools/tool-1", () => HttpResponse.json(inactiveTool)),
       );
 
       renderWithRouter(<Tools />);
@@ -1289,9 +1289,9 @@ describe("Tools", () => {
     it("shows an error toast when a toggle fails with a network error", async () => {
       const activeTool = createMockTool(1, "test-gateway", true, true);
       server.use(
-        http.get("/tools", () => HttpResponse.json([activeTool])),
+        http.get("/api/tools", () => HttpResponse.json([activeTool])),
         // A network-level failure surfaces as a non-ApiError Error in the catch.
-        http.post("/tools/tool-1/state", () => HttpResponse.error()),
+        http.post("/api/tools/tool-1/state", () => HttpResponse.error()),
       );
 
       renderWithRouter(<Tools />);
@@ -1309,12 +1309,12 @@ describe("Tools", () => {
       const activeTool = { ...inactiveTool, enabled: true };
 
       server.use(
-        http.get("/tools", () => HttpResponse.json([inactiveTool])),
-        http.post("/tools/tool-1/state", ({ request }) => {
+        http.get("/api/tools", () => HttpResponse.json([inactiveTool])),
+        http.post("/api/tools/tool-1/state", ({ request }) => {
           expect(new URL(request.url).searchParams.get("activate")).toBe("true");
           return HttpResponse.json({ status: "success", tool: activeTool });
         }),
-        http.get("/tools/tool-1", () => HttpResponse.json(activeTool)),
+        http.get("/api/tools/tool-1", () => HttpResponse.json(activeTool)),
       );
 
       renderWithRouter(<Tools />);
@@ -1338,8 +1338,8 @@ describe("Tools", () => {
     it("shows an error toast and leaves status unchanged when the request fails", async () => {
       const activeTool = createMockTool(1, "test-gateway", true, true);
       server.use(
-        http.get("/tools", () => HttpResponse.json([activeTool])),
-        http.post("/tools/tool-1/state", () =>
+        http.get("/api/tools", () => HttpResponse.json([activeTool])),
+        http.post("/api/tools/tool-1/state", () =>
           HttpResponse.json({ detail: "Permission denied" }, { status: 403 }),
         ),
       );
@@ -1370,7 +1370,7 @@ describe("Tools", () => {
         },
       ];
 
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
       renderWithRouter(<Tools />);
 
@@ -1393,7 +1393,7 @@ describe("Tools", () => {
         },
       ];
 
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
       renderWithRouter(<Tools />);
 
@@ -1421,7 +1421,7 @@ describe("Tools", () => {
         },
       ];
 
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
       renderWithRouter(<Tools />);
 
@@ -1449,7 +1449,7 @@ describe("Tools", () => {
         },
       ];
 
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
       renderWithRouter(<Tools />);
 
@@ -1482,7 +1482,7 @@ describe("Tools", () => {
         },
       ];
 
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
       renderWithRouter(<Tools />);
 
@@ -1505,7 +1505,7 @@ describe("Tools", () => {
         },
       ];
 
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
       renderWithRouter(<Tools />);
 
@@ -1536,7 +1536,7 @@ describe("Tools", () => {
         },
       ];
 
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
 
       renderWithRouter(<Tools />);
 
@@ -1553,7 +1553,7 @@ describe("Tools", () => {
 
   describe("Optimistic delete", () => {
     async function setup(mockTools: Tool[], gatewaySlug: string) {
-      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      server.use(http.get("/api/tools", () => HttpResponse.json(mockTools)));
       renderWithRouter(<Tools />);
       await waitFor(() => expect(screen.getByText(gatewaySlug)).toBeInTheDocument());
 
@@ -1579,9 +1579,9 @@ describe("Tools", () => {
 
       let resolveDelete!: () => void;
       server.use(
-        http.get("/tools", () => HttpResponse.json(mockTools)),
+        http.get("/api/tools", () => HttpResponse.json(mockTools)),
         http.delete(
-          "/tools/tool-1",
+          "/api/tools/tool-1",
           () =>
             new Promise<Response>((resolve) => {
               resolveDelete = () => resolve(new Response(null, { status: 204 }));
@@ -1619,8 +1619,8 @@ describe("Tools", () => {
     it("rolls back: tool badge reappears in card grid when delete API fails", async () => {
       const mockTools = [createMockTool(1, "rollback-gateway")];
       server.use(
-        http.get("/tools", () => HttpResponse.json(mockTools)),
-        http.delete("/tools/tool-1", () =>
+        http.get("/api/tools", () => HttpResponse.json(mockTools)),
+        http.delete("/api/tools/tool-1", () =>
           HttpResponse.json({ detail: "Server error" }, { status: 500 }),
         ),
       );
@@ -1654,8 +1654,8 @@ describe("Tools", () => {
     it("details panel closes immediately when the only tool in a group is deleted", async () => {
       const mockTools = [createMockTool(1, "solo-gateway")];
       server.use(
-        http.get("/tools", () => HttpResponse.json(mockTools)),
-        http.delete("/tools/tool-1", () => new HttpResponse(null, { status: 204 })),
+        http.get("/api/tools", () => HttpResponse.json(mockTools)),
+        http.delete("/api/tools/tool-1", () => new HttpResponse(null, { status: 204 })),
       );
 
       const { user } = await setup(mockTools, "solo-gateway");
@@ -1675,8 +1675,8 @@ describe("Tools", () => {
     it("details panel stays open when one tool is deleted from a multi-tool group", async () => {
       const mockTools = [createMockTool(1, "multi-gateway"), createMockTool(2, "multi-gateway")];
       server.use(
-        http.get("/tools", () => HttpResponse.json(mockTools)),
-        http.delete("/tools/tool-1", () => new HttpResponse(null, { status: 204 })),
+        http.get("/api/tools", () => HttpResponse.json(mockTools)),
+        http.delete("/api/tools/tool-1", () => new HttpResponse(null, { status: 204 })),
       );
 
       const { user } = await setup(mockTools, "multi-gateway");
@@ -1703,9 +1703,9 @@ describe("Tools", () => {
 
       let resolveDelete!: () => void;
       server.use(
-        http.get("/tools", () => HttpResponse.json(mockTools)),
+        http.get("/api/tools", () => HttpResponse.json(mockTools)),
         http.delete(
-          "/tools/tool-1",
+          "/api/tools/tool-1",
           () =>
             new Promise<Response>((resolve) => {
               resolveDelete = () => resolve(new Response(null, { status: 204 }));
@@ -1740,8 +1740,8 @@ describe("Tools", () => {
     it("details panel re-opens after rollback when group had multiple tools", async () => {
       const mockTools = [createMockTool(1, "reopen-gateway"), createMockTool(2, "reopen-gateway")];
       server.use(
-        http.get("/tools", () => HttpResponse.json(mockTools)),
-        http.delete("/tools/tool-1", () =>
+        http.get("/api/tools", () => HttpResponse.json(mockTools)),
+        http.delete("/api/tools/tool-1", () =>
           HttpResponse.json({ detail: "Forbidden" }, { status: 403 }),
         ),
       );
@@ -1770,8 +1770,8 @@ describe("Tools", () => {
     it("shows generic error toast when delete returns no detail field", async () => {
       const mockTools = [createMockTool(1, "err-gateway")];
       server.use(
-        http.get("/tools", () => HttpResponse.json(mockTools)),
-        http.delete("/tools/tool-1", () =>
+        http.get("/api/tools", () => HttpResponse.json(mockTools)),
+        http.delete("/api/tools/tool-1", () =>
           HttpResponse.json({ message: "Unexpected error" }, { status: 500 }),
         ),
       );
@@ -1795,8 +1795,8 @@ describe("Tools", () => {
         createMockTool(3, "snapshot-gateway"),
       ];
       server.use(
-        http.get("/tools", () => HttpResponse.json(mockTools)),
-        http.delete("/tools/tool-1", () =>
+        http.get("/api/tools", () => HttpResponse.json(mockTools)),
+        http.delete("/api/tools/tool-1", () =>
           HttpResponse.json({ detail: "Conflict" }, { status: 409 }),
         ),
       );
@@ -1831,9 +1831,9 @@ describe("Tools", () => {
 
       let resolveDelete!: () => void;
       server.use(
-        http.get("/tools", () => HttpResponse.json(mockTools)),
+        http.get("/api/tools", () => HttpResponse.json(mockTools)),
         http.delete(
-          "/tools/tool-10",
+          "/api/tools/tool-10",
           () =>
             new Promise<Response>((resolve) => {
               resolveDelete = () => resolve(new Response(null, { status: 204 }));
@@ -1874,11 +1874,11 @@ describe("Tools", () => {
 
       let toolsListCalls = 0;
       server.use(
-        http.get("/tools", () => {
+        http.get("/api/tools", () => {
           toolsListCalls += 1;
           return HttpResponse.json([tool]);
         }),
-        http.put("/tools/:id", () => HttpResponse.json({ ...tool, tags: ["tag1", "alerts"] })),
+        http.put("/api/tools/:id", () => HttpResponse.json({ ...tool, tags: ["tag1", "alerts"] })),
       );
 
       renderWithRouter(<Tools />);
@@ -1907,8 +1907,8 @@ describe("Tools", () => {
       const user = userEvent.setup();
       const tool: Tool = { ...createMockTool(1, "test-gateway"), tags: [{ label: "tag1" }] };
       server.use(
-        http.get("/tools", () => HttpResponse.json([tool])),
-        http.put("/tools/:id", () => HttpResponse.json({ detail: "nope" }, { status: 500 })),
+        http.get("/api/tools", () => HttpResponse.json([tool])),
+        http.put("/api/tools/:id", () => HttpResponse.json({ detail: "nope" }, { status: 500 })),
       );
 
       renderWithRouter(<Tools />);
@@ -1933,7 +1933,7 @@ describe("Tools", () => {
   describe("opening from global search", () => {
     it("opens the details panel for a tool referenced by the ?selected= query param", async () => {
       const tool = createMockTool(1, "test-gateway");
-      server.use(http.get("/tools", () => HttpResponse.json([tool])));
+      server.use(http.get("/api/tools", () => HttpResponse.json([tool])));
 
       renderWithRouter(<Tools />, "/app/tools?selected=tool-1");
 

--- a/client/src/test/mocks/handlers.ts
+++ b/client/src/test/mocks/handlers.ts
@@ -23,8 +23,8 @@ export const handlers = [
     return HttpResponse.json({ items: items.slice(0, limit) });
   }),
 
-  // Mock login endpoint
-  http.post("*/app/auth/login", async ({ request }) => {
+  // Mock login endpoint (BFF-owned, not proxied through /api)
+  http.post("*/auth/login", async ({ request }) => {
     const body = await request.json();
     const { email, password } = body as { email: string; password: string }; // pragma: allowlist secret
 
@@ -43,20 +43,20 @@ export const handlers = [
           email_verified: true,
           password_change_required: false,
         },
-        mcpgateway_csrf_token: "mock-csrf-token",
+        csrfToken: "mock-csrf-token",
       });
     }
 
     return HttpResponse.json({ detail: "Invalid credentials" }, { status: 401 });
   }),
 
-  // Mock auth check endpoint
-  http.get("*/app/auth/me", () => {
-    return HttpResponse.json({ detail: "Unauthorized" }, { status: 401 });
+  // Mock session-check endpoint (BFF-owned) — always 200, unauthenticated by default
+  http.get("*/auth/session", () => {
+    return HttpResponse.json({ authenticated: false });
   }),
 
   // Mock gateways endpoint with cursor pagination
-  http.get("*/gateways", ({ request }) => {
+  http.get("*/api/gateways", ({ request }) => {
     const url = new URL(request.url);
     const cursor = url.searchParams.get("cursor");
     const limit = parseInt(url.searchParams.get("limit") || "25", 10);
@@ -86,7 +86,7 @@ export const handlers = [
   }),
 
   // Mock single gateway fetch endpoint
-  http.get("*/gateways/:id", ({ params }) => {
+  http.get("*/api/gateways/:id", ({ params }) => {
     return HttpResponse.json({
       id: params.id,
       name: "Test Server",
@@ -98,12 +98,12 @@ export const handlers = [
   }),
 
   // Mock gateway delete endpoint
-  http.delete("*/gateways/:id", () => {
+  http.delete("*/api/gateways/:id", () => {
     return HttpResponse.json({ success: true });
   }),
 
   // Mock gateway test endpoint
-  http.post("*/gateways/:id/test", () => {
+  http.post("*/api/gateways/:id/test", () => {
     return HttpResponse.json({
       success: true,
       message: "Connection successful",
@@ -111,7 +111,7 @@ export const handlers = [
   }),
 
   // Mock create gateway endpoint
-  http.post("*/gateways", async ({ request }) => {
+  http.post("*/api/gateways", async ({ request }) => {
     const body = (await request.json()) as Record<string, unknown>;
     return HttpResponse.json(
       {
@@ -124,7 +124,7 @@ export const handlers = [
   }),
 
   // Mock update gateway endpoint
-  http.put("*/gateways/:gatewayId", async ({ request, params }) => {
+  http.put("*/api/gateways/:gatewayId", async ({ request, params }) => {
     const body = (await request.json()) as Record<string, unknown>;
     const { gatewayId } = params;
     return HttpResponse.json({
@@ -137,9 +137,9 @@ export const handlers = [
   // Default empty collections so page smoke tests that render these pages without
   // an explicit override don't hit unhandled requests. Specific tests still
   // override these via server.use(...).
-  http.get("*/prompts", () => HttpResponse.json([])),
+  http.get("*/api/prompts", () => HttpResponse.json([])),
 
-  http.get("*/resources", () => HttpResponse.json([])),
+  http.get("*/api/resources", () => HttpResponse.json([])),
 
-  http.get("*/teams", () => HttpResponse.json({ teams: [] })),
+  http.get("*/api/teams", () => HttpResponse.json({ teams: [] })),
 ];

--- a/client/vite.bff.config.ts
+++ b/client/vite.bff.config.ts
@@ -1,0 +1,19 @@
+import { mergeConfig, defineConfig } from "vite";
+
+import baseConfig from "./vite.config";
+
+// Alternate build target for the BFF-served SPA: outputs to
+// client/server/public/ with base '/', instead of vite.config.ts's default
+// (mcpgateway/static/app/ with base '/static/app/', for FastAPI's existing
+// static mount). Everything else — plugins, chunking, etc. — is inherited
+// from the base config. See client/server/src/plugins/static.ts.
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    base: "/",
+    build: {
+      outDir: "server/public",
+      emptyOutDir: true,
+    },
+  })
+);


### PR DESCRIPTION
## Running the BFF locally

**1. FastAPI (terminal A, repo root)**
```bash
cp .env.example .env   # if not already done
make install-dev        # first time only
make dev                 # :8000
```

2. BFF (terminal B)
```bash
cd client/server
cp .env.example .env
# edit .env: FASTAPI_URL=http://127.0.0.1:8000, COOKIE_SECURE=false for local HTTP
npm install
npm run dev                 # :3000, tsx watch
```

REDIS_URL=memory:// by default — no Redis process needed for local dev (in-process session store; state resets on restart).

3. Build the SPA for the BFF to serve
```bash
cd client
npm run build:bff        # outputs to client/server/public/, base "/"
Re-run after any client/src change — the BFF serves whatever's on disk, no rebuild-on-save.
```

4. Use it

Visit `http://127.0.0.1:3000/` — redirects to `/app/login` (unauthed) or `/app/` (authed). Login form posts through the BFF, which holds the FastAPI JWT server-side and hands the browser an opaque session cookie only.

Default seeded admin: `admin@example.com` / `changeme` (first login forces a password change unless `PASSWORD_CHANGE_ENFORCEMENT_ENABLED=false` is set in the root .env).

Troubleshooting
- EADDRINUSE on :3000 → stale tsx watch process: lsof -ti:3000 | xargs kill, restart pnpm dev.
- 401 mid-session → normal, token hard-expires per TOKEN_EXPIRY (default 20 min); BFF auto-revokes and redirects to login.