### PR TITLE
test(sso): move Entra ID integration test to tests/integration

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-13T14:29:13Z",
+  "generated_at": "2026-08-14T11:47:13Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/Makefile
+++ b/Makefile
@@ -807,8 +807,8 @@ clean:
 # help: test-mcp-access-matrix - MCP role/access matrix (Rust transport, edge/full mode)
 # help: test-mcp-plugin-parity - MCP plugin parity E2E for current Python or Rust stack
 # help: test-mcp-session-isolation - MCP session/auth isolation tests for Rust public transport
-# help: test-e2e-sso         - E2E tests requiring a live SSO identity provider (Keycloak or Entra ID)
 # help: test-live-gateway    - Run ALL live-gateway tests (mcp + sso + e2e_rust)
+# help: test-live-gateway    - Run ALL live-gateway tests (mcp + sso + protocol_compliance + e2e_rust)
 # help: test-plugin-integration - Self-contained plugin E2E tests (boots gateway; PLUGIN=<name> ENFORCEMENT=static|binding|both)
 # help: test-plugin-secrets-detection  - Plugin E2E: SecretsDetection
 # help: test-plugin-encoded-exfil      - Plugin E2E: EncodedExfil
@@ -940,11 +940,11 @@ test-mcp-session-isolation: uv  ## MCP session/auth isolation tests for the Rust
 		|| { echo "❌ MCP session/auth isolation tests failed!"; exit 1; }
 	@echo "✅ MCP session/auth isolation tests passed!"
 
-test-e2e-sso: uv  ## E2E tests requiring a live SSO identity provider (Keycloak or Entra ID)
+test-e2e-sso: uv  ## E2E tests requiring a live Keycloak SSO identity provider
 	@echo "🔐 Running SSO-dependent E2E tests against $${MCP_CLI_BASE_URL:-http://localhost:8080}..."
-	@echo "   Requires one of:"
-	@echo "     - Keycloak: 'docker compose --profile sso up -d' (for test_oauth_jwks_e2e.py)"
-	@echo "     - Entra ID: AZURE_CLIENT_ID/AZURE_CLIENT_SECRET/AZURE_TENANT_ID env vars (for test_entra_id_integration.py)"
+	@echo "   Requires: Keycloak via 'docker compose --profile sso up -d' (for test_oauth_jwks_e2e.py)"
+	@echo "   Note: the Entra ID integration test now lives at tests/integration/test_entra_id_integration.py"
+	@echo "         and runs (skipping when AZURE_* creds are absent) as part of the default 'make test'."
 	@$(UV_BIN) run pytest -p playwright tests/live_gateway/sso/ -v -s --tb=short \
 		|| { echo "❌ SSO E2E tests failed!"; exit 1; }
 	@echo "✅ SSO E2E tests passed!"

--- a/docs/docs/testing/entra-id-e2e.md
+++ b/docs/docs/testing/entra-id-e2e.md
@@ -8,7 +8,7 @@ This guide walks you through setting up Azure resources and running fully automa
 
 ## Overview
 
-The E2E tests in `tests/live_gateway/sso/test_entra_id_integration.py` are **fully self-contained**:
+The E2E tests in `tests/integration/test_entra_id_integration.py` are **fully self-contained**:
 
 - **Create** test users and groups in Azure AD before tests
 - **Execute** SSO role mapping tests against real Azure infrastructure
@@ -193,32 +193,32 @@ export TEST_ENTRA_DOMAIN="yourcompany.onmicrosoft.com"
 source .env.test
 
 # Run the tests
-uv run pytest tests/live_gateway/sso/test_entra_id_integration.py -v
+uv run pytest tests/integration/test_entra_id_integration.py -v
 ```
 
 ### Run Specific Test Classes
 
 ```bash
 # Test role mapping only
-uv run pytest tests/live_gateway/sso/test_entra_id_integration.py::TestEntraIDRoleMapping -v
+uv run pytest tests/integration/test_entra_id_integration.py::TestEntraIDRoleMapping -v
 
 # Test HTTP endpoints
-uv run pytest tests/live_gateway/sso/test_entra_id_integration.py::TestEntraIDEndToEndHTTP -v
+uv run pytest tests/integration/test_entra_id_integration.py::TestEntraIDEndToEndHTTP -v
 
 # Test admin role retention behavior
-uv run pytest tests/live_gateway/sso/test_entra_id_integration.py::TestEntraIDAdminRoleRetention -v
+uv run pytest tests/integration/test_entra_id_integration.py::TestEntraIDAdminRoleRetention -v
 
 # Test multiple admin groups
