### PR TITLE
fix(admin-ui): attach CSRF token to gateway refresh and prompt render

### DIFF
--- a/mcpgateway/admin_ui/gateways.js
+++ b/mcpgateway/admin_ui/gateways.js
@@ -20,6 +20,7 @@ import {
   buildTableUrl,
   decodeHtml,
   fetchWithTimeout,
+  getCookie,
   getCurrentTeamId,
   handleFetchError,
   isInactiveChecked,
@@ -1817,7 +1818,12 @@ export const refreshGatewayTools = async function (gatewayId, gatewayName, butto
       {
         method: "POST",
         credentials: "include", // pragma: allowlist secret
-        headers: { Accept: "application/json" },
+        headers: {
+          Accept: "application/json",
+          ...(getCookie("mcpgateway_csrf_token")
+            ? { "X-CSRF-Token": getCookie("mcpgateway_csrf_token") }
+            : {}),
+        },
       }
     );
 

--- a/mcpgateway/admin_ui/prompts.js
+++ b/mcpgateway/admin_ui/prompts.js
@@ -7,6 +7,7 @@ import { applyVisibilityRestrictions, isTeamScopedView } from "./teams.js";
 import {
   decodeHtml,
   fetchWithTimeout,
+  getCookie,
   getCurrentTeamId,
   handleFetchError,
   isInactiveChecked,
@@ -1185,6 +1186,9 @@ export const runPromptTest = async function () {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          ...(getCookie("mcpgateway_csrf_token")
+            ? { "X-CSRF-Token": getCookie("mcpgateway_csrf_token") }
+            : {}),
         },
         credentials: "include", // pragma: allowlist secret
         body: JSON.stringify(args),

--- a/tests/unit/js/gateway.test.js
+++ b/tests/unit/js/gateway.test.js
@@ -60,6 +60,16 @@ vi.mock("../../../mcpgateway/admin_ui/utils", () => ({
   }),
   decodeHtml: vi.fn((s) => s || ""),
   fetchWithTimeout: vi.fn(),
+  // Real cookie-reading implementation (mirrors utils.getCookie) so the CSRF
+  // spread in refreshGatewayTools is exercised against jsdom's document.cookie.
+  getCookie: vi.fn((name) => {
+    const value = `; ${document.cookie}`;
+    const parts = value.split(`; ${name}=`);
+    if (parts.length === 2) {
+      return parts.pop().split(";").shift();
+    }
+    return "";
+  }),
   getCurrentTeamId: vi.fn(() => null),
   handleFetchError: vi.fn((e) => e.message),
   isInactiveChecked: vi.fn(() => false),
@@ -2061,5 +2071,91 @@ describe("refreshToolsForSelectedGateways", () => {
     expect(showErrorMessage).toHaveBeenCalledWith(
       "1 gateway(s) failed. No changes detected"
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refreshGatewayTools — CSRF header (#6071)
+//
+// Regression guard: the POST to /gateways/{id}/tools/refresh must attach
+// X-CSRF-Token from the mcpgateway_csrf_token cookie so it survives admin CSRF
+// validation, following the canonical utils.js:150-158 spread pattern. Without
+// the cookie the header must be absent (the spread yields nothing), never an
+// empty string.
+// ---------------------------------------------------------------------------
+describe("refreshGatewayTools CSRF header", () => {
+  const CSRF_COOKIE_VALUE = "gw-refresh-csrf-token";
+
+  afterEach(() => {
+    document.cookie =
+      "mcpgateway_csrf_token=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+  });
+
+  test("POST /tools/refresh includes X-CSRF-Token from the cookie", async () => {
+    window.ROOT_PATH = "";
+    document.cookie = `mcpgateway_csrf_token=${CSRF_COOKIE_VALUE}`;
+    document.body.innerHTML = `
+      <button id="btn">Refresh</button>
+      <div id="gateways-table"></div>
+    `;
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          success: true,
+          toolsAdded: 0,
+          toolsUpdated: 0,
+          toolsRemoved: 0,
+        }),
+    });
+    window.htmx = { ajax: vi.fn() };
+
+    const button = document.getElementById("btn");
+    const { refreshGatewayTools } = await import(
+      "../../../mcpgateway/admin_ui/gateways.js"
+    );
+
+    await refreshGatewayTools("gw-csrf", "GW", button);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/gateways/gw-csrf/tools/refresh",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "X-CSRF-Token": CSRF_COOKIE_VALUE,
+        }),
+      })
+    );
+  });
+
+  test("omits X-CSRF-Token when no cookie is set", async () => {
+    window.ROOT_PATH = "";
+    document.body.innerHTML = `
+      <button id="btn">Refresh</button>
+      <div id="gateways-table"></div>
+    `;
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          success: true,
+          toolsAdded: 0,
+          toolsUpdated: 0,
+          toolsRemoved: 0,
+        }),
+    });
+    window.htmx = { ajax: vi.fn() };
+
+    const button = document.getElementById("btn");
+    const { refreshGatewayTools } = await import(
+      "../../../mcpgateway/admin_ui/gateways.js"
+    );
+
+    await refreshGatewayTools("gw-no-csrf", "GW", button);
+
+    const [, options] = global.fetch.mock.calls[0];
+    expect(options.headers).not.toHaveProperty("X-CSRF-Token");
   });
 });

