### PR TITLE
fix: report real state in the maintenance System Health card

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -202,6 +202,7 @@ from mcpgateway.utils.orjson_response import ORJSONResponse
 from mcpgateway.utils.pagination import paginate_query
 from mcpgateway.utils.passthrough_headers import PassthroughHeadersError
 from mcpgateway.utils.paths import resolve_root_path as _resolve_root_path
+from mcpgateway.utils.redis_client import is_redis_available
 from mcpgateway.utils.security_cookies import clear_auth_cookie, CookieTooLargeError, set_auth_cookie
 from mcpgateway.utils.services_auth import encode_auth
 from mcpgateway.utils.sqlalchemy_modifier import json_contains_tag_expr
@@ -2326,9 +2327,6 @@ async def get_overview_partial(
         redis_reachable = False
         if redis_available and cache_type.lower() == "redis" and settings.redis_url:
             try:
-                # First-Party
-                from mcpgateway.utils.redis_client import is_redis_available  # pylint: disable=import-outside-toplevel
-
                 redis_reachable = await is_redis_available()
             except Exception:
                 redis_reachable = False
@@ -18295,7 +18293,7 @@ async def admin_generate_support_bundle(
 async def get_maintenance_partial(
     request: Request,
     _user=Depends(get_current_user_with_permissions),
-    _db: Session = Depends(get_db),
+    db: Session = Depends(get_db),
 ):
     """Render the maintenance dashboard partial (platform admin only).
 
@@ -18309,7 +18307,7 @@ async def get_maintenance_partial(
     Args:
         request: FastAPI request object
         _user: Authenticated user with admin permissions
-        _db: Database session for permission checks.
+        db: Database session for permission checks and the health probe.
 
     Returns:
         HTMLResponse: Rendered maintenance dashboard template
@@ -18319,13 +18317,34 @@ async def get_maintenance_partial(
     """
     root_path = _resolve_root_path(request)
 
+    try:
+        db.execute(text("SELECT 1"))
+        database_healthy = True
+    except Exception:  # nosec B110 - a failed probe is the answer, not an error
+        database_healthy = False
+
+    # Only redis exposes a remote liveness check; the other backends are either
+    # in-process or the database we already probed, so they get a plain label.
+    cache_backend = getattr(settings, "cache_type", "database")
+    cache_healthy = None
+    if cache_backend == "redis" and getattr(settings, "redis_url", None):
+        try:
+            cache_healthy = await is_redis_available()
+        except Exception:  # nosec B110 - a failed probe is the answer, not an error
+            cache_healthy = False
+
     # Build payload with settings for the template
     payload = {
         "settings": {
             "metrics_cleanup_enabled": getattr(settings, "metrics_cleanup_enabled", False),
             "metrics_rollup_enabled": getattr(settings, "metrics_rollup_enabled", False),
             "metrics_retention_days": getattr(settings, "metrics_retention_days", 30),
-        }
+        },
+        "health": {
+            "database_healthy": database_healthy,
+            "cache_backend": cache_backend,
+            "cache_healthy": cache_healthy,
+        },
     }
 
     return request.app.state.templates.TemplateResponse(

--- a/mcpgateway/templates/maintenance_partial.html
+++ b/mcpgateway/templates/maintenance_partial.html
@@ -353,33 +353,46 @@
       </svg>
       System Health
     </h3>
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div class="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
         <div class="text-sm font-medium text-gray-500 dark:text-gray-400">Database</div>
+        {% if payload.health.database_healthy %}
         <div class="text-lg font-semibold text-green-600 dark:text-green-400 flex items-center mt-1">
           <svg class="h-5 w-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
           </svg>
           Healthy
         </div>
+        {% else %}
+        <div class="text-lg font-semibold text-red-600 dark:text-red-400 flex items-center mt-1">
+          <svg class="h-5 w-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+          </svg>
+          Unavailable
+        </div>
+        {% endif %}
       </div>
       <div class="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
         <div class="text-sm font-medium text-gray-500 dark:text-gray-400">Cache</div>
+        {% if payload.health.cache_healthy is none %}
+        <div class="text-lg font-semibold text-gray-600 dark:text-gray-300 flex items-center mt-1">
+          {% if payload.health.cache_backend == "memory" %}In-memory{% elif payload.health.cache_backend == "none" %}Disabled{% else %}Database-backed{% endif %}
+        </div>
+        {% elif payload.health.cache_healthy %}
         <div class="text-lg font-semibold text-green-600 dark:text-green-400 flex items-center mt-1">
           <svg class="h-5 w-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
           </svg>
           Operational
         </div>
-      </div>
-      <div class="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
-        <div class="text-sm font-medium text-gray-500 dark:text-gray-400">Background Jobs</div>
-        <div class="text-lg font-semibold text-green-600 dark:text-green-400 flex items-center mt-1">
+        {% else %}
+        <div class="text-lg font-semibold text-red-600 dark:text-red-400 flex items-center mt-1">
           <svg class="h-5 w-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
           </svg>
-          Running
+          Unreachable
         </div>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -20873,9 +20873,74 @@ class TestMaintenanceMisc:
         request.app.state.templates = MagicMock()
         request.app.state.templates.TemplateResponse.return_value = HTMLResponse("<html>Maintenance</html>")
 
-        result = await get_maintenance_partial(request, _user={"email": "admin@test.com"}, _db=mock_db)
+        result = await get_maintenance_partial(request, _user={"email": "admin@test.com"}, db=mock_db)
         assert isinstance(result, HTMLResponse)
         request.app.state.templates.TemplateResponse.assert_called_once()
+
+    @staticmethod
+    def _maintenance_request():
+        """Build a request whose templates render maintenance_partial.html for real."""
+        # Third-Party
+        from fastapi.templating import Jinja2Templates
+
+        request = MagicMock(spec=Request)
+        request.scope = {"root_path": "", "type": "http"}
+        request.app = MagicMock()
+        request.app.state.templates = Jinja2Templates(directory="mcpgateway/templates")
+        return request
+
+    @pytest.mark.asyncio
+    async def test_maintenance_partial_reports_healthy_database(self, monkeypatch, allow_permission, mock_db):
+        """A working database probe renders the healthy state (#6070)."""
+        monkeypatch.setattr("mcpgateway.admin.settings.cache_type", "memory", raising=False)
+
+        request = self._maintenance_request()
+        result = await get_maintenance_partial(request, _user={"email": "admin@test.com"}, db=mock_db)
+
+        body = result.body.decode()
+        assert "Healthy" in body
+        assert "Unavailable" not in body
+
+    @pytest.mark.asyncio
+    async def test_maintenance_partial_reports_unavailable_database(self, monkeypatch, allow_permission, mock_db):
+        """A failing database probe renders the unavailable state (#6070)."""
+        # Third-Party
+        from sqlalchemy.exc import SQLAlchemyError
+
+        monkeypatch.setattr("mcpgateway.admin.settings.cache_type", "memory", raising=False)
+        mock_db.execute.side_effect = SQLAlchemyError("db down")
+
+        request = self._maintenance_request()
+        result = await get_maintenance_partial(request, _user={"email": "admin@test.com"}, db=mock_db)
+
+        body = result.body.decode()
+        assert "Unavailable" in body
+        assert "Healthy" not in body
+
+    @pytest.mark.asyncio
+    async def test_maintenance_partial_shows_cache_backend_without_probe(self, monkeypatch, allow_permission, mock_db):
+        """Non-redis backends get a plain label, never a fabricated status (#6070)."""
+        monkeypatch.setattr("mcpgateway.admin.settings.cache_type", "memory", raising=False)
+
+        request = self._maintenance_request()
+        result = await get_maintenance_partial(request, _user={"email": "admin@test.com"}, db=mock_db)
+
+        body = result.body.decode()
+        assert "In-memory" in body
+        assert "Operational" not in body
+        assert "Background Jobs" not in body
+
+    @pytest.mark.asyncio
+    async def test_maintenance_partial_probes_redis_backend(self, monkeypatch, allow_permission, mock_db):
+        """A redis backend is probed live and rendered unreachable when the ping fails (#6070)."""
+        monkeypatch.setattr("mcpgateway.admin.settings.cache_type", "redis", raising=False)
+        monkeypatch.setattr("mcpgateway.admin.settings.redis_url", "redis://localhost:6379/0", raising=False)
+        monkeypatch.setattr("mcpgateway.admin.is_redis_available", AsyncMock(return_value=False))
+
+        request = self._maintenance_request()
+        result = await get_maintenance_partial(request, _user={"email": "admin@test.com"}, db=mock_db)
+
+        assert "Unreachable" in result.body.decode()
 
     @pytest.mark.asyncio
     async def test_admin_import_preview_success(self, monkeypatch, allow_permission, mock_db):


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #6070

---

## 📝 Summary

The card hardcoded Database = Healthy, Cache = Operational and Background Jobs = Running as literal strings in the template, and the route passed no health data at all. It claimed a healthy system even with the database down.

`get_maintenance_partial` now probes the database with `SELECT 1` and pings Redis when — and only when — Redis is the configured cache backend. `memory`, `database` and `none` have no remote probe distinct from the DB card, so they render a plain backend label rather than an invented status.

The Background Jobs card is removed: there's no queryable job registry to back it, and the issue sanctions dropping unbacked indicators.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

`pytest tests/unit/mcpgateway/test_admin.py -k maintenance` — 23 passed. Four new tests render the real Jinja template through the route:

- working db → `Healthy`, no `Unavailable`
- `db.execute` raising → `Unavailable`, no `Healthy`
- memory backend → `In-memory`, no `Operational`, no `Background Jobs`
- redis backend with a failing ping → `Unreachable`

The three template-contract tests fail on the unpatched template.

Live against a local gateway (`cache_type=database`), the Maintenance tab renders a two-card grid: **Database — Healthy**, **Cache — Database-backed**.

| Check | Command | Status |
|---|---|---|
| Lint | `make ruff` | ✅ All checks passed |
| Docstring coverage | `make interrogate` | ✅ 100.0% |
| Unit tests | `make test` | ✅ 21,7xx passed, 0 failed |
| Pre-commit | `pre-commit run --files <changed>` | ✅ Passed |

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

Also drops the local `is_redis_available` import in `admin_overview` that the new module-level import makes redundant.