-uv run pytest tests/live_gateway/sso/test_entra_id_integration.py::TestEntraIDMultipleAdminGroups -v
+uv run pytest tests/integration/test_entra_id_integration.py::TestEntraIDMultipleAdminGroups -v
 
 # Test token validation
-uv run pytest tests/live_gateway/sso/test_entra_id_integration.py::TestEntraIDTokenValidation -v
+uv run pytest tests/integration/test_entra_id_integration.py::TestEntraIDTokenValidation -v
 ```
 
 ### Run with Debug Output
 
 ```bash
-uv run pytest tests/live_gateway/sso/test_entra_id_integration.py -v -s --log-cli-level=INFO
+uv run pytest tests/integration/test_entra_id_integration.py -v -s --log-cli-level=INFO
 ```
 
 ---
@@ -437,7 +437,7 @@ jobs:
           TEST_ENTRA_USER_PASSWORD: ${{ secrets.TEST_ENTRA_USER_PASSWORD }}
           TEST_ENTRA_DOMAIN: ${{ secrets.TEST_ENTRA_DOMAIN }}
         run: |
-          uv run pytest tests/live_gateway/sso/test_entra_id_integration.py -v
+          uv run pytest tests/integration/test_entra_id_integration.py -v
 ```
 
 ---
@@ -472,7 +472,7 @@ The test fixtures use `pytest` finalizers that run even on test failure, ensurin
 | 4 | Grant admin consent |
 | 5 | (Optional) Enable public client flows for ROPC |
 | 6 | Configure environment variables |
-| 7 | Run tests with `uv run pytest tests/live_gateway/sso/test_entra_id_integration.py -v` |
+| 7 | Run tests with `uv run pytest tests/integration/test_entra_id_integration.py -v` |
 
 ---
 

--- a/tests/integration/test_entra_id_integration.py
+++ b/tests/integration/test_entra_id_integration.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Location: ./tests/live_gateway/sso/test_entra_id_integration.py
+"""Location: ./tests/integration/test_entra_id_integration.py
 Copyright contributors to the MCP-CONTEXT-FORGE project
 SPDX-License-Identifier: Apache-2.0
 

--- a/tests/live_gateway/sso/__init__.py
+++ b/tests/live_gateway/sso/__init__.py
@@ -6,10 +6,14 @@ SPDX-License-Identifier: Apache-2.0
 E2E tests requiring a live Single Sign-On identity provider:
 
 * `test_oauth_jwks_e2e.py` — Keycloak (docker-compose --profile sso)
-* `test_entra_id_integration.py` — Microsoft Entra ID (Azure tenant + creds)
 
-Both are excluded from the default `make test` run because they depend on
-external identity infrastructure that isn't available in CI by default.
-Invoke explicitly via `make test-e2e-sso` once the relevant stack/creds
-are in place.
+Excluded from the default `make test` run because it depends on external
+identity infrastructure that isn't available in CI by default. Invoke
+explicitly via `make test-e2e-sso` once the Keycloak stack is in place.
+
+Note: the in-process Entra ID integration test now lives in
+``tests/integration/test_entra_id_integration.py`` — it uses
+``httpx.ASGITransport`` against the in-process app and skips when the
+AZURE_* credentials are absent, so it runs (and self-skips) as part of
+the normal `make test` flow.
 """


### PR DESCRIPTION
## Summary

Moves the Entra ID integration test out of the live-gateway tree and into the default integration suite. Split out from #6125 at reviewer request — the relocation is unrelated to that PR's fastmcp-removal scope.

The Entra ID suite is fully in-process (`httpx.ASGITransport`) and self-skips when the `AZURE_*` credentials are absent, so it belongs with the integration tests that run under the default `make test` rather than the opt-in live-gateway tree.

## Changes

- `tests/live_gateway/sso/test_entra_id_integration.py` → `tests/integration/test_entra_id_integration.py` (header updated)
- `tests/live_gateway/sso/__init__.py`: docstring now covers only the Keycloak suite and points at the new Entra ID location
- `docs/docs/testing/entra-id-e2e.md`: all pytest invocation paths updated
- `Makefile`: `test-e2e-sso` targets Keycloak only and notes the Entra ID move

## Composition note

This folds the Entra ID test into the default `make test` run for the first time (previously opt-in via `make test-e2e-sso`). Risk is low: the test self-skips without `AZURE_*` credentials.