### PR TITLE
fix: benchmark-mcp-tools tool-argument, denylist, and pool-cap drift (#6082)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-10T13:58:42Z",
+  "generated_at": "2026-08-10T15:21:08Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -390,7 +390,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6065,
+        "line_number": 6079,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6562,
+        "line_number": 6576,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6574,
+        "line_number": 6588,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6646,
+        "line_number": 6660,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7062,
+        "line_number": 7076,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -430,7 +430,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7753,
+        "line_number": 7767,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -836,7 +836,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1741,
+        "line_number": 1749,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -844,7 +844,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1990,
+        "line_number": 1998,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -852,7 +852,7 @@
         "hashed_secret": "afba9d98073dfb79fba7b21516c4d4d676c72935",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2368,
+        "line_number": 2376,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -860,7 +860,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2468,
+        "line_number": 2476,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -868,7 +868,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2468,
+        "line_number": 2476,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -876,7 +876,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2481,
+        "line_number": 2489,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -884,7 +884,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2629,
+        "line_number": 2637,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -892,7 +892,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2650,
+        "line_number": 2658,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -900,7 +900,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2658,
+        "line_number": 2666,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -908,7 +908,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2663,
+        "line_number": 2671,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/Makefile
+++ b/Makefile
@@ -2722,6 +2722,8 @@ MCP_BENCHMARK_WORKERS ?= 4
 MCP_BENCHMARK_MIXED_MASTER_PORT ?= 5567
 MCP_BENCHMARK_TOOLS_MASTER_PORT ?= 5569
 MCP_BENCHMARK_LOCUST_LOG_LEVEL ?= ERROR
+MCP_BENCHMARK_TOOL_POOL_SIZE ?= 0
+MCP_BENCHMARK_TOOL_DENYLIST ?= schema_error,flaky
 MCP_BENCHMARK_WORKER_LOG_DIR ?= reports/mcp_benchmark_workers
 RL_LIMIT_PER_MIN ?= 30
 
@@ -2774,6 +2776,8 @@ benchmark-mcp-mixed:                        ## Quick mixed MCP benchmark against
 	@test -d "$(VENV_DIR)" || $(MAKE) venv
 	@/bin/bash -eu -o pipefail -c 'source $(VENV_DIR)/bin/activate && \
 		LOCUST_LOG_LEVEL=$(MCP_BENCHMARK_LOCUST_LOG_LEVEL) MCP_SERVER_ID=$(MCP_BENCHMARK_SERVER_ID) \
+		MCP_BENCHMARK_TOOL_POOL_SIZE=$(MCP_BENCHMARK_TOOL_POOL_SIZE) \
+		MCP_BENCHMARK_TOOL_DENYLIST=$(MCP_BENCHMARK_TOOL_DENYLIST) \
 		locust -f $(MCP_PROTOCOL_LOCUSTFILE) \
 			--host=$(MCP_BENCHMARK_HOST) \
 			--users=$(MCP_BENCHMARK_USERS) \
@@ -2791,6 +2795,8 @@ benchmark-mcp-tools:                        ## Quick tools-only MCP benchmark ag
 	@test -d "$(VENV_DIR)" || $(MAKE) venv
 	@/bin/bash -eu -o pipefail -c 'source $(VENV_DIR)/bin/activate && \
 		LOCUST_LOG_LEVEL=$(MCP_BENCHMARK_LOCUST_LOG_LEVEL) MCP_SERVER_ID=$(MCP_BENCHMARK_SERVER_ID) \
+		MCP_BENCHMARK_TOOL_POOL_SIZE=$(MCP_BENCHMARK_TOOL_POOL_SIZE) \
+		MCP_BENCHMARK_TOOL_DENYLIST=$(MCP_BENCHMARK_TOOL_DENYLIST) \
 		locust -f $(MCP_PROTOCOL_LOCUSTFILE) \
 			--host=$(MCP_BENCHMARK_HOST) \
 			--users=$(MCP_BENCHMARK_USERS) \
@@ -2917,6 +2923,8 @@ benchmark-mcp-mixed-300:                    ## Distributed 300-user mixed MCP be
 		trap cleanup EXIT INT TERM; \
 		for i in $$(seq 1 $(MCP_BENCHMARK_WORKERS)); do \
 			LOCUST_LOG_LEVEL=$(MCP_BENCHMARK_LOCUST_LOG_LEVEL) MCP_SERVER_ID=$(MCP_BENCHMARK_SERVER_ID) \
+			MCP_BENCHMARK_TOOL_POOL_SIZE=$(MCP_BENCHMARK_TOOL_POOL_SIZE) \
+			MCP_BENCHMARK_TOOL_DENYLIST=$(MCP_BENCHMARK_TOOL_DENYLIST) \
 			locust -f $(MCP_PROTOCOL_LOCUSTFILE) \
 				--worker \
 				--master-host=127.0.0.1 \
@@ -2925,6 +2933,8 @@ benchmark-mcp-mixed-300:                    ## Distributed 300-user mixed MCP be
 			pids="$$pids $$!"; \
 		done; \
 		LOCUST_LOG_LEVEL=$(MCP_BENCHMARK_LOCUST_LOG_LEVEL) MCP_SERVER_ID=$(MCP_BENCHMARK_SERVER_ID) \
+		MCP_BENCHMARK_TOOL_POOL_SIZE=$(MCP_BENCHMARK_TOOL_POOL_SIZE) \
+		MCP_BENCHMARK_TOOL_DENYLIST=$(MCP_BENCHMARK_TOOL_DENYLIST) \
 		locust -f $(MCP_PROTOCOL_LOCUSTFILE) \
 			--host=$(MCP_BENCHMARK_HOST) \
 			--master \
@@ -2953,6 +2963,8 @@ benchmark-mcp-tools-300:                    ## Distributed 300-user tools-only M
 		trap cleanup EXIT INT TERM; \
 		for i in $$(seq 1 $(MCP_BENCHMARK_WORKERS)); do \
 			LOCUST_LOG_LEVEL=$(MCP_BENCHMARK_LOCUST_LOG_LEVEL) MCP_SERVER_ID=$(MCP_BENCHMARK_SERVER_ID) \
+			MCP_BENCHMARK_TOOL_POOL_SIZE=$(MCP_BENCHMARK_TOOL_POOL_SIZE) \
+			MCP_BENCHMARK_TOOL_DENYLIST=$(MCP_BENCHMARK_TOOL_DENYLIST) \
 			locust -f $(MCP_PROTOCOL_LOCUSTFILE) \
 				--worker \
 				--master-host=127.0.0.1 \
@@ -2961,6 +2973,8 @@ benchmark-mcp-tools-300:                    ## Distributed 300-user tools-only M
 			pids="$$pids $$!"; \
 		done; \
 		LOCUST_LOG_LEVEL=$(MCP_BENCHMARK_LOCUST_LOG_LEVEL) MCP_SERVER_ID=$(MCP_BENCHMARK_SERVER_ID) \
+		MCP_BENCHMARK_TOOL_POOL_SIZE=$(MCP_BENCHMARK_TOOL_POOL_SIZE) \
+		MCP_BENCHMARK_TOOL_DENYLIST=$(MCP_BENCHMARK_TOOL_DENYLIST) \
 		locust -f $(MCP_PROTOCOL_LOCUSTFILE) \
 			--host=$(MCP_BENCHMARK_HOST) \
 			--master \

--- a/charts/mcp-stack/files/ocp/locustfile_mcp_protocol.py
+++ b/charts/mcp-stack/files/ocp/locustfile_mcp_protocol.py
@@ -32,6 +32,11 @@ Environment Variables:
     LOADTEST_HOST:             Gateway URL           (default: http://localhost:4444)
     MCP_SERVER_ID:             Virtual server UUID   (auto-detected from /servers if empty)
     MCP_TOOL_NAMES:            Comma-sep tool names  (auto-detected from tools/list if empty)
+    MCP_BENCHMARK_TOOL_DENYLIST: Comma-sep tool names to exclude
+                               (default: schema_error,flaky — deliberate
+                                failure fixtures; set to "" to include them)
+    MCP_BENCHMARK_TOOL_POOL_SIZE: Max tools each user may call
+                               (default: 0 = all discovered tools)
     JWT_SECRET_KEY:            JWT signing secret     (default: my-test-key-but-now-longer-than-32-bytes)
     JWT_ALGORITHM:             JWT algorithm          (default: HS256)
     JWT_AUDIENCE:              JWT audience           (default: mcpgateway-api)
@@ -110,6 +115,18 @@ BEARER_TOKEN = _cfg("MCPGATEWAY_BEARER_TOKEN", "")
 MCP_SERVER_ID = _cfg("MCP_SERVER_ID", "")
 MCP_SERVER_IDS_STR = _cfg("MCP_SERVER_IDS", "")
 MCP_TOOL_NAMES_STR = _cfg("MCP_TOOL_NAMES", "")
+# Tools excluded from the benchmark pool. Defaults cover the fast-time-server's
+# deliberate failure fixtures: schema_error always returns isError, and flaky
+# injects failures by design. Set MCP_BENCHMARK_TOOL_DENYLIST="" to include them.
+MCP_TOOL_DENYLIST: set[str] = {
+    entry.strip().lower().replace("-", "_") for entry in _cfg("MCP_BENCHMARK_TOOL_DENYLIST", "schema_error,flaky").split(",") if entry.strip()
+}
+# Maximum number of discovered tools each user may call. 0 = no cap (default).
+# Set MCP_BENCHMARK_TOOL_POOL_SIZE=6 to reproduce the original 6-tool agent scenario.
+try:
+    MCP_TOOL_POOL_SIZE: int = max(0, int(_cfg("MCP_BENCHMARK_TOOL_POOL_SIZE", "0") or 0))
+except ValueError:
+    MCP_TOOL_POOL_SIZE = 0
 LOCUST_LOG_LEVEL = os.environ.get("LOCUST_LOG_LEVEL", _ENV.get("LOCUST_LOG_LEVEL", "INFO")).upper()
 
 logging.basicConfig(level=getattr(logging, LOCUST_LOG_LEVEL, logging.INFO))
@@ -145,6 +162,7 @@ class ServerTarget:
     tool_names: list[str]
     resource_uris: list[str]
     prompt_targets: list["PromptTarget"]
+    tool_schemas: dict[str, dict]
 
 
 @dataclass(frozen=True)
@@ -158,6 +176,7 @@ _tool_names: list[str] = []
 _resource_uris: list[str] = []
 _prompt_targets: list[PromptTarget] = []
 _server_targets: list[ServerTarget] = []
+_tool_schemas: dict[str, dict] = {}
 _jwt_token: str | None = None
 _server_target_index = 0
 
@@ -269,7 +288,7 @@ def _get_token() -> str:
 
 def _auto_detect(host: str) -> None:
     """Discover MCP server targets and per-target inventories from the gateway REST API."""
-    global _server_id, _tool_names, _resource_uris, _prompt_targets, _server_targets  # pylint: disable=global-statement
+    global _server_id, _tool_names, _resource_uris, _prompt_targets, _server_targets, _tool_schemas  # pylint: disable=global-statement
 
     # Third-Party
     import requests  # pylint: disable=import-outside-toplevel
@@ -346,11 +365,18 @@ def _auto_detect(host: str) -> None:
         if init_result:
             server_name = init_result.get("serverInfo", {}).get("name") or server_name
 
+        tool_schemas: dict[str, dict] = {}
         if MCP_TOOL_NAMES_STR:
             tool_names = [t.strip() for t in MCP_TOOL_NAMES_STR.split(",") if t.strip()]
         else:
             result = _mcp_call("tools/list")
-            tool_names = [t["name"] for t in result.get("tools", []) if "name" in t] if result else []
+            tools = result.get("tools", []) if result else []
+            tool_names = [t["name"] for t in tools if "name" in t]
+            for tool in tools:
+                name = tool.get("name")
+                schema = tool.get("inputSchema")
+                if isinstance(name, str) and isinstance(schema, dict):
+                    tool_schemas[name] = schema
 
         result = _mcp_call("resources/list")
         resource_uris = [r["uri"] for r in result.get("resources", []) if "uri" in r] if result else []
@@ -369,6 +395,11 @@ def _auto_detect(host: str) -> None:
                         required_arguments[arg_name] = _default_prompt_argument_value(prompt_name, arg_name)
                 prompt_targets.append(PromptTarget(name=prompt_name, required_arguments=required_arguments))
 
+        denied = [name for name in tool_names if _is_denied(name)]
+        if denied:
+            tool_names = [name for name in tool_names if not _is_denied(name)]
+            logger.info("server=%s: excluded %d denylisted tool(s): %s", server_id, len(denied), ", ".join(denied))
+
         discovered_targets.append(
             ServerTarget(
                 server_id=server_id,
@@ -376,6 +407,7 @@ def _auto_detect(host: str) -> None:
                 tool_names=tool_names,
                 resource_uris=resource_uris,
                 prompt_targets=prompt_targets,
+                tool_schemas=tool_schemas,
             )
         )
 
@@ -389,6 +421,7 @@ def _auto_detect(host: str) -> None:
     _tool_names = primary.tool_names
     _resource_uris = primary.resource_uris
     _prompt_targets = primary.prompt_targets
+    _tool_schemas = dict(primary.tool_schemas)
 
     logger.info("Using %d MCP server target(s)", len(_server_targets))
     for target in _server_targets:
@@ -400,6 +433,16 @@ def _auto_detect(host: str) -> None:
             len(target.resource_uris),
             len(target.prompt_targets),
         )
+
+    for target in _server_targets:
+        unschematized = [name for name in target.tool_names if not target.tool_schemas.get(name)]
+        if unschematized:
+            logger.warning(
+                "server=%s: %d tool(s) have no inputSchema; falling back to name heuristics: %s",
+                target.server_id,
+                len(unschematized),
+                ", ".join(unschematized),
+            )
 
 
 # =============================================================================
@@ -510,6 +553,144 @@ def _jsonrpc(method: str, params: dict | None = None) -> dict:
     return payload
 
 
+def _synth_value(prop_name: str, spec: dict) -> Any:
+    """Synthesize one benchmark-safe value for a JSON Schema property.
+
+    Args:
+        prop_name: Property name, used to pick realistic string values.
+        spec: JSON Schema fragment describing the property.
+
+    Returns:
+        A value matching the declared type, enum, or default.
+    """
+    if isinstance(spec.get("enum"), list) and spec["enum"]:
+        return spec["enum"][0]
+    if "default" in spec:
+        return spec["default"]
+
+    prop_type = spec.get("type")
+    if isinstance(prop_type, list):
+        prop_type = next((t for t in prop_type if t != "null"), "string")
+
+    if prop_type == "integer":
+        return 1
+    if prop_type == "number":
+        return 1.0
+    if prop_type == "boolean":
+        return True
+    if prop_type == "array":
+        items = spec.get("items")
+        return [_synth_value(prop_name, items)] if isinstance(items, dict) and items else []
+    if prop_type == "object":
+        return _args_from_schema(spec)
+
+    # Default to string, with name-aware values so time tools get real timezones.
+    name = prop_name.lower()
+    if "timezone" in name or name in {"tz", "zone"}:
+        return random.choice(TIMEZONES)
+    if "time" in name or "date" in name:
+        return "2025-06-15T14:30:00Z"
+    if "message" in name or "text" in name or "query" in name or "input" in name:
+        return f"load-test-{random.randint(1, 10000)}"
+    return f"load-test-{prop_name}"
+
+
+def _args_from_schema(schema: dict) -> dict:
+    """Build a minimal valid argument dict from a tool's JSON Schema.
+
+    Only required properties are populated; optional properties are skipped so
+    benchmark payloads stay small and deterministic in shape.
+
+    Args:
+        schema: The tool's ``inputSchema`` from ``tools/list``.
+
+    Returns:
+        Mapping of argument name to synthesized value.
+    """
+    properties = schema.get("properties") or {}
+    required = schema.get("required") or []
+    args: dict[str, Any] = {}
+    for name in required:
+        if not isinstance(name, str):
+            continue
+        spec = properties.get(name)
+        args[name] = _synth_value(name, spec if isinstance(spec, dict) else {})
+    return args
+
+
+def _legacy_name_args(tool_name: str) -> dict:
+    """Guess arguments from a tool name when no schema is available.
+
+    Only used for the ``MCP_TOOL_NAMES`` override path, where tools are supplied
+    by name and ``tools/list`` schemas were never fetched. Checks are ordered
+    most-specific first, because gateway-prefixed names (``fast-time-echo``)
+    contain the substring ``time``.
+
+    Args:
+        tool_name: Tool name, possibly gateway-prefixed.
+
+    Returns:
+        Best-effort argument mapping, or an empty dict when nothing matches.
+    """
+    name = tool_name.lower().replace("-", "_")
+    if "echo" in name:
+        return {"message": f"load-test-{random.randint(1, 10000)}"}
+    if "convert" in name:
+        src = random.choice(TIMEZONES)
+        dst = random.choice([t for t in TIMEZONES if t != src])
+        return {"time": "2025-06-15T14:30:00Z", "source_timezone": src, "target_timezone": dst}
+    if "system_time" in name or "current_time" in name or name.endswith("_time") or "timezone" in name:
+        return {"timezone": random.choice(TIMEZONES)}
+    return {}
+
+
+def _build_tool_args(tool_name: str, schema: dict | None = None) -> dict:
+    """Build arguments for a tool, preferring its declared input schema.
+
+    Args:
+        tool_name: Tool name as returned by ``tools/list``.
+        schema: Optional explicit schema; falls back to the discovery registry.
+
+    Returns:
+        Argument mapping to send as ``params.arguments`` for ``tools/call``.
+    """
+    if schema is None:
+        schema = _tool_schemas.get(tool_name)
+    if isinstance(schema, dict) and ("required" in schema or "properties" in schema):
+        return _args_from_schema(schema)
+    return _legacy_name_args(tool_name)
+
+
+def _is_denied(tool_name: str) -> bool:
+    """Report whether a tool is excluded from the benchmark pool.
+
+    Matching is on the normalized full name or its trailing segment, so a
+    denylist entry of ``schema_error`` also excludes ``fast-time-schema-error``.
+
+    Args:
+        tool_name: Tool name as returned by ``tools/list``.
+
+    Returns:
+        True when the tool should be skipped.
+    """
+    normalized = tool_name.lower().replace("-", "_")
+    return any(normalized == denied or normalized.endswith(f"_{denied}") for denied in MCP_TOOL_DENYLIST)
+
+
+def _limit_pool(tool_names: list[str]) -> list[str]:
+    """Apply the configured tool-pool ceiling.
+
+    Args:
+        tool_names: Discovered tool names.
+
+    Returns:
+        The same list, truncated when ``MCP_TOOL_POOL_SIZE`` is greater than zero.
+    """
+    if MCP_TOOL_POOL_SIZE > 0:
+        return tool_names[:MCP_TOOL_POOL_SIZE]
+    return tool_names
+
+
 # =============================================================================
 # Base MCP User — handles session init, auth, and request mechanics
 # =============================================================================
@@ -536,6 +717,7 @@ class BaseMCPUser(FastHttpUser):
         self._tool_names: list[str] = []
         self._resource_uris: list[str] = []
         self._prompt_targets: list[PromptTarget] = []
+        self._tool_schemas: dict[str, dict] = {}
 
     def _mcp_path(self) -> str:
         return f"/servers/{self._server_id}/mcp"
@@ -612,6 +794,7 @@ class BaseMCPUser(FastHttpUser):
         self._tool_names = list(target.tool_names)
         self._resource_uris = list(target.resource_uris)
         self._prompt_targets = list(target.prompt_targets)
+        self._tool_schemas = dict(target.tool_schemas)
 
     def _ensure_initialized(self):
         """Initialize the MCP session (once per user lifecycle)."""
@@ -635,6 +818,25 @@ class BaseMCPUser(FastHttpUser):
         self._assign_target()
         self._ensure_initialized()
 
+    def _build_tool_args(self, tool_name: str) -> dict:
+        """Build arguments for a tool using the schema discovered for this user's target.
+
+        Args:
+            tool_name: Tool name as returned by ``tools/list``.
+
+        Returns:
+            Argument mapping for ``tools/call``.
+        """
+        return _build_tool_args(tool_name, self._tool_schemas.get(tool_name))
+
+    def _tool_pool(self) -> list[str]:
+        """Return the tools this user may call, honoring the configured ceiling.
+
+        Returns:
+            Callable tool names for the assigned server target.
+        """
+        return _limit_pool(self._tool_names)
+
 
 # =============================================================================
 # User 1: MCPAgentUser — Realistic agent with 6 tools (customer scenario)
@@ -642,12 +844,16 @@ class BaseMCPUser(FastHttpUser):
 
 
 class MCPAgentUser(BaseMCPUser):
-    """Simulates a realistic AI agent that uses 6 MCP tools.
+    """Simulates a realistic AI agent that uses the server's MCP tools.
 
-    Matches the customer scenario: an agent with 6 tools at 150 RPS target.
+    Matches the customer scenario at a 150 RPS target. Set
+    MCP_BENCHMARK_TOOL_POOL_SIZE=6 to restrict the agent to 6 tools exactly as
+    the original customer configuration did; the default is every discovered
+    tool.
+
     Each "turn" the agent:
       1. Calls tools/list (periodic discovery)
-      2. Calls 1-3 tools per turn (random selection from available tools)
+      2. Calls 1-3 tools per turn (random selection from the tool pool)
       3. Occasionally lists resources/prompts
 
     Weight: 10 (dominant — this is the primary scenario to measure)
@@ -657,25 +863,22 @@ class MCPAgentUser(BaseMCPUser):
     wait_time = between(0.05, 0.3)
 
     def _pick_tools(self, n: int = 1) -> list[str]:
-        """Pick n random tools from the discovered set (cap at 6 like the customer)."""
-        pool = self._tool_names[:6] if len(self._tool_names) > 6 else self._tool_names
+        """Pick n random tools from the discovered set.
+
+        The pool is the full discovered tool list unless
+        ``MCP_BENCHMARK_TOOL_POOL_SIZE`` caps it (set it to 6 to reproduce the
+        original 6-tool customer agent scenario).
+
+        Args:
+            n: Number of distinct tools to pick.
+
+        Returns:
+            Up to n tool names, or an empty list when no tools are available.
+        """
+        pool = self._tool_pool()
         if not pool:
             return []
         return random.sample(pool, min(n, len(pool)))
-
-    def _build_tool_args(self, tool_name: str) -> dict:
-        """Build plausible arguments for a tool based on its name."""
-        name_lower = tool_name.lower()
-        if "time" in name_lower or "timezone" in name_lower:
-            return {"timezone": random.choice(TIMEZONES)}
-        if "echo" in name_lower:
-            return {"message": f"load-test-{random.randint(1, 10000)}"}
-        if "convert" in name_lower:
-            src = random.choice(TIMEZONES)
-            dst = random.choice([t for t in TIMEZONES if t != src])
-            return {"time": "2025-06-15T14:30:00Z", "source_timezone": src, "target_timezone": dst}
-        # Generic: many tools accept empty args or have defaults
-        return {}
 
     @task(15)
     @tag("agent", "tools", "call")
@@ -756,18 +959,11 @@ class MCPToolCallerUser(BaseMCPUser):
     @tag("toolcall", "call")
     def call_tool(self):
         """Call a random tool rapidly."""
-        if not self._tool_names:
+        pool = self._tool_pool()
+        if not pool:
             return
-        tool = random.choice(self._tool_names[:6] if len(self._tool_names) > 6 else self._tool_names)
-        name_lower = tool.lower()
-        if "time" in name_lower:
-            args = {"timezone": random.choice(TIMEZONES)}
-        elif "echo" in name_lower:
-            args = {"message": "perf-test"}
-        elif "convert" in name_lower:
-            args = {"time": "2025-01-01T00:00:00Z", "source_timezone": "UTC", "target_timezone": "Europe/London"}
-        else:
-            args = {}
+        tool = random.choice(pool)
+        args = self._build_tool_args(tool)
         self._mcp_request("tools/call", {"name": tool, "arguments": args}, "MCP tools/call [rapid]")
 
     @task(1)
@@ -871,15 +1067,10 @@ class MCPSessionChurnUser(BaseMCPUser):
         self._mcp_request("tools/list", {}, "MCP tools/list [churn]")
 
         # Call a tool
-        if self._tool_names:
-            tool = random.choice(self._tool_names[:6] if len(self._tool_names) > 6 else self._tool_names)
-            name_lower = tool.lower()
-            if "time" in name_lower:
-                args = {"timezone": random.choice(TIMEZONES)}
-            elif "echo" in name_lower:
-                args = {"message": "churn-test"}
-            else:
-                args = {}
+        pool = self._tool_pool()
+        if pool:
+            tool = random.choice(pool)
+            args = self._build_tool_args(tool)
             self._mcp_request("tools/call", {"name": tool, "arguments": args}, "MCP tools/call [churn]")
 
 
@@ -902,16 +1093,12 @@ class MCPStressUser(BaseMCPUser):
     @task(10)
     @tag("stress", "call")
     def stress_call_tool(self):
-        if not self._tool_names:
+        """Call a random tool at constant throughput."""
+        pool = self._tool_pool()
+        if not pool:
             return
-        tool = random.choice(self._tool_names[:6] if len(self._tool_names) > 6 else self._tool_names)
-        name_lower = tool.lower()
-        if "time" in name_lower:
-            args = {"timezone": "UTC"}
-        elif "echo" in name_lower:
-            args = {"message": "stress"}
-        else:
-            args = {}
+        tool = random.choice(pool)
+        args = self._build_tool_args(tool)
         self._mcp_request("tools/call", {"name": tool, "arguments": args}, "MCP tools/call [stress]")
 
     @task(3)
@@ -975,16 +1162,11 @@ class RESTBaselineUser(FastHttpUser):
     @tag("baseline", "rpc", "call")
     def rpc_call_tool(self):
         """tools/call via /rpc (REST JSON-RPC)."""
-        if not _tool_names:
+        pool = _limit_pool(_tool_names)
+        if not pool:
             return
-        tool = random.choice(_tool_names[:6] if len(_tool_names) > 6 else _tool_names)
-        name_lower = tool.lower()
-        if "echo" in name_lower:
-            args = {"message": "baseline"}
-        elif "time" in name_lower:
-            args = {"timezone": "UTC"}
-        else:
-            args = {}
+        tool = random.choice(pool)
+        args = _build_tool_args(tool)
         payload = _jsonrpc("tools/call", {"name": tool, "arguments": args})
         with self.client.post(
             "/rpc",

--- a/charts/mcp-stack/files/ocp/locustfile_mcp_protocol.py
+++ b/charts/mcp-stack/files/ocp/locustfile_mcp_protocol.py
@@ -8,7 +8,7 @@ It exists to isolate MCP protocol overhead from REST API / admin UI / other
 endpoints so we can get a clean RPS number for just the MCP path.
 
 Test scenarios (selectable via --class-picker):
-  MCPAgentUser        (weight 10) - Realistic agent: init once, then call 6 tools
+  MCPAgentUser        (weight 10) - Realistic agent: init once, then call from the discovered tool pool
   MCPToolCallerUser   (weight  5) - Heavy tool caller: tools/call in a tight loop
   MCPDiscoveryUser    (weight  3) - Discovery heavy: tools/list, resources/list, prompts/list
   MCPSessionChurnUser (weight  2) - Session churn: new session per request cycle
@@ -118,9 +118,8 @@ MCP_TOOL_NAMES_STR = _cfg("MCP_TOOL_NAMES", "")
 # Tools excluded from the benchmark pool. Defaults cover the fast-time-server's
 # deliberate failure fixtures: schema_error always returns isError, and flaky
 # injects failures by design. Set MCP_BENCHMARK_TOOL_DENYLIST="" to include them.
-MCP_TOOL_DENYLIST: set[str] = {
-    entry.strip().lower().replace("-", "_") for entry in _cfg("MCP_BENCHMARK_TOOL_DENYLIST", "schema_error,flaky").split(",") if entry.strip()
-}
+_denylist_raw = os.environ.get("MCP_BENCHMARK_TOOL_DENYLIST", _ENV.get("MCP_BENCHMARK_TOOL_DENYLIST", "schema_error,flaky"))
+MCP_TOOL_DENYLIST: set[str] = {entry.strip().lower().replace("-", "_") for entry in _denylist_raw.split(",") if entry.strip()}
 # Maximum number of discovered tools each user may call. 0 = no cap (default).
 # Set MCP_BENCHMARK_TOOL_POOL_SIZE=6 to reproduce the original 6-tool agent scenario.
 try:
@@ -839,7 +838,7 @@ class BaseMCPUser(FastHttpUser):
 
 
 # =============================================================================
-# User 1: MCPAgentUser — Realistic agent with 6 tools (customer scenario)
+# User 1: MCPAgentUser — Realistic agent over the discovered tool pool (customer scenario)
 # =============================================================================
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1471,11 +1471,19 @@ services:
 
   ###############################################################################
   # Fast Time Server - High-performance time/timezone service for MCP
-  # Defaults to the published GHCR image. Override FAST_TIME_IMAGE when building locally:
-  #   FAST_TIME_IMAGE=mcpgateway/fast-time-server:local docker compose build fast_time_server
+  # Pinned by digest so `docker compose pull` cannot change the tool inventory
+  # under the benchmarks. Digest resolved 2026-08-07 (== commit tag
+  # 9b97731fab3cce083d09fe48b4d4760a38d17248); 8 tools exposed:
+  #   echo, flaky, get_system_time, convert_time, schema_error, schema_success,
+  #   get_stats, verify-protocol
+  # When bumping this digest: re-run `tools/list` against the new image and
+  # update MCP_BENCHMARK_TOOL_DENYLIST in the Makefile if new failure fixtures
+  # were added (see tests/loadtest/locustfile_mcp_protocol.py).
+  # Override for local builds:
+  #   FAST_TIME_IMAGE=mcpgateway/fast-time-server:local docker compose up fast_time_server
   ###############################################################################
   fast_time_server:
-    image: ${FAST_TIME_IMAGE:-ghcr.io/ibm/cfex-mcp-fast-time-server:latest}
+    image: ${FAST_TIME_IMAGE:-ghcr.io/ibm/cfex-mcp-fast-time-server@sha256:2f095509d535a0769449f3b9417858f5c233dc74b1e09de335b48b7591d995a1}
     restart: unless-stopped
     networks: [mcpnet]
     ports:
@@ -1865,7 +1873,7 @@ services:
   # Usage: docker compose --profile testing up -d
   ###############################################################################
   fast_test_server:
-    image: ghcr.io/ibm/cfex-mcp-fast-time-server:latest
+    image: ${FAST_TIME_IMAGE:-ghcr.io/ibm/cfex-mcp-fast-time-server@sha256:2f095509d535a0769449f3b9417858f5c233dc74b1e09de335b48b7591d995a1}
     restart: unless-stopped
     networks: [mcpnet]
     ports:

--- a/docs/release/benchmark.md
+++ b/docs/release/benchmark.md
@@ -28,3 +28,9 @@ This file tracks benchmark results by release for local performance runs for dev
 | p90 (ms) | 21000.00 | 3500.00 |
 | p95 (ms) | 30000.00 | 5800.00 |
 | p99 (ms) | 30000.00 | 13000.00 |
+
+> **Note:** The 31.56% failure rate recorded for `benchmark-mcp-tools` predates the
+> fix for #6082. Tool arguments were guessed from tool names, and gateway-prefixed
+> names (`fast-time-echo`) matched the timezone branch, so most `tools/call`
+> requests were rejected with JSON-RPC `-32602`. Arguments are now synthesized
+> from each tool's `inputSchema`; re-measure before comparing against these numbers.

--- a/tests/loadtest/locustfile_mcp_protocol.py
+++ b/tests/loadtest/locustfile_mcp_protocol.py
@@ -31,6 +31,8 @@ Environment Variables:
     MCP_BENCHMARK_TOOL_DENYLIST: Comma-sep tool names to exclude
                                (default: schema_error,flaky — deliberate
                                 failure fixtures; set to "" to include them)
+    MCP_BENCHMARK_TOOL_POOL_SIZE: Max tools each user may call
+                               (default: 0 = all discovered tools)
     JWT_SECRET_KEY:            JWT signing secret     (default: my-test-key-but-now-longer-than-32-bytes)
     JWT_ALGORITHM:             JWT algorithm          (default: HS256)
     JWT_AUDIENCE:              JWT audience           (default: mcpgateway-api)
@@ -109,6 +111,12 @@ MCP_TOOL_NAMES_STR = _cfg("MCP_TOOL_NAMES", "")
 MCP_TOOL_DENYLIST: set[str] = {
     entry.strip().lower().replace("-", "_") for entry in _cfg("MCP_BENCHMARK_TOOL_DENYLIST", "schema_error,flaky").split(",") if entry.strip()
 }
+# Maximum number of discovered tools each user may call. 0 = no cap (default).
+# Set MCP_BENCHMARK_TOOL_POOL_SIZE=6 to reproduce the original 6-tool agent scenario.
+try:
+    MCP_TOOL_POOL_SIZE: int = max(0, int(_cfg("MCP_BENCHMARK_TOOL_POOL_SIZE", "0") or 0))
+except ValueError:
+    MCP_TOOL_POOL_SIZE = 0
 LOCUST_LOG_LEVEL = os.environ.get("LOCUST_LOG_LEVEL", _ENV.get("LOCUST_LOG_LEVEL", "INFO")).upper()
 
 logging.basicConfig(level=getattr(logging, LOCUST_LOG_LEVEL, logging.INFO))
@@ -650,6 +658,20 @@ def _is_denied(tool_name: str) -> bool:
     return any(normalized == denied or normalized.endswith(f"_{denied}") for denied in MCP_TOOL_DENYLIST)
 
 
+def _limit_pool(tool_names: list[str]) -> list[str]:
+    """Apply the configured tool-pool ceiling.
+
+    Args:
+        tool_names: Discovered tool names.
+
+    Returns:
+        The same list, truncated when ``MCP_TOOL_POOL_SIZE`` is greater than zero.
+    """
+    if MCP_TOOL_POOL_SIZE > 0:
+        return tool_names[:MCP_TOOL_POOL_SIZE]
+    return tool_names
+
+
 # =============================================================================
 # Base MCP User — handles session init, auth, and request mechanics
 # =============================================================================
@@ -788,6 +810,14 @@ class BaseMCPUser(FastHttpUser):
         """
         return _build_tool_args(tool_name, self._tool_schemas.get(tool_name))
 
+    def _tool_pool(self) -> list[str]:
+        """Return the tools this user may call, honoring the configured ceiling.
+
+        Returns:
+            Callable tool names for the assigned server target.
+        """
+        return _limit_pool(self._tool_names)
+
 
 # =============================================================================
 # User 1: MCPAgentUser — Realistic agent with 6 tools (customer scenario)
@@ -795,12 +825,16 @@ class BaseMCPUser(FastHttpUser):
 
 
 class MCPAgentUser(BaseMCPUser):
-    """Simulates a realistic AI agent that uses 6 MCP tools.
+    """Simulates a realistic AI agent that uses the server's MCP tools.
 
-    Matches the customer scenario: an agent with 6 tools at 150 RPS target.
+    Matches the customer scenario at a 150 RPS target. Set
+    MCP_BENCHMARK_TOOL_POOL_SIZE=6 to restrict the agent to 6 tools exactly as
+    the original customer configuration did; the default is every discovered
+    tool.
+
     Each "turn" the agent:
       1. Calls tools/list (periodic discovery)
-      2. Calls 1-3 tools per turn (random selection from available tools)
+      2. Calls 1-3 tools per turn (random selection from the tool pool)
       3. Occasionally lists resources/prompts
 
     Weight: 10 (dominant — this is the primary scenario to measure)
@@ -810,8 +844,19 @@ class MCPAgentUser(BaseMCPUser):
     wait_time = between(0.05, 0.3)
 
     def _pick_tools(self, n: int = 1) -> list[str]:
-        """Pick n random tools from the discovered set (cap at 6 like the customer)."""
-        pool = self._tool_names[:6] if len(self._tool_names) > 6 else self._tool_names
+        """Pick n random tools from the discovered set.
+
+        The pool is the full discovered tool list unless
+        ``MCP_BENCHMARK_TOOL_POOL_SIZE`` caps it (set it to 6 to reproduce the
+        original 6-tool customer agent scenario).
+
+        Args:
+            n: Number of distinct tools to pick.
+
+        Returns:
+            Up to n tool names, or an empty list when no tools are available.
+        """
+        pool = self._tool_pool()
         if not pool:
             return []
         return random.sample(pool, min(n, len(pool)))
@@ -895,9 +940,10 @@ class MCPToolCallerUser(BaseMCPUser):
     @tag("toolcall", "call")
     def call_tool(self):
         """Call a random tool rapidly."""
-        if not self._tool_names:
+        pool = self._tool_pool()
+        if not pool:
             return
-        tool = random.choice(self._tool_names[:6] if len(self._tool_names) > 6 else self._tool_names)
+        tool = random.choice(pool)
         args = self._build_tool_args(tool)
         self._mcp_request("tools/call", {"name": tool, "arguments": args}, "MCP tools/call [rapid]")
 
@@ -1001,8 +1047,9 @@ class MCPSessionChurnUser(BaseMCPUser):
         self._mcp_request("tools/list", {}, "MCP tools/list [churn]")
 
         # Call a tool
-        if self._tool_names:
-            tool = random.choice(self._tool_names[:6] if len(self._tool_names) > 6 else self._tool_names)
+        pool = self._tool_pool()
+        if pool:
+            tool = random.choice(pool)
             args = self._build_tool_args(tool)
             self._mcp_request("tools/call", {"name": tool, "arguments": args}, "MCP tools/call [churn]")
 
@@ -1026,9 +1073,11 @@ class MCPStressUser(BaseMCPUser):
     @task(10)
     @tag("stress", "call")
     def stress_call_tool(self):
-        if not self._tool_names:
+        """Call a random tool at constant throughput."""
+        pool = self._tool_pool()
+        if not pool:
             return
-        tool = random.choice(self._tool_names[:6] if len(self._tool_names) > 6 else self._tool_names)
+        tool = random.choice(pool)
         args = self._build_tool_args(tool)
         self._mcp_request("tools/call", {"name": tool, "arguments": args}, "MCP tools/call [stress]")
 
@@ -1093,9 +1142,10 @@ class RESTBaselineUser(FastHttpUser):
     @tag("baseline", "rpc", "call")
     def rpc_call_tool(self):
         """tools/call via /rpc (REST JSON-RPC)."""
-        if not _tool_names:
+        pool = _limit_pool(_tool_names)
+        if not pool:
             return
-        tool = random.choice(_tool_names[:6] if len(_tool_names) > 6 else _tool_names)
+        tool = random.choice(pool)
         args = _build_tool_args(tool)
         payload = _jsonrpc("tools/call", {"name": tool, "arguments": args})
         with self.client.post(

--- a/tests/loadtest/locustfile_mcp_protocol.py
+++ b/tests/loadtest/locustfile_mcp_protocol.py
@@ -615,7 +615,7 @@ def _build_tool_args(tool_name: str, schema: dict | None = None) -> dict:
     """
     if schema is None:
         schema = _tool_schemas.get(tool_name)
-    if isinstance(schema, dict) and (schema.get("required") or schema.get("properties")):
+    if isinstance(schema, dict) and ("required" in schema or "properties" in schema):
         return _args_from_schema(schema)
     return _legacy_name_args(tool_name)
 

--- a/tests/loadtest/locustfile_mcp_protocol.py
+++ b/tests/loadtest/locustfile_mcp_protocol.py
@@ -9,7 +9,7 @@ gateway virtual server endpoint: /servers/{server_id}/mcp
 It exists to isolate MCP protocol overhead from REST API / admin UI / other
 endpoints so we can get a clean RPS number for just the MCP path.
 Test scenarios (selectable via --class-picker):
-  MCPAgentUser        (weight 10) - Realistic agent: init once, then call 6 tools
+  MCPAgentUser        (weight 10) - Realistic agent: init once, then call from the discovered tool pool
   MCPToolCallerUser   (weight  5) - Heavy tool caller: tools/call in a tight loop
   MCPDiscoveryUser    (weight  3) - Discovery heavy: tools/list, resources/list, prompts/list
   MCPSessionChurnUser (weight  2) - Session churn: new session per request cycle
@@ -108,9 +108,8 @@ MCP_TOOL_NAMES_STR = _cfg("MCP_TOOL_NAMES", "")
 # Tools excluded from the benchmark pool. Defaults cover the fast-time-server's
 # deliberate failure fixtures: schema_error always returns isError, and flaky
 # injects failures by design. Set MCP_BENCHMARK_TOOL_DENYLIST="" to include them.
-MCP_TOOL_DENYLIST: set[str] = {
-    entry.strip().lower().replace("-", "_") for entry in _cfg("MCP_BENCHMARK_TOOL_DENYLIST", "schema_error,flaky").split(",") if entry.strip()
-}
+_denylist_raw = os.environ.get("MCP_BENCHMARK_TOOL_DENYLIST", _ENV.get("MCP_BENCHMARK_TOOL_DENYLIST", "schema_error,flaky"))
+MCP_TOOL_DENYLIST: set[str] = {entry.strip().lower().replace("-", "_") for entry in _denylist_raw.split(",") if entry.strip()}
 # Maximum number of discovered tools each user may call. 0 = no cap (default).
 # Set MCP_BENCHMARK_TOOL_POOL_SIZE=6 to reproduce the original 6-tool agent scenario.
 try:
@@ -820,7 +819,7 @@ class BaseMCPUser(FastHttpUser):
 
 
 # =============================================================================
-# User 1: MCPAgentUser — Realistic agent with 6 tools (customer scenario)
+# User 1: MCPAgentUser — Realistic agent over the discovered tool pool (customer scenario)
 # =============================================================================
 
 
@@ -1021,8 +1020,9 @@ class MCPSessionChurnUser(BaseMCPUser):
     wait_time = between(0.1, 0.3)
 
     def on_start(self):
-        # Do NOT call _ensure_initialized — each task cycle initializes fresh
-        pass
+        # Assign server target (need server_id and tool_names) but do NOT call
+        # _ensure_initialized — each task cycle initializes a fresh session
+        self._assign_target()
 
     @task(10)
     @tag("churn", "lifecycle")

--- a/tests/loadtest/locustfile_mcp_protocol.py
+++ b/tests/loadtest/locustfile_mcp_protocol.py
@@ -28,6 +28,9 @@ Environment Variables:
     LOADTEST_HOST:             Gateway URL           (default: http://localhost:4444)
     MCP_SERVER_ID:             Virtual server UUID   (auto-detected from /servers if empty)
     MCP_TOOL_NAMES:            Comma-sep tool names  (auto-detected from tools/list if empty)
+    MCP_BENCHMARK_TOOL_DENYLIST: Comma-sep tool names to exclude
+                               (default: schema_error,flaky — deliberate
+                                failure fixtures; set to "" to include them)
     JWT_SECRET_KEY:            JWT signing secret     (default: my-test-key-but-now-longer-than-32-bytes)
     JWT_ALGORITHM:             JWT algorithm          (default: HS256)
     JWT_AUDIENCE:              JWT audience           (default: mcpgateway-api)
@@ -100,6 +103,12 @@ BEARER_TOKEN = _cfg("MCPGATEWAY_BEARER_TOKEN", "")
 MCP_SERVER_ID = _cfg("MCP_SERVER_ID", "")
 MCP_SERVER_IDS_STR = _cfg("MCP_SERVER_IDS", "")
 MCP_TOOL_NAMES_STR = _cfg("MCP_TOOL_NAMES", "")
+# Tools excluded from the benchmark pool. Defaults cover the fast-time-server's
+# deliberate failure fixtures: schema_error always returns isError, and flaky
+# injects failures by design. Set MCP_BENCHMARK_TOOL_DENYLIST="" to include them.
+MCP_TOOL_DENYLIST: set[str] = {
+    entry.strip().lower().replace("-", "_") for entry in _cfg("MCP_BENCHMARK_TOOL_DENYLIST", "schema_error,flaky").split(",") if entry.strip()
+}
 LOCUST_LOG_LEVEL = os.environ.get("LOCUST_LOG_LEVEL", _ENV.get("LOCUST_LOG_LEVEL", "INFO")).upper()
 
 logging.basicConfig(level=getattr(logging, LOCUST_LOG_LEVEL, logging.INFO))
@@ -358,6 +367,11 @@ def _auto_detect(host: str) -> None:
                     if argument.get("required") and isinstance(arg_name, str) and arg_name:
                         required_arguments[arg_name] = _default_prompt_argument_value(prompt_name, arg_name)
                 prompt_targets.append(PromptTarget(name=prompt_name, required_arguments=required_arguments))
+
+        denied = [name for name in tool_names if _is_denied(name)]
+        if denied:
+            tool_names = [name for name in tool_names if not _is_denied(name)]
+            logger.info("server=%s: excluded %d denylisted tool(s): %s", server_id, len(denied), ", ".join(denied))
 
         discovered_targets.append(
             ServerTarget(
@@ -618,6 +632,22 @@ def _build_tool_args(tool_name: str, schema: dict | None = None) -> dict:
     if isinstance(schema, dict) and ("required" in schema or "properties" in schema):
         return _args_from_schema(schema)
     return _legacy_name_args(tool_name)
+
+
+def _is_denied(tool_name: str) -> bool:
+    """Report whether a tool is excluded from the benchmark pool.
+
+    Matching is on the normalized full name or its trailing segment, so a
+    denylist entry of ``schema_error`` also excludes ``fast-time-schema-error``.
+
+    Args:
+        tool_name: Tool name as returned by ``tools/list``.
+
+    Returns:
+        True when the tool should be skipped.
+    """
+    normalized = tool_name.lower().replace("-", "_")
+    return any(normalized == denied or normalized.endswith(f"_{denied}") for denied in MCP_TOOL_DENYLIST)
 
 
 # =============================================================================

--- a/tests/loadtest/locustfile_mcp_protocol.py
+++ b/tests/loadtest/locustfile_mcp_protocol.py
@@ -51,7 +51,7 @@ import warnings
 # Third-Party
 from locust import between, constant_throughput, events, tag, task
 from locust.contrib.fasthttp import FastHttpUser
-from locust.runners import MasterRunner, WorkerRunner
+from locust.runners import WorkerRunner
 
 # =============================================================================
 # Configuration
@@ -135,6 +135,7 @@ class ServerTarget:
     tool_names: list[str]
     resource_uris: list[str]
     prompt_targets: list["PromptTarget"]
+    tool_schemas: dict[str, dict]
 
 
 @dataclass(frozen=True)
@@ -149,6 +150,7 @@ _tool_names: list[str] = []
 _resource_uris: list[str] = []
 _prompt_targets: list[PromptTarget] = []
 _server_targets: list[ServerTarget] = []
+_tool_schemas: dict[str, dict] = {}
 _jwt_token: str | None = None
 _server_target_index = 0
 
@@ -250,7 +252,7 @@ def _get_token() -> str:
 
 def _auto_detect(host: str) -> None:
     """Discover MCP server targets and per-target inventories from the gateway REST API."""
-    global _server_id, _tool_names, _resource_uris, _prompt_targets, _server_targets  # pylint: disable=global-statement
+    global _server_id, _tool_names, _resource_uris, _prompt_targets, _server_targets, _tool_schemas  # pylint: disable=global-statement
 
     # Third-Party
     import requests  # pylint: disable=import-outside-toplevel
@@ -327,11 +329,18 @@ def _auto_detect(host: str) -> None:
         if init_result:
             server_name = init_result.get("serverInfo", {}).get("name") or server_name
 
+        tool_schemas: dict[str, dict] = {}
         if MCP_TOOL_NAMES_STR:
             tool_names = [t.strip() for t in MCP_TOOL_NAMES_STR.split(",") if t.strip()]
         else:
             result = _mcp_call("tools/list")
-            tool_names = [t["name"] for t in result.get("tools", []) if "name" in t] if result else []
+            tools = result.get("tools", []) if result else []
+            tool_names = [t["name"] for t in tools if "name" in t]
+            for tool in tools:
+                name = tool.get("name")
+                schema = tool.get("inputSchema")
+                if isinstance(name, str) and isinstance(schema, dict):
+                    tool_schemas[name] = schema
 
         result = _mcp_call("resources/list")
         resource_uris = [r["uri"] for r in result.get("resources", []) if "uri" in r] if result else []
@@ -357,6 +366,7 @@ def _auto_detect(host: str) -> None:
                 tool_names=tool_names,
                 resource_uris=resource_uris,
                 prompt_targets=prompt_targets,
+                tool_schemas=tool_schemas,
             )
         )
 
@@ -370,6 +380,7 @@ def _auto_detect(host: str) -> None:
     _tool_names = primary.tool_names
     _resource_uris = primary.resource_uris
     _prompt_targets = primary.prompt_targets
+    _tool_schemas = dict(primary.tool_schemas)
 
     logger.info("Using %d MCP server target(s)", len(_server_targets))
     for target in _server_targets:
@@ -381,6 +392,16 @@ def _auto_detect(host: str) -> None:
             len(target.resource_uris),
             len(target.prompt_targets),
         )
+
+    for target in _server_targets:
+        unschematized = [name for name in target.tool_names if not target.tool_schemas.get(name)]
+        if unschematized:
+            logger.warning(
+                "server=%s: %d tool(s) have no inputSchema; falling back to name heuristics: %s",
+                target.server_id,
+                len(unschematized),
+                ", ".join(unschematized),
+            )
 
 
 # =============================================================================
@@ -491,18 +512,112 @@ def _jsonrpc(method: str, params: dict | None = None) -> dict:
     return payload
 
 
-def _build_tool_args(tool_name: str) -> dict:
-    """Build plausible arguments for a tool based on its name."""
-    name_lower = tool_name.lower()
-    if "convert" in name_lower:
+def _synth_value(prop_name: str, spec: dict) -> Any:
+    """Synthesize one benchmark-safe value for a JSON Schema property.
+
+    Args:
+        prop_name: Property name, used to pick realistic string values.
+        spec: JSON Schema fragment describing the property.
+
+    Returns:
+        A value matching the declared type, enum, or default.
+    """
+    if isinstance(spec.get("enum"), list) and spec["enum"]:
+        return spec["enum"][0]
+    if "default" in spec:
+        return spec["default"]
+
+    prop_type = spec.get("type")
+    if isinstance(prop_type, list):
+        prop_type = next((t for t in prop_type if t != "null"), "string")
+
+    if prop_type == "integer":
+        return 1
+    if prop_type == "number":
+        return 1.0
+    if prop_type == "boolean":
+        return True
+    if prop_type == "array":
+        items = spec.get("items")
+        return [_synth_value(prop_name, items)] if isinstance(items, dict) and items else []
+    if prop_type == "object":
+        return _args_from_schema(spec)
+
+    # Default to string, with name-aware values so time tools get real timezones.
+    name = prop_name.lower()
+    if "timezone" in name or name in {"tz", "zone"}:
+        return random.choice(TIMEZONES)
+    if "time" in name or "date" in name:
+        return "2025-06-15T14:30:00Z"
+    if "message" in name or "text" in name or "query" in name or "input" in name:
+        return f"load-test-{random.randint(1, 10000)}"
+    return f"load-test-{prop_name}"
+
+
+def _args_from_schema(schema: dict) -> dict:
+    """Build a minimal valid argument dict from a tool's JSON Schema.
+
+    Only required properties are populated; optional properties are skipped so
+    benchmark payloads stay small and deterministic in shape.
+
+    Args:
+        schema: The tool's ``inputSchema`` from ``tools/list``.
+
+    Returns:
+        Mapping of argument name to synthesized value.
+    """
+    properties = schema.get("properties") or {}
+    required = schema.get("required") or []
+    args: dict[str, Any] = {}
+    for name in required:
+        if not isinstance(name, str):
+            continue
+        spec = properties.get(name)
+        args[name] = _synth_value(name, spec if isinstance(spec, dict) else {})
+    return args
+
+
+def _legacy_name_args(tool_name: str) -> dict:
+    """Guess arguments from a tool name when no schema is available.
+
+    Only used for the ``MCP_TOOL_NAMES`` override path, where tools are supplied
+    by name and ``tools/list`` schemas were never fetched. Checks are ordered
+    most-specific first, because gateway-prefixed names (``fast-time-echo``)
+    contain the substring ``time``.
+
+    Args:
+        tool_name: Tool name, possibly gateway-prefixed.
+
+    Returns:
+        Best-effort argument mapping, or an empty dict when nothing matches.
+    """
+    name = tool_name.lower().replace("-", "_")
+    if "echo" in name:
+        return {"message": f"load-test-{random.randint(1, 10000)}"}
+    if "convert" in name:
         src = random.choice(TIMEZONES)
         dst = random.choice([t for t in TIMEZONES if t != src])
         return {"time": "2025-06-15T14:30:00Z", "source_timezone": src, "target_timezone": dst}
-    if "time" in name_lower or "timezone" in name_lower:
+    if "system_time" in name or "current_time" in name or name.endswith("_time") or "timezone" in name:
         return {"timezone": random.choice(TIMEZONES)}
-    if "echo" in name_lower:
-        return {"message": f"load-test-{random.randint(1, 10000)}"}
     return {}
+
+
+def _build_tool_args(tool_name: str, schema: dict | None = None) -> dict:
+    """Build arguments for a tool, preferring its declared input schema.
+
+    Args:
+        tool_name: Tool name as returned by ``tools/list``.
+        schema: Optional explicit schema; falls back to the discovery registry.
+
+    Returns:
+        Argument mapping to send as ``params.arguments`` for ``tools/call``.
+    """
+    if schema is None:
+        schema = _tool_schemas.get(tool_name)
+    if isinstance(schema, dict) and (schema.get("required") or schema.get("properties")):
+        return _args_from_schema(schema)
+    return _legacy_name_args(tool_name)
 
 
 # =============================================================================
@@ -531,6 +646,7 @@ class BaseMCPUser(FastHttpUser):
         self._tool_names: list[str] = []
         self._resource_uris: list[str] = []
         self._prompt_targets: list[PromptTarget] = []
+        self._tool_schemas: dict[str, dict] = {}
 
     def _mcp_path(self) -> str:
         return f"/servers/{self._server_id}/mcp"
@@ -607,6 +723,7 @@ class BaseMCPUser(FastHttpUser):
         self._tool_names = list(target.tool_names)
         self._resource_uris = list(target.resource_uris)
         self._prompt_targets = list(target.prompt_targets)
+        self._tool_schemas = dict(target.tool_schemas)
 
     def _ensure_initialized(self):
         """Initialize the MCP session (once per user lifecycle)."""
@@ -631,8 +748,15 @@ class BaseMCPUser(FastHttpUser):
         self._ensure_initialized()
 
     def _build_tool_args(self, tool_name: str) -> dict:
-        """Build plausible arguments for a tool based on its name."""
-        return _build_tool_args(tool_name)
+        """Build arguments for a tool using the schema discovered for this user's target.
+
+        Args:
+            tool_name: Tool name as returned by ``tools/list``.
+
+        Returns:
+            Argument mapping for ``tools/call``.
+        """
+        return _build_tool_args(tool_name, self._tool_schemas.get(tool_name))
 
 
 # =============================================================================

--- a/tests/performance/performance.md
+++ b/tests/performance/performance.md
@@ -509,7 +509,7 @@ The MCP protocol load test (`locustfile_mcp_protocol.py`) sends JSON-RPC request
 
 | User Class | Weight | Simulates |
 |------------|--------|-----------|
-| `MCPAgentUser` | 10 | Realistic AI agent with up to 6 tools — init, discover, call 1-3 tools per turn |
+| `MCPAgentUser` | 10 | Realistic AI agent — init, discover, call 1-3 tools per turn from the full discovered pool (cap with MCP_BENCHMARK_TOOL_POOL_SIZE) |
 | `MCPToolCallerUser` | 5 | Heavy `tools/call` in tight loop |
 | `MCPDiscoveryUser` | 3 | Discovery-heavy — `tools/list`, `resources/list`, `prompts/list`, templates |
 | `MCPSessionChurnUser` | 2 | New MCP session every cycle (serverless worst-case) |

--- a/tests/unit/loadtest/__init__.py
+++ b/tests/unit/loadtest/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/loadtest/__init__.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for the Locust benchmark scripts in tests/loadtest/.
+"""

--- a/tests/unit/loadtest/conftest.py
+++ b/tests/unit/loadtest/conftest.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/loadtest/conftest.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Importing locust runs gevent.monkey.patch_all() at module import time, which
+deadlocks a pytest process that has already imported the standard library and
+the gateway's own modules. The tests in this package only exercise pure helper
+functions, so the patch is neither needed nor safe here.
+
+pytest imports this conftest before any test module in this directory, so the
+variable is set before locust is first imported.
+"""
+
+# Standard
+import os
+
+os.environ.setdefault("LOCUST_SKIP_MONKEY_PATCH", "1")

--- a/tests/unit/loadtest/test_locustfile_mcp_protocol.py
+++ b/tests/unit/loadtest/test_locustfile_mcp_protocol.py
@@ -224,3 +224,42 @@ def test_server_target_carries_tool_schemas():
         tool_schemas={"fast-time-echo": ECHO_SCHEMA},
     )
     assert target.tool_schemas["fast-time-echo"]["required"] == ["message"]
+
+
+def test_is_denied_matches_gateway_prefixed_names(monkeypatch):
+    """Denylist entries match the trailing segment of a gateway-prefixed name."""
+    monkeypatch.setattr(lf, "MCP_TOOL_DENYLIST", {"schema_error", "flaky"})
+    assert lf._is_denied("fast-time-schema-error") is True
+    assert lf._is_denied("fast-time-flaky") is True
+    assert lf._is_denied("flaky") is True
+
+
+def test_is_denied_does_not_match_unrelated_tools(monkeypatch):
+    """Tools that merely contain a denied substring are not excluded."""
+    monkeypatch.setattr(lf, "MCP_TOOL_DENYLIST", {"schema_error", "flaky"})
+    assert lf._is_denied("fast-time-echo") is False
+    assert lf._is_denied("fast-time-get-system-time") is False
+    assert lf._is_denied("fast-time-schema-success") is False
+    assert lf._is_denied("flakiness-report") is False
+
+
+def test_is_denied_empty_denylist_allows_everything(monkeypatch):
+    """An empty MCP_BENCHMARK_TOOL_DENYLIST disables filtering."""
+    monkeypatch.setattr(lf, "MCP_TOOL_DENYLIST", set())
+    assert lf._is_denied("fast-time-schema-error") is False
+
+
+def test_auto_detect_drops_denylisted_tools(fake_gateway, monkeypatch, caplog):
+    """Discovery removes denylisted tools from the pool and logs the exclusion once."""
+    # Standard
+    import logging
+
+    monkeypatch.setattr(lf, "MCP_TOOL_DENYLIST", {"schema_error", "flaky"})
+    with caplog.at_level(logging.INFO, logger=lf.logger.name):
+        lf._auto_detect("http://gateway.test")
+
+    target = lf._server_targets[0]
+    assert "fast-time-flaky" not in target.tool_names
+    assert "fast-time-schema-error" not in target.tool_names
+    assert "fast-time-verify-protocol" in target.tool_names
+    assert "excluded 2 denylisted" in caplog.text

--- a/tests/unit/loadtest/test_locustfile_mcp_protocol.py
+++ b/tests/unit/loadtest/test_locustfile_mcp_protocol.py
@@ -263,3 +263,117 @@ def test_auto_detect_drops_denylisted_tools(fake_gateway, monkeypatch, caplog):
     assert "fast-time-schema-error" not in target.tool_names
     assert "fast-time-verify-protocol" in target.tool_names
     assert "excluded 2 denylisted" in caplog.text
+
+
+SEVEN_TOOLS = [
+    "fast-time-echo",
+    "fast-time-get-system-time",
+    "fast-time-convert-time",
+    "fast-time-get-stats",
+    "fast-time-schema-success",
+    "fast-time-tool-six",
+    "fast-time-tool-seven",
+]
+
+
+def test_limit_pool_returns_every_tool_by_default(monkeypatch):
+    """Regression for #6082: no tool is excluded by position."""
+    monkeypatch.setattr(lf, "MCP_TOOL_POOL_SIZE", 0)
+    assert lf._limit_pool(SEVEN_TOOLS) == SEVEN_TOOLS
+
+
+def test_limit_pool_applies_configured_ceiling(monkeypatch):
+    """MCP_BENCHMARK_TOOL_POOL_SIZE=6 reproduces the 6-tool agent scenario."""
+    monkeypatch.setattr(lf, "MCP_TOOL_POOL_SIZE", 6)
+    assert lf._limit_pool(SEVEN_TOOLS) == SEVEN_TOOLS[:6]
+
+
+def test_limit_pool_ceiling_larger_than_pool_is_a_noop(monkeypatch):
+    """A ceiling above the tool count returns the full pool."""
+    monkeypatch.setattr(lf, "MCP_TOOL_POOL_SIZE", 50)
+    assert lf._limit_pool(SEVEN_TOOLS) == SEVEN_TOOLS
+
+
+def test_user_tool_pool_uses_all_assigned_tools(monkeypatch):
+    """BaseMCPUser._tool_pool exposes every tool on the assigned target."""
+    monkeypatch.setattr(lf, "MCP_TOOL_POOL_SIZE", 0)
+    user = lf.MCPToolCallerUser.__new__(lf.MCPToolCallerUser)
+    user._tool_names = list(SEVEN_TOOLS)
+    assert user._tool_pool() == SEVEN_TOOLS
+
+
+def test_source_has_no_hardcoded_six_tool_cap():
+    """Guard: the literal [:6] slice must not reappear in the benchmark script."""
+    # Standard
+    from pathlib import Path
+
+    source = Path(lf.__file__).read_text(encoding="utf-8")
+    assert "[:6]" not in source
+
+
+def _make_user(cls, tool_names, monkeypatch):
+    """Build a user instance without Locust's environment, recording MCP calls."""
+    monkeypatch.setattr(lf, "MCP_TOOL_POOL_SIZE", 0)
+    user = cls.__new__(cls)
+    user._tool_names = list(tool_names)
+    user._tool_schemas = {"fast-time-echo": ECHO_SCHEMA, "fast-time-flaky": FLAKY_SCHEMA}
+    user._mcp_session_id = "session-1"
+    user._initialized = True
+    user.calls = []
+    user._mcp_request = lambda method, params, name: user.calls.append((method, params, name))
+    return user
+
+
+def test_tool_caller_calls_a_tool_from_the_full_pool(monkeypatch):
+    """MCPToolCallerUser can select any discovered tool, not just the first six."""
+    user = _make_user(lf.MCPToolCallerUser, SEVEN_TOOLS + ["fast-time-verify-protocol"], monkeypatch)
+    for _ in range(200):
+        user.call_tool()
+    selected = {params["name"] for method, params, _ in user.calls if method == "tools/call"}
+    assert "fast-time-verify-protocol" in selected
+
+
+def test_stress_user_calls_a_tool_from_the_full_pool(monkeypatch):
+    """MCPStressUser uses the same unbounded pool."""
+    user = _make_user(lf.MCPStressUser, SEVEN_TOOLS + ["fast-time-verify-protocol"], monkeypatch)
+    for _ in range(200):
+        user.stress_call_tool()
+    selected = {params["name"] for method, params, _ in user.calls if method == "tools/call"}
+    assert "fast-time-verify-protocol" in selected
+
+
+def test_churn_user_runs_full_lifecycle_and_calls_a_tool(monkeypatch):
+    """MCPSessionChurnUser re-initializes and then calls a tool from the full pool."""
+    user = _make_user(lf.MCPSessionChurnUser, SEVEN_TOOLS, monkeypatch)
+    user.full_lifecycle()
+    methods = [method for method, _, _ in user.calls]
+    assert methods == ["initialize", "tools/list", "tools/call"]
+
+
+def test_agent_user_calls_tools_with_schema_derived_args(monkeypatch):
+    """MCPAgentUser sends schema-derived arguments, not name-guessed ones."""
+    user = _make_user(lf.MCPAgentUser, ["fast-time-echo"], monkeypatch)
+    user.agent_call_tool()
+    user.agent_multi_tool_turn()
+    for method, params, _ in user.calls:
+        assert method == "tools/call"
+        assert set(params["arguments"]) == {"message"}
+
+
+def test_call_sites_no_op_when_no_tools_discovered(monkeypatch):
+    """Every tool-calling task exits quietly when discovery returned nothing."""
+    for cls, method_name in (
+        (lf.MCPToolCallerUser, "call_tool"),
+        (lf.MCPStressUser, "stress_call_tool"),
+        (lf.MCPAgentUser, "agent_call_tool"),
+    ):
+        user = _make_user(cls, [], monkeypatch)
+        getattr(user, method_name)()
+        assert user.calls == []
+
+
+def test_rest_baseline_uses_module_level_pool(monkeypatch):
+    """RESTBaselineUser reads the module-level pool through _limit_pool."""
+    monkeypatch.setattr(lf, "MCP_TOOL_POOL_SIZE", 0)
+    monkeypatch.setattr(lf, "_tool_names", SEVEN_TOOLS + ["fast-time-verify-protocol"])
+    assert "fast-time-verify-protocol" in lf._limit_pool(lf._tool_names)

--- a/tests/unit/loadtest/test_locustfile_mcp_protocol.py
+++ b/tests/unit/loadtest/test_locustfile_mcp_protocol.py
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/loadtest/test_locustfile_mcp_protocol.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for the pure helpers in tests/loadtest/locustfile_mcp_protocol.py.
+
+These cover argument synthesis and tool-pool selection only; they never start a
+Locust runner and never touch the network.
+"""
+
+# Standard
+import os
+
+# Belt and braces: conftest.py in this package sets the same variable, but this
+# keeps the module importable on its own (pytest path args, IDE runners).
+# Importing locust without it runs gevent.monkey.patch_all() and hangs pytest.
+os.environ.setdefault("LOCUST_SKIP_MONKEY_PATCH", "1")
+
+# Third-Party
+import pytest  # noqa: E402
+
+# First-Party
+from tests.loadtest import locustfile_mcp_protocol as lf  # noqa: E402
+
+# Real schemas as returned by ghcr.io/ibm/cfex-mcp-fast-time-server tools/list.
+ECHO_SCHEMA = {
+    "type": "object",
+    "required": ["message"],
+    "properties": {
+        "message": {"type": "string"},
+        "delay": {"type": "integer"},
+        "delay_stddev": {"type": "number"},
+    },
+}
+FLAKY_SCHEMA = {
+    "type": "object",
+    "required": ["key"],
+    "properties": {"key": {"type": "string"}, "fail_times": {"type": "integer"}},
+}
+CONVERT_SCHEMA = {
+    "type": "object",
+    "required": ["time", "source_timezone", "target_timezone"],
+    "properties": {
+        "time": {"type": "string"},
+        "source_timezone": {"type": "string"},
+        "target_timezone": {"type": "string"},
+    },
+}
+GET_STATS_SCHEMA = {"type": "object", "properties": {}}
+
+
+def test_args_from_schema_only_includes_required_properties():
+    """Optional properties are omitted so payloads stay minimal."""
+    args = lf._args_from_schema(ECHO_SCHEMA)
+    assert set(args) == {"message"}
+    assert isinstance(args["message"], str)
+
+
+def test_args_from_schema_handles_multiple_required_strings():
+    """Every required property gets a value of the declared type."""
+    args = lf._args_from_schema(CONVERT_SCHEMA)
+    assert set(args) == {"time", "source_timezone", "target_timezone"}
+    assert all(isinstance(v, str) for v in args.values())
+    assert args["source_timezone"] in lf.TIMEZONES
+    assert args["target_timezone"] in lf.TIMEZONES
+
+
+def test_args_from_schema_empty_schema_returns_empty_dict():
+    """A tool with no required properties is called with no arguments."""
+    assert lf._args_from_schema(GET_STATS_SCHEMA) == {}
+
+
+@pytest.mark.parametrize(
+    "spec,expected_type",
+    [
+        ({"type": "string"}, str),
+        ({"type": "integer"}, int),
+        ({"type": "number"}, float),
+        ({"type": "boolean"}, bool),
+        ({"type": "array"}, list),
+        ({"type": "object"}, dict),
+    ],
+)
+def test_synth_value_respects_declared_type(spec, expected_type):
+    """Each JSON Schema scalar/container type maps to a matching Python value."""
+    assert isinstance(lf._synth_value("field", spec), expected_type)
+
+
+def test_synth_value_prefers_enum_then_default():
+    """Enum wins over type guessing; default wins when no enum is present."""
+    assert lf._synth_value("mode", {"type": "string", "enum": ["alpha", "beta"]}) == "alpha"
+    assert lf._synth_value("mode", {"type": "string", "default": "preset"}) == "preset"
+
+
+def test_synth_value_nullable_union_type_uses_first_non_null():
+    """A ["string", "null"] union synthesizes a string, not None."""
+    assert isinstance(lf._synth_value("field", {"type": ["string", "null"]}), str)
+
+
+def test_build_tool_args_uses_schema_for_gateway_prefixed_echo():
+    """Regression for #6082: 'fast-time-echo' must not receive a timezone."""
+    args = lf._build_tool_args("fast-time-echo", ECHO_SCHEMA)
+    assert set(args) == {"message"}
+
+
+def test_build_tool_args_uses_schema_for_unknown_tool_name():
+    """A tool whose name matches no keyword still gets valid required args."""
+    args = lf._build_tool_args("fast-time-flaky", FLAKY_SCHEMA)
+    assert set(args) == {"key"}
+    assert isinstance(args["key"], str) and args["key"]
+
+
+def test_build_tool_args_reads_registered_schema_when_none_passed(monkeypatch):
+    """Module-level schema registry is consulted when no schema is supplied."""
+    monkeypatch.setattr(lf, "_tool_schemas", {"fast-time-echo": ECHO_SCHEMA})
+    assert set(lf._build_tool_args("fast-time-echo")) == {"message"}
+
+
+def test_build_tool_args_falls_back_to_name_heuristic_without_schema(monkeypatch):
+    """MCP_TOOL_NAMES override path has no schemas; echo must beat the time branch."""
+    monkeypatch.setattr(lf, "_tool_schemas", {})
+    assert set(lf._build_tool_args("fast-time-echo")) == {"message"}
+    assert set(lf._build_tool_args("fast-time-get-system-time")) == {"timezone"}
+    assert set(lf._build_tool_args("fast-time-convert-time")) == {"time", "source_timezone", "target_timezone"}
+
+
+class _FakeResponse:
+    """Minimal stand-in for a requests.Response."""
+
+    def __init__(self, payload, headers=None):
+        self._payload = payload
+        self.headers = headers or {}
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+@pytest.fixture()
+def fake_gateway(monkeypatch):
+    """Stub the `requests` module that _auto_detect imports, serving a fixed inventory."""
+    # Standard
+    import sys
+    import types
+
+    tools = [
+        {"name": "fast-time-echo", "inputSchema": ECHO_SCHEMA},
+        {"name": "fast-time-flaky", "inputSchema": FLAKY_SCHEMA},
+        {"name": "fast-time-convert-time", "inputSchema": CONVERT_SCHEMA},
+        {"name": "fast-time-get-stats", "inputSchema": GET_STATS_SCHEMA},
+        {"name": "fast-time-schema-error", "inputSchema": GET_STATS_SCHEMA},
+        {"name": "fast-time-verify-protocol"},  # no inputSchema at all
+    ]
+
+    def fake_get(url, headers=None, timeout=None):
+        return _FakeResponse([{"id": "srv-1", "enabled": True, "associatedTools": ["a"]}])
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        method = json.get("method")
+        if method == "initialize":
+            return _FakeResponse({"result": {"serverInfo": {"name": "fast-time"}}}, {"Mcp-Session-Id": "sid-1"})
+        if method == "tools/list":
+            return _FakeResponse({"result": {"tools": tools}})
+        return _FakeResponse({"result": {}})
+
+    module = types.ModuleType("requests")
+    module.get = fake_get
+    module.post = fake_post
+    monkeypatch.setitem(sys.modules, "requests", module)
+    monkeypatch.setattr(lf, "_server_targets", [])
+    monkeypatch.setattr(lf, "_tool_schemas", {})
+    monkeypatch.setattr(lf, "MCP_TOOL_NAMES_STR", "")
+    return tools
+
+
+def test_auto_detect_captures_input_schemas(fake_gateway, monkeypatch):
+    """Discovery stores each tool's inputSchema on the target and in the module registry."""
+    # raising=False: MCP_TOOL_DENYLIST does not exist until Task 2. Pinning it to
+    # an empty set keeps this test independent of the denylist default either way.
+    monkeypatch.setattr(lf, "MCP_TOOL_DENYLIST", set(), raising=False)
+    lf._auto_detect("http://gateway.test")
+    target = lf._server_targets[0]
+    assert target.tool_schemas["fast-time-echo"]["required"] == ["message"]
+    assert lf._tool_schemas == target.tool_schemas
+    assert "fast-time-verify-protocol" not in target.tool_schemas  # no schema published for it
+
+
+def test_auto_detect_warns_about_tools_without_schema(fake_gateway, monkeypatch, caplog):
+    """A schema-less tool is reported, not silently called with guessed args."""
+    # Standard
+    import logging
+
+    monkeypatch.setattr(lf, "MCP_TOOL_DENYLIST", set(), raising=False)  # attribute arrives in Task 2
+    with caplog.at_level(logging.WARNING, logger=lf.logger.name):
+        lf._auto_detect("http://gateway.test")
+    assert "fast-time-verify-protocol" in caplog.text
+
+
+def test_server_target_carries_tool_schemas():
+    """ServerTarget exposes the discovered per-tool inputSchema map."""
+    target = lf.ServerTarget(
+        server_id="s1",
+        server_name="fast-time",
+        tool_names=["fast-time-echo"],
+        resource_uris=[],
+        prompt_targets=[],
+        tool_schemas={"fast-time-echo": ECHO_SCHEMA},
+    )
+    assert target.tool_schemas["fast-time-echo"]["required"] == ["message"]

--- a/tests/unit/loadtest/test_locustfile_mcp_protocol.py
+++ b/tests/unit/loadtest/test_locustfile_mcp_protocol.py
@@ -125,6 +125,20 @@ def test_build_tool_args_falls_back_to_name_heuristic_without_schema(monkeypatch
     assert set(lf._build_tool_args("fast-time-convert-time")) == {"time", "source_timezone", "target_timezone"}
 
 
+def test_build_tool_args_respects_empty_schema_over_name_heuristic():
+    """A genuinely zero-argument schema must win even when the tool name matches a heuristic.
+
+    Regression for a narrower #6082 variant: a schema with `properties: {}` and no
+    `required` list is falsy on both counts, so a truthiness check on its contents
+    would mistake it for "no schema" and fall through to the name heuristic. A
+    heuristic-matching name (contains "timezone") must not override an explicitly
+    declared empty schema.
+    """
+    schema = {"type": "object", "properties": {}}
+    args = lf._build_tool_args("fast-time-timezone-lookup", schema)
+    assert args == {}
+
+
 class _FakeResponse:
     """Minimal stand-in for a requests.Response."""
 

--- a/tests/unit/loadtest/test_locustfile_mcp_protocol.py
+++ b/tests/unit/loadtest/test_locustfile_mcp_protocol.py
@@ -249,6 +249,41 @@ def test_is_denied_empty_denylist_allows_everything(monkeypatch):
     assert lf._is_denied("fast-time-schema-error") is False
 
 
+def test_empty_denylist_env_var_disables_filtering(monkeypatch):
+    """MCP_BENCHMARK_TOOL_DENYLIST="" must actually disable filtering, not fall through to the default.
+
+    Regression for the final review of #6082: ``_cfg()`` resolves via
+    ``os.environ.get(key) or default``, so an explicitly empty env var is falsy and
+    silently loses to the default. The other denylist tests in this file only
+    monkeypatch the already-parsed ``MCP_TOOL_DENYLIST`` set, which can't catch a bug
+    in the parsing itself — this test reloads the module so the env var is actually
+    re-parsed.
+    """
+    # Standard
+    import importlib
+
+    monkeypatch.setenv("MCP_BENCHMARK_TOOL_DENYLIST", "")
+    try:
+        importlib.reload(lf)
+        assert lf.MCP_TOOL_DENYLIST == set()
+    finally:
+        monkeypatch.delenv("MCP_BENCHMARK_TOOL_DENYLIST", raising=False)
+        importlib.reload(lf)  # restore default state for subsequent tests
+
+
+def test_missing_denylist_env_var_keeps_default(monkeypatch):
+    """Without the env var set at all, the default schema_error,flaky denylist still applies."""
+    # Standard
+    import importlib
+
+    monkeypatch.delenv("MCP_BENCHMARK_TOOL_DENYLIST", raising=False)
+    try:
+        importlib.reload(lf)
+        assert lf.MCP_TOOL_DENYLIST == {"schema_error", "flaky"}
+    finally:
+        importlib.reload(lf)  # restore default state for subsequent tests
+
+
 def test_auto_detect_drops_denylisted_tools(fake_gateway, monkeypatch, caplog):
     """Discovery removes denylisted tools from the pool and logs the exclusion once."""
     # Standard


### PR DESCRIPTION
## Summary

`make benchmark-mcp-tools` discovers fast-time-server tools via `tools/list` at
startup and calls them at random. Three bugs made that signal unreliable:

1. **Wrong arguments.** `_build_tool_args` guessed arguments from substrings in
   the tool name. The gateway prefixes every tool with `fast-time-`, so every
   name contains the substring `time` — `fast-time-echo` was called with
   `{"timezone": ...}` instead of `{"message": ...}` and rejected with
   `-32602`. This is worse than the issue described: it broke the tool the
   heuristic was written for (`echo`), not just unrecognized tools.
2. **No pool cap escape.** Five call sites (not the two the issue names)
   hard-capped the benchmark to the first 6 discovered tools
   (`self._tool_names[:6]`), silently dropping any tool beyond that.
3. **Unpinned image.** `docker-compose.yml` tracked `:latest` for the
   fast-time-server on both services, so `docker compose pull` could change
   the tool inventory under the benchmark with no local signal. Verified this
   already happened: the image `:latest` points to today differs from the one
   cached locally a month ago, and adds an 8th tool (`verify-protocol`).

Measured before this PR: `make benchmark-mcp-tools` reports **~30% failures**
(reproducing the 31.56% recorded in `docs/release/benchmark.md`). After: **0%**
on a healthy stack (2,112 requests, 0 failures — full numbers below).

## Fix

- **Schema-driven argument synthesis.** `_build_tool_args` now reads each
  tool's `inputSchema` (captured during `tools/list` discovery) and
  synthesizes arguments for its `required` properties via `_args_from_schema`
  / `_synth_value`. The old name-substring heuristic (`_legacy_name_args`) is
  kept only as a fallback for the `MCP_TOOL_NAMES` override path, where no
  schema exists — with `echo`/`convert` checked before the generic
  `time`/`timezone` branch, since gateway-prefixed names all contain `time`.
- **Denylist.** `MCP_BENCHMARK_TOOL_DENYLIST` (default `schema_error,flaky`)
  excludes the server's two deliberate failure-injection fixtures from the
  discovered pool at `_auto_detect` time, so they don't skew throughput
  numbers. Schemas can't express "designed to fail," so this is a second
  mechanism alongside the schema-driven arguments, not a replacement for it.
- **Unbounded tool pool.** All five `[:6]` call sites now route through
  `_limit_pool()`, gated by `MCP_BENCHMARK_TOOL_POOL_SIZE` (default `0` =
  every discovered tool; set to `6` to reproduce the original customer
  scenario). Plumbed through six env-var injection sites in the Makefile
  (two different indentation levels — the two-tab and three-tab forms are
  literal suffixes of each other, so each site was edited individually to
  avoid a find-and-replace corrupting the three-tab worker-loop lines).
- **Pinned image.** Both `fast_time_server` and `fast_test_server` now pin
  `ghcr.io/ibm/cfex-mcp-fast-time-server` by digest
  (`sha256:2f095509d5...`, equivalent to commit tag `9b97731f...`), both
  still honoring `FAST_TIME_IMAGE` for local overrides. Pinned by digest
  rather than a version tag because this image has no semver tags — GHCR
  holds only `latest` and commit-SHA tags.

## Scope decision: the OpenShift chart fork

`charts/mcp-stack/files/ocp/locustfile_mcp_protocol.py` is a ~1,000-line fork
of the benchmark script, deployed via
`charts/mcp-stack/profiles/ocp/values-pgo.yaml`. It is **not** in #6082's file
list, but it carried all three bugs, including a worse branch order in its
argument heuristic (`time` checked before `convert`, so `convert_time` was
*always* rejected there). Leaving it unfixed means OpenShift benchmark runs
keep reporting inflated failure rates after this merges. Included it in this
PR rather than filing a follow-up, since the fix is a mechanical, verified
port of the same logic.

## A bug found and fixed during review, not in the original issue

Final review surfaced two Important findings, both fixed and re-reviewed clean:

- `MCP_BENCHMARK_TOOL_DENYLIST=""` was documented as disabling the denylist
  but was a no-op — the shared `_cfg()` helper's `or`-chaining treats an
  empty string as falsy and falls through to the default. Fixed by parsing
  this one variable directly against env-var presence instead of `_cfg()`.
- `MCPSessionChurnUser.on_start` was `pass` (pre-existing, predates this PR),
  so it never called `_assign_target()` — every request from that user class
  targeted a broken path (`/servers//mcp`) and its `tools/call` step was
  silently always skipped. Fixed since it's one line in a method this PR's
  pool-cap task already touched, and the OpenShift fork's equivalent method
  was already correct — leaving it unfixed here would have left the two
  files diverged for no reason.

## Verification

Full validation gate, run once at the end against the final branch state:

| Check | Result |
|---|---|
| `make ruff` (changed files) | main locustfile clean; OCP fork 21 findings, down from 22 pre-branch, no new ones |
| `make pylint` (main locustfile) | 9.59/10 |
| `make test` | 21,754 passed, 0 failed |
| `make coverage diff-cover` | 98% total; touched files are outside `mcpgateway`'s instrumented coverage scope, so diff-cover has nothing to gate |
| `make detect-secrets-scan` | clean; baseline refreshed only for Makefile line-number drift from the new env-var injections |
| `make testing-up` | stack healthy, confirmed the pinned digest is what's actually running |
| `make benchmark-mcp-tools` | **0 failures / 2,112 requests** (30s run, 125 users) |

Additional live checks against the running stack:
- `tools/list` through the gateway reports 8 tools including `verify-protocol`
  (the tool that used to sit beyond the `[:6]` boundary).
- Direct `MCPAgentUser` run: all 6 non-denylisted tools called, 0 failures on
  each, including `verify-protocol`.
- `MCP_BENCHMARK_TOOL_DENYLIST=` (empty) now reports `tools=8` with no
  exclusion — confirming the opt-out fix.
- Sibling `tests/loadtest/locustfile.py` (untouched by this PR) still
  imports cleanly; `docker compose config` still resolves both services to
  the pinned digest with `FAST_TIME_IMAGE` override intact; OCP fork parses.

## Known follow-ups (not filed as issues yet, flagging for the reviewer)

- Four different pinned references to the same fast-time-server image now
  coexist (this PR's digest pin, two commit-tag pins in
  `plugin-integration.yml` / `run_plugin_tests.sh`, and `wrapper.yml`'s
  `:latest`). Worth a follow-up chore to unify.
- `tests/loadtest/locustfile.py`'s hand-maintained `TOOLS_WITH_REQUIRED_ARGS`
  list could be replaced by the same schema-driven approach — separate issue,
  large blast radius (8k+ lines).
- `schema_error` returns `isError: true` inside a successful JSON-RPC
  response, so it currently counts as a benchmark success. Whether MCP-level
  tool errors should count as failures is a deliberate metric change, not
  something this PR decided unilaterally.

Closes #6082