### PR TITLE
chore: remove stale suggestion-mode option from .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -99,10 +99,6 @@ recursive=no
 # source root.
 source-roots=
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no

--- a/.pylintrc.plugins
+++ b/.pylintrc.plugins
@@ -27,7 +27,6 @@ persistent=yes
 py-version=3.11
 recursive=no
 source-roots=
-suggestion-mode=yes
 unsafe-load-any-extension=no
 
 [BASIC]


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #6232

---

## 📝 Summary

Removes the stale `suggestion-mode=yes` option from `.pylintrc` along with its comment block (lines 102–104). This option was removed in pylint 3.x and is no longer recognised in pylint 4.x, causing a spurious `E0015: Unrecognized option found: suggestion-mode` warning on every pylint run.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Chore (deps, CI, tooling)

---

## 🧪 Verification

| Check      | Command                                                                 | Status |
|------------|-------------------------------------------------------------------------|--------|
| Lint suite | `uv tool run pylint mcpgateway/plugins/control_telemetry.py --disable=all --enable=W0611` | ✅ 10.00/10, no E0015 |
| Stash test | `git stash && pylint …` vs `git stash pop && pylint …` | ✅ E0015 present before, gone after |

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

No tests needed — this is a config-only deletion with no logic impact. The E0015 warning is cosmetic but noisy; removing the option restores a clean pylint baseline.