### PR TITLE
feat: add frontend-compatible email links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -306,6 +306,9 @@ HOST=0.0.0.0
 
 # Local origin used for CORS/cookies in development examples
 APP_DOMAIN=http://localhost:8080
+# Trusted React/UI origin and optional path prefix for links in invitation and password emails.
+# When unset, browser-facing links use APP_DOMAIN plus APP_ROOT_PATH.
+# UI_BASE_URL=http://localhost:3000
 
 # Enable Admin UI and Admin API for local development
 MCPGATEWAY_UI_ENABLED=true

--- a/.env.example
+++ b/.env.example
@@ -307,7 +307,7 @@ HOST=0.0.0.0
 # Local origin used for CORS/cookies in development examples
 APP_DOMAIN=http://localhost:8080
 # Trusted React/UI origin and optional path prefix for links in invitation and password emails.
-# When unset, browser-facing links use APP_DOMAIN plus APP_ROOT_PATH.
+# When unset, password recovery uses legacy /admin routes; invitations use APP_DOMAIN plus APP_ROOT_PATH.
 # UI_BASE_URL=http://localhost:3000
 
 # Enable Admin UI and Admin API for local development

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-14T16:05:27Z",
+  "generated_at": "2026-08-17T09:33:27Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -116,7 +116,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 769,
+        "line_number": 772,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1014,
+        "line_number": 1017,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1313,
+        "line_number": 1316,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1348,
+        "line_number": 1351,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1437,
+        "line_number": 1440,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1442,
+        "line_number": 1445,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1447,
+        "line_number": 1450,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1453,
+        "line_number": 1456,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1465,
+        "line_number": 1468,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1483,
+        "line_number": 1486,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1544,
+        "line_number": 1547,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1914,7 +1914,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 151,
+        "line_number": 177,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1922,7 +1922,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 456,
+        "line_number": 482,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1930,7 +1930,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 900,
+        "line_number": 926,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1938,7 +1938,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1407,
+        "line_number": 1433,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -1946,7 +1946,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1411,
+        "line_number": 1437,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4812,7 +4812,7 @@
         "hashed_secret": "a24a9eab46fcd2eb51c24d7e647a1e398c2c4b26",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2191,
+        "line_number": 2252,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -121,11 +121,12 @@ ContextForge uses this trusted base to generate these browser-facing email links
 - `https://ui.example.com/contextforge/reset-password/{token}`
 - `https://ui.example.com/contextforge/forgot-password`
 
-When `UI_BASE_URL` is unset, links use `APP_DOMAIN + APP_ROOT_PATH`. That fallback host must serve the
-`/accept-invitation/{token}`, `/reset-password/{token}`, and `/forgot-password` frontend routes; ContextForge does
-not provide those React pages. If the React client is deployed separately, configure `UI_BASE_URL` or email links
-will point at the gateway and may return 404. ContextForge never derives these links from the inbound `Host` header.
-Tokens are URL-encoded as individual path segments.
+When `UI_BASE_URL` is unset, links use `APP_DOMAIN + APP_ROOT_PATH` as their base. Password-reset and account-lockout
+emails preserve compatibility with the bundled Admin UI by using `/admin/reset-password/{token}` and
+`/admin/forgot-password`; these routes require `MCPGATEWAY_ADMIN_API_ENABLED=true`. Invitation emails continue to use
+`/accept-invitation/{token}`, so the fallback host must serve that frontend route. ContextForge does not provide the
+React invitation page. If the React client is deployed separately, configure `UI_BASE_URL`. ContextForge never
+derives these links from the inbound `Host` header. Tokens are URL-encoded as individual path segments.
 
 `UI_BASE_URL` controls links only; it does not configure browser access to gateway APIs. For a React client on a
 different origin, add that exact origin to `ALLOWED_ORIGINS`. Deployments using cross-origin cookies must also set

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -98,6 +98,7 @@ ContextForge supports multiple database backends with full feature parity across
 | `CLIENT_MODE`      | Client-only mode for gateway-as-client   | `false`                | bool                   |
 | `DATABASE_URL`     | SQLAlchemy connection URL                | `sqlite:///./mcp.db`   | any SQLAlchemy dialect |
 | `APP_ROOT_PATH`    | Subpath prefix for app (e.g. `/gateway`) | (empty)                | string                 |
+| `UI_BASE_URL`      | Trusted base URL for browser-facing links in invitation and password emails | (unset) | HTTP/HTTPS URL |
 | `TEMPLATES_DIR`    | Path to Jinja2 templates                 | `mcpgateway/templates` | path                   |
 | `STATIC_DIR`       | Path to static files                     | `mcpgateway/static`    | path                   |
 | `PROTOCOL_VERSION` | MCP protocol version supported           | `2025-06-18`           | string                 |
@@ -105,6 +106,27 @@ ContextForge supports multiple database backends with full feature parity across
 
 !!! tip "Subpath Deployment"
     Use `APP_ROOT_PATH=/foo` if reverse-proxying under a subpath like `https://host.com/foo/`.
+
+### Browser-facing email links
+
+Set `UI_BASE_URL` when the React client is deployed at a different origin or path from the gateway:
+
+```bash
+UI_BASE_URL=https://ui.example.com/contextforge
+```
+
+ContextForge uses this trusted base to generate these browser-facing email links:
+
+- `https://ui.example.com/contextforge/accept-invitation/{token}`
+- `https://ui.example.com/contextforge/reset-password/{token}`
+- `https://ui.example.com/contextforge/forgot-password`
+
+When `UI_BASE_URL` is unset, links use `APP_DOMAIN + APP_ROOT_PATH`. ContextForge never derives these links from
+the inbound `Host` header. Tokens are URL-encoded as individual path segments.
+
+`UI_BASE_URL` controls links only; it does not configure browser access to gateway APIs. For a React client on a
+different origin, add that exact origin to `ALLOWED_ORIGINS`. Deployments using cross-origin cookies must also set
+appropriate secure-cookie, SameSite, credential, and CSRF configuration.
 
 ### Authentication
 

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -121,8 +121,11 @@ ContextForge uses this trusted base to generate these browser-facing email links
 - `https://ui.example.com/contextforge/reset-password/{token}`
 - `https://ui.example.com/contextforge/forgot-password`
 
-When `UI_BASE_URL` is unset, links use `APP_DOMAIN + APP_ROOT_PATH`. ContextForge never derives these links from
-the inbound `Host` header. Tokens are URL-encoded as individual path segments.
+When `UI_BASE_URL` is unset, links use `APP_DOMAIN + APP_ROOT_PATH`. That fallback host must serve the
+`/accept-invitation/{token}`, `/reset-password/{token}`, and `/forgot-password` frontend routes; ContextForge does
+not provide those React pages. If the React client is deployed separately, configure `UI_BASE_URL` or email links
+will point at the gateway and may return 404. ContextForge never derives these links from the inbound `Host` header.
+Tokens are URL-encoded as individual path segments.
 
 `UI_BASE_URL` controls links only; it does not configure browser access to gateway APIs. For a React client on a
 different origin, add that exact origin to `ALLOWED_ORIGINS`. Deployments using cross-origin cookies must also set

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1631,6 +1631,13 @@ class Settings(BaseSettings):
             if self.debug and not self.dev_mode:
                 logger.warning("🐛 SECURITY WARNING: Debug mode is enabled in non-dev mode. This may leak sensitive information! Set DEBUG=false for production.")
 
+            if self.smtp_enabled and self.ui_base_url is None:
+                logger.warning(
+                    "SMTP_ENABLED=true while UI_BASE_URL is unset. Browser-facing email links will use "
+                    "APP_DOMAIN plus APP_ROOT_PATH. Ensure that fallback serves /accept-invitation/{token}, "
+                    "/reset-password/{token}, and /forgot-password, or configure UI_BASE_URL for the React client."
+                )
+
         # CSRF secret key fallback to JWT secret key.
         # NOTE: SecretStr("") is truthy, so the emptiness check must go through
         # get_secret_value(); `if not self.csrf_secret_key` would never fire and

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1191,6 +1191,21 @@ class Settings(BaseSettings):
         description="Trusted base URL for browser-facing UI links. Falls back to APP_DOMAIN plus APP_ROOT_PATH when unset.",
     )
 
+    @field_validator("ui_base_url", mode="before")
+    @classmethod
+    def normalize_ui_base_url(cls, value: object) -> object:
+        """Treat an empty environment override as unset.
+
+        Args:
+            value: Raw configured frontend base URL.
+
+        Returns:
+            object: ``None`` for blank strings, otherwise the original value.
+        """
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value
+
     @field_validator("ui_base_url")
     @classmethod
     def validate_ui_base_url(cls, value: Optional[HttpUrl]) -> Optional[HttpUrl]:

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1186,6 +1186,34 @@ class Settings(BaseSettings):
 
     # Domain configuration
     app_domain: HttpUrl = Field(default=HttpUrl("http://localhost:4444"))
+    ui_base_url: Optional[HttpUrl] = Field(
+        default=None,
+        description="Trusted base URL for browser-facing UI links. Falls back to APP_DOMAIN plus APP_ROOT_PATH when unset.",
+    )
+
+    @field_validator("ui_base_url")
+    @classmethod
+    def validate_ui_base_url(cls, value: Optional[HttpUrl]) -> Optional[HttpUrl]:
+        """Reject URL components unsuitable for a trusted frontend base.
+
+        Args:
+            value: Configured frontend base URL.
+
+        Returns:
+            Optional[HttpUrl]: Validated frontend base URL.
+
+        Raises:
+            ValueError: If credentials, query parameters, or fragments are present.
+        """
+        if value is None:
+            return None
+        if value.username or value.password:
+            raise ValueError("UI_BASE_URL must not contain credentials")
+        if value.query:
+            raise ValueError("UI_BASE_URL must not contain a query string")
+        if value.fragment:
+            raise ValueError("UI_BASE_URL must not contain a fragment")
+        return value
 
     # Security settings
     secure_cookies: bool = Field(default=True)

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1633,9 +1633,9 @@ class Settings(BaseSettings):
 
             if self.smtp_enabled and self.ui_base_url is None:
                 logger.warning(
-                    "SMTP_ENABLED=true while UI_BASE_URL is unset. Browser-facing email links will use "
-                    "APP_DOMAIN plus APP_ROOT_PATH. Ensure that fallback serves /accept-invitation/{token}, "
-                    "/reset-password/{token}, and /forgot-password, or configure UI_BASE_URL for the React client."
+                    "SMTP_ENABLED=true while UI_BASE_URL is unset. Invitation links will use APP_DOMAIN plus "
+                    "APP_ROOT_PATH and require /accept-invitation/{token}. Password-recovery links will use legacy "
+                    "/admin routes and require MCPGATEWAY_ADMIN_API_ENABLED=true. Configure UI_BASE_URL for the React client."
                 )
 
         # CSRF secret key fallback to JWT secret key.

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1632,10 +1632,15 @@ class Settings(BaseSettings):
                 logger.warning("🐛 SECURITY WARNING: Debug mode is enabled in non-dev mode. This may leak sensitive information! Set DEBUG=false for production.")
 
             if self.smtp_enabled and self.ui_base_url is None:
+                password_route_warning = (
+                    "Password-recovery links will use legacy /admin routes because MCPGATEWAY_ADMIN_API_ENABLED=true."
+                    if self.mcpgateway_admin_api_enabled
+                    else "Password-recovery links will use frontend /forgot-password and /reset-password/{token} routes because MCPGATEWAY_ADMIN_API_ENABLED=false."
+                )
                 logger.warning(
                     "SMTP_ENABLED=true while UI_BASE_URL is unset. Invitation links will use APP_DOMAIN plus "
-                    "APP_ROOT_PATH and require /accept-invitation/{token}. Password-recovery links will use legacy "
-                    "/admin routes and require MCPGATEWAY_ADMIN_API_ENABLED=true. Configure UI_BASE_URL for the React client."
+                    "APP_ROOT_PATH and require /accept-invitation/{token}. %s Configure UI_BASE_URL for the React client.",
+                    password_route_warning,
                 )
 
         # CSRF secret key fallback to JWT secret key.

--- a/mcpgateway/middleware/rate_limit_middleware.py
+++ b/mcpgateway/middleware/rate_limit_middleware.py
@@ -105,6 +105,11 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
                 "limit": settings.rate_limit_critical_rpm,
                 "burst": settings.rate_limit_critical_burst,
             },
+            "CRITICAL_INVITATION": {
+                "pattern": r"^/teams/[^/]+/invitations/?$",
+                "limit": settings.rate_limit_critical_rpm,
+                "burst": settings.rate_limit_critical_burst,
+            },
             "HIGH": {
                 "pattern": r"^/(tokens|oauth|rbac)(/|$)",
                 "limit": settings.rate_limit_high_rpm,

--- a/mcpgateway/middleware/rate_limit_middleware.py
+++ b/mcpgateway/middleware/rate_limit_middleware.py
@@ -27,7 +27,7 @@ import logging
 import re
 import threading
 import time
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 import uuid
 
 # Third-Party
@@ -106,7 +106,8 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
                 "burst": settings.rate_limit_critical_burst,
             },
             "CRITICAL_INVITATION": {
-                "pattern": r"^/teams/[^/]+/invitations/?$",
+                "pattern": r"^/(?:v1/)?teams/[^/]+/invitations/?$",
+                "methods": {"POST"},
                 "limit": settings.rate_limit_critical_rpm,
                 "burst": settings.rate_limit_critical_burst,
             },
