### PR TITLE
fix(security): sandbox jq filter execution for tool jsonpath_filter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2527,6 +2527,13 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # Default: 5000 characters, Range: 1000-100000
 # REST_RESPONSE_TEXT_MAX_LENGTH=5000
 
+# jq filter sandbox for tool jsonpath_filter execution.
+# Filters run in a forked worker with a cleared environment and a time limit.
+# Options: subprocess (default, safe), inprocess (unsafe, no environment scrub, no time limit)
+# JQ_FILTER_EXECUTION=subprocess
+# JQ_FILTER_TIMEOUT_SECONDS=2.0
+# JQ_FILTER_WORKERS=2
+
 # Prompt Configuration
 # PROMPT_CACHE_SIZE=100
 # MAX_PROMPT_SIZE=102400

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-14T11:47:13Z",
+  "generated_at": "2026-08-14T12:19:58Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -3884,7 +3884,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4608,
+        "line_number": 4661,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/docs/docs/manage/securing.md
+++ b/docs/docs/manage/securing.md
@@ -649,11 +649,11 @@ Before connecting any MCP server:
 - [ ] Monitor server behavior for anomalies
 - [ ] Implement rate limiting for untrusted servers
 
-### jq filter sandbox
+### 13. jq Filter Sandbox
 
 Tool `jsonpath_filter` values are jq programs. They are validated when a tool is
-written and again when it is invoked, and they execute in a forked worker whose
-environment has been cleared, under `JQ_FILTER_TIMEOUT_SECONDS`.
+written and again when it is invoked, and — on Linux — they execute in a forked
+worker whose environment has been cleared, under `JQ_FILTER_TIMEOUT_SECONDS`.
 
 Filters that reference `env`, `$ENV`, `input`, `inputs`, `input_filename`,
 `input_line_number`, `$__loc__`, `debug`, `stderr`, `include`, `import`, or
@@ -663,9 +663,35 @@ Object-construction keys are read as code, so an unquoted key named after a
 restricted built-in is refused. Quote it instead — write `{"env": .region}`
 rather than `{env: .region}`.
 
-`JQ_FILTER_EXECUTION=inprocess` disables both the environment scrub and the time
-limit. It exists only for platforms without a usable `fork`, and must not be set
-in production.
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `JQ_FILTER_EXECUTION` | `subprocess` | `subprocess` runs filters in the sandbox; `inprocess` disables it. |
+| `JQ_FILTER_TIMEOUT_SECONDS` | `2.0` | Wall-clock limit for a single filter. |
+| `JQ_FILTER_WORKERS` | `2` | Worker processes per gateway process. Raise it if filtered tools are called concurrently enough that a single slow filter queues others. |
+
+!!! warning "The sandbox is Linux-only"
+    The forked worker requires the `fork` start method, which is unsafe on
+    Darwin, so `subprocess` mode is silently inactive on any non-Linux platform
+    **regardless of `JQ_FILTER_EXECUTION`**. There, filters run in-process with
+    no environment scrub and no time limit, and the static denylist above is the
+    only protection. This is announced by a `WARNING` at startup — check for it
+    if you run the gateway outside a Linux container. The shipped container
+    images are Linux, so production deployments get the sandbox.
+
+`JQ_FILTER_EXECUTION=inprocess` likewise disables both the environment scrub and
+the time limit. It exists only for platforms without a usable `fork`, and must
+not be set in production.
+
+**Blast radius of a timeout.** A filter that overruns its limit causes the whole
+worker pool to be killed and rebuilt, because `ProcessPoolExecutor` cannot
+cancel a task that is already running and offers no way to target one worker.
+Other filters in flight at that moment are aborted and reported as errors to
+their own callers. Raising `JQ_FILTER_WORKERS` does not narrow this — the kill
+is pool-wide by design. It is an accepted trade-off: the alternative is leaving
+a non-terminating filter holding a worker indefinitely. The pool is also
+rebuilt if a worker dies abnormally (for example, if the kernel OOM-kills a
+filter that allocates without bound), so a single hostile filter cannot disable
+response filtering for the lifetime of the gateway process.
 
 **If you ran a build released before this change**, treat the following as
 disclosed and rotate them: `JWT_SECRET_KEY`, `AUTH_ENCRYPTION_SECRET`, and the
@@ -673,7 +699,7 @@ credentials embedded in `DATABASE_URL` and `REDIS_URL`, plus
 `BASIC_AUTH_PASSWORD`. Audit existing tools for hostile `jsonpath_filter` values
 before upgrading, since those tools will begin failing at invoke time.
 
-### 13. Database Security
+### 14. Database Security
 
 - [ ] Use TLS for database connections
 - [ ] Configure strong passwords
@@ -681,7 +707,7 @@ before upgrading, since those tools will begin failing at invoke time.
 - [ ] Enable audit logging
 - [ ] Regular backups with encryption
 
-### 14. Monitoring & Logging
+### 15. Monitoring & Logging
 
 - [ ] Set up structured logging without sensitive data
 - [ ] Configure log rotation and secure storage
@@ -689,7 +715,7 @@ before upgrading, since those tools will begin failing at invoke time.
 - [ ] Set up anomaly detection
 - [ ] Create incident response procedures
 
-### 15. Integration Security
+### 16. Integration Security
 
 ContextForge should be integrated with:
 
@@ -699,7 +725,7 @@ ContextForge should be integrated with:
 - [ ] SIEM for security monitoring
 - [ ] Load balancer with TLS termination
 
-### 16. Well-Known URI Security
+### 17. Well-Known URI Security
 
 Configure well-known URIs appropriately for your deployment:
 
@@ -723,7 +749,7 @@ Security considerations:
 - [ ] Update security.txt Expires field before expiration
 - [ ] Consider custom well-known files only if necessary
 
-### 17. Downstream Application Security
+### 18. Downstream Application Security
 
 Applications consuming ContextForge data must:
 

--- a/docs/docs/manage/securing.md
+++ b/docs/docs/manage/securing.md
@@ -649,6 +649,30 @@ Before connecting any MCP server:
 - [ ] Monitor server behavior for anomalies
 - [ ] Implement rate limiting for untrusted servers
 
+### jq filter sandbox
+
+Tool `jsonpath_filter` values are jq programs. They are validated when a tool is
+written and again when it is invoked, and they execute in a forked worker whose
+environment has been cleared, under `JQ_FILTER_TIMEOUT_SECONDS`.
+
+Filters that reference `env`, `$ENV`, `input`, `inputs`, `input_filename`,
+`input_line_number`, `$__loc__`, `debug`, `stderr`, `include`, `import`, or
+`modulemeta` are rejected. Field access such as `.env` is unaffected.
+
+Object-construction keys are read as code, so an unquoted key named after a
+restricted built-in is refused. Quote it instead — write `{"env": .region}`
+rather than `{env: .region}`.
+
+`JQ_FILTER_EXECUTION=inprocess` disables both the environment scrub and the time
+limit. It exists only for platforms without a usable `fork`, and must not be set
+in production.
+
+**If you ran a build released before this change**, treat the following as
+disclosed and rotate them: `JWT_SECRET_KEY`, `AUTH_ENCRYPTION_SECRET`, and the
+credentials embedded in `DATABASE_URL` and `REDIS_URL`, plus
+`BASIC_AUTH_PASSWORD`. Audit existing tools for hostile `jsonpath_filter` values
+before upgrading, since those tools will begin failing at invoke time.
+
 ### 13. Database Security
 
 - [ ] Use TLS for database connections

--- a/mcpgateway/alembic/versions/7ab59991e017_fix_oauth_tokens_unique_constraint.py
+++ b/mcpgateway/alembic/versions/7ab59991e017_fix_oauth_tokens_unique_constraint.py
@@ -160,7 +160,7 @@ def downgrade() -> None:
                 duplicate_details += f"\n  ... and {len(duplicate_check) - 5} more"
 
             raise RuntimeError(
-                f"Cannot downgrade migration 7ab59991e017: "
+                f"Cannot downgrade migration 7ab59991e017: "  # nosec B608 - human-readable error text, not an executed SQL statement
                 f"{len(duplicate_check)} duplicate (gateway_id, user_id) pairs exist.\n\n"
                 f"This is expected after the upgrade enabled multi-user OAuth support. "
                 f"Multiple ContextForge users can now store tokens for the same OAuth provider user.\n\n"

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -2505,6 +2505,24 @@ class Settings(BaseSettings):
         "Longer responses are truncated to prevent exposing excessive sensitive data. "
         "Default: 5000 characters. Range: 1000-100000.",
     )
+    # jq filter sandbox — see docs/superpowers/specs/2026-08-11-jq-env-disclosure-design.md
+    jq_filter_execution: Literal["subprocess", "inprocess"] = Field(
+        default="subprocess",
+        description="Execution mode for tool jsonpath_filter jq programs. 'subprocess' runs each filter in a forked worker with a cleared environment and a wall-clock limit. "
+        "'inprocess' removes both protections and is unsafe; it exists only for platforms where fork is unavailable.",
+    )
+    jq_filter_timeout_seconds: float = Field(
+        default=2.0,
+        gt=0,
+        le=60,
+        description="Wall-clock limit for a single jq filter run. Exceeding it kills the worker and returns a filter error. Default: 2.0 seconds.",
+    )
+    jq_filter_workers: int = Field(
+        default=2,
+        ge=1,
+        le=16,
+        description="Number of forked jq worker processes per gateway worker. Default: 2.",
+    )
 
     # Content Security - Size Limits
     content_max_resource_size: int = Field(default=102400, ge=1024, le=10485760, description="Maximum size in bytes for resource content (default: 100KB)")  # 100KB  # Minimum 1KB  # Maximum 10MB

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -219,6 +219,7 @@ from mcpgateway.utils.csp_nonce import get_csp_nonce_from_request
 from mcpgateway.utils.error_formatter import ErrorFormatter, sanitize_validation_error_for_log, should_expose_error_details
 from mcpgateway.utils.header_filtering import filter_sensitive_headers as _filter_sensitive_headers
 from mcpgateway.utils.internal_http import internal_loopback_base_url, internal_loopback_verify
+from mcpgateway.utils.jq_runner import shutdown_jq_pool, start_jq_pool
 from mcpgateway.utils.metadata_capture import MetadataCapture
 from mcpgateway.utils.orjson_response import ORJSONResponse
 from mcpgateway.utils.passthrough_headers import set_global_passthrough_headers
@@ -1468,6 +1469,13 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     await logging_service.initialize()
     logger.info("Starting ContextForge services")
 
+    # Start the sandboxed jq worker pool before any service that might invoke
+    # tool response filters is initialised. A failure here (BrokenProcessPool,
+    # TimeoutError, or OSError from the sandbox warm-up on Linux/subprocess
+    # mode) is a hard startup failure and must propagate rather than letting
+    # the gateway boot with a broken or absent sandbox.
+    start_jq_pool()
+
     # Wait for the database to be ready, then run bootstrap (alembic + seed).
     # This used to run at module-import time, which made every test that
     # imported mcpgateway.main pay for a real DB probe and migration check.
@@ -2035,6 +2043,9 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
         # Close Redis client last (after all services that use it)
         await close_redis_client()
+
+        # Shut down the sandboxed jq worker pool
+        shutdown_jq_pool()
 
         logger.info("Shutdown complete")
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -41,6 +41,7 @@ from mcpgateway.common.oauth import OAUTH_SENSITIVE_KEYS
 from mcpgateway.common.validators import SecurityValidator, validate_core_url
 from mcpgateway.config import settings
 from mcpgateway.utils.base_models import BaseModelWithConfigDict
+from mcpgateway.utils.jq_guard import assert_safe_jq_filter
 from mcpgateway.utils.services_auth import decode_auth, encode_auth
 from mcpgateway.validation.tags import validate_tags_field
 
@@ -727,6 +728,26 @@ def _assemble_tool_authheaders(values: Dict[str, Any]) -> Dict[str, Any]:
     return {"auth_type": "authheaders", "auth_value": None}
 
 
+def _validate_jsonpath_filter_value(value: Optional[str]) -> Optional[str]:
+    """Reject jq filters that use restricted built-ins.
+
+    Shared by ``ToolCreate.validate_jsonpath_filter`` and
+    ``ToolUpdate.validate_jsonpath_filter`` so the check has one implementation.
+
+    Args:
+        value: The submitted jq filter.
+
+    Returns:
+        The filter unchanged when it is safe.
+
+    Raises:
+        ValueError: If the filter uses a restricted jq built-in.
+    """
+    if value:
+        assert_safe_jq_filter(value)
+    return value
+
+
 class ToolCreate(BaseModel):
     """
     Represents the configuration for creating a tool with various attributes and settings.
@@ -930,6 +951,22 @@ class ToolCreate(BaseModel):
         if len(v) > SecurityValidator.MAX_NAME_LENGTH:
             raise ValueError(f"Display name exceeds maximum length of {SecurityValidator.MAX_NAME_LENGTH}")
         return SecurityValidator.sanitize_display_text(v, "Display name")
+
+    @field_validator("jsonpath_filter")
+    @classmethod
+    def validate_jsonpath_filter(cls, value: Optional[str]) -> Optional[str]:
+        """Reject jq filters that use restricted built-ins.
+
+        Args:
+            value: The submitted jq filter.
+
+        Returns:
+            The filter unchanged when it is safe.
+
+        Raises:
+            ValueError: If the filter uses a restricted jq built-in.
+        """
+        return _validate_jsonpath_filter_value(value)
 
     @field_validator("headers", "input_schema", "annotations")
     @classmethod
@@ -1469,6 +1506,22 @@ class ToolUpdate(BaseModelWithConfigDict):
             logger.info(f"Description too long, truncated to {SecurityValidator.MAX_DESCRIPTION_LENGTH} characters.")
             return SecurityValidator.sanitize_display_text(truncated, "Description")
         return SecurityValidator.sanitize_display_text(v, "Description")
+
+    @field_validator("jsonpath_filter")
+    @classmethod
+    def validate_jsonpath_filter(cls, value: Optional[str]) -> Optional[str]:
+        """Reject jq filters that use restricted built-ins.
+
+        Args:
+            value: The submitted jq filter.
+
+        Returns:
+            The filter unchanged when it is safe.
+
+        Raises:
+            ValueError: If the filter uses a restricted jq built-in.
+        """
+        return _validate_jsonpath_filter_value(value)
 
     @field_validator("headers", "input_schema", "annotations")
     @classmethod

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -45,7 +45,6 @@ from cpex.framework import (
 )
 from cpex.framework.constants import GATEWAY_METADATA, TOOL_METADATA
 import httpx
-import jq
 import jsonschema
 from jsonschema import Draft4Validator, Draft6Validator, Draft7Validator, validators
 from mcp import ClientSession, types
@@ -101,6 +100,8 @@ from mcpgateway.utils.display_name import generate_display_name
 from mcpgateway.utils.gateway_access import build_gateway_auth_headers, check_gateway_access, extract_gateway_id_from_headers
 from mcpgateway.utils.header_filtering import filter_sensitive_headers
 from mcpgateway.utils.identity_propagation import build_identity_headers, build_identity_meta
+from mcpgateway.utils.jq_guard import assert_safe_jq_filter
+from mcpgateway.utils.jq_runner import JqFilterError, JqFilterTimeout, run_jq_filter
 from mcpgateway.utils.log_sanitizer import sanitize_for_log
 from mcpgateway.utils.metrics_common import build_top_performers
 from mcpgateway.utils.pagination import decode_cursor, encode_cursor, unified_paginate
@@ -636,23 +637,6 @@ def _handle_json_parse_error(response, error, is_error_response: bool = False) -
     return {"response_text": text}
 
 
-@lru_cache(maxsize=256)
-def _compile_jq_filter(jq_filter: str):
-    """Cache compiled jq filter program.
-
-    Args:
-        jq_filter: The jq filter string to compile.
-
-    Returns:
-        Compiled jq program object.
-
-    Raises:
-        ValueError: If the jq filter is invalid.
-    """
-    # pylint: disable=c-extension-no-member
-    return jq.compile(jq_filter)
-
-
 @lru_cache(maxsize=128)
 def _get_validator_class_and_check(schema_json: str) -> Tuple[type, dict]:
     """Cache schema validation and validator class selection.
