### PR TITLE
fix(helm): fix OCP PGO deployment failures on fresh clusters

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$|^.secrets.baseline$",
+    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-07T15:50:12Z",
+  "generated_at": "2026-09-08T10:01:50Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1518,7 +1518,7 @@
         "hashed_secret": "602a3bcd9e73d7abd64dc26b0cb407e963c9f806",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 188,
+        "line_number": 191,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1526,7 +1526,7 @@
         "hashed_secret": "de7c0d0731b4b25d51e1d5025b8559d073d3c0e7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 353,
+        "line_number": 356,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1534,7 +1534,7 @@
         "hashed_secret": "d09a50d86d7403a4bc3ee1823f91ec14fb14acd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 362,
+        "line_number": 365,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1542,7 +1542,7 @@
         "hashed_secret": "2bdb52a577a3b6376b125fa94bfa4366a53c5ea0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 364,
+        "line_number": 367,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1550,7 +1550,7 @@
         "hashed_secret": "ae0131d240ba7cc32be22b778cb4a62ccfbd3660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 370,
+        "line_number": 373,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1558,7 +1558,7 @@
         "hashed_secret": "7e15bb5c01e7dd56499e37c634cf791d3a519aee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 581,
+        "line_number": 584,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ansible/ocp/playbooks/deploy.yml
+++ b/ansible/ocp/playbooks/deploy.yml
@@ -39,6 +39,30 @@
       failed_when: confirm.user_input | lower not in ['yes', 'y']
       when: not (skip_confirm | default(false) | bool)
 
+    # Pre-create the gateway secret with Helm ownership labels so the migration
+    # hook pod finds it immediately (before Helm creates regular resources).
+    - name: Load secrets values file
+      ansible.builtin.include_vars:
+        file: "{{ ocp_secrets }}"
+        name: secret_values
+
+    - name: Pre-create gateway secret with Helm ownership labels
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ ocp_namespace }}-mcp-stack-gateway-secret"
+            namespace: "{{ ocp_namespace }}"
+            labels:
+              app.kubernetes.io/managed-by: Helm
+            annotations:
+              meta.helm.sh/release-name: "{{ ocp_namespace }}"
+              meta.helm.sh/release-namespace: "{{ ocp_namespace }}"
+          stringData: "{{ dict(secret_values.mcpContextForge.secret | dict2items | map(attribute='key') | list | zip(secret_values.mcpContextForge.secret | dict2items | map(attribute='value') | map('string') | list)) }}"
+      no_log: true
+
     - name: Install ContextForge Helm chart
       ansible.builtin.command:
         cmd: >

--- a/ansible/ocp/playbooks/deploy.yml
+++ b/ansible/ocp/playbooks/deploy.yml
@@ -45,6 +45,43 @@
       ansible.builtin.include_vars:
         file: "{{ ocp_secrets }}"
         name: secret_values
+      no_log: true
+
+    # Derive the secret name from the chart's own mcp-stack.fullname helper so
+    # it always matches what Helm renders, regardless of the release name.
+    - name: Derive gateway secret name from chart template
+      ansible.builtin.command:
+        cmd: >
+          helm template {{ ocp_namespace }} {{ ocp_chart_path }}
+          -n {{ ocp_namespace }}
+          -f {{ ocp_values }}
+          -f {{ ocp_secrets }}
+          --show-only templates/secret-gateway.yaml
+      register: gateway_secret_template
+      changed_when: false
+      no_log: true
+
+    - name: Parse gateway secret name from template output
+      ansible.builtin.set_fact:
+        gateway_secret_name: >-
+          {{ (gateway_secret_template.stdout | from_yaml).metadata.name }}
+
+    - name: Expand secret dict to items (single pass)
+      ansible.builtin.set_fact:
+        gateway_secret_items: "{{ secret_values.mcpContextForge.secret | dict2items }}"
+      no_log: true
+
+    - name: Coerce secret values to strings
+      ansible.builtin.set_fact:
+        gateway_secret_data: >-
+          {{ dict(gateway_secret_items | map(attribute='key') | list
+             | zip(gateway_secret_items
+               | map(attribute='value')
+               | map('string')
+               | map('regex_replace', '^True$', 'true')
+               | map('regex_replace', '^False$', 'false')
+               | list)) }}
+      no_log: true
 
     - name: Pre-create gateway secret with Helm ownership labels
       kubernetes.core.k8s:
@@ -53,14 +90,14 @@
           apiVersion: v1
           kind: Secret
           metadata:
-            name: "{{ ocp_namespace }}-mcp-stack-gateway-secret"
+            name: "{{ gateway_secret_name }}"
             namespace: "{{ ocp_namespace }}"
             labels:
               app.kubernetes.io/managed-by: Helm
             annotations:
               meta.helm.sh/release-name: "{{ ocp_namespace }}"
               meta.helm.sh/release-namespace: "{{ ocp_namespace }}"
-          stringData: "{{ dict(secret_values.mcpContextForge.secret | dict2items | map(attribute='key') | list | zip(secret_values.mcpContextForge.secret | dict2items | map(attribute='value') | map('string') | list)) }}"
+          stringData: "{{ gateway_secret_data }}"
       no_log: true
 
     - name: Install ContextForge Helm chart

--- a/ansible/ocp/playbooks/setup.yml
+++ b/ansible/ocp/playbooks/setup.yml
@@ -65,6 +65,14 @@
       ansible.builtin.debug:
         msg: "Namespace: {{ 'created' if ns_result.changed else 'already exists' }}"
 