@@ -177,10 +178,16 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             compiled.append((pattern, config))
         return compiled
 
-    def get_endpoint_tier(self, path: str) -> Dict[str, Any]:
-        """Get tier config for endpoint."""
+    @staticmethod
+    def _tier_allows_method(config: Dict[str, Any], method: Optional[str]) -> bool:
+        """Check whether a tier applies to the request method."""
+        methods = config.get("methods")
+        return not methods or (method is not None and method.upper() in methods)
+
+    def get_endpoint_tier(self, path: str, method: Optional[str] = None) -> Dict[str, Any]:
+        """Get tier config for endpoint and request method."""
         for pattern, config in self.compiled_tiers:
-            if pattern.match(path):
+            if pattern.match(path) and self._tier_allows_method(config, method):
                 return config
         return self.default_tier
 
@@ -214,10 +221,10 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         if is_trusted_internal_mcp_request(request):
             return await call_next(request)
 
-        tier = self.get_endpoint_tier(request.url.path)
+        tier = self.get_endpoint_tier(request.url.path, request.method)
         dimensions = self._get_client_dimensions(request)
 
-        tier_name = self._get_tier_name(request.url.path)
+        tier_name = self._get_tier_name(request.url.path, request.method)
 
         # Check lockout first — a locked-out dimension blocks regardless of
         # whether the sliding window has cleared.
@@ -282,10 +289,10 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
         return response
 
-    def _get_tier_name(self, path: str) -> str:
-        """Get tier name for logging."""
+    def _get_tier_name(self, path: str, method: Optional[str] = None) -> str:
+        """Get tier name for logging by endpoint and request method."""
         for tier_name, config in self.endpoint_tiers.items():
-            if re.match(config["pattern"], path):
+            if re.match(config["pattern"], path) and self._tier_allows_method(config, method):
                 return tier_name
         return "LOW"
 

--- a/mcpgateway/routers/teams.py
+++ b/mcpgateway/routers/teams.py
@@ -148,8 +148,16 @@ async def create_team(request: TeamCreateRequest, current_user_ctx: dict = Depen
             members_added=[SeededMemberResponse(email=member.email, role=member.role) for member in result.members_added],
             invitations_sent=[SeededInvitationResponse(email=invite.email, role=invite.role, invitation_id=invite.invitation_id) for invite in result.invitations_sent],
         )
+        invitation_service = TeamInvitationService(db) if result.invitations_to_deliver else None
         db.commit()
         db.close()
+
+        if invitation_service:
+            await invitation_service.deliver_invitation_emails(
+                result.invitations_to_deliver,
+                team.name,
+                current_user_ctx.get("full_name") or current_user_ctx["email"],
+            )
         return response
     except HTTPException:
         raise
