### PR TITLE
feat(ui-rewrite): match Figma design for Settings Users/Teams tables and forms

### DIFF
--- a/client/e2e/users.spec.ts
+++ b/client/e2e/users.spec.ts
@@ -59,7 +59,7 @@ test.describe("Users page", () => {
     await page.waitForLoadState("networkidle");
 
     const main = page.getByRole("main");
-    await expect(page.getByRole("heading", { name: "Users" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Users", exact: true })).toBeVisible();
     await expect(main.getByText("John Doe")).toBeVisible();
     await expect(main.getByText("john@example.com")).toBeVisible();
     await expect(page.getByRole("cell", { name: "User" })).toBeVisible();
@@ -78,7 +78,23 @@ test.describe("Users page", () => {
     await page.goto("/app/users");
 
     await expect(page).toHaveURL(/\/app\/settings\/users/);
-    await expect(page.getByRole("heading", { name: "Users" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Users", exact: true })).toBeVisible();
+  });
+
+  test("preserves the query string when redirecting the legacy /app/users route", async ({
+    page,
+  }) => {
+    await page.route("**/auth/email/admin/users?*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ users: [MOCK_USER] }),
+      });
+    });
+
+    await page.goto("/app/users?selected=john%40example.com");
+
+    await expect(page).toHaveURL(/\/app\/settings\/users\?selected=john%40example\.com/);
   });
 
   test("loads more users when pagination cursor is present", async ({ page }) => {
@@ -155,7 +171,7 @@ test.describe("Users page", () => {
     await page.getByRole("button", { name: "Create User" }).click();
 
     await expect.poll(() => createCount).toBe(1);
-    await expect(page.getByRole("heading", { name: "Users" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Users", exact: true })).toBeVisible();
     await expect(page.getByText("newuser@example.com")).toBeVisible();
   });
 
@@ -175,17 +191,24 @@ test.describe("Users page", () => {
       await expect(page.getByRole("heading", { name: "Create User" })).toBeVisible();
     });
 
-    test("email is required", async ({ page }) => {
+    test("keeps Create User disabled until required fields are filled", async ({ page }) => {
+      const submit = page.getByRole("button", { name: "Create User" });
+      await expect(submit).toBeDisabled();
+
+      await page.locator("#user-email").fill("user@example.com");
+      await expect(submit).toBeDisabled();
+
       await page.locator("#user-password").fill("securepassword");
+      await expect(submit).toBeDisabled();
+
       await page.locator("#user-confirm-password").fill("securepassword");
-
-      await page.getByRole("button", { name: "Create User" }).click();
-
-      await expect(page.getByText("Invalid email address")).toBeVisible();
+      await expect(submit).toBeEnabled();
     });
 
-    test("password is required", async ({ page }) => {
+    test("shows an error for a too-short password", async ({ page }) => {
       await page.locator("#user-email").fill("user@example.com");
+      await page.locator("#user-password").fill("short");
+      await page.locator("#user-confirm-password").fill("short");
 
       await page.getByRole("button", { name: "Create User" }).click();
 
@@ -268,7 +291,7 @@ test.describe("Users page", () => {
     await page.getByRole("button", { name: "Save Changes" }).click();
 
     await expect.poll(() => patchCount).toBe(1);
-    await expect(page.getByRole("heading", { name: "Users" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Users", exact: true })).toBeVisible();
     await expect(page.getByText("John Updated")).toBeVisible();
     await expect(
       page.locator("[data-sonner-toast]").filter({ hasText: /updated successfully/ }),

--- a/client/src/components/servers/ServersTable.tsx
+++ b/client/src/components/servers/ServersTable.tsx
@@ -160,7 +160,7 @@ export function ServersTable({
     <div className="overflow-hidden">
       <Table className="min-w-full border-separate border-spacing-y-1.5">
         <TableCaption className="sr-only">List of MCP servers with status and actions</TableCaption>
-        <TableHeader className="bg-white dark:bg-transparent">
+        <TableHeader className="bg-main">
           <TableRow className="border-none hover:bg-transparent">
             <TableHead className="border-b border-border h-12 px-4 text-xs font-medium text-neutral-600 dark:text-neutral-400">
               Name
@@ -200,7 +200,7 @@ export function ServersTable({
             return (
               <TableRow
                 key={server.id}
-                className="bg-neutral-50 dark:bg-neutral-800 hover:bg-neutral-100 dark:hover:bg-neutral-700/60 [&>td:first-child]:rounded-l-lg [&>td:last-child]:rounded-r-lg"
+                className="bg-white dark:bg-neutral-800 hover:bg-neutral-100 dark:hover:bg-neutral-700/60 [&>td:first-child]:rounded-l-lg [&>td:last-child]:rounded-r-lg"
               >
                 <TableCell className="px-4 py-2.5">
                   <div className="flex items-center gap-3">

--- a/client/src/components/settings/settings-toolbar.tsx
+++ b/client/src/components/settings/settings-toolbar.tsx
@@ -1,0 +1,45 @@
+import { createContext, useContext, useEffect } from "react";
+import { createPortal } from "react-dom";
+import type { ReactNode } from "react";
+
+interface SettingsTabsContextValue {
+  /**
+   * DOM node of the Settings tab-row toolbar slot, or `null` when a page is
+   * rendered outside the Settings shell (e.g. in isolation in tests).
+   */
+  toolbar: HTMLElement | null;
+  /** Hide or show the Settings tab strip (and its toolbar). */
+  setTabsHidden: (hidden: boolean) => void;
+}
+
+const SettingsTabsContext = createContext<SettingsTabsContextValue>({
+  toolbar: null,
+  setTabsHidden: () => {},
+});
+
+export const SettingsTabsProvider = SettingsTabsContext.Provider;
+
+/**
+ * Renders its children into the Settings tab-row toolbar slot when available,
+ * so a tab's actions (search, create, …) sit on the same line as the tab
+ * triggers. When no slot is present it falls back to rendering inline, which
+ * keeps the hosted page usable on its own.
+ */
+export function SettingsToolbar({ children }: { children: ReactNode }) {
+  const { toolbar } = useContext(SettingsTabsContext);
+  if (toolbar) return createPortal(children, toolbar);
+  return <>{children}</>;
+}
+
+/**
+ * Hides the Settings tab strip (the Users/Teams tabs and their toolbar) while
+ * `hidden` is true — e.g. when a hosted page shows a full-page create or edit
+ * form. No-ops when the page is rendered outside the Settings shell.
+ */
+export function useHideSettingsTabs(hidden: boolean) {
+  const { setTabsHidden } = useContext(SettingsTabsContext);
+  useEffect(() => {
+    setTabsHidden(hidden);
+    return () => setTabsHidden(false);
+  }, [hidden, setTabsHidden]);
+}

--- a/client/src/components/teams/TeamForm.test.tsx
+++ b/client/src/components/teams/TeamForm.test.tsx
@@ -158,17 +158,17 @@ describe("TeamForm", () => {
         expect(memberInput).toHaveValue("Alice (alice@example.com)");
       });
 
-      // Change the role from owner -> member (fires the role change handler).
+      // Change the role from member -> owner (fires the role change handler).
       // The member row's role Select is the first select-trigger in the form.
       const roleTrigger = document.querySelectorAll<HTMLElement>('[data-slot="select-trigger"]')[0];
-      expect(roleTrigger).toHaveTextContent("owner");
+      expect(roleTrigger).toHaveTextContent("member");
 
       await user.click(roleTrigger);
-      const memberOption = await screen.findByRole("option", { name: /^member$/i });
-      await user.click(memberOption);
+      const ownerOption = await screen.findByRole("option", { name: /^owner$/i });
+      await user.click(ownerOption);
 
       await waitFor(() => {
-        expect(roleTrigger).toHaveTextContent("member");
+        expect(roleTrigger).toHaveTextContent("owner");
       });
     });
 
@@ -176,7 +176,7 @@ describe("TeamForm", () => {
       const user = userEvent.setup();
       renderForm();
 
-      // Starts with one owner row -> one Remove button.
+      // Starts with one member row -> one Remove button.
       expect(screen.getAllByRole("button", { name: /remove/i })).toHaveLength(1);
 
       await user.click(screen.getByRole("button", { name: /add team member/i }));

--- a/client/src/components/teams/TeamForm.tsx
+++ b/client/src/components/teams/TeamForm.tsx
@@ -115,7 +115,7 @@ export function TeamForm({ isOpen, onToggle, onSuccess, team }: TeamFormProps) {
                 onChange={(e) => setName(e.target.value)}
                 placeholder={intl.formatMessage({ id: "teams.create.namePlaceholder" })}
                 disabled={isSubmitting}
-                className="h-10 border-neutral-300 dark:border-neutral-700"
+                className="h-10 border-neutral-300 shadow-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0 dark:border-neutral-700"
               />
               <p className="text-xs text-neutral-500 dark:text-neutral-400">
                 {intl.formatMessage({ id: "teams.create.nameHint" })}
@@ -130,7 +130,7 @@ export function TeamForm({ isOpen, onToggle, onSuccess, team }: TeamFormProps) {
               aria-label={intl.formatMessage({ id: "teams.create.descriptionLabel" })}
               disabled={isSubmitting}
               rows={3}
-              className="resize-none border-neutral-300 dark:border-neutral-700"
+              className="resize-none border-neutral-300 focus-visible:ring-1 focus-visible:ring-offset-0 dark:border-neutral-700"
             />
 
             {/* Visibility */}
@@ -208,7 +208,7 @@ export function TeamForm({ isOpen, onToggle, onSuccess, team }: TeamFormProps) {
                         emptyText={intl.formatMessage({ id: "teams.create.memberPlaceholder" })}
                         allowCustomValue={false}
                         disabled={isSubmitting}
-                        className="h-10 border-neutral-300 dark:border-neutral-700"
+                        className="h-10 border-neutral-300 shadow-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0 dark:border-neutral-700"
                       />
                       <Select
                         value={member.role}
@@ -217,7 +217,7 @@ export function TeamForm({ isOpen, onToggle, onSuccess, team }: TeamFormProps) {
                         }
                         disabled={isSubmitting}
                       >
-                        <SelectTrigger className="h-10 w-full border-neutral-300 dark:border-neutral-700">
+                        <SelectTrigger className="h-10 w-full border-neutral-300 shadow-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0 dark:border-neutral-700">
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
@@ -269,7 +269,7 @@ export function TeamForm({ isOpen, onToggle, onSuccess, team }: TeamFormProps) {
               <Select value={maxMembers} onValueChange={setMaxMembers} disabled={isSubmitting}>
                 <SelectTrigger
                   id="max-members"
-                  className="h-10 w-full border-neutral-300 dark:border-neutral-700"
+                  className="h-10 w-full border-neutral-300 shadow-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0 dark:border-neutral-700"
                 >
                   <SelectValue />
                 </SelectTrigger>

--- a/client/src/components/teams/TeamsTable.tsx
+++ b/client/src/components/teams/TeamsTable.tsx
@@ -63,7 +63,7 @@ export function TeamsTable({
         <TableCaption className="sr-only">
           {intl.formatMessage({ id: "teams.table.caption" })}
         </TableCaption>
-        <TableHeader className="bg-white dark:bg-transparent">
+        <TableHeader className="bg-main">
           <TableRow className="border-none hover:bg-transparent">
             <TableHead className="border-b border-border h-12 px-4 text-xs font-medium text-neutral-600 dark:text-neutral-400">
               {intl.formatMessage({ id: "teams.table.name" })}
@@ -92,7 +92,7 @@ export function TeamsTable({
             return (
               <TableRow
                 key={team.id}
-                className="bg-neutral-50 dark:bg-neutral-800 hover:bg-neutral-100 dark:hover:bg-neutral-700/60 [&>td:first-child]:rounded-l-lg [&>td:last-child]:rounded-r-lg"
+                className="bg-white dark:bg-neutral-800 hover:bg-neutral-100 dark:hover:bg-neutral-700/60 [&>td:first-child]:rounded-l-lg [&>td:last-child]:rounded-r-lg"
               >
                 <TableCell className="px-4 py-2.5">
                   <div className="flex items-center gap-3">

--- a/client/src/components/users/PasswordInput.tsx
+++ b/client/src/components/users/PasswordInput.tsx
@@ -57,7 +57,7 @@ export function PasswordInput({
           value={value}
           onChange={(event) => onChange(event.target.value)}
           placeholder={placeholder}
-          className="rounded-md border-neutral-300 px-4 pr-10 text-sm text-neutral-900 shadow-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0 placeholder:text-neutral-400 dark:border-neutral-700 dark:text-neutral-100 dark:placeholder:text-neutral-500"
+          className="h-10 border-neutral-300 pr-10 shadow-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0 dark:border-neutral-700"
           aria-invalid={!!error}
           aria-describedby={error ? errorId : hint ? hintId : undefined}
         />

--- a/client/src/components/users/UserActionsMenu.test.tsx
+++ b/client/src/components/users/UserActionsMenu.test.tsx
@@ -58,13 +58,15 @@ describe("UserActionsMenu", () => {
     expect(onDelete).toHaveBeenCalledWith(mockUser.email);
   });
 
-  it("delete menu item has red text class", async () => {
+  it("delete menu item shares the default (non-destructive) text color of edit", async () => {
     const user = userEvent.setup();
     renderWithProviders(
       <UserActionsMenu user={mockUser} displayName="Alice" onEdit={vi.fn()} onDelete={vi.fn()} />,
     );
     await user.click(screen.getByRole("button"));
+    const editItem = await screen.findByRole("menuitem", { name: /edit/i });
     const deleteItem = await screen.findByRole("menuitem", { name: /delete/i });
-    expect(deleteItem.className).toContain("text-red");
+    expect(deleteItem.className).not.toContain("text-red");
+    expect(deleteItem.className).toBe(editItem.className);
   });
 });

--- a/client/src/components/users/UserActionsMenu.tsx
+++ b/client/src/components/users/UserActionsMenu.tsx
@@ -1,4 +1,4 @@
-import { Edit, MoreVertical, Trash2 } from "lucide-react";
+import { MoreVertical } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -38,15 +38,9 @@ export function UserActionsMenu({ user, displayName, onEdit, onDelete }: UserAct
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" role="menu">
         <DropdownMenuItem onClick={() => onEdit(user)} role="menuitem">
-          <Edit className="mr-2 h-4 w-4" aria-hidden="true" />
           {intl.formatMessage({ id: "users.table.actions.edit" })}
         </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => onDelete(user.email)}
-          className="text-red-600 dark:text-red-400"
-          role="menuitem"
-        >
-          <Trash2 className="mr-2 h-4 w-4" aria-hidden="true" />
+        <DropdownMenuItem onClick={() => onDelete(user.email)} role="menuitem">
           {intl.formatMessage({ id: "users.table.actions.delete" })}
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/client/src/components/users/UserForm.test.tsx
+++ b/client/src/components/users/UserForm.test.tsx
@@ -312,6 +312,9 @@ describe("UserForm", () => {
       });
       vi.mocked(useUserFormModule.useUserForm).mockReturnValue({
         ...defaultFormState,
+        email: "user@example.com",
+        password: "securepassword", // pragma: allowlist secret
+        confirmPassword: "securepassword", // pragma: allowlist secret
         handleSubmit,
         isValid: true,
       });
@@ -334,6 +337,9 @@ describe("UserForm", () => {
       });
       vi.mocked(useUserFormModule.useUserForm).mockReturnValue({
         ...defaultFormState,
+        email: "user@example.com",
+        password: "securepassword", // pragma: allowlist secret
+        confirmPassword: "securepassword", // pragma: allowlist secret
         handleSubmit,
         isValid: true,
       });
@@ -356,6 +362,9 @@ describe("UserForm", () => {
       });
       vi.mocked(useUserFormModule.useUserForm).mockReturnValue({
         ...defaultFormState,
+        email: "user@example.com",
+        password: "securepassword", // pragma: allowlist secret
+        confirmPassword: "securepassword", // pragma: allowlist secret
         handleSubmit,
         isValid: true,
       });
@@ -371,16 +380,27 @@ describe("UserForm", () => {
       });
     });
 
-    it("should keep submit button enabled when form is invalid", () => {
+    it("disables submit button when required fields are empty (create mode)", () => {
       vi.mocked(useUserFormModule.useUserForm).mockReturnValue({
         ...defaultFormState,
-        isValid: false,
       });
 
       render(<UserForm isOpen={true} onToggle={vi.fn()} />, { wrapper });
 
-      const submitButton = screen.getByText("Create User");
-      expect(submitButton).toBeEnabled();
+      expect(screen.getByText("Create User")).toBeDisabled();
+    });
+
+    it("enables submit button once required fields are filled", () => {
+      vi.mocked(useUserFormModule.useUserForm).mockReturnValue({
+        ...defaultFormState,
+        email: "user@example.com",
+        password: "securepassword", // pragma: allowlist secret
+        confirmPassword: "securepassword", // pragma: allowlist secret
+      });
+
+      render(<UserForm isOpen={true} onToggle={vi.fn()} />, { wrapper });
+
+      expect(screen.getByText("Create User")).toBeEnabled();
     });
 
     it("should disable submit button when submitting", () => {

--- a/client/src/components/users/UserForm.tsx
+++ b/client/src/components/users/UserForm.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ChevronDown, User } from "lucide-react";
+import { ChevronDown, Lock, User } from "lucide-react";
 import { useIntl } from "react-intl";
 import { BackButton } from "@/components/ui/back-button";
 import { Button } from "@/components/ui/button";
@@ -110,6 +110,12 @@ export function UserForm({
 
   const [advancedOpen, setAdvancedOpen] = React.useState(isEditMode);
 
+  // In create mode, keep the submit button disabled until every required field
+  // (email + both password fields) has a value. Edit mode has no such gate:
+  // email is fixed and the password is optional.
+  const requiredFieldsMissing =
+    !isEditMode && (!email.trim() || password.length === 0 || confirmPassword.length === 0);
+
   const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     handleSubmit(
       event,
@@ -133,14 +139,14 @@ export function UserForm({
 
       <div className="rounded-xl border border-neutral-200 bg-inherit p-0 shadow-[0_12px_40px_rgba(15,23,42,0.12)] dark:border-neutral-800">
         <div className="flex flex-col gap-8 p-6 sm:p-8">
-          <div className="flex flex-col gap-4">
-            <div className="flex items-center gap-3">
-              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-sm bg-blue-500 text-white shadow-sm">
-                <User className="h-5 w-5" />
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center gap-2.5">
+              <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-sm bg-emerald-500 shadow-sm">
+                <User className="h-4 w-4 text-white" />
               </div>
               <h2
                 id="user-form-title"
-                className="text-2xl font-semibold tracking-tight text-neutral-950 dark:text-neutral-50"
+                className="align-middle text-base font-semibold leading-6 tracking-normal text-neutral-950 dark:text-neutral-50"
               >
                 {intl.formatMessage({
                   id: isEditMode ? "users.edit.dialog.title" : "users.form.title",
@@ -162,8 +168,19 @@ export function UserForm({
                   <p className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
                     {intl.formatMessage({ id: "users.form.email" })}
                   </p>
-                  <p className="rounded-md border border-neutral-200 bg-neutral-50 px-4 py-2 text-sm text-neutral-600 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-400">
-                    {user?.email}
+                  <div
+                    className="flex h-10 cursor-not-allowed items-center justify-between gap-2 rounded-md border border-neutral-300 bg-neutral-50 px-4 text-sm text-neutral-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-400"
+                    title={intl.formatMessage({ id: "users.form.email.readonly" })}
+                    aria-disabled="true"
+                  >
+                    <span className="truncate">{user?.email}</span>
+                    <Lock
+                      className="h-4 w-4 shrink-0 text-neutral-400 dark:text-neutral-500"
+                      aria-hidden="true"
+                    />
+                  </div>
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                    {intl.formatMessage({ id: "users.form.email.readonly" })}
                   </p>
                 </>
               ) : (
@@ -180,7 +197,7 @@ export function UserForm({
                     value={email}
                     onChange={(event) => setEmail(event.target.value)}
                     placeholder={intl.formatMessage({ id: "users.form.email.placeholder" })}
-                    className="rounded-md border-neutral-300 bg-white px-4 text-sm text-neutral-900 shadow-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0 placeholder:text-neutral-400 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500"
+                    className="h-10 border-neutral-300 shadow-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0 dark:border-neutral-700"
                     aria-invalid={!!errors.email}
                     aria-describedby={errors.email ? "user-email-error" : undefined}
                   />
@@ -200,7 +217,7 @@ export function UserForm({
                 value={fullName}
                 onChange={(event) => setFullName(event.target.value)}
                 placeholder={intl.formatMessage({ id: "users.form.fullName.placeholder" })}
-                className="rounded-md border-neutral-300 bg-white px-4 text-sm text-neutral-900 shadow-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0 placeholder:text-neutral-400 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500"
+                className="h-10 border-neutral-300 shadow-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0 dark:border-neutral-700"
                 aria-invalid={!!errors.fullName}
                 aria-describedby={errors.fullName ? "user-full-name-error" : undefined}
               />
@@ -240,7 +257,7 @@ export function UserForm({
                 type="button"
                 variant="ghost"
                 onClick={() => setAdvancedOpen((current) => !current)}
-                className="inline-flex w-full items-center gap-2 rounded-md border border-neutral-200 px-3 py-2 text-sm font-medium text-neutral-600 transition hover:text-neutral-950 dark:border-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-300"
+                className="inline-flex w-full items-center justify-start gap-2 rounded-md border border-neutral-200 px-3 py-2 text-sm font-medium text-neutral-600 transition hover:text-neutral-950 dark:border-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-300"
                 aria-expanded={advancedOpen}
                 aria-controls="advanced-settings-region"
               >
@@ -295,20 +312,11 @@ export function UserForm({
                 </div>
               )}
 
-              <div className="flex items-center justify-end gap-3 pt-6">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  onClick={onToggle}
-                  className="h-10 rounded-md px-3 text-sm font-medium text-neutral-700 hover:bg-neutral-100 hover:text-neutral-950 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:hover:text-neutral-100"
-                >
+              <div className="flex justify-end gap-3 pt-2">
+                <Button type="button" variant="ghost" onClick={onToggle} disabled={isSubmitting}>
                   {intl.formatMessage({ id: "users.form.button.cancel" })}
                 </Button>
-                <Button
-                  type="submit"
-                  disabled={isSubmitting}
-                  className="h-10 rounded-md bg-neutral-950 px-4 text-sm font-medium text-white hover:enabled:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:enabled:bg-neutral-200"
-                >
+                <Button type="submit" disabled={isSubmitting || requiredFieldsMissing}>
                   {isSubmitting
                     ? intl.formatMessage({
                         id: isEditMode ? "users.form.button.saving" : "users.form.button.creating",

--- a/client/src/components/users/UsersTable.tsx
+++ b/client/src/components/users/UsersTable.tsx
@@ -1,4 +1,4 @@
-import { Check, Laptop, Lock, User as UserIcon } from "lucide-react";
+import { Check, Laptop, Lock, Monitor, User as UserIcon } from "lucide-react";
 import type { IntlShape } from "react-intl";
 import { useIntl } from "react-intl";
 
@@ -37,7 +37,7 @@ export function UsersTable({ users, onDeleteClick, onEditClick }: UsersTableProp
         <TableCaption className="sr-only">
           {intl.formatMessage({ id: "users.table.caption" })}
         </TableCaption>
-        <TableHeader>
+        <TableHeader className="bg-main">
           <TableRow className="hover:bg-transparent data-[state=selected]:bg-transparent">
             <TableHead className="border-b border-border h-[52px] px-2 pl-3 text-[13px] font-normal leading-4 text-muted-foreground">
               {intl.formatMessage({ id: "users.table.user" })}
@@ -76,6 +76,8 @@ export function UsersTable({ users, onDeleteClick, onEditClick }: UsersTableProp
             });
             const providerLabel =
               user.auth_provider.charAt(0).toUpperCase() + user.auth_provider.slice(1);
+            const isLocalProvider = user.auth_provider.toLowerCase() === "local";
+            const ProviderIcon = isLocalProvider ? Monitor : Laptop;
 
             let securityLabel = intl.formatMessage({ id: "users.security.noFlags" });
             let securityIconClass = "text-muted-foreground";
@@ -94,15 +96,12 @@ export function UsersTable({ users, onDeleteClick, onEditClick }: UsersTableProp
             return (
               <TableRow
                 key={user.email}
-                className="overflow-hidden border-0 bg-card hover:bg-muted data-[state=selected]:bg-muted"
+                className="overflow-hidden border-0 bg-white dark:bg-neutral-800 hover:bg-neutral-100 dark:hover:bg-neutral-700/60 data-[state=selected]:bg-neutral-100 dark:data-[state=selected]:bg-neutral-700/60"
               >
                 <TableCell className="rounded-l-lg px-3 py-2.5">
                   <div className="flex items-center gap-2">
-                    <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded bg-accent">
-                      <UserIcon
-                        className="h-[18px] w-[18px] text-accent-foreground"
-                        strokeWidth={1.5}
-                      />
+                    <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded bg-emerald-500">
+                      <UserIcon className="h-[18px] w-[18px] text-white" strokeWidth={1.5} />
                     </div>
                     <div className="min-w-0">
                       <div className="truncate text-sm leading-5 text-card-foreground">
@@ -121,7 +120,7 @@ export function UsersTable({ users, onDeleteClick, onEditClick }: UsersTableProp
                   <div className="flex items-center gap-1.5 text-[13px] leading-4 text-muted-foreground">
                     <Check
                       className={
-                        user.is_active ? "h-3 w-3 text-accent-foreground" : "h-3 w-3 text-muted"
+                        user.is_active ? "h-3 w-3 text-emerald-400" : "h-3 w-3 text-neutral-500"
                       }
                       strokeWidth={1.5}
                       aria-hidden="true"
@@ -131,7 +130,11 @@ export function UsersTable({ users, onDeleteClick, onEditClick }: UsersTableProp
                 </TableCell>
                 <TableCell className="px-3 py-2.5">
                   <div className="flex items-center gap-2 text-xs leading-4 text-muted-foreground">
-                    <Laptop className="h-3 w-3 shrink-0" strokeWidth={1.5} aria-hidden="true" />
+                    <ProviderIcon
+                      className="h-3 w-3 shrink-0"
+                      strokeWidth={1.5}
+                      aria-hidden="true"
+                    />
                     <span>{providerLabel}</span>
                   </div>
                 </TableCell>

--- a/client/src/hooks/useTeamForm.test.ts
+++ b/client/src/hooks/useTeamForm.test.ts
@@ -56,14 +56,14 @@ beforeEach(() => {
 
 describe("useTeamForm", () => {
   describe("Initial State", () => {
-    it("initializes with defaults and a single owner member row", () => {
+    it("initializes with defaults and a single member row", () => {
       const { result } = renderHook(() => useTeamForm());
 
       expect(result.current.name).toBe("");
       expect(result.current.description).toBe("");
       expect(result.current.visibility).toBe("private");
       expect(result.current.maxMembers).toBe("100");
-      expect(result.current.members).toEqual([{ email: "", role: "owner" }]);
+      expect(result.current.members).toEqual([{ email: "", role: "member" }]);
       expect(result.current.error).toBeNull();
       expect(result.current.isSubmitting).toBe(false);
     });
@@ -183,7 +183,7 @@ describe("useTeamForm", () => {
 
       act(() => {
         result.current.setName("Engineering");
-        result.current.handleMemberEmailChange(0, "owner@example.com");
+        result.current.handleMemberEmailChange(0, "member@example.com");
       });
 
       await act(async () => {
@@ -191,7 +191,7 @@ describe("useTeamForm", () => {
       });
 
       await waitFor(() => expect(memberBodies).toHaveLength(1));
-      expect(memberBodies[0]).toMatchObject({ email: "owner@example.com", role: "owner" });
+      expect(memberBodies[0]).toMatchObject({ email: "member@example.com", role: "member" });
     });
 
     it("closes the form and warns via toast when a member add fails", async () => {

--- a/client/src/hooks/useTeamForm.ts
+++ b/client/src/hooks/useTeamForm.ts
@@ -67,7 +67,7 @@ export interface UseTeamFormReturn {
   handleSubmit: (event: FormEvent<HTMLFormElement>, onSuccess?: () => void) => Promise<void>;
 }
 
-const INITIAL_MEMBERS: TeamMember[] = [{ email: "", role: "owner" }];
+const INITIAL_MEMBERS: TeamMember[] = [{ email: "", role: "member" }];
 const DEFAULT_MAX_MEMBERS = "100";
 const MAX_MEMBERS_PRESETS = ["10", "25", "50", "100", "250", "500"];
 
@@ -140,12 +140,12 @@ export function useTeamForm(team?: Team): UseTeamFormReturn {
     setDescription(team?.description ?? "");
     setVisibility(team?.visibility ?? "private");
     setMaxMembers(initialMaxMembers(team));
-    setMembers([{ email: "", role: "owner" }]);
+    setMembers([{ email: "", role: "member" }]);
     setError(null);
   }, [team]);
 
   const handleAddMember = useCallback(() => {
-    setMembers((prev) => [...prev, { email: "", role: "owner" }]);
+    setMembers((prev) => [...prev, { email: "", role: "member" }]);
   }, []);
 
   const handleRemoveMember = useCallback((index: number) => {

--- a/client/src/i18n/locales/en-US/users.json
+++ b/client/src/i18n/locales/en-US/users.json
@@ -1,5 +1,5 @@
 {
-  "users.createUser": "Create User",
+  "users.createUser": "Create user",
   "users.date.never": "Never",
   "users.empty.title": "No users found",
   "users.emptyState.description": "Create user accounts with email and password authentication.",
@@ -13,6 +13,7 @@
   "users.form.confirmPassword": "Confirm Password",
   "users.form.description": "Create a new user account with email and password authentication.",
   "users.form.email.placeholder": "user@example.com",
+  "users.form.email.readonly": "Email address can't be changed",
   "users.form.email": "Email",
   "users.form.error.createFailed": "Failed to create user. Please try again.",
   "users.form.error.emailInvalid": "Invalid email address",

--- a/client/src/i18n/locales/es-ES/users.json
+++ b/client/src/i18n/locales/es-ES/users.json
@@ -1,5 +1,5 @@
 {
-  "users.createUser": "Crear Usuario",
+  "users.createUser": "Crear usuario",
   "users.date.never": "Nunca",
   "users.empty.title": "No se encontraron usuarios",
   "users.emptyState.description": "Cree cuentas de usuario con autenticación por correo electrónico y contraseña.",
@@ -13,6 +13,7 @@
   "users.form.confirmPassword": "Confirmar Contraseña",
   "users.form.description": "Cree una nueva cuenta de usuario con autenticación por correo electrónico y contraseña.",
   "users.form.email.placeholder": "usuario@ejemplo.com",
+  "users.form.email.readonly": "El correo electrónico no se puede cambiar",
   "users.form.email": "Correo Electrónico",
   "users.form.error.createFailed": "Error al crear usuario. Por favor, inténtelo de nuevo.",
   "users.form.error.emailInvalid": "Correo electrónico inválido",

--- a/client/src/i18n/locales/pt-BR/users.json
+++ b/client/src/i18n/locales/pt-BR/users.json
@@ -1,5 +1,5 @@
 {
-  "users.createUser": "Criar Usuário",
+  "users.createUser": "Criar usuário",
   "users.date.never": "Nunca",
   "users.empty.title": "Nenhum usuário encontrado",
   "users.emptyState.description": "Crie contas de usuário com autenticação por e-mail e senha.",
@@ -13,6 +13,7 @@
   "users.form.confirmPassword": "Confirmar Senha",
   "users.form.description": "Crie uma nova conta de usuário com autenticação por e-mail e senha.",
   "users.form.email.placeholder": "usuario@exemplo.com",
+  "users.form.email.readonly": "O e-mail não pode ser alterado",
   "users.form.email": "E-mail",
   "users.form.error.createFailed": "Falha ao criar usuário. Por favor, tente novamente.",
   "users.form.error.emailInvalid": "E-mail inválido",

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -1,7 +1,9 @@
+import { useMemo, useState } from "react";
 import { useIntl } from "react-intl";
 import { useAuthContext } from "@/auth/AuthContext";
 import { Redirect, useRouter } from "@/router";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { SettingsTabsProvider } from "@/components/settings/settings-toolbar";
 import { Users } from "@/pages/Users";
 import { Teams } from "@/pages/Teams";
 
@@ -16,37 +18,63 @@ export function Settings({ tab }: SettingsProps) {
   const { user } = useAuthContext();
   const { navigate } = useRouter();
   const isAdmin = Boolean(user?.is_admin);
+  // Toolbar slot rendered on the tab row; the active tab portals its actions
+  // (search, create, …) here so they sit inline with the tab triggers.
+  const [toolbarEl, setToolbarEl] = useState<HTMLDivElement | null>(null);
+  // The active tab hides the tab strip while showing a full-page form.
+  const [tabsHidden, setTabsHidden] = useState(false);
+  const tabsContext = useMemo(() => ({ toolbar: toolbarEl, setTabsHidden }), [toolbarEl]);
 
-  if (tab !== undefined && !(ADMIN_TABS as readonly string[]).includes(tab)) {
+  // A tab segment is only valid for admins requesting a known tab; anything
+  // else (unknown tab, or a non-admin deep-linking a tab) falls back to the
+  // Settings root.
+  const isValidTab =
+    tab === undefined || (isAdmin && (ADMIN_TABS as readonly string[]).includes(tab));
+  if (!isValidTab) {
     return <Redirect to="/app/settings" />;
   }
-  if (tab !== undefined && !isAdmin) {
-    return <Redirect to="/app/settings" />;
+
+  // Non-admins have no tabs to show; keep a visible heading so the page isn't
+  // blank. Admins get the tabbed shell, where the tab row itself acts as the
+  // page header (per design), so the standalone "Settings" title is dropped.
+  if (!isAdmin) {
+    return (
+      <main className="space-y-6 p-6">
+        <h1 className="text-xl font-semibold text-foreground">
+          {intl.formatMessage({ id: "settings.title" })}
+        </h1>
+      </main>
+    );
   }
 
   return (
     <main className="space-y-6 p-6">
-      <h1 className="text-xl font-semibold text-foreground">
-        {intl.formatMessage({ id: "settings.title" })}
-      </h1>
-      {isAdmin && (
-        <Tabs value={tab ?? "users"} onValueChange={(value) => navigate(`/app/settings/${value}`)}>
-          <TabsList variant="line">
-            <TabsTrigger variant="line" value="users">
-              {intl.formatMessage({ id: "settings.tabs.users" })}
-            </TabsTrigger>
-            <TabsTrigger variant="line" value="teams">
-              {intl.formatMessage({ id: "settings.tabs.teams" })}
-            </TabsTrigger>
-          </TabsList>
+      <Tabs value={tab ?? "users"} onValueChange={(value) => navigate(`/app/settings/${value}`)}>
+        {!tabsHidden && (
+          <div className="flex items-end justify-between gap-4">
+            <TabsList variant="line" className="w-auto">
+              <TabsTrigger variant="line" value="users">
+                {intl.formatMessage({ id: "settings.tabs.users" })}
+              </TabsTrigger>
+              <TabsTrigger variant="line" value="teams">
+                {intl.formatMessage({ id: "settings.tabs.teams" })}
+              </TabsTrigger>
+            </TabsList>
+            {/* min-h-10 reserves the toolbar's populated height so the tab row
+                keeps a constant height whether or not the active tab has filled
+                the slot yet (prevents the tabs jumping on load). */}
+            <div ref={setToolbarEl} className="flex shrink-0 items-center gap-3 pb-2 min-h-10" />
+          </div>
+        )}
+        <SettingsTabsProvider value={tabsContext}>
           <TabsContent value="users">
             <Users />
           </TabsContent>
           <TabsContent value="teams">
             <Teams />
           </TabsContent>
-        </Tabs>
-      )}
+        </SettingsTabsProvider>
+      </Tabs>
     </main>
   );
 }

--- a/client/src/pages/Teams.tsx
+++ b/client/src/pages/Teams.tsx
@@ -8,6 +8,7 @@ import { TeamsTable } from "@/components/teams/TeamsTable";
 import { TeamForm } from "@/components/teams/TeamForm";
 import { ConfirmDialog } from "@/components/servers/ConfirmDialog";
 import { ManageTeamMembersDialog } from "@/components/teams/ManageTeamMembersDialog";
+import { SettingsToolbar, useHideSettingsTabs } from "@/components/settings/settings-toolbar";
 import { useQuery } from "@/hooks/useQuery";
 import { useLocalSearch } from "@/hooks/useLocalSearch";
 import { api } from "@/api/client";
@@ -29,6 +30,10 @@ export function Teams() {
   const [membersDialogOpen, setMembersDialogOpen] = useState(false);
   const [teamForMembers, setTeamForMembers] = useState<Team | null>(null);
   const [teamToEdit, setTeamToEdit] = useState<Team | null>(null);
+
+  // While the create/edit form is open it takes over the whole area, so hide
+  // the Settings tab strip + toolbar.
+  useHideSettingsTabs(createFormOpen || teamToEdit != null);
 
   const queryPath = useMemo(() => {
     const params = new URLSearchParams();
@@ -183,132 +188,140 @@ export function Teams() {
           }}
           onSuccess={teamToEdit ? handleEditSuccess : handleCreateSuccess}
         />
-      ) : isLoading ? (
-        <div
-          role="status"
-          aria-live="polite"
-          aria-busy="true"
-          className="flex items-center justify-center p-12"
-        >
-          <span className="sr-only">{intl.formatMessage({ id: "teams.loading.sr" })}</span>
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-primary" />
-        </div>
       ) : (
-        <>
-          {error && (
+        <div className="space-y-6">
+          {isLoading ? (
             <div
-              className="mb-6 rounded-lg border border-destructive/20 bg-destructive/10 p-4"
-              role="alert"
-              aria-live="assertive"
-              aria-atomic="true"
+              role="status"
+              aria-live="polite"
+              aria-busy="true"
+              className="flex items-center justify-center p-12"
             >
-              <h3 className="mb-1 font-semibold">
-                {intl.formatMessage({ id: "teams.error.loading" })}
-              </h3>
-              <p className="text-destructive">{error}</p>
+              <span className="sr-only">{intl.formatMessage({ id: "teams.loading.sr" })}</span>
+              <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-primary" />
             </div>
-          )}
-
-          {allTeams.length > 0 ? (
+          ) : (
             <>
-              <div className="flex justify-between items-center mb-6">
-                <h2 className="text-base font-semibold text-foreground">
-                  {intl.formatMessage({ id: "teams.all.title" })}
-                </h2>
-                <div className="flex items-center gap-3">
-                  <ListSearch
-                    value={query}
-                    onChange={setQuery}
-                    ariaLabel={intl.formatMessage(
-                      { id: "common.searchLabel" },
-                      { entity: intl.formatMessage({ id: "navigation.teams" }) },
-                    )}
-                    placeholder={intl.formatMessage({ id: "common.search" })}
+              {error && (
+                <div
+                  className="rounded-lg border border-destructive/20 bg-destructive/10 p-4"
+                  role="alert"
+                  aria-live="assertive"
+                  aria-atomic="true"
+                >
+                  <h3 className="mb-1 font-semibold">
+                    {intl.formatMessage({ id: "teams.error.loading" })}
+                  </h3>
+                  <p className="text-destructive">{error}</p>
+                </div>
+              )}
+
+              {allTeams.length > 0 ? (
+                <>
+                  <header className="flex items-center justify-end">
+                    {/* The Settings tab already labels this section, so the visible
+                        title is dropped per design; kept sr-only for accessibility. */}
+                    <h2 className="sr-only">{intl.formatMessage({ id: "teams.all.title" })}</h2>
+                    {/* Hosted inside the Settings tabs, these actions render on the
+                        tab row (via the toolbar slot); standalone they fall back inline. */}
+                    <SettingsToolbar>
+                      <div className="flex items-center gap-3">
+                        <ListSearch
+                          value={query}
+                          onChange={setQuery}
+                          ariaLabel={intl.formatMessage(
+                            { id: "common.searchLabel" },
+                            { entity: intl.formatMessage({ id: "navigation.teams" }) },
+                          )}
+                          placeholder={intl.formatMessage({ id: "common.search" })}
+                        />
+                        <Button
+                          variant="default"
+                          className="h-7 rounded-sm px-4"
+                          onClick={() => setCreateFormOpen(true)}
+                        >
+                          <Plus className="h-4 w-4" />
+                          {intl.formatMessage({ id: "teams.createTeam" })}
+                        </Button>
+                      </div>
+                    </SettingsToolbar>
+                  </header>
+
+                  <TeamsTable
+                    teams={results}
+                    isLoading={false}
+                    onEdit={handleEdit}
+                    onManageMembers={handleManageMembers}
+                    onDelete={handleDelete}
                   />
+                  {query.trim() && results.length === 0 && (
+                    <p className="mt-6 text-sm text-muted-foreground">
+                      {intl.formatMessage({ id: "common.search.noResults" })}
+                    </p>
+                  )}
+
+                  <div className="flex items-center justify-between mt-6">
+                    <div className="flex items-center gap-4">
+                      <div className="text-sm text-gray-600 dark:text-gray-400">
+                        {intl.formatMessage({ id: "teams.showing" }, { count: results.length })}
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <label
+                          htmlFor="limit-select"
+                          className="text-sm text-gray-600 dark:text-gray-400"
+                        >
+                          {intl.formatMessage({ id: "teams.perPage" })}
+                        </label>
+                        <select
+                          id="limit-select"
+                          value={limit}
+                          onChange={(e) => handleLimitChange(Number(e.target.value))}
+                          className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-2 py-1 text-sm"
+                        >
+                          <option value={10}>10</option>
+                          <option value={25}>25</option>
+                          <option value={50}>50</option>
+                          <option value={100}>100</option>
+                        </select>
+                      </div>
+                    </div>
+                    {!query.trim() && nextCursor && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleLoadMore}
+                        disabled={loadingMore}
+                        aria-label={intl.formatMessage({ id: "teams.loadMore.aria" })}
+                      >
+                        {loadingMore
+                          ? intl.formatMessage({ id: "teams.loadMore.loading" })
+                          : intl.formatMessage({ id: "teams.loadMore" })}
+                      </Button>
+                    )}
+                  </div>
+                </>
+              ) : (
+                <div className="border border-border rounded-lg p-6 flex flex-col gap-2">
+                  <h2 className="text-base font-medium">
+                    {intl.formatMessage({ id: "teams.empty.title" })}
+                  </h2>
+                  <div className="py-5">
+                    <p className="text-sm text-foreground">
+                      {intl.formatMessage({ id: "teams.empty.description" })}
+                    </p>
+                  </div>
                   <Button
-                    variant="default"
-                    className="h-7 rounded-sm px-4"
+                    className="bg-foreground text-background hover:bg-foreground/90 h-8 w-38 rounded-sm px-2 gap-1.5 text-sm font-medium"
                     onClick={() => setCreateFormOpen(true)}
                   >
-                    <Plus className="h-4 w-4" />
+                    <Plus className="size-3" />
                     {intl.formatMessage({ id: "teams.createTeam" })}
                   </Button>
                 </div>
-              </div>
-
-              <TeamsTable
-                teams={results}
-                isLoading={false}
-                onEdit={handleEdit}
-                onManageMembers={handleManageMembers}
-                onDelete={handleDelete}
-              />
-              {query.trim() && results.length === 0 && (
-                <p className="mt-6 text-sm text-muted-foreground">
-                  {intl.formatMessage({ id: "common.search.noResults" })}
-                </p>
               )}
-
-              <div className="flex items-center justify-between mt-6">
-                <div className="flex items-center gap-4">
-                  <div className="text-sm text-gray-600 dark:text-gray-400">
-                    {intl.formatMessage({ id: "teams.showing" }, { count: results.length })}
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <label
-                      htmlFor="limit-select"
-                      className="text-sm text-gray-600 dark:text-gray-400"
-                    >
-                      {intl.formatMessage({ id: "teams.perPage" })}
-                    </label>
-                    <select
-                      id="limit-select"
-                      value={limit}
-                      onChange={(e) => handleLimitChange(Number(e.target.value))}
-                      className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-2 py-1 text-sm"
-                    >
-                      <option value={10}>10</option>
-                      <option value={25}>25</option>
-                      <option value={50}>50</option>
-                      <option value={100}>100</option>
-                    </select>
-                  </div>
-                </div>
-                {!query.trim() && nextCursor && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleLoadMore}
-                    disabled={loadingMore}
-                    aria-label={intl.formatMessage({ id: "teams.loadMore.aria" })}
-                  >
-                    {loadingMore
-                      ? intl.formatMessage({ id: "teams.loadMore.loading" })
-                      : intl.formatMessage({ id: "teams.loadMore" })}
-                  </Button>
-                )}
-              </div>
             </>
-          ) : (
-            <div className="border border-border rounded-lg p-6 flex flex-col gap-2">
-              <h2 className="text-base font-medium">
-                {intl.formatMessage({ id: "teams.empty.title" })}
-              </h2>
-              <div className="py-5">
-                <p className="text-sm text-foreground">
-                  {intl.formatMessage({ id: "teams.empty.description" })}
-                </p>
-              </div>
-              <Button
-                className="bg-foreground text-background hover:bg-foreground/90 h-8 w-38 rounded-sm px-2 gap-1.5 text-sm font-medium"
-                onClick={() => setCreateFormOpen(true)}
-              >
-                <Plus className="size-3" />
-                {intl.formatMessage({ id: "teams.createTeam" })}
-              </Button>
-            </div>
           )}
-        </>
+        </div>
       )}
 
       {teamToDelete && (

--- a/client/src/pages/Users.test.tsx
+++ b/client/src/pages/Users.test.tsx
@@ -893,7 +893,7 @@ describe("Users", () => {
       expect(header).toBeInTheDocument();
       expect(header).toHaveClass("flex");
       expect(header).toHaveClass("items-center");
-      expect(header).toHaveClass("justify-between");
+      expect(header).toHaveClass("justify-end");
     });
   });
 

--- a/client/src/pages/Users.tsx
+++ b/client/src/pages/Users.tsx
@@ -4,6 +4,7 @@ import { useIntl } from "react-intl";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { ListSearch } from "@/components/ui/list-search";
+import { SettingsToolbar, useHideSettingsTabs } from "@/components/settings/settings-toolbar";
 import { UserForm } from "@/components/users/UserForm";
 import { UsersTable } from "@/components/users/UsersTable";
 import { ConfirmDialog } from "@/components/servers/ConfirmDialog";
@@ -174,6 +175,10 @@ export function Users() {
   const getUserText = useCallback((user: User) => `${user.full_name ?? ""} ${user.email}`, []);
   const { query, setQuery, results } = useLocalSearch(allUsers, getUserText);
 
+  // While the create/edit form is open it takes over the whole area, so hide
+  // the Settings tab strip + toolbar.
+  useHideSettingsTabs(isFormOpen);
+
   return (
     <div>
       {isFormOpen ? (
@@ -205,29 +210,35 @@ export function Users() {
         />
       ) : (
         <div className="space-y-6">
-          <header className="flex items-center justify-between">
-            <h2 className="text-xl font-semibold text-foreground">
-              {intl.formatMessage({ id: "users.title" })}
-            </h2>
-            <div className="flex items-center gap-3">
-              <ListSearch
-                value={query}
-                onChange={setQuery}
-                ariaLabel={intl.formatMessage(
-                  { id: "common.searchLabel" },
-                  { entity: intl.formatMessage({ id: "navigation.users" }) },
+          <header className="flex items-center justify-end">
+            {/* The Settings tab already labels this section, so the visible
+                title is dropped per design; kept sr-only for accessibility. */}
+            <h2 className="sr-only">{intl.formatMessage({ id: "users.title" })}</h2>
+            {/* Hosted inside the Settings tabs, these actions render on the tab
+                row (via the toolbar slot); standalone they fall back inline. */}
+            <SettingsToolbar>
+              <div className="flex items-center gap-3">
+                {allUsers.length > 0 && (
+                  <ListSearch
+                    value={query}
+                    onChange={setQuery}
+                    ariaLabel={intl.formatMessage(
+                      { id: "common.searchLabel" },
+                      { entity: intl.formatMessage({ id: "navigation.users" }) },
+                    )}
+                    placeholder={intl.formatMessage({ id: "common.search" })}
+                  />
                 )}
-                placeholder={intl.formatMessage({ id: "common.search" })}
-              />
-              <Button
-                onClick={() => setIsFormOpen(true)}
-                className="gap-2"
-                aria-label={intl.formatMessage({ id: "users.createUser" })}
-              >
-                <Plus className="h-4 w-4" aria-hidden="true" />
-                {intl.formatMessage({ id: "users.createUser" })}
-              </Button>
-            </div>
+                <Button
+                  variant="default"
+                  className="h-7 rounded-sm px-4"
+                  onClick={() => setIsFormOpen(true)}
+                >
+                  <Plus className="h-4 w-4" aria-hidden="true" />
+                  {intl.formatMessage({ id: "users.createUser" })}
+                </Button>
+              </div>
+            </SettingsToolbar>
           </header>
           {isLoading ? (
             <div
@@ -284,7 +295,7 @@ export function Users() {
                           id="users-limit-select"
                           value={limit}
                           onChange={(event) => handleLimitChange(Number(event.target.value))}
-                          className="rounded-md border border-input bg-background px-2 py-1 text-sm"
+                          className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-2 py-1 text-sm"
                         >
                           <option value={10}>10</option>
                           <option value={25}>25</option>


### PR DESCRIPTION
  ## 🔗 Related Issue

  Relates to #5551 — design polish on top of the Users/Teams-as-Settings-tabs work.

  ## 📝 Summary

  Aligns the Settings page (Users/Teams tabs), their tables, and their create/edit forms with the Figma design, and fixes several light-mode and layout inconsistencies. Frontend-only (`client/`).

  **Settings shell**

  - The tab row now acts as the page header — dropped the standalone "Settings" / "Users" / "All teams" titles (kept `sr-only` for accessibility). Non-admins still get a visible "Settings" heading so the page isn't blank.
  - New `components/settings/settings-toolbar.tsx`: a tab-row **toolbar slot** (context + portal). Each tab renders its search box + create button into the slot so they sit inline with the tabs, right-aligned; falls back to inline rendering when a page is used standalone.
  - The tab strip is **hidden while a create/edit form is open**, so the form takes over the full area (matching the design).
  - Fixed a **layout shift** where the tabs jumped down on load (the toolbar slot now reserves a constant height).
  - The search box shows only when rows exist; the underline is scoped to the tabs only.

  **Tables (Users, Teams, MCP servers)**

  - Light mode: table headers now match the main content background (`bg-main`) instead of an inconsistent white band; rows use a white background so they read as cards. Dark mode is unchanged.
  - Users table: green avatar, emerald/neutral status icons (matching MCP servers), a desktop icon for the `local` provider, and an icon-less overflow menu where Delete shares Edit's color.
  - Per-page dropdown restyled to match the Teams/servers tables.

  **Forms (Users, Teams)**

  - Match Figma: smaller title, green header icon, transparent inputs matching the Teams form, and a thin focus ring matching the MCP servers form (applied to all inputs, selects, and textarea).
  - Left-aligned "Advanced settings" toggle; Cancel/Save buttons match the Teams form buttons.
  - "Create user" is disabled until the required fields (email + both passwords) are filled.
  - Edit mode: the readonly email now reads as a disabled field — lock icon, muted styling, an "Email address can't be changed" hint, plus `not-allowed` cursor and tooltip on hover.
  - Team member rows now default to the `member` role (was `owner`), consistent with the Manage Members dialog.

  **i18n**

  - Sentence-case "Create user" (en/es/pt); new `users.form.email.readonly` key.

  **Tests**

  - Updated unit and e2e tests to match the new behavior (create-disabled gate, icon-less menu, sr-only headings, default `member` role).

  ## 🏷️ Type of Change

  - [ ] Bug fix
  - [x] Feature / Enhancement
  - [ ] Documentation
  - [ ] Refactor
  - [ ] Chore (deps, CI, tooling)

  ## 🧪 Verification

  | Check | Command | Status |
  |---|---|---|
  | Lint | `cd client && npm run lint` | ✅ |
  | Types | `cd client && npx tsc --noEmit` | ✅ |
  | Format | `cd client && npm run format:check` | ✅ |
  | Unit tests | `cd client && npm run test:run` | ✅ 2683 passed / 1 skipped |
  | E2E | `cd client && npx playwright test e2e/users.spec.ts e2e/teams.spec.ts` | ✅ 45 + 28 passed |

  ## ✅ Checklist

  - [x] Code formatted
  - [x] Tests added/updated for changes
  - [ ] Documentation updated (if applicable)
  - [x] No secrets or credentials committed

## DEMO

https://github.com/user-attachments/assets/edf57370-78ff-46ef-8bb0-3781ae190448
