### PR TITLE
feat(oauth): per-gateway use_dcr flag for Dynamic Client Registration

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
+    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-12T15:30:22Z",
+  "generated_at": "2026-08-10T16:59:56Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -258,7 +258,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2047,
+        "line_number": 2039,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2135,
+        "line_number": 2127,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2485,
+        "line_number": 2477,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3850,
+        "line_number": 3842,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3941,
+        "line_number": 3933,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3984,
+        "line_number": 3976,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3989,
+        "line_number": 3981,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3994,
+        "line_number": 3986,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -390,7 +390,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6079,
+        "line_number": 6064,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6576,
+        "line_number": 6561,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6588,
+        "line_number": 6573,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6660,
+        "line_number": 6645,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7076,
+        "line_number": 7061,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -430,7 +430,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7767,
+        "line_number": 7752,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -836,7 +836,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1749,
+        "line_number": 1741,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -844,7 +844,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1998,
+        "line_number": 1990,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -852,7 +852,7 @@
         "hashed_secret": "afba9d98073dfb79fba7b21516c4d4d676c72935",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2376,
+        "line_number": 2368,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -860,7 +860,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2476,
+        "line_number": 2468,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -868,7 +868,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2476,
+        "line_number": 2468,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -876,7 +876,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2489,
+        "line_number": 2481,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -884,7 +884,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2637,
+        "line_number": 2629,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -892,7 +892,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2658,
+        "line_number": 2650,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -900,7 +900,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2666,
+        "line_number": 2658,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -908,7 +908,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2671,
+        "line_number": 2663,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1999,6 +1999,14 @@
         "line_number": 187,
         "type": "Secret Keyword",
         "verified_result": null
