### PR TITLE
fix(config): ignore empty env vars for boolean Settings fields

### DIFF
--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -3106,7 +3106,7 @@ Disallow: /
     # ===================================
 
     slug_refresh_batch_size: int = Field(default=1000, description="Batch size for gateway/tool slug refresh at startup")
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", case_sensitive=False, extra="ignore")
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", case_sensitive=False, extra="ignore", env_ignore_empty=True)
 
     gateway_tool_name_separator: str = "-"
     valid_slug_separator_regexp: ClassVar[str] = r"^(-{1,2}|[_.])$"


### PR DESCRIPTION
## 📌 Summary

Fixes `docker compose exec` crashing with a Pydantic `ValidationError` on
seven `EXPERIMENTAL_RUST_MCP_*_ENABLED` settings, including the
`create_jwt_token` command documented in the README's 5-minute setup. The
gateway service itself was never affected — only one-off commands run via
`docker compose exec`.

Closes #6122

## 🔁 Reproduction Steps

1. Follow the 5-minute setup: `cp .env.example .env`, `docker compose up -d`.
2. Leave `EXPERIMENTAL_RUST_MCP_*_ENABLED` unset (the `.env.example` default).
3. Run:
   ```bash
   docker compose exec gateway python3 -m mcpgateway.utils.create_jwt_token \
     --username admin@example.com --exp 10080 --secret "$JWT_SECRET_KEY"
   ```
4. Crash with 7 `bool_parsing` validation errors.

## 🐞 Root Cause

`docker-compose.yml` passes the `EXPERIMENTAL_RUST_MCP_*_ENABLED` vars as
`${VAR:-}`, which resolves to an empty string when unset. `docker-entrypoint.sh`
resolves that empty string into a real `true`/`false` based on `RUST_MCP_MODE`
before launching gunicorn, but that resolution only happens inside the
entrypoint's own process tree. `docker compose exec` bypasses the entrypoint
and spawns a new process directly against the container's original env
(still `""`). `mcpgateway/config.py`'s `Settings` model had no
`env_ignore_empty` config, so Pydantic rejected the empty string as an
invalid bool literal instead of falling back to the field default.

## 💡 Fix Description

Set `env_ignore_empty=True` on the `Settings` model's `SettingsConfigDict`
(`mcpgateway/config.py`). This tells Pydantic to treat an empty env var the
same as unset and fall back to the field default, rather than failing
validation.

Considered and rejected: defaulting these vars to `false` directly in
`docker-compose.yml` or via a Containerfile `ENV`. Both would break
`RUST_MCP_MODE=shadow/edge/full` auto-derivation, since `docker-entrypoint.sh`
relies on the same empty-string sentinel to distinguish "unset, derive from
mode preset" from "explicitly set to false" — a compose/image-level default
removes that distinction. Fixing it at the Pydantic layer preserves the
entrypoint's mode-preset logic untouched.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

|Check|Command|Status|
|-|-|-|
|Lint suite|`make lint`| |
|Unit tests|`make test`| |
|Coverage ≥ 80 %|`make coverage`| |
|Manual regression no longer fails|`docker compose exec gateway python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 10080 --secret "$JWT_SECRET_KEY"` with `EXPERIMENTAL_RUST_MCP_*_ENABLED` unset| |

## 📐 MCP Compliance (if relevant)

- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed
