### PR TITLE
fix(tools): enforce duplicate check on custom_name rename via edit

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -7017,7 +7017,6 @@ class ToolService(BaseService):
                     tool.custom_name = tool_update.name
                 tool.name = tool_update.name
 
-
             if tool_update.custom_name is not None:
                 if tool_update.custom_name != tool.custom_name and not name_is_changing:
                     tool_visibility_ref = tool.visibility if tool_update.visibility is None else tool_update.visibility.lower()

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -7025,7 +7025,7 @@ class ToolService(BaseService):
             if tool_update.custom_name is not None:
                 if tool_update.custom_name != tool.custom_name and not name_is_changing:
                     tool_visibility_ref = tool.visibility if tool_update.visibility is None else tool_update.visibility.lower()
-                    self._check_tool_name_conflict( db,tool_update.custom_name,tool_visibility_ref,tool.id,team_id=tool.team_id,owner_email=tool.owner_email)
+                    self._check_tool_name_conflict(db, tool_update.custom_name, tool_visibility_ref, tool.id, team_id=tool.team_id, owner_email=tool.owner_email)
                 tool.custom_name = tool_update.custom_name
             if tool_update.displayName is not None:
                 tool.display_name = tool_update.displayName

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -7017,16 +7017,16 @@ class ToolService(BaseService):
                     tool.custom_name = tool_update.name
                 tool.name = tool_update.name
 
-            # Check for conflicts when visibility changes without a name change
-            if tool_update.visibility is not None and tool_update.visibility.lower() != tool.visibility and not name_is_changing:
-                new_visibility = tool_update.visibility.lower()
-                self._check_tool_name_conflict(db, tool.custom_name, new_visibility, tool.id, team_id=tool.team_id, owner_email=tool.owner_email)
 
             if tool_update.custom_name is not None:
                 if tool_update.custom_name != tool.custom_name and not name_is_changing:
                     tool_visibility_ref = tool.visibility if tool_update.visibility is None else tool_update.visibility.lower()
                     self._check_tool_name_conflict(db, tool_update.custom_name, tool_visibility_ref, tool.id, team_id=tool.team_id, owner_email=tool.owner_email)
                 tool.custom_name = tool_update.custom_name
+
+            if tool_update.visibility is not None and tool_update.visibility.lower() != tool.visibility and not name_is_changing:
+                new_visibility = tool_update.visibility.lower()
+                self._check_tool_name_conflict(db, tool.custom_name, new_visibility, tool.id, team_id=tool.team_id, owner_email=tool.owner_email)
             if tool_update.displayName is not None:
                 tool.display_name = tool_update.displayName
             if tool_update.url is not None:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -7023,6 +7023,9 @@ class ToolService(BaseService):
                 self._check_tool_name_conflict(db, tool.custom_name, new_visibility, tool.id, team_id=tool.team_id, owner_email=tool.owner_email)
 
             if tool_update.custom_name is not None:
+                if tool_update.custom_name != tool.custom_name and not name_is_changing:
+                    tool_visibility_ref = tool.visibility if tool_update.visibility is None else tool_update.visibility.lower()
+                    self._check_tool_name_conflict( db,tool_update.custom_name,tool_visibility_ref,tool.id,team_id=tool.team_id,owner_email=tool.owner_email)
                 tool.custom_name = tool_update.custom_name
             if tool_update.displayName is not None:
                 tool.display_name = tool_update.displayName

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -2704,12 +2704,10 @@ class TestUpdateToolAdditional:
 
     @pytest.mark.asyncio
     async def test_update_tool_custom_name_conflict_on_edit(self, tool_service, mock_tool):
-        """update_tool should raise ToolNameConflictError when only custom_name changes.
-
-        """
+        """update_tool should raise ToolNameConflictError when only custom_name changes."""
         db = MagicMock()
         mock_tool.version = 1
-        mock_tool.name = "old-name"          
+        mock_tool.name = "old-name"
         mock_tool.custom_name = "old-name"
         mock_tool.visibility = "public"
         mock_tool.team_id = None
@@ -2722,9 +2720,80 @@ class TestUpdateToolAdditional:
         existing_conflict.visibility = "public"
 
         tool_update = MagicMock()
