### PR TITLE
fix: delete team-membership history when deleting a user

### DIFF
--- a/mcpgateway/services/email_auth_service.py
+++ b/mcpgateway/services/email_auth_service.py
@@ -2119,6 +2119,11 @@ class EmailAuthService:
             self.db.query(PendingUserApproval).filter(PendingUserApproval.approved_by == email).update({PendingUserApproval.approved_by: None}, synchronize_session=False)
             self.db.query(SSOAuthSession).filter(SSOAuthSession.user_email == email).update({SSOAuthSession.user_email: None}, synchronize_session=False)
 
+            # Team-membership history rows reference this user's member rows (and the user
+            # itself) via FKs that alembic created without ON DELETE CASCADE, so they must
+            # be removed before the member rows and the user row are deleted.
+            self.db.execute(delete(EmailTeamMemberHistory).where(EmailTeamMemberHistory.user_email == email))
+
             # Remove user from all team memberships BEFORE deleting teams
             # This prevents FK constraint issues when teams are deleted
             team_members_stmt = delete(EmailTeamMember).where(EmailTeamMember.user_email == email)

--- a/tests/unit/mcpgateway/services/test_email_auth_basic.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_basic.py
@@ -2671,7 +2671,7 @@ class TestEmailAuthServiceUserDeletion:
         mock_teams_result = MagicMock()
         mock_teams_result.scalars.return_value.all.return_value = []
 
-        mock_db.execute.side_effect = [mock_user_result, mock_teams_result, MagicMock(), MagicMock()]
+        mock_db.execute.side_effect = [mock_user_result, mock_teams_result, MagicMock(), MagicMock(), MagicMock()]
 
         query_mocks = {}
 
@@ -2718,6 +2718,52 @@ class TestEmailAuthServiceUserDeletion:
         query_mocks[(SSOAuthSession,)].update.assert_called_once_with({SSOAuthSession.user_email: None}, synchronize_session=False)
 
     @pytest.mark.asyncio
+    async def test_delete_user_deletes_team_member_history(self, service, mock_db, mock_user):
+        """Test user deletion removes the user's team-membership history rows (issue #6066)."""
+        # Third-Party
+        from sqlalchemy.sql.dml import Delete
+
+        mock_user_result = MagicMock()
+        mock_user_result.scalar_one_or_none.return_value = mock_user
+
+        mock_teams_result = MagicMock()
+        mock_teams_result.scalars.return_value.all.return_value = []
+
+        mock_db.execute.side_effect = [mock_user_result, mock_teams_result, MagicMock(), MagicMock(), MagicMock()]
+
+        def _build_query():
+            q = MagicMock()
+            q.filter.return_value = q
+            q.order_by.return_value = q
+            q.update.return_value = 0
+            q.delete.return_value = 0
+            q.first.return_value = None
+            return q
+
+        mock_db.query.side_effect = lambda *entities: _build_query()
+
+        mock_role_svc = MagicMock()
+        mock_role_svc.delete_all_user_roles = AsyncMock(return_value=0)
+
+        def _close_task(coro):
+            coro.close()
+            return None
+
+        with patch.object(type(service), "role_service", new_callable=lambda: property(lambda self: mock_role_svc)):
+            with patch("asyncio.create_task", side_effect=_close_task):
+                result = await service.delete_user("test@example.com")
+
+        assert result is True
+
+        history_deletes = [
+            call.args[0]
+            for call in mock_db.execute.call_args_list
+            if call.args and isinstance(call.args[0], Delete) and call.args[0].table.name == EmailTeamMemberHistory.__tablename__
+        ]
+        assert history_deletes, "delete_user must delete the user's email_team_member_history rows"
+        assert any("user_email" in str(stmt.whereclause) for stmt in history_deletes)
+
+    @pytest.mark.asyncio
     async def test_delete_user_not_found(self, service, mock_db):
         """Test deleting non-existent user."""
         mock_result = MagicMock()
@@ -2751,7 +2797,7 @@ class TestEmailAuthServiceUserDeletion:
         # Fifth execute: team members (empty)
         mock_empty_result = MagicMock()
 
-        mock_db.execute.side_effect = [mock_user_result, mock_teams_result, mock_members_result, mock_empty_result, mock_empty_result]
+        mock_db.execute.side_effect = [mock_user_result, mock_teams_result, mock_members_result, mock_empty_result, mock_empty_result, mock_empty_result]
 
         mock_role_svc = MagicMock()
         mock_role_svc.delete_all_user_roles = AsyncMock(return_value=0)
@@ -2805,6 +2851,7 @@ class TestEmailAuthServiceUserDeletion:
             mock_single_member,  # Just the user as member
             mock_delete_history,  # Delete team member history records
             mock_delete_team_members_for_team,  # Delete team members (for the team)
+            MagicMock(),  # Delete this user's team member history records
             mock_delete_team_members_all,  # Delete team members (remove user from all teams)
             mock_delete_auth_events,  # Delete auth events
         ]
@@ -2906,6 +2953,7 @@ class TestEmailAuthServiceUserDeletion:
             mock_single_member,
             mock_empty,  # delete history
             mock_empty,  # delete team members
+            mock_empty,  # delete this user's history
             mock_empty,  # delete user memberships
             mock_empty,  # delete auth events
         ]


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #6066

---

## 📝 Summary

`EmailAuthService.delete_user()` removed the user's `EmailTeamMember` rows and the user row, but never their `EmailTeamMemberHistory` rows.

The `email_team_member_history` table as created by alembic declares its `team_member_id` and `user_email` foreign keys **without** `ON DELETE CASCADE`. The ORM model in `db.py` does carry `ondelete="CASCADE"`, but that DDL never reaches an alembic-managed schema — which is every real deployment, since bootstrap runs alembic. So the member-row delete violated the FK and any user who had ever belonged to a team could not be deleted.

The fix deletes the user's history rows by `user_email` immediately before the member-row delete. Filtering on `user_email` is sufficient: history rows are only ever written with the member's own email (`personal_team_service.py`, `team_management_service.py`), and the NOT NULL `user_email` FK to `email_users.email` independently requires those rows to go before the user row.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

`pytest tests/unit/mcpgateway/services/test_email_auth_basic.py -k delete_user` — 12 passed. The new `test_delete_user_deletes_team_member_history` fails on unpatched source (`assert []`), so it pins the behaviour rather than the implementation.

| Check | Command | Status |
|---|---|---|
| Lint | `make ruff` | ✅ All checks passed |
| Docstring coverage | `make interrogate` | ✅ 100.0% |
| Unit tests | `make test` | ✅ 21,7xx passed, 0 failed |
| Pre-commit | `pre-commit run --files <changed>` | ✅ Passed |

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

Deliberately no alembic FK-alter migration here. The service-level delete is backend-agnostic and fixes deletion on every database; aligning the alembic DDL with the model's `ondelete="CASCADE"` would need a SQLite batch table rebuild and isn't required for the fix. Happy to add it as a follow-up if you'd prefer the schema and the model to agree.

Four existing `delete_user` tests hard-code the length of `mock_db.execute.side_effect`, so the extra `DELETE` exhausted their mock lists — each was extended by one entry.
