### PR TITLE
chore: patch timeouts for additionals span

### DIFF
--- a/tests/e2e/test_otel_control_telemetry_e2e.py
+++ b/tests/e2e/test_otel_control_telemetry_e2e.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 import secrets
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 # Third-Party
@@ -117,7 +118,6 @@ from mcpgateway.plugins import (  # noqa: E402
 from mcpgateway.plugins.policy import HOOK_PAYLOAD_POLICIES  # noqa: E402
 from mcpgateway.routers.observability import router as observability_router  # noqa: E402
 from mcpgateway.services.observability_service import ObservabilityService  # noqa: E402
-from mcpgateway.services.tool_service import tool_service  # noqa: E402
 from mcpgateway.utils.create_jwt_token import get_jwt_token  # noqa: E402
 from mcpgateway.utils.verify_credentials import require_admin_auth, require_auth  # noqa: E402
 
@@ -153,6 +153,29 @@ def _auth_headers() -> dict:
     """
     token = make_test_jwt(ADMIN_EMAIL, is_admin=True)
     return make_auth_headers(token)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_outbound_rest_request(monkeypatch, mock_request: AsyncMock) -> None:
+    """Patch ``_build_pinned_rest_http_client`` so the SSRF-pinning path returns a stub.
+
+    The SSRF connection-pinning path in ``ToolService.invoke_tool`` calls
+    ``_build_pinned_rest_http_client()`` to get a *fresh* client, bypassing any
+    direct patch to ``tool_service._http_client``.  We must patch the factory
+    function itself to intercept the outbound REST call and avoid a real network
+    attempt (which would burn the full 60-second ``asyncio.wait_for`` timeout).
+
+    Mirrors the identical helper in ``test_otel_plugin_metadata_e2e.py``.
+    """
+
+    def build_client():
+        return SimpleNamespace(request=mock_request, get=AsyncMock(), aclose=AsyncMock())
+
+    monkeypatch.setattr("mcpgateway.services.tool_service._build_pinned_rest_http_client", build_client)
 
 
 # ---------------------------------------------------------------------------
@@ -272,12 +295,15 @@ async def control_telemetry_app(monkeypatch, tmp_path):
     test_app.dependency_overrides[get_permission_service] = mock_get_permission_service
 
     # Mock only the outbound HTTP call to the fictitious upstream tool backend.
+    # Patch the factory function so the SSRF-pinning path also returns a stub
+    # client instead of making a real network connection (which would burn the
+    # full 60-second asyncio.wait_for timeout on the .invalid fixture host).
     upstream_response = httpx.Response(
         200,
         json={"content": [{"type": "text", "text": "hello from upstream"}], "isError": False},
         request=httpx.Request("POST", CONTROL_UPSTREAM_URL),
     )
-    monkeypatch.setattr(tool_service._http_client, "request", AsyncMock(return_value=upstream_response))
+    _mock_outbound_rest_request(monkeypatch, AsyncMock(return_value=upstream_response))
 
     transport = ASGITransport(app=test_app)
     async with AsyncClient(transport=transport, base_url="http://e2e-test") as client:
@@ -695,12 +721,13 @@ async def denying_plugin_app(monkeypatch, tmp_path):
     test_app.dependency_overrides[get_jwt_token] = mock_get_jwt_token
     test_app.dependency_overrides[get_permission_service] = mock_get_permission_service
 
+    # Patch the factory so the SSRF-pinning path returns a stub client.
     upstream_response = httpx.Response(
         200,
         json={"content": [{"type": "text", "text": "hello"}], "isError": False},
         request=httpx.Request("POST", CONTROL_UPSTREAM_URL),
     )
-    monkeypatch.setattr(tool_service._http_client, "request", AsyncMock(return_value=upstream_response))
+    _mock_outbound_rest_request(monkeypatch, AsyncMock(return_value=upstream_response))
 
     transport = ASGITransport(app=test_app)
     async with AsyncClient(transport=transport, base_url="http://e2e-test") as client:

--- a/tests/e2e/test_otel_control_telemetry_e2e.py
+++ b/tests/e2e/test_otel_control_telemetry_e2e.py
@@ -163,13 +163,22 @@ def _auth_headers() -> dict:
 def _mock_outbound_rest_request(monkeypatch, mock_request: AsyncMock) -> None:
     """Patch ``_build_pinned_rest_http_client`` so the SSRF-pinning path returns a stub.
 
-    The SSRF connection-pinning path in ``ToolService.invoke_tool`` calls
-    ``_build_pinned_rest_http_client()`` to get a *fresh* client, bypassing any
-    direct patch to ``tool_service._http_client``.  We must patch the factory
-    function itself to intercept the outbound REST call and avoid a real network
-    attempt (which would burn the full 60-second ``asyncio.wait_for`` timeout).
+    TEMPORARY WORKAROUND — reduces CI execution time while a proper solution is designed.
 
-    Mirrors the identical helper in ``test_otel_plugin_metadata_e2e.py``.
+    Ideally these tests would exercise a real upstream backend (a local stub HTTP server)
+    rather than mocking the transport layer.  Mocking the outbound HTTP client is
+    architecturally wrong for an E2E suite whose purpose is to validate the full gateway
+    request pipeline; the correct fix is to stand up a lightweight test server that the
+    fixture tool URL points at.  That work is tracked separately.
+
+    Why this patch is needed in the interim: ``ToolService.invoke_tool``'s SSRF
+    connection-pinning path calls ``_build_pinned_rest_http_client()`` to build a *fresh*
+    ``ResilientHttpClient``, completely bypassing any direct patch to
+    ``tool_service._http_client``.  Without patching the factory, the ``_deterministic_dns``
+    conftest stub resolves ``*.invalid`` to a real public IP, the pinning branch is entered,
+    and the real ``asyncio.wait_for(..., timeout=60)`` fires — burning 60 seconds per test.
+
+    Mirrors the identical helper already present in ``test_otel_plugin_metadata_e2e.py``.
     """
 
     def build_client():
@@ -294,10 +303,8 @@ async def control_telemetry_app(monkeypatch, tmp_path):
     test_app.dependency_overrides[get_jwt_token] = mock_get_jwt_token
     test_app.dependency_overrides[get_permission_service] = mock_get_permission_service
 
-    # Mock only the outbound HTTP call to the fictitious upstream tool backend.
-    # Patch the factory function so the SSRF-pinning path also returns a stub
-    # client instead of making a real network connection (which would burn the
-    # full 60-second asyncio.wait_for timeout on the .invalid fixture host).
+    # TEMPORARY WORKAROUND: mock the outbound HTTP call to avoid 60-second timeouts.
+    # See _mock_outbound_rest_request() docstring for rationale and the proper long-term fix.
     upstream_response = httpx.Response(
         200,
         json={"content": [{"type": "text", "text": "hello from upstream"}], "isError": False},
@@ -721,7 +728,8 @@ async def denying_plugin_app(monkeypatch, tmp_path):
     test_app.dependency_overrides[get_jwt_token] = mock_get_jwt_token
     test_app.dependency_overrides[get_permission_service] = mock_get_permission_service
 
-    # Patch the factory so the SSRF-pinning path returns a stub client.
+    # TEMPORARY WORKAROUND: mock the outbound HTTP call to avoid 60-second timeouts.
+    # See _mock_outbound_rest_request() docstring for rationale and the proper long-term fix.
     upstream_response = httpx.Response(
         200,
         json={"content": [{"type": "text", "text": "hello"}], "isError": False},


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #6003 (follow-on: five tests in `test_otel_control_telemetry_e2e.py` each burned the full 60-second `asyncio.wait_for` timeout, making `make test` take 5+ extra minutes)

---

## 📝 Summary

Five tests in `tests/e2e/test_otel_control_telemetry_e2e.py` were silently spending 60 seconds each on every run — **passing**, but bloating `make test` by over 5 minutes. The tests never went red because the 60-second timeout produced a JSON-RPC error envelope that still satisfied the observability span assertions.

**Root cause:** Both test fixtures (`control_telemetry_app` and `denying_plugin_app`) patched `tool_service._http_client.request` directly. However, `ToolService.invoke_tool`'s SSRF connection-pinning path (line 5552) calls `_build_pinned_rest_http_client()` to build a **fresh** `ResilientHttpClient`, completely bypassing the patched instance attribute. The session-scoped `_deterministic_dns` conftest fixture stubs `socket.getaddrinfo` to return a real public IP (`93.184.215.14`) for any non-loopback host — including `internal.e2e-fixture.invalid` — so DNS "succeeded", the pinning branch was always entered, and a real TCP connection was attempted against the fixture host, burning the full timeout every time.

**Fix:** Added a `_mock_outbound_rest_request()` helper that patches the **factory function** `mcpgateway.services.tool_service._build_pinned_rest_http_client` via `monkeypatch.setattr`, returning a `SimpleNamespace` stub with `request`/`get`/`aclose` `AsyncMock` attributes. Both fixtures now call this helper. This mirrors the identical pattern already used in the sibling file `test_otel_plugin_metadata_e2e.py`. The now-unused `from mcpgateway.services.tool_service import tool_service` import is also removed.

No production code changed. No test logic or assertions changed.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other

---

## 🧪 Verification

**Without fix** (stash applied, original code):

60.21s call  test_control_summary_span_present_in_db
60.11s call  test_control_result_span_per_plugin_present_in_db
60.10s call  test_control_telemetry_does_not_leak_tool_arguments
60.10s call  test_control_result_span_has_per_control_fields
60.10s call  test_control_summary_attributes_trusted_fields
Total: 7 passed, 2 skipped in 303.50s (5 min 3 sec)

**With fix** (this branch):
0.18s call  test_control_summary_span_present_in_db
0.09s call  test_control_result_span_per_plugin_present_in_db
0.09s call  test_control_telemetry_does_not_leak_tool_arguments
0.09s call  test_control_result_span_has_per_control_fields
0.09s call  test_control_summary_attributes_trusted_fields
Total: 7 passed, 2 skipped in 3.44s|


| Check | Command | Status |
|---|---|---|
| Lint suite | `make ruff` | ✅ clean |
| Target file tests | `pytest tests/e2e/test_otel_control_telemetry_e2e.py -v` | ✅ 7 passed, 2 skipped in 3.44s |

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable) — not applicable, test-only change
- [x] No secrets or credentials committed

---

## 📓 Notes

**Why CI never caught this:** The tests always *passed* — the timeout produced a JSON-RPC error envelope that flowed through the plugin hooks and emitted the control telemetry spans the assertions check. CI shows green; only the per-test duration column in the log reveals the 60s cost, which is easy to miss.

**cpex PR #148 is unrelated:** That cpex fix (`PluginViolationError.executions`) is purely additive and the existing `mark_denied()` workaround in `tool_service.py` continues to work unchanged both before and after that cpex release. No adaptation required here.

**Pattern reference:** The `_mock_outbound_rest_request` helper is identical to the one already present in `tests/e2e/test_otel_plugin_metadata_e2e.py:229` — this file was the only e2e file missing the factory patch.