-        tool_update.name = "old-name"        
-        tool_update.custom_name = "demo"     
-        tool_update.visibility = None        
+        tool_update.name = "old-name"
+        tool_update.custom_name = "demo"
+        tool_update.visibility = None
+
+        with patch("mcpgateway.services.tool_service.get_for_update") as mock_gfu:
+            mock_gfu.side_effect = [mock_tool, existing_conflict]
+            with pytest.raises(ToolNameConflictError):
+                await tool_service.update_tool(db, "tool-1", tool_update)
+
+    @pytest.mark.asyncio
+    async def test_update_tool_custom_name_only_success(self, tool_service, mock_tool):
+        """Renaming custom_name to a non-conflicting value succeeds."""
+        db = MagicMock()
+        mock_tool.version = 1
+        mock_tool.name = "old-name"
+        mock_tool.custom_name = "old-name"
+        mock_tool.visibility = "public"
+        mock_tool.team_id = None
+        mock_tool.owner_email = "user@example.com"
+
+        tool_update = _make_tool_update(name="old-name", custom_name="brand-new-name")
+
+        with (
+            patch("mcpgateway.services.tool_service.get_for_update", side_effect=[mock_tool, None]),
+            patch.object(tool_service, "_notify_tool_updated", AsyncMock()),
+            patch.object(tool_service, "convert_tool_to_read", return_value={"id": "tool-1"}),
+        ):
+            result = await tool_service.update_tool(db, "tool-1", tool_update)
+
+        assert result is not None
+        assert mock_tool.custom_name == "brand-new-name"
+
+    @pytest.mark.asyncio
+    async def test_update_tool_custom_name_conflict_team_visibility(self, tool_service, mock_tool):
+        """custom_name conflict check uses team scope when tool visibility is team."""
+        db = MagicMock()
+        mock_tool.version = 1
+        mock_tool.name = "old-name"
+        mock_tool.custom_name = "old-name"
+        mock_tool.visibility = "team"
+        mock_tool.team_id = "team-42"
+        mock_tool.owner_email = None
+
+        existing_conflict = MagicMock()
+        existing_conflict.custom_name = "taken"
+        existing_conflict.enabled = True
+        existing_conflict.id = 99
+        existing_conflict.visibility = "team"
+
+        tool_update = _make_tool_update(name="old-name", custom_name="taken")
+
+        with patch("mcpgateway.services.tool_service.get_for_update") as mock_gfu:
+            mock_gfu.side_effect = [mock_tool, existing_conflict]
+            with pytest.raises(ToolNameConflictError):
+                await tool_service.update_tool(db, "tool-1", tool_update)
+
+    @pytest.mark.asyncio
+    async def test_update_tool_custom_name_conflict_private_visibility(self, tool_service, mock_tool):
+        """custom_name conflict check uses private scope when tool visibility is private."""
+        db = MagicMock()
+        mock_tool.version = 1
+        mock_tool.name = "old-name"
+        mock_tool.custom_name = "old-name"
+        mock_tool.visibility = "private"
+        mock_tool.team_id = None
+        mock_tool.owner_email = "user@example.com"
+
+        existing_conflict = MagicMock()
+        existing_conflict.custom_name = "taken"
+        existing_conflict.enabled = True
+        existing_conflict.id = 99
+        existing_conflict.visibility = "private"
+
+        tool_update = _make_tool_update(name="old-name", custom_name="taken")
 
         with patch("mcpgateway.services.tool_service.get_for_update") as mock_gfu:
             mock_gfu.side_effect = [mock_tool, existing_conflict]

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -2703,6 +2703,35 @@ class TestUpdateToolAdditional:
                 await tool_service.update_tool(db, "tool-1", tool_update)
 
     @pytest.mark.asyncio
+    async def test_update_tool_custom_name_conflict_on_edit(self, tool_service, mock_tool):
+        """update_tool should raise ToolNameConflictError when only custom_name changes.
+
+        """
+        db = MagicMock()
+        mock_tool.version = 1
+        mock_tool.name = "old-name"          
+        mock_tool.custom_name = "old-name"
+        mock_tool.visibility = "public"
+        mock_tool.team_id = None
+        mock_tool.owner_email = "user@example.com"
+
+        existing_conflict = MagicMock()
+        existing_conflict.custom_name = "demo"
+        existing_conflict.enabled = True
+        existing_conflict.id = 99
+        existing_conflict.visibility = "public"
+
+        tool_update = MagicMock()
+        tool_update.name = "old-name"        
+        tool_update.custom_name = "demo"     
+        tool_update.visibility = None        
+
+        with patch("mcpgateway.services.tool_service.get_for_update") as mock_gfu:
+            mock_gfu.side_effect = [mock_tool, existing_conflict]
+            with pytest.raises(ToolNameConflictError):
+                await tool_service.update_tool(db, "tool-1", tool_update)
+
+    @pytest.mark.asyncio
     async def test_update_tool_not_found_during_update(self, tool_service):
         """update_tool should raise ToolNotFoundError for unknown tool_id."""
         db = MagicMock()


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 🔗 Related Issue

Closes #6057

---

## 💡 Fix Description


The UI edit form posts `name` as a hidden unchanged field, so `name_is_changing` is always
`False` and the existing conflict check never ran for `custom_name`-only edits.

Added a `_check_tool_name_conflict` call inside the `custom_name` assignment block
(`tool_service.py`) that fires when `custom_name` is changing and
`name_is_changing` is `False` — to make sue no tool have same custom_name.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Lint suite | `make lint` | ✅ |
| Unit tests | `make test` | ✅ |
| Coverage ≥ 80% | `make coverage` | ✅ |
| Manual regression | Open edit modal → rename `custom_name` to an existing tool's name → expect 409 | ✅  |

The new regression test `test_update_tool_custom_name_conflict_on_edit` fails on the unpatched
code and passes with the fix applied.

---

## 📐 MCP Compliance

- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed

---

## 📓 Notes

**Files changed:**

- `mcpgateway/services/tool_service.py` — naming conflict check added before `custom_name` assignment
  block.
- `tests/unit/mcpgateway/services/test_tool_service_coverage.py` — one new async test
  `test_update_tool_custom_name_conflict_on_edit` added to `TestUpdateToolAdditional`,
  reproducing the exact UI-path failure scenario.