### PR TITLE
Apply team_id filter for admin callers on tools, resources, prompts, servers and a2a (#6150)

### DIFF
--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -1002,6 +1002,9 @@ class A2AAgentService(BaseService):
 
         query = await self._apply_access_control(query, db, user_email, token_teams, team_id)
 
+        if team_id:
+            query = query.where(DbA2AAgent.team_id == team_id)
+
         if visibility:
             query = query.where(DbA2AAgent.visibility == visibility)
 

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -1467,6 +1467,9 @@ class PromptService(BaseService):
 
             query = await self._apply_access_control(query, db, user_email, token_teams, team_id)
 
+            if team_id:
+                query = query.where(DbPrompt.team_id == team_id)
+
             if visibility:
                 query = query.where(DbPrompt.visibility == visibility)
 

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -1266,6 +1266,9 @@ class ResourceService(BaseService):
 
             query = await self._apply_access_control(query, db, user_email, token_teams, team_id)
 
+            if team_id:
+                query = query.where(DbResource.team_id == team_id)
+
             if visibility:
                 query = query.where(DbResource.visibility == visibility)
 

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -833,6 +833,9 @@ class ServerService(BaseService):
 
         query = await self._apply_access_control(query, db, user_email, token_teams, team_id)
 
+        if team_id:
+            query = query.where(DbServer.team_id == team_id)
+
         if visibility:
             query = query.where(DbServer.visibility == visibility)
 

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -2825,6 +2825,9 @@ class ToolService(BaseService):
                 query = query.where(DbTool.enabled)
             query = await self._apply_access_control(query, db, user_email, token_teams, team_id)
 
+            if team_id:
+                query = query.where(DbTool.team_id == team_id)
+
             if visibility:
                 query = query.where(DbTool.visibility == visibility)
 

--- a/tests/unit/mcpgateway/services/test_team_id_admin_filter.py
+++ b/tests/unit/mcpgateway/services/test_team_id_admin_filter.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for admin team_id filtering on list endpoints.
+
+Companion to the gateway fix in #5929 / issue #5496. For admin callers the
+``_apply_access_control`` bypass branches return before ``team_id`` is applied,
+so ``GET /tools|/resources|/prompts|/servers|/a2a?team_id=<id>`` used to ignore
+the filter and leak items from other teams (issue #6150). Each list method now
+applies an exact ``team_id`` filter after access control, exactly as
+``list_gateways`` already does.
+"""
+
+# Standard
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.services.a2a_service import A2AAgentService
+from mcpgateway.services.prompt_service import PromptService
+from mcpgateway.services.resource_service import ResourceService
+from mcpgateway.services.server_service import ServerService
+from mcpgateway.services.tool_service import ToolService
+
+
+# (service factory, module path for patching, list method name, table name)
+_CASES = [
+    (ToolService, "mcpgateway.services.tool_service", "list_tools", "tools"),
+    (ResourceService, "mcpgateway.services.resource_service", "list_resources", "resources"),
+    (PromptService, "mcpgateway.services.prompt_service", "list_prompts", "prompts"),
+    (ServerService, "mcpgateway.services.server_service", "list_servers", "servers"),
+    (A2AAgentService, "mcpgateway.services.a2a_service", "list_agents", "a2a_agents"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("service_cls, module, method_name, table", _CASES, ids=[c[3] for c in _CASES])
+async def test_admin_team_id_is_an_exact_filter(service_cls, module, method_name, table, monkeypatch):
+    """Admin team_id filtering restricts to the requested team on every list endpoint."""
+    db = MagicMock()
+
+    mock_cache = MagicMock()
+    mock_cache.get = AsyncMock(return_value=None)
+    mock_cache.set = AsyncMock()
+    mock_cache.hash_filters = MagicMock(return_value="h")
+    monkeypatch.setattr(f"{module}._get_registry_cache", lambda: mock_cache)
+
+    mock_paginate = AsyncMock(return_value=([], None))
+    monkeypatch.setattr(f"{module}.unified_paginate", mock_paginate)
+    monkeypatch.setattr("mcpgateway.services.base_service.is_user_admin", MagicMock(return_value=True))
+
+    service = service_cls()
+    await getattr(service, method_name)(
+        db,
+        user_email="admin@test.com",
+        token_teams=None,
+        team_id="team-1",
+    )
+
+    query = mock_paginate.await_args.kwargs["query"]
+    compiled = str(query.compile(compile_kwargs={"literal_binds": True}))
+    assert f"{table}.team_id = 'team-1'" in compiled


### PR DESCRIPTION
Fixes #6150

### Problem

The `team_id` query parameter is silently ignored for admin callers on `GET /tools`, `GET /resources`, `GET /prompts`, `GET /servers` and `GET /a2a`. Every item is returned regardless of the value supplied, including `visibility=team` items scoped to a different team.

This is the same defect #5496 described for gateways, which #5929 fixed in `list_gateways`. The five sibling endpoints were never fixed.

### Root cause

All six list methods apply `team_id` through `BaseService._apply_access_control()`, but both admin bypass branches return before `team_id` is used:

```python
if user_email is None and token_teams is None:
    return query.where(model_cls.visibility != "private")   # team_id unused

if token_teams is None:
    if is_user_admin(db, user_email):
        return query.where(or_(...))                        # team_id unused
```

Only the non-admin fall-through passes `team_id` to `_apply_visibility_filter`, which is why the filter works for regular users but not admins.

`list_gateways` already handles this by applying an exact filter *after* `_apply_access_control`:

```python
query = await self._apply_access_control(query, db, user_email, token_teams, team_id)
if team_id:
    query = query.where(DbGateway.team_id == team_id)
```

### Fix

Apply the identical exact-team filter in the five sibling list methods (`list_tools`, `list_resources`, `list_prompts`, `list_servers`, `list_agents`), matching the merged gateway behaviour. This keeps the change consistent with #5929 and touches only the list paths.

### Tests

Added `tests/unit/mcpgateway/services/test_team_id_admin_filter.py`, a parameterized test asserting the compiled query for an admin caller contains `<table>.team_id = '<id>'` on all five endpoints. Verified it fails on every case before this change and passes after. `test_base_service.py` and `test_authorization_access.py` still pass (96 passed), so non-admin visibility semantics are unchanged.