### PR TITLE
fix: omit transport from dataplane config

### DIFF
--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -62,7 +62,6 @@ class BackendConfig(TypedDict):
 
     name: str
     url: str
-    transport: str
     passthrough_headers: list[str]
     add_headers: dict[str, str]
     remove_headers: list[str]
@@ -229,14 +228,13 @@ class DataplanePublisherService:
 
             prompt_map = {prompt["id"]: prompt["name"] for prompt in prompts}
 
-            # The dataplane proxies streamable-HTTP upstreams only. Legacy
-            # HTTP+SSE gateways are excluded so the published config never
-            # advertises a backend the dataplane cannot serve.
+            # The dataplane proxies streamable-HTTP upstreams only. Exclude
+            # every other transport before building its transport-agnostic
+            # backend config.
             gateway_base = {
                 gateway["id"]: {
                     "name": gateway["name"],
                     "url": gateway["url"],
-                    "transport": gateway["transport"],
                     "passthrough_headers": gateway["passthrough_headers"] or [],
                     "add_headers": gateway.get("add_headers") or {},
                     "remove_headers": gateway.get("remove_headers") or [],

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -281,17 +281,18 @@ async def test_full_payload_generation_with_mock_db():
         assert "g1" in server1["backends"]
 
         backend = server1["backends"]["g1"]
-        assert backend["name"] == "Gateway 1"
-        assert backend["url"] == "http://localhost:9000"
-        assert backend["transport"] == "STREAMABLEHTTP"
-        assert backend["passthrough_headers"] == ["Authorization"]
-        assert backend["add_headers"] == {"X-Tenant": "acme"}
-        assert backend["remove_headers"] == ["Cookie"]
-        assert backend["capabilities"] == {"resources": {"subscribe": True}}
-        assert backend["allowed_tool_names"] == ["public_tool", "private_tool"]
-        assert backend["allowed_resource_names"] == ["Resource 1"]
-        assert backend["allowed_resource_uris"] == ["resource://one"]
-        assert backend["allowed_prompt_names"] == ["Prompt 1"]
+        assert backend == {
+            "name": "Gateway 1",
+            "url": "http://localhost:9000",
+            "passthrough_headers": ["Authorization"],
+            "add_headers": {"X-Tenant": "acme"},
+            "remove_headers": ["Cookie"],
+            "capabilities": {"resources": {"subscribe": True}},
+            "allowed_tool_names": ["public_tool", "private_tool"],
+            "allowed_resource_names": ["Resource 1"],
+            "allowed_resource_uris": ["resource://one"],
+            "allowed_prompt_names": ["Prompt 1"],
+        }
 
         # Verify the gateway SELECT projection actually includes the new columns
         # (guards against getattr-on-Row silently returning None when columns are missing from SELECT)
@@ -410,7 +411,8 @@ def test_create_payload_filters_empty_backends():
     assert "server1" not in result[USER1_ID]["virtual_hosts"]
 
 
-def test_create_payload_excludes_non_streamable_gateways():
+@pytest.mark.parametrize("transport", ["SSE", "STDIO"])
+def test_create_payload_excludes_non_streamable_gateways(transport: str):
     """create_payload() drops backends whose transport the dataplane cannot serve."""
     from mcpgateway.services.dataplane_publisher import DataplanePublisherService
 
@@ -421,11 +423,11 @@ def test_create_payload_excludes_non_streamable_gateways():
                 {
                     "id": "server1",
                     "backend_items": {
-                        "gateway_sse": {"tools": ["tool1"], "resources": [], "prompts": []},
+                        "gateway_non_streamable": {"tools": ["tool1"], "resources": [], "prompts": []},
                     },
                 }
             ],
-            "gateways": [{"id": "gateway_sse", "name": "SSE Gateway", "url": "http://localhost:9000/sse", "transport": "SSE", "passthrough_headers": None}],
+            "gateways": [{"id": "gateway_non_streamable", "name": "Unsupported Gateway", "url": "http://localhost:9000/mcp", "transport": transport, "passthrough_headers": None}],
             "prompts": [],
             "resources": [],
         }
@@ -433,7 +435,7 @@ def test_create_payload_excludes_non_streamable_gateways():
 
     result = service.create_payload(data)
 
-    # The SSE backend is excluded and the now-backendless server is omitted.
+    # The unsupported backend is excluded and the now-backendless server is omitted.
     assert result[USER1_ID]["virtual_hosts"] == {}
 
 


### PR DESCRIPTION
## Summary

- keep the dataplane publisher limited to `STREAMABLEHTTP` gateways
- omit the obsolete `transport` property from published backend configuration
- cover both SSE and STDIO with the existing non-Streamable gateway filter test

## Why

The Rust dataplane now has a single unconditional upstream transport and no
transport selector. The control-plane publisher should match that contract
instead of sending a field the dataplane no longer models.

This is the control-plane companion to
[contextforge-org/contextforge-data-plane#79](https://github.com/contextforge-org/contextforge-data-plane/pull/79).

## Impact

SSE and STDIO remain available on control-plane-owned routes. This change only
prevents those gateway types from entering dataplane configuration and removes
transport selection from the published backend payload.

## Validation

- dataplane publisher unit tests: 25 passed
- Ruff: passed
- Bandit: passed
- pylint on the publisher: 10.00/10
- repository pre-commit hooks: passed