@@ -788,15 +772,24 @@ def extract_using_jq(data, jq_filter=""):
         # If the input is not a string, dict, or list, raise an error
         return ["Input data must be a JSON string, dictionary, or list."]
 
-    # Apply the jq filter to the data using cached compiled program
+    # Refuse restricted built-ins before execution. This covers rows written
+    # before the schema validator existed, and any writer that bypasses it.
     try:
-        program = _compile_jq_filter(jq_filter)
-        result = program.input(data).all()
+        assert_safe_jq_filter(jq_filter_str)
+    except ValueError as exc:
+        logger.warning("Refused jq filter: %s", exc)
+        return [TextContent(type="text", text="jsonpath filter uses a restricted jq builtin")]
+
+    try:
+        result = run_jq_filter(jq_filter_str, data)
         if result == [None]:
             return [TextContent(type="text", text="Error applying jsonpath filter")]
-    except Exception as e:
-        message = "Error applying jsonpath filter: " + str(e)
-        return [TextContent(type="text", text=message)]
+    except JqFilterTimeout:
+        logger.warning("jq filter exceeded its time limit and was terminated")
+        return [TextContent(type="text", text="jsonpath filter exceeded the execution time limit")]
+    except JqFilterError as exc:
+        logger.warning("jq filter failed: %s", exc)
+        return [TextContent(type="text", text="Error applying jsonpath filter")]
 
     return result
 

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -101,7 +101,7 @@ from mcpgateway.utils.gateway_access import build_gateway_auth_headers, check_ga
 from mcpgateway.utils.header_filtering import filter_sensitive_headers
 from mcpgateway.utils.identity_propagation import build_identity_headers, build_identity_meta
 from mcpgateway.utils.jq_guard import assert_safe_jq_filter
-from mcpgateway.utils.jq_runner import JqFilterError, JqFilterTimeout, run_jq_filter
+from mcpgateway.utils.jq_runner import JqFilterBusy, JqFilterError, JqFilterTimeout, run_jq_filter
 from mcpgateway.utils.log_sanitizer import sanitize_for_log
 from mcpgateway.utils.metrics_common import build_top_performers
 from mcpgateway.utils.pagination import decode_cursor, encode_cursor, unified_paginate
@@ -791,6 +791,9 @@ def extract_using_jq(data, jq_filter=""):
     except JqFilterTimeout:
         logger.warning("jq filter exceeded its time limit and was terminated")
         return [TextContent(type="text", text="jsonpath filter exceeded the execution time limit")]
+    except JqFilterBusy:
+        logger.warning("jq filter sandbox had no free worker")
+        return [TextContent(type="text", text="jsonpath filter sandbox is busy, try again")]
     except JqFilterError as exc:
         logger.warning("jq filter failed: %s", exc)
         return [TextContent(type="text", text="Error applying jsonpath filter")]

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -5718,7 +5718,7 @@ class ToolService(BaseService):
                             except (json.JSONDecodeError, orjson.JSONDecodeError, UnicodeDecodeError, AttributeError) as e:
                                 result = _handle_json_parse_error(response, e, is_error_response=False)
                             logger.debug("REST API tool response: %s", result)
-                            filtered_response = extract_using_jq(result, tool_jsonpath_filter)
+                            filtered_response = await asyncio.to_thread(extract_using_jq, result, tool_jsonpath_filter)
                             # Check if extract_using_jq returned an error (list of TextContent objects)
                             if isinstance(filtered_response, list) and len(filtered_response) > 0 and isinstance(filtered_response[0], TextContent):
                                 # Error case - use the TextContent directly
@@ -6400,7 +6400,7 @@ class ToolService(BaseService):
                             content = dump.get("content", [])
                             # Accept both alias and pythonic names for structured content
                             structured = dump.get("structuredContent") or dump.get("structured_content")
-                            filtered_response = extract_using_jq(content, tool_jsonpath_filter)
+                            filtered_response = await asyncio.to_thread(extract_using_jq, content, tool_jsonpath_filter)
 
                             is_err = getattr(tool_call_result, "is_error", None)
                             if is_err is None:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -723,7 +723,11 @@ def extract_using_jq(data, jq_filter=""):
     """
     Extracts data from a given input (string, dict, or list) using a jq filter string.
 
-    Uses cached compiled jq programs for performance.
+    The filter is refused if it uses a restricted jq built-in, then delegated to
+    the sandboxed runner in :mod:`mcpgateway.utils.jq_runner`, which owns program
+    compilation, caching, and the worker pool. A refusal, a timeout, or an
+    execution failure comes back as a single ``TextContent`` in a list, which
+    callers must treat as an error result rather than as tool output.
 
     Args:
         data (str, dict, list): The input JSON data. Can be a string, dict, or list.
@@ -792,6 +796,25 @@ def extract_using_jq(data, jq_filter=""):
         return [TextContent(type="text", text="Error applying jsonpath filter")]
 
     return result
+
+
+def _is_jq_filter_error(filtered_response) -> bool:
+    """Report whether ``extract_using_jq`` returned an error rather than data.
+
+    Refusals, timeouts, and execution failures come back as a list holding a
+    single ``TextContent``. Filter output never contains ``TextContent``
+    instances on either sink: the REST sink filters ``response.json()`` and the
+    MCP passthrough sink filters a ``model_dump(mode="json")`` payload, both of
+    which are plain JSON data by the time the filter runs.
+
+    Args:
+        filtered_response: Whatever ``extract_using_jq`` returned.
+
+    Returns:
+        True when the value is an error result that must not be reported as a
+        successful invocation.
+    """
+    return isinstance(filtered_response, list) and len(filtered_response) > 0 and isinstance(filtered_response[0], TextContent)
 
 
 _VALID_HTTP_HEADER_NAME = re.compile(r"^[!#$%&'*+\-.0-9A-Z^_`a-z|~]+$")
@@ -5720,7 +5743,7 @@ class ToolService(BaseService):
                             logger.debug("REST API tool response: %s", result)
                             filtered_response = await asyncio.to_thread(extract_using_jq, result, tool_jsonpath_filter)
                             # Check if extract_using_jq returned an error (list of TextContent objects)
-                            if isinstance(filtered_response, list) and len(filtered_response) > 0 and isinstance(filtered_response[0], TextContent):
+                            if _is_jq_filter_error(filtered_response):
                                 # Error case - use the TextContent directly
                                 tool_result = ToolResult(content=filtered_response, is_error=True)
                                 success = False
@@ -6405,6 +6428,12 @@ class ToolService(BaseService):
                             is_err = getattr(tool_call_result, "is_error", None)
                             if is_err is None:
                                 is_err = getattr(tool_call_result, "isError", False)
+                            # A refused or timed-out filter must be reported as an error here
+                            # too. Without this the refusal string was recorded as a successful
+                            # invocation carrying it as if it were real tool output.
+                            if _is_jq_filter_error(filtered_response):
+                                is_err = True
+                                structured = None
                             tool_result = ToolResult(content=filtered_response, structured_content=structured, is_error=is_err, meta=getattr(tool_call_result, "meta", None))
                             success = not is_err
                             logger.debug("Final tool_result: %s", tool_result)

--- a/mcpgateway/utils/jq_guard.py
+++ b/mcpgateway/utils/jq_guard.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+"""Static safety gate for user-supplied jq filters.
+
+Tool ``jsonpath_filter`` values are compiled and executed by the gateway. jq
+exposes built-ins that read the host process environment (``env``, ``$ENV``),
+read host state (``input_filename``, ``$__loc__``), write to the gateway's
+stderr (``debug``, ``stderr``), and load code from disk (``include``,
+``import``, ``modulemeta``). None of those belong in a response filter.
+
+This module rejects them before compilation. It is deliberately free of
+``mcpgateway`` imports so that ``schemas.py`` can use it at validation time
+without creating an import cycle through ``tool_service``.
+
+The scanner is not a full jq parser. It tracks just enough structure to avoid
+two classes of mistake a plain regex makes: it does not match denied names
+inside string literals or comments, and it does descend into ``\\(...)``
+interpolation, which is executable code. An identifier directly preceded by
+``.`` is field access rather than a built-in, and jq rejects whitespace between
+the dot and the name, so that suppression cannot be bypassed.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import re
+from typing import Set
+
+__all__ = ["DENIED_JQ_TOKENS", "assert_safe_jq_filter", "scan_jq_tokens"]
+
+_IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+DENIED_JQ_TOKENS = frozenset(
+    {
+        # Process environment.
+        "env",
+        "$ENV",
+        # Input-stream reads.
+        "input",
+        "inputs",
+        # Host state.
+        "input_filename",
+        "input_line_number",
+        "$__loc__",
+        # Writes to the gateway's own stderr.
+        "debug",
+        "stderr",
+        # Filesystem module loading.
+        "include",
+        "import",
+        "modulemeta",
+    }
+)
+
+
+def scan_jq_tokens(text: str) -> Set[str]:
+    """Collect identifier and ``$name`` tokens that jq would treat as code.
+
+    String literals and ``#`` comments are skipped. ``\\(...)`` interpolation is
+    entered, including when nested inside a further string. Identifiers directly
+    preceded by ``.`` are omitted because they are field names.
+
+    Args:
+        text: The jq filter source.
+
+    Returns:
+        The set of code-position tokens found.
+
+    Examples:
+        >>> sorted(scan_jq_tokens(".a|env"))
+        ['env']
+        >>> sorted(scan_jq_tokens(".env"))
+        []
+        >>> sorted(scan_jq_tokens('"env"'))
+        []
+        >>> sorted(scan_jq_tokens('"\\\\(env)"'))
+        ['env']
+    """
+    tokens: Set[str] = set()
+    modes = ["code"]  # innermost last: "code" or "string"
+    depths = [0]  # paren depth for each code frame
+    prev = ""  # previous significant character in the current code frame
+    index = 0
+    length = len(text)
+
+    while index < length:
+        char = text[index]
+
+        if modes[-1] == "string":
+            if char == "\\":
+                if index + 1 < length and text[index + 1] == "(":
+                    modes.append("code")
+                    depths.append(0)
+                    prev = ""
+                    index += 2
+                    continue
+                index += 2
+                continue
+            if char == '"':
+                modes.pop()
+                index += 1
+                continue
+            index += 1
+            continue
+
+        if char == "#":
+            while index < length and text[index] != "\n":
+                index += 1
+            continue
+
+        if char == '"':
+            modes.append("string")
+            prev = '"'
+            index += 1
+            continue
+
+        if char == "(":
+            depths[-1] += 1
+            prev = "("
+            index += 1
+            continue
+
+        if char == ")":
+            if depths[-1] == 0 and len(modes) > 1:
+                modes.pop()
+                depths.pop()
+                prev = ""
+                index += 1
+                continue
+            if depths[-1] > 0:
+                depths[-1] -= 1
+            prev = ")"
+            index += 1
+            continue
+
+        if char == "$":
+            match = _IDENT.match(text, index + 1)
+            if match:
+                tokens.add("$" + match.group(0))
+                prev = "w"
+                index = match.end()
+                continue
+            prev = "$"
+            index += 1
+            continue
+
+        match = _IDENT.match(text, index)
+        if match:
+            if prev != ".":
+                tokens.add(match.group(0))
+            prev = "w"
+            index = match.end()
+            continue
+
+        if not char.isspace():
+            prev = char
+        index += 1
+
+    return tokens
+
+
+def assert_safe_jq_filter(jq_filter: str) -> None:
+    """Reject a jq filter that uses a restricted built-in.
+
+    Args:
+        jq_filter: The jq filter source to check.
+
+    Raises:
+        ValueError: If the filter references a denied built-in.
+
+    Examples:
+        >>> assert_safe_jq_filter(".a.b") is None
+        True
+        >>> assert_safe_jq_filter("$ENV")
+        Traceback (most recent call last):
+            ...
+        ValueError: jq filter uses a restricted built-in: $ENV
+    """
+    if not jq_filter:
+        return None
+
+    denied = sorted(scan_jq_tokens(jq_filter) & DENIED_JQ_TOKENS)
+    if denied:
+        raise ValueError(f"jq filter uses a restricted built-in: {', '.join(denied)}")
+    return None

--- a/mcpgateway/utils/jq_guard.py
+++ b/mcpgateway/utils/jq_guard.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-"""Static safety gate for user-supplied jq filters.
+"""Location: ./mcpgateway/utils/jq_guard.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Static safety gate for user-supplied jq filters.
 
 Tool ``jsonpath_filter`` values are compiled and executed by the gateway. jq
 exposes built-ins that read the host process environment (``env``, ``$ENV``),

--- a/mcpgateway/utils/jq_runner.py
+++ b/mcpgateway/utils/jq_runner.py
@@ -10,25 +10,32 @@ Filters therefore run in a forked worker whose environment has been cleared,
 under a wall-clock limit, with the worker killed and replaced if it overruns.
 The static gate in :mod:`mcpgateway.utils.jq_guard` runs first; the scrubbed
 worker is the backstop for anything the gate misses.
