### PR TITLE
fix(ui-rewrite): stop profile menu shifting header content

### DIFF
--- a/client/src/components/layout/HeaderProfileMenu.test.tsx
+++ b/client/src/components/layout/HeaderProfileMenu.test.tsx
@@ -114,6 +114,21 @@ describe("HeaderProfileMenu", () => {
     expect(localStorage.getItem("theme-preference")).toBe("system");
   });
 
+  it("does not scroll-lock the body while the menu is open", async () => {
+    // Regression: a modal dropdown wraps its content in react-remove-scroll,
+    // which locks the body (overflow:hidden + compensating padding) on open and
+    // shifts centered header content sideways. modal={false} must avoid this.
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.click(screen.getByRole("button", { name: "Bobo Example" }));
+    // Menu is open (its items are rendered).
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+
+    expect(document.body).not.toHaveAttribute("data-scroll-locked");
+    expect(document.body.style.overflow).not.toBe("hidden");
+  });
+
   it("renders null when user is not logged in", () => {
     mockUser = null;
     const { container } = renderMenu();

--- a/client/src/components/layout/HeaderProfileMenu.tsx
+++ b/client/src/components/layout/HeaderProfileMenu.tsx
@@ -24,7 +24,7 @@ export function HeaderProfileMenu() {
   const displayName = user.full_name || user.email || "Profile";
 
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         {/* TODO: User photo/avatar data is not currently available, using fallback for now. */}
         <Button


### PR DESCRIPTION
**Bug** 

What was happening: 
Layout shift on opening the profile dropdown / changing theme

Details: 
The avatar / theme dropdown (`HeaderProfileMenu`) used Radix's default modal`DropdownMenu`. A modal Radix menu wraps its content in `react-remove-scroll`, which locks the body on open (`overflow: hidden` plus a compensating `padding-right` equal to the scrollbar width). That padding injection nudges centered header content sideways every time the menu opens or closes.

This is a separate cause from #5946 (`scrollbar-gutter: stable` on `html`): that fix addresses the document-level scrollbar toggling, but the modal scroll-lock still measures a nonzero gap and pads the body regardless of page height.

**Change**

- Set `modal={false}` on the profile `DropdownMenu`. This disables Radix's scroll-lock, so no compensating body padding is injected and centered content no longer jumps. The page stays scrollable while the menu is open and outside-click still closes it (no focus trap / background-scroll block, both fine for this menu).
- Add a regression test asserting the body gets no `data-scroll-locked` / `overflow: hidden` while the menu is open. Confirmed it fails with `modal={true}` (Radix sets `data-scroll-locked="1"`) and passes with `modal={false}`.

**Verification**

- Visually confirmed: no horizontal shift on open/close.
- `HeaderProfileMenu.test.tsx`: 8/8 passing.

fixed: 
https://github.com/user-attachments/assets/c0ab1e5d-ce9e-43c0-be15-c9750f53ec39

