### PR TITLE
fix(oauth): add tool-discovery trigger for token-exchange gateways

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-12T15:30:22Z",
+  "generated_at": "2026-08-12T09:20:04Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -258,7 +258,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2047,
+        "line_number": 2046,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2135,
+        "line_number": 2134,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2485,
+        "line_number": 2484,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3850,
+        "line_number": 3849,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3941,
+        "line_number": 3940,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3984,
+        "line_number": 3983,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3989,
+        "line_number": 3988,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3994,
+        "line_number": 3993,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1120,7 +1120,7 @@
         "hashed_secret": "6357356babb60e56a10f966756c1523e768554c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 199,
+        "line_number": 225,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1128,7 +1128,7 @@
         "hashed_secret": "5237629943e0f8297ce640ac71466386c1d33111",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 200,
+        "line_number": 226,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1136,7 +1136,7 @@
         "hashed_secret": "bba01aaf8824007c006df1c0eacfb9489e509535",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 241,
+        "line_number": 267,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1144,7 +1144,7 @@
         "hashed_secret": "5c216af8faacfff02f8ee00326ecfcfb3334922f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 291,
+        "line_number": 317,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2358,7 +2358,7 @@
         "hashed_secret": "1513802ada0ec04c2446206e16baa7256ebff74b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 661,
+        "line_number": 636,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3890,7 +3890,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 887,
+        "line_number": 888,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3910,7 +3910,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14947,
+        "line_number": 14959,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-12T09:20:04Z",
+  "generated_at": "2026-08-13T08:58:29Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -258,7 +258,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2046,
+        "line_number": 2047,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2134,
+        "line_number": 2135,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2484,
+        "line_number": 2485,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3849,
+        "line_number": 3850,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3940,
+        "line_number": 3941,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3983,
+        "line_number": 3984,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3988,
+        "line_number": 3989,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3993,
+        "line_number": 3994,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1120,7 +1120,7 @@
         "hashed_secret": "6357356babb60e56a10f966756c1523e768554c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 225,
+        "line_number": 229,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1128,7 +1128,7 @@
         "hashed_secret": "5237629943e0f8297ce640ac71466386c1d33111",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 226,
+        "line_number": 230,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1136,7 +1136,7 @@
         "hashed_secret": "bba01aaf8824007c006df1c0eacfb9489e509535",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 267,
+        "line_number": 271,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1144,7 +1144,7 @@
         "hashed_secret": "5c216af8faacfff02f8ee00326ecfcfb3334922f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 317,
+        "line_number": 321,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2358,7 +2358,7 @@
         "hashed_secret": "1513802ada0ec04c2446206e16baa7256ebff74b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 636,
+        "line_number": 661,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/architecture/oauth-design.md
+++ b/docs/docs/architecture/oauth-design.md
@@ -192,6 +192,32 @@ Typical use case: the user authenticates to ContextForge once (JWT/SSO), and eve
 - **`inbound_user_jwt`** (default): The ContextForge JWT presented by the calling user on the current request is used as the `subject_token` in the exchange. This requires the inbound request to carry a verifiable JWT (not an opaque API key).
 - **`user_oauth_token`**: The user's previously stored per-gateway OAuth access token (obtained via the Authorization Code flow described above) is used as the `subject_token` instead. This is supported on the tool-invocation path; gateway connection/health-check paths fail closed for `token-exchange` because they have no per-request user context.
 
+### Tool discovery for token-exchange gateways
+
+Registration (`POST /gateways`) intentionally skips the discovery probe for
+`grant_type: "token-exchange"` — there is no end-user JWT at registration
+time, so the gateway is persisted with an empty tool list. Two explicit,
+authenticated triggers populate it afterwards:
+
+- **`POST /gateways/{gateway_id}/tools/refresh`** — the manual-refresh API.
+  For token-exchange gateways the caller's own inbound ContextForge JWT is
+  used as the RFC 8693 `subject_token` for a single discovery-time exchange;
+  the exchanged token (never the raw JWT) authenticates the MCP connection.
+- **`POST /oauth/fetch-tools/{gateway_id}`** — the Admin UI `🔧 Fetch Tools`
+  button. For token-exchange gateways this delegates to the same
+  manual-refresh pipeline.
+
+The subject token is resolved from the `Authorization: Bearer` header first,
+falling back to the HttpOnly `jwt_token` session cookie (Admin UI sessions
+cannot attach a bearer header). Both routes are CSRF-protected for
+cookie-credentialed callers, and both fail closed: a caller without a
+structurally valid JWT gets an error — the raw credential is never forwarded
+upstream. Every exchange attempt (success or failure) is audited via the
+structured `token-exchange` event with the request's correlation id.
+
+There is no `🔐 Authorize` step for token-exchange gateways — no user
+consent flow exists, and the Admin UI hides that action for them.
+
 ### `subject_token_type`
 
 Per RFC 8693 §3, `subject_token_type` tells the Authorization Server how to interpret `subject_token`:

--- a/docs/docs/architecture/oauth-design.md
+++ b/docs/docs/architecture/oauth-design.md
@@ -207,13 +207,17 @@ authenticated triggers populate it afterwards:
   button. For token-exchange gateways this delegates to the same
   manual-refresh pipeline.
 
-The subject token is resolved from the `Authorization: Bearer` header first,
-falling back to the HttpOnly `jwt_token` session cookie (Admin UI sessions
-cannot attach a bearer header). Both routes are CSRF-protected for
-cookie-credentialed callers, and both fail closed: a caller without a
-structurally valid JWT gets an error — the raw credential is never forwarded
-upstream. Every exchange attempt (success or failure) is audited via the
-structured `token-exchange` event with the request's correlation id.
+The subject token is resolved from the `Authorization: Bearer` header if one
+is present; the HttpOnly `jwt_token` session cookie is only consulted when no
+bearer credential was presented at all (Admin UI sessions cannot attach a
+bearer header). A bearer credential that isn't a structurally valid JWT never
+falls back to the cookie — that cookie could belong to a different principal
+than the one the bearer already authenticated the request as, so the request
+fails closed instead of silently swapping identities. Both routes are
+CSRF-protected for cookie-credentialed callers, and both fail closed: a caller
+without a structurally valid JWT gets an error — the raw credential is never
+forwarded upstream. Every exchange attempt (success or failure) is audited via
+the structured `token-exchange` event with the request's correlation id.
 
 There is no `🔐 Authorize` step for token-exchange gateways — no user
 consent flow exists, and the Admin UI hides that action for them.

--- a/mcpgateway/admin_ui/gateways.js
+++ b/mcpgateway/admin_ui/gateways.js
@@ -1,4 +1,4 @@
-import { loadAuthHeaders, updateAuthHeadersJSON } from "./auth.js";
+import { getAuthHeaders, loadAuthHeaders, updateAuthHeadersJSON } from "./auth.js";
 import { MASKED_AUTH_VALUE } from "./constants.js";
 import { closeModal, openModal } from "./modals.js";
 import { initPromptSelect } from "./prompts.js";