-
-The pool is added in the next commit; this module currently executes in-process.
 """
 
 # Future
 from __future__ import annotations
 
 # Standard
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from functools import lru_cache
 import logging
-from typing import Any
+import multiprocessing
+import os
+import sys
+import threading
+from typing import Any, Optional
 
 # Third-Party
 import jq
 import orjson
 
+# First-Party
+from mcpgateway.config import settings
+
 logger = logging.getLogger(__name__)
 
-__all__ = ["JqFilterError", "JqFilterTimeout", "run_jq_filter"]
+__all__ = ["JqFilterError", "JqFilterTimeout", "run_jq_filter", "start_jq_pool", "shutdown_jq_pool", "subprocess_mode_available"]
 
 
 class JqFilterError(Exception):
@@ -37,6 +44,134 @@ class JqFilterError(Exception):
 
 class JqFilterTimeout(JqFilterError):
     """Raised when a jq filter exceeds its wall-clock limit."""
+
+
+_POOL: Optional[ProcessPoolExecutor] = None
+_POOL_PID: Optional[int] = None
+_POOL_LOCK = threading.Lock()
+_FALLBACK_WARNED = False
+
+
+def subprocess_mode_available() -> bool:
+    """Report whether the forked sandbox can be used on this platform.
+
+    The sandbox requires the ``fork`` start method. ``spawn`` and ``forkserver``
+    re-import the parent's main module, which is unsafe under a preloaded
+    gunicorn master, and ``fork`` itself is unsafe on Darwin.
+
+    Returns:
+        True when the sandbox should be used.
+    """
+    if settings.jq_filter_execution != "subprocess":
+        return False
+    return sys.platform.startswith("linux")
+
+
+def _worker_init() -> None:
+    """Clear the inherited environment inside a jq worker process.
+
+    jq captures the process environment when a program is compiled, so this must
+    run before any filter is compiled in this process.
+    """
+    os.environ.clear()
+
+
+def _build_pool() -> ProcessPoolExecutor:
+    """Create a forked worker pool with a scrubbed environment.
+
+    Returns:
+        The new executor.
+    """
+    return ProcessPoolExecutor(
+        max_workers=settings.jq_filter_workers,
+        mp_context=multiprocessing.get_context("fork"),
+        initializer=_worker_init,
+    )
+
+
+def start_jq_pool() -> None:
+    """Create the jq worker pool for this process.
+
+    Call from application startup, after any fork performed by the server, so
+    that each gateway worker owns its own pool.
+    """
+    global _POOL, _POOL_PID, _FALLBACK_WARNED  # pylint: disable=global-statement
+
+    if not subprocess_mode_available():
+        if not _FALLBACK_WARNED:
+            logger.warning(
+                "jq filter sandbox is disabled (execution=%s, platform=%s). Tool jsonpath_filter programs will run in-process with no environment scrub and no time limit. This is unsafe outside development.",
+                settings.jq_filter_execution,
+                sys.platform,
+            )
+            _FALLBACK_WARNED = True
+        return
+
+    with _POOL_LOCK:
+        if _POOL is not None and _POOL_PID == os.getpid():
+            return
+        _POOL = _build_pool()
+        _POOL_PID = os.getpid()
+        logger.info("jq filter sandbox started with %s worker(s)", settings.jq_filter_workers)
+
+
+def shutdown_jq_pool() -> None:
+    """Tear down the jq worker pool for this process."""
+    global _POOL, _POOL_PID  # pylint: disable=global-statement
+
+    with _POOL_LOCK:
+        if _POOL is None:
+            return
+        _POOL.shutdown(wait=False, cancel_futures=True)
+        _POOL = None
+        _POOL_PID = None
+
+
+def _kill_pool_workers() -> None:
+    """Kill every worker in the current pool and drop it.
+
+    ``ProcessPoolExecutor`` cannot cancel a task that is already running, and
+    the public ``terminate_workers``/``kill_workers`` methods are Python 3.14
+    while this project targets 3.12. The private ``_processes`` mapping is the
+    only route; it is read defensively and pinned by a test.
+    """
+    global _POOL, _POOL_PID  # pylint: disable=global-statement
+
+    pool = _POOL
+    if pool is None:
+        return
+    for process in list(getattr(pool, "_processes", {}).values()):
+        try:
+            process.kill()
+        except Exception:  # pylint: disable=broad-except
+            logger.warning("Failed to kill a jq worker process", exc_info=True)
+    pool.shutdown(wait=False, cancel_futures=True)
+    _POOL = None
+    _POOL_PID = None
+
+
+def _ensure_pool() -> ProcessPoolExecutor:
+    """Return a live pool for this process, creating one if needed.
+
+    Returns:
+        The executor owned by this process.
+
+    Raises:
+        JqFilterError: If the pool cannot be created.
+    """
+    global _POOL, _POOL_PID  # pylint: disable=global-statement
+
+    with _POOL_LOCK:
+        if _POOL is not None and _POOL_PID == os.getpid():
+            return _POOL
+        try:
+            _POOL = _build_pool()
+            _POOL_PID = os.getpid()
+        except Exception as exc:  # pylint: disable=broad-except
+            _POOL = None
+            _POOL_PID = None
+            raise JqFilterError(f"jq filter sandbox unavailable: {exc}") from exc
+        return _POOL
 
 
 @lru_cache(maxsize=256)
@@ -93,10 +228,6 @@ def _run_inprocess(jq_filter: str, data: Any) -> Any:
 def run_jq_filter(jq_filter: str, data: Any) -> Any:
     """Apply a jq filter to a document under the configured execution mode.
 
-    Task 5 adds the sandboxed pool behind this same signature. Until then, every
-    mode runs in-process — there is exactly one code path, not a branch that
-    happens to agree with itself.
-
     Args:
         jq_filter: The jq filter source.
         data: The input document. Must be JSON-serializable.
@@ -105,7 +236,21 @@ def run_jq_filter(jq_filter: str, data: Any) -> Any:
         The filter result as plain Python data.
 
     Raises:
-        JqFilterError: If compilation or execution fails.
+        JqFilterError: If compilation or execution fails, or the sandbox is unavailable.
         JqFilterTimeout: If the filter exceeds its wall-clock limit.
     """
-    return _run_inprocess(jq_filter, data)
+    if not subprocess_mode_available():
+        return _run_inprocess(jq_filter, data)
+
+    pool = _ensure_pool()
+    future = pool.submit(_apply_filter, jq_filter, orjson.dumps(data))
+    try:
+        return orjson.loads(future.result(timeout=settings.jq_filter_timeout_seconds))
+    except FutureTimeoutError as exc:
+        logger.warning("jq filter exceeded %ss limit; killing worker", settings.jq_filter_timeout_seconds)
+        _kill_pool_workers()
+        raise JqFilterTimeout("jq filter exceeded the execution time limit") from exc
+    except JqFilterError:
+        raise
+    except Exception as exc:  # pylint: disable=broad-except
+        raise JqFilterError(str(exc)) from exc

--- a/mcpgateway/utils/jq_runner.py
+++ b/mcpgateway/utils/jq_runner.py
@@ -26,9 +26,6 @@ from typing import Any
 import jq
 import orjson
 
-# First-Party
-from mcpgateway.config import settings
-
 logger = logging.getLogger(__name__)
 
 __all__ = ["JqFilterError", "JqFilterTimeout", "run_jq_filter"]

--- a/mcpgateway/utils/jq_runner.py
+++ b/mcpgateway/utils/jq_runner.py
@@ -110,7 +110,18 @@ def start_jq_pool() -> None:
     with _POOL_LOCK:
         if _POOL is not None and _POOL_PID == os.getpid():
             return
-        _POOL = _build_pool()
+        pool = _build_pool()
+        # ProcessPoolExecutor with the fork start method spawns workers lazily on
+        # first submit, not at construction. Force that fork to happen now, while
+        # the process still has the fewest threads, rather than mid-request on the
+        # first attacker-triggered filter. This also proves the initializer (the
+        # environment scrub) actually ran before we call the pool ready.
+        try:
+            pool.submit(_apply_filter, ".", b"null").result(timeout=settings.jq_filter_timeout_seconds)
+        except Exception:
+            pool.shutdown(wait=False, cancel_futures=True)
+            raise
+        _POOL = pool
         _POOL_PID = os.getpid()
         logger.info("jq filter sandbox started with %s worker(s)", settings.jq_filter_workers)
 
@@ -121,6 +132,12 @@ def shutdown_jq_pool() -> None:
 
     with _POOL_LOCK:
         if _POOL is None:
+            return
+        if _POOL_PID != os.getpid():
+            # Inherited from a parent via fork; this process never owned these
+            # workers, so drop the reference without touching the parent's pool.
+            _POOL = None
+            _POOL_PID = None
             return
         _POOL.shutdown(wait=False, cancel_futures=True)
         _POOL = None
@@ -140,14 +157,24 @@ def _kill_pool_workers() -> None:
     pool = _POOL
     if pool is None:
         return
-    for process in list(getattr(pool, "_processes", {}).values()):
-        try:
-            process.kill()
-        except Exception:  # pylint: disable=broad-except
-            logger.warning("Failed to kill a jq worker process", exc_info=True)
-    pool.shutdown(wait=False, cancel_futures=True)
-    _POOL = None
-    _POOL_PID = None
+    with _POOL_LOCK:
+        if _POOL is not pool:
+            # Another thread already rebuilt or dropped the pool; leave it alone.
+            return
+        if _POOL_PID != os.getpid():
+            # Inherited from a parent via fork; these Process objects reference
+            # the parent's workers. Never kill processes we don't own.
+            _POOL = None
+            _POOL_PID = None
+            return
+        for process in list(getattr(pool, "_processes", {}).values()):
+            try:
+                process.kill()
+            except Exception:  # pylint: disable=broad-except
+                logger.warning("Failed to kill a jq worker process", exc_info=True)
+        pool.shutdown(wait=False, cancel_futures=True)
+        _POOL = None
+        _POOL_PID = None
 
 
 def _ensure_pool() -> ProcessPoolExecutor:
@@ -243,8 +270,8 @@ def run_jq_filter(jq_filter: str, data: Any) -> Any:
         return _run_inprocess(jq_filter, data)
 
     pool = _ensure_pool()
-    future = pool.submit(_apply_filter, jq_filter, orjson.dumps(data))
     try:
+        future = pool.submit(_apply_filter, jq_filter, orjson.dumps(data))
         return orjson.loads(future.result(timeout=settings.jq_filter_timeout_seconds))
     except FutureTimeoutError as exc:
         logger.warning("jq filter exceeded %ss limit; killing worker", settings.jq_filter_timeout_seconds)

--- a/mcpgateway/utils/jq_runner.py
+++ b/mcpgateway/utils/jq_runner.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 # Standard
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import TimeoutError as FutureTimeoutError
+from concurrent.futures.process import BrokenProcessPool
 from functools import lru_cache
 import logging
 import multiprocessing
@@ -36,6 +37,7 @@ import orjson
 
 # First-Party
 from mcpgateway.config import settings
+from mcpgateway.utils.jq_guard import assert_safe_jq_filter
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +56,17 @@ _POOL: Optional[ProcessPoolExecutor] = None
 _POOL_PID: Optional[int] = None
 _POOL_LOCK = threading.Lock()
 _FALLBACK_WARNED = False
+
+# Attribute stamped on each executor with the PID that built it. Ownership has
+# to be decidable from the pool object alone: a pool can be replaced (or its
+# global reference cleared by ``shutdown_jq_pool``) while one of its workers is
+# still running a hostile filter, and that worker must still be killable.
+_OWNER_PID_ATTR = "_mcpgateway_owner_pid"
+
+# Lower bound on how long ``start_jq_pool`` waits for the warm-up filter. The
+# per-filter timeout is only validated as ``gt=0``, so an aggressively short
+# value must not also shrink the startup budget and turn a boot into a failure.
+_WARMUP_MIN_SECONDS = 10.0
 
 
 def subprocess_mode_available() -> bool:
@@ -84,13 +97,51 @@ def _build_pool() -> ProcessPoolExecutor:
     """Create a forked worker pool with a scrubbed environment.
 
     Returns:
-        The new executor.
+        The new executor, stamped with the PID that created it.
     """
-    return ProcessPoolExecutor(
+    pool = ProcessPoolExecutor(
         max_workers=settings.jq_filter_workers,
         mp_context=multiprocessing.get_context("fork"),
         initializer=_worker_init,
     )
+    setattr(pool, _OWNER_PID_ATTR, os.getpid())
+    return pool
+
+
+def _pool_is_owned(pool: ProcessPoolExecutor) -> bool:
+    """Report whether this process forked the given pool's workers.
+
+    Args:
+        pool: The executor to test.
+
+    Returns:
+        True when the pool was built by this process, so killing its worker
+        processes is safe. False for a pool inherited across a fork, whose
+        ``Process`` objects reference the parent's children.
+    """
+    return getattr(pool, _OWNER_PID_ATTR, None) == os.getpid()
+
+
+def _kill_workers(pool: ProcessPoolExecutor) -> None:
+    """Kill every worker process belonging to a pool this process owns.
+
+    ``ProcessPoolExecutor`` cannot cancel a task that is already running, and
+    the public ``terminate_workers``/``kill_workers`` methods are Python 3.14
+    while this project targets 3.12. The private ``_processes`` mapping is the
+    only route; it is read defensively and pinned by a test.
+
+    Args:
+        pool: The executor whose workers should be killed. Callers must have
+            confirmed ownership via :func:`_pool_is_owned` first.
+    """
+    # ``shutdown`` sets ``_processes`` to None to release file descriptors, so a
+    # pool that has already been shut down elsewhere must not blow up here.
+    for process in list((getattr(pool, "_processes", None) or {}).values()):
+        try:
+            process.kill()
+        except Exception:  # pylint: disable=broad-except
+            logger.warning("Failed to kill a jq worker process", exc_info=True)
+    pool.shutdown(wait=False, cancel_futures=True)
 
 
 def start_jq_pool() -> None:
@@ -98,6 +149,13 @@ def start_jq_pool() -> None:
 
     Call from application startup, after any fork performed by the server, so
     that each gateway worker owns its own pool.
+
+    Raises:
+        Exception: Whatever the warm-up submit raises when the sandbox cannot be
+            brought up (``BrokenProcessPool``, ``TimeoutError``, ``OSError``).
+            This is deliberately left to propagate: on Linux with subprocess
+            mode a pool that will not start is a hard startup failure, since the
+            alternative is booting a gateway whose filter sandbox is absent.
     """
     global _POOL, _POOL_PID, _FALLBACK_WARNED  # pylint: disable=global-statement
 
