### PR TITLE
fix(transports): share plugin context with tool, prompt and resource hooks on /mcp

### DIFF
--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -44,6 +44,7 @@ from uuid import uuid4
 
 # Third-Party
 import anyio
+from cpex.framework import GlobalContext, PluginContextTable
 from fastapi import HTTPException
 from fastapi.security.utils import get_authorization_scheme_param
 import httpx
@@ -1682,6 +1683,57 @@ def _truthy_is_error(result: Any) -> bool:
     return getattr(result, "is_error", False) is True or getattr(result, "isError", False) is True
 
 
+def _get_plugin_contexts_or_none() -> Tuple[Optional[GlobalContext], Optional[PluginContextTable]]:
+    """Retrieves the plugin contexts recorded by the HTTP_PRE_REQUEST hooks.
+
+    ``HttpAuthMiddleware`` stores the ``GlobalContext`` and the
+    ``PluginContextTable`` produced by ``HTTP_PRE_REQUEST`` on ``request.state``
+    (backed by the ASGI ``scope["state"]`` dictionary) so that later hooks can
+    read state written by earlier ones. The REST handlers in
+    ``mcpgateway/main.py`` forward both into the service layer; without the same
+    hand-off here, ``TOOL_PRE_INVOKE`` hooks reached through ``/mcp`` always see
+    an empty context.
+
+    Reading from the ASGI scope rather than from a ``ContextVar`` mirrors path 2
+    of :func:`_get_request_context_or_default` and survives the task-group
+    boundaries introduced by the MCP SDK.
+
+    Returns:
+        Tuple[Optional[GlobalContext], Optional[PluginContextTable]]: The global
+        context and context table left behind by the pre-request hooks, or
+        ``(None, None)`` when no request context is active, the transport is not
+        driven by an ASGI scope, or the plugin manager recorded nothing.
+
+    Examples:
+        >>> _get_plugin_contexts_or_none()
+        (None, None)
+    """
+    try:
+        request = mcp_app.request_context.request
+    except LookupError:
+        return None, None
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.debug("Failed to resolve request context for plugin contexts: %s", exc)
+        return None, None
+
+    scope = getattr(request, "scope", None)
+    if not isinstance(scope, dict):
+        return None, None
+
+    state = scope.get("state")
+    if not isinstance(state, dict):
+        return None, None
+
+    global_context = state.get("plugin_global_context")
+    context_table = state.get("plugin_context_table")
+    # ``PluginContextTable`` is an alias for ``dict[str, PluginContext]``, so the
+    # runtime check is against ``dict``.
+    return (
+        global_context if isinstance(global_context, GlobalContext) else None,
+        context_table if isinstance(context_table, dict) else None,
+    )
+
+
 @mcp_app.call_tool(validate_input=False)
 async def call_tool(
     name: str, arguments: dict
@@ -1914,6 +1966,9 @@ async def call_tool(
             # Pool not initialized - execute locally
             pass
 
+    # Cross-hook plugin state sharing on /mcp (issue #3879).
+    plugin_global_context, plugin_context_table = _get_plugin_contexts_or_none()
+
     try:
         async with get_db() as db:
             # Use tool service for all tool invocations (handles direct_proxy internally)
@@ -1928,6 +1983,8 @@ async def call_tool(
                 server_id=server_id,
                 meta_data=meta_data,
                 require_model_visible=True,
+                plugin_global_context=plugin_global_context,
+                plugin_context_table=plugin_context_table,
             )
             if not result or not result.content:
                 logger.warning("No content returned by tool: %s", name)

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -1691,8 +1691,9 @@ def _get_plugin_contexts_or_none() -> Tuple[Optional[GlobalContext], Optional[Pl
     (backed by the ASGI ``scope["state"]`` dictionary) so that later hooks can
     read state written by earlier ones. The REST handlers in
     ``mcpgateway/main.py`` forward both into the service layer; without the same
-    hand-off here, ``TOOL_PRE_INVOKE`` hooks reached through ``/mcp`` always see
-    an empty context.
+    hand-off here, ``TOOL_PRE_INVOKE``, ``PROMPT_PRE_FETCH`` and
+    ``RESOURCE_PRE_FETCH`` hooks reached through ``/mcp`` always see an empty
+    context.
 
     Reading from the ASGI scope rather than from a ``ContextVar`` mirrors path 2
     of :func:`_get_request_context_or_default` and survives the task-group
@@ -1754,6 +1755,10 @@ async def call_tool(
     This function supports the MCP protocol's tool calling with structured content validation.
     In direct_proxy mode, returns the raw CallToolResult from the remote server.
     In normal mode, converts ToolResult to CallToolResult with content normalization.
+
+    Plugin contexts recorded by ``HTTP_PRE_REQUEST`` are read from the ASGI scope via
+    :func:`_get_plugin_contexts_or_none` and forwarded to ``invoke_tool`` so that
+    ``TOOL_PRE_INVOKE`` hooks share state with earlier hooks.
 
     Args:
         name (str): The name of the tool to invoke.
@@ -2639,6 +2644,10 @@ async def get_prompt(prompt_id: str, arguments: dict[str, str] | None = None) ->
     """
     Retrieves a prompt by ID, optionally substituting arguments.
 
+    Plugin contexts recorded by ``HTTP_PRE_REQUEST`` are read from the ASGI scope via
+    :func:`_get_plugin_contexts_or_none` and forwarded to ``get_prompt`` so that
+    ``PROMPT_PRE_FETCH`` hooks share state with earlier hooks.
+
     Args:
         prompt_id (str): The ID of the prompt to retrieve.
         arguments (Optional[dict[str, str]]): Optional dictionary of arguments to substitute into the prompt.
@@ -2692,6 +2701,9 @@ async def get_prompt(prompt_id: str, arguments: dict[str, str] | None = None) ->
         # request_context might not be active in some edge cases (e.g. tests)
         logger.debug("No active request context found")
 
+    # Cross-hook plugin state sharing on /mcp (issue #3879).
+    plugin_global_context, plugin_context_table = _get_plugin_contexts_or_none()
+
     try:
         async with get_db() as db:
             try:
@@ -2703,6 +2715,8 @@ async def get_prompt(prompt_id: str, arguments: dict[str, str] | None = None) ->
                     server_id=server_id,
                     token_teams=token_teams,
                     _meta_data=meta_data,
+                    plugin_global_context=plugin_global_context,
+                    plugin_context_table=plugin_context_table,
                 )
             except Exception as e:
                 logger.exception("Error getting prompt '%s': %s", prompt_id, e)
@@ -2817,6 +2831,11 @@ async def read_resource(resource_uri: str) -> Union[str, bytes, Iterable[ReadRes
     """
     Reads the content of a resource specified by its URI.
 
+    Plugin contexts recorded by ``HTTP_PRE_REQUEST`` are read from the ASGI scope via
+    :func:`_get_plugin_contexts_or_none` and forwarded to ``read_resource`` so that
+    ``RESOURCE_PRE_FETCH`` hooks share state with earlier hooks. The direct-proxy
+    branch bypasses the gateway-side resource hooks and is unaffected.
+
     Args:
         resource_uri (str): The URI of the resource to read.
 
@@ -2869,6 +2888,9 @@ async def read_resource(resource_uri: str) -> Union[str, bytes, Iterable[ReadRes
         # request_context might not be active in some edge cases (e.g. tests)
         logger.debug("No active request context found")
 
+    # Cross-hook plugin state sharing on /mcp (issue #3879).
+    plugin_global_context, plugin_context_table = _get_plugin_contexts_or_none()
+
     try:
         async with get_db() as db:
             # Check for X-Context-Forge-Gateway-Id header first for direct proxy mode
@@ -2917,6 +2939,8 @@ async def read_resource(resource_uri: str) -> Union[str, bytes, Iterable[ReadRes
                     token_teams=token_teams,
                     meta_data=meta_data,
                     request_headers=request_headers,
+                    plugin_global_context=plugin_global_context,
+                    plugin_context_table=plugin_context_table,
                 )
             except (ResourceError, ResourceNotFoundError):
                 raise

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -4113,13 +4113,16 @@ def _malformed_scope_cases():
     ]
 
 
-@pytest.mark.parametrize("case_id,scope,expect_global,expect_table", _malformed_scope_cases(), ids=[c[0] for c in _malformed_scope_cases()])
+_MALFORMED_SCOPE_CASES = _malformed_scope_cases()
+
+
+@pytest.mark.parametrize("case_id,scope,expect_global,expect_table", _MALFORMED_SCOPE_CASES, ids=[c[0] for c in _MALFORMED_SCOPE_CASES])
 def test_get_plugin_contexts_rejects_malformed_scope_state(case_id, scope, expect_global, expect_table):
     """Malformed ``scope["state"]`` must degrade to ``None`` instead of leaking junk.
 
-    The helper feeds ``invoke_tool`` directly, which in turn hands the values to
-    the plugin manager. Passing a wrongly typed object through would surface as
-    an opaque failure deep inside a hook, so each slot is type-guarded
+    The helper feeds the service layer directly, which in turn hands the values
+    to the plugin manager. Passing a wrongly typed object through would surface
+    as an opaque failure deep inside a hook, so each slot is type-guarded
     independently - a bad ``plugin_global_context`` must not discard an
     otherwise valid ``plugin_context_table``.
     """
@@ -4139,43 +4142,156 @@ def test_get_plugin_contexts_rejects_malformed_scope_state(case_id, scope, expec
     assert (context_table is not None) is expect_table, f"{case_id}: unexpected context table {context_table!r}"
 
 
+def test_get_plugin_contexts_swallows_unexpected_request_context_errors(caplog):
+    """A non-``LookupError`` while resolving the request context degrades to ``(None, None)``.
+
+    ``LookupError`` is the documented "no active request" signal; anything else
+    is a defect somewhere below the transport. The helper must never turn that
+    into a 500 on ``/mcp`` - it logs at debug level and behaves exactly as if no
+    pre-request hooks had run.
+    """
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _get_plugin_contexts_or_none, mcp_app
+
+    def _explode(self):
+        raise RuntimeError("request context unavailable")
+
+    type(mcp_app).request_context = property(_explode)
+    try:
+        with caplog.at_level("DEBUG", logger="mcpgateway.transports.streamablehttp_transport"):
+            result = _get_plugin_contexts_or_none()
+    finally:
+        type(mcp_app).request_context = property(lambda self: (_ for _ in ()).throw(LookupError))
+
+    assert result == (None, None)
+    assert "request context unavailable" in caplog.text
+
+
 @pytest.mark.asyncio
-async def test_call_tool_cross_hook_sharing_end_to_end_with_real_plugin(monkeypatch):
-    """End-to-end reproduction of #3879 driving a real ``PluginManager``.
+async def test_get_prompt_forwards_plugin_contexts_from_scope(monkeypatch):
+    """``get_prompt`` on /mcp must carry cross-hook plugin state like ``call_tool``.
 
-    The issue's repro is a custom authorization plugin that writes state in
-    ``HTTP_PRE_REQUEST`` and reads it back in ``TOOL_PRE_INVOKE`` over ``/mcp``.
-    The other tests in this file assert *which objects* ``call_tool`` forwards;
-    this one asserts those objects are actually sufficient for the real plugin
-    manager to resolve cross-hook state, using the shared
-    ``CrossHookContextPlugin`` fixture which raises ``ValueError`` the moment a
-    hook cannot see what an earlier hook stored.
+    Same gap as #3879 for ``PROMPT_PRE_FETCH``: the REST handler forwards the
+    contexts, the streamable HTTP transport did not.
+    """
+    # Third-Party
+    from mcp.types import PromptMessage, TextContent
 
-    The ``invoke_tool`` stub stands in for the database-backed tool lookup only;
-    it runs the same ``TOOL_PRE_INVOKE`` dispatch that ``ToolService`` performs,
-    so the middleware -> ASGI scope -> ``call_tool`` -> plugin-manager chain is
-    exercised for real.
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import get_prompt, mcp_app, prompt_service
+
+    mock_result = MagicMock()
+    mock_result.messages = [PromptMessage(role="user", content=TextContent(type="text", text="hi"))]
+    mock_result.description = "desc"
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield MagicMock()
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default",
+        AsyncMock(return_value=("server-1", {}, {})),
+    )
+    monkeypatch.setattr(prompt_service, "get_prompt", AsyncMock(return_value=mock_result))
+
+    mock_ctx, global_context, context_table = _plugin_context_scope()
+
+    type(mcp_app).request_context = property(lambda self: mock_ctx)
+    try:
+        await get_prompt("my_prompt", {"a": "b"})
+    finally:
+        type(mcp_app).request_context = property(lambda self: (_ for _ in ()).throw(LookupError))
+
+    kwargs = prompt_service.get_prompt.await_args.kwargs
+    assert kwargs["plugin_global_context"] is global_context
+    assert kwargs["plugin_context_table"] is context_table
+
+
+@pytest.mark.asyncio
+async def test_read_resource_forwards_plugin_contexts_from_scope(monkeypatch):
+    """``read_resource`` on /mcp must carry cross-hook plugin state like ``call_tool``.
+
+    Same gap as #3879 for ``RESOURCE_PRE_FETCH``: the REST handler forwards the
+    contexts, the streamable HTTP transport did not.
+    """
+    # Third-Party
+    from pydantic import AnyUrl
+
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import mcp_app, read_resource, resource_service
+
+    mock_result = MagicMock()
+    mock_result.text = "resource content"
+    mock_result.blob = None
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield MagicMock()
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default",
+        AsyncMock(return_value=("server-1", {}, {})),
+    )
+    monkeypatch.setattr(resource_service, "read_resource", AsyncMock(return_value=mock_result))
+
+    mock_ctx, global_context, context_table = _plugin_context_scope()
+
+    type(mcp_app).request_context = property(lambda self: mock_ctx)
+    try:
+        await read_resource(AnyUrl("file:///test.txt"))
+    finally:
+        type(mcp_app).request_context = property(lambda self: (_ for _ in ()).throw(LookupError))
+
+    kwargs = resource_service.read_resource.await_args.kwargs
+    assert kwargs["plugin_global_context"] is global_context
+    assert kwargs["plugin_context_table"] is context_table
+
+
+# ---------------------------------------------------------------------------
+# End-to-end reproduction of #3879 against a real PluginManager.
+#
+# The forwarding tests above assert *which objects* the transport hands to the
+# service layer. The tests below assert those objects are actually sufficient
+# for the real plugin manager to resolve cross-hook state, using the shared
+# ``CrossHookContextPlugin`` fixture - it raises ``ValueError`` the moment a
+# hook cannot see what an earlier hook stored, so reaching the assertions is
+# the guarantee.
+# ---------------------------------------------------------------------------
+
+_CROSS_HOOK_CONFIG = "plugins/fixtures/configs/cross_hook_context.yaml"
+
+
+@asynccontextmanager
+async def _cross_hook_plugin_session():
+    """Run the HTTP hooks of ``CrossHookContextPlugin`` and expose their contexts.
+
+    Mirrors what ``HttpAuthMiddleware`` and the RBAC layer do before the MCP SDK
+    takes over: ``HTTP_PRE_REQUEST`` then ``HTTP_AUTH_CHECK_PERMISSION``, with
+    the resulting contexts stashed on the ASGI scope.
+
+    Yields:
+        tuple: ``(manager, mock_ctx, global_context, context_table)`` where
+        ``mock_ctx`` mimics ``mcp_app.request_context`` for that request.
     """
     # Standard
     from pathlib import Path
 
     # Third-Party
-    from cpex.framework import HttpAuthCheckPermissionPayload, HttpHeaderPayload, HttpHookType, PluginManager, ToolHookType, ToolPreInvokePayload
+    from cpex.framework import HttpAuthCheckPermissionPayload, HttpHookType, PluginManager
 
     # First-Party
     from mcpgateway.middleware.http_auth_middleware import run_pre_request_hooks
-    from mcpgateway.transports.streamablehttp_transport import call_tool, mcp_app, tool_service
 
-    config_file = Path(__file__).parent.parent / "plugins" / "fixtures" / "configs" / "cross_hook_context.yaml"
+    config_file = Path(__file__).parent.parent / _CROSS_HOOK_CONFIG
 
-    # ``PluginManager`` is a Borg singleton - reset around the test so the shared
-    # state never leaks into the rest of this module.
+    # ``PluginManager`` is a Borg singleton - reset around the session so the
+    # shared state never leaks into the rest of this module.
     PluginManager.reset()
     manager = PluginManager(str(config_file))
     await manager.initialize()
-
     try:
-        # 1. HTTP_PRE_REQUEST, exactly as ``HttpAuthMiddleware`` runs it on /mcp.
         _headers, global_context, context_table = await run_pre_request_hooks(
             plugin_manager=manager,
             headers={"authorization": "Bearer test-token"},
@@ -4186,7 +4302,6 @@ async def test_call_tool_cross_hook_sharing_end_to_end_with_real_plugin(monkeypa
         )
         assert global_context is not None and context_table
 
-        # 2. HTTP_AUTH_CHECK_PERMISSION, which the fixture plugin also requires.
         _perm_result, context_table = await manager.invoke_hook(
             HttpHookType.HTTP_AUTH_CHECK_PERMISSION,
             payload=HttpAuthCheckPermissionPayload(user_email="user@example.com", permission="tools.read"),
@@ -4194,18 +4309,96 @@ async def test_call_tool_cross_hook_sharing_end_to_end_with_real_plugin(monkeypa
             local_contexts=context_table,
         )
 
-        # 3. Hand the contexts over on the ASGI scope, the way the middleware does.
         mock_ctx = MagicMock()
         mock_ctx.meta = None
         mock_ctx.request.scope = {
             "type": "http",
             "state": {"plugin_global_context": global_context, "plugin_context_table": context_table},
         }
+        yield manager, mock_ctx, global_context, context_table
+    finally:
+        await manager.shutdown()
+        PluginManager.reset()
 
-        tool_contexts = {}
+
+def _e2e_transport_patches(monkeypatch):
+    """Stub the database session and request-context resolution for the e2e tests.
+
+    Args:
+        monkeypatch: The pytest monkeypatch fixture.
+    """
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield MagicMock()
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default",
+        AsyncMock(return_value=("server-1", {}, {})),
+    )
+
+
+async def _dispatch_pre_hook(manager, hook_type, payload, kwargs, sink):
+    """Invoke a pre-hook with the contexts a transport handler forwarded.
+
+    This is the same dispatch the service layer performs (see
+    ``ToolService.invoke_tool``, ``PromptService.get_prompt`` and
+    ``ResourceService.read_resource``); only the database-backed lookup around
+    it is stubbed out.
+
+    Args:
+        manager: The initialised ``PluginManager``.
+        hook_type: Which pre-hook to run.
+        payload: The hook payload.
+        kwargs: Keyword arguments captured from the transport handler.
+        sink: Dict that receives the context table the hook produced.
+    """
+    _result, table = await manager.invoke_hook(
+        hook_type,
+        payload=payload,
+        global_context=kwargs["plugin_global_context"],
+        local_contexts=kwargs["plugin_context_table"],
+        violations_as_exceptions=True,
+    )
+    sink.update(table or {})
+
+
+def _assert_http_state_visible(contexts, global_context):
+    """Assert the state written by the HTTP hooks reached the MCP hook.
+
+    Args:
+        contexts: Context table produced by the MCP pre-hook.
+        global_context: The global context shared by every hook of the request.
+
+    Returns:
+        dict: The plugin state, for hook-specific assertions.
+    """
+    assert contexts, "the MCP pre-hook produced no context table"
+    state = next(iter(contexts.values())).state
+    assert state["http_timestamp"] == "2025-01-01T00:00:00Z"
+    assert state["http_request_path"] == "/mcp"
+    assert state["permission_checked"] is True
+    assert global_context.state["shared_request_id"] == global_context.request_id
+    return state
+
+
+@pytest.mark.asyncio
+async def test_call_tool_cross_hook_sharing_end_to_end_with_real_plugin(monkeypatch):
+    """The issue's own repro: HTTP_PRE_REQUEST state must reach TOOL_PRE_INVOKE over /mcp."""
+    # Third-Party
+    from cpex.framework import HttpHeaderPayload, ToolHookType, ToolPreInvokePayload
+
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import call_tool, mcp_app, tool_service
+
+    _e2e_transport_patches(monkeypatch)
+    tool_contexts = {}
+
+    async with _cross_hook_plugin_session() as (manager, mock_ctx, global_context, _table):
 
         async def fake_invoke_tool(**kwargs):
-            """Run TOOL_PRE_INVOKE the way ``ToolService.invoke_tool`` does.
+            """Stand in for the DB-backed tool lookup; run the real pre-hook.
 
             Args:
                 **kwargs: Arguments forwarded by ``call_tool``.
@@ -4213,15 +4406,13 @@ async def test_call_tool_cross_hook_sharing_end_to_end_with_real_plugin(monkeypa
             Returns:
                 MagicMock: A minimal successful tool result.
             """
-            _result, table = await manager.invoke_hook(
+            await _dispatch_pre_hook(
+                manager,
                 ToolHookType.TOOL_PRE_INVOKE,
-                payload=ToolPreInvokePayload(name=kwargs["name"], args=kwargs["arguments"], headers=HttpHeaderPayload(root={})),
-                global_context=kwargs["plugin_global_context"],
-                local_contexts=kwargs["plugin_context_table"],
-                violations_as_exceptions=True,
+                ToolPreInvokePayload(name=kwargs["name"], args=kwargs["arguments"], headers=HttpHeaderPayload(root={})),
+                kwargs,
+                tool_contexts,
             )
-            tool_contexts.update(table or {})
-
             tool_result = MagicMock()
             content = MagicMock()
             content.type = "text"
@@ -4233,90 +4424,157 @@ async def test_call_tool_cross_hook_sharing_end_to_end_with_real_plugin(monkeypa
             tool_result.model_dump = lambda by_alias=True: {}
             return tool_result
 
-        @asynccontextmanager
-        async def fake_get_db():
-            """Yield a stand-in session.
-
-            Yields:
-                MagicMock: Unused by the stubbed ``invoke_tool``.
-            """
-            yield MagicMock()
-
-        monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
-        monkeypatch.setattr(
-            "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default",
-            AsyncMock(return_value=("server-1", {}, {})),
-        )
         monkeypatch.setattr(tool_service, "invoke_tool", fake_invoke_tool)
 
-        # 4. Drive the /mcp tool call. The fixture plugin raises if any earlier
-        #    hook's state is missing, so reaching the assertions is the guarantee.
         type(mcp_app).request_context = property(lambda self: mock_ctx)
         try:
             await call_tool("test_cross_hook_tool", {"foo": "bar"})
         finally:
             type(mcp_app).request_context = property(lambda self: (_ for _ in ()).throw(LookupError))
 
-        assert tool_contexts, "TOOL_PRE_INVOKE produced no context table"
-        state = next(iter(tool_contexts.values())).state
-        # State written by HTTP_PRE_REQUEST, HTTP_AUTH_CHECK_PERMISSION and
-        # TOOL_PRE_INVOKE must all be visible on the same plugin context.
-        assert state["http_timestamp"] == "2025-01-01T00:00:00Z"
-        assert state["http_request_path"] == "/mcp"
-        assert state["permission_checked"] is True
+        state = _assert_http_state_visible(tool_contexts, global_context)
         assert state["tool_name"] == "test_cross_hook_tool"
-        assert global_context.state["shared_request_id"] == global_context.request_id
-    finally:
-        await manager.shutdown()
-        PluginManager.reset()
 
 
 @pytest.mark.asyncio
-async def test_cross_hook_plugin_fails_without_forwarded_contexts():
-    """Negative control: dropping the contexts reproduces the #3879 failure.
-
-    Guards the guard - without this, the end-to-end test above would still pass
-    if the fixture plugin silently stopped checking for earlier hook state.
-    """
-    # Standard
-    from pathlib import Path
-
+async def test_get_prompt_cross_hook_sharing_end_to_end_with_real_plugin(monkeypatch):
+    """HTTP_PRE_REQUEST state must reach PROMPT_PRE_FETCH over /mcp."""
     # Third-Party
-    from cpex.framework import HttpHeaderPayload, PluginManager, ToolHookType, ToolPreInvokePayload
-    from cpex.framework.errors import PluginError
+    from cpex.framework import PromptHookType, PromptPrehookPayload
+    from mcp.types import PromptMessage, TextContent
 
     # First-Party
-    from mcpgateway.middleware.http_auth_middleware import run_pre_request_hooks
+    from mcpgateway.transports.streamablehttp_transport import get_prompt, mcp_app, prompt_service
 
-    config_file = Path(__file__).parent.parent / "plugins" / "fixtures" / "configs" / "cross_hook_context.yaml"
+    _e2e_transport_patches(monkeypatch)
+    prompt_contexts = {}
 
-    PluginManager.reset()
-    manager = PluginManager(str(config_file))
-    await manager.initialize()
+    async with _cross_hook_plugin_session() as (manager, mock_ctx, global_context, _table):
 
-    try:
-        _headers, global_context, _context_table = await run_pre_request_hooks(
-            plugin_manager=manager,
-            headers={"authorization": "Bearer test-token"},
-            path="/mcp",
-            method="POST",
-        )
+        async def fake_get_prompt(**kwargs):
+            """Stand in for the DB-backed prompt lookup; run the real pre-hook.
 
-        # This is precisely the pre-fix behaviour: TOOL_PRE_INVOKE reached with
-        # ``local_contexts=None`` because /mcp never read them off the scope.
+            Args:
+                **kwargs: Arguments forwarded by ``get_prompt``.
+
+            Returns:
+                MagicMock: A minimal successful prompt result.
+            """
+            await _dispatch_pre_hook(
+                manager,
+                PromptHookType.PROMPT_PRE_FETCH,
+                PromptPrehookPayload(prompt_id=kwargs["prompt_id"], args=kwargs["arguments"]),
+                kwargs,
+                prompt_contexts,
+            )
+            prompt_result = MagicMock()
+            prompt_result.messages = [PromptMessage(role="user", content=TextContent(type="text", text="hi"))]
+            prompt_result.description = "desc"
+            return prompt_result
+
+        monkeypatch.setattr(prompt_service, "get_prompt", fake_get_prompt)
+
+        type(mcp_app).request_context = property(lambda self: mock_ctx)
+        try:
+            await get_prompt("test_cross_hook_prompt", {"a": "b"})
+        finally:
+            type(mcp_app).request_context = property(lambda self: (_ for _ in ()).throw(LookupError))
+
+        state = _assert_http_state_visible(prompt_contexts, global_context)
+        assert state["prompt_id"] == "test_cross_hook_prompt"
+
+
+@pytest.mark.asyncio
+async def test_read_resource_cross_hook_sharing_end_to_end_with_real_plugin(monkeypatch):
+    """HTTP_PRE_REQUEST state must reach RESOURCE_PRE_FETCH over /mcp."""
+    # Third-Party
+    from cpex.framework import ResourceHookType, ResourcePreFetchPayload
+    from pydantic import AnyUrl
+
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import mcp_app, read_resource, resource_service
+
+    _e2e_transport_patches(monkeypatch)
+    resource_contexts = {}
+
+    async with _cross_hook_plugin_session() as (manager, mock_ctx, global_context, _table):
+
+        async def fake_read_resource(**kwargs):
+            """Stand in for the DB-backed resource lookup; run the real pre-hook.
+
+            Args:
+                **kwargs: Arguments forwarded by ``read_resource``.
+
+            Returns:
+                MagicMock: A minimal successful text resource.
+            """
+            await _dispatch_pre_hook(
+                manager,
+                ResourceHookType.RESOURCE_PRE_FETCH,
+                ResourcePreFetchPayload(uri=kwargs["resource_uri"], metadata={}),
+                kwargs,
+                resource_contexts,
+            )
+            resource_result = MagicMock()
+            resource_result.text = "resource content"
+            resource_result.blob = None
+            return resource_result
+
+        monkeypatch.setattr(resource_service, "read_resource", fake_read_resource)
+
+        type(mcp_app).request_context = property(lambda self: mock_ctx)
+        try:
+            await read_resource(AnyUrl("file:///cross-hook.txt"))
+        finally:
+            type(mcp_app).request_context = property(lambda self: (_ for _ in ()).throw(LookupError))
+
+        state = _assert_http_state_visible(resource_contexts, global_context)
+        assert state["resource_uri"] == "file:///cross-hook.txt"
+
+
+def _pre_fix_failure_cases():
+    """Enumerate the MCP pre-hooks and the error each raises without forwarded contexts.
+
+    Returns:
+        list: ``(hook_type, payload_factory, expected_message)`` tuples.
+    """
+    # Third-Party
+    from cpex.framework import HttpHeaderPayload, PromptHookType, PromptPrehookPayload, ResourceHookType, ResourcePreFetchPayload, ToolHookType, ToolPreInvokePayload
+
+    return [
+        (ToolHookType.TOOL_PRE_INVOKE, lambda: ToolPreInvokePayload(name="t", args={}, headers=HttpHeaderPayload(root={})), "http_timestamp not found in tool hook"),
+        (PromptHookType.PROMPT_PRE_FETCH, lambda: PromptPrehookPayload(prompt_id="p", args={}), "http_timestamp not found in prompt hook"),
+        (ResourceHookType.RESOURCE_PRE_FETCH, lambda: ResourcePreFetchPayload(uri="file:///r.txt", metadata={}), "http_timestamp not found in resource hook"),
+    ]
+
+
+_PRE_FIX_FAILURE_CASES = _pre_fix_failure_cases()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("hook_type,payload_factory,expected_message", _PRE_FIX_FAILURE_CASES, ids=[str(c[0]) for c in _PRE_FIX_FAILURE_CASES])
+async def test_cross_hook_plugin_fails_without_forwarded_contexts(hook_type, payload_factory, expected_message):
+    """Negative control: dropping the contexts reproduces the #3879 failure for every hook.
+
+    Guards the guard - without this, the end-to-end tests above would still pass
+    if the fixture plugin silently stopped checking for earlier hook state.
+    This is precisely the pre-fix behaviour: the MCP pre-hook reached with
+    ``local_contexts=None`` because /mcp never read them off the scope.
+    """
+    # Third-Party
+    from cpex.framework.errors import PluginError
+
+    async with _cross_hook_plugin_session() as (manager, _mock_ctx, global_context, _table):
         with pytest.raises(PluginError) as exc_info:
             await manager.invoke_hook(
-                ToolHookType.TOOL_PRE_INVOKE,
-                payload=ToolPreInvokePayload(name="test_cross_hook_tool", args={}, headers=HttpHeaderPayload(root={})),
+                hook_type,
+                payload=payload_factory(),
                 global_context=global_context,
                 local_contexts=None,
                 violations_as_exceptions=True,
             )
 
-        assert "http_timestamp not found in tool hook" in str(exc_info.value)
-    finally:
-        await manager.shutdown()
-        PluginManager.reset()
+        assert expected_message in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -3962,6 +3962,128 @@ async def test_call_tool_with_request_context_no_meta(monkeypatch):
         type(mcp_app).request_context = property(lambda self: (_ for _ in ()).throw(LookupError))
 
 
+def _plugin_context_scope():
+    """Build a request whose ASGI scope carries the pre-request plugin contexts.
+
+    Returns:
+        tuple: ``(mock_ctx, global_context, context_table)`` where ``mock_ctx``
+        mimics ``mcp_app.request_context`` for a request that already went
+        through ``HttpAuthMiddleware``.
+    """
+    # Third-Party
+    from cpex.framework import GlobalContext
+    from cpex.framework.models import PluginContext
+
+    global_context = GlobalContext(request_id="req-3879")
+    context_table = {"AuthPlugin": PluginContext(global_context=global_context, state={"user_token": "abc"})}
+
+    mock_ctx = MagicMock()
+    mock_ctx.meta = None
+    mock_ctx.request.scope = {
+        "type": "http",
+        "state": {"plugin_global_context": global_context, "plugin_context_table": context_table},
+    }
+    return mock_ctx, global_context, context_table
+
+
+@pytest.mark.asyncio
+async def test_call_tool_forwards_plugin_contexts_from_scope(monkeypatch):
+    """Regression guard for #3879 - /mcp tool calls must carry cross-hook plugin state.
+
+    ``HttpAuthMiddleware`` records the HTTP_PRE_REQUEST contexts on the ASGI
+    scope. Without forwarding them, TOOL_PRE_INVOKE hooks reached through the
+    streamable HTTP transport see an empty context, unlike the REST paths.
+    """
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import call_tool, mcp_app, tool_service
+
+    mock_db = MagicMock()
+    mock_result = MagicMock()
+    mock_content = MagicMock()
+    mock_content.type = "text"
+    mock_content.text = "hello"
+    mock_content.annotations = None
+    mock_content.meta = None
+    mock_result.content = [mock_content]
+    mock_result.structured_content = None
+    mock_result.model_dump = lambda by_alias=True: {}
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default",
+        AsyncMock(return_value=("server-1", {}, {})),
+    )
+    monkeypatch.setattr(tool_service, "invoke_tool", AsyncMock(return_value=mock_result))
+
+    mock_ctx, global_context, context_table = _plugin_context_scope()
+
+    type(mcp_app).request_context = property(lambda self: mock_ctx)
+    try:
+        await call_tool("mytool", {"foo": "bar"})
+    finally:
+        type(mcp_app).request_context = property(lambda self: (_ for _ in ()).throw(LookupError))
+
+    kwargs = tool_service.invoke_tool.await_args.kwargs
+    assert kwargs["plugin_global_context"] is global_context
+    assert kwargs["plugin_context_table"] is context_table
+
+
+@pytest.mark.asyncio
+async def test_call_tool_passes_none_when_scope_has_no_plugin_contexts(monkeypatch):
+    """Requests without pre-request hooks keep the previous behaviour."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import call_tool, mcp_app, tool_service
+
+    mock_db = MagicMock()
+    mock_result = MagicMock()
+    mock_content = MagicMock()
+    mock_content.type = "text"
+    mock_content.text = "hello"
+    mock_content.annotations = None
+    mock_content.meta = None
+    mock_result.content = [mock_content]
+    mock_result.structured_content = None
+    mock_result.model_dump = lambda by_alias=True: {}
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default",
+        AsyncMock(return_value=("server-1", {}, {})),
+    )
+    monkeypatch.setattr(tool_service, "invoke_tool", AsyncMock(return_value=mock_result))
+
+    mock_ctx = MagicMock()
+    mock_ctx.meta = None
+    mock_ctx.request.scope = {"type": "http", "state": {}}
+
+    type(mcp_app).request_context = property(lambda self: mock_ctx)
+    try:
+        await call_tool("mytool", {"foo": "bar"})
+    finally:
+        type(mcp_app).request_context = property(lambda self: (_ for _ in ()).throw(LookupError))
+
+    kwargs = tool_service.invoke_tool.await_args.kwargs
+    assert kwargs["plugin_global_context"] is None
+    assert kwargs["plugin_context_table"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_plugin_contexts_returns_none_without_request_context():
+    """The helper degrades to ``(None, None)`` outside an HTTP request."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _get_plugin_contexts_or_none
+
+    assert _get_plugin_contexts_or_none() == (None, None)
+
+
 @pytest.mark.asyncio
 async def test_call_tool_apps_client_still_requires_model_visibility(monkeypatch):
     """Apps-capable clients must use AppBridge for app-visible helper tools."""

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -4084,6 +4084,241 @@ async def test_get_plugin_contexts_returns_none_without_request_context():
     assert _get_plugin_contexts_or_none() == (None, None)
 
 
+def _malformed_scope_cases():
+    """Enumerate the scope shapes the type guards in the helper must reject.
+
+    Returns:
+        list: ``(case_id, scope, expect_global, expect_table)`` tuples where the
+        two ``expect_*`` flags say whether the corresponding slot should survive.
+    """
+    # Third-Party
+    from cpex.framework import GlobalContext
+    from cpex.framework.models import PluginContext
+
+    good_global = GlobalContext(request_id="req-3879")
+    good_table = {"AuthPlugin": PluginContext(global_context=good_global)}
+
+    return [
+        # ``scope`` is not a mapping at all - e.g. a transport that is not ASGI driven.
+        ("scope_not_a_dict", object(), False, False),
+        # ``state`` absent: an ASGI server that does not support lifespan state.
+        ("state_missing", {"type": "http"}, False, False),
+        # ``state`` present but not a mapping.
+        ("state_not_a_dict", {"type": "http", "state": ["not", "a", "dict"]}, False, False),
+        # Wrong type in one slot must not poison the other.
+        ("global_context_wrong_type", {"type": "http", "state": {"plugin_global_context": "not-a-context", "plugin_context_table": good_table}}, False, True),
+        ("context_table_wrong_type", {"type": "http", "state": {"plugin_global_context": good_global, "plugin_context_table": ["not", "a", "table"]}}, True, False),
+        # Explicit ``None`` values are the normal "no pre-request hooks ran" case.
+        ("both_none", {"type": "http", "state": {"plugin_global_context": None, "plugin_context_table": None}}, False, False),
+    ]
+
+
+@pytest.mark.parametrize("case_id,scope,expect_global,expect_table", _malformed_scope_cases(), ids=[c[0] for c in _malformed_scope_cases()])
+def test_get_plugin_contexts_rejects_malformed_scope_state(case_id, scope, expect_global, expect_table):
+    """Malformed ``scope["state"]`` must degrade to ``None`` instead of leaking junk.
+
+    The helper feeds ``invoke_tool`` directly, which in turn hands the values to
+    the plugin manager. Passing a wrongly typed object through would surface as
+    an opaque failure deep inside a hook, so each slot is type-guarded
+    independently - a bad ``plugin_global_context`` must not discard an
+    otherwise valid ``plugin_context_table``.
+    """
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _get_plugin_contexts_or_none, mcp_app
+
+    mock_ctx = MagicMock()
+    mock_ctx.request.scope = scope
+
+    type(mcp_app).request_context = property(lambda self: mock_ctx)
+    try:
+        global_context, context_table = _get_plugin_contexts_or_none()
+    finally:
+        type(mcp_app).request_context = property(lambda self: (_ for _ in ()).throw(LookupError))
+
+    assert (global_context is not None) is expect_global, f"{case_id}: unexpected global context {global_context!r}"
+    assert (context_table is not None) is expect_table, f"{case_id}: unexpected context table {context_table!r}"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_cross_hook_sharing_end_to_end_with_real_plugin(monkeypatch):
+    """End-to-end reproduction of #3879 driving a real ``PluginManager``.
+
+    The issue's repro is a custom authorization plugin that writes state in
+    ``HTTP_PRE_REQUEST`` and reads it back in ``TOOL_PRE_INVOKE`` over ``/mcp``.
+    The other tests in this file assert *which objects* ``call_tool`` forwards;
+    this one asserts those objects are actually sufficient for the real plugin
+    manager to resolve cross-hook state, using the shared
+    ``CrossHookContextPlugin`` fixture which raises ``ValueError`` the moment a
+    hook cannot see what an earlier hook stored.
+
+    The ``invoke_tool`` stub stands in for the database-backed tool lookup only;
+    it runs the same ``TOOL_PRE_INVOKE`` dispatch that ``ToolService`` performs,
+    so the middleware -> ASGI scope -> ``call_tool`` -> plugin-manager chain is
+    exercised for real.
+    """
+    # Standard
+    from pathlib import Path
+
+    # Third-Party
+    from cpex.framework import HttpAuthCheckPermissionPayload, HttpHeaderPayload, HttpHookType, PluginManager, ToolHookType, ToolPreInvokePayload
+
+    # First-Party
+    from mcpgateway.middleware.http_auth_middleware import run_pre_request_hooks
+    from mcpgateway.transports.streamablehttp_transport import call_tool, mcp_app, tool_service
+
+    config_file = Path(__file__).parent.parent / "plugins" / "fixtures" / "configs" / "cross_hook_context.yaml"
+
+    # ``PluginManager`` is a Borg singleton - reset around the test so the shared
+    # state never leaks into the rest of this module.
+    PluginManager.reset()
+    manager = PluginManager(str(config_file))
+    await manager.initialize()
+
+    try:
+        # 1. HTTP_PRE_REQUEST, exactly as ``HttpAuthMiddleware`` runs it on /mcp.
+        _headers, global_context, context_table = await run_pre_request_hooks(
+            plugin_manager=manager,
+            headers={"authorization": "Bearer test-token"},
+            path="/mcp",
+            method="POST",
+            client_host="127.0.0.1",
+            client_port=54321,
+        )
+        assert global_context is not None and context_table
+
+        # 2. HTTP_AUTH_CHECK_PERMISSION, which the fixture plugin also requires.
+        _perm_result, context_table = await manager.invoke_hook(
+            HttpHookType.HTTP_AUTH_CHECK_PERMISSION,
+            payload=HttpAuthCheckPermissionPayload(user_email="user@example.com", permission="tools.read"),
+            global_context=global_context,
+            local_contexts=context_table,
+        )
+
+        # 3. Hand the contexts over on the ASGI scope, the way the middleware does.
+        mock_ctx = MagicMock()
+        mock_ctx.meta = None
+        mock_ctx.request.scope = {
+            "type": "http",
+            "state": {"plugin_global_context": global_context, "plugin_context_table": context_table},
+        }
+
+        tool_contexts = {}
+
+        async def fake_invoke_tool(**kwargs):
+            """Run TOOL_PRE_INVOKE the way ``ToolService.invoke_tool`` does.
+
+            Args:
+                **kwargs: Arguments forwarded by ``call_tool``.
+
+            Returns:
+                MagicMock: A minimal successful tool result.
+            """
+            _result, table = await manager.invoke_hook(
+                ToolHookType.TOOL_PRE_INVOKE,
+                payload=ToolPreInvokePayload(name=kwargs["name"], args=kwargs["arguments"], headers=HttpHeaderPayload(root={})),
+                global_context=kwargs["plugin_global_context"],
+                local_contexts=kwargs["plugin_context_table"],
+                violations_as_exceptions=True,
+            )
+            tool_contexts.update(table or {})
+
+            tool_result = MagicMock()
+            content = MagicMock()
+            content.type = "text"
+            content.text = "ok"
+            content.annotations = None
+            content.meta = None
+            tool_result.content = [content]
+            tool_result.structured_content = None
+            tool_result.model_dump = lambda by_alias=True: {}
+            return tool_result
+
+        @asynccontextmanager
+        async def fake_get_db():
+            """Yield a stand-in session.
+
+            Yields:
+                MagicMock: Unused by the stubbed ``invoke_tool``.
+            """
+            yield MagicMock()
+
+        monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+        monkeypatch.setattr(
+            "mcpgateway.transports.streamablehttp_transport._get_request_context_or_default",
+            AsyncMock(return_value=("server-1", {}, {})),
+        )
+        monkeypatch.setattr(tool_service, "invoke_tool", fake_invoke_tool)
+
+        # 4. Drive the /mcp tool call. The fixture plugin raises if any earlier
+        #    hook's state is missing, so reaching the assertions is the guarantee.
+        type(mcp_app).request_context = property(lambda self: mock_ctx)
+        try:
+            await call_tool("test_cross_hook_tool", {"foo": "bar"})
+        finally:
+            type(mcp_app).request_context = property(lambda self: (_ for _ in ()).throw(LookupError))
+
+        assert tool_contexts, "TOOL_PRE_INVOKE produced no context table"
+        state = next(iter(tool_contexts.values())).state
+        # State written by HTTP_PRE_REQUEST, HTTP_AUTH_CHECK_PERMISSION and
+        # TOOL_PRE_INVOKE must all be visible on the same plugin context.
+        assert state["http_timestamp"] == "2025-01-01T00:00:00Z"
+        assert state["http_request_path"] == "/mcp"
+        assert state["permission_checked"] is True
+        assert state["tool_name"] == "test_cross_hook_tool"
+        assert global_context.state["shared_request_id"] == global_context.request_id
+    finally:
+        await manager.shutdown()
+        PluginManager.reset()
+
+
+@pytest.mark.asyncio
+async def test_cross_hook_plugin_fails_without_forwarded_contexts():
+    """Negative control: dropping the contexts reproduces the #3879 failure.
+
+    Guards the guard - without this, the end-to-end test above would still pass
+    if the fixture plugin silently stopped checking for earlier hook state.
+    """
+    # Standard
+    from pathlib import Path
+
+    # Third-Party
+    from cpex.framework import HttpHeaderPayload, PluginManager, ToolHookType, ToolPreInvokePayload
+    from cpex.framework.errors import PluginError
+
+    # First-Party
+    from mcpgateway.middleware.http_auth_middleware import run_pre_request_hooks
+
+    config_file = Path(__file__).parent.parent / "plugins" / "fixtures" / "configs" / "cross_hook_context.yaml"
+
+    PluginManager.reset()
+    manager = PluginManager(str(config_file))
+    await manager.initialize()
+
+    try:
+        _headers, global_context, _context_table = await run_pre_request_hooks(
+            plugin_manager=manager,
+            headers={"authorization": "Bearer test-token"},
+            path="/mcp",
+            method="POST",
+        )
+
+        # This is precisely the pre-fix behaviour: TOOL_PRE_INVOKE reached with
+        # ``local_contexts=None`` because /mcp never read them off the scope.
+        with pytest.raises(PluginError) as exc_info:
+            await manager.invoke_hook(
+                ToolHookType.TOOL_PRE_INVOKE,
+                payload=ToolPreInvokePayload(name="test_cross_hook_tool", args={}, headers=HttpHeaderPayload(root={})),
+                global_context=global_context,
+                local_contexts=None,
+                violations_as_exceptions=True,
+            )
+
+        assert "http_timestamp not found in tool hook" in str(exc_info.value)
+    finally:
+        await manager.shutdown()
+        PluginManager.reset()
+
+
 @pytest.mark.asyncio
 async def test_call_tool_apps_client_still_requires_model_visibility(monkeypatch):
     """Apps-capable clients must use AppBridge for app-visible helper tools."""


### PR DESCRIPTION
## 📌 Summary

Closes #3879.

Tool calls, prompt fetches and resource reads made over the Streamable HTTP `/mcp`
transport never receive the plugin contexts produced by `HTTP_PRE_REQUEST`, so a plugin
cannot share state between its own hooks on the one path an MCP client actually uses. Every REST handler already
forwards them; `/mcp` is the only remaining gap.

## 🔁 Reproduction Steps

1. Register an `http_pre_request` + `tool_pre_invoke` plugin that stores a value in
   `context.state` during the first hook and reads it back in the second
   (e.g. a per-user authorization plugin that stashes the caller's token).
2. Call the tool over `POST /servers/{server_id}/mcp/`.
3. `tool_pre_invoke` observes an empty context and the stored value is gone.

The same plugin works when the tool is invoked over the REST API.

## 🐞 Root Cause

`HttpAuthMiddleware` records the results of the pre-request hooks on the request
state (`mcpgateway/middleware/http_auth_middleware.py:224-227`):

```python
if context_table:
    request.state.plugin_context_table = context_table
if global_context:
    request.state.plugin_global_context = global_context
```

`ToolService.invoke_tool()` accepts both (`plugin_context_table` is documented as
"Optional plugin context table from previous hooks for cross-hook state sharing"),
and `mcpgateway/main.py` reads them off `request.state` at every REST call site.

`call_tool()` in `mcpgateway/transports/streamablehttp_transport.py` does not — it
calls `invoke_tool()` without either argument, so `tool_service` builds a fresh
`GlobalContext` and passes `local_contexts=None` to the hook manager. Anything a
plugin wrote during `HTTP_PRE_REQUEST` is dropped.

## 💡 Fix Description

`call_tool()`, `get_prompt()` and `read_resource()` now resolve the two contexts and
forward them to the matching service method — all three already accept the arguments.

The new `_get_plugin_contexts_or_none()` helper reads them from the ASGI scope
(`scope["state"]`, which is what `request.state` writes into) rather than from a
`ContextVar`. This mirrors path 2 of the existing `_get_request_context_or_default()`
helper and, as its docstring notes, survives the task-group boundaries introduced by
the MCP SDK where `ContextVar`s may be lost. Missing or unexpected values degrade to
`(None, None)`, i.e. exactly today's behaviour.

Scope notes:

- Only the local `invoke_tool()` path is touched. `invoke_tool_direct()`
  (`direct_proxy`) does not take plugin contexts, and the Rust runtime is tracked
  separately in #4119.

Relationship to the earlier attempt: #3915 fixed the same gap and was closed in favour
of a CPEX gated-extensions approach. Since then `main` has continued to standardise on
`plugin_context_table` — it is threaded through ~13 REST call sites in `main.py` and
`middleware/rbac.py` now uses it to share context with `HTTP_AUTH_CHECK_PERMISSION` —
while `mcpgateway/transports/` still contains zero references to it. This PR closes
that inconsistency with the mechanism already in use. If maintainers would rather land
this as a CPEX gated extension, I'm glad to redo it that way.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

19 tests cover the change in `tests/unit/mcpgateway/transports/test_streamablehttp_transport.py`:
forwarding for all three handlers, every type-guard fallback of the helper, an
end-to-end run of the issue's repro against a real `PluginManager` with the shared
`CrossHookContextPlugin` fixture for each of `TOOL_PRE_INVOKE` / `PROMPT_PRE_FETCH` /
`RESOURCE_PRE_FETCH`, and a negative control per hook that reproduces the pre-fix
failure with `local_contexts=None`.

| Check | Status |
|---|---|
| `pytest tests/unit/mcpgateway/transports/ tests/unit/mcpgateway/plugins/` + prompt/resource service tests | 1870 passed, 39 skipped |
| `pytest --doctest-modules mcpgateway/transports/streamablehttp_transport.py` | passed |
| `pre-commit run --files <both files>` | clean |
| `pylint mcpgateway/transports/streamablehttp_transport.py` | no new findings vs `main` |

## 📐 MCP Compliance (if relevant)

- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist

- [x] Code formatted (`black`, `isort`, `ruff`)
- [x] No secrets/credentials committed
- [x] DCO sign-off included

