### PR TITLE
chore: align make dev log level with uvicorn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -459,7 +459,8 @@ dev:
 	@trap 'echo "🛑 Stopping background processes..."; jobs -p | xargs $(XARGS_FLAGS) kill 2>/dev/null || true' EXIT; \
 	$(MAKE) js-build watch-css & \
 	WATCH_CSS_PID=$$!; \
-	TEMPLATES_AUTO_RELOAD=true $(VENV_DIR)/bin/uvicorn mcpgateway.main:app --host 0.0.0.0 --port 8000 --reload --reload-exclude='public/' || { kill $$WATCH_CSS_PID 2>/dev/null || true; exit 1; }
+	export LOG_LEVEL=$${LOG_LEVEL:-WARNING}; \
+	TEMPLATES_AUTO_RELOAD=true $(VENV_DIR)/bin/uvicorn mcpgateway.main:app --host 0.0.0.0 --port 8000 --reload --reload-exclude='public/' --log-level warning || { kill $$WATCH_CSS_PID 2>/dev/null || true; exit 1; }
 
 .PHONY: dev-echo
 dev-echo: js-build               ## Run dev server with SQL query logging enabled


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

# Pull Request

## 🔗 Related Issue

Closes #6102 

---

## 📝 Summary


This PR aligns the default logging behavior of the `make dev` target with the expected developer experience.
### Changes
- Export `LOG_LEVEL=WARNING` by default in the `dev` Makefile target while preserving explicit user overrides (e.g. `LOG_LEVEL=DEBUG make dev`).
- Pass `--log-level warning` to Uvicorn to suppress default HTTP access log noise during development.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

Validated manually that:
- `LOG_LEVEL` defaults to `WARNING` only when not explicitly provided.
- `LOG_LEVEL=DEBUG make dev` preserves verbose logging.
- Application `INFO` logs are suppressed at the default log level.


| Check                     | Command                                  | Status |
|---------------------------|------------------------------------------|--------|
| Default dev logging       | `make dev`                               | ✅ |
| DEBUG override            | `LOG_LEVEL=DEBUG make dev`               | ✅ |
| Lint suite                | Not run                                  | N/A |
| Unit tests                | Not run (Makefile-only change)           | N/A |
| Coverage ≥ 80%            | Not applicable                           | N/A |

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

_NA_