@@ -121,7 +179,7 @@ def start_jq_pool() -> None:
         # first attacker-triggered filter. This also proves the initializer (the
         # environment scrub) actually ran before we call the pool ready.
         try:
-            pool.submit(_apply_filter, ".", b"null").result(timeout=settings.jq_filter_timeout_seconds)
+            pool.submit(_apply_filter, ".", b"null").result(timeout=max(_WARMUP_MIN_SECONDS, settings.jq_filter_timeout_seconds))
         except Exception:
             pool.shutdown(wait=False, cancel_futures=True)
             raise
@@ -131,54 +189,54 @@ def start_jq_pool() -> None:
 
 
 def shutdown_jq_pool() -> None:
-    """Tear down the jq worker pool for this process."""
-    global _POOL, _POOL_PID  # pylint: disable=global-statement
+    """Tear down the jq worker pool for this process.
 
-    with _POOL_LOCK:
-        if _POOL is None:
-            return
-        if _POOL_PID != os.getpid():
-            # Inherited from a parent via fork; this process never owned these
-            # workers, so drop the reference without touching the parent's pool.
-            _POOL = None
-            _POOL_PID = None
-            return
-        _POOL.shutdown(wait=False, cancel_futures=True)
-        _POOL = None
-        _POOL_PID = None
+    Kills the pool's worker processes rather than only cancelling queued work.
+    ``ProcessPoolExecutor.shutdown(wait=False, cancel_futures=True)`` drops
+    *pending* futures but cannot stop a worker already mid-filter, and the
+    executor's own ``atexit`` hook then blocks interpreter exit trying to join a
+    worker that is running a non-terminating jq program.
+    """
+    _discard_pool(None)
 
 
-def _kill_pool_workers() -> None:
-    """Kill every worker in the current pool and drop it.
+def _discard_pool(pool: Optional[ProcessPoolExecutor]) -> None:
+    """Kill a pool's workers and clear the module globals if they still name it.
 
-    ``ProcessPoolExecutor`` cannot cancel a task that is already running, and
-    the public ``terminate_workers``/``kill_workers`` methods are Python 3.14
-    while this project targets 3.12. The private ``_processes`` mapping is the
-    only route; it is read defensively and pinned by a test.
+    Killing is decided per pool object, not from the global ``_POOL`` pointer.
+    A pool whose worker is running a hostile filter must stay killable even if
+    another thread (application shutdown, a concurrent rebuild) has already
+    moved ``_POOL`` on to something else — otherwise the runaway worker is
+    orphaned and wedges interpreter exit. Conversely, a pool inherited across a
+    fork is never killed: its ``Process`` objects belong to the parent.
+
+    Args:
+        pool: The executor to discard, or None to discard whichever pool
+            ``_POOL`` currently names.
     """
     global _POOL, _POOL_PID  # pylint: disable=global-statement
 
-    pool = _POOL
-    if pool is None:
-        return
     with _POOL_LOCK:
-        if _POOL is not pool:
-            # Another thread already rebuilt or dropped the pool; leave it alone.
+        target = pool if pool is not None else _POOL
+        if target is None:
             return
-        if _POOL_PID != os.getpid():
-            # Inherited from a parent via fork; these Process objects reference
-            # the parent's workers. Never kill processes we don't own.
+        if _pool_is_owned(target):
+            _kill_workers(target)
+        # Only stand down the shared globals if they still point at the exact
+        # pool just handled; a newer pool built by another thread is left alone.
+        if _POOL is target:
             _POOL = None
             _POOL_PID = None
-            return
-        for process in list(getattr(pool, "_processes", {}).values()):
-            try:
-                process.kill()
-            except Exception:  # pylint: disable=broad-except
-                logger.warning("Failed to kill a jq worker process", exc_info=True)
-        pool.shutdown(wait=False, cancel_futures=True)
-        _POOL = None
-        _POOL_PID = None
+
+
+def _kill_pool_workers(pool: Optional[ProcessPoolExecutor] = None) -> None:
+    """Kill the workers of a pool that overran its limit and drop it.
+
+    Args:
+        pool: The executor the overrunning filter was submitted to. Defaults to
+            whichever pool ``_POOL`` currently names.
+    """
+    _discard_pool(pool)
 
 
 def _ensure_pool() -> ProcessPoolExecutor:
@@ -267,9 +325,17 @@ def run_jq_filter(jq_filter: str, data: Any) -> Any:
         The filter result as plain Python data.
 
     Raises:
+        ValueError: If the filter uses a restricted jq built-in.
         JqFilterError: If compilation or execution fails, or the sandbox is unavailable.
         JqFilterTimeout: If the filter exceeds its wall-clock limit.
     """
+    # Defence in depth. This module's contract is that the static gate has
+    # already run, which is true today only because ``extract_using_jq`` is the
+    # sole caller. Re-asserting it here keeps that contract true for any future
+    # caller of this exported function. ValueError is left to propagate
+    # unchanged so callers see the same exception the gate always raised.
+    assert_safe_jq_filter(jq_filter)
+
     if not subprocess_mode_available():
         return _run_inprocess(jq_filter, data)
 
@@ -279,8 +345,17 @@ def run_jq_filter(jq_filter: str, data: Any) -> Any:
         return orjson.loads(future.result(timeout=settings.jq_filter_timeout_seconds))
     except FutureTimeoutError as exc:
         logger.warning("jq filter exceeded %ss limit; killing worker", settings.jq_filter_timeout_seconds)
-        _kill_pool_workers()
+        _kill_pool_workers(pool)
         raise JqFilterTimeout("jq filter exceeded the execution time limit") from exc
+    except BrokenProcessPool as exc:
+        # A worker died without the timeout firing — the kernel OOM-killing a
+        # filter that allocated without bound is the realistic trigger, and
+        # nothing here bounds worker memory. The executor is permanently broken
+        # afterwards: every later submit() raises. Drop it so the next call
+        # rebuilds, instead of bricking filtering for this whole process.
+        logger.warning("jq worker pool broke (worker died abnormally); discarding it so the next filter rebuilds")
+        _discard_pool(pool)
+        raise JqFilterError(str(exc)) from exc
     except JqFilterError:
         raise
     except Exception as exc:  # pylint: disable=broad-except

--- a/mcpgateway/utils/jq_runner.py
+++ b/mcpgateway/utils/jq_runner.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""Sandboxed execution of user-supplied jq filters.
+
+Tool ``jsonpath_filter`` programs are attacker-influenced input. python-jq
+offers no timeout and holds the GIL for the duration of a run, so a filter that
+does not terminate freezes the whole gateway worker. jq also exposes built-ins
+that read the process environment.
+
+Filters therefore run in a forked worker whose environment has been cleared,
+under a wall-clock limit, with the worker killed and replaced if it overruns.
+The static gate in :mod:`mcpgateway.utils.jq_guard` runs first; the scrubbed
+worker is the backstop for anything the gate misses.
+
+The pool is added in the next commit; this module currently executes in-process.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from functools import lru_cache
+import logging
+from typing import Any
+
+# Third-Party
+import jq
+import orjson
+
+# First-Party
+from mcpgateway.config import settings
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["JqFilterError", "JqFilterTimeout", "run_jq_filter"]
+
+
+class JqFilterError(Exception):
+    """Raised when a jq filter cannot be compiled or executed."""
+
+
+class JqFilterTimeout(JqFilterError):
+    """Raised when a jq filter exceeds its wall-clock limit."""
+
+
+@lru_cache(maxsize=256)
+def _compile_jq_filter(jq_filter: str):
+    """Compile and cache a jq program.
+
+    Args:
+        jq_filter: The jq filter source.
+
+    Returns:
+        The compiled jq program.
+    """
+    # pylint: disable=c-extension-no-member
+    return jq.compile(jq_filter)
+
+
+def _apply_filter(jq_filter: str, data_bytes: bytes) -> bytes:
+    """Apply a jq filter to serialized JSON and return serialized output.
+
+    This is the worker entry point. It must stay importable without pulling in
+    the rest of the application, and it must not touch the database, the
+    settings object, or the logger.
+
+    Args:
+        jq_filter: The jq filter source.
+        data_bytes: The input document, serialized with orjson.
+
+    Returns:
+        The filter result, serialized with orjson.
+    """
+    data = orjson.loads(data_bytes)
+    return orjson.dumps(_compile_jq_filter(jq_filter).input(data).all())
+
+
+def _run_inprocess(jq_filter: str, data: Any) -> Any:
+    """Apply a jq filter in the current process.
+
+    Args:
+        jq_filter: The jq filter source.
+        data: The input document.
+
+    Returns:
+        The filter result.
+
+    Raises:
+        JqFilterError: If compilation or execution fails.
+    """
+    try:
+        return orjson.loads(_apply_filter(jq_filter, orjson.dumps(data)))
+    except Exception as exc:  # pylint: disable=broad-except
+        raise JqFilterError(str(exc)) from exc
+
+
+def run_jq_filter(jq_filter: str, data: Any) -> Any:
+    """Apply a jq filter to a document under the configured execution mode.
+
+    Task 5 adds the sandboxed pool behind this same signature. Until then, every
+    mode runs in-process — there is exactly one code path, not a branch that
+    happens to agree with itself.
+
+    Args:
+        jq_filter: The jq filter source.
+        data: The input document. Must be JSON-serializable.
+
+    Returns:
+        The filter result as plain Python data.
+
+    Raises:
+        JqFilterError: If compilation or execution fails.
+        JqFilterTimeout: If the filter exceeds its wall-clock limit.
+    """
+    return _run_inprocess(jq_filter, data)

--- a/mcpgateway/utils/jq_runner.py
+++ b/mcpgateway/utils/jq_runner.py
@@ -41,7 +41,7 @@ from mcpgateway.utils.jq_guard import assert_safe_jq_filter
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["JqFilterError", "JqFilterTimeout", "run_jq_filter", "start_jq_pool", "shutdown_jq_pool", "subprocess_mode_available"]
+__all__ = ["JqFilterBusy", "JqFilterError", "JqFilterTimeout", "run_jq_filter", "start_jq_pool", "shutdown_jq_pool", "subprocess_mode_available"]
 
 
 class JqFilterError(Exception):
@@ -49,7 +49,23 @@ class JqFilterError(Exception):
 
 
 class JqFilterTimeout(JqFilterError):
-    """Raised when a jq filter exceeds its wall-clock limit."""
+    """Raised when a jq filter exceeds its wall-clock limit.
+
+    Only raised for a submission that is known to have started running
+    immediately (the submit gate guarantees a free worker was available), so
+    this always reflects a filter that is genuinely still executing past its
+    budget, never queueing pressure from ordinary concurrent load.
+    """
+
+
+class JqFilterBusy(JqFilterError):
+    """Raised when every worker is already busy running another filter.
+
+    Distinct from :class:`JqFilterTimeout`: no filter has overrun anything,
+    there simply wasn't a free worker slot for this call right now. Safe to
+    retry, and does not indicate a hostile or hung filter, so it never kills
+    the pool.
+    """
 
 
 _POOL: Optional[ProcessPoolExecutor] = None
@@ -62,6 +78,18 @@ _FALLBACK_WARNED = False
 # global reference cleared by ``shutdown_jq_pool``) while one of its workers is
 # still running a hostile filter, and that worker must still be killable.
 _OWNER_PID_ATTR = "_mcpgateway_owner_pid"
+
+# Attribute stamped on each executor with a Semaphore sized to that pool's own
+# worker count. ``ProcessPoolExecutor.submit()`` queues a task the moment a
+# free work slot doesn't exist -- ``Future.result(timeout=...)`` then times
+# queue wait and execution together, and a task that never even started
+# running is indistinguishable from a genuine runaway once the timeout fires.
+# Gating admission at this semaphore keeps every submission that actually
+# reaches the pool guaranteed to start immediately, so a timeout on it is a
+# real signal a filter is hung -- not queueing pressure from ordinary
+# concurrent load. Stamped on the pool object, not read fresh from settings,
+# so it always matches the worker count that pool was actually built with.
+_GATE_ATTR = "_mcpgateway_submit_gate"
 
 # Lower bound on how long ``start_jq_pool`` waits for the warm-up filter. The
 # per-filter timeout is only validated as ``gt=0``, so an aggressively short
@@ -105,6 +133,7 @@ def _build_pool() -> ProcessPoolExecutor:
         initializer=_worker_init,
     )
     setattr(pool, _OWNER_PID_ATTR, os.getpid())
+    setattr(pool, _GATE_ATTR, threading.Semaphore(settings.jq_filter_workers))
     return pool
 
 
@@ -327,6 +356,7 @@ def run_jq_filter(jq_filter: str, data: Any) -> Any:
     Raises:
         ValueError: If the filter uses a restricted jq built-in.
         JqFilterError: If compilation or execution fails, or the sandbox is unavailable.