+      },
+      {
+        "hashed_secret": "12ddd9843a2c0e828322020cd6ea34f0b14eec9b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 272,
+        "type": "Secret Keyword",
+        "verified_result": null
       }
     ],
     "docs/docs/manage/export-import-reference.md": [
@@ -2358,7 +2366,7 @@
         "hashed_secret": "1513802ada0ec04c2446206e16baa7256ebff74b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 661,
+        "line_number": 636,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3864,7 +3872,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 171,
+        "line_number": 176,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3872,7 +3880,7 @@
         "hashed_secret": "1073ab6cda4b991cd29f9e83a307f34004ae9327",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 177,
+        "line_number": 182,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3880,7 +3888,7 @@
         "hashed_secret": "d4fe581561f18ee5006254a7e53f53cbed780bc2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 259,
+        "line_number": 269,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3890,7 +3898,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 887,
+        "line_number": 925,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3900,7 +3908,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4608,
+        "line_number": 4632,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-10T16:59:56Z",
+  "generated_at": "2026-08-13T06:46:36Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -258,7 +258,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2039,
+        "line_number": 2047,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2127,
+        "line_number": 2135,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2477,
+        "line_number": 2485,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3842,
+        "line_number": 3850,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3933,
+        "line_number": 3941,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3976,
+        "line_number": 3984,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3981,
+        "line_number": 3989,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3986,
+        "line_number": 3994,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -390,7 +390,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6064,
+        "line_number": 6079,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6561,
+        "line_number": 6576,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6573,
+        "line_number": 6588,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6645,
+        "line_number": 6660,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7061,
+        "line_number": 7076,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -430,7 +430,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7752,
+        "line_number": 7767,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -836,7 +836,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1741,
+        "line_number": 1749,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -844,7 +844,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1990,
+        "line_number": 1998,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -852,7 +852,7 @@
         "hashed_secret": "afba9d98073dfb79fba7b21516c4d4d676c72935",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2368,
+        "line_number": 2376,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -860,7 +860,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2468,
+        "line_number": 2476,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -868,7 +868,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2468,
+        "line_number": 2476,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -876,7 +876,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2481,
+        "line_number": 2489,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -884,7 +884,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2629,
+        "line_number": 2637,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -892,7 +892,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2650,
+        "line_number": 2658,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -900,7 +900,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2658,
+        "line_number": 2666,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -908,7 +908,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2663,
+        "line_number": 2671,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2366,7 +2366,7 @@
         "hashed_secret": "1513802ada0ec04c2446206e16baa7256ebff74b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 636,
+        "line_number": 661,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3872,7 +3872,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 176,
+        "line_number": 171,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3880,7 +3880,7 @@
         "hashed_secret": "1073ab6cda4b991cd29f9e83a307f34004ae9327",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 182,
+        "line_number": 177,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3888,7 +3888,7 @@
         "hashed_secret": "d4fe581561f18ee5006254a7e53f53cbed780bc2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 269,
+        "line_number": 259,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3898,7 +3898,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 925,
+        "line_number": 935,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3908,7 +3908,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4632,
+        "line_number": 4637,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/docs/docs/manage/dcr.md
+++ b/docs/docs/manage/dcr.md
@@ -313,6 +313,35 @@ and [Manual Client Credentials](#manual-client-credentials-fallback) examples).
 
 ---
 
+## Per-Gateway Token Endpoint Auth Method (`token_endpoint_auth_method`)
+
+`oauth_config.token_endpoint_auth_method` overrides the global
+`MCPGATEWAY_DCR_TOKEN_ENDPOINT_AUTH_METHOD` setting for a single gateway's
+DCR registration request (RFC 7591).
+
+| `oauth_config.token_endpoint_auth_method` | Registration behavior |
+|---|---|
+| `client_secret_basic` | Registers the client with `token_endpoint_auth_method: client_secret_basic` |
+| `client_secret_post` | Registers the client with `token_endpoint_auth_method: client_secret_post` |
+| absent / empty | Registration uses the global `MCPGATEWAY_DCR_TOKEN_ENDPOINT_AUTH_METHOD` |
+
+- Only `client_secret_basic` and `client_secret_post` are accepted.
+  `none`, `private_key_jwt`, and any other value are rejected at create/update
+  time: the gateway runtime authenticates DCR-registered clients with a client
+  secret, so public-client (`none`) registration is not supported yet.
+- The authorization server's registration response is authoritative: the
+  `token_endpoint_auth_method` the AS confirms is what gets stored back into
+  `oauth_config` and used for subsequent token requests.
+- UIs that send the ICA-style boolean `useClientSecretTokenAuthMethod` should
+  map it here: `true` -> `client_secret_basic`. The 1.0-style `false` ->
+  `none` (public PKCE client) mapping is a separate follow-up; ContextForge
+  does not currently support token endpoint auth method `none`.
+- Invalid values in an existing gateway row (for example, written before the
+  validation landed) are treated as absent at registration time, deferring to
+  the global setting.
+
+---
+
 ## Database Schema
 
 DCR uses three tables:

--- a/docs/docs/manage/dcr.md
+++ b/docs/docs/manage/dcr.md
@@ -216,6 +216,103 @@ Note: No `client_secret` - PKCE provides security.
 
 ---
 
+## Per-Gateway Control (`use_dcr`)
+
+DCR is normally governed by two **deployment-global** environment variables
+(`MCPGATEWAY_DCR_ENABLED`, `MCPGATEWAY_DCR_AUTO_REGISTER_ON_MISSING_CREDENTIALS`).
+For fleets where different authorization servers need different behavior, set
+`oauth_config.use_dcr` **per gateway** to override the global auto-register
+setting for that gateway alone:
+
+| `oauth_config.use_dcr` | `MCPGATEWAY_DCR_ENABLED` | `MCPGATEWAY_DCR_AUTO_REGISTER_ON_MISSING_CREDENTIALS` | Result when gateway has `issuer` but no `client_id` |
+|------------------------|--------------------------|--------------------------------------------------------|-----------------------------------------------------|
+| absent                 | `true`                   | `true`                                                 | DCR (default behavior)                              |
+| absent                 | any                      | `false`                                                | 400 - provide credentials manually                  |
+| `true`                 | `true`                   | any                                                    | DCR (forces registration)                           |
+| `true`                 | `false`                  | any                                                    | 400 - DCR disabled globally                         |
+| `false`                | any                      | any                                                    | never DCR - 400 - provide credentials manually      |
+| invalid value          | any                      | any                                                    | rejected at create/update (400); treated as absent at runtime |
+
+- `use_dcr` accepts native booleans or the strings `"true"`/`"false"`
+  (case-insensitive) for interop with clients that serialize booleans to strings.
+- `None`, `""`, or whitespace-only values are treated as **absent**
+  (same empty-means-unset convention as every other `oauth_config` field).
+- `use_dcr: true` cannot re-enable DCR when the deployment master switch
+  `MCPGATEWAY_DCR_ENABLED=false` - the global flag always wins.
+- The flag is read only when a gateway has an `issuer` and no `client_id`.
+  Gateways with full credentials are unaffected.
+
+### Example: force DCR for one gateway while the global auto-register is off
+
+```json
+{
+  "name": "Force-DCR Gateway",
+  "url": "https://mcp.example.com/sse",
+  "auth_type": "oauth",
+  "oauth_config": {
+    "grant_type": "authorization_code",
+    "issuer": "https://keycloak.example.com/realms/mcp",
+    "redirect_uri": "https://gateway.example.com/oauth/callback",
+    "use_dcr": true
+  }
+}
+```
+
+### Example: explicit opt-out - never auto-register this gateway
+
+```json
+{
+  "name": "Manual-Only Gateway",
+  "url": "https://mcp.example.com/sse",
+  "auth_type": "oauth",
+  "oauth_config": {
+    "grant_type": "authorization_code",
+    "issuer": "https://auth.saas-provider.com",
+    "client_id": "pre-provisioned-client",
+    "client_secret": "pre-provisioned-secret",
+    "authorization_url": "https://auth.saas-provider.com/authorize",
+    "token_url": "https://auth.saas-provider.com/token",
+    "redirect_uri": "https://gateway.example.com/oauth/callback",
+    "use_dcr": false
+  }
+}
+```
+
+### Example: absent - defer to global settings (default)
+
+Omit `use_dcr` entirely; behavior matches the global environment variables
+exactly (see the [Automatic Registration](#automatic-registration-recommended)
+and [Manual Client Credentials](#manual-client-credentials-fallback) examples).
+
+### Migrating from global-only to per-gateway control
+
+1. Audit existing gateways that would be affected by DCR:
+
+   ```sql
+   SELECT id, name, oauth_config
+   FROM gateways
+   WHERE oauth_config->>'issuer' IS NOT NULL
+     AND oauth_config->>'client_id' IS NULL;
+   ```
+
+2. For each gateway, decide and set `use_dcr`:
+
+   - `true` if the authorization server supports RFC 7591 and the gateway
+     should keep auto-registering;
+   - `false` if credentials are provisioned out-of-band and registration must
+     never happen.
+
+3. Flip the global default:
+
+   ```bash
+   MCPGATEWAY_DCR_AUTO_REGISTER_ON_MISSING_CREDENTIALS=false
+   ```
+
+4. Update each gateway via the admin API (`PUT /gateways/{id}`) and verify
+   first-use registration works for the `use_dcr: true` gateways.
+
+---
+
 ## Database Schema
 
 DCR uses three tables:

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -2445,6 +2445,43 @@ def parse_use_dcr_flag(value: Any) -> Optional[bool]:
     raise ValueError(f"oauth_config.use_dcr must be a boolean or 'true'/'false' string, got type {type(value).__name__}")
 
 
+_SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS = frozenset({"client_secret_basic", "client_secret_post"})
+
+
+def parse_token_endpoint_auth_method(value: Any) -> Optional[str]:
+    """Parse the per-gateway ``token_endpoint_auth_method`` from an oauth_config value.
+
+    Accepts the two token endpoint auth methods the gateway runtime actually
+    executes at the token endpoint (see ``OAuthManager._client_credentials_flow``):
+    ``client_secret_basic`` and ``client_secret_post``. ``None`` and
+    empty/whitespace-only strings are treated as absent, matching the
+    empty-means-unset convention used for other oauth_config fields (see
+    ``_validate_oauth_config_urls`` in schemas.py).
+
+    Args:
+        value: Raw ``oauth_config["token_endpoint_auth_method"]`` value.
+
+    Returns:
+        ``None`` when absent, the normalized method string when valid.
+
+    Raises:
+        ValueError: If the value is not a string or is not one of the supported
+            methods (e.g. ``none``, ``private_key_jwt``, integers, lists).
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        lowered = stripped.lower()
+        if lowered in _SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS:
+            return lowered
+        supported = ", ".join(sorted(_SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS))
+        raise ValueError(f"oauth_config.token_endpoint_auth_method must be one of: {supported}; got: {value!r}")
+    raise ValueError(f"oauth_config.token_endpoint_auth_method must be a string, got type {type(value).__name__}")
+
+
 # CWE-400: Limits for user-supplied meta_data forwarded to upstream MCP servers.
 # Keeps arbitrarily large dicts from amplifying into downstream network/DB load.
 # These are now read from config (settings.meta_max_keys, etc.) but kept as

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -2410,6 +2410,41 @@ def validate_core_url(value: str, field_name: str = "URL") -> str:
     return SecurityValidator.validate_url(value, field_name)
 
 
+def parse_use_dcr_flag(value: Any) -> Optional[bool]:
+    """Parse the per-gateway ``use_dcr`` flag from an oauth_config value.
+
+    Accepts native booleans and case-insensitive ``"true"``/``"false"`` strings
+    (whitespace-stripped). ``None`` and empty/whitespace-only strings are treated
+    as absent, matching the empty-means-unset convention used for other
+    oauth_config fields (see ``_validate_oauth_config_urls`` in schemas.py).
+
+    Args:
+        value: Raw ``oauth_config["use_dcr"]`` value.
+
+    Returns:
+        ``None`` when absent, ``True`` or ``False`` when valid.
+
+    Raises:
+        ValueError: If the value is not a boolean, an empty/parseable string, or
+            ``None`` (e.g. integers, lists, malformed strings).
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        lowered = stripped.lower()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+        raise ValueError(f"oauth_config.use_dcr must be a boolean or 'true'/'false' string, got: {value!r}")
+    raise ValueError(f"oauth_config.use_dcr must be a boolean or 'true'/'false' string, got type {type(value).__name__}")
+
+
 # CWE-400: Limits for user-supplied meta_data forwarded to upstream MCP servers.
 # Keeps arbitrarily large dicts from amplifying into downstream network/DB load.
 # These are now read from config (settings.meta_max_keys, etc.) but kept as

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -30,7 +30,7 @@ from sqlalchemy.orm import Session
 from mcpgateway.auth import normalize_token_teams
 from mcpgateway.auth_context import get_user_email
 from mcpgateway.common.query_params import QueryErrorCode
-from mcpgateway.common.validators import SecurityValidator, parse_use_dcr_flag
+from mcpgateway.common.validators import SecurityValidator, parse_token_endpoint_auth_method, parse_use_dcr_flag
 from mcpgateway.config import settings
 from mcpgateway.db import Gateway, get_db, Permissions
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
@@ -535,6 +535,15 @@ async def initiate_oauth_flow(
                 use_dcr_flag = None
                 logger.warning(f"Gateway {SecurityValidator.sanitize_log_message(gateway_id)} has invalid use_dcr value ({use_dcr_err}); treating as absent")
 
+            # Per-gateway token_endpoint_auth_method with the same read-time
+            # safety net as use_dcr: invalid values (e.g. legacy rows) are
+            # logged and treated as absent, deferring to the global setting.
+            try:
+                token_endpoint_auth_method = parse_token_endpoint_auth_method(oauth_config.get("token_endpoint_auth_method"))
+            except ValueError as auth_method_err:
+                token_endpoint_auth_method = None
+                logger.warning(f"Gateway {SecurityValidator.sanitize_log_message(gateway_id)} has invalid token_endpoint_auth_method value ({auth_method_err}); treating as absent")
+
             if use_dcr_flag is False:
                 # Explicit per-gateway opt-out: never auto-register.
                 logger.warning(f"Gateway {SecurityValidator.sanitize_log_message(gateway_id)} has issuer but no client_id, and use_dcr=false")
@@ -578,6 +587,7 @@ async def initiate_oauth_flow(
                         issuer=issuer,
                         redirect_uri=oauth_config.get("redirect_uri"),
                         scopes=oauth_config.get("scopes", settings.dcr_default_scopes),
+                        token_endpoint_auth_method=token_endpoint_auth_method,
                         db=db,
                     )
 

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -30,7 +30,7 @@ from sqlalchemy.orm import Session
 from mcpgateway.auth import normalize_token_teams
 from mcpgateway.auth_context import get_user_email
 from mcpgateway.common.query_params import QueryErrorCode
-from mcpgateway.common.validators import SecurityValidator
+from mcpgateway.common.validators import SecurityValidator, parse_use_dcr_flag
 from mcpgateway.config import settings
 from mcpgateway.db import Gateway, get_db, Permissions
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
@@ -526,8 +526,46 @@ async def initiate_oauth_flow(
         client_id = oauth_config.get("client_id")
 
         if issuer and not client_id:
-            if settings.dcr_enabled and settings.dcr_auto_register_on_missing_credentials:
-                logger.info(f"Gateway {SecurityValidator.sanitize_log_message(gateway_id)} has issuer but no client_id. Attempting DCR...")
+            # Per-gateway use_dcr flag with a read-time safety net: invalid
+            # values (e.g. legacy rows written before validation) are logged
+            # and treated as absent.
+            try:
+                use_dcr_flag = parse_use_dcr_flag(oauth_config.get("use_dcr"))
+            except ValueError as use_dcr_err:
+                use_dcr_flag = None
+                logger.warning(f"Gateway {SecurityValidator.sanitize_log_message(gateway_id)} has invalid use_dcr value ({use_dcr_err}); treating as absent")
+
+            if use_dcr_flag is False:
+                # Explicit per-gateway opt-out: never auto-register.
+                logger.warning(f"Gateway {SecurityValidator.sanitize_log_message(gateway_id)} has issuer but no client_id, and use_dcr=false")
+                raise HTTPException(
+                    status_code=400,
+                    detail="Gateway OAuth configuration is incomplete. use_dcr=false prevents Dynamic Client Registration; please provide client_id and client_secret manually.",
+                )
+
+            if not settings.dcr_enabled:
+                if use_dcr_flag is True:
+                    logger.warning(f"Gateway {SecurityValidator.sanitize_log_message(gateway_id)} requested DCR (use_dcr=true) but DCR is disabled globally")
+                    raise HTTPException(
+                        status_code=400,
+                        detail="DCR is disabled globally (MCPGATEWAY_DCR_ENABLED=false). Cannot honor use_dcr=true. Please enable DCR deployment-wide or provide client_id and client_secret manually.",
+                    )
+                # Absent flag, DCR disabled globally - existing behavior
+                logger.warning(f"Gateway {SecurityValidator.sanitize_log_message(gateway_id)} has issuer but no client_id, and DCR is disabled globally")
+                raise HTTPException(
+                    status_code=400,
+                    detail="Gateway OAuth configuration is incomplete. Please provide client_id and client_secret, or enable DCR (Dynamic Client Registration) by setting MCPGATEWAY_DCR_ENABLED=true.",
+                )
+
+            # dcr_enabled is true at this point; registration happens when the
+            # per-gateway flag forces it or the global auto-register is on.
+            should_register = use_dcr_flag is True or settings.dcr_auto_register_on_missing_credentials
+
+            if should_register:
+                logger.info(
+                    f"Gateway {SecurityValidator.sanitize_log_message(gateway_id)} has issuer but no client_id. Attempting DCR "
+                    f"(use_dcr={use_dcr_flag}, global auto-register={settings.dcr_auto_register_on_missing_credentials})..."
+                )
 
                 try:
                     # Initialize DCR service
@@ -600,11 +638,11 @@ async def initiate_oauth_flow(
                     logger.error(f"Unexpected error during DCR for gateway {SecurityValidator.sanitize_log_message(gateway_id)}: {dcr_ex}")
                     raise HTTPException(status_code=500, detail="Failed to register OAuth client")
             else:
-                # DCR is disabled or auto-register is off
+                # Absent flag + global auto-register off - existing behavior
                 logger.warning(f"Gateway {SecurityValidator.sanitize_log_message(gateway_id)} has issuer but no client_id, and DCR auto-registration is disabled")
                 raise HTTPException(
                     status_code=400,
-                    detail="Gateway OAuth configuration is incomplete. Please provide client_id and client_secret, or enable DCR (Dynamic Client Registration) by setting MCPGATEWAY_DCR_ENABLED=true and MCPGATEWAY_DCR_AUTO_REGISTER_ON_MISSING_CREDENTIALS=true",
+                    detail="Gateway OAuth configuration is incomplete. Please provide client_id and client_secret, or set use_dcr=true for this gateway, or enable global auto-registration with MCPGATEWAY_DCR_AUTO_REGISTER_ON_MISSING_CREDENTIALS=true",
                 )
 
         # Validate required fields for OAuth flow

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -38,7 +38,7 @@ from mcpgateway.common.models import Resource as MCPResource
 from mcpgateway.common.models import ResourceContent, TextContent
 from mcpgateway.common.models import Tool as MCPTool
 from mcpgateway.common.oauth import OAUTH_SENSITIVE_KEYS
-from mcpgateway.common.validators import SecurityValidator, parse_use_dcr_flag, validate_core_url
+from mcpgateway.common.validators import SecurityValidator, parse_token_endpoint_auth_method, parse_use_dcr_flag, validate_core_url
 from mcpgateway.config import settings
 from mcpgateway.utils.base_models import BaseModelWithConfigDict
 from mcpgateway.utils.services_auth import decode_auth, encode_auth
@@ -165,10 +165,13 @@ def _validate_oauth_config_urls(v: Optional[Dict[str, Any]]) -> Optional[Dict[st
 
 
 def _validate_oauth_config_flags(v: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
-    """Validate boolean-flag entries in OAuth config dicts.
+    """Validate boolean-flag and enumerated entries in OAuth config dicts.
 
     Currently validates ``use_dcr`` (per-gateway Dynamic Client Registration
-    control) via [`parse_use_dcr_flag`](mcpgateway/common/validators.py).
+    control) via [`parse_use_dcr_flag`](mcpgateway/common/validators.py) and
+    ``token_endpoint_auth_method`` (per-gateway token endpoint auth method for
+    DCR registration) via
+    [`parse_token_endpoint_auth_method`](mcpgateway/common/validators.py).
 
     Args:
         v: OAuth configuration dict or ``None``.
@@ -177,12 +180,14 @@ def _validate_oauth_config_flags(v: Optional[Dict[str, Any]]) -> Optional[Dict[s
         The original dict when valid.
 
     Raises:
-        ValueError: If a flag field has an invalid value.
+        ValueError: If a flag or enumerated field has an invalid value.
     """
     if v is None or not isinstance(v, dict):
         return v
     if "use_dcr" in v:
         parse_use_dcr_flag(v["use_dcr"])
+    if "token_endpoint_auth_method" in v:
+        parse_token_endpoint_auth_method(v["token_endpoint_auth_method"])
     return v
 
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -38,7 +38,7 @@ from mcpgateway.common.models import Resource as MCPResource
 from mcpgateway.common.models import ResourceContent, TextContent
 from mcpgateway.common.models import Tool as MCPTool
 from mcpgateway.common.oauth import OAUTH_SENSITIVE_KEYS
-from mcpgateway.common.validators import SecurityValidator, validate_core_url
+from mcpgateway.common.validators import SecurityValidator, parse_use_dcr_flag, validate_core_url
 from mcpgateway.config import settings
 from mcpgateway.utils.base_models import BaseModelWithConfigDict
 from mcpgateway.utils.services_auth import decode_auth, encode_auth
@@ -161,6 +161,28 @@ def _validate_oauth_config_urls(v: Optional[Dict[str, Any]]) -> Optional[Dict[st
         if not isinstance(server, str):
             raise ValueError(f"oauth_config.authorization_servers[{idx}] must be a string URL")
         validate_core_url(server, f"OAuth config authorization_servers[{idx}]")
+    return v
+
+
+def _validate_oauth_config_flags(v: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Validate boolean-flag entries in OAuth config dicts.
+
+    Currently validates ``use_dcr`` (per-gateway Dynamic Client Registration
+    control) via [`parse_use_dcr_flag`](mcpgateway/common/validators.py).
+
+    Args:
+        v: OAuth configuration dict or ``None``.
+
+    Returns:
+        The original dict when valid.
+
+    Raises:
+        ValueError: If a flag field has an invalid value.
+    """
+    if v is None or not isinstance(v, dict):
+        return v
+    if "use_dcr" in v:
+        parse_use_dcr_flag(v["use_dcr"])
     return v
 
 
@@ -3207,8 +3229,9 @@ class GatewayCreate(BaseModelWithConfigDict):
     @field_validator("oauth_config", mode="before")
     @classmethod
     def validate_oauth_config(cls, v: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
-        """Validate URL-bearing OAuth configuration entries."""
-        return _validate_oauth_config_urls(v)
+        """Validate URL-bearing and boolean-flag OAuth configuration entries."""
+        v = _validate_oauth_config_urls(v)
+        return _validate_oauth_config_flags(v)
 
     @field_validator("description")
     @classmethod
@@ -3571,8 +3594,9 @@ class GatewayUpdate(BaseModelWithConfigDict):
     @field_validator("oauth_config", mode="before")
     @classmethod
     def validate_oauth_config(cls, v: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
-        """Validate URL-bearing OAuth configuration entries."""
-        return _validate_oauth_config_urls(v)
+        """Validate URL-bearing and boolean-flag OAuth configuration entries."""
+        v = _validate_oauth_config_urls(v)
+        return _validate_oauth_config_flags(v)
 
     @field_validator("description", mode="before")
     @classmethod

--- a/mcpgateway/services/dcr_service.py
+++ b/mcpgateway/services/dcr_service.py
@@ -14,7 +14,7 @@ This module handles OAuth 2.0 Dynamic Client Registration (DCR) including:
 # Standard
 from datetime import datetime, timezone
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from urllib.parse import urlsplit
 
 # Third-Party
@@ -150,7 +150,9 @@ class DcrService:
         except httpx.HTTPError as e:
             raise DcrError(f"Failed to discover AS metadata for {normalized_issuer}: {e}")
 
-    async def register_client(self, gateway_id: str, gateway_name: str, issuer: str, redirect_uri: str, scopes: List[str], db: Session) -> RegisteredOAuthClient:
+    async def register_client(
+        self, gateway_id: str, gateway_name: str, issuer: str, redirect_uri: str, scopes: List[str], db: Session, token_endpoint_auth_method: Optional[str] = None
+    ) -> RegisteredOAuthClient:
         """Register as OAuth client with upstream AS (RFC 7591).
 
         Args:
@@ -160,6 +162,9 @@ class DcrService:
             redirect_uri: OAuth redirect URI
             scopes: List of OAuth scopes
             db: Database session
+            token_endpoint_auth_method: Per-gateway token endpoint auth method
+                override; ``None`` defers to the global
+                ``dcr_token_endpoint_auth_method`` setting.
 
         Returns:
             RegisteredOAuthClient record
@@ -205,7 +210,7 @@ class DcrService:
             "redirect_uris": [redirect_uri],
             "grant_types": requested_grant_types,
             "response_types": ["code"],
-            "token_endpoint_auth_method": self.settings.dcr_token_endpoint_auth_method,
+            "token_endpoint_auth_method": token_endpoint_auth_method or self.settings.dcr_token_endpoint_auth_method,
             "scope": " ".join(scopes),
         }
 
@@ -250,7 +255,7 @@ class DcrService:
             grant_types=orjson.dumps(registration_response.get("grant_types", requested_grant_types)).decode(),
             response_types=orjson.dumps(registration_response.get("response_types", ["code"])).decode(),
             scope=registration_response.get("scope", " ".join(scopes)),
-            token_endpoint_auth_method=registration_response.get("token_endpoint_auth_method", self.settings.dcr_token_endpoint_auth_method),
+            token_endpoint_auth_method=registration_response.get("token_endpoint_auth_method", token_endpoint_auth_method or self.settings.dcr_token_endpoint_auth_method),
             registration_client_uri=registration_response.get("registration_client_uri"),
             registration_access_token_encrypted=registration_access_token_encrypted,
             created_at=datetime.now(timezone.utc),
@@ -271,7 +276,9 @@ class DcrService:
 
         return registered_client
 
-    async def get_or_register_client(self, gateway_id: str, gateway_name: str, issuer: str, redirect_uri: str, scopes: List[str], db: Session) -> RegisteredOAuthClient:
+    async def get_or_register_client(
+        self, gateway_id: str, gateway_name: str, issuer: str, redirect_uri: str, scopes: List[str], db: Session, token_endpoint_auth_method: Optional[str] = None
+    ) -> RegisteredOAuthClient:
         """Get existing registered client or register new one.
 
         Args:
@@ -281,6 +288,9 @@ class DcrService:
             redirect_uri: OAuth redirect URI
             scopes: List of OAuth scopes
             db: Database session
+            token_endpoint_auth_method: Per-gateway token endpoint auth method
+                override; ``None`` defers to the global
+                ``dcr_token_endpoint_auth_method`` setting.
 
         Returns:
             RegisteredOAuthClient record
@@ -312,7 +322,7 @@ class DcrService:
         logger.info(
             "No existing client found for gateway %s, registering new client with %s", SecurityValidator.sanitize_log_message(gateway_id), SecurityValidator.sanitize_log_message(normalized_issuer)
         )
-        return await self.register_client(gateway_id, gateway_name, normalized_issuer, redirect_uri, scopes, db)
+        return await self.register_client(gateway_id, gateway_name, normalized_issuer, redirect_uri, scopes, db, token_endpoint_auth_method)
 
     async def update_client_registration(self, client_record: RegisteredOAuthClient, db: Session) -> RegisteredOAuthClient:
         """Update existing client registration (RFC 7591 section 4.2).

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -3637,3 +3637,155 @@ class TestPersistLearnedAudience:
 
         assert original == {"issuer": "https://idp.example.com"}
         assert gateway.oauth_config is not original
+
+
+class TestUseDcrFlagGate:
+    """Per-gateway ``use_dcr`` flag overrides the global DCR settings (Phase 1.4)."""
+
+    def _gateway(self, oauth_config: dict):
+        mock_gateway = Mock(spec=Gateway)
+        mock_gateway.id = "gateway123"
+        mock_gateway.name = "Gateway"
+        mock_gateway.url = "https://mcp.example.com"
+        mock_gateway.visibility = "public"
+        mock_gateway.team_id = None
+        mock_gateway.auth_type = None
+        mock_gateway.oauth_config = oauth_config
+        return mock_gateway
+
+    def _base_oauth_config(self, use_dcr: object = None) -> dict:
+        config = {
+            "grant_type": "authorization_code",
+            "issuer": "https://issuer.example.com",
+            "redirect_uri": "https://gateway.example.com/oauth/callback",
+        }
+        if use_dcr is not None:
+            config["use_dcr"] = use_dcr
+        return config
+
+    def _patch_dcr_success(self):
+        class _Registered:
+            client_id = "client-123"
+            client_secret_encrypted = None
+            token_endpoint_auth_method = "client_secret_post"
+
+        class _FakeDcrService:
+            async def get_or_register_client(self, **_kwargs):
+                return _Registered()
+
+            async def discover_as_metadata(self, _issuer):
+                return {"authorization_endpoint": "https://issuer.example.com/auth", "token_endpoint": "https://issuer.example.com/token"}
+
+        return patch("mcpgateway.routers.oauth_router.DcrService", return_value=_FakeDcrService())
+
+    def _patch_oauth_manager(self, auth_data):
+        def _patcher(mock_oauth_mgr):
+            mock_mgr = Mock()
+            mock_mgr.initiate_authorization_code_flow = AsyncMock(return_value=auth_data)
+            mock_oauth_mgr.return_value = mock_mgr
+            return mock_mgr
+
+        return _patcher
+
+    def _load_handler(self):
+        from mcpgateway.routers.oauth_router import initiate_oauth_flow
+
+        return initiate_oauth_flow
+
+    @pytest.mark.asyncio
+    async def test_use_dcr_true_registers_when_global_auto_register_off(self, mock_db, mock_request, mock_current_user):
+        """Force-enable: use_dcr=true overrides dcr_auto_register_on_missing_credentials=false."""
+        mock_gateway = self._gateway(self._base_oauth_config(use_dcr=True))
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        with self._patch_dcr_success():
+            with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_mgr:
+                self._patch_oauth_manager({"authorization_url": "https://issuer.example.com/auth"})(mock_oauth_mgr)
+                with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                    with patch("mcpgateway.routers.oauth_router.settings") as mock_settings:
+                        mock_settings.dcr_enabled = True
+                        mock_settings.dcr_auto_register_on_missing_credentials = False
+                        mock_settings.dcr_default_scopes = ["openid"]
+
+                        result = await self._load_handler()("gateway123", mock_request, mock_current_user, mock_db)
+
+        assert isinstance(result, RedirectResponse)
+        assert mock_gateway.oauth_config["client_id"] == "client-123"
+        mock_db.commit.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_use_dcr_false_skips_dcr_when_global_auto_register_on(self, mock_db, mock_request, mock_current_user):
+        """Explicit opt-out: use_dcr=false (string form) skips DCR even when global auto-register is on."""
+        mock_gateway = self._gateway(self._base_oauth_config(use_dcr="false"))
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        with patch("mcpgateway.routers.oauth_router.DcrService") as mock_dcr:
+            with patch("mcpgateway.routers.oauth_router.settings") as mock_settings:
+                mock_settings.dcr_enabled = True
+                mock_settings.dcr_auto_register_on_missing_credentials = True
+
+                with pytest.raises(HTTPException) as exc_info:
+                    await self._load_handler()("gateway123", mock_request, mock_current_user, mock_db)
+
+        assert exc_info.value.status_code == 400
+        assert "use_dcr=false" in str(exc_info.value.detail)
+        mock_dcr.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_use_dcr_true_requires_global_dcr_enabled(self, mock_db, mock_request, mock_current_user):
+        """Master switch: use_dcr=true cannot re-enable a globally disabled DCR deployment."""
+        mock_gateway = self._gateway(self._base_oauth_config(use_dcr=True))
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        with patch("mcpgateway.routers.oauth_router.DcrService") as mock_dcr:
+            with patch("mcpgateway.routers.oauth_router.settings") as mock_settings:
+                mock_settings.dcr_enabled = False
+                mock_settings.dcr_auto_register_on_missing_credentials = True
+
+                with pytest.raises(HTTPException) as exc_info:
+                    await self._load_handler()("gateway123", mock_request, mock_current_user, mock_db)
+
+        assert exc_info.value.status_code == 400
+        assert "MCPGATEWAY_DCR_ENABLED=false" in str(exc_info.value.detail)
+        assert "Cannot honor use_dcr=true" in str(exc_info.value.detail)
+        mock_dcr.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invalid_use_dcr_runtime_treated_as_absent(self, mock_db, mock_request, mock_current_user):
+        """Read-time safety net: malformed legacy values log a warning and behave as absent."""
+        mock_gateway = self._gateway(self._base_oauth_config(use_dcr="tru"))
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        with self._patch_dcr_success():
+            with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_mgr:
+                self._patch_oauth_manager({"authorization_url": "https://issuer.example.com/auth"})(mock_oauth_mgr)
+                with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                    with patch("mcpgateway.routers.oauth_router.settings") as mock_settings:
+                        mock_settings.dcr_enabled = True
+                        mock_settings.dcr_auto_register_on_missing_credentials = True
+                        mock_settings.dcr_default_scopes = ["openid"]
+
+                        result = await self._load_handler()("gateway123", mock_request, mock_current_user, mock_db)
+
+        assert isinstance(result, RedirectResponse)
+        assert mock_gateway.oauth_config["client_id"] == "client-123"
+
+    @pytest.mark.asyncio
+    async def test_use_dcr_absent_preserves_current_behavior(self, mock_db, mock_request, mock_current_user):
+        """Backward-compat pin: a gateway without use_dcr follows the global settings exactly."""
+        mock_gateway = self._gateway(self._base_oauth_config(use_dcr=None))
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        with self._patch_dcr_success():
+            with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_mgr:
+                self._patch_oauth_manager({"authorization_url": "https://issuer.example.com/auth"})(mock_oauth_mgr)
+                with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                    with patch("mcpgateway.routers.oauth_router.settings") as mock_settings:
+                        mock_settings.dcr_enabled = True
+                        mock_settings.dcr_auto_register_on_missing_credentials = True
+                        mock_settings.dcr_default_scopes = ["openid"]
+
+                        result = await self._load_handler()("gateway123", mock_request, mock_current_user, mock_db)
+
+        assert isinstance(result, RedirectResponse)
+        assert mock_gateway.oauth_config["client_id"] == "client-123"

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -3789,3 +3789,77 @@ class TestUseDcrFlagGate:
 
         assert isinstance(result, RedirectResponse)
         assert mock_gateway.oauth_config["client_id"] == "client-123"
+
+    @pytest.mark.asyncio
+    async def test_per_gateway_token_auth_method_forwarded_to_registration(self, mock_db, mock_request, mock_current_user):
+        """Per-gateway token_endpoint_auth_method reaches the DCR registration call."""
+        captured = {}
+
+        class _Registered:
+            client_id = "client-123"
+            client_secret_encrypted = None
+            token_endpoint_auth_method = "client_secret_post"
+
+        class _FakeDcrService:
+            async def get_or_register_client(self, **_kwargs):
+                captured.update(_kwargs)
+                return _Registered()
+
+            async def discover_as_metadata(self, _issuer):
+                return {"authorization_endpoint": "https://issuer.example.com/auth", "token_endpoint": "https://issuer.example.com/token"}
+
+        config = self._base_oauth_config(use_dcr=True)
+        config["token_endpoint_auth_method"] = "client_secret_post"
+        mock_gateway = self._gateway(config)
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        with patch("mcpgateway.routers.oauth_router.DcrService", return_value=_FakeDcrService()):
+            with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_mgr:
+                self._patch_oauth_manager({"authorization_url": "https://issuer.example.com/auth"})(mock_oauth_mgr)
+                with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                    with patch("mcpgateway.routers.oauth_router.settings") as mock_settings:
+                        mock_settings.dcr_enabled = True
+                        mock_settings.dcr_auto_register_on_missing_credentials = False
+                        mock_settings.dcr_default_scopes = ["openid"]
+
+                        result = await self._load_handler()("gateway123", mock_request, mock_current_user, mock_db)
+
+        assert isinstance(result, RedirectResponse)
+        assert captured["token_endpoint_auth_method"] == "client_secret_post"
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_auth_method_runtime_treated_as_absent(self, mock_db, mock_request, mock_current_user):
+        """Read-time safety net: malformed token_endpoint_auth_method defers to the global default."""
+        captured = {}
+
+        class _Registered:
+            client_id = "client-123"
+            client_secret_encrypted = None
+            token_endpoint_auth_method = "client_secret_basic"
+
+        class _FakeDcrService:
+            async def get_or_register_client(self, **_kwargs):
+                captured.update(_kwargs)
+                return _Registered()
+
+            async def discover_as_metadata(self, _issuer):
+                return {"authorization_endpoint": "https://issuer.example.com/auth", "token_endpoint": "https://issuer.example.com/token"}
+
+        config = self._base_oauth_config(use_dcr=True)
+        config["token_endpoint_auth_method"] = "none"
+        mock_gateway = self._gateway(config)
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        with patch("mcpgateway.routers.oauth_router.DcrService", return_value=_FakeDcrService()):
+            with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_mgr:
+                self._patch_oauth_manager({"authorization_url": "https://issuer.example.com/auth"})(mock_oauth_mgr)
+                with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                    with patch("mcpgateway.routers.oauth_router.settings") as mock_settings:
+                        mock_settings.dcr_enabled = True
+                        mock_settings.dcr_auto_register_on_missing_credentials = False
+                        mock_settings.dcr_default_scopes = ["openid"]
+
+                        result = await self._load_handler()("gateway123", mock_request, mock_current_user, mock_db)
+
+        assert isinstance(result, RedirectResponse)
+        assert captured["token_endpoint_auth_method"] is None

--- a/tests/unit/mcpgateway/services/test_dcr_service.py
+++ b/tests/unit/mcpgateway/services/test_dcr_service.py
@@ -530,6 +530,69 @@ class TestRegisterClient:
             assert request_json["scope"] == "mcp:read"
 
     @pytest.mark.asyncio
+    async def test_register_client_uses_per_gateway_token_auth_method(self, test_db):
+        """Per-gateway token_endpoint_auth_method is sent in the registration request."""
+        dcr_service = DcrService()
+
+        mock_metadata = {"registration_endpoint": "https://as.example.com/register"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json = MagicMock(return_value={"client_id": "test", "redirect_uris": []})
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch.object(dcr_service, "discover_as_metadata") as mock_discover, patch.object(dcr_service, "_get_client", return_value=mock_client):
+            mock_discover.return_value = mock_metadata
+
+            await dcr_service.register_client(
+                gateway_id="test-gw-tea",
+                gateway_name="Test Gateway",
+                issuer="https://as.example.com",
+                redirect_uri="http://localhost:4444/callback",
+                scopes=["mcp:read"],
+                token_endpoint_auth_method="client_secret_post",
+                db=test_db,
+            )
+
+            call_kwargs = mock_client.post.call_args[1]
+            request_json = call_kwargs["json"]
+
+            assert request_json["token_endpoint_auth_method"] == "client_secret_post"
+
+    @pytest.mark.asyncio
+    async def test_register_client_defaults_token_auth_method_to_global(self, test_db):
+        """Absent per-gateway value defers to the global dcr_token_endpoint_auth_method setting."""
+        dcr_service = DcrService()
+
+        mock_metadata = {"registration_endpoint": "https://as.example.com/register"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json = MagicMock(return_value={"client_id": "test", "redirect_uris": []})
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch.object(dcr_service, "discover_as_metadata") as mock_discover, patch.object(dcr_service, "_get_client", return_value=mock_client):
+            mock_discover.return_value = mock_metadata
+
+            await dcr_service.register_client(
+                gateway_id="test-gw-default",
+                gateway_name="Test Gateway",
+                issuer="https://as.example.com",
+                redirect_uri="http://localhost:4444/callback",
+                scopes=["mcp:read"],
+                db=test_db,
+            )
+
+            call_kwargs = mock_client.post.call_args[1]
+            request_json = call_kwargs["json"]
+
+            assert request_json["token_endpoint_auth_method"] == dcr_service.settings.dcr_token_endpoint_auth_method
+
+    @pytest.mark.asyncio
     async def test_register_client_includes_refresh_token_when_supported(self, test_db):
         """Test that refresh_token is included when AS advertises support."""
         dcr_service = DcrService()

--- a/tests/unit/mcpgateway/test_schemas_validators_extra.py
+++ b/tests/unit/mcpgateway/test_schemas_validators_extra.py
@@ -19,7 +19,7 @@ import pytest
 
 # First-Party
 from mcpgateway.common.models import ResourceContent
-from mcpgateway.common.validators import SecurityValidator, parse_use_dcr_flag
+from mcpgateway.common.validators import SecurityValidator, parse_token_endpoint_auth_method, parse_use_dcr_flag
 from mcpgateway.config import settings
 from mcpgateway.schemas import (
     _coerce_visibility,
@@ -1590,3 +1590,56 @@ class TestUseDcrSchemaValidation:
     def test_gateway_update_rejects_invalid_use_dcr(self):
         with pytest.raises(ValidationError):
             GatewayUpdate(oauth_config={"use_dcr": "tru"})
+
+
+class TestParseTokenEndpointAuthMethod:
+    """Unit tests for parse_token_endpoint_auth_method() in common/validators."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (None, None),
+            ("client_secret_basic", "client_secret_basic"),
+            ("client_secret_post", "client_secret_post"),
+            ("CLIENT_SECRET_BASIC", "client_secret_basic"),
+            ("  client_secret_post  ", "client_secret_post"),
+            ("", None),
+            ("   ", None),
+        ],
+    )
+    def test_valid_values(self, value, expected):
+        assert parse_token_endpoint_auth_method(value) == expected
+
+    @pytest.mark.parametrize("value", ["none", "private_key_jwt", "client-secret-basic", "basic", 1, 3.14, [], {}, {"a": 1}])
+    def test_invalid_values_raise(self, value):
+        with pytest.raises(ValueError):
+            parse_token_endpoint_auth_method(value)
+
+
+class TestTokenEndpointAuthMethodSchemaValidation:
+    """Write-time validation of oauth_config.token_endpoint_auth_method on GatewayCreate/GatewayUpdate."""
+
+    def _gateway(self, oauth_config):
+        return GatewayCreate(
+            name="test-gateway",
+            url="https://mcp.example.com",
+            oauth_config=oauth_config,
+        )
+
+    @pytest.mark.parametrize("value", ["none", "private_key_jwt", "client-secret-basic", 1, 0, [], {"a": 1}])
+    def test_invalid_token_endpoint_auth_method_rejected(self, value):
+        with pytest.raises(ValidationError):
+            self._gateway({"token_endpoint_auth_method": value})
+
+    @pytest.mark.parametrize("value", ["client_secret_basic", "client_secret_post", "CLIENT_SECRET_POST", "", "   "])
+    def test_valid_token_endpoint_auth_method_accepted(self, value):
+        gateway = self._gateway({"token_endpoint_auth_method": value})
+        assert gateway.oauth_config["token_endpoint_auth_method"] == value
+
+    def test_gateway_update_accepts_token_endpoint_auth_method(self):
+        update = GatewayUpdate(oauth_config={"token_endpoint_auth_method": "client_secret_basic"})
+        assert update.oauth_config["token_endpoint_auth_method"] == "client_secret_basic"
+
+    def test_gateway_update_rejects_invalid_token_endpoint_auth_method(self):
+        with pytest.raises(ValidationError):
+            GatewayUpdate(oauth_config={"token_endpoint_auth_method": "none"})

--- a/tests/unit/mcpgateway/test_schemas_validators_extra.py
+++ b/tests/unit/mcpgateway/test_schemas_validators_extra.py
@@ -19,7 +19,7 @@ import pytest
 
 # First-Party
 from mcpgateway.common.models import ResourceContent
-from mcpgateway.common.validators import SecurityValidator
+from mcpgateway.common.validators import SecurityValidator, parse_use_dcr_flag
 from mcpgateway.config import settings
 from mcpgateway.schemas import (
     _coerce_visibility,
@@ -1534,3 +1534,59 @@ class TestToolNameLengthValidation:
         with pytest.raises(ValidationError) as exc_info:
             ToolCreate(name=name, inputSchema={})
         assert "Tool name exceeds MCP spec limit of 128 characters (got 129)" in str(exc_info.value)
+
+
+class TestParseUseDcrFlag:
+    """Unit tests for parse_use_dcr_flag() in common/validators."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (None, None),
+            (True, True),
+            (False, False),
+            ("true", True),
+            ("false", False),
+            ("TRUE", True),
+            ("False", False),
+            (" tRuE ", True),
+            ("", None),
+            ("   ", None),
+        ],
+    )
+    def test_valid_values(self, value, expected):
+        assert parse_use_dcr_flag(value) is expected
+
+    @pytest.mark.parametrize("value", [1, 0, 3.14, "tru", "yes", [], {}, {"a": 1}])
+    def test_invalid_values_raise(self, value):
+        with pytest.raises(ValueError):
+            parse_use_dcr_flag(value)
+
+
+class TestUseDcrSchemaValidation:
+    """Write-time validation of oauth_config.use_dcr on GatewayCreate/GatewayUpdate."""
+
+    def _gateway(self, oauth_config):
+        return GatewayCreate(
+            name="test-gateway",
+            url="https://mcp.example.com",
+            oauth_config=oauth_config,
+        )
+
+    @pytest.mark.parametrize("value", ["tru", 1, 0, [], {"a": 1}])
+    def test_invalid_use_dcr_rejected(self, value):
+        with pytest.raises(ValidationError):
+            self._gateway({"use_dcr": value})
+
+    @pytest.mark.parametrize("value", [True, False, "true", "false", "TRUE", "", "   "])
+    def test_valid_use_dcr_accepted(self, value):
+        gateway = self._gateway({"use_dcr": value})
+        assert gateway.oauth_config["use_dcr"] == value
+
+    def test_gateway_update_accepts_use_dcr_string(self):
+        update = GatewayUpdate(oauth_config={"use_dcr": "false"})
+        assert update.oauth_config["use_dcr"] == "false"
+
+    def test_gateway_update_rejects_invalid_use_dcr(self):
+        with pytest.raises(ValidationError):
+            GatewayUpdate(oauth_config={"use_dcr": "tru"})


### PR DESCRIPTION
## Problem

DCR is all-or-nothing per deployment. `MCPGATEWAY_DCR_ENABLED` and `MCPGATEWAY_DCR_AUTO_REGISTER_ON_MISSING_CREDENTIALS` decide registration for the entire gateway fleet; there is no way to express per-gateway intent. Integrators that already carry a per-server `useDcr` toggle in their own data model send it into `oauth_config`, where it is stored and ignored.

### Closes #6167

## Root Cause

The Phase 1.4 decision gate in `oauth_router.py` reads only global settings:

```python
if issuer and not client_id:
    if settings.dcr_enabled and settings.dcr_auto_register_on_missing_credentials:
```

`oauth_config` is a free-form dictionary, so per-gateway flags arrive today — but nothing reads them, so stored-but-inert configuration accumulates silently and every credential-less gateway auto-registers (or none do).

## Solution

Add `oauth_config.use_dcr`, a per-gateway override with explicit precedence over the global auto-register setting:

| `use_dcr` | `MCPGATEWAY_DCR_ENABLED` | `MCPGATEWAY_DCR_AUTO_REGISTER_...` | Result (issuer present, no client_id) |
|---|---|---|---|
| absent | true | true | DCR — current behavior |
| absent | any | false | 400 — current behavior |
| **true** | true | any | **DCR (force)** — new |
| true | false | any | 400 — global master switch always wins |
| **false** | any | any | **never DCR → 400** — new |
| invalid | any | any | rejected at create/update; treated as absent at runtime |

**Design decisions:**
- Primary change site: the Phase 1.4 gate. No `config.py`, `db.py`, or migration changes; `dcr_service.py` gains one optional passthrough parameter (see the second change below).
- Accepts native booleans **and** `"true"`/`"false"` strings (case-insensitive) so string-serializing clients (e.g. ICA's `Boolean.toString()`) work unchanged (`parse_use_dcr_flag` in `common/validators.py`).
- `""`/whitespace → absent, matching the existing empty-means-unset convention for `oauth_config` fields.
- Write-time strict (new `_validate_oauth_config_flags` chained into `GatewayCreate`/`GatewayUpdate` after the URL validator), read-time lenient (invalid persisted values log + behave as absent).
- Backward compatibility is pinned by a dedicated regression test: gateways without the flag behave exactly as before.

## Implementation Details

- `mcpgateway/common/validators.py` — `parse_use_dcr_flag(value) -> Optional[bool]`; `None`/empty → `None`, bool passthrough, case-insensitive `"true"`/`"false"`, `ValueError` otherwise.
- `mcpgateway/schemas.py` — `_validate_oauth_config_flags` validates `use_dcr` via the parser; chained after `_validate_oauth_config_urls` in both `GatewayCreate` and `GatewayUpdate` field validators.
- `mcpgateway/routers/oauth_router.py` — Phase 1.4 gate restructured: flag parse with safety net → explicit opt-out 400 (`use_dcr=false`) → master-switch 400 (env-var-named, distinct from gateway-config errors) → `should_register = flag is True or global auto-register` → existing DCR attempt body unchanged (DcrError 500 path intact).
- `tests/unit/mcpgateway/routers/test_oauth_router.py` — `TestUseDcrFlagGate`: force-enable overrides global-off; string `"false"` opt-out with global-on (asserts zero registration calls); master-switch refusal; invalid-value runtime fallback; absent-flag backward-compat pin.
- `tests/unit/mcpgateway/test_schemas_validators_extra.py` — `TestParseUseDcrFlag` (10 valid + 8 invalid parser cases) and `TestUseDcrSchemaValidation` (write-time rejection, bool/string/empty acceptance, GatewayUpdate parity).
- `docs/docs/manage/dcr.md` — "Per-Gateway Control (`use_dcr`)" section with the semantics table, force/opt-out/absent JSON examples, and a global→per-gateway migration subsection (audit SQL + steps).

## Testing

- `pytest tests/unit/mcpgateway/routers/test_oauth_router.py` — 189 passed (184 pre-existing + 5 new)
- `pytest tests/unit/mcpgateway/test_schemas_validators_extra.py` — 121 passed (incl. new parser + schema classes)
- Combined run of both files: 310 passed
- `ruff` — clean on all changed lines (3 remaining findings in the touched test file pre-exist on `main`; verified by stashing)
- `mypy` — error count identical to baseline (3834 before = 3834 after) on the three changed source files; zero findings on changed lines
- Existing DCR suite (success, disabled, unexpected-error, learned-resource persistence regressions) unchanged and green

## Checklist

- [x] Tests pass locally (targeted + combined)
- [x] Documentation updated (dcr.md)
- [x] Backward compatibility regression test pinned
- [ ] Security implications considered — flag is read-only at the gate; no new privileges, no SSRF surface (no new URLs), no logging of secrets
---

## Per-Gateway Token Endpoint Auth Method (`token_endpoint_auth_method`) — 2026-08-13

### Problem

ICA 1.0 consumes `useClientSecretTokenAuthMethod` at DCR registration time, but ContextForge's registration request always uses the global `MCPGATEWAY_DCR_TOKEN_ENDPOINT_AUTH_METHOD`. ICA20 sends the boolean into `oauth_config`, where it is stored and ignored — the same stored-but-inert pattern this PR eliminates for `use_dcr`.

### Solution

Add `oauth_config.token_endpoint_auth_method`, an optional per-gateway override for the RFC 7591 registration request:

| `token_endpoint_auth_method` | Registration payload |
|---|---|
| `client_secret_basic` | `token_endpoint_auth_method: client_secret_basic` |
| `client_secret_post` | `token_endpoint_auth_method: client_secret_post` |
| absent / empty | global `MCPGATEWAY_DCR_TOKEN_ENDPOINT_AUTH_METHOD` (byte-identical payload) |

- Only the two methods the runtime actually executes at the token endpoint are accepted; `none`/`private_key_jwt`/anything else → 400 at create/update, treated as absent (log) at registration time — same write-time-strict / read-time-lenient pattern as `use_dcr`.
- The AS registration response stays authoritative: the method the AS confirms is stored back into `oauth_config` and used for token requests.
- Backward compatibility pinned: absent value ⇒ `dcr_service` behavior is byte-identical to before (global setting), verified by a dedicated test.

### Implementation Details

- `mcpgateway/common/validators.py` — `parse_token_endpoint_auth_method(value) -> Optional[str]` mirroring `parse_use_dcr_flag`.
- `mcpgateway/schemas.py` — `_validate_oauth_config_flags` now chained through both parsers (shared by `GatewayCreate`/`GatewayUpdate`).
- `mcpgateway/services/dcr_service.py` — `token_endpoint_auth_method: Optional[str] = None` on `register_client`/`get_or_register_client`; request uses it when present, else the global setting (also used as the stored-record fallback when the AS response omits the field).
- `mcpgateway/routers/oauth_router.py` — parsed at the Phase 1.4 gate with the same safety net as `use_dcr`, forwarded to the registration call.
- Tests: `TestParseTokenEndpointAuthMethod` + `TestTokenEndpointAuthMethodSchemaValidation` (schemas/validators), per-gateway vs global-default payload assertions (`test_dcr_service.py`), router-level forward + invalid-at-runtime-as-absent (`test_oauth_router.py`).

### Testing

- Full unit suite: 21,841 passed, 2 failed — both failures (`test_config.py` CSRF warnings) reproduce identically on `main` with the changes stashed. 34 new tests added, zero regressions.
- `ruff` — zero new findings on changed files/lines (all remaining findings verified pre-existing on `main` via stash).
- `interrogate` — 100% on all four changed source files.
- Secret scan — no new secrets; baseline re-generated and hook green.

## Out of Scope / Excluded (tracked here)

| Item | Status | Reason |
|---|---|---|
| `appendLoginHint`, `skipScope`, `userInfoUri`, `accessTokenType` activations in `oauth_config` | ❌ cancelled | Re-assessed as not required by ICA20 adapters; keys stay stored-but-inert in `oauth_config` until a consumer exists |
| 1.0-style boolean `useClientSecretTokenAuthMethod` false → `none` mapping | ⏳ follow-up | Runtime cannot authenticate public (`none`) clients; keep boolean↔string mapping documented, implement `none` when runtime supports it |
| `loginAttributes` (ICA `feature/ICAA-41111-main`) | ⏳ follow-up issues | New in ICA 1.0; absent from ICA20 and ContextForge — filed as separate issues in both repos, deliberately excluded from this PR |
| DCR `client_id`/registration drift fixes | ❌ excluded | Out of this PR's scope per milestone plan |