+    # Step 2b: Grant nonroot-v2 SCC to default service account (required for Redis UID 999).
+    # nonroot-v2 allows any non-root UID (covers 999) and still permits seccompProfile,
+    # so it is narrower than anyuid and avoids root-escalation risk (CWE-250).
+    - name: Grant nonroot-v2 SCC to default service account
+      ansible.builtin.command:
+        cmd: oc adm policy add-scc-to-user nonroot-v2 -z default -n {{ ocp_namespace }}
+      changed_when: false
+
     # Step 3: Apply PostgresCluster CR
     - name: Check if PostgresCluster is already running
       kubernetes.core.k8s_info:

--- a/docs/docs/deployment/openshift-pgo.md
+++ b/docs/docs/deployment/openshift-pgo.md
@@ -79,7 +79,7 @@ If you don't need HA or automated backups (dev/test, POCs, teams without cluster
 
 The following tools must be installed locally before you begin:
 
-1. **`oc` CLI** — with cluster access (developer or admin). Log in before running any commands:
+1. **`oc` CLI** — with **cluster-admin** (or equivalent) privileges. The setup playbook runs `oc adm policy add-scc-to-user nonroot-v2` to grant the Redis pod permission to run as UID 999 — this requires cluster-admin. Log in before running any commands:
    ```bash
    oc login <api-url>
    oc whoami   # verify
@@ -167,6 +167,9 @@ testing:
 ## Deployment steps
 
 The Make commands below wrap Ansible playbooks (`ansible/ocp/playbooks/`). You can also run the playbooks directly — see [ansible/ocp/README.md](https://github.com/IBM/mcp-context-forge/blob/main/ansible/ocp/README.md) for details.
+
+**Prerequisite: Create a namespace**
+`oc new-project <namespace-change-me>`
 
 **Step 1 — Create Docker Hub pull secret** (one-time per namespace):
 


### PR DESCRIPTION
## 🔗 Related Issue

Closes https://github.com/IBM/mcp-context-forge/issues/6195

---

## 📝 Summary

Fixes three issues that block `make ocp-setup && make ocp-deploy` from completing on a fresh OpenShift cluster after the security hardening changes in Release 1.0.7

**Problem 1 - Helm secret race condition (`deploy.yml`)**
The migration Job is a `pre-install` hook that fires before Helm creates regular resources. This means the gateway secret doesn't exist when the migration pod starts, so the app falls back to the `__REPLACE_ME__` placeholder and crashes. Fixed by pre-creating the secret with Helm ownership labels in the deploy playbook before `helm install` runs.

**Problem 2 — Missing SCC grant (`setup.yml`)**
`runAsUser: 999` was added to the Redis container in Release 1.0.7. UID 999 is outside the OCP namespace-allocated UID range enforced by the `restricted-v2` SCC, so the Redis pod is never created. Fixed by granting `nonroot-v2` SCC to the default service account during namespace setup. `nonroot-v2` allows any non-root UID (covers 999), still permits `seccompProfile`, and is narrower than `anyuid`.

**Problem 3 — (resolved by Problem 2 fix)**
The original fix used `anyuid` which rejects `seccompProfile`, requiring a conditional in `deployment-redis.yaml` and an override in `values-pgo.yaml`. Switching to `nonroot-v2` resolves this — both of those changes revert entirely.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix

---

## 🧪 Verification

Verified by deploying from scratch on a fresh Fyre Quick Burn cluster (OCP 4.22):

| Check | Command | Status |
|---|---|---|
| Full deploy from clean namespace | `make ocp-setup OCP_NS=contextforge && make ocp-deploy OCP_NS=contextforge` | ✅ All pods `1/1 Running` |
| Gateway pods | `oc get pods -n contextforge` | ✅ 3/3 Running |
| Redis pod | `oc get pods -n contextforge \| grep redis` | ✅ 1/1 Running |
| Migration job | `oc get jobs -n contextforge` | ✅ Completed cleanly |
| Gateway secret created | `oc get secret contextforge-mcp-stack-gateway-secret -n contextforge` | ✅ Present with correct values |
| nonroot-v2 SCC applied | `oc get rolebinding -n contextforge \| grep nonroot` | ✅ Bound to default SA |

**Before :** `make ocp-deploy` failed with migration pod `SecurityConfigurationError` and Redis `FailedCreate`.

**After (with fix):** Clean deploy, all 10 pods reach `Running` status within ~2 minutes.

---

## ✅ Checklist

- [x] No secrets or credentials committed

---

## 📓 Notes

**Files changed:**

| File | Change |
|------|--------|
| `ansible/ocp/playbooks/deploy.yml` | Pre-creates gateway secret with Helm ownership labels before `helm install`; `no_log: true` added; secret values coerced to strings |
| `ansible/ocp/playbooks/setup.yml` | Grants `nonroot-v2` SCC (not `anyuid`) to default service account after namespace creation |
| `charts/mcp-stack/profiles/ocp/values-pgo.yaml` | Reverted — `podSecurityContext` override no longer needed with `nonroot-v2` |
| `charts/mcp-stack/templates/deployment-redis.yaml` | Reverted — `seccompProfile` conditional no longer needed with `nonroot-v2` |

These failures only surface on a **fresh** cluster because on previously deployed clusters, manual SCC grants from earlier runs persist and mask the issue. Anyone spinning up a new Quick Burn cluster after Release 1.0.7 will hit all three failures.