### PR TITLE
fix: give the admin module the initialized LoggingService

### DIFF
--- a/mcpgateway/api/v1/__init__.py
+++ b/mcpgateway/api/v1/__init__.py
@@ -275,9 +275,8 @@ def _assemble_routers(  # noqa: C901 — deliberate single-function assembly, co
 
         try:
             # First-Party
-            from mcpgateway.admin import admin_router, set_logging_service, validate_section_permissions  # pylint: disable=import-outside-toplevel
+            from mcpgateway.admin import admin_router, validate_section_permissions  # pylint: disable=import-outside-toplevel
 
-            set_logging_service(logging_service)
             target_router.include_router(admin_router)
             validate_section_permissions(admin_router)
             logger.info("Admin router included - Admin API enabled")

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -12844,6 +12844,16 @@ if settings.legacy_api_enabled:
 else:  # pragma: no cover
     logger.info("Legacy route shims disabled (LEGACY_API_ENABLED=false)")
 
+if settings.mcpgateway_admin_api_enabled:
+    # The admin module must observe the LoggingService that lifespan initializes,
+    # not the throwaway instance mcpgateway.api.v1 uses for its own logger — an
+    # uninitialized service has no storage, so the Logs tab stays empty and log
+    # export always returns 503 (#6068).
+    # First-Party
+    from mcpgateway.admin import set_logging_service  # pylint: disable=import-outside-toplevel  # noqa: E402
+
+    set_logging_service(logging_service)
+
 # ---------------------------------------------------------------------------
 # Unversioned routes — mounted directly on app (no /v1 prefix)
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/test_api_v1.py
+++ b/tests/unit/mcpgateway/test_api_v1.py
@@ -559,12 +559,18 @@ class TestBuildV1RouterGroupF:
         # Group A intact even when admin cluster fails
         assert "/v1/sentinel-protocol" in _route_paths(v1)
 
-    def test_set_logging_service_called_when_admin_enabled(self):
+    def test_admin_logging_service_not_overridden_when_admin_enabled(self):
+        """Router assembly must leave the admin module's LoggingService alone (#6068).
+
+        api.v1 owns an uninitialized LoggingService for its own logger; injecting it
+        into mcpgateway.admin left the admin routes without log storage forever.
+        main.py wires the lifespan-initialized instance instead.
+        """
         settings = _settings(mcpgateway_admin_api_enabled=True)
         mods = self._admin_modules()
         with patch.dict(sys.modules, mods):
             build_v1_router(settings, **_required_kwargs())
-        mods["mcpgateway.admin"].set_logging_service.assert_called_once()
+        mods["mcpgateway.admin"].set_logging_service.assert_not_called()
 
     def test_validate_section_permissions_called_when_admin_enabled(self):
         settings = _settings(mcpgateway_admin_api_enabled=True)

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -6174,3 +6174,30 @@ class TestA2AInvokeBodyEndpoint:
         response = test_client.post("/a2a/agent-1/invoke", json={"parameters": {}, "interaction_type": "query"}, headers=auth_headers)
         assert response.status_code in [200, 404]
         assert mock_context.called
+
+
+class TestAdminLoggingServiceWiring:
+    """The admin module must share main's lifespan-initialized LoggingService."""
+
+    def test_admin_uses_main_logging_service(self):
+        """Only the instance lifespan initializes has log storage (#6068).
+
+        When admin observed a different instance, ``logging_service.get_storage()``
+        returned None forever: the Logs tab stayed empty and log export 503'd.
+
+        conftest imports main with the admin API disabled, so this asserts the
+        wiring in a subprocess that imports main the way production does.
+        """
+        # Standard
+        import subprocess  # pylint: disable=import-outside-toplevel
+        import sys  # pylint: disable=import-outside-toplevel
+
+        env = {**os.environ, "MCPGATEWAY_ADMIN_API_ENABLED": "true"}
+        result = subprocess.run(
+            [sys.executable, "-c", "import mcpgateway.admin as a, mcpgateway.main as m; print(a.logging_service is m.logging_service)"],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        )
+        assert result.stdout.strip().splitlines()[-1] == "True", result.stderr


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #6068

---

## 📝 Summary

Two `LoggingService()` instances existed. `lifespan` initializes the one in `main.py` — that call is what creates the log storage. But router assembly injected `api/v1`'s own, never-initialized instance into `mcpgateway.admin` via `set_logging_service()`.

The admin routes therefore saw `logging_service.get_storage()` return `None` forever: the Logs tab rendered empty and log export answered 503 on every request.

This drops the injection from `_assemble_routers()` and wires the lifespan-managed instance from `main.py` after router assembly instead. `api/v1` keeps its own instance for its module logger, which is all it needed it for.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

`pytest tests/unit/mcpgateway/test_api_v1.py tests/unit/mcpgateway/test_admin.py` — passed.

Two regression tests, both verified failing on unpatched source:
- `test_admin_logging_service_not_overridden_when_admin_enabled` — assembly must not touch the admin module's service.
- `test_admin_uses_main_logging_service` — main's wiring produces one shared instance.

| Check | Command | Status |
|---|---|---|
| Lint | `make ruff` | ✅ All checks passed |
| Docstring coverage | `make interrogate` | ✅ 100.0% |
| Unit tests | `make test` | ✅ 21,7xx passed, 0 failed |
| Pre-commit | `pre-commit run --files <changed>` | ✅ Passed |

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

Worth flagging why the suite never caught this: `tests/conftest.py` calls `set_logging_service(main_mod.logging_service)` itself, so every test saw correctly-wired services regardless of production behaviour. It also imports `main` with the admin API disabled, so main's new wiring block doesn't execute in-process. The second regression test therefore imports `main` in a subprocess with `MCPGATEWAY_ADMIN_API_ENABLED=true`, which is the arrangement production actually uses.

`test_set_logging_service_called_when_admin_enabled` asserted the old behaviour and has been replaced by its inverse.
