### PR TITLE
fix(compose): eliminate idle DB connection churn in traces

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
+    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-07T13:52:41Z",
+  "generated_at": "2026-08-10T08:37:15Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -525,7 +525,12 @@ services:
       - DB_POOL_SIZE=20                # Pool size per worker
       - DB_MAX_OVERFLOW=10             # Extra connections under load
       - DB_POOL_TIMEOUT=60             # Time to wait for connection before failing
-      - DB_POOL_RECYCLE=60             # Recycle before PgBouncer CLIENT_IDLE_TIMEOUT (half of 120s)
+      # pre_ping already replaces connections PgBouncer closed at CLIENT_IDLE_TIMEOUT,
+      # so a short recycle is redundant and causes connect churn: with 51 workers'
+      # pools, most connections idle >60s between uses and get recycled on EVERY
+      # checkout. -1 disables time-based recycling; stale connections are still
+      # detected and replaced transparently by the pre-ping.
+      - DB_POOL_RECYCLE=${DB_POOL_RECYCLE:--1}  # Disable; pre_ping covers pgbouncer idle closes
       # ═══════════════════════════════════════════════════════════════════════════
       # Database Startup Resilience (prevents crash-loop on DB outage)
       # ═══════════════════════════════════════════════════════════════════════════
@@ -1010,7 +1015,7 @@ services:
       - SERVER_IDLE_TIMEOUT=600        # Close unused server connections after 10 min
       # Timeout settings
       - QUERY_WAIT_TIMEOUT=60          # Max wait for available connection before failing request
-      - CLIENT_IDLE_TIMEOUT=120        # Close idle client connections (4x IDLE_TRANSACTION_TIMEOUT; DB_POOL_RECYCLE=60 is half this, ensuring proactive recycle before PgBouncer closes them)
+      - CLIENT_IDLE_TIMEOUT=${CLIENT_IDLE_TIMEOUT:-600}  # Close idle client connections after 10min (matches SERVER_IDLE_TIMEOUT; with DB_POOL_RECYCLE=-1 + pre_ping, idle-close at 120s caused connect churn in every trace)
       - SERVER_CONNECT_TIMEOUT=5       # Timeout for new connections to PostgreSQL
       # Transaction cleanup - critical for avoiding idle-in-transaction buildup
       # NOTE: In transaction pooling, session-level advisory locks (used by migrations)


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Relates to #1995 (SQLAlchemy pool configuration for PgBouncer deployments) — addresses the idle-connection churn aspect; does not implement the `pre_ping=false` recommendation discussed there.

---

## 📝 Summary

The compose stack's gateway/PgBouncer timeout interaction caused constant physical reconnects, visible as a `connect` span on nearly every traced query.

**Mechanism:**

1. `DB_POOL_RECYCLE=60` recycled any pooled connection idle longer than 60s.
2. With 51 workers × pool size 20 (~1000 pooled connections), most connections idle far longer than that at moderate traffic — so nearly every checkout became a physical reconnect instead of a pool reuse.
3. PgBouncer's `CLIENT_IDLE_TIMEOUT=120` then closed those connections from its side at 120s, compounding the churn.

**Changes (docker-compose.yml only):**

- `DB_POOL_RECYCLE=-1` — `pool_pre_ping` already detects and transparently replaces connections PgBouncer has closed, so short time-based recycling is redundant and was the direct cause of the connect churn. Overridable via `${DB_POOL_RECYCLE:--1}`.
- `CLIENT_IDLE_TIMEOUT=600` (was 120) — matches `SERVER_IDLE_TIMEOUT`, so idle pooled connections survive the background-tick cadence instead of being killed between uses. Overridable via `${CLIENT_IDLE_TIMEOUT:-600}`.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

_Note: config-only change to the compose stack; no Python code paths are touched, so there is no unit-test surface. The `.secrets.baseline` delta is a `detect-secrets` regeneration artifact (timestamp + exclude-regex rewrite) with no new findings._

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

Verified in the running compose stack: with warm pools, 4 sequential sessions produced **1 physical connect and 0 closes** (previously: a connect span per query at moderate traffic). Idle connect rate collapses once pools are warm; `pre_ping` transparently replaces any connections PgBouncer does close.

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | N/A — YAML-only change |
| Unit tests                | `make test`     | N/A — no Python code changed |
| Coverage ≥ 80%            | `make coverage` | N/A — no Python code changed |

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

Both timeouts are exposed as environment overrides (`DB_POOL_RECYCLE`, `CLIENT_IDLE_TIMEOUT`) so deployments with different traffic profiles can tune without editing the compose file.
