### PR TITLE
Feat/server catalog UI adjustments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -454,7 +454,7 @@ js-build:                        ## Install npm dependencies and build JS bundle
 		echo ""; \
 	elif command -v npm >/dev/null 2>&1; then \
 		npm install --no-audit --no-fund && npm run build:css && npm run vite:build && \
-		CACHE_TYPE=memory python -c \
+		CACHE_TYPE=memory $(VENV_DIR)/bin/python -c \
 		  "import json; from mcpgateway.main import app; open('client/openapi.json', 'w').write(json.dumps(app.openapi(), indent=2))" && \
 		echo "OpenAPI spec exported to client/openapi.json" && \
 		cd client && npm install --no-audit --no-fund && npm run build; \

--- a/client/src/components/server-catalog/CatalogResults.tsx
+++ b/client/src/components/server-catalog/CatalogResults.tsx
@@ -174,11 +174,11 @@ export function CatalogServerDetailsDialog({
 
 export function CatalogResults({
   servers,
-  hasOpenServers,
+  emptyStateMessageId,
   onView,
 }: {
   servers: CatalogServer[];
-  hasOpenServers: boolean;
+  emptyStateMessageId: string;
   onView: (server: CatalogServer, trigger: HTMLButtonElement) => void;
 }) {
   const intl = useIntl();
@@ -203,9 +203,7 @@ export function CatalogResults({
           ))}
         </ul>
       ) : (
-        <EmptyStatePlaceholder
-          messageId={hasOpenServers ? "mcpServer.catalog.noResults" : "mcpServer.catalog.empty"}
-        />
+        <EmptyStatePlaceholder messageId={emptyStateMessageId} />
       )}
     </>
   );

