### PR TITLE
fix(resources): surface text_content in ResourceRead and wire view/edit

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-13T14:29:13Z",
+  "generated_at": "2026-08-14T11:33:11Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -3894,7 +3894,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14942,
+        "line_number": 14954,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3884,7 +3884,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4608,
+        "line_number": 4610,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -3894,7 +3894,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14959,
+        "line_number": 14942,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4658,7 +4658,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 398,
+        "line_number": 440,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/mcpgateway/admin_ui/resources.js
+++ b/mcpgateway/admin_ui/resources.js
@@ -324,7 +324,7 @@ export const viewResource = async function (resourceId) {
     const resource = data.resource;
 
     // console.log("Resource JSON:\n", JSON.stringify(resource, null, 2));
-    // const content = data.content;
+    const content = resource.content;
 
     const resourceDetailsDiv = safeGetElement("resource-details");
     if (resourceDetailsDiv) {
@@ -404,29 +404,19 @@ export const viewResource = async function (resourceId) {
       statusP.appendChild(statusSpan);
       container.appendChild(statusP);
 
-      // Content display - safely handle different types
-      // const contentDiv = document.createElement("div");
-      // const contentStrong = document.createElement("strong");
-      // contentStrong.textContent = "Content:";
-      // contentDiv.appendChild(contentStrong);
-
-      // const contentPre = document.createElement("pre");
-      // contentPre.className =
-      //     "mt-1 bg-gray-100 p-2 rounded overflow-auto max-h-80 dark:bg-gray-800 dark:text-gray-100";
-
-      // // Handle content display - extract actual content from object if needed
-      // let contentStr = extractContent(
-      //     content,
-      //     resource.description || "No content available",
-      // );
-
-      // if (!contentStr.trim()) {
-      //     contentStr = resource.description || "No content available";
-      // }
-
-      // contentPre.textContent = contentStr;
-      // contentDiv.appendChild(contentPre);
-      // container.appendChild(contentDiv);
+      // Content display — only render when the resource has stored text content
+      if (content !== null && content !== undefined && String(content).trim() !== "") {
+        const contentDiv = document.createElement("div");
+        const contentStrong = document.createElement("strong");
+        contentStrong.textContent = "Content:";
+        contentDiv.appendChild(contentStrong);
+        const contentPre = document.createElement("pre");
+        contentPre.className =
+          "mt-1 bg-gray-100 p-2 rounded overflow-auto max-h-80 dark:bg-gray-800 dark:text-gray-100 text-sm whitespace-pre-wrap break-words";
+        contentPre.textContent = String(content);
+        contentDiv.appendChild(contentPre);
+        container.appendChild(contentDiv);
+      }
 
       // Metrics display
       if (resource.metrics) {
@@ -606,7 +596,7 @@ export const editResource = async function (resourceId) {
 
     const data = await response.json();
     const resource = data.resource;
-    // const content = data.content;
+    const content = resource.content;
     // Ensure hidden inactive flag is preserved
     const isInactiveCheckedBool = isInactiveChecked("resources");
     let hiddenField = safeGetElement("edit-resource-show-inactive");
@@ -673,7 +663,7 @@ export const editResource = async function (resourceId) {
     const nameField = safeGetElement("edit-resource-name");
     const descField = safeGetElement("edit-resource-description");
     const mimeField = safeGetElement("edit-resource-mime-type");
-    // const contentField = safeGetElement("edit-resource-content");
+    const contentField = safeGetElement("edit-resource-content");
 
     if (uriField && uriValidation.valid) {
       uriField.value = uriValidation.value;
@@ -687,6 +677,14 @@ export const editResource = async function (resourceId) {
     if (mimeField) {
       mimeField.value = resource.mimeType || "";
     }
+    // CodeMirror wraps this textarea and hides it — set value on the editor
+    // instance if available, otherwise fall back to the raw textarea.
+    if (window.editResourceContentEditor) {
+      window.editResourceContentEditor.setValue(content || "");
+      window.editResourceContentEditor.refresh();
+    } else if (contentField) {
+      contentField.value = content || "";
+    }
 
     // Set tags field
     const tagsField = safeGetElement("edit-resource-tags");
@@ -698,34 +696,6 @@ export const editResource = async function (resourceId) {
         : [];
       tagsField.value = rawTags.join(", ");
     }
-
-    // if (contentField) {
-    //     let contentStr = extractContent(
-    //         content,
-    //         resource.description || "No content available",
-    //     );
-
-    //     if (!contentStr.trim()) {
-    //         contentStr = resource.description || "No content available";
-    //     }
-
-    //     contentField.value = contentStr;
-    // }
-
-    // // Update CodeMirror editor if it exists
-    // if (window.editResourceContentEditor) {
-    //     let contentStr = extractContent(
-    //         content,
-    //         resource.description || "No content available",
-    //     );
-
-    //     if (!contentStr.trim()) {
-    //         contentStr = resource.description || "No content available";
-    //     }
-
-    //     window.editResourceContentEditor.setValue(contentStr);
-    //     window.editResourceContentEditor.refresh();
-    // }
 
     openModal("resource-edit-modal");
     applyVisibilityRestrictions(["edit-resource-visibility"]); // Disable public radio if restricted, preserve checked state

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -6454,8 +6454,7 @@ async def get_resource_info(
     """
     Get resource metadata by ID.
 
-    Returns the resource metadata including the enabled status. This endpoint
-    is different from GET /resources/{resource_id} which returns the resource content.
+    Returns the resource including the enabled status.
 
     Args:
         resource_id (str): ID of the resource.

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -2349,7 +2349,6 @@ class ResourceRead(BaseModelWithConfigDict):
     owner_email: Optional[str] = Field(None, description="Email of the user who owns this resource")
     visibility: Optional[Literal["private", "team", "public"]] = Field(default="public", description="Visibility level: private, team, or public")
 
-
     content: Optional[str] = Field(None, description="Stored text content of the resource, if any")
 
     # MCP protocol fields

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -2349,6 +2349,9 @@ class ResourceRead(BaseModelWithConfigDict):
     owner_email: Optional[str] = Field(None, description="Email of the user who owns this resource")
     visibility: Optional[Literal["private", "team", "public"]] = Field(default="public", description="Visibility level: private, team, or public")
 
+
+    content: Optional[str] = Field(None, description="Stored text content of the resource, if any")
+
     # MCP protocol fields
     title: Optional[str] = Field(None, max_length=255, description="Human-readable title for the resource")
     annotations: Optional[Annotations] = Field(None, description="Optional annotations for client rendering hints")

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -674,7 +674,7 @@ class ResourceService(BaseService):
             )
 
             db_resource.team = self._get_team_name(db, db_resource.team_id)
-            return self.convert_resource_to_read(db_resource)
+            return self.convert_resource_to_read(db_resource, include_content=True)
         except IntegrityError as ie:
             logger.error("IntegrityErrors in group: %s", ie)
 
@@ -2940,7 +2940,7 @@ class ResourceService(BaseService):
                 )
 
             resource.team = self._get_team_name(db, resource.team_id)
-            return self.convert_resource_to_read(resource)
+            return self.convert_resource_to_read(resource, include_content=True)
         except PermissionError as e:
             # Structured logging: Log permission error
             structured_logger.log(
@@ -3368,7 +3368,7 @@ class ResourceService(BaseService):
                 },
             )
 
-            return self.convert_resource_to_read(resource)
+            return self.convert_resource_to_read(resource, include_content=True)
         except PermissionError as pe:
             db.rollback()
 

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -363,6 +363,7 @@ class ResourceService(BaseService):
         resource_dict["updated_at"] = getattr(resource, "updated_at", resource_dict.get("updated_at"))
         resource_dict["is_active"] = getattr(resource, "is_active", resource_dict.get("is_active"))
         resource_dict["enabled"] = getattr(resource, "enabled", resource_dict.get("enabled"))
+        resource_dict["content"] = getattr(resource, "text_content", None)
 
         # Compute aggregated metrics from the resource's metrics list (only if requested)
         if include_metrics:

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -314,7 +314,7 @@ class ResourceService(BaseService):
 
         return top_performers
 
-    def convert_resource_to_read(self, resource: DbResource, include_metrics: bool = False) -> ResourceRead:
+    def convert_resource_to_read(self, resource: DbResource, include_metrics: bool = False, include_content: bool = False) -> ResourceRead:
         """
         Converts a DbResource instance into a ResourceRead model, optionally including aggregated metrics.
 
@@ -322,6 +322,9 @@ class ResourceService(BaseService):
             resource (DbResource): The ORM instance of the resource.
             include_metrics (bool): Whether to include metrics in the result. Defaults to False.
                 Set to False for list operations to avoid N+1 query issues.
+            include_content (bool): Whether to include stored text content. Defaults to False.
+                Set to True only on single-resource detail paths (view/edit modals, GET /resources/{id})
+                to keep list payloads lean
 
         Returns:
             ResourceRead: The Pydantic model representing the resource, optionally including aggregated metrics.
@@ -363,7 +366,7 @@ class ResourceService(BaseService):
         resource_dict["updated_at"] = getattr(resource, "updated_at", resource_dict.get("updated_at"))
         resource_dict["is_active"] = getattr(resource, "is_active", resource_dict.get("is_active"))
         resource_dict["enabled"] = getattr(resource, "enabled", resource_dict.get("enabled"))
-        resource_dict["content"] = getattr(resource, "text_content", None)
+        resource_dict["content"] = getattr(resource, "text_content", None) if include_content else None
 
         # Compute aggregated metrics from the resource's metrics list (only if requested)
         if include_metrics:
@@ -3725,7 +3728,7 @@ class ResourceService(BaseService):
                 )
                 raise ResourceNotFoundError(f"Resource not found: {resource_id}")
 
-            resource_read = self.convert_resource_to_read(resource)
+            resource_read = self.convert_resource_to_read(resource, include_content=True)
 
             structured_logger.log(
                 level="INFO",

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -9126,22 +9126,17 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                         For interactive MCP Apps use: text/html;profile=mcp-app
                       </p>
                     </div>
-                    <!-- Removing Content form Edit Form -->
-                    <!-- Remove required attribute to avoid browser validation issues -->
-
-                    <!--
                     <div>
-                      <label class="block text-sm font-medium text-gray-700"
+                      <label
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >Content</label
                       >
-
                       <textarea
                         name="content"
                         id="edit-resource-content"
-                        class="mt-1 px-1.5 block w-full h-48 rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                        class="mt-1 px-1.5 block w-full h-48 rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       ></textarea>
                     </div>
-                    -->
 
                     <!-- Tags Section -->
                     <div>

--- a/tests/unit/js/resources.test.js
+++ b/tests/unit/js/resources.test.js
@@ -977,3 +977,232 @@ describe("initResourceSelect - Select All respects search filter", () => {
     vi.unstubAllGlobals();
   });
 });
+
+// ---------------------------------------------------------------------------
+// viewResource - content rendering 
+// ---------------------------------------------------------------------------
+describe("viewResource - content rendering", () => {
+  beforeEach(() => {
+    window.ROOT_PATH = "";
+  });
+
+  test("renders Content block when resource.content is present", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const details = document.createElement("div");
+    details.id = "resource-details";
+    document.body.appendChild(details);
+
+    fetchWithTimeout.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          resource: {
+            id: "r-content",
+            name: "content-resource",
+            uri: "res://r-content",
+            content: "hello from stored content",
+          },
+        }),
+    });
+
+    await viewResource("r-content");
+
+    expect(details.innerHTML).toContain("Content:");
+    expect(details.innerHTML).toContain("hello from stored content");
+    consoleSpy.mockRestore();
+  });
+
+  test("does not render Content block when resource.content is null", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const details = document.createElement("div");
+    details.id = "resource-details";
+    document.body.appendChild(details);
+
+    fetchWithTimeout.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          resource: {
+            id: "r-no-content",
+            name: "no-content-resource",
+            uri: "res://r-no-content",
+            content: null,
+          },
+        }),
+    });
+
+    await viewResource("r-no-content");
+
+    expect(details.innerHTML).not.toContain("Content:");
+    consoleSpy.mockRestore();
+  });
+
+  test("does not render Content block when resource.content is empty string", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const details = document.createElement("div");
+    details.id = "resource-details";
+    document.body.appendChild(details);
+
+    fetchWithTimeout.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          resource: {
+            id: "r-empty-content",
+            name: "empty-content-resource",
+            uri: "res://r-empty-content",
+            content: "   ",
+          },
+        }),
+    });
+
+    await viewResource("r-empty-content");
+
+    expect(details.innerHTML).not.toContain("Content:");
+    consoleSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// editResource - content rendering 
+// ---------------------------------------------------------------------------
+describe("editResource - content rendering", () => {
+  beforeEach(() => {
+    window.ROOT_PATH = "";
+    delete window.location;
+    window.location = { href: "http://localhost/admin" };
+  });
+
+  function buildEditFormWithContent() {
+    const form = document.createElement("form");
+    form.id = "edit-resource-form";
+    document.body.appendChild(form);
+
+    const hiddenField = document.createElement("input");
+    hiddenField.type = "hidden";
+    hiddenField.id = "edit-resource-show-inactive";
+    document.body.appendChild(hiddenField);
+
+    ["edit-resource-name", "edit-resource-uri", "edit-resource-description",
+      "edit-resource-mime-type", "edit-resource-tags"].forEach((id) => {
+      const input = document.createElement("input");
+      input.id = id;
+      document.body.appendChild(input);
+    });
+    ["public", "team", "private"].forEach((v) => {
+      const radio = document.createElement("input");
+      radio.type = "radio";
+      radio.id = `edit-resource-visibility-${v}`;
+      document.body.appendChild(radio);
+    });
+    const textarea = document.createElement("textarea");
+    textarea.id = "edit-resource-content";
+    document.body.appendChild(textarea);
+  }
+
+  test("sets textarea value when resource.content is present", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    buildEditFormWithContent();
+
+    fetchWithTimeout.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          resource: {
+            id: "r1",
+            name: "my-res",
+            uri: "res://r1",
+            content: "stored text body",
+          },
+        }),
+    });
+
+    await editResource("r1");
+
+    expect(document.getElementById("edit-resource-content").value).toBe("stored text body");
+    consoleSpy.mockRestore();
+  });
+
+  test("sets textarea to empty string when resource.content is null", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    buildEditFormWithContent();
+
+    fetchWithTimeout.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          resource: {
+            id: "r1",
+            name: "my-res",
+            uri: "res://r1",
+            content: null,
+          },
+        }),
+    });
+
+    await editResource("r1");
+
+    expect(document.getElementById("edit-resource-content").value).toBe("");
+    consoleSpy.mockRestore();
+  });
+
+  test("calls editResourceContentEditor.setValue with content when editor is present", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    buildEditFormWithContent();
+
+    const mockEditor = { setValue: vi.fn(), refresh: vi.fn() };
+    window.editResourceContentEditor = mockEditor;
+
+    fetchWithTimeout.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          resource: {
+            id: "r1",
+            name: "my-res",
+            uri: "res://r1",
+            content: "codemirror content",
+          },
+        }),
+    });
+
+    await editResource("r1");
+
+    expect(mockEditor.setValue).toHaveBeenCalledWith("codemirror content");
+    expect(mockEditor.refresh).toHaveBeenCalled();
+
+    delete window.editResourceContentEditor;
+    consoleSpy.mockRestore();
+  });
+
+  test("calls editResourceContentEditor.setValue with empty string when content is null", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    buildEditFormWithContent();
+
+    const mockEditor = { setValue: vi.fn(), refresh: vi.fn() };
+    window.editResourceContentEditor = mockEditor;
+
+    fetchWithTimeout.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          resource: {
+            id: "r1",
+            name: "my-res",
+            uri: "res://r1",
+            content: null,
+          },
+        }),
+    });
+
+    await editResource("r1");
+
+    expect(mockEditor.setValue).toHaveBeenCalledWith("");
+
+    delete window.editResourceContentEditor;
+    consoleSpy.mockRestore();
+  });
+});

