### PR TITLE
fix(admin-ui): read chartRegistry from Admin, not window (#6055)

### DIFF
--- a/mcpgateway/admin_ui/tabs.js
+++ b/mcpgateway/admin_ui/tabs.js
@@ -353,11 +353,20 @@ export const showTab = function (tabName) {
       tabName !== "observability"
     ) {
       console.log("Leaving observability tab, triggering cleanup...");
-      // Destroy all observability charts
-      window.chartRegistry.destroyByPrefix("metrics-");
-      window.chartRegistry.destroyByPrefix("tools-");
-      window.chartRegistry.destroyByPrefix("prompts-");
-      window.chartRegistry.destroyByPrefix("resources-");
+      // The registry is defined as Admin.chartRegistry in app.js, not on window
+      // directly (see events.js, which uses Admin.chartRegistry.destroyAll()).
+      // Reading window.chartRegistry threw a TypeError that propagated out of
+      // switchTab, so leaving the observability tab failed with "Failed to
+      // switch to <name> tab" and the panel never changed. It only surfaced
+      // once observability was enabled, since this block is gated on the
+      // observability panel being the visible one.
+      const chartRegistry = window.Admin && window.Admin.chartRegistry;
+      if (chartRegistry) {
+        chartRegistry.destroyByPrefix("metrics-");
+        chartRegistry.destroyByPrefix("tools-");
+        chartRegistry.destroyByPrefix("prompts-");
+        chartRegistry.destroyByPrefix("resources-");
+      }
       // Dispatch event so Alpine components can stop intervals and reset state
       document.dispatchEvent(new CustomEvent("observability:leave"));
     }


### PR DESCRIPTION
Closes #6055.

Thanks to @msureshkumar88 for the report — the diagnosis there was accurate down to the file and line, so this is essentially implementing what the issue already specified.

## The bug

`tabs.js` reads `window.chartRegistry`, but the registry is defined as `Admin.chartRegistry` in `app.js`, inside an IIFE closed over `window.Admin`. `events.js:944` already uses the correct path. So `window.chartRegistry` is always `undefined`, and calling a method on it throws:

```
TypeError: Cannot read properties of undefined (reading 'destroyByPrefix')
Error: Failed to switch to tools tab
```

The throw propagates out of the tab-switch handler, so the switch aborts and the previous panel stays visible — the user is effectively stuck on the Observability tab.

Only reachable with `OBSERVABILITY_ENABLED=true`, since the block is gated on the observability panel being the visible one. That is presumably why it has gone unnoticed while the setting defaults to `false`.

## The fix

Use `window.Admin.chartRegistry`, with a presence check so a missing registry degrades to skipping chart cleanup rather than breaking navigation.

## Verification

Headless browser against this branch, switching away from Observability to Tools and Gateways:

| | before | after |
|---|---|---|
| panel visible after switch | `false` | `true` |
| console errors | 8 | 0 |

Full unit suite on the patched tree: 0 failures.

Companion PR: #6127 (Closes #6054, the panel rendering blank under the CSP-safe Alpine build). The two are independent and can be reviewed in either order.