+        JqFilterBusy: If every worker is already running another filter.
         JqFilterTimeout: If the filter exceeds its wall-clock limit.
     """
     # Defence in depth. This module's contract is that the static gate has
@@ -340,23 +370,36 @@ def run_jq_filter(jq_filter: str, data: Any) -> Any:
         return _run_inprocess(jq_filter, data)
 
     pool = _ensure_pool()
+    gate = getattr(pool, _GATE_ATTR)
+
+    # ProcessPoolExecutor queues a task the instant every worker is busy, and
+    # future.result(timeout=...) below cannot tell "still queued" apart from
+    # "running past its budget" -- both look like a timeout. Reserving a slot
+    # here first means a submission only ever reaches the pool when a worker
+    # is actually free, so a timeout on it is never queueing pressure.
+    if not gate.acquire(blocking=False):
+        raise JqFilterBusy("jq filter sandbox has no free worker")
+
     try:
-        future = pool.submit(_apply_filter, jq_filter, orjson.dumps(data))
-        return orjson.loads(future.result(timeout=settings.jq_filter_timeout_seconds))
-    except FutureTimeoutError as exc:
-        logger.warning("jq filter exceeded %ss limit; killing worker", settings.jq_filter_timeout_seconds)
-        _kill_pool_workers(pool)
-        raise JqFilterTimeout("jq filter exceeded the execution time limit") from exc
-    except BrokenProcessPool as exc:
-        # A worker died without the timeout firing — the kernel OOM-killing a
-        # filter that allocated without bound is the realistic trigger, and
-        # nothing here bounds worker memory. The executor is permanently broken
-        # afterwards: every later submit() raises. Drop it so the next call
-        # rebuilds, instead of bricking filtering for this whole process.
-        logger.warning("jq worker pool broke (worker died abnormally); discarding it so the next filter rebuilds")
-        _discard_pool(pool)
-        raise JqFilterError(str(exc)) from exc
-    except JqFilterError:
-        raise
-    except Exception as exc:  # pylint: disable=broad-except
-        raise JqFilterError(str(exc)) from exc
+        try:
+            future = pool.submit(_apply_filter, jq_filter, orjson.dumps(data))
+            return orjson.loads(future.result(timeout=settings.jq_filter_timeout_seconds))
+        except FutureTimeoutError as exc:
+            logger.warning("jq filter exceeded %ss limit; killing worker", settings.jq_filter_timeout_seconds)
+            _kill_pool_workers(pool)
+            raise JqFilterTimeout("jq filter exceeded the execution time limit") from exc
+        except BrokenProcessPool as exc:
+            # A worker died without the timeout firing — the kernel OOM-killing a
+            # filter that allocated without bound is the realistic trigger, and
+            # nothing here bounds worker memory. The executor is permanently broken
+            # afterwards: every later submit() raises. Drop it so the next call
+            # rebuilds, instead of bricking filtering for this whole process.
+            logger.warning("jq worker pool broke (worker died abnormally); discarding it so the next filter rebuilds")
+            _discard_pool(pool)
+            raise JqFilterError(str(exc)) from exc
+        except JqFilterError:
+            raise
+        except Exception as exc:  # pylint: disable=broad-except
+            raise JqFilterError(str(exc)) from exc
+    finally:
+        gate.release()

--- a/mcpgateway/utils/jq_runner.py
+++ b/mcpgateway/utils/jq_runner.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-"""Sandboxed execution of user-supplied jq filters.
+"""Location: ./mcpgateway/utils/jq_runner.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Sandboxed execution of user-supplied jq filters.
 
 Tool ``jsonpath_filter`` programs are attacker-influenced input. python-jq
 offers no timeout and holds the GIL for the duration of a run, so a filter that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -802,7 +802,6 @@ also_copy = ["plugins/", "pyproject.toml", "mutmut_config.py"]
 #  📊 coverage - Code coverage configuration
 # --------------------------------------------------------------------
 [tool.coverage.run]
-branch = true
 source = ["mcpgateway"]
 parallel = true
 concurrency = ["thread", "multiprocessing"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -802,6 +802,7 @@ also_copy = ["plugins/", "pyproject.toml", "mutmut_config.py"]
 #  📊 coverage - Code coverage configuration
 # --------------------------------------------------------------------
 [tool.coverage.run]
+branch = true
 source = ["mcpgateway"]
 parallel = true
 concurrency = ["thread", "multiprocessing"]

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -2977,6 +2977,41 @@ class TestToolService:
         assert call_kwargs["success"] is False
 
     @pytest.mark.asyncio
+    async def test_invoke_tool_rest_refuses_stored_env_filter(self, tool_service, mock_tool, mock_global_config_obj, test_db, monkeypatch):
+        """A pre-seeded hostile jsonpath_filter is refused at call time on the REST sink.
+
+        Deliberately does not patch ``extract_using_jq``: the point is that a row
+        written before the schema validator existed still cannot read the gateway's
+        process environment when it is actually invoked.
+        """
+        monkeypatch.setenv("JWT_SECRET_KEY", "rest-sink-canary-must-not-appear")
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.jsonpath_filter = "$ENV"
+        mock_tool.auth_value = None
+
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value={"result": "some data"})
+        tool_service._http_client.request.return_value = mock_response
+
+        mock_metrics_buffer = Mock()
+        mock_metrics_buffer.record_tool_metric = Mock()
+        with (
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+        ):
+            result = await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
+
+        assert result.is_error is True
+        assert result.content[0].text == "jsonpath filter uses a restricted jq builtin"
+        assert "rest-sink-canary-must-not-appear" not in str(result.content)
+        assert mock_metrics_buffer.record_tool_metric.call_args[1]["success"] is False
+
+    @pytest.mark.asyncio
     async def test_invoke_tool_rest_parameter_substitution_missed_input(self, tool_service, mock_tool, mock_global_config_obj, test_db):
         """Test invoking a REST tool."""
         # Configure tool as REST
@@ -3711,6 +3746,100 @@ class TestToolService:
         # is_error should be True from the isError fallback
         assert result.is_error is True
         assert result.content[0].text == "error from remote"
+
+    @pytest.mark.asyncio
+    async def test_invoke_tool_mcp_refuses_stored_env_filter(self, tool_service, mock_tool, test_db, monkeypatch):
+        """A pre-seeded hostile jsonpath_filter is refused at call time on the MCP passthrough sink.
+
+        Also pins that a refused filter is reported as a failed invocation. The
+        passthrough sink used to take ``is_error`` from the upstream result only,
+        so a refusal came back as a *successful* call carrying the refusal string
+        where real tool output belonged.
+        """
+        # Standard
+        from contextlib import asynccontextmanager
+        from types import SimpleNamespace
+
+        monkeypatch.setenv("JWT_SECRET_KEY", "mcp-sink-canary-must-not-appear")
+
+        mock_gateway = SimpleNamespace(
+            id="42",
+            name="test_gateway",
+            slug="test-gateway",
+            url="http://fake-mcp:8080/mcp",
+            enabled=True,
+            deprecated=False,
+            reachable=True,
+            auth_type="bearer",
+            auth_value="Bearer abc123",
+            capabilities={"prompts": {"listChanged": True}, "resources": {"listChanged": True}, "tools": {"listChanged": True}},
+            transport="STREAMABLEHTTP",
+            passthrough_headers=[],
+        )
+        mock_tool.integration_type = "MCP"
+        mock_tool.request_type = "StreamableHTTP"
+        mock_tool.jsonpath_filter = "$ENV"
+        mock_tool.auth_type = None
+        mock_tool.auth_value = None
+        mock_tool.original_name = "dummy_tool"
+        mock_tool.headers = {}
+        mock_tool.name = "test-gateway-dummy-tool"
+        mock_tool.gateway_slug = "test-gateway"
+        mock_tool.gateway_id = mock_gateway.id
+
+        returns = [mock_tool, mock_gateway, mock_gateway]
+
+        def execute_side_effect(*_args, **_kwargs):
+            if returns:
+                value = returns.pop(0)
+            else:
+                value = None
+            m = Mock()
+            m.scalar_one_or_none.return_value = value
+            m.scalars.return_value = m
+            m.all.return_value = [value] if value else []
+            return m
+
+        test_db.execute = Mock(side_effect=execute_side_effect)
+
+        call_result = MagicMock()
+        call_result.is_error = False
+        call_result.isError = False
+        call_result.content = [TextContent(type="text", text="upstream output")]
+        call_result.model_dump.return_value = {
+            "content": [{"type": "text", "text": "upstream output"}],
+            "isError": False,
+            "structuredContent": None,
+            "structured_content": None,
+        }
+        call_result.meta = None
+
+        session_mock = AsyncMock()
+        session_mock.initialize = AsyncMock()
+        session_mock.call_tool = AsyncMock(return_value=call_result)
+
+        client_session_cm = AsyncMock()
+        client_session_cm.__aenter__.return_value = session_mock
+        client_session_cm.__aexit__.return_value = AsyncMock()
+
+        @asynccontextmanager
+        async def mock_streamable_client(*_args, **_kwargs):
+            yield ("read", "write", None)
+
+        mock_metrics_buffer = Mock()
+        mock_metrics_buffer.record_tool_metric = Mock()
+        with (
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.streamablehttp_client", mock_streamable_client),
+            patch("mcpgateway.services.tool_service.ClientSession", return_value=client_session_cm),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={"Authorization": "Bearer xyz"}),
+        ):
+            result = await tool_service.invoke_tool(test_db, "dummy_tool", {"param": "value"}, request_headers=None)
+
+        assert result.is_error is True
+        assert result.content[0].text == "jsonpath filter uses a restricted jq builtin"
+        assert "mcp-sink-canary-must-not-appear" not in str(result.content)
+        assert mock_metrics_buffer.record_tool_metric.call_args[1]["success"] is False
 
     @pytest.mark.asyncio
     async def test_invoke_tool_mcp_non_standard(self, tool_service, mock_tool, test_db):

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -295,25 +295,20 @@ class TestToolServiceHelpersExtended:
 
     def test_extract_using_jq_handles_none_result(self, monkeypatch):
         """[None] result should map to error message."""
-
-        class DummyProgram:
-            def input(self, _data):
-                return self
-
-            def all(self):
-                return [None]
-
-        monkeypatch.setattr("mcpgateway.services.tool_service._compile_jq_filter", lambda _f: DummyProgram())
+        monkeypatch.setattr("mcpgateway.services.tool_service.run_jq_filter", lambda *_args: [None])
 
         result = extract_using_jq({"a": 1}, ".a")
         assert result == [TextContent(type="text", text="Error applying jsonpath filter")]
 
-    def test_extract_using_jq_returns_exception_message(self, monkeypatch):
-        """Exceptions during jq execution should return list with TextContent error."""
-        monkeypatch.setattr("mcpgateway.services.tool_service._compile_jq_filter", lambda _f: (_ for _ in ()).throw(RuntimeError("boom")))
+    def test_extract_using_jq_hides_engine_error_detail(self, monkeypatch):
+        """Filter engine errors are logged, not returned to the caller."""
+        # First-Party
+        from mcpgateway.utils.jq_runner import JqFilterError
+
+        monkeypatch.setattr("mcpgateway.services.tool_service.run_jq_filter", lambda *_args: (_ for _ in ()).throw(JqFilterError("boom")))
 
         result = extract_using_jq({"a": 1}, ".a")
-        assert result == [TextContent(type="text", text="Error applying jsonpath filter: boom")]
+        assert result == [TextContent(type="text", text="Error applying jsonpath filter")]
 
     def test_tool_service_plugin_env_override(self, monkeypatch):
         """PLUGINS_ENABLED env flag controls whether the plugin factory is available."""
@@ -5522,25 +5517,14 @@ class TestToolService:
 #                               extract_using_jq                              #
 # --------------------------------------------------------------------------- #
 def test_extract_using_jq_happy_path():
-    """Test jq filter extraction works correctly with caching."""
-    # First-Party
-    from mcpgateway.services.tool_service import _compile_jq_filter
-
-    # Clear cache for clean test state
-    _compile_jq_filter.cache_clear()
-
+    """Test jq filter extraction returns correct results through the sandbox."""
     data = {"a": 123, "b": 456}
 
-    # Test actual behavior (no mocking)
     result = extract_using_jq(data, ".a")
     assert result == [123]
 
-    # Verify caching works
     result2 = extract_using_jq({"a": 999}, ".a")
     assert result2 == [999]
-
-    info = _compile_jq_filter.cache_info()
-    assert info.hits == 1  # Second call hit cache
 
 
 def test_extract_using_jq_short_circuits_and_errors():
@@ -5877,21 +5861,21 @@ class TestMappingIntegrationSecurity:
 class TestJqFilterCaching:
     """Tests for jq filter caching (#1813)."""
 
-    def test_jq_caching_works(self):
-        """Verify jq filter compilation is cached."""
+    def test_jq_caching_works(self, monkeypatch):
+        """Verify jq filter compilation is cached within an executing process (#1813)."""
         # First-Party
-        from mcpgateway.services.tool_service import _compile_jq_filter
+        from mcpgateway.config import settings
+        from mcpgateway.utils.jq_runner import _compile_jq_filter
 
+        # Caching lives with the compiler. In sandbox mode that is the worker
+        # process, so assert it in the mode where the cache is observable.
+        monkeypatch.setattr(settings, "jq_filter_execution", "inprocess")
         _compile_jq_filter.cache_clear()
 
-        result1 = extract_using_jq({"a": 1}, ".a")
-        assert result1 == [1]
+        assert extract_using_jq({"a": 1}, ".a") == [1]
+        assert extract_using_jq({"a": 99}, ".a") == [99]
 
-        result2 = extract_using_jq({"a": 99}, ".a")
-        assert result2 == [99]
-
-        info = _compile_jq_filter.cache_info()
-        assert info.hits == 1
+        assert _compile_jq_filter.cache_info().hits == 1
 
     def test_empty_filter_bypasses_cache(self):
         """Empty filter should return data directly without caching."""

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -4212,13 +4212,7 @@ class TestExtractUsingJqErrors:
         # First-Party
         import mcpgateway.services.tool_service as ts
 
-        with patch.object(ts, "_compile_jq_filter") as mock_compile:
-            mock_prog = MagicMock()
-            mock_input = MagicMock()
-            mock_input.all = MagicMock(return_value=[None])
-            mock_prog.input = MagicMock(return_value=mock_input)
-            mock_compile.return_value = mock_prog
-
+        with patch.object(ts, "run_jq_filter", return_value=[None]):
             result = extract_using_jq({"key": "value"}, ".x")
         assert isinstance(result, list)
         assert len(result) == 1
@@ -4226,16 +4220,18 @@ class TestExtractUsingJqErrors:
         assert result[0].text == "Error applying jsonpath filter"
 
     def test_jq_filter_exception(self):
-        """When jq raises exception, returns error message as TextContent in list."""
+        """When the filter engine raises, a fixed error message is returned."""
         # First-Party
         import mcpgateway.services.tool_service as ts
+        from mcpgateway.utils.jq_runner import JqFilterError
 
-        with patch.object(ts, "_compile_jq_filter", side_effect=ValueError("bad filter")):
+        with patch.object(ts, "run_jq_filter", side_effect=JqFilterError("bad filter")):
             result = extract_using_jq({"data": 1}, "bad_filter")
         assert isinstance(result, list)
         assert len(result) == 1
         assert isinstance(result[0], TextContent)
-        assert "Error" in result[0].text
+        assert result[0].text == "Error applying jsonpath filter"
+        assert "bad filter" not in result[0].text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/services/test_tool_service_helpers.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_helpers.py
@@ -39,3 +39,38 @@ def test_extract_using_jq_edge_cases():
     assert tool_service.extract_using_jq({"a": 1}, "") == {"a": 1}
     assert tool_service.extract_using_jq("not json", ".a") == ["Invalid JSON string provided."]
     assert tool_service.extract_using_jq(123, ".a") == ["Input data must be a JSON string, dictionary, or list."]
+
+
+def test_extract_using_jq_rejects_restricted_builtin():
+    """A stored hostile filter is refused at invoke time, not executed."""
+    # First-Party
+    from mcpgateway.common.models import TextContent
+    from mcpgateway.services import tool_service
+
+    result = tool_service.extract_using_jq({"a": 1}, "$ENV")
+    assert result == [TextContent(type="text", text="jsonpath filter uses a restricted jq builtin")]
+
+
+def test_extract_using_jq_does_not_echo_engine_errors(monkeypatch):
+    """Filter engine detail goes to the log, never to the caller."""
+    # First-Party
+    from mcpgateway.common.models import TextContent
+    from mcpgateway.services import tool_service
+    from mcpgateway.utils.jq_runner import JqFilterError
+
+    monkeypatch.setattr(tool_service, "run_jq_filter", lambda *_args: (_ for _ in ()).throw(JqFilterError("secret path /etc/app/x")))
+    result = tool_service.extract_using_jq({"a": 1}, ".a")
+    assert result == [TextContent(type="text", text="Error applying jsonpath filter")]
+    assert "secret path" not in result[0].text
+
+
+def test_extract_using_jq_reports_timeout_distinctly(monkeypatch):
+    """A timed-out filter is distinguishable from a malformed one."""
+    # First-Party
+    from mcpgateway.common.models import TextContent
+    from mcpgateway.services import tool_service
+    from mcpgateway.utils.jq_runner import JqFilterTimeout
+
+    monkeypatch.setattr(tool_service, "run_jq_filter", lambda *_args: (_ for _ in ()).throw(JqFilterTimeout("too slow")))
+    result = tool_service.extract_using_jq({"a": 1}, ".a")
+    assert result == [TextContent(type="text", text="jsonpath filter exceeded the execution time limit")]

--- a/tests/unit/mcpgateway/services/test_tool_service_helpers.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_helpers.py
@@ -74,3 +74,15 @@ def test_extract_using_jq_reports_timeout_distinctly(monkeypatch):
     monkeypatch.setattr(tool_service, "run_jq_filter", lambda *_args: (_ for _ in ()).throw(JqFilterTimeout("too slow")))
     result = tool_service.extract_using_jq({"a": 1}, ".a")
     assert result == [TextContent(type="text", text="jsonpath filter exceeded the execution time limit")]
+
+
+def test_extract_using_jq_reports_busy_distinctly_from_timeout(monkeypatch):
+    """A full pool with no free worker is distinguishable from a genuine timeout."""
+    # First-Party
+    from mcpgateway.common.models import TextContent
+    from mcpgateway.services import tool_service
+    from mcpgateway.utils.jq_runner import JqFilterBusy
+
+    monkeypatch.setattr(tool_service, "run_jq_filter", lambda *_args: (_ for _ in ()).throw(JqFilterBusy("no free worker")))
+    result = tool_service.extract_using_jq({"a": 1}, ".a")
+    assert result == [TextContent(type="text", text="jsonpath filter sandbox is busy, try again")]

--- a/tests/unit/mcpgateway/test_jsonpath_filter_validation.py
+++ b/tests/unit/mcpgateway/test_jsonpath_filter_validation.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""The jsonpath_filter field must reject restricted jq built-ins at write time."""
+
+# Third-Party
+from pydantic import ValidationError
+import pytest
+
+# First-Party
+from mcpgateway.schemas import ToolCreate, ToolUpdate
+
+HOSTILE = ["$ENV", "env", '"\\(env)"', 'include "evil"; leak']
+
+
+@pytest.mark.parametrize("jq_filter", HOSTILE)
+def test_tool_create_rejects_hostile_filter(jq_filter):
+    """A hostile filter never reaches the database through ToolCreate."""
+    with pytest.raises(ValidationError, match="restricted"):
+        ToolCreate(name="probe", url="https://example.com/api", jsonpath_filter=jq_filter)
+
+
+@pytest.mark.parametrize("jq_filter", HOSTILE)
+def test_tool_update_rejects_hostile_filter(jq_filter):
+    """A hostile filter cannot be smuggled in through an update."""
+    with pytest.raises(ValidationError, match="restricted"):
+        ToolUpdate(jsonpath_filter=jq_filter)
+
+
+def test_legitimate_filter_is_accepted():
+    """Ordinary field-extraction filters keep working."""
+    tool = ToolCreate(name="probe", url="https://example.com/api", jsonpath_filter=".data.items[].id")
+    assert tool.jsonpath_filter == ".data.items[].id"
+
+
+def test_env_named_field_is_accepted():
+    """A field literally named 'env' is data access, not the built-in."""
+    tool = ToolCreate(name="probe", url="https://example.com/api", jsonpath_filter=".env.region")
+    assert tool.jsonpath_filter == ".env.region"
+
+
+def test_empty_filter_is_accepted():
+    """The default empty filter means 'no filtering'."""
+    assert ToolCreate(name="probe", url="https://example.com/api", jsonpath_filter="").jsonpath_filter == ""
+
+
+def test_federated_peer_tool_with_hostile_filter_is_dropped():
+    """A malicious upstream gateway cannot plant a hostile filter via discovery."""
+    # First-Party
+    from mcpgateway.services.gateway_service import GatewayService
+
+    service = GatewayService()
+    tools = [
+        {"name": "good_tool", "url": "https://example.com/a", "jsonpath_filter": ".data"},
+        {"name": "evil_tool", "url": "https://example.com/b", "jsonpath_filter": "$ENV"},
+    ]
+    valid, errors = service._validate_tools(tools)  # pylint: disable=protected-access
+
+    assert [tool.name for tool in valid] == ["good_tool"]
+    assert any("evil_tool" in err and "restricted" in err for err in errors)

--- a/tests/unit/mcpgateway/test_jsonpath_filter_validation.py
+++ b/tests/unit/mcpgateway/test_jsonpath_filter_validation.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-"""The jsonpath_filter field must reject restricted jq built-ins at write time."""
+"""Location: ./tests/unit/mcpgateway/test_jsonpath_filter_validation.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+The jsonpath_filter field must reject restricted jq built-ins at write time.
+"""
 
 # Third-Party
 from pydantic import ValidationError
@@ -56,3 +61,18 @@ def test_federated_peer_tool_with_hostile_filter_is_dropped():
 
     assert [tool.name for tool in valid] == ["good_tool"]
     assert any("evil_tool" in err and "restricted" in err for err in errors)
+
+
+def test_all_tools_rejected_reports_the_reason():
+    """A wholly hostile peer fails registration with a legible cause."""
+    # First-Party
+    from mcpgateway.services.gateway_service import GatewayService
+
+    service = GatewayService()
+    tools = [{"name": "evil_tool", "url": "https://example.com/b", "jsonpath_filter": "$ENV"}]
+
+    with pytest.raises(Exception) as excinfo:
+        service._validate_tools(tools)  # pylint: disable=protected-access
+
+    assert "restricted" in str(excinfo.value)
+    assert "evil_tool" in str(excinfo.value)

--- a/tests/unit/mcpgateway/utils/test_jq_guard.py
+++ b/tests/unit/mcpgateway/utils/test_jq_guard.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-"""Tests for the static jq filter safety gate."""
+"""Location: ./tests/unit/mcpgateway/utils/test_jq_guard.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Tests for the static jq filter safety gate.
+"""
 
 # Third-Party
 import pytest

--- a/tests/unit/mcpgateway/utils/test_jq_guard.py
+++ b/tests/unit/mcpgateway/utils/test_jq_guard.py
@@ -111,3 +111,9 @@ def test_unquoted_object_keys_are_refused(jq_filter):
 def test_quoted_object_key_is_the_workaround():
     """The quoted form of the same filter is accepted."""
     assert assert_safe_jq_filter('{"env": .a}') is None
+
+
+def test_plain_string_escape_is_not_interpolation():
+    """A backslash escape that is not '\\(' stays inside the string, not code."""
+    assert scan_jq_tokens('"a\\tb\\"c"') == set()
+    assert assert_safe_jq_filter('"a\\tb\\"c"') is None

--- a/tests/unit/mcpgateway/utils/test_jq_guard.py
+++ b/tests/unit/mcpgateway/utils/test_jq_guard.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+"""Tests for the static jq filter safety gate."""
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.utils.jq_guard import assert_safe_jq_filter, scan_jq_tokens
+
+DENIED = [
+    "$ENV",
+    "env",
+    "env.CANARY",
+    '$ENV["CANARY"]',
+    "$ENV|keys",
+    ".a|env",
+    "[.[]|env]",
+    ".a as $x|env",
+    "{k:$ENV}",
+    "env # trailing comment",
+    "$ENV # trailing comment",
+    '"\\(env)"',
+    '"\\($ENV.CANARY)"',
+    '"\\("\\(env)")"',
+    "{$ENV}",
+    'include "evil"; leak',
+    'import "evil" as e; e::leak',
+    '"evil"|modulemeta',
+    "input",
+    "inputs",
+    "input_filename",
+    "input_line_number",
+    "$__loc__",
+    "debug",
+    "stderr",
+]
+
+ALLOWED = [
+    ".env",
+    ".environment",
+    ".inputs",
+    '."env"',
+    '.["env"]',
+    '"env"',
+    '"this mentions env and inputs"',
+    "# env\n.a",
+    ".a.b[].c",
+    ".a|select(.b==1)|map(.c)",
+    "to_entries|from_entries",
+    '{"env": .a}',
+    '{"input": .a}',
+    "  .a  ",
+    "",
+    "halt",
+    "halt_error",
+]
+
+# Harmless constructs the guard rejects anyway. Object-construction keys are
+# scanned as code positions, so an unquoted key named after a restricted
+# built-in is refused. Quoting the key is the workaround, and the guard stays
+# simple rather than growing a context rule that would widen bypass surface.
+ACCEPTED_FALSE_POSITIVES = ["{env: .a}", "{env}", "{input: .a}"]
+
+
+@pytest.mark.parametrize("jq_filter", DENIED)
+def test_denied_filters_raise(jq_filter):
+    """Every environment, IO, or module-loading construct is rejected."""
+    with pytest.raises(ValueError, match="restricted"):
+        assert_safe_jq_filter(jq_filter)
+
+
+@pytest.mark.parametrize("jq_filter", ALLOWED)
+def test_allowed_filters_pass(jq_filter):
+    """Legitimate field access and string content are not rejected."""
+    assert_safe_jq_filter(jq_filter) is None
+
+
+def test_string_literals_are_not_scanned_as_code():
+    """A denied name inside a string literal is data, not a built-in."""
+    assert scan_jq_tokens('"env" + "inputs"') == set()
+
+
+def test_interpolation_is_scanned_as_code():
+    """Interpolation holds executable code and must be descended into."""
+    assert "env" in scan_jq_tokens('"\\(env)"')
+
+
+def test_field_access_is_not_a_builtin():
+    """An identifier directly after a dot is a field name."""
+    assert scan_jq_tokens(".env.inputs") == set()
+
+
+def test_error_names_the_offending_token():
+    """Operators need to know which construct was rejected."""
+    with pytest.raises(ValueError, match=r"\$ENV"):
+        assert_safe_jq_filter("$ENV")
+
+
+@pytest.mark.parametrize("jq_filter", ACCEPTED_FALSE_POSITIVES)
+def test_unquoted_object_keys_are_refused(jq_filter):
+    """Documented false positive: quote an object key named after a built-in."""
+    with pytest.raises(ValueError, match="restricted"):
+        assert_safe_jq_filter(jq_filter)
+
+
+def test_quoted_object_key_is_the_workaround():
+    """The quoted form of the same filter is accepted."""
+    assert assert_safe_jq_filter('{"env": .a}') is None

--- a/tests/unit/mcpgateway/utils/test_jq_guard.py
+++ b/tests/unit/mcpgateway/utils/test_jq_guard.py
@@ -117,3 +117,10 @@ def test_plain_string_escape_is_not_interpolation():
     """A backslash escape that is not '\\(' stays inside the string, not code."""
     assert scan_jq_tokens('"a\\tb\\"c"') == set()
     assert assert_safe_jq_filter('"a\\tb\\"c"') is None
+
+
+def test_lone_dollar_advances_without_forming_a_token():
+    """A '$' not followed by an identifier is not valid jq and yields no token."""
+    assert scan_jq_tokens("$") == set()
+    assert scan_jq_tokens("$)") == set()
+    assert assert_safe_jq_filter("$)") is None

--- a/tests/unit/mcpgateway/utils/test_jq_runner.py
+++ b/tests/unit/mcpgateway/utils/test_jq_runner.py
@@ -18,7 +18,7 @@ import pytest
 
 # First-Party
 from mcpgateway.config import settings
-from mcpgateway.utils.jq_runner import JqFilterError, JqFilterTimeout, run_jq_filter, shutdown_jq_pool, start_jq_pool, subprocess_mode_available
+from mcpgateway.utils.jq_runner import JqFilterBusy, JqFilterError, JqFilterTimeout, run_jq_filter, shutdown_jq_pool, start_jq_pool, subprocess_mode_available
 
 linux_only = pytest.mark.skipif(not sys.platform.startswith("linux"), reason="fork-based sandbox is Linux-only")
 
@@ -271,6 +271,9 @@ def test_run_jq_filter_wraps_a_generic_submit_failure(monkeypatch):
     from mcpgateway.utils import jq_runner
 
     class _BrokenSubmitPool:
+        def __init__(self):
+            setattr(self, jq_runner._GATE_ATTR, threading.Semaphore(1))  # pylint: disable=protected-access
+
         def submit(self, *_args, **_kwargs):
             raise RuntimeError("cannot schedule new futures after shutdown")
 
@@ -289,6 +292,9 @@ def test_run_jq_filter_does_not_double_wrap_a_jq_filter_error(monkeypatch):
     original = JqFilterError("already the right shape")
 
     class _DirectlyFailingPool:
+        def __init__(self):
+            setattr(self, jq_runner._GATE_ATTR, threading.Semaphore(1))  # pylint: disable=protected-access
+
         def submit(self, *_args, **_kwargs):
             raise original
 
@@ -439,3 +445,69 @@ def test_shutdown_kills_a_worker_running_a_runaway_filter(monkeypatch):
         assert errors and isinstance(errors[0], JqFilterError)
     finally:
         shutdown_jq_pool()
+
+
+@linux_only
+def test_a_full_pool_fails_fast_instead_of_queueing(monkeypatch):
+    """A submission with no free worker is refused immediately, not queued.
+
+    Reproduces the reported race precisely: with every worker already running
+    a filter, a further call must not sit in ProcessPoolExecutor's internal
+    queue consuming the same wall-clock budget meant for runaway detection --
+    it must fail fast with JqFilterBusy, and it must not touch the pool.
+    """
+    shutdown_jq_pool()
+    monkeypatch.setattr(settings, "jq_filter_workers", 1)
+    monkeypatch.setattr(settings, "jq_filter_timeout_seconds", 5.0)
+    start_jq_pool()
+    processes_before = _worker_processes()
+
+    busy_thread_result = []
+
+    def _occupy_the_only_worker():
+        try:
+            run_jq_filter("reduce range(100000000000) as $i (0; .+1)", {"a": 1})
+        except Exception as exc:  # pylint: disable=broad-except
+            busy_thread_result.append(exc)
+
+    occupier = threading.Thread(target=_occupy_the_only_worker, daemon=True)
+    occupier.start()
+    try:
+        assert _wait_until(lambda: all(p.is_alive() for p in processes_before), timeout=5.0)
+        time.sleep(0.3)  # let the occupier's filter actually start running
+
+        start = time.monotonic()
+        with pytest.raises(JqFilterBusy):
+            run_jq_filter(".a", {"a": 1})
+        elapsed = time.monotonic() - start
+
+        # Fails fast: nowhere near the 5s per-filter timeout budget.
+        assert elapsed < 1.0, f"a full pool should fail immediately, took {elapsed}s"
+
+        # The occupier's worker was never touched by the second call.
+        assert all(p.is_alive() for p in processes_before)
+    finally:
+        occupier.join(timeout=10.0)
+        shutdown_jq_pool()
+
+    assert busy_thread_result and isinstance(busy_thread_result[0], JqFilterTimeout)
+
+
+@linux_only
+def test_gate_is_released_after_a_normal_call(jq_pool):
+    """A completed call frees its slot for the next one, even with one worker."""
+    # First-Party
+    from mcpgateway.utils import jq_runner
+
+    gate = getattr(jq_runner._POOL, jq_runner._GATE_ATTR)  # pylint: disable=protected-access
+    for _ in range(3):
+        assert run_jq_filter(".a", {"a": 1}) == [1]
+    # Every acquire in the loop above was matched by a release.
+    assert gate.acquire(blocking=False)
+    gate.release()
+
+
+def test_jq_filter_busy_is_a_jq_filter_error():
+    """JqFilterBusy is catchable alongside every other jq failure mode."""
+    assert issubclass(JqFilterBusy, JqFilterError)
+    assert not issubclass(JqFilterBusy, JqFilterTimeout)

--- a/tests/unit/mcpgateway/utils/test_jq_runner.py
+++ b/tests/unit/mcpgateway/utils/test_jq_runner.py
@@ -1,12 +1,17 @@
 # -*- coding: utf-8 -*-
 """Tests for sandboxed jq filter execution."""
 
+# Standard
+import sys
+
 # Third-Party
 import pytest
 
 # First-Party
 from mcpgateway.config import settings
-from mcpgateway.utils.jq_runner import JqFilterError, run_jq_filter
+from mcpgateway.utils.jq_runner import JqFilterError, JqFilterTimeout, run_jq_filter, shutdown_jq_pool, start_jq_pool, subprocess_mode_available
+
+linux_only = pytest.mark.skipif(not sys.platform.startswith("linux"), reason="fork-based sandbox is Linux-only")
 
 
 def test_jq_filter_settings_defaults():
@@ -38,3 +43,79 @@ def test_compiled_programs_are_cached():
     _compile_jq_filter(".a")
     _compile_jq_filter(".a")
     assert _compile_jq_filter.cache_info().hits == 1
+
+
+@pytest.fixture
+def jq_pool():
+    """Provide a started pool and tear it down afterwards."""
+    start_jq_pool()
+    yield
+    shutdown_jq_pool()
+
+
+@linux_only
+def test_worker_environment_is_scrubbed(jq_pool, monkeypatch):
+    """A worker cannot see the gateway's secrets even without the static gate.
+
+    Asserts absence of the parent's values rather than an exactly empty mapping.
+    Under pytest the child reliably comes back with terminal-geometry variables
+    (``LINES``, ``COLUMNS``) repopulated after the initializer runs, so an
+    ``== [{}]`` assertion fails for reasons that have nothing to do with the
+    security property. Verified separately: in a clean process the worker's
+    ``$ENV`` is exactly ``{}`` and ``os.getenv`` of a seeded secret returns None.
+    """
+    monkeypatch.setenv("JQ_RUNNER_CANARY", "LEAKED")
+    monkeypatch.setenv("JWT_SECRET_KEY", "sentinel-value-must-not-appear")
+
+    worker_env = run_jq_filter("$ENV", {"a": 1})[0]
+
+    assert "JQ_RUNNER_CANARY" not in worker_env
+    assert "JWT_SECRET_KEY" not in worker_env
+    assert "sentinel-value-must-not-appear" not in str(worker_env)
+
+
+@linux_only
+def test_ordinary_filter_runs_in_worker(jq_pool):
+    """Normal filters produce the same results through the sandbox."""
+    assert run_jq_filter(".a", {"a": 42}) == [42]
+
+
+@linux_only
+def test_runaway_filter_times_out_and_pool_recovers(jq_pool, monkeypatch):
+    """A non-terminating filter is killed, and the next call still works."""
+    monkeypatch.setattr(settings, "jq_filter_timeout_seconds", 1.0)
+    with pytest.raises(JqFilterTimeout):
+        run_jq_filter("reduce range(100000000000) as $i (0; .+1)", {"a": 1})
+    assert run_jq_filter(".a", {"a": 7}) == [7]
+
+
+@linux_only
+def test_private_processes_attribute_still_exists(jq_pool):
+    """The kill path depends on a private CPython attribute; fail loudly if it moves.
+
+    ``ProcessPoolExecutor`` starts workers lazily, so ``_processes`` is an empty
+    dict until the first submit. Run a filter before asserting.
+    """
+    # First-Party
+    from mcpgateway.utils import jq_runner
+
+    assert run_jq_filter(".a", {"a": 1}) == [1]
+    assert getattr(jq_runner._POOL, "_processes", None), "ProcessPoolExecutor._processes is gone; the timeout kill path needs rewriting"  # pylint: disable=protected-access
+
+
+def test_subprocess_mode_unavailable_off_linux(monkeypatch):
+    """Non-Linux platforms fall back to in-process execution."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    assert subprocess_mode_available() is False
+
+
+def test_pool_failure_fails_closed(monkeypatch):
+    """If the pool cannot be built, filters error rather than silently running in-process."""
+    # First-Party
+    from mcpgateway.utils import jq_runner
+
+    shutdown_jq_pool()
+    monkeypatch.setattr(jq_runner, "subprocess_mode_available", lambda: True)
+    monkeypatch.setattr(jq_runner, "_build_pool", lambda: (_ for _ in ()).throw(OSError("no fork for you")))
+    with pytest.raises(JqFilterError):
+        run_jq_filter(".a", {"a": 1})

--- a/tests/unit/mcpgateway/utils/test_jq_runner.py
+++ b/tests/unit/mcpgateway/utils/test_jq_runner.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 """Tests for sandboxed jq filter execution."""
 
+# Third-Party
+import pytest
+
 # First-Party
 from mcpgateway.config import settings
+from mcpgateway.utils.jq_runner import JqFilterError, run_jq_filter
 
 
 def test_jq_filter_settings_defaults():
@@ -10,3 +14,27 @@ def test_jq_filter_settings_defaults():
     assert settings.jq_filter_execution == "subprocess"
     assert settings.jq_filter_timeout_seconds == 2.0
     assert settings.jq_filter_workers == 2
+
+
+def test_inprocess_mode_applies_filter(monkeypatch):
+    """In-process mode still evaluates ordinary filters correctly."""
+    monkeypatch.setattr(settings, "jq_filter_execution", "inprocess")
+    assert run_jq_filter(".a", {"a": 42}) == [42]
+
+
+def test_inprocess_mode_reports_compile_errors(monkeypatch):
+    """A malformed filter surfaces as JqFilterError, not a raw jq exception."""
+    monkeypatch.setattr(settings, "jq_filter_execution", "inprocess")
+    with pytest.raises(JqFilterError):
+        run_jq_filter("this is not jq |||", {"a": 1})
+
+
+def test_compiled_programs_are_cached():
+    """Compilation is cached so repeated invocations stay cheap."""
+    # First-Party
+    from mcpgateway.utils.jq_runner import _compile_jq_filter
+
+    _compile_jq_filter.cache_clear()
+    _compile_jq_filter(".a")
+    _compile_jq_filter(".a")
+    assert _compile_jq_filter.cache_info().hits == 1

--- a/tests/unit/mcpgateway/utils/test_jq_runner.py
+++ b/tests/unit/mcpgateway/utils/test_jq_runner.py
@@ -189,6 +189,98 @@ def test_run_jq_filter_reasserts_the_static_gate(monkeypatch):
         run_jq_filter("$ENV", {"a": 1})
 
 
+def test_start_jq_pool_warns_once_when_sandbox_unavailable(monkeypatch):
+    """A disabled sandbox logs a warning on first call and stays silent after."""
+    # First-Party
+    from mcpgateway.utils import jq_runner
+
+    monkeypatch.setattr(jq_runner, "subprocess_mode_available", lambda: False)
+    monkeypatch.setattr(jq_runner, "_FALLBACK_WARNED", False)
+    calls = []
+    monkeypatch.setattr(jq_runner.logger, "warning", lambda *a, **k: calls.append(a))
+
+    start_jq_pool()
+    start_jq_pool()
+
+    assert len(calls) == 1
+    assert jq_runner._FALLBACK_WARNED is True  # pylint: disable=protected-access
+
+
+def test_start_jq_pool_cleans_up_on_warmup_failure(monkeypatch):
+    """A pool that fails its warm-up submit is shut down, and the failure propagates."""
+    # First-Party
+    from mcpgateway.utils import jq_runner
+
+    shutdown_jq_pool()
+    monkeypatch.setattr(jq_runner, "subprocess_mode_available", lambda: True)
+
+    class _FailingFuture:
+        def result(self, timeout=None):  # pylint: disable=unused-argument
+            raise TimeoutError("warm-up never completed")
+
+    class _FailingPool:
+        def __init__(self):
+            self.shutdown_calls = []
+
+        def submit(self, *_args, **_kwargs):
+            return _FailingFuture()
+
+        def shutdown(self, wait=False, cancel_futures=False):  # pylint: disable=unused-argument
+            self.shutdown_calls.append((wait, cancel_futures))
+
+    failing_pool = _FailingPool()
+    monkeypatch.setattr(jq_runner, "_build_pool", lambda: failing_pool)
+
+    with pytest.raises(TimeoutError):
+        start_jq_pool()
+
+    assert failing_pool.shutdown_calls == [(False, True)]
+    assert jq_runner._POOL is None  # pylint: disable=protected-access
+
+
+def test_kill_workers_logs_when_process_kill_raises(monkeypatch):
+    """A process that refuses to die is logged, not left to crash the caller."""
+    # First-Party
+    from mcpgateway.utils import jq_runner
+
+    class _StubbornProcess:
+        def kill(self):
+            raise OSError("no such process")
+
+    class _StubPool:
+        def __init__(self):
+            self._processes = {1: _StubbornProcess()}
+            self.shutdown_calls = []
+
+        def shutdown(self, wait=False, cancel_futures=False):  # pylint: disable=unused-argument
+            self.shutdown_calls.append((wait, cancel_futures))
+
+    warnings = []
+    monkeypatch.setattr(jq_runner.logger, "warning", lambda *a, **k: warnings.append(a))
+
+    pool = _StubPool()
+    jq_runner._kill_workers(pool)  # pylint: disable=protected-access
+
+    assert len(warnings) == 1
+    assert pool.shutdown_calls == [(False, True)]
+
+
+def test_run_jq_filter_wraps_a_generic_submit_failure(monkeypatch):
+    """An exception from submit/result that isn't a timeout or a broken pool is still wrapped."""
+    # First-Party
+    from mcpgateway.utils import jq_runner
+
+    class _BrokenSubmitPool:
+        def submit(self, *_args, **_kwargs):
+            raise RuntimeError("cannot schedule new futures after shutdown")
+
+    monkeypatch.setattr(jq_runner, "subprocess_mode_available", lambda: True)
+    monkeypatch.setattr(jq_runner, "_ensure_pool", lambda: _BrokenSubmitPool())
+
+    with pytest.raises(JqFilterError):
+        run_jq_filter(".a", {"a": 1})
+
+
 def _worker_processes():
     """Return the live ``Process`` objects of the current pool.
 

--- a/tests/unit/mcpgateway/utils/test_jq_runner.py
+++ b/tests/unit/mcpgateway/utils/test_jq_runner.py
@@ -281,6 +281,26 @@ def test_run_jq_filter_wraps_a_generic_submit_failure(monkeypatch):
         run_jq_filter(".a", {"a": 1})
 
 
+def test_run_jq_filter_does_not_double_wrap_a_jq_filter_error(monkeypatch):
+    """A JqFilterError raised directly from the pool is re-raised, not re-wrapped."""
+    # First-Party
+    from mcpgateway.utils import jq_runner
+
+    original = JqFilterError("already the right shape")
+
+    class _DirectlyFailingPool:
+        def submit(self, *_args, **_kwargs):
+            raise original
+
+    monkeypatch.setattr(jq_runner, "subprocess_mode_available", lambda: True)
+    monkeypatch.setattr(jq_runner, "_ensure_pool", lambda: _DirectlyFailingPool())
+
+    with pytest.raises(JqFilterError) as excinfo:
+        run_jq_filter(".a", {"a": 1})
+
+    assert excinfo.value is original
+
+
 def _worker_processes():
     """Return the live ``Process`` objects of the current pool.
 

--- a/tests/unit/mcpgateway/utils/test_jq_runner.py
+++ b/tests/unit/mcpgateway/utils/test_jq_runner.py
@@ -8,7 +8,10 @@ Tests for sandboxed jq filter execution.
 
 # Standard
 import os
+import signal
 import sys
+import threading
+import time
 
 # Third-Party
 import pytest
@@ -70,6 +73,19 @@ def test_worker_environment_is_scrubbed(monkeypatch):
     canaries in the first place, and the assertions below would pass even with
     ``_worker_init``'s ``os.environ.clear()`` removed entirely.
 
+    ``shutdown_jq_pool`` runs first, before the canaries are set, because
+    ``start_jq_pool`` returns early and reuses any pool already built under this
+    PID. Earlier tests in this file — and ``tool_service`` tests that reach
+    ``extract_using_jq`` in the default subprocess mode — can leave a live pool
+    behind, and without the explicit teardown this test would silently assert
+    against a worker forked before the canaries existed, passing even with
+    ``_worker_init``'s ``os.environ.clear()`` removed entirely.
+
+    ``run_jq_filter`` now re-asserts the static gate itself, which would refuse
+    ``$ENV`` outright. The gate is stubbed out here on purpose: the point of
+    this test is that the worker-side scrub holds *without* the gate, since the
+    scrub is the backstop for anything the gate misses.
+
     Asserts absence of the parent's values rather than an exactly empty mapping.
     Under pytest the child reliably comes back with terminal-geometry variables
     (``LINES``, ``COLUMNS``) repopulated after the initializer runs, so an
@@ -77,6 +93,11 @@ def test_worker_environment_is_scrubbed(monkeypatch):
     security property. Verified separately: in a clean process the worker's
     ``$ENV`` is exactly ``{}`` and ``os.getenv`` of a seeded secret returns None.
     """
+    # First-Party
+    from mcpgateway.utils import jq_runner
+
+    shutdown_jq_pool()
+    monkeypatch.setattr(jq_runner, "assert_safe_jq_filter", lambda _filter: None)
     monkeypatch.setenv("JQ_RUNNER_CANARY", "LEAKED")
     monkeypatch.setenv("JWT_SECRET_KEY", "sentinel-value-must-not-appear")
 
@@ -159,3 +180,150 @@ def test_pool_is_rebuilt_after_pid_change(jq_pool, monkeypatch):
     monkeypatch.setattr(jq_runner, "_POOL_PID", -1)
     assert run_jq_filter(".a", {"a": 5}) == [5]
     assert jq_runner._POOL_PID == os.getpid()  # pylint: disable=protected-access
+
+
+def test_run_jq_filter_reasserts_the_static_gate(monkeypatch):
+    """The runner refuses a restricted built-in even if a caller skips the gate."""
+    monkeypatch.setattr(settings, "jq_filter_execution", "inprocess")
+    with pytest.raises(ValueError, match="restricted built-in"):
+        run_jq_filter("$ENV", {"a": 1})
+
+
+def _worker_processes():
+    """Return the live ``Process`` objects of the current pool.
+
+    Returns:
+        A list of ``multiprocessing.Process`` objects owned by the pool.
+    """
+    # First-Party
+    from mcpgateway.utils import jq_runner
+
+    return list(getattr(jq_runner._POOL, "_processes", {}).values())  # pylint: disable=protected-access
+
+
+def _wait_until(predicate, timeout=15.0):
+    """Poll a predicate until it holds or the deadline passes.
+
+    Args:
+        predicate: Zero-argument callable returning a truthy value when done.
+        timeout: Seconds to keep polling.
+
+    Returns:
+        The last value the predicate returned.
+    """
+    deadline = time.monotonic() + timeout
+    result = predicate()
+    while not result and time.monotonic() < deadline:
+        time.sleep(0.05)
+        result = predicate()
+    return result
+
+
+@linux_only
+def test_pool_recovers_after_a_worker_dies_abnormally(monkeypatch):
+    """An OOM-style worker death must not brick filtering for the whole process.
+
+    ``ProcessPoolExecutor`` marks itself permanently broken when a worker dies
+    outside its control, so every later ``submit`` raises ``BrokenProcessPool``.
+    Only the timeout path used to drop the pool, which left an attacker able to
+    disable filtering for the lifetime of the gateway worker with a single
+    unbounded-allocation filter. SIGKILL stands in for the OOM killer here.
+    """
+    # First-Party
+    from mcpgateway.utils import jq_runner
+
+    shutdown_jq_pool()
+    monkeypatch.setattr(settings, "jq_filter_workers", 1)
+    start_jq_pool()
+    try:
+        broken = jq_runner._POOL  # pylint: disable=protected-access
+        processes = _worker_processes()
+        assert processes, "warm-up should have forked a worker"
+        for process in processes:
+            os.kill(process.pid, signal.SIGKILL)
+
+        assert _wait_until(lambda: bool(getattr(broken, "_broken", False))), "ProcessPoolExecutor never reported the dead worker; the recovery path needs rechecking"
+
+        with pytest.raises(JqFilterError):
+            run_jq_filter(".a", {"a": 1})
+
+        # The broken executor must have been discarded, not handed out again.
+        assert jq_runner._POOL is not broken  # pylint: disable=protected-access
+        assert run_jq_filter(".a", {"a": 1}) == [1]
+        assert run_jq_filter(".a", {"a": 2}) == [2]
+    finally:
+        shutdown_jq_pool()
+
+
+@linux_only
+def test_kill_targets_the_given_pool_even_after_pool_is_replaced(monkeypatch):
+    """A timeout kills the pool its filter ran in, not whichever pool is current.
+
+    The previous identity check bailed out whenever ``_POOL`` had moved on,
+    which orphaned the runaway worker of the pool that actually overran.
+    """
+    # First-Party
+    from mcpgateway.utils import jq_runner
+
+    shutdown_jq_pool()
+    monkeypatch.setattr(settings, "jq_filter_workers", 1)
+    start_jq_pool()
+    stale = jq_runner._POOL  # pylint: disable=protected-access
+    stale_processes = _worker_processes()
+    assert stale_processes
+
+    # Simulate another thread having replaced the global pool meanwhile.
+    replacement = jq_runner._build_pool()  # pylint: disable=protected-access
+    jq_runner._POOL = replacement  # pylint: disable=protected-access
+    jq_runner._POOL_PID = os.getpid()  # pylint: disable=protected-access
+    try:
+        jq_runner._kill_pool_workers(stale)  # pylint: disable=protected-access
+
+        assert _wait_until(lambda: all(not p.is_alive() for p in stale_processes)), "the stale pool's workers survived the kill"
+        # The newer pool is untouched and still usable.
+        assert jq_runner._POOL is replacement  # pylint: disable=protected-access
+        assert run_jq_filter(".a", {"a": 3}) == [3]
+    finally:
+        shutdown_jq_pool()
+
+
+@linux_only
+def test_shutdown_kills_a_worker_running_a_runaway_filter(monkeypatch):
+    """Shutdown must not leave a non-terminating filter running.
+
+    ``shutdown(wait=False, cancel_futures=True)`` cancels queued work but cannot
+    stop a worker mid-filter, and ``ProcessPoolExecutor``'s own ``atexit`` hook
+    then blocks interpreter exit joining it. Reproduces the composed race: a
+    hostile filter is running, shutdown clears the global pool, and the caller's
+    own timeout fires only afterwards.
+    """
+    shutdown_jq_pool()
+    monkeypatch.setattr(settings, "jq_filter_workers", 1)
+    monkeypatch.setattr(settings, "jq_filter_timeout_seconds", 30.0)
+    start_jq_pool()
+    processes = _worker_processes()
+    assert processes
+
+    errors = []
+
+    def _runaway():
+        try:
+            run_jq_filter("reduce range(100000000000) as $i (0; .+1)", {"a": 1})
+        except Exception as exc:  # pylint: disable=broad-except
+            errors.append(exc)
+
+    thread = threading.Thread(target=_runaway, daemon=True)
+    thread.start()
+    try:
+        # Let the worker actually pick the job up before shutting down.
+        assert _wait_until(lambda: all(p.is_alive() for p in processes), timeout=5.0)
+        time.sleep(0.5)
+
+        shutdown_jq_pool()
+
+        assert _wait_until(lambda: all(not p.is_alive() for p in processes)), "the runaway worker outlived shutdown_jq_pool"
+        thread.join(timeout=15.0)
+        assert not thread.is_alive(), "the caller stayed blocked on a worker that shutdown was supposed to kill"
+        assert errors and isinstance(errors[0], JqFilterError)
+    finally:
+        shutdown_jq_pool()

--- a/tests/unit/mcpgateway/utils/test_jq_runner.py
+++ b/tests/unit/mcpgateway/utils/test_jq_runner.py
@@ -54,8 +54,15 @@ def jq_pool():
 
 
 @linux_only
-def test_worker_environment_is_scrubbed(jq_pool, monkeypatch):
+def test_worker_environment_is_scrubbed(monkeypatch):
     """A worker cannot see the gateway's secrets even without the static gate.
+
+    Deliberately does not use the ``jq_pool`` fixture: ``start_jq_pool`` now warms
+    the pool by forking a worker before returning, so the fork must happen *after*
+    the canary variables are set, not before. Otherwise a worker forked by the
+    fixture (before this test's ``monkeypatch.setenv`` calls) would never see the
+    canaries in the first place, and the assertions below would pass even with
+    ``_worker_init``'s ``os.environ.clear()`` removed entirely.
 
     Asserts absence of the parent's values rather than an exactly empty mapping.
     Under pytest the child reliably comes back with terminal-geometry variables
@@ -67,11 +74,15 @@ def test_worker_environment_is_scrubbed(jq_pool, monkeypatch):
     monkeypatch.setenv("JQ_RUNNER_CANARY", "LEAKED")
     monkeypatch.setenv("JWT_SECRET_KEY", "sentinel-value-must-not-appear")
 
-    worker_env = run_jq_filter("$ENV", {"a": 1})[0]
+    start_jq_pool()
+    try:
+        worker_env = run_jq_filter("$ENV", {"a": 1})[0]
 
-    assert "JQ_RUNNER_CANARY" not in worker_env
-    assert "JWT_SECRET_KEY" not in worker_env
-    assert "sentinel-value-must-not-appear" not in str(worker_env)
+        assert "JQ_RUNNER_CANARY" not in worker_env
+        assert "JWT_SECRET_KEY" not in worker_env
+        assert "sentinel-value-must-not-appear" not in str(worker_env)
+    finally:
+        shutdown_jq_pool()
 
 
 @linux_only
@@ -93,8 +104,11 @@ def test_runaway_filter_times_out_and_pool_recovers(jq_pool, monkeypatch):
 def test_private_processes_attribute_still_exists(jq_pool):
     """The kill path depends on a private CPython attribute; fail loudly if it moves.
 
-    ``ProcessPoolExecutor`` starts workers lazily, so ``_processes`` is an empty
-    dict until the first submit. Run a filter before asserting.
+    ``ProcessPoolExecutor`` starts workers lazily, so ``_processes`` would be an
+    empty dict until the first submit — ``start_jq_pool``'s warm-up submit already
+    populates it by the time the ``jq_pool`` fixture returns, but this still runs
+    a filter of its own before asserting so the check does not depend on that
+    warm-up behavior.
     """
     # First-Party
     from mcpgateway.utils import jq_runner

--- a/tests/unit/mcpgateway/utils/test_jq_runner.py
+++ b/tests/unit/mcpgateway/utils/test_jq_runner.py
@@ -2,6 +2,7 @@
 """Tests for sandboxed jq filter execution."""
 
 # Standard
+import os
 import sys
 
 # Third-Party
@@ -133,3 +134,23 @@ def test_pool_failure_fails_closed(monkeypatch):
     monkeypatch.setattr(jq_runner, "_build_pool", lambda: (_ for _ in ()).throw(OSError("no fork for you")))
     with pytest.raises(JqFilterError):
         run_jq_filter(".a", {"a": 1})
+
+
+def test_pool_is_reused_within_a_process(jq_pool):
+    """Repeated startup calls do not churn the pool."""
+    # First-Party
+    from mcpgateway.utils import jq_runner
+
+    first = jq_runner._POOL  # pylint: disable=protected-access
+    start_jq_pool()
+    assert jq_runner._POOL is first  # pylint: disable=protected-access
+
+
+def test_pool_is_rebuilt_after_pid_change(jq_pool, monkeypatch):
+    """A pool inherited across a fork is discarded rather than reused."""
+    # First-Party
+    from mcpgateway.utils import jq_runner
+
+    monkeypatch.setattr(jq_runner, "_POOL_PID", -1)
+    assert run_jq_filter(".a", {"a": 5}) == [5]
+    assert jq_runner._POOL_PID == os.getpid()  # pylint: disable=protected-access

--- a/tests/unit/mcpgateway/utils/test_jq_runner.py
+++ b/tests/unit/mcpgateway/utils/test_jq_runner.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+"""Tests for sandboxed jq filter execution."""
+
+# First-Party
+from mcpgateway.config import settings
+
+
+def test_jq_filter_settings_defaults():
+    """The sandbox is on by default with a short wall-clock limit."""
+    assert settings.jq_filter_execution == "subprocess"
+    assert settings.jq_filter_timeout_seconds == 2.0
+    assert settings.jq_filter_workers == 2

--- a/tests/unit/mcpgateway/utils/test_jq_runner.py
+++ b/tests/unit/mcpgateway/utils/test_jq_runner.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-"""Tests for sandboxed jq filter execution."""
+"""Location: ./tests/unit/mcpgateway/utils/test_jq_runner.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Tests for sandboxed jq filter execution.
+"""
 
 # Standard
 import os


### PR DESCRIPTION
## Summary

Hardens execution of the `jsonpath_filter` field on REST tools. That field is a jq
program supplied at tool-registration time and executed against the tool's response
at invocation time. This change adds:

- A static safety gate that rejects filters referencing environment, host-state,
  logging, or filesystem-module-loading jq built-ins, enforced both when a tool is
  written (create/update) and when it's invoked (covers rows written before this
  change).
- Sandboxed execution: filters now run in a forked worker pool with a cleared
  process environment and a wall-clock timeout, so a filter can no longer read the
  gateway process's environment or wedge a worker indefinitely. A broken worker is
  detected and the pool recovers automatically on the next call.
- Config: `JQ_FILTER_EXECUTION`, `JQ_FILTER_TIMEOUT_SECONDS`, `JQ_FILTER_WORKERS`.
- Docs: new "jq Filter Sandbox" section in `docs/docs/manage/securing.md`, including
  guidance to rotate `JWT_SECRET_KEY`, `AUTH_ENCRYPTION_SECRET`, `DATABASE_URL`,
  `REDIS_URL`, and `BASIC_AUTH_PASSWORD` on any deployment that ran a build prior to
  this fix.

Addresses an internally-tracked security report (PSIRT REF 3874125 / ADV0318908).

One unrelated one-line change is included: a `# nosec B608` on a bandit false
positive in an existing OAuth-token migration file, surfaced because the full lint
gate ran end-to-end for the first time during this work.
