### PR TITLE
fix(ci): scope branch coverage to the pytest step to fix combine crash

### DIFF
--- a/.github/pytest-branch-coverage.coveragerc
+++ b/.github/pytest-branch-coverage.coveragerc
@@ -1,0 +1,40 @@
+; Coverage config for the "Run pytest" step in .github/workflows/pytest.yml only.
+;
+; That step passes --cov-branch on the CLI, but coverage.py's own fork-safety
+; hook (registered because pyproject.toml sets concurrency = ["thread",
+; "multiprocessing"]) gives each process forked during the run its own
+; coverage session, and that session reads its mode from whatever on-disk
+; config it finds -- not from the parent's CLI flags. pyproject.toml's
+; [tool.coverage.run] has no `branch` setting, so a forked child ends up
+; writing statement-only data while the CLI-driven parent writes branch data,
+; and `coverage combine()` then raises:
+;   DataError: Can't combine statement coverage data with branch data
+;
+; This file is deliberately NOT a change to pyproject.toml: the doctest
+; coverage step in the same workflow shares that file and has its own
+; threshold calibrated against statement-mode measurement, so making
+; branch=true the global default would push it below its gate. Passing
+; --cov-config=<this file> to only the "Run pytest" step keeps the fix scoped
+; to the one step that forks real processes under coverage instrumentation.
+[run]
+source = mcpgateway
+parallel = true
+branch = true
+concurrency = thread, multiprocessing
+omit =
+    mcpgateway/alembic/*
+    mcpgateway/tools/builder/*
+    */tests/*
+    */test_*.py
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self.debug
+    if TYPE_CHECKING:
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.
+ignore_errors = true

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -123,6 +123,7 @@ jobs:
             --durations=10 \
             --ignore=tests/fuzz \
             --cov=mcpgateway \
+            --cov-config=.github/pytest-branch-coverage.coveragerc \
             --cov-report=xml \
             --cov-report=html \
             --cov-report=term \


### PR DESCRIPTION
## Summary

Fixes #6207.

The `pytest (py3.12)` job crashes in its coverage-combine step whenever a test forks a real OS process (via `ProcessPoolExecutor`/`multiprocessing` with the `fork` start method) that executes any code under `mcpgateway/`. Every actual test still passes — the crash happens after the run, while `pytest-cov` merges per-process coverage data files, and it fails the whole job (exit code 3) regardless of test results.

**Root cause:** `pyproject.toml`'s `[tool.coverage.run]` sets `concurrency = ["thread", "multiprocessing"]`, which makes `coverage.py` register an `os.register_at_fork()` hook so each forked process writes its own coverage data file. That hook's session reads `branch` mode from on-disk config, not from the parent's CLI `--cov-branch` flag — and `pyproject.toml` has no `branch` key. So a forked child writes statement-only data while the CLI-driven parent writes branch data, and `coverage combine()` raises `DataError: Can't combine statement coverage data with branch data`.

**Fix:** a dedicated `.github/pytest-branch-coverage.coveragerc` with `branch = true`, passed to only the "Run pytest" step via `--cov-config`. Deliberately not a change to `pyproject.toml` — the workflow's separate "Doctest coverage with threshold" step shares that file and has its own 30% gate calibrated against statement-mode measurement; making `branch = true` the global default drops that measurement to ~27.75%, failing a previously-passing, unrelated gate. Scoping the change to `--cov-config` on one step avoids that.

## Verification

Reproduced and fixed with a standalone repro (not part of the test suite, just used to validate this fix):

```python
import multiprocessing
from concurrent.futures import ProcessPoolExecutor

def _child(x):
    from mcpgateway.utils.create_slug import slugify
    return slugify(f"item-{x}")

def test_forks_and_executes_instrumented_code():
    ctx = multiprocessing.get_context("fork")
    with ProcessPoolExecutor(max_workers=1, mp_context=ctx) as pool:
        assert pool.submit(_child, 41).result() == "item-41"
```

- Without the fix: `pytest --cov=mcpgateway --cov-branch <repro>` → `INTERNALERROR`, deterministic across repeated runs, reproduces with both `-n 0` and `-n 2` (not xdist-specific).
- With `--cov-config=.github/pytest-branch-coverage.coveragerc` added: 3/3 clean runs, no crash.
- Confirmed the doctest-coverage step's invocation doesn't pass `--cov-config` and is untouched by this change.
