### PR TITLE
fix(compose): eliminate idle DB connection churn in traces

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
+    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-07T14:56:50Z",
+  "generated_at": "2026-08-10T11:28:05Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -804,7 +804,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 948,
+        "line_number": 953,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -812,7 +812,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1051,
+        "line_number": 1056,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -820,7 +820,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1166,
+        "line_number": 1171,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -828,7 +828,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1201,
+        "line_number": 1206,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -836,7 +836,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1741,
+        "line_number": 1746,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -844,7 +844,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1990,
+        "line_number": 1995,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -852,7 +852,7 @@
         "hashed_secret": "afba9d98073dfb79fba7b21516c4d4d676c72935",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2368,
+        "line_number": 2373,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -860,7 +860,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2468,
+        "line_number": 2473,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -868,7 +868,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2468,
+        "line_number": 2473,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -876,7 +876,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2481,
+        "line_number": 2486,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -884,7 +884,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2629,
+        "line_number": 2634,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -892,7 +892,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2650,
+        "line_number": 2655,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -900,7 +900,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2658,
+        "line_number": 2663,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -908,7 +908,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2663,
+        "line_number": 2668,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -525,7 +525,12 @@ services:
       - DB_POOL_SIZE=20                # Pool size per worker
       - DB_MAX_OVERFLOW=10             # Extra connections under load
       - DB_POOL_TIMEOUT=60             # Time to wait for connection before failing
-      - DB_POOL_RECYCLE=60             # Recycle before PgBouncer CLIENT_IDLE_TIMEOUT (half of 120s)
+      # pre_ping already replaces connections PgBouncer closed at CLIENT_IDLE_TIMEOUT,
+      # so a short recycle is redundant and causes connect churn: with 51 workers'
+      # pools, most connections idle >60s between uses and get recycled on EVERY
+      # checkout. -1 disables time-based recycling; stale connections are still
+      # detected and replaced transparently by the pre-ping.
+      - DB_POOL_RECYCLE=${DB_POOL_RECYCLE:--1}  # Disable; pre_ping covers pgbouncer idle closes
       # ═══════════════════════════════════════════════════════════════════════════
       # Database Startup Resilience (prevents crash-loop on DB outage)
       # ═══════════════════════════════════════════════════════════════════════════
@@ -1010,7 +1015,7 @@ services:
       - SERVER_IDLE_TIMEOUT=600        # Close unused server connections after 10 min
       # Timeout settings
       - QUERY_WAIT_TIMEOUT=60          # Max wait for available connection before failing request
-      - CLIENT_IDLE_TIMEOUT=120        # Close idle client connections (4x IDLE_TRANSACTION_TIMEOUT; DB_POOL_RECYCLE=60 is half this, ensuring proactive recycle before PgBouncer closes them)
+      - CLIENT_IDLE_TIMEOUT=${CLIENT_IDLE_TIMEOUT:-600}  # Close idle client connections after 10min (matches SERVER_IDLE_TIMEOUT; with DB_POOL_RECYCLE=-1 + pre_ping, idle-close at 120s caused connect churn in every trace)
       - SERVER_CONNECT_TIMEOUT=5       # Timeout for new connections to PostgreSQL
       # Transaction cleanup - critical for avoiding idle-in-transaction buildup
       # NOTE: In transaction pooling, session-level advisory locks (used by migrations)


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Relates to #1995 (SQLAlchemy pool configuration for PgBouncer deployments) — addresses the idle-connection churn aspect; does not implement the `pre_ping=false` recommendation discussed there.

---

## 📝 Summary

The compose stack's gateway/PgBouncer timeout interaction caused constant physical reconnects, visible as a `connect` span on nearly every traced query.

**Mechanism:**

1. `DB_POOL_RECYCLE=60` recycled any pooled connection idle longer than 60s.
2. With 51 workers × pool size 20 (~1000 pooled connections), most connections idle far longer than that at moderate traffic — so nearly every checkout became a physical reconnect instead of a pool reuse.
3. PgBouncer's `CLIENT_IDLE_TIMEOUT=120` then closed those connections from its side at 120s, compounding the churn.

**Changes (docker-compose.yml only):**

- `DB_POOL_RECYCLE=-1` — `pool_pre_ping` already detects and transparently replaces connections PgBouncer has closed, so short time-based recycling is redundant and was the direct cause of the connect churn. Overridable via `${DB_POOL_RECYCLE:--1}`.
- `CLIENT_IDLE_TIMEOUT=600` (was 120) — matches `SERVER_IDLE_TIMEOUT`, so idle pooled connections survive the background-tick cadence instead of being killed between uses. Overridable via `${CLIENT_IDLE_TIMEOUT:-600}`.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

_Note: config-only change to the compose stack; no Python code paths are touched, so there is no unit-test surface. The `.secrets.baseline` delta is a `detect-secrets` regeneration artifact (timestamp + exclude-regex rewrite) with no new findings._

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

Verified in the running compose stack: with warm pools, 4 sequential sessions produced **1 physical connect and 0 closes** (previously: a connect span per query at moderate traffic). Idle connect rate collapses once pools are warm; `pre_ping` transparently replaces any connections PgBouncer does close.

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | N/A — YAML-only change |
| Unit tests                | `make test`     | N/A — no Python code changed |
| Coverage ≥ 80%            | `make coverage` | N/A — no Python code changed |

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

Both timeouts are exposed as environment overrides (`DB_POOL_RECYCLE`, `CLIENT_IDLE_TIMEOUT`) so deployments with different traffic profiles can tune without editing the compose file.\n\nSupersedes #6156. This replacement uses the rebased branch pushed to IBM/mcp-context-forge.

---

Related to #6104 (Gateway Performance Tracking epic); already linked to #1995.

---

Related to #6104 (Gateway Performance Tracking epic); already linked to #1995.