--- a/tests/unit/js/prompts.test.js
+++ b/tests/unit/js/prompts.test.js
@@ -41,6 +41,16 @@ vi.mock("../../../mcpgateway/admin_ui/security.js", () => ({
 vi.mock("../../../mcpgateway/admin_ui/utils", () => ({
   decodeHtml: vi.fn((s) => s || ""),
   fetchWithTimeout: vi.fn(),
+  // Real cookie-reading implementation (mirrors utils.getCookie) so the CSRF
+  // spread in runPromptTest is exercised against jsdom's document.cookie.
+  getCookie: vi.fn((name) => {
+    const value = `; ${document.cookie}`;
+    const parts = value.split(`; ${name}=`);
+    if (parts.length === 2) {
+      return parts.pop().split(";").shift();
+    }
+    return "";
+  }),
   getCurrentTeamId: vi.fn(() => null),
   handleFetchError: vi.fn((e) => e.message),
   isInactiveChecked: vi.fn(() => false),
@@ -944,6 +954,110 @@ describe("runPromptTest - Extended", () => {
     expect(result.innerHTML).not.toContain("Error");
 
     consoleSpy.mockRestore();
+    logSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runPromptTest — CSRF header (#6072)
+//
+// Regression guard: the "Render Prompt" test action POSTs to /prompts/{id} and
+// must attach X-CSRF-Token from the mcpgateway_csrf_token cookie so it survives
+// CSRF validation, following the canonical utils.js:150-158 spread pattern.
+// Without the cookie the header must be absent (the spread yields nothing).
+//
+// runPromptTest reads promptTestState.currentTestPrompt, which is populated by
+// testPrompt(id) (the GET that opens the modal). Each test therefore drives
+// testPrompt first, then runPromptTest, and asserts against the POST call.
+// Unique prompt IDs per test sidestep testPrompt's 1000ms per-id debounce.
+// ---------------------------------------------------------------------------
+describe("runPromptTest CSRF header", () => {
+  const CSRF_COOKIE_VALUE = "prompt-render-csrf-token";
+
+  afterEach(() => {
+    document.cookie =
+      "mcpgateway_csrf_token=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+  });
+
+  function setupPromptTestDOM() {
+    const form = document.createElement("form");
+    form.id = "prompt-test-form";
+    document.body.appendChild(form);
+
+    for (const id of ["prompt-test-loading", "prompt-test-result"]) {
+      const el = document.createElement("div");
+      el.id = id;
+      document.body.appendChild(el);
+    }
+  }
+
+  // Two fetches: [0] testPrompt GET prompt details, [1] runPromptTest POST render.
+  function stubFetchSequence() {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ id: "will-be-overridden", name: "p", arguments: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            messages: [{ role: "user", content: { text: "rendered" } }],
+          }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  test("POST /prompts/{id} includes X-CSRF-Token from the cookie", async () => {
+    window.ROOT_PATH = "";
+    document.cookie = `mcpgateway_csrf_token=${CSRF_COOKIE_VALUE}`;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    setupPromptTestDOM();
+
+    const fetchMock = stubFetchSequence();
+    const { testPrompt, runPromptTest } = await import(
+      "../../../mcpgateway/admin_ui/prompts.js"
+    );
+
+    await testPrompt("csrf-prompt-1");
+    await runPromptTest();
+
+    // The second fetch is the render POST; assert its CSRF header.
+    const postCall = fetchMock.mock.calls[1];
+    expect(postCall[1]).toEqual(
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "X-CSRF-Token": CSRF_COOKIE_VALUE,
+        }),
+      })
+    );
+
+    logSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  test("omits X-CSRF-Token when no cookie is set", async () => {
+    window.ROOT_PATH = "";
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    setupPromptTestDOM();
+
+    const fetchMock = stubFetchSequence();
+    const { testPrompt, runPromptTest } = await import(
+      "../../../mcpgateway/admin_ui/prompts.js"
+    );
+
+    await testPrompt("csrf-prompt-2");
+    await runPromptTest();
+
+    const postCall = fetchMock.mock.calls[1];
+    expect(postCall[1].method).toBe("POST");
+    expect(postCall[1].headers).not.toHaveProperty("X-CSRF-Token");
+
     logSpy.mockRestore();
     vi.unstubAllGlobals();
   });


### PR DESCRIPTION
Closes #6071
Closes #6072

Two admin UI actions POST without the X-CSRF-Token header that every other mutating call attaches, so both fail closed with a 403 for cookie-session users:

- gateways.js refreshGatewayTools POSTs to /gateways/{id}/tools/refresh with only an Accept header (#6071)
- prompts.js Render Prompt POSTs to /prompts/{id} with only a Content-Type header (#6072)

Both now attach the token using the same conditional getCookie("mcpgateway_csrf_token") pattern as utils.js, importing getCookie from the shared module. The routes and server-side CSRF middleware are unchanged and were already correct.

Regression tests added in tests/unit/js/gateway.test.js and tests/unit/js/prompts.test.js assert each POST carries the X-CSRF-Token header when the cookie is present and omits it when absent. Both fail if the header spread is reverted. The two suites pass (110 tests), and the existing CSRF suite is untouched.