--- a/tests/unit/js/resources.test.js
+++ b/tests/unit/js/resources.test.js
@@ -979,7 +979,7 @@ describe("initResourceSelect - Select All respects search filter", () => {
 });
 
 // ---------------------------------------------------------------------------
-// viewResource - content rendering 
+// viewResource - content rendering
 // ---------------------------------------------------------------------------
 describe("viewResource - content rendering", () => {
   beforeEach(() => {
@@ -1067,7 +1067,7 @@ describe("viewResource - content rendering", () => {
 });
 
 // ---------------------------------------------------------------------------
-// editResource - content rendering 
+// editResource - content rendering
 // ---------------------------------------------------------------------------
 describe("editResource - content rendering", () => {
   beforeEach(() => {

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -2128,6 +2128,22 @@ class TestUtilityMethods:
         result = resource_service.convert_resource_to_read(mock_resource, include_metrics=False)
         assert result.tags == ["plain", "dict-label", "dict-name", "obj-label", "obj-name"]
 
+    def test_convert_resource_to_read_maps_text_content_to_content(self, resource_service, mock_resource):
+        """text_content from DB row must appear as content in ResourceRead."""
+        mock_resource.text_content = "Hello paddddd"
+
+        result = resource_service.convert_resource_to_read(mock_resource, include_metrics=False)
+
+        assert result.content == "Hello paddddd"
+
+    def test_convert_resource_to_read_content_none_when_no_text_content(self, resource_service, mock_resource):
+        """content must be None when the resource has no stored text_content."""
+        mock_resource.text_content = None
+
+        result = resource_service.convert_resource_to_read(mock_resource, include_metrics=False)
+
+        assert result.content is None
+
     def test_init_creates_service_with_expected_attributes(self):
         """Cover ResourceService.__init__ — verify core attributes are set."""
         # First-Party

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -422,6 +422,57 @@ class TestResourceRegistration:
             # Should handle binary content correctly
             mock_db.add.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_register_resource_response_includes_content(self, resource_service, mock_db, sample_resource_create, mock_resource):
+        """POST /resources response must include content; converter must be called with include_content=True."""
+        # Mock database responses - use separate mock objects to avoid conflicts
+        mock_scalar = MagicMock()
+        mock_scalar.scalar_one_or_none.return_value = None  # No existing resource
+        mock_db.execute.return_value = mock_scalar
+
+        # Mock validation and notification
+        with (
+            patch.object(resource_service, "_detect_mime_type", return_value="text/plain"),
+            patch.object(resource_service, "_notify_resource_added", new_callable=AsyncMock),
+            patch.object(resource_service, "convert_resource_to_read") as mock_convert,
+        ):
+            mock_convert.return_value = ResourceRead(
+                id="39334ce0ed2644d79ede8913a66930c9",
+                uri=sample_resource_create.uri,
+                name=sample_resource_create.name,
+                description=sample_resource_create.description or "",
+                mime_type="text/plain",
+                size=len(sample_resource_create.content),
+                enabled=True,
+                content=sample_resource_create.content,
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+                template=None,
+                metrics={
+                    "total_executions": 0,
+                    "successful_executions": 0,
+                    "failed_executions": 0,
+                    "failure_rate": 0.0,
+                    "min_response_time": None,
+                    "max_response_time": None,
+                    "avg_response_time": None,
+                    "last_execution_time": None,
+                },
+            )
+
+            # Call method
+            result = await resource_service.register_resource(mock_db, sample_resource_create)
+
+            # Verify database operations
+            mock_db.add.assert_called_once()
+            mock_db.commit.assert_called_once()
+            mock_db.refresh.assert_called_once()
+
+            # Verify converter was called with include_content=True so content is not null
+            mock_convert.assert_called_once_with(mock_db.refresh.call_args[0][0], include_content=True)
+
+            # Verify result carries content back to the caller
+            assert result.content == sample_resource_create.content
 
 # --------------------------------------------------------------------------- #
 # Resource listing tests                                                      #
@@ -1053,6 +1104,23 @@ class TestResourceManagement:
             assert mock_resource.name == "Updated Name"
             assert mock_resource.description == "Updated description"
             mock_db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_resource_response_includes_content(self, resource_service, mock_db, mock_resource):
+        """PUT /resources/{id} response must include content (not null) for the caller's own write."""
+        mock_resource.text_content = "Updated content"
+        mock_resource.binary_content = None
+        update_data = ResourceUpdate(name="Updated Name", content="Updated content")
+
+        mock_scalar = MagicMock()
+        mock_scalar.scalar_one_or_none.return_value = mock_resource
+        mock_db.execute.return_value = mock_scalar
+        mock_db.get.return_value = mock_resource
+
+        with patch.object(resource_service, "_notify_resource_updated", new_callable=AsyncMock):
+            result = await resource_service.update_resource(mock_db, mock_resource.id, update_data)
+
+        assert result.content == "Updated content"
 
     @pytest.mark.asyncio
     async def test_update_resource_accepts_ui_extension_metadata(self, resource_service, mock_db, mock_resource, monkeypatch):
@@ -2130,11 +2198,11 @@ class TestUtilityMethods:
 
     def test_convert_resource_to_read_maps_text_content_to_content(self, resource_service, mock_resource):
         """text_content from DB row must appear as content in ResourceRead."""
-        mock_resource.text_content = "Hello paddddd"
+        mock_resource.text_content = "Hello, this is mock resource content"
 
-        result = resource_service.convert_resource_to_read(mock_resource, include_metrics=False)
+        result = resource_service.convert_resource_to_read(mock_resource, include_metrics=False, include_content=True)
 
-        assert result.content == "Hello paddddd"
+        assert result.content == "Hello, this is mock resource content"
 
     def test_convert_resource_to_read_content_none_when_no_text_content(self, resource_service, mock_resource):
         """content must be None when the resource has no stored text_content."""


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #6058

---

## 📝 Summary

`ResourceRead` had no `content` field, so `text_content` stored in the
database was silently discarded on every read. The Admin UI view and edit
modals had the content display and prefill code commented out as a
defensive measure — without a working read path, rendering the field
would have overwritten stored content with blank on every save.

This PR adds `content` to `ResourceRead`, maps `text_content → content`
in `convert_resource_to_read`, and restores the commented-out UI code
with the CodeMirror editor wired correctly.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Lint suite | `make lint` |✅ |
| Unit tests | `make test` | ✅|
| Coverage ≥ 80% | `make coverage` |✅ |
| Targeted fast run | `python -m pytest tests/unit/mcpgateway/services/test_resource_service.py -k "convert_resource_to_read" -v` | ✅|
| Manual — View modal | Create resource with text content → open View modal → content renders | ✅|
| Manual — Edit modal | Open Edit modal → content textarea prefilled with stored value | ✅|
| Manual — Save edit | Edit content → save → reopen → updated content persists |✅ |

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

**Root cause:** `ResourceRead` (Pydantic schema) never had a `content`
field. `ResourceCreate` and `ResourceUpdate` accepted `content` on
writes, which was correctly stored in `DbResource.text_content`. But
`convert_resource_to_read` never mapped `text_content` back.

**Files changed:**

- `mcpgateway/schemas.py` — added `content: Optional[str]` to `ResourceRead`
- `mcpgateway/services/resource_service.py` — mapped
  `text_content → content` in `convert_resource_to_read`
- `mcpgateway/admin_ui/resources.js` — uncommented `resource.content` read on view and edit paths; wired edit prefill through
- `mcpgateway/templates/admin.html` — uncommented the content textarea in the edit modal with dark-mode CSS classes


<img width="2988" height="1678" alt="image" src="https://github.com/user-attachments/assets/7339eb38-5899-46d9-97f5-2f7f2e0e822f" />
<img width="2986" height="1690" alt="image" src="https://github.com/user-attachments/assets/e9f2379c-d3b1-4709-98a9-01172888e6a5" />
