### PR TITLE
feat(admin): add team picker to virtual server create/edit forms

### DIFF
--- a/mcpgateway/admin_ui/servers.js
+++ b/mcpgateway/admin_ui/servers.js
@@ -15,7 +15,34 @@ import {
   showErrorMessage,
   decodeHtml,
   makeCopyIdButton,
+  getCurrentTeamId,
 } from "./utils.js";
+
+/**
+ * Resolve team id from API payload (camelCase or snake_case).
+ */
+export const teamIdFromServer = function (server) {
+  if (!server) {
+    return "";
+  }
+  return server.teamId || server.team_id || "";
+};
+
+/**
+ * Set the virtual-server team select to a preferred value.
+ */
+export const setServerTeamSelect = function (selectId, preferredTeamId) {
+  const select = safeGetElement(selectId);
+  if (!select) {
+    return "";
+  }
+  const fallbackTeamId = getCurrentTeamId() || "";
+  const teamId = preferredTeamId || fallbackTeamId;
+  if (teamId) {
+    select.value = teamId;
+  }
+  return teamId;
+};
 
 /**
  * SECURE: View Server function
@@ -96,6 +123,7 @@ export const viewServer = async function (serverId) {
       const fields = [
         { label: "URL", value: getCatalogUrl(server) || "N/A" },
         { label: "Type", value: "Virtual Server" },
+        { label: "Team", value: server.team || teamIdFromServer(server) || "N/A" },
         { label: "Visibility", value: server.visibility || "private" },
       ];
 
@@ -726,18 +754,13 @@ export const editServer = async function (serverId) {
       }
     }
 
-    const teamId = new URL(window.location.href).searchParams.get("team_id");
-
-    if (teamId) {
-      const hiddenInput = document.createElement("input");
-      hiddenInput.type = "hidden";
-      hiddenInput.name = "team_id";
-      hiddenInput.value = teamId;
-      editForm.appendChild(hiddenInput);
-    }
+    const scopedTeamId =
+      setServerTeamSelect("edit-server-team-id", teamIdFromServer(server)) ||
+      getCurrentTeamId() ||
+      new URL(window.location.href).searchParams.get("team_id");
 
     // Initialize View Public toggle for Edit Server modal
-    if (teamId) {
+    if (scopedTeamId) {
       const viewPublicCheckbox = document.getElementById(
         "edit-server-view-public"
       );
@@ -752,7 +775,7 @@ export const editServer = async function (serverId) {
           "edit-server-resources",
           "edit-server-prompts",
         ],
-        teamId
+        scopedTeamId
       );
     }
 
@@ -968,7 +991,7 @@ export const editServer = async function (serverId) {
     }, 350);
 
     // Auto-enable "View Public" if server has public associations not visible in team-filtered selectors
-    if (teamId) {
+    if (scopedTeamId) {
       setTimeout(() => {
         const viewPublicCheckbox = document.getElementById(
           "edit-server-view-public"

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -2987,6 +2987,9 @@
                 servers.
               </p>
             </div>
+            {% with select_id='add-server-team-id', default_team_id=selected_team_id %}
+            {% include 'server_team_field.html' %}
+            {% endwith %}
             <!-- Visibility options -->
             <div class="mt-4">
               <label
@@ -11117,6 +11120,10 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                         filter servers.
                       </p>
                     </div>
+
+                    {% with select_id='edit-server-team-id', default_team_id=none %}
+                    {% include 'server_team_field.html' %}
+                    {% endwith %}
 
                     <!-- Visibility options -->
                     <div id="edit-server-visibility" class="mt-4">

--- a/mcpgateway/templates/server_team_field.html
+++ b/mcpgateway/templates/server_team_field.html
@@ -1,0 +1,29 @@
+{# Team assignment field for virtual-server create/edit forms. #}
+{% if user_teams %}
+<div class="mt-4">
+  <label
+    class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+    for="{{ select_id }}"
+    >Team</label
+  >
+  <select
+    name="team_id"
+    id="{{ select_id }}"
+    class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:text-gray-300"
+  >
+    <option value="">Select a team...</option>
+    {% for team in user_teams %}
+    <option
+      value="{{ team.id }}"
+      {% if default_team_id and default_team_id == team.id %}selected{% endif %}
+    >
+      {{ team.name }}{% if team.is_personal %} (personal){% endif %}
+    </option>
+    {% endfor %}
+  </select>
+  <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+    Assign the virtual server to a shared team so other members can manage it.
+    When left unset, the platform assigns your personal team.
+  </p>
+</div>
+{% endif %}

--- a/tests/unit/js/server-team-select.test.js
+++ b/tests/unit/js/server-team-select.test.js
@@ -1,0 +1,36 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import {
+  teamIdFromServer,
+  setServerTeamSelect,
+} from "../../../mcpgateway/admin_ui/servers.js";
+
+describe("virtual server team select helpers", () => {
+  beforeEach(() => {
+    document.body.innerHTML =
+      '<select id="edit-server-team-id">' +
+      '<option value="">Select a team...</option>' +
+      '<option value="team-a">Team A</option>' +
+      '<option value="team-b">Team B</option>' +
+      "</select>";
+    window.USER_TEAMS_DATA = [
+      { id: "team-a", name: "Team A" },
+      { id: "team-b", name: "Team B" },
+    ];
+  });
+
+  test("teamIdFromServer prefers camelCase teamId", () => {
+    expect(teamIdFromServer({ teamId: "team-a", team_id: "team-b" })).toBe(
+      "team-a"
+    );
+  });
+
+  test("teamIdFromServer falls back to snake_case team_id", () => {
+    expect(teamIdFromServer({ team_id: "team-b" })).toBe("team-b");
+  });
+
+  test("setServerTeamSelect applies preferred team id", () => {
+    const applied = setServerTeamSelect("edit-server-team-id", "team-b");
+    expect(applied).toBe("team-b");
+    expect(document.getElementById("edit-server-team-id").value).toBe("team-b");
+  });
+});

--- a/tests/unit/js/servers.test.js
+++ b/tests/unit/js/servers.test.js
@@ -56,6 +56,7 @@ vi.mock("../../../mcpgateway/admin_ui/utils", () => ({
     btn.textContent = "Copy";
     return btn;
   }),
+  getCurrentTeamId: vi.fn(() => null),
 }));
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary

- Adds an explicit **Team** dropdown on virtual server **create** and **edit** forms (reusable `server_team_field.html` partial).
- Edit form pre-selects the server's current team from `teamId` in `GET /admin/servers/{id}`.
- Server detail modal displays the assigned team name.
- Removes the edit-only hidden `team_id` injection that only worked when `?team_id=` was present in the URL.

## Problem

New virtual servers default to the creator's **personal team** because the admin UI had no team picker—only a hidden field when browsing a team-scoped catalog. Users could not assign or reassign a server to a shared team (e.g. General) from the form.

The backend already reads `team_id` via `_form_team_id()` on create/edit; this change adds the missing UI.

## Test plan

- [x] `npx vitest run tests/unit/js/server-team-select.test.js` (3 tests)
- [ ] Create virtual server → select a shared team → save → verify team in list/detail
- [ ] Edit existing server → team dropdown shows current assignment → change team → save
- [ ] Team-scoped catalog (`?team_id=`) still pre-selects that team on create

## Notes

Follow-up ideas for separate PRs/discussion:
- Slug field on virtual servers (fork parity)
- Whether `_validate_server_team_assignment` should allow any active team member vs team owners only