--- a/client/src/components/server-catalog/CatalogResults.tsx
+++ b/client/src/components/server-catalog/CatalogResults.tsx
@@ -59,7 +59,7 @@ function CatalogCard({
 
   return (
     <li className="min-w-0">
-      <Card className="h-full min-h-[200px] gap-0 rounded-xl border border-border bg-card p-0 py-0 shadow-none ring-0">
+      <Card className="h-full min-h-[200px] gap-0 rounded-xl border border-border bg-card p-0 py-0 shadow-none ring-0 transition-colors hover:border-ring dark:hover:border-muted-foreground">
         <article className="flex h-full flex-col" aria-labelledby={headingId}>
           <CardContent className="flex flex-1 flex-col px-5 py-5">
             <div className="flex items-start justify-between gap-3">

--- a/client/src/components/server-catalog/CatalogResults.tsx
+++ b/client/src/components/server-catalog/CatalogResults.tsx
@@ -65,16 +65,16 @@ function CatalogCard({
             <div className="flex items-start justify-between gap-3">
               <CatalogLogo server={server} />
               {server.is_registered && (
-                <StatusDot tone="success" className="text-xs text-muted-foreground">
+                <StatusDot tone="success" className="text-sm text-muted-foreground">
                   {intl.formatMessage({ id: "mcpServer.catalog.connected" })}
                 </StatusDot>
               )}
             </div>
 
-            <h2 id={headingId} className="mt-4 truncate text-sm font-semibold text-foreground">
+            <h2 id={headingId} className="mt-4 truncate text-sm font-medium text-foreground">
               {server.name}
             </h2>
-            <p className="mt-3 line-clamp-2 min-h-8 text-[13px] leading-4 text-muted-foreground">
+            <p className="mt-3 line-clamp-2 min-h-10 text-sm text-muted-foreground">
               {server.description}
             </p>
 

--- a/client/src/components/server-catalog/CatalogToolbar.tsx
+++ b/client/src/components/server-catalog/CatalogToolbar.tsx
@@ -1,12 +1,12 @@
 import { useId } from "react";
-import { Filter, Search } from "lucide-react";
+import { Filter } from "lucide-react";
 import { useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
 import { CardTag } from "@/components/ui/card-tag";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { ListSearch } from "@/components/ui/list-search";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   Select,
@@ -70,7 +70,7 @@ function CatalogViewToggle({
         className="h-8 flex-1 rounded-md font-medium aria-pressed:bg-background aria-pressed:text-foreground aria-pressed:shadow-xs"
         onClick={() => onChange(true)}
       >
-        {intl.formatMessage({ id: "mcpServer.catalog.installed" })}
+        {intl.formatMessage({ id: "mcpServer.catalog.connected" })}
       </Button>
     </div>
   );
@@ -102,13 +102,14 @@ function CatalogFiltersPopover({
         <Button
           type="button"
           variant="ghost"
-          className="h-10 justify-start sm:justify-center"
+          size="sm"
+          className="w-fit gap-2 self-center text-xs text-secondary-foreground"
           aria-label={intl.formatMessage(
             { id: "mcpServer.catalog.filtersActive" },
             { count: activeFilterCount },
           )}
         >
-          <Filter className="size-4" aria-hidden="true" />
+          <Filter className="size-3.5" aria-hidden="true" />
           {intl.formatMessage({ id: "mcpServer.catalog.filters" })}
           {activeFilterCount > 0 && (
             <CardTag variant="neutral" className="rounded-full" aria-hidden="true">
@@ -245,21 +246,14 @@ export function CatalogToolbar({
     <div className="flex flex-col gap-4 py-6 lg:flex-row lg:items-center lg:justify-between">
       <CatalogViewToggle installedOnly={installedOnly} onChange={onInstalledChange} />
 
-      <div className="flex w-full flex-col gap-3 sm:flex-row lg:w-auto">
-        <div className="relative w-full sm:w-[432px]">
-          <Search
-            className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
-            aria-hidden="true"
-          />
-          <Input
-            type="search"
-            value={search}
-            onChange={(event) => onSearchChange(event.target.value)}
-            placeholder={intl.formatMessage({ id: "mcpServer.catalog.searchPlaceholder" })}
-            aria-label={intl.formatMessage({ id: "mcpServer.catalog.searchLabel" })}
-            className="h-10 pl-9"
-          />
-        </div>
+      <div className="flex w-full flex-col gap-2 sm:flex-row lg:w-auto">
+        <ListSearch
+          value={search}
+          onChange={onSearchChange}
+          ariaLabel={intl.formatMessage({ id: "mcpServer.catalog.searchLabel" })}
+          placeholder={intl.formatMessage({ id: "mcpServer.catalog.searchPlaceholder" })}
+          expandedWidthClassName="w-full sm:w-[432px]"
+        />
 
         <CatalogFiltersPopover {...filterProps} />
       </div>

--- a/client/src/components/ui/list-search.tsx
+++ b/client/src/components/ui/list-search.tsx
@@ -11,6 +11,8 @@ interface ListSearchProps {
   ariaLabel: string;
   placeholder?: string;
   className?: string;
+  /** Width class applied to the input while expanded (e.g. "w-48", "w-full sm:w-[432px]"). */
+  expandedWidthClassName?: string;
 }
 
 /** Expandable list-table search box; collapses to an icon, filtering owned by the caller. */
@@ -20,6 +22,7 @@ export function ListSearch({
   ariaLabel,
   placeholder,
   className,
+  expandedWidthClassName = "w-48",
 }: ListSearchProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -50,8 +53,8 @@ export function ListSearch({
         className={cn(
           "h-8 rounded-md border-border bg-muted/50 text-sm shadow-none transition-[width,padding,color,background-color,border-color] duration-200 ease-out placeholder:text-muted-foreground focus-visible:bg-background",
           open
-            ? "w-48 px-3 text-foreground"
-            : "w-0 px-0 text-transparent caret-foreground border-transparent",
+            ? cn(expandedWidthClassName, "px-3 text-foreground")
+            : "w-0 overflow-hidden border-0 bg-transparent px-0 text-transparent caret-foreground",
         )}
       />
     </div>

--- a/client/src/i18n/locales/en-US/mcpServer.json
+++ b/client/src/i18n/locales/en-US/mcpServer.json
@@ -5,7 +5,6 @@
   "mcpServer.neverUsed": "Never used",
   "mcpServer.catalog.title": "Server catalog",
   "mcpServer.catalog.all": "All",
-  "mcpServer.catalog.installed": "Installed",
   "mcpServer.catalog.searchPlaceholder": "Search MCP servers...",
   "mcpServer.catalog.searchLabel": "Search MCP servers",
   "mcpServer.catalog.filters": "Filters",
@@ -29,6 +28,7 @@
   "mcpServer.catalog.resultsLabel": "Catalog servers",
   "mcpServer.catalog.empty": "No open MCP servers are available.",
   "mcpServer.catalog.noResults": "No MCP servers match the active search and filters.",
+  "mcpServer.catalog.noneConnected": "No MCP server catalog options are connected.",
   "mcpServer.catalog.disabled": "Server catalog is disabled for this gateway.",
   "mcpServer.catalog.error": "Unable to load server catalog. Try again."
 }

--- a/client/src/i18n/locales/es-ES/mcpServer.json
+++ b/client/src/i18n/locales/es-ES/mcpServer.json
@@ -5,7 +5,6 @@
   "mcpServer.neverUsed": "Nunca usado",
   "mcpServer.catalog.title": "Catálogo de servidores",
   "mcpServer.catalog.all": "Todos",
-  "mcpServer.catalog.installed": "Instalados",
   "mcpServer.catalog.searchPlaceholder": "Buscar servidores MCP...",
   "mcpServer.catalog.searchLabel": "Buscar servidores MCP",
   "mcpServer.catalog.filters": "Filtros",
@@ -29,6 +28,7 @@
   "mcpServer.catalog.resultsLabel": "Servidores del catálogo",
   "mcpServer.catalog.empty": "No hay servidores MCP abiertos disponibles.",
   "mcpServer.catalog.noResults": "Ningún servidor MCP coincide con la búsqueda y los filtros activos.",
+  "mcpServer.catalog.noneConnected": "Ninguna opción del catálogo de servidores MCP está conectada.",
   "mcpServer.catalog.disabled": "El catálogo de servidores está deshabilitado para esta puerta de enlace.",
   "mcpServer.catalog.error": "No se pudo cargar el catálogo de servidores. Inténtalo de nuevo."
 }

--- a/client/src/i18n/locales/pt-BR/mcpServer.json
+++ b/client/src/i18n/locales/pt-BR/mcpServer.json
@@ -5,7 +5,6 @@
   "mcpServer.neverUsed": "Nunca usado",
   "mcpServer.catalog.title": "Catálogo de servidores",
   "mcpServer.catalog.all": "Todos",
-  "mcpServer.catalog.installed": "Instalados",
   "mcpServer.catalog.searchPlaceholder": "Pesquisar servidores MCP...",
   "mcpServer.catalog.searchLabel": "Pesquisar servidores MCP",
   "mcpServer.catalog.filters": "Filtros",
@@ -29,6 +28,7 @@
   "mcpServer.catalog.resultsLabel": "Servidores do catálogo",
   "mcpServer.catalog.empty": "Nenhum servidor MCP aberto está disponível.",
   "mcpServer.catalog.noResults": "Nenhum servidor MCP corresponde à pesquisa e aos filtros ativos.",
+  "mcpServer.catalog.noneConnected": "Nenhuma opção do catálogo de servidores MCP está conectada.",
   "mcpServer.catalog.disabled": "O catálogo de servidores está desabilitado para este gateway.",
   "mcpServer.catalog.error": "Não foi possível carregar o catálogo de servidores. Tente novamente."
 }

--- a/client/src/pages/ServerCatalog.test.tsx
+++ b/client/src/pages/ServerCatalog.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import type { CatalogListResponse, CatalogServer } from "@/generated/types";
@@ -131,6 +131,43 @@ describe("ServerCatalog", () => {
     await waitFor(() => expect(viewButton).toHaveFocus());
   });
 
+  it("shows a not-connected status in the details dialog for an unregistered server", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<ServerCatalog />);
+
+    await user.click(screen.getByRole("button", { name: "View Public Notes" }));
+
+    expect(within(screen.getByRole("dialog")).getByText("Not connected")).toBeInTheDocument();
+  });
+
+  it("renders the catalog logo image and falls back to the default icon on load error", () => {
+    mockUseQuery.mockReturnValue(
+      queryResult({
+        data: {
+          ...response,
+          servers: [
+            { ...openConnected, logo_url: "https://cdn.example/globalping-logo.png" },
+            openAvailable,
+            apiKeyServer,
+          ],
+        },
+      }),
+    );
+
+    const { container } = renderWithRouter(<ServerCatalog />);
+
+    const logoImg = container.querySelector('img[src="https://cdn.example/globalping-logo.png"]');
+    expect(logoImg).toBeInTheDocument();
+    expect(container.querySelector('[aria-label="Globalping icon"]')).not.toBeInTheDocument();
+
+    fireEvent.error(logoImg as HTMLImageElement);
+
+    expect(
+      container.querySelector('img[src="https://cdn.example/globalping-logo.png"]'),
+    ).not.toBeInTheDocument();
+    expect(container.querySelector('[aria-label="Globalping icon"]')).toBeInTheDocument();
+  });
+
   it("uses a labelled pressed-button group for catalog views", () => {
     renderWithRouter(<ServerCatalog />);
 
@@ -190,6 +227,45 @@ describe("ServerCatalog", () => {
     expect(screen.queryByRole("heading", { name: "Globalping" })).not.toBeInTheDocument();
   });
 
+  it("filters by provider and reflects it in the URL", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<ServerCatalog />);
+
+    await user.click(screen.getByRole("button", { name: /^Filters$/ }));
+    await user.click(screen.getByRole("combobox", { name: "Provider" }));
+    await user.click(screen.getByRole("option", { name: "jsDelivr" }));
+
+    await waitFor(() => expect(window.location.search).toContain("provider=jsDelivr"));
+    expect(screen.getByRole("heading", { name: "Globalping" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Public Notes" })).not.toBeInTheDocument();
+  });
+
+  it("sets the auth type filter via the Authentication select", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<ServerCatalog />);
+
+    await user.click(screen.getByRole("button", { name: /^Filters$/ }));
+    await user.click(screen.getByRole("combobox", { name: "Authentication" }));
+    await user.click(screen.getByRole("option", { name: "Open" }));
+
+    await waitFor(() => expect(window.location.search).toContain("auth_type=Open"));
+    expect(screen.getByRole("heading", { name: "Globalping" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Public Notes" })).toBeInTheDocument();
+  });
+
+  it("clears active filters via the Clear button", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<ServerCatalog />, "/app/server-catalog?category=Productivity");
+
+    expect(screen.queryByRole("heading", { name: "Globalping" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Filters, 1 active" }));
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+
+    await waitFor(() => expect(window.location.search).not.toContain("category"));
+    expect(screen.getByRole("heading", { name: "Globalping" })).toBeInTheDocument();
+  });
+
   it("supports repeatable OR tag filters", async () => {
     const user = userEvent.setup();
     renderWithRouter(<ServerCatalog />);
@@ -244,9 +320,7 @@ describe("ServerCatalog", () => {
     renderWithRouter(<ServerCatalog />);
     await user.click(screen.getByRole("button", { name: "Connected" }));
 
-    expect(
-      screen.getByText("No MCP server catalog options are connected."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("No MCP server catalog options are connected.")).toBeInTheDocument();
     expect(
       screen.queryByText("No MCP servers match the active search and filters."),
     ).not.toBeInTheDocument();

--- a/client/src/pages/ServerCatalog.test.tsx
+++ b/client/src/pages/ServerCatalog.test.tsx
@@ -106,7 +106,7 @@ describe("ServerCatalog", () => {
     expect(screen.getByRole("heading", { name: "Globalping" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Public Notes" })).toBeInTheDocument();
     expect(screen.queryByText("Secret Service")).not.toBeInTheDocument();
-    expect(screen.getByText("Connected")).toBeInTheDocument();
+    expect(within(catalogList).getByText("Connected")).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent("2 servers shown");
     expect(screen.getByRole("button", { name: "View Globalping" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "View Public Notes" })).toBeInTheDocument();
@@ -139,7 +139,7 @@ describe("ServerCatalog", () => {
       "aria-pressed",
       "true",
     );
-    expect(within(viewOptions).getByRole("button", { name: "Installed" })).toHaveAttribute(
+    expect(within(viewOptions).getByRole("button", { name: "Connected" })).toHaveAttribute(
       "aria-pressed",
       "false",
     );
@@ -151,7 +151,7 @@ describe("ServerCatalog", () => {
       "/app/server-catalog?search=global&show_registered_only=true",
     );
 
-    expect(screen.getByRole("button", { name: "Installed" })).toHaveAttribute(
+    expect(screen.getByRole("button", { name: "Connected" })).toHaveAttribute(
       "aria-pressed",
       "true",
     );
@@ -169,7 +169,7 @@ describe("ServerCatalog", () => {
     expect(screen.getByRole("heading", { name: "Public Notes" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Globalping" })).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Installed" }));
+    await user.click(screen.getByRole("button", { name: "Connected" }));
     expect(window.location.search).toContain("show_registered_only=true");
     expect(
       screen.getByText("No MCP servers match the active search and filters."),
@@ -233,5 +233,22 @@ describe("ServerCatalog", () => {
 
     expect(screen.getByText("No open MCP servers are available.")).toBeInTheDocument();
     expect(screen.queryByText("Secret Service")).not.toBeInTheDocument();
+  });
+
+  it("shows a dedicated empty state on the Connected tab when nothing is connected", async () => {
+    const user = userEvent.setup();
+    mockUseQuery.mockReturnValue(
+      queryResult({ data: { ...response, servers: [openAvailable, apiKeyServer], total: 2 } }),
+    );
+
+    renderWithRouter(<ServerCatalog />);
+    await user.click(screen.getByRole("button", { name: "Connected" }));
+
+    expect(
+      screen.getByText("No MCP server catalog options are connected."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("No MCP servers match the active search and filters."),
+    ).not.toBeInTheDocument();
   });
 });

--- a/client/src/pages/ServerCatalog.tsx
+++ b/client/src/pages/ServerCatalog.tsx
@@ -143,6 +143,14 @@ export function ServerCatalog() {
   const hasOpenServers = Boolean(
     data?.servers.some((server) => server.auth_type === OPEN_AUTH_TYPE),
   );
+  const hasConnectedServers = Boolean(
+    data?.servers.some((server) => server.auth_type === OPEN_AUTH_TYPE && server.is_registered),
+  );
+  const emptyStateMessageId = !hasOpenServers
+    ? "mcpServer.catalog.empty"
+    : filters.installedOnly && !hasConnectedServers
+      ? "mcpServer.catalog.noneConnected"
+      : "mcpServer.catalog.noResults";
   const activeFilterCount =
     Number(Boolean(filters.category)) +
     Number(Boolean(filters.provider)) +
@@ -213,7 +221,11 @@ export function ServerCatalog() {
         onClear={clearFilters}
       />
 
-      <CatalogResults servers={servers} hasOpenServers={hasOpenServers} onView={handleView} />
+      <CatalogResults
+        servers={servers}
+        emptyStateMessageId={emptyStateMessageId}
+        onView={handleView}
+      />
 
       <CatalogServerDetailsDialog server={selectedServer} onOpenChange={handleDetailsOpenChange} />
     </CatalogPageLayout>

--- a/client/src/pages/ServerCatalog.tsx
+++ b/client/src/pages/ServerCatalog.tsx
@@ -97,12 +97,15 @@ function useCatalogFilters() {
   return { filters, updateQuery, setSingleFilter, toggleTag, clearFilters };
 }
 
-function filterOpenServers(servers: CatalogServer[], filters: CatalogFilters): CatalogServer[] {
+function getOpenServers(servers: CatalogServer[]): CatalogServer[] {
+  // Catalog MVP is intentionally fail-closed: only the exact Open value is visible.
+  return servers.filter((server) => server.auth_type === OPEN_AUTH_TYPE);
+}
+
+function filterOpenServers(openServers: CatalogServer[], filters: CatalogFilters): CatalogServer[] {
   const search = filters.search.trim().toLocaleLowerCase();
 
-  return servers.filter((server) => {
-    // Catalog MVP is intentionally fail-closed: only the exact Open value is visible.
-    if (server.auth_type !== OPEN_AUTH_TYPE) return false;
+  return openServers.filter((server) => {
     if (filters.authType && server.auth_type !== filters.authType) return false;
     if (filters.category && server.category !== filters.category) return false;
     if (filters.provider && server.provider !== filters.provider) return false;
@@ -114,6 +117,10 @@ function filterOpenServers(servers: CatalogServer[], filters: CatalogFilters): C
     if (!search) return true;
     return `${server.name} ${server.description}`.toLocaleLowerCase().includes(search);
   });
+}
+
+function sortedUnique(values: Array<string | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))].sort();
 }
 
 function CatalogPageLayout({ children }: { children: ReactNode }) {
@@ -136,16 +143,24 @@ export function ServerCatalog() {
   const { data, error, isLoading } = useQuery<CatalogListResponse>(CATALOG_PATH);
   const { filters, updateQuery, setSingleFilter, toggleTag, clearFilters } = useCatalogFilters();
 
-  const servers = useMemo(
-    () => filterOpenServers(data?.servers ?? [], filters),
-    [data?.servers, filters],
+  const openServers = useMemo(() => getOpenServers(data?.servers ?? []), [data?.servers]);
+  const servers = useMemo(() => filterOpenServers(openServers, filters), [openServers, filters]);
+  // Scoped to the servers actually visible in this auth-type view, so the dropdowns never
+  // offer a category/provider/tag that would filter the list down to zero results.
+  const categoryOptions = useMemo(
+    () => sortedUnique(openServers.map((server) => server.category)),
+    [openServers],
   );
-  const hasOpenServers = Boolean(
-    data?.servers.some((server) => server.auth_type === OPEN_AUTH_TYPE),
+  const providerOptions = useMemo(
+    () => sortedUnique(openServers.map((server) => server.provider)),
+    [openServers],
   );
-  const hasConnectedServers = Boolean(
-    data?.servers.some((server) => server.auth_type === OPEN_AUTH_TYPE && server.is_registered),
+  const tagOptions = useMemo(
+    () => sortedUnique(openServers.flatMap((server) => server.tags ?? [])),
+    [openServers],
   );
+  const hasOpenServers = openServers.length > 0;
+  const hasConnectedServers = openServers.some((server) => server.is_registered);
   const emptyStateMessageId = !hasOpenServers
     ? "mcpServer.catalog.empty"
     : filters.installedOnly && !hasConnectedServers
@@ -210,9 +225,9 @@ export function ServerCatalog() {
         provider={filters.provider}
         authType={filters.authType}
         selectedTags={filters.tags}
-        categories={data?.categories ?? []}
-        providers={data?.providers ?? []}
-        availableTags={data?.all_tags ?? []}
+        categories={categoryOptions}
+        providers={providerOptions}
+        availableTags={tagOptions}
         activeFilterCount={activeFilterCount}
         onSearchChange={(search) => updateQuery({ search: search || null })}
         onInstalledChange={(installedOnly) => updateQuery({ show_registered_only: installedOnly })}


### PR DESCRIPTION
 Follow up to: https://github.com/IBM/mcp-context-forge/pull/6169 ... suggested adjustments to styles, content, filter behavior:
 
 Commits: 
  - e8d6d7455: Swap search input for shared ListSearch; compact the Filters button; rename "Installed" tab to
  "Connected" with its own empty-state message.
  - 2b646c0fb: Card typography tweaks (title weight, description size, spacing).
  - 1c365cc5d: Hover border state on catalog cards.
  - 9cd0cf80b: (Bug fix) filter dropdowns now derive options from Open-only servers instead of the full
  unfiltered catalog.
  - 7ba191696: Tests for provider/auth selects, Clear button, dialog status, and logo fallback; plus a lint
  fix.
 

https://github.com/user-attachments/assets/ccf2241b-652d-4746-b17a-aa6322669421

