### PR TITLE
feat: add --csv and --html output to benchmark-mcp-tools

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-12T15:30:22Z",
+  "generated_at": "2026-08-12T14:47:09Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -390,7 +390,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6079,
+        "line_number": 6087,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6576,
+        "line_number": 6584,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6588,
+        "line_number": 6596,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6660,
+        "line_number": 6668,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7076,
+        "line_number": 7084,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -430,7 +430,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7767,
+        "line_number": 7775,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-12T14:47:09Z",
+  "generated_at": "2026-08-13T10:07:37Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/Makefile
+++ b/Makefile
@@ -2725,6 +2725,8 @@ MCP_BENCHMARK_LOCUST_LOG_LEVEL ?= ERROR
 MCP_BENCHMARK_TOOL_POOL_SIZE ?= 0
 MCP_BENCHMARK_TOOL_DENYLIST ?= schema_error,flaky
 MCP_BENCHMARK_WORKER_LOG_DIR ?= reports/mcp_benchmark_workers
+MCP_BENCHMARK_HTML_REPORT    := reports/benchmark_mcp_tools.html
+MCP_BENCHMARK_CSV_PREFIX     := reports/benchmark_mcp_tools
 RL_LIMIT_PER_MIN ?= 30
 
 load-test-mcp-protocol:                    ## MCP Streamable HTTP protocol test (150 users, 2min)
@@ -2793,6 +2795,7 @@ benchmark-mcp-tools:                        ## Quick tools-only MCP benchmark ag
 	@echo "   Server: $(MCP_BENCHMARK_SERVER_ID)"
 	@echo "   Users: $(MCP_BENCHMARK_USERS), Spawn: $(MCP_BENCHMARK_SPAWN_RATE)/s, Duration: $(MCP_BENCHMARK_RUN_TIME)"
 	@test -d "$(VENV_DIR)" || $(MAKE) venv
+	@mkdir -p reports
 	@/bin/bash -eu -o pipefail -c 'source $(VENV_DIR)/bin/activate && \
 		LOCUST_LOG_LEVEL=$(MCP_BENCHMARK_LOCUST_LOG_LEVEL) MCP_SERVER_ID=$(MCP_BENCHMARK_SERVER_ID) \
 		MCP_BENCHMARK_TOOL_POOL_SIZE=$(MCP_BENCHMARK_TOOL_POOL_SIZE) \
@@ -2803,8 +2806,13 @@ benchmark-mcp-tools:                        ## Quick tools-only MCP benchmark ag
 			--spawn-rate=$(MCP_BENCHMARK_SPAWN_RATE) \
 			--run-time=$(MCP_BENCHMARK_RUN_TIME) \
 			--headless \
+			--html=$(MCP_BENCHMARK_HTML_REPORT) \
+			--csv=$(MCP_BENCHMARK_CSV_PREFIX) \
 			--only-summary \
 			MCPToolCallerUser'
+	@echo ""
+	@echo "📄 HTML Report: $(MCP_BENCHMARK_HTML_REPORT)"
+	@echo "📊 CSV Reports: $(MCP_BENCHMARK_CSV_PREFIX)_stats.csv"
 
 # help: benchmark-rate-limiter   - Rate limiter correctness test: unique users, controlled pacing
 .PHONY: benchmark-rate-limiter

--- a/Makefile
+++ b/Makefile
@@ -2724,9 +2724,9 @@ MCP_BENCHMARK_TOOLS_MASTER_PORT ?= 5569
 MCP_BENCHMARK_LOCUST_LOG_LEVEL ?= ERROR
 MCP_BENCHMARK_TOOL_POOL_SIZE ?= 0
 MCP_BENCHMARK_TOOL_DENYLIST ?= schema_error,flaky
-MCP_BENCHMARK_WORKER_LOG_DIR ?= reports/mcp_benchmark_workers
-MCP_BENCHMARK_HTML_REPORT    := reports/benchmark_mcp_tools.html
-MCP_BENCHMARK_CSV_PREFIX     := reports/benchmark_mcp_tools
+MCP_BENCHMARK_WORKER_LOG_DIR      ?= reports/mcp_benchmark_workers
+MCP_BENCHMARK_TOOLS_HTML_REPORT   ?= reports/benchmark_mcp_tools.html
+MCP_BENCHMARK_TOOLS_CSV_PREFIX    ?= reports/benchmark_mcp_tools
 RL_LIMIT_PER_MIN ?= 30
 
 load-test-mcp-protocol:                    ## MCP Streamable HTTP protocol test (150 users, 2min)
@@ -2806,13 +2806,13 @@ benchmark-mcp-tools:                        ## Quick tools-only MCP benchmark ag
 			--spawn-rate=$(MCP_BENCHMARK_SPAWN_RATE) \
 			--run-time=$(MCP_BENCHMARK_RUN_TIME) \
 			--headless \
-			--html=$(MCP_BENCHMARK_HTML_REPORT) \
-			--csv=$(MCP_BENCHMARK_CSV_PREFIX) \
+			--html=$(MCP_BENCHMARK_TOOLS_HTML_REPORT) \
+			--csv=$(MCP_BENCHMARK_TOOLS_CSV_PREFIX) \
 			--only-summary \
 			MCPToolCallerUser'
 	@echo ""
-	@echo "📄 HTML Report: $(MCP_BENCHMARK_HTML_REPORT)"
-	@echo "📊 CSV Reports: $(MCP_BENCHMARK_CSV_PREFIX)_stats.csv"
+	@echo "📄 HTML Report: $(MCP_BENCHMARK_TOOLS_HTML_REPORT)"
+	@echo "📊 CSV Reports: $(MCP_BENCHMARK_TOOLS_CSV_PREFIX)_stats.csv"
 
 # help: benchmark-rate-limiter   - Rate limiter correctness test: unique users, controlled pacing
 .PHONY: benchmark-rate-limiter


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes https://github.com/IBM/mcp-context-forge/issues/6206

---

## 📝 Summary

benchmark-mcp-tools is a nightly pipeline target that uploads evidence to COS but previously produced stdout only — no CSV, no HTML. This adds --csv and --html to its locust invocation, making it symmetric with load-test. Adds mkdir -p reports guard and two report variables (MCP_BENCHMARK_TOOLS_HTML_REPORT, MCP_BENCHMARK_TOOLS_CSV_PREFIX). --only-summary console output is unchanged.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Chore (deps, CI, tooling)

---

## 🧪 Verification

_List exact commands, screenshots, videos, logs, reproduction steps, or manual validation. If evidence is not feasible, explain why._

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Reports created | make benchmark-mcp-tools | Verified: reports/benchmark_mcp_tools_stats.csv and reports/benchmark_mcp_tools.html written

Ran make benchmark-mcp-tools against a local gateway. Reports created successfully:
- reports/benchmark_mcp_tools_stats.csv — written, contains Aggregated row ✅
- reports/benchmark_mcp_tools.html — written ✅
- Console --only-summary output unchanged ✅

---

## ✅ Checklist

- [x] No secrets or credentials committed

---

## Notes

--only-summary is retained — the locust invocation still prints the console summary table after the run. The --csv and --html flags only add file output on top of that. The _stats.csv, _stats_history.csv, and _failures.csv files are all written automatically by locust when a CSV prefix is given; only _stats.csv is consumed by the performance capture system.