@@ -774,13 +782,13 @@ async def invite_team_member(team_id: str, request: TeamInviteRequest, current_u
         team_name = team.name if team else "Unknown Team"
 
         db.commit()
+        db.close()
         delivery = await invitation_service.deliver_invitation_email(
             invitation=invitation,
             team_name=team_name,
             inviter_name=current_user.get("full_name") or current_user["email"],
         )
 
-        db.close()
         return TeamInvitationCreateResponse(
             id=invitation.id,
             team_id=invitation.team_id,

--- a/mcpgateway/routers/teams.py
+++ b/mcpgateway/routers/teams.py
@@ -22,7 +22,7 @@ Examples:
 from typing import Any, cast, List, Optional, Union
 
 # Third-Party
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 # First-Party
@@ -55,7 +55,7 @@ from mcpgateway.schemas import (
 )
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.permission_service import PermissionService
-from mcpgateway.services.team_invitation_service import TeamInvitationService
+from mcpgateway.services.team_invitation_service import failed_invitation_delivery_result, TeamInvitationService
 from mcpgateway.services.team_management_service import (
     InvalidRoleError,
     JoinRequestNotFoundError,
@@ -83,7 +83,9 @@ teams_router = APIRouter()
 
 @teams_router.post("/", response_model=TeamCreateResponse, status_code=status.HTTP_201_CREATED)
 @require_permission("teams.create")
-async def create_team(request: TeamCreateRequest, current_user_ctx: dict = Depends(get_current_user_with_permissions), db: Session = Depends(get_db)) -> TeamCreateResponse:
+async def create_team(
+    request: TeamCreateRequest, background_tasks: BackgroundTasks, current_user_ctx: dict = Depends(get_current_user_with_permissions), db: Session = Depends(get_db)
+) -> TeamCreateResponse:
     """Create a new team, optionally seeding it with members.
 
     Members supplied in the request are routed by the server: an address that
@@ -94,6 +96,7 @@ async def create_team(request: TeamCreateRequest, current_user_ctx: dict = Depen
 
     Args:
         request: Team creation request data
+        background_tasks: Response-scoped background task scheduler
         current_user_ctx: Currently authenticated user context
         db: Database session
 
@@ -153,7 +156,8 @@ async def create_team(request: TeamCreateRequest, current_user_ctx: dict = Depen
         db.close()
 
         if invitation_service:
-            await invitation_service.deliver_invitation_emails(
+            background_tasks.add_task(
+                invitation_service.deliver_invitation_emails,
                 result.invitations_to_deliver,
                 team.name,
                 current_user_ctx.get("full_name") or current_user_ctx["email"],
@@ -783,11 +787,15 @@ async def invite_team_member(team_id: str, request: TeamInviteRequest, current_u
 
         db.commit()
         db.close()
-        delivery = await invitation_service.deliver_invitation_email(
-            invitation=invitation,
-            team_name=team_name,
-            inviter_name=current_user.get("full_name") or current_user["email"],
-        )
+        try:
+            delivery = await invitation_service.deliver_invitation_email(
+                invitation=invitation,
+                team_name=team_name,
+                inviter_name=current_user.get("full_name") or current_user["email"],
+            )
+        except Exception:  # pragma: no cover - final boundary after persistence
+            logger.warning("Team invitation email delivery failed for invitation %s", SecurityValidator.sanitize_log_message(invitation.id))
+            delivery = failed_invitation_delivery_result()
 
         return TeamInvitationCreateResponse(
             id=invitation.id,

--- a/mcpgateway/routers/teams.py
+++ b/mcpgateway/routers/teams.py
@@ -41,6 +41,7 @@ from mcpgateway.schemas import (
     TeamCreateRequest,
     TeamCreateResponse,
     TeamDiscoveryResponse,
+    TeamInvitationCreateResponse,
     TeamInvitationResponse,
     TeamInviteRequest,
     TeamJoinRequest,
@@ -735,9 +736,9 @@ async def remove_team_member(team_id: str, user_email: str, current_user: dict =
 # ---------------------------------------------------------------------------
 
 
-@teams_router.post("/{team_id}/invitations", response_model=TeamInvitationResponse, status_code=status.HTTP_201_CREATED)
+@teams_router.post("/{team_id}/invitations", response_model=TeamInvitationCreateResponse, status_code=status.HTTP_201_CREATED)
 @require_permission("teams.manage_members")
-async def invite_team_member(team_id: str, request: TeamInviteRequest, current_user: dict = Depends(get_current_user_with_permissions), db: Session = Depends(get_db)) -> TeamInvitationResponse:
+async def invite_team_member(team_id: str, request: TeamInviteRequest, current_user: dict = Depends(get_current_user_with_permissions), db: Session = Depends(get_db)) -> TeamInvitationCreateResponse:
     """Invite a user to join a team.
 
     Args:
@@ -747,7 +748,7 @@ async def invite_team_member(team_id: str, request: TeamInviteRequest, current_u
         db: Database session
 
     Returns:
-        TeamInvitationResponse: Created invitation data
+        TeamInvitationCreateResponse: Created invitation and email delivery data
 
     Raises:
         HTTPException: If team not found, access denied, or invitation fails
@@ -773,8 +774,14 @@ async def invite_team_member(team_id: str, request: TeamInviteRequest, current_u
         team_name = team.name if team else "Unknown Team"
 
         db.commit()
+        delivery = await invitation_service.deliver_invitation_email(
+            invitation=invitation,
+            team_name=team_name,
+            inviter_name=current_user.get("full_name") or current_user["email"],
+        )
+
         db.close()
-        return TeamInvitationResponse(
+        return TeamInvitationCreateResponse(
             id=invitation.id,
             team_id=invitation.team_id,
             team_name=team_name,
@@ -786,6 +793,9 @@ async def invite_team_member(team_id: str, request: TeamInviteRequest, current_u
             token=invitation.token,
             is_active=invitation.is_active,
             is_expired=invitation.is_expired(),
+            invitation_url=delivery.invitation_url,
+            email_delivery_status=delivery.status,
+            warning=delivery.warning,
         )
     except HTTPException:
         raise

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -7130,6 +7130,22 @@ class TeamInvitationResponse(BaseModel):
     is_expired: bool = Field(..., description="Whether the invitation has expired")
 
 
+class EmailDeliveryStatus(str, Enum):
+    """Outcome of a best-effort notification email delivery."""
+
+    SENT = "sent"
+    FAILED = "failed"
+    DISABLED = "disabled"
+
+
+class TeamInvitationCreateResponse(TeamInvitationResponse):
+    """Schema for a newly created invitation and its email-delivery outcome."""
+
+    invitation_url: str = Field(..., description="Trusted frontend URL for accepting the invitation")
+    email_delivery_status: EmailDeliveryStatus = Field(..., description="Invitation email delivery outcome")
+    warning: Optional[str] = Field(default=None, description="Safe client-facing delivery warning")
+
+
 class TeamMemberAddRequest(BaseModel):
     """Schema for adding a team member.
 

--- a/mcpgateway/services/email_auth_service.py
+++ b/mcpgateway/services/email_auth_service.py
@@ -30,7 +30,6 @@ import re
 import secrets
 import time
 from typing import Optional
-import urllib.parse
 import warnings
 
 # Third-Party
@@ -60,7 +59,7 @@ from mcpgateway.db import (
 )
 from mcpgateway.schemas import PaginationLinks, PaginationMeta
 from mcpgateway.services.argon2_service import Argon2PasswordService
-from mcpgateway.services.email_notification_service import AuthEmailNotificationService
+from mcpgateway.services.email_notification_service import AuthEmailNotificationService, build_frontend_url
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.metrics import password_reset_completions_counter, password_reset_requests_counter
 from mcpgateway.utils.pagination import unified_paginate
@@ -446,9 +445,7 @@ class EmailAuthService:
         Returns:
             str: Absolute forgot-password URL.
         """
-        app_domain = str(getattr(settings, "app_domain", "http://localhost:4444")).rstrip("/")
-        root_path = str(getattr(settings, "app_root_path", "")).rstrip("/")
-        return f"{app_domain}{root_path}/admin/forgot-password"
+        return build_frontend_url("/forgot-password")
 
     @staticmethod
     def _build_reset_password_url(token: str) -> str:
@@ -460,10 +457,7 @@ class EmailAuthService:
         Returns:
             str: Absolute reset-password URL.
         """
-        safe_token = urllib.parse.quote(token, safe="")
-        app_domain = str(getattr(settings, "app_domain", "http://localhost:4444")).rstrip("/")
-        root_path = str(getattr(settings, "app_root_path", "")).rstrip("/")
-        return f"{app_domain}{root_path}/admin/reset-password/{safe_token}"
+        return build_frontend_url("/reset-password", token)
 
     async def _invalidate_user_auth_cache(self, email: str) -> None:
         """Invalidate cached authentication data for a user.

--- a/mcpgateway/services/email_notification_service.py
+++ b/mcpgateway/services/email_notification_service.py
@@ -54,8 +54,8 @@ def build_frontend_url(path: str, token: Optional[str] = None) -> str:
         app_domain = str(getattr(settings, "app_domain", "http://localhost:4444")).rstrip("/")
         root_path = str(getattr(settings, "app_root_path", "") or "").strip("/")
         base_url = f"{app_domain}/{root_path}" if root_path else app_domain
-        # Preserve bundled Admin UI password recovery when no separate frontend is configured.
-        if path in {"/forgot-password", "/reset-password"}:
+        # Preserve bundled Admin UI password recovery only when those routes are mounted.
+        if path in {"/forgot-password", "/reset-password"} and settings.mcpgateway_admin_api_enabled:
             path = f"/admin{path}"
 
     url = f"{base_url}{path}"

--- a/mcpgateway/services/email_notification_service.py
+++ b/mcpgateway/services/email_notification_service.py
@@ -16,16 +16,48 @@ import re
 import smtplib
 import ssl
 from typing import Any, Dict, Optional
+import urllib.parse
 
 # Third-Party
 from jinja2 import Environment, FileSystemLoader, select_autoescape, TemplateNotFound
 
 # First-Party
 from mcpgateway.config import settings
+from mcpgateway.schemas import EmailDeliveryStatus
 from mcpgateway.services.logging_service import LoggingService
 
 logging_service = LoggingService()
 logger = logging_service.get_logger(__name__)
+
+
+def build_frontend_url(path: str, token: Optional[str] = None) -> str:
+    """Build a trusted browser-facing URL for email notifications.
+
+    Args:
+        path: Frontend route beginning with ``/``.
+        token: Optional secret token appended as one URL-encoded path segment.
+
+    Returns:
+        str: Absolute frontend URL.
+
+    Raises:
+        ValueError: If path is not an absolute frontend route.
+    """
+    if not path.startswith("/") or path.startswith("//"):
+        raise ValueError("Frontend path must start with exactly one slash")
+
+    configured_ui_base = getattr(settings, "ui_base_url", None)
+    if configured_ui_base:
+        base_url = str(configured_ui_base).rstrip("/")
+    else:
+        app_domain = str(getattr(settings, "app_domain", "http://localhost:4444")).rstrip("/")
+        root_path = str(getattr(settings, "app_root_path", "") or "").strip("/")
+        base_url = f"{app_domain}/{root_path}" if root_path else app_domain
+
+    url = f"{base_url}{path}"
+    if token is not None:
+        url = f"{url.rstrip('/')}/{urllib.parse.quote(token, safe='')}"
+    return url
 
 
 class AuthEmailNotificationService:
@@ -97,13 +129,14 @@ class AuthEmailNotificationService:
         compact = re.sub(r"\s+", " ", no_tags).strip()
         return compact
 
-    async def _send_email(self, to_email: str, subject: str, html_body: str) -> bool:
+    async def _send_email(self, to_email: str, subject: str, html_body: str, text_body: Optional[str] = None) -> bool:
         """Send an email asynchronously.
 
         Args:
             to_email: Destination email address.
             subject: Message subject.
             html_body: HTML message body.
+            text_body: Optional explicit plaintext message body.
 
         Returns:
             bool: True when message is sent successfully.
@@ -111,15 +144,16 @@ class AuthEmailNotificationService:
         if not self._smtp_ready():
             logger.info("SMTP not configured. Skipping email to %s with subject '%s'.", to_email, subject)
             return False
-        return await asyncio.to_thread(self._send_email_sync, to_email, subject, html_body)
+        return await asyncio.to_thread(self._send_email_sync, to_email, subject, html_body, text_body)
 
-    def _send_email_sync(self, to_email: str, subject: str, html_body: str) -> bool:
+    def _send_email_sync(self, to_email: str, subject: str, html_body: str, text_body: Optional[str] = None) -> bool:
         """Send an email synchronously over SMTP.
 
         Args:
             to_email: Destination email address.
             subject: Message subject.
             html_body: HTML message body.
+            text_body: Optional explicit plaintext message body.
 
         Returns:
             bool: True when message is sent successfully.
@@ -133,7 +167,7 @@ class AuthEmailNotificationService:
         message["Subject"] = subject
         message["From"] = formataddr((from_name, from_email))
         message["To"] = to_email
-        message.set_content(self._html_to_text(html_body))
+        message.set_content(text_body or self._html_to_text(html_body))
         message.add_alternative(html_body, subtype="html")
 
         smtp_host = str(getattr(settings, "smtp_host", ""))
@@ -161,8 +195,103 @@ class AuthEmailNotificationService:
             logger.info("Auth notification email sent to %s", to_email)
             return True
         except Exception as exc:
-            logger.warning("Failed to send auth notification email to %s: %s", to_email, exc)
+            logger.warning("Failed to send auth notification email to %s (%s)", to_email, type(exc).__name__)
             return False
+
+    async def send_team_invitation_email(
+        self,
+        to_email: str,
+        team_name: str,
+        inviter_name: str,
+        role: str,
+        invitation_url: str,
+        expires_at: str,
+        token: str,
+    ) -> bool:
+        """Send a team invitation email.
+
+        Args:
+            to_email: Destination email address.
+            team_name: Invited team display name.
+            inviter_name: Inviter display name.
+            role: Role granted after acceptance.
+            invitation_url: Trusted frontend acceptance URL.
+            expires_at: Invitation expiry timestamp.
+            token: Raw invitation token included as fallback.
+
+        Returns:
+            bool: True when message is sent successfully.
+        """
+        subject = f"Invitation to join {team_name} on ContextForge"
+        html_body = self._render_template(
+            template_name="team_invitation_email.html",
+            context={
+                "recipient_email": to_email,
+                "team_name": team_name,
+                "inviter_name": inviter_name,
+                "role": role,
+                "invitation_url": invitation_url,
+                "expires_at": expires_at,
+                "token": token,
+            },
+            fallback_title="Team invitation",
+            fallback_body=f"{inviter_name} invited you to join {team_name} as {role}. Accept: {invitation_url}\nExpires: {expires_at}\nToken: {token}",
+        )
+        text_body = (
+            "ContextForge team invitation\n\n"
+            f"{inviter_name} invited you to join {team_name} as {role}.\n\n"
+            f"Accept invitation: {invitation_url}\n"
+            f"Expires: {expires_at}\n\n"
+            f"Fallback invitation token: {token}\n"
+        )
+        return await self._send_email(to_email, subject, html_body, text_body)
+
+    async def deliver_team_invitation_email(
+        self,
+        invitation_id: str,
+        to_email: str,
+        team_name: str,
+        inviter_name: str,
+        role: str,
+        invitation_url: str,
+        expires_at: str,
+        token: str,
+    ) -> EmailDeliveryStatus:
+        """Deliver a persisted invitation without exposing transport failures.
+
+        Args:
+            invitation_id: Persisted invitation identifier used for safe logging.
+            to_email: Destination email address.
+            team_name: Invited team display name.
+            inviter_name: Inviter display name.
+            role: Role granted after acceptance.
+            invitation_url: Trusted frontend acceptance URL.
+            expires_at: Invitation expiry timestamp.
+            token: Raw invitation token included in the email only.
+
+        Returns:
+            EmailDeliveryStatus: Delivery outcome.
+        """
+        if not getattr(settings, "smtp_enabled", False):
+            return EmailDeliveryStatus.DISABLED
+
+        try:
+            sent = await self.send_team_invitation_email(
+                to_email=to_email,
+                team_name=team_name,
+                inviter_name=inviter_name,
+                role=role,
+                invitation_url=invitation_url,
+                expires_at=expires_at,
+                token=token,
+            )
+        except Exception:  # pragma: no cover - defensive boundary around best-effort delivery
+            sent = False
+
+        if sent:
+            return EmailDeliveryStatus.SENT
+        logger.warning("Team invitation email delivery failed for invitation %s", invitation_id)
+        return EmailDeliveryStatus.FAILED
 
     async def send_password_reset_email(self, to_email: str, full_name: Optional[str], reset_url: str, expires_minutes: int) -> bool:
         """Send password-reset email containing a one-time reset link.

--- a/mcpgateway/services/email_notification_service.py
+++ b/mcpgateway/services/email_notification_service.py
@@ -22,6 +22,7 @@ import urllib.parse
 from jinja2 import Environment, FileSystemLoader, select_autoescape, TemplateNotFound
 
 # First-Party
+from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.schemas import EmailDeliveryStatus
 from mcpgateway.services.logging_service import LoggingService
@@ -53,6 +54,8 @@ def build_frontend_url(path: str, token: Optional[str] = None) -> str:
         app_domain = str(getattr(settings, "app_domain", "http://localhost:4444")).rstrip("/")
         root_path = str(getattr(settings, "app_root_path", "") or "").strip("/")
         base_url = f"{app_domain}/{root_path}" if root_path else app_domain
+        if path in {"/forgot-password", "/reset-password"}:
+            path = f"/admin{path}"
 
     url = f"{base_url}{path}"
     if token is not None:
@@ -290,7 +293,7 @@ class AuthEmailNotificationService:
 
         if sent:
             return EmailDeliveryStatus.SENT
-        logger.warning("Team invitation email delivery failed for invitation %s", invitation_id)
+        logger.warning("Team invitation email delivery failed for invitation %s", SecurityValidator.sanitize_log_message(invitation_id))
         return EmailDeliveryStatus.FAILED
 
     async def send_password_reset_email(self, to_email: str, full_name: Optional[str], reset_url: str, expires_minutes: int) -> bool:

--- a/mcpgateway/services/email_notification_service.py
+++ b/mcpgateway/services/email_notification_service.py
@@ -54,6 +54,9 @@ def build_frontend_url(path: str, token: Optional[str] = None) -> str:
         app_domain = str(getattr(settings, "app_domain", "http://localhost:4444")).rstrip("/")
         root_path = str(getattr(settings, "app_root_path", "") or "").strip("/")
         base_url = f"{app_domain}/{root_path}" if root_path else app_domain
+        # Preserve bundled Admin UI password recovery when no separate frontend is configured.
+        if path in {"/forgot-password", "/reset-password"}:
+            path = f"/admin{path}"
 
     url = f"{base_url}{path}"
     if token is not None:

--- a/mcpgateway/services/email_notification_service.py
+++ b/mcpgateway/services/email_notification_service.py
@@ -54,8 +54,6 @@ def build_frontend_url(path: str, token: Optional[str] = None) -> str:
         app_domain = str(getattr(settings, "app_domain", "http://localhost:4444")).rstrip("/")
         root_path = str(getattr(settings, "app_root_path", "") or "").strip("/")
         base_url = f"{app_domain}/{root_path}" if root_path else app_domain
-        if path in {"/forgot-password", "/reset-password"}:
-            path = f"/admin{path}"
 
     url = f"{base_url}{path}"
     if token is not None:

--- a/mcpgateway/services/team_invitation_service.py
+++ b/mcpgateway/services/team_invitation_service.py
@@ -125,9 +125,7 @@ class TeamInvitationService:
         warning = _DELIVERY_WARNING if status == EmailDeliveryStatus.FAILED else None
         return InvitationDeliveryResult(invitation_url=invitation_url, status=status, warning=warning)
 
-    async def deliver_invitation_emails(
-        self, invitations: Sequence[EmailTeamInvitation], team_name: str, inviter_name: str
-    ) -> List[InvitationDeliveryResult]:
+    async def deliver_invitation_emails(self, invitations: Sequence[EmailTeamInvitation], team_name: str, inviter_name: str) -> List[InvitationDeliveryResult]:
         """Deliver persisted invitations with bounded SMTP concurrency.
 
         Args:

--- a/mcpgateway/services/team_invitation_service.py
+++ b/mcpgateway/services/team_invitation_service.py
@@ -42,6 +42,7 @@ logger = logging_service.get_logger(__name__)
 
 _INVITATION_EMAIL_CONCURRENCY = 5
 _DELIVERY_WARNING = "Invitation created, but the email could not be delivered."
+_DELIVERY_DISABLED_WARNING = "Invitation created, but email delivery is disabled."
 
 
 @dataclass(frozen=True)
@@ -51,6 +52,18 @@ class InvitationDeliveryResult:
     invitation_url: str
     status: EmailDeliveryStatus
     warning: Optional[str] = None
+
+
+def failed_invitation_delivery_result(invitation_url: str = "") -> InvitationDeliveryResult:
+    """Build a safe result for an unexpected best-effort delivery failure.
+
+    Args:
+        invitation_url: Trusted URL if construction succeeded.
+
+    Returns:
+        InvitationDeliveryResult: Non-throwing failed delivery result.
+    """
+    return InvitationDeliveryResult(invitation_url=invitation_url, status=EmailDeliveryStatus.FAILED, warning=_DELIVERY_WARNING)
 
 
 class TeamInvitationService:
@@ -106,8 +119,9 @@ class TeamInvitationService:
         Returns:
             InvitationDeliveryResult: Trusted URL and safe delivery outcome.
         """
-        invitation_url = build_frontend_url("/accept-invitation", invitation.token)
+        invitation_url = ""
         try:
+            invitation_url = build_frontend_url("/accept-invitation", invitation.token)
             status = await self.email_notification_service.deliver_team_invitation_email(
                 invitation_id=invitation.id,
                 to_email=invitation.email,
@@ -119,10 +133,13 @@ class TeamInvitationService:
                 token=invitation.token,
             )
         except Exception:  # pragma: no cover - defensive boundary around best-effort delivery
-            status = EmailDeliveryStatus.FAILED
             logger.warning("Team invitation email delivery failed for invitation %s", SecurityValidator.sanitize_log_message(invitation.id))
+            return failed_invitation_delivery_result(invitation_url)
 
-        warning = _DELIVERY_WARNING if status == EmailDeliveryStatus.FAILED else None
+        warning = {
+            EmailDeliveryStatus.FAILED: _DELIVERY_WARNING,
+            EmailDeliveryStatus.DISABLED: _DELIVERY_DISABLED_WARNING,
+        }.get(status)
         return InvitationDeliveryResult(invitation_url=invitation_url, status=status, warning=warning)
 
     async def deliver_invitation_emails(self, invitations: Sequence[EmailTeamInvitation], team_name: str, inviter_name: str) -> List[InvitationDeliveryResult]:
@@ -144,11 +161,7 @@ class TeamInvitationService:
                     return await self.deliver_invitation_email(invitation, team_name, inviter_name)
                 except Exception:  # pragma: no cover - defensive isolation between batch items
                     logger.warning("Team invitation email delivery failed for invitation %s", SecurityValidator.sanitize_log_message(invitation.id))
-                    return InvitationDeliveryResult(
-                        invitation_url=build_frontend_url("/accept-invitation", invitation.token),
-                        status=EmailDeliveryStatus.FAILED,
-                        warning=_DELIVERY_WARNING,
-                    )
+                    return failed_invitation_delivery_result()
 
         return list(await asyncio.gather(*(deliver(invitation) for invitation in invitations)))
 

--- a/mcpgateway/services/team_invitation_service.py
+++ b/mcpgateway/services/team_invitation_service.py
@@ -17,9 +17,10 @@ Examples:
 
 # Standard
 import asyncio
+from dataclasses import dataclass
 from datetime import timedelta
 import secrets
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Sequence
 
 # Third-Party
 from sqlalchemy.exc import IntegrityError
@@ -30,12 +31,26 @@ from mcpgateway.cache.auth_cache import auth_cache
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.db import EmailTeam, EmailTeamInvitation, EmailTeamMember, EmailUser, utc_now
+from mcpgateway.schemas import EmailDeliveryStatus
+from mcpgateway.services.email_notification_service import AuthEmailNotificationService, build_frontend_url
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.team_management_service import check_team_member_capacity, get_user_team_count, TeamManagementService
 
 # Initialize logging
 logging_service = LoggingService()
 logger = logging_service.get_logger(__name__)
+
+_INVITATION_EMAIL_CONCURRENCY = 5
+_DELIVERY_WARNING = "Invitation created, but the email could not be delivered."
+
+
+@dataclass(frozen=True)
+class InvitationDeliveryResult:
+    """Frontend URL and best-effort email outcome for an invitation."""
+
+    invitation_url: str
+    status: EmailDeliveryStatus
+    warning: Optional[str] = None
 
 
 class TeamInvitationService:
@@ -78,6 +93,66 @@ class TeamInvitationService:
             'TeamInvitationService'
         """
         self.db = db
+        self.email_notification_service = AuthEmailNotificationService()
+
+    async def deliver_invitation_email(self, invitation: EmailTeamInvitation, team_name: str, inviter_name: str) -> InvitationDeliveryResult:
+        """Deliver email for a persisted invitation.
+
+        Args:
+            invitation: Persisted invitation row.
+            team_name: Team display name.
+            inviter_name: Inviter display name.
+
+        Returns:
+            InvitationDeliveryResult: Trusted URL and safe delivery outcome.
+        """
+        invitation_url = build_frontend_url("/accept-invitation", invitation.token)
+        try:
+            status = await self.email_notification_service.deliver_team_invitation_email(
+                invitation_id=invitation.id,
+                to_email=invitation.email,
+                team_name=team_name,
+                inviter_name=inviter_name,
+                role=invitation.role,
+                invitation_url=invitation_url,
+                expires_at=invitation.expires_at.isoformat(),
+                token=invitation.token,
+            )
+        except Exception:  # pragma: no cover - defensive boundary around best-effort delivery
+            status = EmailDeliveryStatus.FAILED
+            logger.warning("Team invitation email delivery failed for invitation %s", SecurityValidator.sanitize_log_message(invitation.id))
+
+        warning = _DELIVERY_WARNING if status == EmailDeliveryStatus.FAILED else None
+        return InvitationDeliveryResult(invitation_url=invitation_url, status=status, warning=warning)
+
+    async def deliver_invitation_emails(
+        self, invitations: Sequence[EmailTeamInvitation], team_name: str, inviter_name: str
+    ) -> List[InvitationDeliveryResult]:
+        """Deliver persisted invitations with bounded SMTP concurrency.
+
+        Args:
+            invitations: Persisted invitation rows.
+            team_name: Team display name.
+            inviter_name: Inviter display name.
+
+        Returns:
+            List[InvitationDeliveryResult]: Results in input order.
+        """
+        semaphore = asyncio.Semaphore(_INVITATION_EMAIL_CONCURRENCY)
+
+        async def deliver(invitation: EmailTeamInvitation) -> InvitationDeliveryResult:
+            async with semaphore:
+                try:
+                    return await self.deliver_invitation_email(invitation, team_name, inviter_name)
+                except Exception:  # pragma: no cover - defensive isolation between batch items
+                    logger.warning("Team invitation email delivery failed for invitation %s", SecurityValidator.sanitize_log_message(invitation.id))
+                    return InvitationDeliveryResult(
+                        invitation_url=build_frontend_url("/accept-invitation", invitation.token),
+                        status=EmailDeliveryStatus.FAILED,
+                        warning=_DELIVERY_WARNING,
+                    )
+
+        return list(await asyncio.gather(*(deliver(invitation) for invitation in invitations)))
 
     def _get_user_team_count(self, user_email: str) -> int:
         """Get the number of active teams a user belongs to.

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -268,11 +268,13 @@ class TeamSeedResult:
         team: The created (or reactivated) team.
         members_added: Seeds that resolved to a direct membership.
         invitations_sent: Seeds that resolved to an invitation.
+        invitations_to_deliver: Persisted invitations awaiting best-effort email delivery.
     """
 
     team: EmailTeam
     members_added: List[SeededMember] = field(default_factory=list)
     invitations_sent: List[SeededInvitation] = field(default_factory=list)
+    invitations_to_deliver: List[EmailTeamInvitation] = field(default_factory=list, repr=False)
 
 
 class _Unset:
@@ -873,16 +875,6 @@ class TeamManagementService:
 
             team_id = str(team.id)
 
-            # Invitations were flushed with commit=False above. Delivery starts
-            # only after the outer team transaction commits successfully.
-            if invitations:
-                inviter = self.db.query(EmailUser).filter(EmailUser.email == created_by).first()
-                inviter_name = inviter.get_display_name() if inviter else created_by
-                # First-Party
-                from mcpgateway.services.team_invitation_service import TeamInvitationService  # pylint: disable=import-outside-toplevel,cyclic-import,reimported
-
-                await TeamInvitationService(self.db).deliver_invitation_emails(invitations, team.name, inviter_name)
-
             # Post-commit bookkeeping for each seeded member, matching add_member_to_team()
             for member, action in memberships:
                 self._log_team_member_action(member.id, team_id, member.user_email, member.role, action, created_by)
@@ -907,6 +899,7 @@ class TeamManagementService:
                 team=team,
                 members_added=[SeededMember(email=member.user_email, role=member.role) for member, _ in memberships],
                 invitations_sent=[SeededInvitation(email=invitation.email, role=invitation.role, invitation_id=invitation.id) for invitation in invitations],
+                invitations_to_deliver=invitations,
             )
 
         except Exception as e:

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -873,6 +873,16 @@ class TeamManagementService:
 
             team_id = str(team.id)
 
+            # Invitations were flushed with commit=False above. Delivery starts
+            # only after the outer team transaction commits successfully.
+            if invitations:
+                inviter = self.db.query(EmailUser).filter(EmailUser.email == created_by).first()
+                inviter_name = inviter.get_display_name() if inviter else created_by
+                # First-Party
+                from mcpgateway.services.team_invitation_service import TeamInvitationService  # pylint: disable=import-outside-toplevel,cyclic-import,reimported
+
+                await TeamInvitationService(self.db).deliver_invitation_emails(invitations, team.name, inviter_name)
+
             # Post-commit bookkeeping for each seeded member, matching add_member_to_team()
             for member, action in memberships:
                 self._log_team_member_action(member.id, team_id, member.user_email, member.role, action, created_by)

--- a/mcpgateway/templates/team_invitation_email.html
+++ b/mcpgateway/templates/team_invitation_email.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>ContextForge team invitation</title>
+</head>
+<body>
+  <h1>Join {{ team_name }}</h1>
+  <p>{{ inviter_name }} invited you to join <strong>{{ team_name }}</strong> as <strong>{{ role }}</strong>.</p>
+  <p><a href="{{ invitation_url }}">Accept invitation</a></p>
+  <p>This invitation expires at {{ expires_at }}.</p>
+  <p>If the link does not work, use this invitation token:</p>
+  <p><code>{{ token }}</code></p>
+  <p>This message was sent to {{ recipient_email }} by ContextForge.</p>
+</body>
+</html>

--- a/tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py
@@ -114,6 +114,7 @@ class TestRateLimitMiddlewareTiers:
     def mock_request(self):
         """Create mock HTTP request."""
         request = MagicMock()
+        request.method = "GET"
         request.headers = {}
         request.client.host = "192.168.1.100"
         request.url.path = "/api/test"
@@ -151,11 +152,34 @@ class TestRateLimitMiddlewareTiers:
         assert tier["burst"] == 0
 
     def test_endpoint_tier_critical_for_team_invitations(self, middleware):
-        """SMTP-producing team invitations use the strict tier."""
-        tier = middleware.get_endpoint_tier("/teams/team-123/invitations")
-        assert tier["limit"] == 10
-        assert tier["burst"] == 0
-        assert middleware._get_tier_name("/teams/team-123/invitations") == "CRITICAL_INVITATION"
+        """Only SMTP-producing POST invitation requests use the strict tier."""
+        for path in ("/teams/team-123/invitations", "/v1/teams/team-123/invitations"):
+            post_tier = middleware.get_endpoint_tier(path, "POST")
+
+            assert post_tier["limit"] == 10
+            assert post_tier["burst"] == 0
+            assert middleware._get_tier_name(path, "POST") == "CRITICAL_INVITATION"
+            assert middleware.get_endpoint_tier(path, "GET") == middleware.default_tier
+            assert middleware._get_tier_name(path, "GET") == "LOW"
+
+    @pytest.mark.asyncio
+    async def test_invitation_get_and_post_use_separate_rate_limit_buckets(self, middleware, mock_request):
+        """Read-only invitation polling cannot consume SMTP invitation quota."""
+        mock_request.url.path = "/teams/team-123/invitations"
+        mock_request.state.user_email = None
+        mock_request.state.user = None
+        mock_request.state.team_id = None
+        call_next = AsyncMock(side_effect=lambda _request: MagicMock(headers={}))
+
+        mock_request.method = "GET"
+        get_response = await middleware.dispatch(mock_request, call_next)
+        mock_request.method = "POST"
+        post_response = await middleware.dispatch(mock_request, call_next)
+
+        assert get_response.headers["X-RateLimit-Limit"] == "500"
+        assert post_response.headers["X-RateLimit-Limit"] == "10"
+        assert "ratelimit:ip:192.168.1.100:LOW" in middleware._memory_store
+        assert "ratelimit:ip:192.168.1.100:CRITICAL_INVITATION" in middleware._memory_store
 
     def test_endpoint_tier_high(self, middleware):
         """Test HIGH tier detection for token endpoints."""

--- a/tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py
@@ -150,6 +150,13 @@ class TestRateLimitMiddlewareTiers:
         assert tier["limit"] == 10
         assert tier["burst"] == 0
 
+    def test_endpoint_tier_critical_for_team_invitations(self, middleware):
+        """SMTP-producing team invitations use the strict tier."""
+        tier = middleware.get_endpoint_tier("/teams/team-123/invitations")
+        assert tier["limit"] == 10
+        assert tier["burst"] == 0
+        assert middleware._get_tier_name("/teams/team-123/invitations") == "CRITICAL_INVITATION"
+
     def test_endpoint_tier_high(self, middleware):
         """Test HIGH tier detection for token endpoints."""
         tier = middleware.get_endpoint_tier("/tokens/list")

--- a/tests/unit/mcpgateway/routers/test_teams.py
+++ b/tests/unit/mcpgateway/routers/test_teams.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session
 
 from mcpgateway.db import EmailTeam, EmailTeamInvitation, EmailTeamJoinRequest, EmailTeamMember, EmailUser
 from mcpgateway.schemas import (
+    EmailDeliveryStatus,
     EmailUserResponse,
     TeamCreateRequest,
     TeamInviteRequest,
@@ -25,7 +26,7 @@ from mcpgateway.schemas import (
     TeamMemberUpdateRequest,
     TeamUpdateRequest,
 )
-from mcpgateway.services.team_invitation_service import TeamInvitationService
+from mcpgateway.services.team_invitation_service import InvitationDeliveryResult, TeamInvitationService
 from mcpgateway.services.team_management_service import SeededInvitation, SeededMember, TeamManagementService, TeamMemberLimitExceededError, TeamSeedResult
 
 from tests.utils.rbac_mocks import patch_rbac_decorators, restore_rbac_decorators
@@ -1146,6 +1147,12 @@ class TestTeamsRouter:
 
             mock_invite_service = AsyncMock(spec=TeamInvitationService)
             mock_invite_service.create_invitation = AsyncMock(return_value=mock_invitation)
+            mock_invite_service.deliver_invitation_email = AsyncMock(
+                return_value=InvitationDeliveryResult(
+                    invitation_url=f"https://ui.example/accept-invitation/{mock_invitation.token}",
+                    status=EmailDeliveryStatus.DISABLED,
+                )
+            )
             MockInviteService.return_value = mock_invite_service
 
             from mcpgateway.routers.teams import invite_team_member
@@ -1156,6 +1163,42 @@ class TestTeamsRouter:
             assert result.email == mock_invitation.email
             assert result.role == mock_invitation.role
             assert result.team_name == mock_team.name
+            assert result.email_delivery_status == "disabled"
+            assert result.warning is None
+            assert result.invitation_url.endswith(f"/accept-invitation/{mock_invitation.token}")
+
+    @pytest.mark.asyncio
+    async def test_invite_team_member_reports_delivery_failure_after_commit(self, mock_user_context, mock_db, mock_invitation, mock_team):
+        """Committed invitation survives best-effort SMTP failure."""
+        request = TeamInviteRequest(email="invited@example.com", role="member")
+
+        with (
+            patch("mcpgateway.routers.teams.TeamManagementService") as MockTeamService,
+            patch("mcpgateway.routers.teams.TeamInvitationService") as MockInviteService,
+        ):
+            team_service = AsyncMock(spec=TeamManagementService)
+            team_service.get_user_role_in_team = AsyncMock(return_value="owner")
+            team_service.get_team_by_id = AsyncMock(return_value=mock_team)
+            MockTeamService.return_value = team_service
+            invitation_service = AsyncMock(spec=TeamInvitationService)
+            invitation_service.create_invitation = AsyncMock(return_value=mock_invitation)
+            invitation_service.deliver_invitation_email = AsyncMock(
+                return_value=InvitationDeliveryResult(
+                    invitation_url=f"https://ui.example/accept-invitation/{mock_invitation.token}",
+                    status=EmailDeliveryStatus.FAILED,
+                    warning="Invitation created, but the email could not be delivered.",
+                )
+            )
+            MockInviteService.return_value = invitation_service
+
+            from mcpgateway.routers.teams import invite_team_member
+
+            result = await invite_team_member(mock_team.id, request, current_user=mock_user_context, db=mock_db)
+
+        assert result.email_delivery_status == "failed"
+        assert result.warning == "Invitation created, but the email could not be delivered."
+        mock_db.commit.assert_called()
+        invitation_service.deliver_invitation_email.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_invite_team_member_insufficient_permissions(self, mock_user_context, mock_db):

--- a/tests/unit/mcpgateway/routers/test_teams.py
+++ b/tests/unit/mcpgateway/routers/test_teams.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
-from fastapi import HTTPException, status
+from fastapi import BackgroundTasks, HTTPException, status
 import pytest
 from sqlalchemy.orm import Session
 
@@ -234,7 +234,7 @@ class TestTeamsRouter:
             # Import the function to test
             from mcpgateway.routers.teams import create_team
 
-            result = await create_team(request, current_user_ctx=mock_user_context, db=mock_db)
+            result = await create_team(request, BackgroundTasks(), current_user_ctx=mock_user_context, db=mock_db)
 
             assert result.id == mock_team.id
             assert result.name == mock_team.name
@@ -286,7 +286,10 @@ class TestTeamsRouter:
 
             from mcpgateway.routers.teams import create_team
 
-            result = await create_team(request, current_user_ctx=mock_user_context, db=mock_db)
+            background_tasks = BackgroundTasks()
+            result = await create_team(request, background_tasks, current_user_ctx=mock_user_context, db=mock_db)
+            invitation_service.deliver_invitation_emails.assert_not_awaited()
+            await background_tasks()
 
             # The team fields stay at the top level, so existing clients keep working
             assert result.id == mock_team.id
@@ -309,7 +312,7 @@ class TestTeamsRouter:
 
             from mcpgateway.routers.teams import create_team
 
-            result = await create_team(request, current_user_ctx=mock_user_context, db=mock_db)
+            result = await create_team(request, BackgroundTasks(), current_user_ctx=mock_user_context, db=mock_db)
 
             assert result.members_added == []
             assert result.invitations_sent == []
@@ -328,7 +331,7 @@ class TestTeamsRouter:
             from mcpgateway.routers.teams import create_team
 
             with pytest.raises(HTTPException) as exc_info:
-                await create_team(request, current_user_ctx=mock_user_context, db=mock_db)
+                await create_team(request, BackgroundTasks(), current_user_ctx=mock_user_context, db=mock_db)
 
             assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
             assert "exceeding the maximum" in str(exc_info.value.detail)
@@ -352,7 +355,7 @@ class TestTeamsRouter:
             from mcpgateway.routers.teams import create_team
 
             with pytest.raises(HTTPException) as exc_info:
-                await create_team(request, current_user_ctx=mock_user_context, db=mock_db)
+                await create_team(request, BackgroundTasks(), current_user_ctx=mock_user_context, db=mock_db)
 
             assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
             assert "Service validation error" in str(exc_info.value.detail)
@@ -371,7 +374,7 @@ class TestTeamsRouter:
             from mcpgateway.routers.teams import create_team
 
             with pytest.raises(HTTPException) as exc_info:
-                await create_team(request, current_user_ctx=mock_user_context, db=mock_db)
+                await create_team(request, BackgroundTasks(), current_user_ctx=mock_user_context, db=mock_db)
 
             assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
             assert "Failed to create team" in str(exc_info.value.detail)
@@ -705,7 +708,7 @@ class TestTeamsRouter:
 
             from mcpgateway.routers.teams import create_team
 
-            result = await create_team(request, current_user_ctx=mock_sso_platform_admin_context, db=mock_db)
+            result = await create_team(request, BackgroundTasks(), current_user_ctx=mock_sso_platform_admin_context, db=mock_db)
 
             # Should succeed despite allow_team_creation=False
             assert result.id == mock_team.id
@@ -1216,6 +1219,34 @@ class TestTeamsRouter:
         invitation_service.deliver_invitation_email.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_invite_team_member_contains_delivery_exception_after_commit(self, mock_user_context, mock_db, mock_invitation, mock_team):
+        """Unexpected post-commit delivery error returns created invitation, not HTTP 500."""
+        request = TeamInviteRequest(email="invited@example.com", role="member")
+
+        with (
+            patch("mcpgateway.routers.teams.TeamManagementService") as MockTeamService,
+            patch("mcpgateway.routers.teams.TeamInvitationService") as MockInviteService,
+        ):
+            team_service = AsyncMock(spec=TeamManagementService)
+            team_service.get_user_role_in_team = AsyncMock(return_value="owner")
+            team_service.get_team_by_id = AsyncMock(return_value=mock_team)
+            MockTeamService.return_value = team_service
+            invitation_service = AsyncMock(spec=TeamInvitationService)
+            invitation_service.create_invitation = AsyncMock(return_value=mock_invitation)
+            invitation_service.deliver_invitation_email = AsyncMock(side_effect=RuntimeError("unexpected delivery error"))
+            MockInviteService.return_value = invitation_service
+
+            from mcpgateway.routers.teams import invite_team_member
+
+            result = await invite_team_member(mock_team.id, request, current_user=mock_user_context, db=mock_db)
+
+        assert result.id == mock_invitation.id
+        assert result.email_delivery_status == EmailDeliveryStatus.FAILED
+        assert result.warning == "Invitation created, but the email could not be delivered."
+        mock_db.commit.assert_called_once()
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_invite_team_member_insufficient_permissions(self, mock_user_context, mock_db):
         """Test inviting a user without owner permissions."""
         team_id = str(uuid4())
@@ -1610,7 +1641,7 @@ class TestTeamsRouter:
             from mcpgateway.routers.teams import create_team
 
             with pytest.raises(HTTPException) as exc_info:
-                await create_team(request, current_user_ctx=mock_user_context, db=mock_db)
+                await create_team(request, BackgroundTasks(), current_user_ctx=mock_user_context, db=mock_db)
 
             assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
             assert "max_members cannot exceed" in str(exc_info.value.detail)
@@ -1630,7 +1661,7 @@ class TestTeamsRouter:
 
             from mcpgateway.routers.teams import create_team
 
-            result = await create_team(request, current_user_ctx=mock_user_context, db=mock_db)
+            result = await create_team(request, BackgroundTasks(), current_user_ctx=mock_user_context, db=mock_db)
             assert result.id == mock_team.id
 
     @pytest.mark.asyncio
@@ -1647,7 +1678,7 @@ class TestTeamsRouter:
 
             from mcpgateway.routers.teams import create_team
 
-            result = await create_team(request, current_user_ctx=mock_admin_context, db=mock_db)
+            result = await create_team(request, BackgroundTasks(), current_user_ctx=mock_admin_context, db=mock_db)
             assert result.id == mock_team.id
             mock_service.create_team_with_members.assert_called_once()
 

--- a/tests/unit/mcpgateway/routers/test_teams.py
+++ b/tests/unit/mcpgateway/routers/test_teams.py
@@ -250,8 +250,8 @@ class TestTeamsRouter:
             )
 
     @pytest.mark.asyncio
-    async def test_create_team_reports_seeded_members_and_invitations(self, mock_user_context, mock_team, mock_db):
-        """Seeded members are reported back so the form can confirm without re-querying."""
+    async def test_create_team_reports_seeded_members_and_invitations(self, mock_user_context, mock_team, mock_invitation, mock_db):
+        """Seeded members are reported and email delivery starts after DB close."""
         request = TeamCreateRequest(
             name="New Team",
             visibility="private",
@@ -265,12 +265,24 @@ class TestTeamsRouter:
             team=mock_team,
             members_added=[SeededMember(email="alice@example.com", role="member")],
             invitations_sent=[SeededInvitation(email="external@partner.com", role="owner", invitation_id="inv-1")],
+            invitations_to_deliver=[mock_invitation],
         )
 
-        with mock_permission_check(is_admin=False), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
+        async def deliver_after_close(*_args):
+            assert mock_db.close.called
+            return []
+
+        with (
+            mock_permission_check(is_admin=False),
+            patch("mcpgateway.routers.teams.TeamManagementService") as MockService,
+            patch("mcpgateway.routers.teams.TeamInvitationService") as MockInvitationService,
+        ):
             mock_service = AsyncMock(spec=TeamManagementService)
             mock_service.create_team_with_members = AsyncMock(return_value=seed_result)
             MockService.return_value = mock_service
+            invitation_service = AsyncMock(spec=TeamInvitationService)
+            invitation_service.deliver_invitation_emails = AsyncMock(side_effect=deliver_after_close)
+            MockInvitationService.return_value = invitation_service
 
             from mcpgateway.routers.teams import create_team
 
@@ -283,6 +295,7 @@ class TestTeamsRouter:
             assert [(i.email, i.role, i.invitation_id) for i in result.invitations_sent] == [("external@partner.com", "owner", "inv-1")]
 
             assert mock_service.create_team_with_members.call_args.kwargs["members"] == request.members
+            invitation_service.deliver_invitation_emails.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_create_team_with_explicit_empty_members(self, mock_user_context, mock_team, mock_db):
@@ -1182,13 +1195,15 @@ class TestTeamsRouter:
             MockTeamService.return_value = team_service
             invitation_service = AsyncMock(spec=TeamInvitationService)
             invitation_service.create_invitation = AsyncMock(return_value=mock_invitation)
-            invitation_service.deliver_invitation_email = AsyncMock(
-                return_value=InvitationDeliveryResult(
+            async def deliver_after_close(**_kwargs):
+                assert mock_db.close.called
+                return InvitationDeliveryResult(
                     invitation_url=f"https://ui.example/accept-invitation/{mock_invitation.token}",
                     status=EmailDeliveryStatus.FAILED,
                     warning="Invitation created, but the email could not be delivered.",
                 )
-            )
+
+            invitation_service.deliver_invitation_email = AsyncMock(side_effect=deliver_after_close)
             MockInviteService.return_value = invitation_service
 
             from mcpgateway.routers.teams import invite_team_member

--- a/tests/unit/mcpgateway/routers/test_teams_coverage.py
+++ b/tests/unit/mcpgateway/routers/test_teams_coverage.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 
 # Third-Party
 import pytest
-from fastapi import HTTPException, status
+from fastapi import BackgroundTasks, HTTPException, status
 from sqlalchemy.orm import Session
 
 
@@ -165,7 +165,7 @@ class TestUpdateTeamMaxMembersCap:
 
             req = TeamCreateRequest(name="BigTeam", max_members=200)
             with pytest.raises(HTTPException) as exc:
-                await teams.create_team(req, current_user_ctx=user_ctx, db=db)
+                await teams.create_team(req, BackgroundTasks(), current_user_ctx=user_ctx, db=db)
             assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
             assert "cannot exceed" in exc.value.detail
 
@@ -177,7 +177,7 @@ class TestUpdateTeamMaxMembersCap:
             from mcpgateway.schemas import TeamCreateRequest
 
             req = TeamCreateRequest(name="BigTeam", max_members=500)
-            result = await teams.create_team(req, current_user_ctx=admin_ctx, db=db)
+            result = await teams.create_team(req, BackgroundTasks(), current_user_ctx=admin_ctx, db=db)
             assert result.max_members == 500
 
     @pytest.mark.asyncio
@@ -188,7 +188,7 @@ class TestUpdateTeamMaxMembersCap:
             from mcpgateway.schemas import TeamCreateRequest
 
             req = TeamCreateRequest(name="Team", max_members=100)
-            result = await teams.create_team(req, current_user_ctx=user_ctx, db=db)
+            result = await teams.create_team(req, BackgroundTasks(), current_user_ctx=user_ctx, db=db)
             assert result.max_members == 100
 
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/routers/test_teams_v2.py
+++ b/tests/unit/mcpgateway/routers/test_teams_v2.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 
 # Third-Party
 import pytest
-from fastapi import HTTPException, status
+from fastapi import BackgroundTasks, HTTPException, status
 from sqlalchemy.orm import Session
 
 
@@ -139,7 +139,7 @@ class TestTeamsRouterV2:
             mock_service.create_team_with_members = AsyncMock(return_value=TeamSeedResult(team=mock_team))
             MockService.return_value = mock_service
 
-            result = await teams.create_team(request, current_user_ctx=mock_user_context, db=mock_db)
+            result = await teams.create_team(request, BackgroundTasks(), current_user_ctx=mock_user_context, db=mock_db)
 
             assert result.id == mock_team.id
             assert result.name == mock_team.name
@@ -172,7 +172,7 @@ class TestTeamsRouterV2:
             MockService.return_value = mock_service
 
             with pytest.raises(HTTPException) as exc_info:
-                await teams.create_team(request, current_user_ctx=mock_user_context)
+                await teams.create_team(request, BackgroundTasks(), current_user_ctx=mock_user_context)
 
             assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
             assert "Team name cannot be empty" in str(exc_info.value.detail)

--- a/tests/unit/mcpgateway/services/test_email_auth_basic.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_basic.py
@@ -223,18 +223,26 @@ class TestEmailAuthBasic:
             # without exposing the method or checking database calls
             assert True  # Just verify no exception was raised
 
-    def test_build_password_reset_urls(self, service):
-        """Unset React base preserves bundled Admin UI recovery URLs."""
+    @pytest.mark.parametrize(
+        ("admin_api_enabled", "expected_forgot_url", "expected_reset_url"),
+        [
+            (True, "https://gateway.example.com/root/admin/forgot-password", "https://gateway.example.com/root/admin/reset-password/tok%20en"),
+            (False, "https://gateway.example.com/root/forgot-password", "https://gateway.example.com/root/reset-password/tok%20en"),
+        ],
+    )
+    def test_build_password_reset_urls(self, service, admin_api_enabled, expected_forgot_url, expected_reset_url):
+        """Unset React base uses Admin UI only when its routes are mounted."""
         with patch("mcpgateway.services.email_notification_service.settings") as mock_settings:
             mock_settings.ui_base_url = None
             mock_settings.app_domain = "https://gateway.example.com/"
             mock_settings.app_root_path = "/root/"
+            mock_settings.mcpgateway_admin_api_enabled = admin_api_enabled
 
             forgot_url = service._build_forgot_password_url()
             reset_url = service._build_reset_password_url("tok en")
 
-        assert forgot_url == "https://gateway.example.com/root/admin/forgot-password"
-        assert reset_url == "https://gateway.example.com/root/admin/reset-password/tok%20en"
+        assert forgot_url == expected_forgot_url
+        assert reset_url == expected_reset_url
 
     def test_build_password_reset_urls_use_configured_ui_base(self, service):
         """Configured React base URL preserves its path prefix."""

--- a/tests/unit/mcpgateway/services/test_email_auth_basic.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_basic.py
@@ -233,8 +233,8 @@ class TestEmailAuthBasic:
             forgot_url = service._build_forgot_password_url()
             reset_url = service._build_reset_password_url("tok en")
 
-        assert forgot_url == "https://gateway.example.com/root/forgot-password"
-        assert reset_url == "https://gateway.example.com/root/reset-password/tok%20en"
+        assert forgot_url == "https://gateway.example.com/root/admin/forgot-password"
+        assert reset_url == "https://gateway.example.com/root/admin/reset-password/tok%20en"
 
     def test_build_password_reset_urls_use_configured_ui_base(self, service):
         """Configured React base URL preserves its path prefix."""

--- a/tests/unit/mcpgateway/services/test_email_auth_basic.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_basic.py
@@ -233,8 +233,8 @@ class TestEmailAuthBasic:
             forgot_url = service._build_forgot_password_url()
             reset_url = service._build_reset_password_url("tok en")
 
-        assert forgot_url == "https://gateway.example.com/root/admin/forgot-password"
-        assert reset_url == "https://gateway.example.com/root/admin/reset-password/tok%20en"
+        assert forgot_url == "https://gateway.example.com/root/forgot-password"
+        assert reset_url == "https://gateway.example.com/root/reset-password/tok%20en"
 
     def test_build_password_reset_urls_use_configured_ui_base(self, service):
         """Configured React base URL preserves its path prefix."""

--- a/tests/unit/mcpgateway/services/test_email_auth_basic.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_basic.py
@@ -225,15 +225,27 @@ class TestEmailAuthBasic:
 
     def test_build_password_reset_urls(self, service):
         """Build forgot/reset URLs from app settings."""
-        with patch("mcpgateway.services.email_auth_service.settings") as mock_settings:
+        with patch("mcpgateway.services.email_notification_service.settings") as mock_settings:
+            mock_settings.ui_base_url = None
             mock_settings.app_domain = "https://gateway.example.com/"
             mock_settings.app_root_path = "/root/"
 
             forgot_url = service._build_forgot_password_url()
             reset_url = service._build_reset_password_url("tok en")
 
-        assert forgot_url == "https://gateway.example.com/root/admin/forgot-password"
-        assert reset_url.endswith("/admin/reset-password/tok%20en")
+        assert forgot_url == "https://gateway.example.com/root/forgot-password"
+        assert reset_url == "https://gateway.example.com/root/reset-password/tok%20en"
+
+    def test_build_password_reset_urls_use_configured_ui_base(self, service):
+        """Configured React base URL preserves its path prefix."""
+        with patch("mcpgateway.services.email_notification_service.settings") as mock_settings:
+            mock_settings.ui_base_url = "https://ui.example.com/contextforge/"
+
+            forgot_url = service._build_forgot_password_url()
+            reset_url = service._build_reset_password_url("tok/en")
+
+        assert forgot_url == "https://ui.example.com/contextforge/forgot-password"
+        assert reset_url == "https://ui.example.com/contextforge/reset-password/tok%2Fen"
 
     def test_recent_password_reset_request_count(self, service, mock_db):
         """Count helper returns integer count from query scalar."""

--- a/tests/unit/mcpgateway/services/test_email_auth_basic.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_basic.py
@@ -224,7 +224,7 @@ class TestEmailAuthBasic:
             assert True  # Just verify no exception was raised
 
     def test_build_password_reset_urls(self, service):
-        """Build forgot/reset URLs from app settings."""
+        """Unset React base preserves bundled Admin UI recovery URLs."""
         with patch("mcpgateway.services.email_notification_service.settings") as mock_settings:
             mock_settings.ui_base_url = None
             mock_settings.app_domain = "https://gateway.example.com/"
@@ -233,8 +233,8 @@ class TestEmailAuthBasic:
             forgot_url = service._build_forgot_password_url()
             reset_url = service._build_reset_password_url("tok en")
 
-        assert forgot_url == "https://gateway.example.com/root/forgot-password"
-        assert reset_url == "https://gateway.example.com/root/reset-password/tok%20en"
+        assert forgot_url == "https://gateway.example.com/root/admin/forgot-password"
+        assert reset_url == "https://gateway.example.com/root/admin/reset-password/tok%20en"
 
     def test_build_password_reset_urls_use_configured_ui_base(self, service):
         """Configured React base URL preserves its path prefix."""

--- a/tests/unit/mcpgateway/services/test_email_notification_service.py
+++ b/tests/unit/mcpgateway/services/test_email_notification_service.py
@@ -72,14 +72,24 @@ class TestAuthEmailNotificationService:
         assert result == "https://ui.example.com/contextforge/accept-invitation/tok%2Fen%20%3F"
 
     def test_build_frontend_url_falls_back_to_domain_and_root_path(self):
-        """Frontend links fall back to trusted gateway configuration."""
+        """Password links fall back to bundled Admin UI routes."""
         with patch("mcpgateway.services.email_notification_service.settings") as mock_settings:
             mock_settings.ui_base_url = None
             mock_settings.app_domain = "https://gateway.example.com/"
             mock_settings.app_root_path = "/root/"
             result = build_frontend_url("/forgot-password")
 
-        assert result == "https://gateway.example.com/root/forgot-password"
+        assert result == "https://gateway.example.com/root/admin/forgot-password"
+
+    def test_build_frontend_url_invitation_fallback_remains_frontend_route(self):
+        """Invitation fallback does not inherit legacy Admin UI prefix."""
+        with patch("mcpgateway.services.email_notification_service.settings") as mock_settings:
+            mock_settings.ui_base_url = None
+            mock_settings.app_domain = "https://gateway.example.com/"
+            mock_settings.app_root_path = "/root/"
+            result = build_frontend_url("/accept-invitation", "tok/en")
+
+        assert result == "https://gateway.example.com/root/accept-invitation/tok%2Fen"
 
     def test_build_frontend_url_rejects_untrusted_path_shape(self):
         """Frontend helper rejects relative and scheme-relative paths."""

--- a/tests/unit/mcpgateway/services/test_email_notification_service.py
+++ b/tests/unit/mcpgateway/services/test_email_notification_service.py
@@ -14,7 +14,8 @@ from jinja2 import TemplateNotFound
 import pytest
 
 # First-Party
-from mcpgateway.services.email_notification_service import AuthEmailNotificationService
+from mcpgateway.services.email_notification_service import AuthEmailNotificationService, build_frontend_url
+from mcpgateway.schemas import EmailDeliveryStatus
 
 
 class TestAuthEmailNotificationService:
@@ -61,6 +62,31 @@ class TestAuthEmailNotificationService:
             mock_settings.smtp_host = "smtp.example.com"
             mock_settings.smtp_from_email = "noreply@example.com"
             assert service._smtp_ready() is True
+
+    def test_build_frontend_url_prefers_ui_base_and_encodes_token(self):
+        """Frontend links use configured React base and encode token as one segment."""
+        with patch("mcpgateway.services.email_notification_service.settings") as mock_settings:
+            mock_settings.ui_base_url = "https://ui.example.com/contextforge/"
+            result = build_frontend_url("/accept-invitation", "tok/en ?")
+
+        assert result == "https://ui.example.com/contextforge/accept-invitation/tok%2Fen%20%3F"
+
+    def test_build_frontend_url_falls_back_to_domain_and_root_path(self):
+        """Frontend links fall back to trusted gateway configuration."""
+        with patch("mcpgateway.services.email_notification_service.settings") as mock_settings:
+            mock_settings.ui_base_url = None
+            mock_settings.app_domain = "https://gateway.example.com/"
+            mock_settings.app_root_path = "/root/"
+            result = build_frontend_url("/forgot-password")
+
+        assert result == "https://gateway.example.com/root/forgot-password"
+
+    def test_build_frontend_url_rejects_untrusted_path_shape(self):
+        """Frontend helper rejects relative and scheme-relative paths."""
+        with pytest.raises(ValueError):
+            build_frontend_url("reset-password")
+        with pytest.raises(ValueError):
+            build_frontend_url("//attacker.example/path")
 
     def test_render_template_success(self, service):
         """_render_template returns rendered template when available."""
@@ -227,3 +253,115 @@ class TestAuthEmailNotificationService:
         assert call_args[0] == "eve@example.com"
         assert "temporarily locked" in call_args[1].lower()
         assert "eve" in call_args[2]
+
+    @pytest.mark.asyncio
+    async def test_send_team_invitation_email_has_html_and_plaintext(self, service):
+        """Invitation email includes trusted link and raw-token fallback in both parts."""
+        with patch.object(service, "_send_email", new=AsyncMock(return_value=True)) as send_mock:
+            result = await service.send_team_invitation_email(
+                to_email="invitee@example.com",
+                team_name="Engineering",
+                inviter_name="Alice",
+                role="member",
+                invitation_url="https://ui.example/accept-invitation/token",
+                expires_at="2026-08-20T12:00:00+00:00",
+                token="token",
+            )
+
+        assert result is True
+        args = send_mock.await_args.args
+        assert "Engineering" in args[1]
+        assert "https://ui.example/accept-invitation/token" in args[2]
+        assert "Fallback invitation token: token" in args[3]
+
+    @pytest.mark.asyncio
+    async def test_send_team_invitation_email_autoescapes_user_values(self, service):
+        """Invitation HTML escapes team and inviter values."""
+        with patch.object(service, "_send_email", new=AsyncMock(return_value=True)) as send_mock:
+            await service.send_team_invitation_email(
+                to_email="invitee@example.com",
+                team_name="<script>alert(1)</script>",
+                inviter_name="<b>Alice</b>",
+                role="member",
+                invitation_url="https://ui.example/accept-invitation/token",
+                expires_at="2026-08-20T12:00:00+00:00",
+                token="token",
+            )
+
+        html_body = send_mock.await_args.args[2]
+        assert "<script>" not in html_body
+        assert "&lt;script&gt;" in html_body
+        assert "<b>Alice</b>" not in html_body
+
+    @pytest.mark.asyncio
+    async def test_deliver_team_invitation_email_statuses(self, service):
+        """Delivery distinguishes disabled, successful, and failed SMTP."""
+        kwargs = {
+            "invitation_id": "invite-id",
+            "to_email": "invitee@example.com",
+            "team_name": "Engineering",
+            "inviter_name": "Alice",
+            "role": "member",
+            "invitation_url": "https://ui.example/accept-invitation/token",
+            "expires_at": "2026-08-20T12:00:00+00:00",
+            "token": "token",
+        }
+        with patch("mcpgateway.services.email_notification_service.settings") as mock_settings:
+            mock_settings.smtp_enabled = False
+            with patch.object(service, "send_team_invitation_email", new=AsyncMock()) as send_mock:
+                assert await service.deliver_team_invitation_email(**kwargs) == EmailDeliveryStatus.DISABLED
+                send_mock.assert_not_awaited()
+
+            mock_settings.smtp_enabled = True
+            with patch.object(service, "send_team_invitation_email", new=AsyncMock(return_value=True)):
+                assert await service.deliver_team_invitation_email(**kwargs) == EmailDeliveryStatus.SENT
+            with patch.object(service, "send_team_invitation_email", new=AsyncMock(return_value=False)):
+                assert await service.deliver_team_invitation_email(**kwargs) == EmailDeliveryStatus.FAILED
+
+    @pytest.mark.asyncio
+    async def test_delivery_logs_do_not_expose_tokens_or_smtp_error(self, service, caplog):
+        """Failed delivery logs invitation ID without token or transport details."""
+        secret_token = "invitation-token-canary"  # pragma: allowlist secret
+        smtp_detail = "smtp-password-canary"  # pragma: allowlist secret
+        with (
+            patch("mcpgateway.services.email_notification_service.settings") as mock_settings,
+            patch.object(service, "send_team_invitation_email", new=AsyncMock(side_effect=RuntimeError(smtp_detail))),
+        ):
+            mock_settings.smtp_enabled = True
+            status = await service.deliver_team_invitation_email(
+                invitation_id="invite-id",
+                to_email="invitee@example.com",
+                team_name="Engineering",
+                inviter_name="Alice",
+                role="member",
+                invitation_url=f"https://ui.example/accept-invitation/{secret_token}",
+                expires_at="2026-08-20T12:00:00+00:00",
+                token=secret_token,
+            )
+
+        assert status == EmailDeliveryStatus.FAILED
+        assert "invite-id" in caplog.text
+        assert secret_token not in caplog.text
+        assert smtp_detail not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_enabled_but_incomplete_smtp_is_failed_without_connection(self, service):
+        """Enabled SMTP missing required settings reports failed, not disabled."""
+        with patch("mcpgateway.services.email_notification_service.settings") as mock_settings:
+            mock_settings.smtp_enabled = True
+            mock_settings.smtp_host = None
+            mock_settings.smtp_from_email = None
+            with patch.object(service, "_send_email_sync") as sync_send:
+                status = await service.deliver_team_invitation_email(
+                    invitation_id="invite-id",
+                    to_email="invitee@example.com",
+                    team_name="Engineering",
+                    inviter_name="Alice",
+                    role="member",
+                    invitation_url="https://ui.example/accept-invitation/token",
+                    expires_at="2026-08-20T12:00:00+00:00",
+                    token="token",
+                )
+
+        assert status == EmailDeliveryStatus.FAILED
+        sync_send.assert_not_called()

--- a/tests/unit/mcpgateway/services/test_email_notification_service.py
+++ b/tests/unit/mcpgateway/services/test_email_notification_service.py
@@ -79,7 +79,7 @@ class TestAuthEmailNotificationService:
             mock_settings.app_root_path = "/root/"
             result = build_frontend_url("/forgot-password")
 
-        assert result == "https://gateway.example.com/root/admin/forgot-password"
+        assert result == "https://gateway.example.com/root/forgot-password"
 
     def test_build_frontend_url_rejects_untrusted_path_shape(self):
         """Frontend helper rejects relative and scheme-relative paths."""

--- a/tests/unit/mcpgateway/services/test_email_notification_service.py
+++ b/tests/unit/mcpgateway/services/test_email_notification_service.py
@@ -71,15 +71,23 @@ class TestAuthEmailNotificationService:
 
         assert result == "https://ui.example.com/contextforge/accept-invitation/tok%2Fen%20%3F"
 
-    def test_build_frontend_url_falls_back_to_domain_and_root_path(self):
-        """Password links fall back to bundled Admin UI routes."""
+    @pytest.mark.parametrize(
+        ("admin_api_enabled", "expected_url"),
+        [
+            (True, "https://gateway.example.com/root/admin/forgot-password"),
+            (False, "https://gateway.example.com/root/forgot-password"),
+        ],
+    )
+    def test_build_frontend_url_falls_back_to_domain_and_root_path(self, admin_api_enabled, expected_url):
+        """Password fallback uses Admin UI only when its routes are mounted."""
         with patch("mcpgateway.services.email_notification_service.settings") as mock_settings:
             mock_settings.ui_base_url = None
             mock_settings.app_domain = "https://gateway.example.com/"
             mock_settings.app_root_path = "/root/"
+            mock_settings.mcpgateway_admin_api_enabled = admin_api_enabled
             result = build_frontend_url("/forgot-password")
 
-        assert result == "https://gateway.example.com/root/admin/forgot-password"
+        assert result == expected_url
 
     def test_build_frontend_url_invitation_fallback_remains_frontend_route(self):
         """Invitation fallback does not inherit legacy Admin UI prefix."""

--- a/tests/unit/mcpgateway/services/test_email_notification_service.py
+++ b/tests/unit/mcpgateway/services/test_email_notification_service.py
@@ -79,7 +79,7 @@ class TestAuthEmailNotificationService:
             mock_settings.app_root_path = "/root/"
             result = build_frontend_url("/forgot-password")
 
-        assert result == "https://gateway.example.com/root/forgot-password"
+        assert result == "https://gateway.example.com/root/admin/forgot-password"
 
     def test_build_frontend_url_rejects_untrusted_path_shape(self):
         """Frontend helper rejects relative and scheme-relative paths."""

--- a/tests/unit/mcpgateway/services/test_team_invitation_service.py
+++ b/tests/unit/mcpgateway/services/test_team_invitation_service.py
@@ -7,7 +7,9 @@ Comprehensive tests for Team Invitation Service functionality.
 """
 
 # Standard
-from unittest.mock import MagicMock, patch
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 import pytest
@@ -15,7 +17,8 @@ from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.db import EmailTeam, EmailTeamInvitation, EmailTeamMember, EmailUser
-from mcpgateway.services.team_invitation_service import TeamInvitationService
+from mcpgateway.schemas import EmailDeliveryStatus
+from mcpgateway.services.team_invitation_service import InvitationDeliveryResult, TeamInvitationService
 from mcpgateway.services.team_management_service import TeamMemberLimitExceededError
 
 
@@ -1188,3 +1191,56 @@ class TestTeamInvitationService:
             call_kwargs = MockInvitation.call_args[1]
             # Check that expires_at was set (we can't easily check the exact value due to datetime)
             assert "expires_at" in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_deliver_invitation_email_builds_shared_result(self, service):
+        """Single delivery centralizes URL, status, and warning construction."""
+        invitation = MagicMock(spec=EmailTeamInvitation)
+        invitation.id = "invite-id"
+        invitation.email = "invitee@example.com"
+        invitation.role = "member"
+        invitation.token = "tok/en"
+        invitation.expires_at = datetime(2026, 8, 20, tzinfo=timezone.utc)
+        service.email_notification_service.deliver_team_invitation_email = AsyncMock(return_value=EmailDeliveryStatus.SENT)
+
+        with patch("mcpgateway.services.team_invitation_service.build_frontend_url", return_value="https://ui.example/accept-invitation/tok%2Fen"):
+            result = await service.deliver_invitation_email(invitation, "Engineering", "Alice")
+
+        assert result == InvitationDeliveryResult(
+            invitation_url="https://ui.example/accept-invitation/tok%2Fen",
+            status=EmailDeliveryStatus.SENT,
+        )
+
+    @pytest.mark.asyncio
+    async def test_batch_delivery_is_bounded_and_failure_isolated(self, service):
+        """Batch delivery limits SMTP fan-out and preserves remaining results."""
+        active = 0
+        peak = 0
+
+        async def deliver(invitation, team_name, inviter_name):
+            nonlocal active, peak
+            active += 1
+            peak = max(peak, active)
+            await asyncio.sleep(0)
+            active -= 1
+            if invitation.id == "bad":
+                raise RuntimeError("smtp failure")
+            return InvitationDeliveryResult(invitation_url=f"https://ui.example/{invitation.id}", status=EmailDeliveryStatus.SENT)
+
+        invitations = []
+        for invitation_id in ["one", "two", "bad", "four", "five", "six", "seven"]:
+            invitation = MagicMock(spec=EmailTeamInvitation)
+            invitation.id = invitation_id
+            invitation.token = invitation_id
+            invitations.append(invitation)
+
+        with (
+            patch.object(service, "deliver_invitation_email", new=AsyncMock(side_effect=deliver)),
+            patch("mcpgateway.services.team_invitation_service.build_frontend_url", side_effect=lambda path, token: f"https://ui.example{path}/{token}"),
+        ):
+            results = await service.deliver_invitation_emails(invitations, "Engineering", "Alice")
+
+        assert peak <= 5
+        assert len(results) == len(invitations)
+        assert results[2].status == EmailDeliveryStatus.FAILED
+        assert results[2].warning == "Invitation created, but the email could not be delivered."

--- a/tests/unit/mcpgateway/services/test_team_invitation_service.py
+++ b/tests/unit/mcpgateway/services/test_team_invitation_service.py
@@ -1212,6 +1212,40 @@ class TestTeamInvitationService:
         )
 
     @pytest.mark.asyncio
+    async def test_deliver_invitation_email_contains_url_build_failure(self, service):
+        """Malformed URL configuration cannot escape best-effort delivery boundary."""
+        invitation = MagicMock(spec=EmailTeamInvitation)
+        invitation.id = "invite-id"
+        invitation.token = "token"
+        service.email_notification_service.deliver_team_invitation_email = AsyncMock()
+
+        with patch("mcpgateway.services.team_invitation_service.build_frontend_url", side_effect=ValueError("bad URL")):
+            result = await service.deliver_invitation_email(invitation, "Engineering", "Alice")
+
+        assert result == InvitationDeliveryResult(
+            invitation_url="",
+            status=EmailDeliveryStatus.FAILED,
+            warning="Invitation created, but the email could not be delivered.",
+        )
+        service.email_notification_service.deliver_team_invitation_email.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_deliver_invitation_email_warns_when_smtp_disabled(self, service):
+        """Disabled SMTP remains a visible non-delivery outcome."""
+        invitation = MagicMock(spec=EmailTeamInvitation)
+        invitation.id = "invite-id"
+        invitation.email = "invitee@example.com"
+        invitation.role = "member"
+        invitation.token = "token"
+        invitation.expires_at = datetime(2026, 8, 20, tzinfo=timezone.utc)
+        service.email_notification_service.deliver_team_invitation_email = AsyncMock(return_value=EmailDeliveryStatus.DISABLED)
+
+        result = await service.deliver_invitation_email(invitation, "Engineering", "Alice")
+
+        assert result.status == EmailDeliveryStatus.DISABLED
+        assert result.warning == "Invitation created, but email delivery is disabled."
+
+    @pytest.mark.asyncio
     async def test_batch_delivery_is_bounded_and_failure_isolated(self, service):
         """Batch delivery limits SMTP fan-out and preserves remaining results."""
         active = 0

--- a/tests/unit/mcpgateway/services/test_team_member_seeding.py
+++ b/tests/unit/mcpgateway/services/test_team_member_seeding.py
@@ -609,38 +609,21 @@ class TestSeededInvitationTokens:
 
 
 class TestSeededInvitationDelivery:
-    """Seeded invitation email starts only after outer transaction commit."""
+    """Seeded invitations are returned for post-session email delivery."""
 
     @pytest.mark.asyncio
-    async def test_delivery_occurs_after_commit(self, service, test_db):
-        """commit=False invitation creation never sends before team commit."""
-        events = []
-        original_commit = test_db.commit
+    async def test_persisted_invitation_is_returned_for_delivery(self, service):
+        """The router can close its DB session before starting SMTP delivery."""
+        result = await service.create_team_with_members(
+            name="Engineering",
+            description=None,
+            created_by=CREATOR,
+            visibility="private",
+            members=[TeamMemberSeed(email="external@partner.com", role="member")],
+        )
 
-        def tracked_commit():
-            events.append("commit")
-            return original_commit()
-
-        async def tracked_delivery(invitations, team_name, inviter_name):
-            events.append("delivery")
-            assert invitations[0].id
-            assert team_name == "Engineering"
-            assert inviter_name
-            return []
-
-        with (
-            patch.object(test_db, "commit", side_effect=tracked_commit),
-            patch.object(TeamInvitationService, "deliver_invitation_emails", new=AsyncMock(side_effect=tracked_delivery)),
-        ):
-            await service.create_team_with_members(
-                name="Engineering",
-                description=None,
-                created_by=CREATOR,
-                visibility="private",
-                members=[TeamMemberSeed(email="external@partner.com", role="member")],
-            )
-
-        assert events[:2] == ["commit", "delivery"]
+        assert len(result.invitations_to_deliver) == 1
+        assert result.invitations_to_deliver[0].id == result.invitations_sent[0].invitation_id
 
 
 class TestCreateTeamUnchanged:

--- a/tests/unit/mcpgateway/services/test_team_member_seeding.py
+++ b/tests/unit/mcpgateway/services/test_team_member_seeding.py
@@ -21,6 +21,7 @@ import pytest
 from mcpgateway.config import settings
 from mcpgateway.db import EmailTeam, EmailTeamInvitation, EmailTeamMember, EmailTeamMemberHistory, EmailUser, utc_now
 from mcpgateway.schemas import MAX_TEAM_MEMBER_SEEDS, TeamMemberSeed
+from mcpgateway.services.team_invitation_service import TeamInvitationService
 from mcpgateway.services.team_management_service import TeamManagementService, TeamMemberLimitExceededError, TeamMemberSeedError
 
 CREATOR = "creator@example.com"
@@ -605,6 +606,41 @@ class TestSeededInvitationTokens:
         # URL-safe base64 alphabet (secrets.token_urlsafe): letters, digits, '-' and '_'.
         assert all(re.fullmatch(r"[A-Za-z0-9_-]+", token) for token in tokens)
         assert len(set(tokens)) == len(tokens), "tokens must be unique across invitations"
+
+
+class TestSeededInvitationDelivery:
+    """Seeded invitation email starts only after outer transaction commit."""
+
+    @pytest.mark.asyncio
+    async def test_delivery_occurs_after_commit(self, service, test_db):
+        """commit=False invitation creation never sends before team commit."""
+        events = []
+        original_commit = test_db.commit
+
+        def tracked_commit():
+            events.append("commit")
+            return original_commit()
+
+        async def tracked_delivery(invitations, team_name, inviter_name):
+            events.append("delivery")
+            assert invitations[0].id
+            assert team_name == "Engineering"
+            assert inviter_name
+            return []
+
+        with (
+            patch.object(test_db, "commit", side_effect=tracked_commit),
+            patch.object(TeamInvitationService, "deliver_invitation_emails", new=AsyncMock(side_effect=tracked_delivery)),
+        ):
+            await service.create_team_with_members(
+                name="Engineering",
+                description=None,
+                created_by=CREATOR,
+                visibility="private",
+                members=[TeamMemberSeed(email="external@partner.com", role="member")],
+            )
+
+        assert events[:2] == ["commit", "delivery"]
 
 
 class TestCreateTeamUnchanged:

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -79,7 +79,7 @@ def test_ui_base_url_treats_blank_string_as_unset():
 
 
 def test_smtp_without_ui_base_url_warns_about_frontend_routes(caplog):
-    """SMTP with fallback links warns operators that frontend routes must exist."""
+    """SMTP fallback warns about invitation and legacy password routes."""
     caplog.set_level(logging.WARNING, logger="mcpgateway.config")
 
     Settings(smtp_enabled=True, ui_base_url=None, environment="development", _env_file=None)
@@ -87,6 +87,7 @@ def test_smtp_without_ui_base_url_warns_about_frontend_routes(caplog):
     warnings = [record.getMessage() for record in caplog.records]
     assert any("SMTP_ENABLED=true while UI_BASE_URL is unset" in message for message in warnings)
     assert any("/accept-invitation/{token}" in message for message in warnings)
+    assert any("MCPGATEWAY_ADMIN_API_ENABLED=true" in message for message in warnings)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -78,16 +78,23 @@ def test_ui_base_url_treats_blank_string_as_unset():
     assert configured.ui_base_url is None
 
 
-def test_smtp_without_ui_base_url_warns_about_frontend_routes(caplog):
-    """SMTP fallback warns about invitation and legacy password routes."""
+@pytest.mark.parametrize(
+    ("admin_api_enabled", "expected_password_route"),
+    [
+        (True, "legacy /admin routes"),
+        (False, "frontend /forgot-password and /reset-password/{token} routes"),
+    ],
+)
+def test_smtp_without_ui_base_url_warns_about_frontend_routes(caplog, admin_api_enabled, expected_password_route):
+    """SMTP fallback warning describes active invitation and password routes."""
     caplog.set_level(logging.WARNING, logger="mcpgateway.config")
 
-    Settings(smtp_enabled=True, ui_base_url=None, environment="development", _env_file=None)
+    Settings(smtp_enabled=True, ui_base_url=None, mcpgateway_admin_api_enabled=admin_api_enabled, environment="development", _env_file=None)
 
     warnings = [record.getMessage() for record in caplog.records]
     assert any("SMTP_ENABLED=true while UI_BASE_URL is unset" in message for message in warnings)
     assert any("/accept-invitation/{token}" in message for message in warnings)
-    assert any("MCPGATEWAY_ADMIN_API_ENABLED=true" in message for message in warnings)
+    assert any(expected_password_route in message for message in warnings)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -78,6 +78,33 @@ def test_ui_base_url_treats_blank_string_as_unset():
     assert configured.ui_base_url is None
 
 
+def test_smtp_without_ui_base_url_warns_about_frontend_routes(caplog):
+    """SMTP with fallback links warns operators that frontend routes must exist."""
+    caplog.set_level(logging.WARNING, logger="mcpgateway.config")
+
+    Settings(smtp_enabled=True, ui_base_url=None, environment="development", _env_file=None)
+
+    warnings = [record.getMessage() for record in caplog.records]
+    assert any("SMTP_ENABLED=true while UI_BASE_URL is unset" in message for message in warnings)
+    assert any("/accept-invitation/{token}" in message for message in warnings)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"smtp_enabled": False, "ui_base_url": None},
+        {"smtp_enabled": True, "ui_base_url": "https://ui.example.com/contextforge"},
+    ],
+)
+def test_frontend_route_warning_only_for_smtp_fallback(caplog, overrides):
+    """Configured UI links and disabled SMTP do not produce fallback warnings."""
+    caplog.set_level(logging.WARNING, logger="mcpgateway.config")
+
+    Settings(environment="development", _env_file=None, **overrides)
+
+    assert not any("SMTP_ENABLED=true while UI_BASE_URL is unset" in record.getMessage() for record in caplog.records)
+
+
 # --------------------------------------------------------------------------- #
 #                         SSO field validators                            #
 # --------------------------------------------------------------------------- #

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -52,6 +52,26 @@ def test_parse_allowed_origins_json_and_csv():
     assert s_csv.allowed_origins == {"https://x.com", "https://y.com"}
 
 
+@pytest.mark.parametrize(
+    ("url", "message"),
+    [
+        ("https://user:password@ui.example.com", "credentials"),  # pragma: allowlist secret
+        ("https://ui.example.com/app?tenant=one", "query string"),
+        ("https://ui.example.com/app#fragment", "fragment"),
+    ],
+)
+def test_ui_base_url_rejects_unsafe_components(url, message):
+    """Frontend base URL must not carry credentials or URL suffix state."""
+    with pytest.raises(ValueError, match=message):
+        Settings(ui_base_url=url, environment="development", _env_file=None)
+
+
+def test_ui_base_url_allows_path_prefix():
+    """Frontend base URL may include a deployment path prefix."""
+    configured = Settings(ui_base_url="https://ui.example.com/contextforge", environment="development", _env_file=None)
+    assert str(configured.ui_base_url) == "https://ui.example.com/contextforge"
+
+
 # --------------------------------------------------------------------------- #
 #                         SSO field validators                            #
 # --------------------------------------------------------------------------- #

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -72,6 +72,12 @@ def test_ui_base_url_allows_path_prefix():
     assert str(configured.ui_base_url) == "https://ui.example.com/contextforge"
 
 
+def test_ui_base_url_treats_blank_string_as_unset():
+    """Blank environment override preserves gateway UI fallback behavior."""
+    configured = Settings(ui_base_url="", environment="development", _env_file=None)
+    assert configured.ui_base_url is None
+
+
 # --------------------------------------------------------------------------- #
 #                         SSO field validators                            #
 # --------------------------------------------------------------------------- #

--- a/tests/unit/mcpgateway/test_team_governance_flags.py
+++ b/tests/unit/mcpgateway/test_team_governance_flags.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
-from fastapi import HTTPException
+from fastapi import BackgroundTasks, HTTPException
 import pytest
 from sqlalchemy.orm import Session
 
@@ -52,7 +52,7 @@ class TestAllowTeamCreationFlag:
         db = MagicMock(spec=Session)
 
         with pytest.raises(HTTPException) as exc_info:
-            await create_team(request=request, current_user_ctx=current_user_ctx, db=db)
+            await create_team(request=request, background_tasks=BackgroundTasks(), current_user_ctx=current_user_ctx, db=db)
         assert exc_info.value.status_code == 403
         assert "disabled" in exc_info.value.detail.lower()
 
@@ -92,7 +92,7 @@ class TestAllowTeamCreationFlag:
         current_user_ctx = {"email": "admin@example.com", "is_admin": True}
         db = MagicMock(spec=Session)
 
-        result = await create_team(request=request, current_user_ctx=current_user_ctx, db=db)
+        result = await create_team(request=request, background_tasks=BackgroundTasks(), current_user_ctx=current_user_ctx, db=db)
         assert result.name == "Admin Team"
 
 
@@ -748,7 +748,7 @@ class TestCreateTeamWithMembersDenyPaths:
         db = MagicMock(spec=Session)
 
         with pytest.raises(HTTPException) as exc_info:
-            await create_team(request=request, current_user_ctx={"email": "", "token_teams": None}, db=db)
+            await create_team(request=request, background_tasks=BackgroundTasks(), current_user_ctx={"email": "", "token_teams": None}, db=db)
         assert exc_info.value.status_code == 401
 
     @pytest.mark.asyncio
@@ -772,7 +772,7 @@ class TestCreateTeamWithMembersDenyPaths:
         db = MagicMock(spec=Session)
 
         with pytest.raises(HTTPException) as exc_info:
-            await create_team(request=request, current_user_ctx={"email": "user@example.com", "token_teams": None}, db=db)
+            await create_team(request=request, background_tasks=BackgroundTasks(), current_user_ctx={"email": "user@example.com", "token_teams": None}, db=db)
         assert exc_info.value.status_code == 403
         assert "disabled" in exc_info.value.detail.lower()
 
@@ -810,6 +810,6 @@ class TestCreateTeamWithMembersDenyPaths:
         db = MagicMock(spec=Session)
 
         with pytest.raises(HTTPException) as exc_info:
-            await create_team(request=request, current_user_ctx={"email": "user@example.com", "token_teams": None}, db=db)
+            await create_team(request=request, background_tasks=BackgroundTasks(), current_user_ctx={"email": "user@example.com", "token_teams": None}, db=db)
         assert exc_info.value.status_code == 400
         assert "invitations are currently disabled" in exc_info.value.detail

--- a/tests/unit/mcpgateway/utils/test_jq_runner.py
+++ b/tests/unit/mcpgateway/utils/test_jq_runner.py
@@ -162,6 +162,7 @@ def test_pool_failure_fails_closed(monkeypatch):
         run_jq_filter(".a", {"a": 1})
 
 
+@linux_only
 def test_pool_is_reused_within_a_process(jq_pool):
     """Repeated startup calls do not churn the pool."""
     # First-Party
@@ -172,6 +173,7 @@ def test_pool_is_reused_within_a_process(jq_pool):
     assert jq_runner._POOL is first  # pylint: disable=protected-access
 
 
+@linux_only
 def test_pool_is_rebuilt_after_pid_change(jq_pool, monkeypatch):
     """A pool inherited across a fork is discarded rather than reused."""
     # First-Party


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #5813

---

## 📝 Summary

Adds backend-owned invitation email delivery and shared frontend-compatible links for team invitations, password resets, and account-lockout recovery.

A trusted optional `UI_BASE_URL` supports a separately deployed React client. When unset, links fall back to `APP_DOMAIN + APP_ROOT_PATH`. Invitation delivery occurs only after transaction commit, reports safe delivery status to API clients, and uses bounded concurrency for seeded invitations.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

---

## 🏷️ Type of Change

- [ ] Bug fix
- [x] Feature / Enhancement
- [x] Documentation
- [x] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Focused unit tests | `pytest -q tests/unit/mcpgateway/services/test_email_notification_service.py tests/unit/mcpgateway/services/test_team_invitation_service.py tests/unit/mcpgateway/services/test_team_member_seeding.py tests/unit/mcpgateway/routers/test_teams.py tests/unit/mcpgateway/services/test_email_auth_basic.py tests/unit/mcpgateway/test_config.py -x` | Passed: 530 tests; 12 existing skips |
| Python lint | `make ruff` | Passed |
| Docstring coverage | `make interrogate` | Passed: 100% |
| Import and router assembly | `python -c 'from mcpgateway.services.team_invitation_service import TeamInvitationService; from mcpgateway.services.team_management_service import TeamManagementService; from mcpgateway.main import app; print(len(app.routes))'` | Passed |
| Diff whitespace | `git diff --check` | Passed |
| Security scan | `make bandit` | Blocked by existing unrelated B608 finding in migration `7ab59991e017_fix_oauth_tokens_unique_constraint.py` |
| Documentation build | `make -C docs build` | Not run: repository lacks `docs/.venv` |

---

## ✅ Checklist

- [x] Code formatted
- [x] Tests added/updated for changes
- [x] Documentation updated
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

`UI_BASE_URL` rejects embedded credentials, query strings, and fragments. SMTP errors expose only exception class in logs; invitation tokens, token-bearing URLs, SMTP credentials, and raw transport errors are not logged.