@@ -1812,12 +1812,13 @@ export const refreshGatewayTools = async function (gatewayId, gatewayName, butto
   }
 
   try {
+    const authHeaders = await getAuthHeaders(false);
     const response = await fetch(
       `${window.ROOT_PATH}/gateways/${gatewayId}/tools/refresh`,
       {
         method: "POST",
         credentials: "include", // pragma: allowlist secret
-        headers: { Accept: "application/json" },
+        headers: { Accept: "application/json", ...authHeaders },
       }
     );
 
@@ -1897,6 +1898,7 @@ export const refreshToolsForSelectedGateways = async function(buttonEl) {
   let removed = 0;
   let failed = 0;
 
+  const authHeaders = await getAuthHeaders(false);
   await Promise.allSettled(
     realGwIds.map(async (gid) => {
       try {
@@ -1905,7 +1907,7 @@ export const refreshToolsForSelectedGateways = async function(buttonEl) {
           {
             method: "POST",
             credentials: "include", // pragma: allowlist secret
-            headers: { Accept: "application/json" },
+            headers: { Accept: "application/json", ...authHeaders },
           }
         );
         const data = await res.json();

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -17,7 +17,7 @@ import json
 import logging
 import re
 import secrets
-from typing import Annotated, Any, Dict
+from typing import Annotated, Any, Dict, Optional
 from urllib.parse import urlparse
 
 # Third-Party
@@ -52,6 +52,7 @@ logger = logging.getLogger(__name__)
 
 ADMIN_CSRF_COOKIE_NAME = "mcpgateway_csrf_token"
 ADMIN_CSRF_HEADER_NAME = "x-csrf-token"
+GRANT_TYPE_TOKEN_EXCHANGE = "token-exchange"
 
 
 async def enforce_fetch_tools_csrf(request: Request) -> None:
@@ -1083,6 +1084,57 @@ async def get_oauth_status(
         raise HTTPException(status_code=500, detail="Failed to get OAuth status")
 
 
+async def _fetch_tools_via_token_exchange(gateway_id: str, gateway_service: Any, requester_email: Optional[str], request: Request) -> Dict[str, Any]:
+    """Fetch tools for a token-exchange gateway via the manual-refresh pipeline.
+
+    Token-exchange has no consent step: delegate to the manual-refresh pipeline,
+    which exchanges the caller's inbound JWT (bearer header or jwt_token cookie)
+    via ``_resolve_token_exchange_header`` (issue #5382). Exception order matters:
+    ``GatewayNotFoundError`` and ``GatewayConnectionError`` both subclass
+    ``GatewayError`` — a bare ``GatewayError`` clause first would misclassify
+    not-found and connection failures as 409 instead of 404/400.
+
+    Args:
+        gateway_id: ID of the gateway to fetch tools for.
+        gateway_service: GatewayService instance used to perform the refresh.
+        requester_email: Email of the requesting user, or None.
+        request: Incoming request, forwarded so the subject token can be resolved.
+
+    Returns:
+        Dict containing success status and message with number of tools fetched.
+
+    Raises:
+        HTTPException: If the gateway is not found (404), the connection fails
+            (re-raised for the caller to map to 400), a refresh is already in
+            progress (409), or the refresh otherwise fails (400).
+    """
+    # First-Party
+    from mcpgateway.services.gateway_service import GatewayConnectionError, GatewayError, GatewayNotFoundError  # pylint: disable=import-outside-toplevel
+
+    try:
+        refresh_result = await gateway_service.refresh_gateway_manually(
+            gateway_id=gateway_id,
+            include_resources=True,
+            include_prompts=True,
+            user_email=requester_email,
+            request_headers=dict(request.headers),
+        )
+    except GatewayNotFoundError:
+        raise HTTPException(status_code=404, detail=f"Gateway not found: {gateway_id}")
+    except GatewayConnectionError:
+        raise  # outer handler maps to 400
+    except GatewayError as ge:
+        logger.warning(f"Token-exchange tool refresh conflict for gateway {SecurityValidator.sanitize_log_message(gateway_id)}: {SecurityValidator.sanitize_log_message(str(ge))}")
+        raise HTTPException(status_code=409, detail="Refresh already in progress for this gateway")
+
+    if refresh_result.get("success") is False:
+        logger.error(f"Token-exchange tool fetch failed for gateway {SecurityValidator.sanitize_log_message(gateway_id)}: {SecurityValidator.sanitize_log_message(str(refresh_result.get('error')))}")
+        raise HTTPException(status_code=400, detail="Failed to fetch tools")
+
+    fetched = int(refresh_result.get("tools_added", 0)) + int(refresh_result.get("tools_updated", 0))
+    return {"success": True, "message": f"Successfully fetched and created {fetched} tools"}
+
+
 @oauth_router.post("/fetch-tools/{gateway_id}")
 @require_permission("gateways.update")
 async def fetch_tools_after_oauth(
@@ -1118,40 +1170,13 @@ async def fetch_tools_after_oauth(
         await _enforce_gateway_access(gateway_id, gateway, current_user, db, request=request)
 
         # First-Party
-        from mcpgateway.services.gateway_service import GatewayConnectionError, GatewayError, GatewayNotFoundError, GatewayService
+        from mcpgateway.services.gateway_service import GatewayConnectionError, GatewayService
 
         gateway_service = GatewayService()
 
         grant_type = gateway.oauth_config.get("grant_type") if isinstance(gateway.oauth_config, dict) else None
-        if grant_type == "token-exchange":
-            # Token-exchange has no consent step: delegate to the manual-refresh
-            # pipeline, which exchanges the caller's inbound JWT (bearer header or
-            # jwt_token cookie) via _resolve_token_exchange_header (issue #5382).
-            # Exception order matters: GatewayNotFoundError and GatewayConnectionError
-            # both subclass GatewayError — a bare GatewayError clause first would turn
-            # not-found into 409 and connection failures into 409 instead of 400.
-            try:
-                refresh_result = await gateway_service.refresh_gateway_manually(
-                    gateway_id=gateway_id,
-                    include_resources=True,
-                    include_prompts=True,
-                    user_email=requester_email,
-                    request_headers=dict(request.headers),
-                )
-            except GatewayNotFoundError:
-                raise HTTPException(status_code=404, detail=f"Gateway not found: {gateway_id}")
-            except GatewayConnectionError:
-                raise  # outer handler maps to 400
-            except GatewayError as ge:
-                logger.warning(f"Token-exchange tool refresh conflict for gateway {SecurityValidator.sanitize_log_message(gateway_id)}: {SecurityValidator.sanitize_log_message(str(ge))}")
-                raise HTTPException(status_code=409, detail="Refresh already in progress for this gateway")
-            if refresh_result.get("success") is False:
-                logger.error(
-                    f"Token-exchange tool fetch failed for gateway {SecurityValidator.sanitize_log_message(gateway_id)}: {SecurityValidator.sanitize_log_message(str(refresh_result.get('error')))}"
-                )
-                raise HTTPException(status_code=400, detail="Failed to fetch tools")
-            fetched = int(refresh_result.get("tools_added", 0)) + int(refresh_result.get("tools_updated", 0))
-            return {"success": True, "message": f"Successfully fetched and created {fetched} tools"}
+        if grant_type == GRANT_TYPE_TOKEN_EXCHANGE:
+            return await _fetch_tools_via_token_exchange(gateway_id, gateway_service, requester_email, request)
 
         result = await gateway_service.fetch_tools_after_oauth(db, gateway_id, requester_email)
         tools_count = len(result.get("tools", []))

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -1143,7 +1143,8 @@ async def fetch_tools_after_oauth(
             except GatewayConnectionError:
                 raise  # outer handler maps to 400
             except GatewayError as ge:
-                raise HTTPException(status_code=409, detail=str(ge))
+                logger.warning(f"Token-exchange tool refresh conflict for gateway {SecurityValidator.sanitize_log_message(gateway_id)}: {SecurityValidator.sanitize_log_message(str(ge))}")
+                raise HTTPException(status_code=409, detail="Refresh already in progress for this gateway")
             if refresh_result.get("success") is False:
                 logger.error(
                     f"Token-exchange tool fetch failed for gateway {SecurityValidator.sanitize_log_message(gateway_id)}: "

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -1147,8 +1147,7 @@ async def fetch_tools_after_oauth(
                 raise HTTPException(status_code=409, detail="Refresh already in progress for this gateway")
             if refresh_result.get("success") is False:
                 logger.error(
-                    f"Token-exchange tool fetch failed for gateway {SecurityValidator.sanitize_log_message(gateway_id)}: "
-                    f"{SecurityValidator.sanitize_log_message(str(refresh_result.get('error')))}"
+                    f"Token-exchange tool fetch failed for gateway {SecurityValidator.sanitize_log_message(gateway_id)}: {SecurityValidator.sanitize_log_message(str(refresh_result.get('error')))}"
                 )
                 raise HTTPException(status_code=400, detail="Failed to fetch tools")
             fetched = int(refresh_result.get("tools_added", 0)) + int(refresh_result.get("tools_updated", 0))

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -1084,7 +1084,16 @@ async def get_oauth_status(
         raise HTTPException(status_code=500, detail="Failed to get OAuth status")
 
 
-async def _fetch_tools_via_token_exchange(gateway_id: str, gateway_service: Any, requester_email: Optional[str], request: Request) -> Dict[str, Any]:
+async def _fetch_tools_via_token_exchange(
+    gateway_id: str,
+    gateway_service: Any,
+    requester_email: Optional[str],
+    request: Request,
+    *,
+    gateway_not_found_error: type,
+    gateway_connection_error: type,
+    gateway_error: type,
+) -> Dict[str, Any]:
     """Fetch tools for a token-exchange gateway via the manual-refresh pipeline.
 
     Token-exchange has no consent step: delegate to the manual-refresh pipeline,
@@ -1094,11 +1103,27 @@ async def _fetch_tools_via_token_exchange(gateway_id: str, gateway_service: Any,
     ``GatewayError`` — a bare ``GatewayError`` clause first would misclassify
     not-found and connection failures as 409 instead of 404/400.
 
+    Blast radius note: ``extract_subject_jwt()`` only checks the inbound JWT's
+    compact-serialization *shape*, not its ``exp`` claim. An expired jwt_token
+    cookie still passes that check, gets forwarded as the RFC 8693 subject_token,
+    and is rejected by the Authorization Server -- which trips
+    ``_resolve_token_exchange_header()``'s ``set_failure()`` negative cache for
+    the ``(gateway_id, user, audience)`` key. Until that cache entry's TTL
+    drains, every subsequent call here for the same user+gateway+audience
+    short-circuits via ``is_failed()``, even after the user re-authenticates
+    with a fresh cookie. A future increase to the negative-cache TTL widens
+    this window and should account for it.
+
     Args:
         gateway_id: ID of the gateway to fetch tools for.
         gateway_service: GatewayService instance used to perform the refresh.
         requester_email: Email of the requesting user, or None.
         request: Incoming request, forwarded so the subject token can be resolved.
+        gateway_not_found_error: The caller's ``GatewayNotFoundError`` class, passed
+            in rather than re-imported here so both scopes reference the same
+            exception object the outer handler's ``except`` clauses were built with.
+        gateway_connection_error: The caller's ``GatewayConnectionError`` class, same rationale.
+        gateway_error: The caller's ``GatewayError`` class, same rationale.
 
     Returns:
         Dict containing success status and message with number of tools fetched.
@@ -1108,9 +1133,6 @@ async def _fetch_tools_via_token_exchange(gateway_id: str, gateway_service: Any,
             (re-raised for the caller to map to 400), a refresh is already in
             progress (409), or the refresh otherwise fails (400).
     """
-    # First-Party
-    from mcpgateway.services.gateway_service import GatewayConnectionError, GatewayError, GatewayNotFoundError  # pylint: disable=import-outside-toplevel
-
     try:
         refresh_result = await gateway_service.refresh_gateway_manually(
             gateway_id=gateway_id,
@@ -1119,11 +1141,11 @@ async def _fetch_tools_via_token_exchange(gateway_id: str, gateway_service: Any,
             user_email=requester_email,
             request_headers=dict(request.headers),
         )
-    except GatewayNotFoundError:
+    except gateway_not_found_error:
         raise HTTPException(status_code=404, detail=f"Gateway not found: {gateway_id}")
-    except GatewayConnectionError:
+    except gateway_connection_error:
         raise  # outer handler maps to 400
-    except GatewayError as ge:
+    except gateway_error as ge:
         logger.warning(f"Token-exchange tool refresh conflict for gateway {SecurityValidator.sanitize_log_message(gateway_id)}: {SecurityValidator.sanitize_log_message(str(ge))}")
         raise HTTPException(status_code=409, detail="Refresh already in progress for this gateway")
 
@@ -1170,13 +1192,21 @@ async def fetch_tools_after_oauth(
         await _enforce_gateway_access(gateway_id, gateway, current_user, db, request=request)
 
         # First-Party
-        from mcpgateway.services.gateway_service import GatewayConnectionError, GatewayService
+        from mcpgateway.services.gateway_service import GatewayConnectionError, GatewayError, GatewayNotFoundError, GatewayService
 
         gateway_service = GatewayService()
 
         grant_type = gateway.oauth_config.get("grant_type") if isinstance(gateway.oauth_config, dict) else None
         if grant_type == GRANT_TYPE_TOKEN_EXCHANGE:
-            return await _fetch_tools_via_token_exchange(gateway_id, gateway_service, requester_email, request)
+            return await _fetch_tools_via_token_exchange(
+                gateway_id,
+                gateway_service,
+                requester_email,
+                request,
+                gateway_not_found_error=GatewayNotFoundError,
+                gateway_connection_error=GatewayConnectionError,
+                gateway_error=GatewayError,
+            )
 
         result = await gateway_service.fetch_tools_after_oauth(db, gateway_id, requester_email)
         tools_count = len(result.get("tools", []))

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -1092,7 +1092,7 @@ async def fetch_tools_after_oauth(
     current_user: EmailUserResponse = Depends(get_current_user_with_permissions),
     db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
-    """Fetch tools from MCP server after OAuth completion for Authorization Code flow.
+    """Fetch tools from the MCP server after OAuth completion (authorization_code) or via on-demand token exchange (token-exchange).
 
     Args:
         gateway_id: ID of the gateway to fetch tools for
@@ -1118,9 +1118,41 @@ async def fetch_tools_after_oauth(
         await _enforce_gateway_access(gateway_id, gateway, current_user, db, request=request)
 
         # First-Party
-        from mcpgateway.services.gateway_service import GatewayConnectionError, GatewayService
+        from mcpgateway.services.gateway_service import GatewayConnectionError, GatewayError, GatewayNotFoundError, GatewayService
 
         gateway_service = GatewayService()
+
+        grant_type = gateway.oauth_config.get("grant_type") if isinstance(gateway.oauth_config, dict) else None
+        if grant_type == "token-exchange":
+            # Token-exchange has no consent step: delegate to the manual-refresh
+            # pipeline, which exchanges the caller's inbound JWT (bearer header or
+            # jwt_token cookie) via _resolve_token_exchange_header (issue #5382).
+            # Exception order matters: GatewayNotFoundError and GatewayConnectionError
+            # both subclass GatewayError — a bare GatewayError clause first would turn
+            # not-found into 409 and connection failures into 409 instead of 400.
+            try:
+                refresh_result = await gateway_service.refresh_gateway_manually(
+                    gateway_id=gateway_id,
+                    include_resources=True,
+                    include_prompts=True,
+                    user_email=requester_email,
+                    request_headers=dict(request.headers),
+                )
+            except GatewayNotFoundError:
+                raise HTTPException(status_code=404, detail=f"Gateway not found: {gateway_id}")
+            except GatewayConnectionError:
+                raise  # outer handler maps to 400
+            except GatewayError as ge:
+                raise HTTPException(status_code=409, detail=str(ge))
+            if refresh_result.get("success") is False:
+                logger.error(
+                    f"Token-exchange tool fetch failed for gateway {SecurityValidator.sanitize_log_message(gateway_id)}: "
+                    f"{SecurityValidator.sanitize_log_message(str(refresh_result.get('error')))}"
+                )
+                raise HTTPException(status_code=400, detail="Failed to fetch tools")
+            fetched = int(refresh_result.get("tools_added", 0)) + int(refresh_result.get("tools_updated", 0))
+            return {"success": True, "message": f"Successfully fetched and created {fetched} tools"}
+
         result = await gateway_service.fetch_tools_after_oauth(db, gateway_id, requester_email)
         tools_count = len(result.get("tools", []))
 

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -117,7 +117,7 @@ from mcpgateway.utils.retry_manager import ResilientHttpClient
 from mcpgateway.utils.services_auth import decode_auth, encode_auth
 from mcpgateway.utils.sqlalchemy_modifier import json_contains_tag_expr
 from mcpgateway.utils.ssl_context_cache import get_cached_ssl_context
-from mcpgateway.utils.subject_token import extract_inbound_bearer, looks_like_jwt
+from mcpgateway.utils.subject_token import extract_subject_jwt
 from mcpgateway.utils.token_exchange_audit import audit_token_exchange
 from mcpgateway.utils.url_auth import apply_query_param_auth, sanitize_exception_message, sanitize_url_for_logging
 from mcpgateway.utils.validate_signature import validate_signature
@@ -950,11 +950,16 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             logger.debug("token-exchange short-circuited by negative cache for gateway %s", gateway_name, extra={"gateway_id": gateway_id})
             raise GatewayConnectionError(f"Token exchange unavailable for gateway '{gateway_name}'. Contact your administrator.")
 
-        subject_token = extract_inbound_bearer(request_headers or {})
-        if subject_token and not looks_like_jwt(subject_token):
-            subject_token = None
+        # Subject token: Authorization bearer first, then the HttpOnly jwt_token
+        # cookie (Admin UI sessions cannot attach a bearer header). Both routes
+        # sit behind CSRF enforcement at the endpoint/middleware layer.
+        subject_token = extract_subject_jwt(request_headers or {})
         if not subject_token:
             raise GatewayConnectionError(f"User authentication required for token-exchange gateway '{gateway_name}'.")
+
+        rh = request_headers or {}
+        correlation_id = rh.get("x-correlation-id") or rh.get("X-Correlation-ID")
+        request_id = rh.get("x-request-id") or rh.get("X-Request-ID")
 
         async with self._token_exchange_cache.lock(gateway_id, user_key, audience):
             cached = await self._token_exchange_cache.get(gateway_id, user_key, audience)
@@ -990,8 +995,8 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     upstream=gateway_name,
                     error=safe_reason,
                     latency_ms=latency_ms,
-                    correlation_id=None,
-                    request_id=None,
+                    correlation_id=correlation_id,
+                    request_id=request_id,
                 )
                 sec_logger.log(
                     level="WARNING",
@@ -1017,8 +1022,8 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 upstream=gateway_name,
                 error=None,
                 latency_ms=latency_ms,
-                correlation_id=None,
-                request_id=None,
+                correlation_id=correlation_id,
+                request_id=request_id,
             )
             sec_logger.log(
                 level="INFO",

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -5089,6 +5089,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       </button>
 
                       {% if gateway.authType == 'oauth' %}
+                      {% if not (gateway.oauth_config and gateway.oauth_config.grant_type == 'token-exchange') %}
                       <!-- Row 2: OAuth Authorize | Fetch Tools -->
                       <a
                         href="{{ root_path }}/oauth/authorize/{{ gateway.id }}"
@@ -5105,6 +5106,17 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       >
                         🔧 Fetch Tools
                       </button>
+                      {% else %}
+                      <!-- Row 2 (token-exchange): no consent flow to authorize — Fetch Tools spans both columns -->
+                      <button
+                        data-action-click="fetchToolsForGateway" data-arg0="{{ gateway.id|tojson_attr }}" data-arg1="{{ gateway.name|tojson_attr }}"
+                        class="col-span-2 flex items-center justify-center px-1 py-1 text-xs font-medium rounded-md text-green-600 hover:text-green-900 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20 transition-colors"
+                        x-tooltip="'🔧 Fetch Tools from MCP Server'"
+                        id="fetch-tools-{{ gateway.id }}"
+                      >
+                        🔧 Fetch Tools
+                      </button>
+                      {% endif %}
 
                       <!-- Row 3: View | Edit -->
                       <button

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -5112,7 +5112,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                         data-action-click="fetchToolsForGateway" data-arg0="{{ gateway.id|tojson_attr }}" data-arg1="{{ gateway.name|tojson_attr }}"
                         class="col-span-2 flex items-center justify-center px-1 py-1 text-xs font-medium rounded-md text-green-600 hover:text-green-900 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20 transition-colors"
                         x-tooltip="'🔧 Fetch Tools from MCP Server'"
-                        id="fetch-tools-{{ gateway.id }}"
+                        id="fetch-tools-te-{{ gateway.id }}"
                       >
                         🔧 Fetch Tools
                       </button>

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -5089,7 +5089,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       </button>
 
                       {% if gateway.authType == 'oauth' %}
-                      {% if not (gateway.oauth_config and gateway.oauth_config.grant_type == 'token-exchange') %}
+                      {% if not (gateway.oauthConfig and gateway.oauthConfig.grant_type == 'token-exchange') %}
                       <!-- Row 2: OAuth Authorize | Fetch Tools -->
                       <a
                         href="{{ root_path }}/oauth/authorize/{{ gateway.id }}"

--- a/mcpgateway/templates/gateways_partial.html
+++ b/mcpgateway/templates/gateways_partial.html
@@ -70,7 +70,7 @@
                 class="w-full flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
               >Test</button>
 
-              {% if gateway.authType == 'oauth' and can_authorize %}
+              {% if gateway.authType == 'oauth' and can_authorize and not (gateway.oauthConfig and gateway.oauthConfig.grant_type == 'token-exchange') %}
               <!-- OAuth Authorize -->
               <a
                 href="{{ root_path }}/oauth/authorize/{{ gateway.id }}"

--- a/mcpgateway/utils/subject_token.py
+++ b/mcpgateway/utils/subject_token.py
@@ -8,7 +8,10 @@ Extract the inbound user bearer to use as RFC 8693 subject_token.
 
 # Standard
 from http.cookies import CookieError, SimpleCookie
+import logging
 from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
 
 
 def extract_inbound_bearer(request_headers: Optional[Dict[str, str]]) -> Optional[str]:
@@ -85,7 +88,10 @@ def extract_subject_jwt(request_headers: Optional[Dict[str, str]]) -> Optional[s
     jar = SimpleCookie()
     try:
         jar.load(raw_cookie)
-    except (CookieError, AttributeError, TypeError):
+    except CookieError:
+        return None
+    except (AttributeError, TypeError) as e:
+        logger.debug(f"Unexpected cookie parsing error: {type(e).__name__}: {e}")
         return None
     morsel = jar.get("jwt_token")
     cookie_token = morsel.value if morsel is not None else None

--- a/mcpgateway/utils/subject_token.py
+++ b/mcpgateway/utils/subject_token.py
@@ -66,6 +66,13 @@ def extract_subject_jwt(request_headers: Optional[Dict[str, str]]) -> Optional[s
     Each candidate must structurally be a compact-serialization JWT (H2:
     an opaque CF session/API token is never forwarded to an external AS).
 
+    Fail-closed on a mixed credential: if a bearer credential is present at
+    all, it is the one the auth dependency already authenticated the request
+    against, so a non-JWT-shaped bearer must not fall back to the cookie --
+    that cookie may belong to a different principal than the one the bearer
+    authenticated (CWE-287/CWE-346). The cookie is only consulted when no
+    bearer credential was presented.
+
     Args:
         request_headers: Inbound request headers, or None.
 
@@ -74,8 +81,8 @@ def extract_subject_jwt(request_headers: Optional[Dict[str, str]]) -> Optional[s
         structurally valid JWT is present.
     """
     token = extract_inbound_bearer(request_headers)
-    if token and looks_like_jwt(token):
-        return token
+    if token is not None:
+        return token if looks_like_jwt(token) else None
     if not request_headers:
         return None
     raw_cookie = None

--- a/mcpgateway/utils/subject_token.py
+++ b/mcpgateway/utils/subject_token.py
@@ -7,6 +7,7 @@ Extract the inbound user bearer to use as RFC 8693 subject_token.
 """
 
 # Standard
+from http.cookies import CookieError, SimpleCookie
 from typing import Dict, Optional
 
 
@@ -50,3 +51,44 @@ def looks_like_jwt(token: Optional[str]) -> bool:
         return False
     parts = token.split(".")
     return len(parts) == 3 and all(parts)
+
+
+def extract_subject_jwt(request_headers: Optional[Dict[str, str]]) -> Optional[str]:
+    """Resolve the RFC 8693 subject token from a bearer header or the ``jwt_token`` cookie.
+
+    Resolution order: ``Authorization: Bearer`` header first, then the
+    ``jwt_token`` cookie parsed from the raw ``Cookie`` header. Admin UI
+    sessions authenticate with an HttpOnly ``jwt_token`` cookie and cannot
+    attach a bearer header, so the cookie path is the primary UI route.
+    Each candidate must structurally be a compact-serialization JWT (H2:
+    an opaque CF session/API token is never forwarded to an external AS).
+
+    Args:
+        request_headers: Inbound request headers, or None.
+
+    Returns:
+        The JWT string to use as ``subject_token``, or None if no
+        structurally valid JWT is present.
+    """
+    token = extract_inbound_bearer(request_headers)
+    if token and looks_like_jwt(token):
+        return token
+    if not request_headers:
+        return None
+    raw_cookie = None
+    for k, v in request_headers.items():
+        if k.lower() == "cookie" and isinstance(v, str):
+            raw_cookie = v
+            break
+    if not raw_cookie:
+        return None
+    jar = SimpleCookie()
+    try:
+        jar.load(raw_cookie)
+    except (CookieError, AttributeError, TypeError):
+        return None
+    morsel = jar.get("jwt_token")
+    cookie_token = morsel.value if morsel is not None else None
+    if cookie_token and looks_like_jwt(cookie_token):
+        return cookie_token
+    return None

--- a/tests/unit/js/gateway.test.js
+++ b/tests/unit/js/gateway.test.js
@@ -19,6 +19,7 @@ import { fetchWithTimeout, showErrorMessage, showSuccessMessage } from "../../..
 import { openModal } from "../../../mcpgateway/admin_ui/modals";
 
 vi.mock("../../../mcpgateway/admin_ui/auth.js", () => ({
+  getAuthHeaders: vi.fn().mockResolvedValue({ "X-CSRF-Token": "csrf-abc" }),
   loadAuthHeaders: vi.fn(),
   updateAuthHeadersJSON: vi.fn(),
 }));
@@ -1555,7 +1556,7 @@ describe("refreshGatewayTools", () => {
       expect.objectContaining({
         method: "POST",
         credentials: "include", // pragma: allowlist secret
-        headers: { Accept: "application/json" },
+        headers: { Accept: "application/json", "X-CSRF-Token": "csrf-abc" },
       })
     );
 
@@ -1571,6 +1572,37 @@ describe("refreshGatewayTools", () => {
         swap: "outerHTML",
       })
     );
+  });
+
+  test("sends CSRF/auth headers on the refresh request", async () => {
+    window.ROOT_PATH = "";
+    document.body.innerHTML = `
+      <button id="refresh-btn">Refresh</button>
+      <div id="gateways-table"></div>
+      <input id="show-inactive-gateways" type="checkbox" />
+      <input id="gateways-search-input" value="" />
+      <input id="gateways-tag-filter" value="" />
+    `;
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        success: true,
+        toolsAdded: 5,
+        toolsUpdated: 2,
+        toolsRemoved: 1,
+      }),
+    });
+
+    window.htmx = {
+      ajax: vi.fn(),
+    };
+
+    const { refreshGatewayTools } = await import("../../../mcpgateway/admin_ui/gateways.js");
+    await refreshGatewayTools("gw-1", "GW", null);
+    const [, opts] = global.fetch.mock.calls[0];
+    expect(opts.headers["X-CSRF-Token"]).toBe("csrf-abc");
+    expect(opts.headers.Accept).toBe("application/json");
   });
 
   test("disables button during refresh and restores text after", async () => {
@@ -1871,6 +1903,9 @@ describe("refreshToolsForSelectedGateways", () => {
     expect(showSuccessMessage).toHaveBeenCalledWith(
       "2 added, 1 updated, 0 removed"
     );
+
+    const [, opts] = global.fetch.mock.calls[0];
+    expect(opts.headers["X-CSRF-Token"]).toBe("csrf-abc");
   });
 
   test("shows error when only null sentinel is selected", async () => {

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -1256,7 +1256,7 @@ class TestOAuthRouter:
         """token-exchange gateways route through refresh_gateway_manually, not fetch_tools_after_oauth."""
         request = Mock(spec=Request)
         request.state = SimpleNamespace(token_teams=["team-1"])
-        request.headers = {"cookie": "jwt_token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1In0.c2ln"}
+        request.headers = {"cookie": "jwt_token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1In0.c2ln"}  # pragma: allowlist secret
         gateway = Mock(spec=Gateway)
         gateway.visibility = "public"
         gateway.team_id = None

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -1251,6 +1251,99 @@ class TestOAuthRouter:
         result = _resolve_token_teams_for_scope_check(request, current_user)
         assert result is None
 
+    @pytest.mark.asyncio
+    async def test_fetch_tools_token_exchange_delegates_to_manual_refresh(self, mock_db, mock_current_user):
+        """token-exchange gateways route through refresh_gateway_manually, not fetch_tools_after_oauth."""
+        request = Mock(spec=Request)
+        request.state = SimpleNamespace(token_teams=["team-1"])
+        request.headers = {"cookie": "jwt_token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1In0.c2ln"}
+        gateway = Mock(spec=Gateway)
+        gateway.visibility = "public"
+        gateway.team_id = None
+        gateway.owner_email = None
+        gateway.oauth_config = {"grant_type": "token-exchange", "token_url": "https://as.example.com/token", "target_audience": "aud"}
+        mock_db.execute.return_value.scalar_one_or_none.return_value = gateway
+
+        refresh_result = {"success": True, "tools_added": 2, "tools_updated": 1, "tools_removed": 0}
+        with patch("mcpgateway.services.gateway_service.GatewayService") as mock_service_class:
+            mock_service = Mock()
+            mock_service.refresh_gateway_manually = AsyncMock(return_value=refresh_result)
+            mock_service.fetch_tools_after_oauth = AsyncMock()
+            mock_service_class.return_value = mock_service
+
+            # First-Party
+            from mcpgateway.routers.oauth_router import fetch_tools_after_oauth
+
+            with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED):
+                result = await fetch_tools_after_oauth(gateway_id="gw-te", request=request, current_user={"email": "admin@example.com", "is_admin": True}, db=mock_db)
+
+        assert result["success"] is True
+        assert "Successfully fetched and created 3 tools" in result["message"]
+        mock_service.fetch_tools_after_oauth.assert_not_called()
+        kwargs = mock_service.refresh_gateway_manually.await_args.kwargs
+        assert kwargs["gateway_id"] == "gw-te"
+        assert kwargs["user_email"] == "admin@example.com"
+        assert kwargs["request_headers"]["cookie"].startswith("jwt_token=")
+
+    @pytest.mark.asyncio
+    async def test_fetch_tools_token_exchange_failure_maps_to_400(self, mock_db, mock_current_user):
+        """success=False from refresh_gateway_manually must surface as HTTP 400, not 200."""
+        request = Mock(spec=Request)
+        request.state = SimpleNamespace(token_teams=["team-1"])
+        request.headers = {}
+        gateway = Mock(spec=Gateway)
+        gateway.visibility = "public"
+        gateway.team_id = None
+        gateway.owner_email = None
+        gateway.oauth_config = {"grant_type": "token-exchange", "token_url": "https://as.example.com/token", "target_audience": "aud"}
+        mock_db.execute.return_value.scalar_one_or_none.return_value = gateway
+
+        refresh_result = {"success": False, "error": "User authentication required for token-exchange gateway 'gw'."}
+        with patch("mcpgateway.services.gateway_service.GatewayService") as mock_service_class:
+            mock_service = Mock()
+            mock_service.refresh_gateway_manually = AsyncMock(return_value=refresh_result)
+            mock_service_class.return_value = mock_service
+
+            # First-Party
+            from mcpgateway.routers.oauth_router import fetch_tools_after_oauth
+
+            with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED):
+                with pytest.raises(HTTPException) as exc_info:
+                    await fetch_tools_after_oauth(gateway_id="gw-te", request=request, current_user={"email": "admin@example.com", "is_admin": True}, db=mock_db)
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "Failed to fetch tools"
+
+    @pytest.mark.asyncio
+    async def test_fetch_tools_token_exchange_concurrent_refresh_maps_to_409(self, mock_db, mock_current_user):
+        """GatewayError (refresh already in progress) must map to HTTP 409."""
+        # First-Party
+        from mcpgateway.services.gateway_service import GatewayError
+
+        request = Mock(spec=Request)
+        request.state = SimpleNamespace(token_teams=["team-1"])
+        request.headers = {}
+        gateway = Mock(spec=Gateway)
+        gateway.visibility = "public"
+        gateway.team_id = None
+        gateway.owner_email = None
+        gateway.oauth_config = {"grant_type": "token-exchange", "token_url": "https://as.example.com/token", "target_audience": "aud"}
+        mock_db.execute.return_value.scalar_one_or_none.return_value = gateway
+
+        with patch("mcpgateway.services.gateway_service.GatewayService") as mock_service_class:
+            mock_service = Mock()
+            mock_service.refresh_gateway_manually = AsyncMock(side_effect=GatewayError("Refresh already in progress for gateway gw"))
+            mock_service_class.return_value = mock_service
+
+            # First-Party
+            from mcpgateway.routers.oauth_router import fetch_tools_after_oauth
+
+            with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED):
+                with pytest.raises(HTTPException) as exc_info:
+                    await fetch_tools_after_oauth(gateway_id="gw-te", request=request, current_user={"email": "admin@example.com", "is_admin": True}, db=mock_db)
+
+        assert exc_info.value.status_code == 409
+
 
 class TestOAuthAccessHelpers:
     def test_resolve_token_teams_for_scope_check_invalid_state_value_fails_closed(self):

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -1344,6 +1344,75 @@ class TestOAuthRouter:
 
         assert exc_info.value.status_code == 409
 
+    @pytest.mark.asyncio
+    async def test_fetch_tools_token_exchange_gateway_not_found_maps_to_404(self, mock_db, mock_current_user):
+        """GatewayNotFoundError raised mid-refresh (gateway deleted concurrently) must map to HTTP 404.
+
+        Distinct from the earlier `if not gateway` check in the handler: that guards the
+        gateway row not existing at request start, this guards it disappearing during the
+        manual-refresh call itself.
+        """
+        # First-Party
+        from mcpgateway.services.gateway_service import GatewayNotFoundError
+
+        request = Mock(spec=Request)
+        request.state = SimpleNamespace(token_teams=["team-1"])
+        request.headers = {}
+        gateway = Mock(spec=Gateway)
+        gateway.visibility = "public"
+        gateway.team_id = None
+        gateway.owner_email = None
+        gateway.oauth_config = {"grant_type": "token-exchange", "token_url": "https://as.example.com/token", "target_audience": "aud"}
+        mock_db.execute.return_value.scalar_one_or_none.return_value = gateway
+
+        with patch("mcpgateway.services.gateway_service.GatewayService") as mock_service_class:
+            mock_service = Mock()
+            mock_service.refresh_gateway_manually = AsyncMock(side_effect=GatewayNotFoundError("Gateway with ID 'gw-te' not found"))
+            mock_service_class.return_value = mock_service
+
+            # First-Party
+            from mcpgateway.routers.oauth_router import fetch_tools_after_oauth
+
+            with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED):
+                with pytest.raises(HTTPException) as exc_info:
+                    await fetch_tools_after_oauth(gateway_id="gw-te", request=request, current_user={"email": "admin@example.com", "is_admin": True}, db=mock_db)
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_fetch_tools_token_exchange_connection_error_maps_to_400(self, mock_db, mock_current_user):
+        """GatewayConnectionError must be re-raised past the inner handler and mapped to HTTP 400
+        by the endpoint's outer `except GatewayConnectionError` clause (not swallowed as 409 by
+        the inner bare `except GatewayError` clause).
+        """
+        # First-Party
+        from mcpgateway.services.gateway_service import GatewayConnectionError
+
+        request = Mock(spec=Request)
+        request.state = SimpleNamespace(token_teams=["team-1"])
+        request.headers = {}
+        gateway = Mock(spec=Gateway)
+        gateway.visibility = "public"
+        gateway.team_id = None
+        gateway.owner_email = None
+        gateway.oauth_config = {"grant_type": "token-exchange", "token_url": "https://as.example.com/token", "target_audience": "aud"}
+        mock_db.execute.return_value.scalar_one_or_none.return_value = gateway
+
+        with patch("mcpgateway.services.gateway_service.GatewayService") as mock_service_class:
+            mock_service = Mock()
+            mock_service.refresh_gateway_manually = AsyncMock(side_effect=GatewayConnectionError("some connection failure"))
+            mock_service_class.return_value = mock_service
+
+            # First-Party
+            from mcpgateway.routers.oauth_router import fetch_tools_after_oauth
+
+            with patch("mcpgateway.routers.oauth_router.token_scoping_middleware._check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED):
+                with pytest.raises(HTTPException) as exc_info:
+                    await fetch_tools_after_oauth(gateway_id="gw-te", request=request, current_user={"email": "admin@example.com", "is_admin": True}, db=mock_db)
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "Failed to fetch tools"
+
 
 class TestOAuthAccessHelpers:
     def test_resolve_token_teams_for_scope_check_invalid_state_value_fails_closed(self):

--- a/tests/unit/mcpgateway/services/test_token_exchange_integration.py
+++ b/tests/unit/mcpgateway/services/test_token_exchange_integration.py
@@ -8,7 +8,7 @@ Module documentation...
 """
 # tests/unit/mcpgateway/services/test_token_exchange_integration.py
 # Standard
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 import pytest
@@ -1044,3 +1044,59 @@ class TestRestIntegrationB2Wiring:
         pinned_client.aclose.assert_awaited_once()
         svc._token_exchange_cache.invalidate.assert_awaited_once()
         svc._resolve_token_exchange_header.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+class TestGatewayRefreshTokenExchangeSubjectSources:
+    """Issue #5382: manual-refresh resolver accepts the jwt_token cookie as subject source."""
+
+    def _svc(self):
+        """GatewayService with a stubbed exchange and cache-miss token cache."""
+        # First-Party
+        from mcpgateway.services.gateway_service import GatewayService
+
+        svc = GatewayService()
+        svc.oauth_manager = MagicMock()
+        svc.oauth_manager.token_exchange = AsyncMock(return_value={"access_token": "exch-tok", "expires_in": 300})
+        svc._token_exchange_cache = _mock_te_cache(get_return=None)
+        return svc
+
+    async def test_resolve_header_accepts_cookie_jwt(self):
+        """Cookie-only request headers (Admin UI session) must resolve a subject token."""
+        svc = self._svc()
+        header = await svc._resolve_token_exchange_header(
+            dict(_TE_CFG),
+            "gw-1",
+            "gw-name",
+            "admin@example.com",
+            {"cookie": f"jwt_token={_FAKE_JWT}"},
+        )
+        assert header == {"Authorization": "Bearer exch-tok"}
+        assert svc.oauth_manager.token_exchange.await_args.kwargs["subject_token"] == _FAKE_JWT
+
+    async def test_resolve_header_rejects_opaque_cookie(self):
+        """A non-JWT jwt_token cookie must fail closed, never reach the AS."""
+        svc = self._svc()
+        with pytest.raises(GatewayConnectionError):
+            await svc._resolve_token_exchange_header(
+                dict(_TE_CFG),
+                "gw-1",
+                "gw-name",
+                "admin@example.com",
+                {"cookie": "jwt_token=opaque-not-a-jwt"},
+            )
+        svc.oauth_manager.token_exchange.assert_not_awaited()
+
+    async def test_resolve_header_audits_correlation_id(self):
+        """x-correlation-id / x-request-id from inbound headers must reach the audit event."""
+        svc = self._svc()
+        with patch("mcpgateway.services.gateway_service.audit_token_exchange") as mock_audit:
+            await svc._resolve_token_exchange_header(
+                dict(_TE_CFG),
+                "gw-1",
+                "gw-name",
+                "admin@example.com",
+                {"cookie": f"jwt_token={_FAKE_JWT}", "x-correlation-id": "corr-42", "x-request-id": "req-7"},
+            )
+        assert mock_audit.call_args.kwargs["correlation_id"] == "corr-42"
+        assert mock_audit.call_args.kwargs["request_id"] == "req-7"

--- a/tests/unit/mcpgateway/utils/test_subject_token.py
+++ b/tests/unit/mcpgateway/utils/test_subject_token.py
@@ -4,7 +4,7 @@
 # First-Party
 from mcpgateway.utils.subject_token import extract_subject_jwt
 
-JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhIn0.sig"  # three non-empty segments
+JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhIn0.sig"  # pragma: allowlist secret
 
 
 def test_bearer_header_wins():

--- a/tests/unit/mcpgateway/utils/test_subject_token.py
+++ b/tests/unit/mcpgateway/utils/test_subject_token.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-"""Tests for mcpgateway.utils.subject_token."""
+"""Location: ./tests/unit/mcpgateway/utils/test_subject_token.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Tests for mcpgateway.utils.subject_token.
+"""
 
 # First-Party
 from mcpgateway.utils.subject_token import extract_subject_jwt

--- a/tests/unit/mcpgateway/utils/test_subject_token.py
+++ b/tests/unit/mcpgateway/utils/test_subject_token.py
@@ -75,3 +75,8 @@ def test_cookie_error_returns_none():
 def test_headers_present_but_no_cookie_key():
     headers = {"X-Something": "value"}
     assert extract_subject_jwt(headers) is None
+
+
+def test_opaque_bearer_and_no_jwt_token_cookie_returns_none():
+    headers = {"Authorization": "Bearer opaque-session-token", "cookie": "mcpgateway_csrf_token=abc"}
+    assert extract_subject_jwt(headers) is None

--- a/tests/unit/mcpgateway/utils/test_subject_token.py
+++ b/tests/unit/mcpgateway/utils/test_subject_token.py
@@ -31,9 +31,19 @@ def test_cookie_header_case_insensitive():
     assert extract_subject_jwt(headers) == JWT
 
 
-def test_opaque_bearer_falls_through_to_cookie():
+def test_opaque_bearer_does_not_fall_back_to_cookie():
+    """Deny-path regression for CWE-287/CWE-346: an opaque bearer must not be
+    silently swapped for a same- or different-principal cookie JWT."""
     headers = {"Authorization": "Bearer opaque-session-token", "cookie": f"jwt_token={JWT}"}
-    assert extract_subject_jwt(headers) == JWT
+    assert extract_subject_jwt(headers) is None
+
+
+def test_opaque_bearer_does_not_fall_back_to_other_principal_cookie():
+    """Mixed-credential deny path: bearer authenticates principal A, cookie
+    carries a JWT for principal B -- must fail closed, never forward B's token."""
+    other_principal_jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJiIn0.sig2"  # pragma: allowlist secret
+    headers = {"Authorization": "Bearer opaque-session-token-for-principal-a", "cookie": f"jwt_token={other_principal_jwt}"}
+    assert extract_subject_jwt(headers) is None
 
 
 def test_opaque_cookie_rejected():

--- a/tests/unit/mcpgateway/utils/test_subject_token.py
+++ b/tests/unit/mcpgateway/utils/test_subject_token.py
@@ -6,6 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 Tests for mcpgateway.utils.subject_token.
 """
 
+# Standard
+from http.cookies import CookieError
+from unittest.mock import patch
+
 # First-Party
 from mcpgateway.utils.subject_token import extract_subject_jwt
 
@@ -49,4 +53,25 @@ def test_no_jwt_token_cookie():
 
 def test_malformed_cookie_header_returns_none():
     headers = {"cookie": ";;;=;;"}
+    assert extract_subject_jwt(headers) is None
+
+
+def test_unexpected_cookie_parse_error_is_logged_and_returns_none(caplog):
+    headers = {"cookie": f"jwt_token={JWT}"}
+    with patch("mcpgateway.utils.subject_token.SimpleCookie") as mock_jar_cls:
+        mock_jar_cls.return_value.load.side_effect = TypeError("boom")
+        with caplog.at_level("DEBUG", logger="mcpgateway.utils.subject_token"):
+            assert extract_subject_jwt(headers) is None
+    assert "TypeError" in caplog.text
+
+
+def test_cookie_error_returns_none():
+    headers = {"cookie": f"jwt_token={JWT}"}
+    with patch("mcpgateway.utils.subject_token.SimpleCookie") as mock_jar_cls:
+        mock_jar_cls.return_value.load.side_effect = CookieError("bad cookie")
+        assert extract_subject_jwt(headers) is None
+
+
+def test_headers_present_but_no_cookie_key():
+    headers = {"X-Something": "value"}
     assert extract_subject_jwt(headers) is None

--- a/tests/unit/mcpgateway/utils/test_subject_token.py
+++ b/tests/unit/mcpgateway/utils/test_subject_token.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""Tests for mcpgateway.utils.subject_token."""
+
+# First-Party
+from mcpgateway.utils.subject_token import extract_subject_jwt
+
+JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhIn0.sig"  # three non-empty segments
+
+
+def test_bearer_header_wins():
+    headers = {"Authorization": f"Bearer {JWT}", "cookie": "jwt_token=other.jwt.tok"}
+    assert extract_subject_jwt(headers) == JWT
+
+
+def test_cookie_fallback_when_no_bearer():
+    headers = {"cookie": f"jwt_token={JWT}; mcpgateway_csrf_token=abc"}
+    assert extract_subject_jwt(headers) == JWT
+
+
+def test_cookie_header_case_insensitive():
+    headers = {"Cookie": f"jwt_token={JWT}"}
+    assert extract_subject_jwt(headers) == JWT
+
+
+def test_opaque_bearer_falls_through_to_cookie():
+    headers = {"Authorization": "Bearer opaque-session-token", "cookie": f"jwt_token={JWT}"}
+    assert extract_subject_jwt(headers) == JWT
+
+
+def test_opaque_cookie_rejected():
+    headers = {"cookie": "jwt_token=not-a-jwt"}
+    assert extract_subject_jwt(headers) is None
+
+
+def test_no_headers():
+    assert extract_subject_jwt(None) is None
+    assert extract_subject_jwt({}) is None
+
+
+def test_no_jwt_token_cookie():
+    headers = {"cookie": "mcpgateway_csrf_token=abc; other=1"}
+    assert extract_subject_jwt(headers) is None
+
+
+def test_malformed_cookie_header_returns_none():
+    headers = {"cookie": ";;;=;;"}
+    assert extract_subject_jwt(headers) is None


### PR DESCRIPTION
## Summary

- Registration of a `grant_type: "token-exchange"` gateway intentionally skips discovery (no per-request end-user JWT exists at registration time), but nothing else ever populated its tool list through the documented API. `refresh_gateway_manually()` (from PR #5224) already does the RFC 8693 exchange + connect + catalog sync, but only accepted the caller's JWT via an `Authorization: Bearer` header — unusable from the Admin UI, whose session JWT lives in an HttpOnly cookie the page's own JS cannot read.
- `extract_subject_jwt()` resolves the subject JWT from a bearer header first, falling back to the `jwt_token` cookie, so `GatewayService._resolve_token_exchange_header()` now accepts either.
- `POST /oauth/fetch-tools/{gateway_id}` (the Admin UI's "Fetch Tools" trigger, reached via `/gateways/{id}/tools/refresh`) now delegates to `refresh_gateway_manually()` for token-exchange gateways instead of the `authorization_code`-only legacy path. `authorization_code` handling is unchanged.
- Along the way: the Admin UI's gateway-refresh `fetch()` calls sent no `X-CSRF-Token`, so cookie-authenticated sessions were being rejected by the global CSRF middleware before this even mattered — fixed. The "🔐 Authorize" link (no consent flow exists for token-exchange) is now hidden for those gateways in the live gateway list.
- `docs/docs/architecture/oauth-design.md` documents both discovery triggers.

## Verification

Beyond the unit/integration test suite (253 Python tests across the touched modules + full `make test` green, 2323 JS tests green, `make coverage`/`diff-cover` at 93% on changed lines, `make ruff/bandit/interrogate/pylint/verify` clean, `make detect-secrets-scan` clean), a real end-to-end run proved the fix works against live infrastructure: two live gateway processes (this branch's merge-base on `main`, and this branch's HEAD), a real downstream MCP server (`ghcr.io/ibm/cfex-mcp-fast-time-server`), a real minimal RFC 8693 Authorization Server, and real minted JWTs — 16/16 checks passed, including a CSRF-still-enforced regression guard and a direct render of the actual Admin UI template proving the Authorize link is genuinely hidden for token-exchange gateways. Full config, commands, and output are posted as a PR comment.

Closes #5382

## Test plan

- [x] `make test` (full suite, 22593 items)
- [x] `make test-js` (2323 passed)
- [x] `make coverage` / `make diff-cover` (93% on changed lines)
- [x] `make ruff bandit interrogate pylint verify`
- [x] `make detect-secrets-scan`
- [x] Real end-to-end verification (BEFORE/AFTER live servers, real downstream MCP server, real AS stub) — see PR comment