### PR TITLE
feat(auth): add session refresh and validate endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,7 +116,7 @@ CSRF_TRUSTED_ORIGINS=["http://localhost:4444","http://localhost:8080"]
 # WARNING: Setting this env var REPLACES the config.py default entirely — it does not append.
 # Leave unset to use the secure default maintained in mcpgateway/config.py (csrf_exempt_paths).
 # Only set explicitly if you need a fully custom list (you must include every path you want exempt).
-#CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/refresh","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/admin","/admin/login","/admin/forgot-password","/admin/reset-password","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics","/mcp/","/sse","/message","/rpc","/api/metrics/","/toolops/","/tokens","/teams/","/llmchat/","/api/logs/","/_internal/mcp/"]
+#CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/admin","/admin/login","/admin/forgot-password","/admin/reset-password","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics","/mcp/","/sse","/message","/rpc","/api/metrics/","/toolops/","/tokens","/teams/","/llmchat/","/api/logs/","/_internal/mcp/"]
 
 # Bootstrap admin credentials (email auth)
 # PRODUCTION: Change these values
@@ -1113,6 +1113,18 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 
 # Expiry time for generated JWT tokens (in minutes; e.g. 7 days)
 # TOKEN_EXPIRY=10080
+
+# Session lifecycle (POST /auth/refresh + GET /auth/validate)
+# Absolute maximum session lifetime in minutes, enforced at refresh (0 disables the cap)
+# SESSION_MAX_LIFETIME=480
+
+# Maximum POST /auth/refresh requests per minute per client dimension (IP/user/team)
+# SESSION_REFRESH_RATE_LIMIT=10
+
+# Client-behavior hints surfaced via GET /auth/validate (seconds)
+# SESSION_WARNING_TIME=60
+# SESSION_REFRESH_BUFFER=300
+# SESSION_ACTIVITY_TRACKING=true
 
 # SECURITY: Require expiration claim in all tokens (default: true)
 # Set to false only for backward compatibility with legacy tokens

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-21T10:23:38Z",
+  "generated_at": "2026-08-21T12:35:45Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -132,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1370,
+        "line_number": 1382,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1405,
+        "line_number": 1417,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1494,
+        "line_number": 1506,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1499,
+        "line_number": 1511,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1504,
+        "line_number": 1516,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1510,
+        "line_number": 1522,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1522,
+        "line_number": 1534,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1540,
+        "line_number": 1552,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1601,
+        "line_number": 1613,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -373,6 +373,21 @@ class Settings(BaseSettings):
     # Idle timeout configuration
     token_idle_timeout: int = Field(default=60, ge=5, le=1440, description="Maximum idle time in minutes before token requires refresh (5-1440).")  # 60 minutes
 
+    # Session lifecycle configuration (enforced by POST /auth/refresh; surfaced to UI clients via GET /auth/validate)
+    session_max_lifetime: int = Field(
+        default=480,
+        ge=0,
+        le=10080,
+        description="Absolute maximum session lifetime in minutes, enforced at refresh (0 disables the cap). A session cannot be extended past this age regardless of activity.",
+    )
+    session_refresh_rate_limit: int = Field(default=10, ge=1, le=600, description="Maximum POST /auth/refresh requests per minute per client dimension (IP/user/team), enforced by RateLimitMiddleware.")
+    session_warning_time: int = Field(default=60, ge=10, le=3600, description="Seconds before session expiry at which UI clients should warn the user (client-behavior hint).")
+    session_refresh_buffer: int = Field(default=300, ge=30, le=3600, description="Seconds before token expiry at which UI clients should silently refresh the session (client-behavior hint).")
+    session_activity_tracking: bool = Field(
+        default=True,
+        description="Whether UI clients should track user activity to drive idle detection (client-behavior hint; server-side idle enforcement is TOKEN_IDLE_TIMEOUT).",
+    )
+
     # Token blocklist cleanup
     token_blocklist_cleanup_hours: int = Field(default=24, ge=1, le=168, description="Hours to retain expired tokens in blocklist before cleanup (1-168).")
 
@@ -409,7 +424,7 @@ class Settings(BaseSettings):
             "/health",
             "/auth/login",
             "/auth/logout",
-            "/auth/refresh",
+            # /auth/refresh is NOT exempt: cookie-authenticated refresh requires a CSRF token
             "/auth/email/login",
             "/auth/email/register",
             "/auth/email/forgot-password",

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -380,7 +380,9 @@ class Settings(BaseSettings):
         le=10080,
         description="Absolute maximum session lifetime in minutes, enforced at refresh (0 disables the cap). A session cannot be extended past this age regardless of activity.",
     )
-    session_refresh_rate_limit: int = Field(default=10, ge=1, le=600, description="Maximum POST /auth/refresh requests per minute per client dimension (IP/user/team), enforced by RateLimitMiddleware.")
+    session_refresh_rate_limit: int = Field(
+        default=10, ge=1, le=600, description="Maximum POST /auth/refresh requests per minute per client dimension (IP/user/team), enforced by RateLimitMiddleware."
+    )
     session_warning_time: int = Field(default=60, ge=10, le=3600, description="Seconds before session expiry at which UI clients should warn the user (client-behavior hint).")
     session_refresh_buffer: int = Field(default=300, ge=30, le=3600, description="Seconds before token expiry at which UI clients should silently refresh the session (client-behavior hint).")
     session_activity_tracking: bool = Field(

--- a/mcpgateway/middleware/rate_limit_middleware.py
+++ b/mcpgateway/middleware/rate_limit_middleware.py
@@ -111,6 +111,11 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
                 "limit": settings.rate_limit_critical_rpm,
                 "burst": settings.rate_limit_critical_burst,
             },
+            "SESSION_REFRESH": {
+                "pattern": r"^(/v1)?/auth/refresh$",
+                "limit": settings.session_refresh_rate_limit,
+                "burst": settings.session_refresh_rate_limit,
+            },
             "HIGH": {
                 "pattern": r"^/(tokens|oauth|rbac)(/|$)",
                 "limit": settings.rate_limit_high_rpm,

--- a/mcpgateway/routers/auth.py
+++ b/mcpgateway/routers/auth.py
@@ -17,12 +17,13 @@ import uuid
 # Third-Party
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials
 import jwt
 from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 
 # First-Party
-from mcpgateway.auth import get_current_user
+from mcpgateway.auth import get_current_user, TokenValidationError, validate_token_user
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.db import EmailUser, SessionLocal
@@ -34,7 +35,7 @@ from mcpgateway.services.email_auth_service import EmailAuthService
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.token_blocklist_service import get_token_blocklist_service
 from mcpgateway.utils.security_cookies import set_auth_cookie
-from mcpgateway.utils.verify_credentials import get_auth_header_value, verify_jwt_token_cached
+from mcpgateway.utils.verify_credentials import get_auth_header_value, security, verify_jwt_token_cached
 
 # Initialize logging
 logging_service = LoggingService()
@@ -364,6 +365,32 @@ class SessionValidateResponse(BaseModel):
     config: Dict[str, Any]
 
 
+async def get_session_user(request: Request, credentials: Optional[HTTPAuthorizationCredentials] = Depends(security)) -> EmailUser:
+    """Authenticate the request via bearer header or session cookie.
+
+    Args:
+        request: FastAPI request object
+        credentials: Optional bearer credentials from the configured auth header
+
+    Returns:
+        EmailUser: Authenticated user
+
+    Raises:
+        HTTPException: 401 if neither a valid bearer token nor a valid session cookie is presented
+    """
+    if credentials and credentials.credentials:
+        return await get_current_user(credentials, request=request)
+
+    cookie_token = request.cookies.get("jwt_token") or request.cookies.get("access_token")
+    if not cookie_token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required", headers={"WWW-Authenticate": "Bearer"})
+
+    try:
+        return await validate_token_user(request, cookie_token)
+    except TokenValidationError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+
 def _extract_raw_token(request: Request) -> tuple[Optional[str], bool]:
     """Extract the raw JWT from the auth header or cookie.
 
@@ -476,7 +503,7 @@ def _session_config_hints() -> Dict[str, Any]:
 
 
 @auth_router.get("/validate", response_model=SessionValidateResponse)
-async def validate_session(request: Request, current_user: EmailUser = Depends(get_current_user)) -> SessionValidateResponse:
+async def validate_session(request: Request, current_user: EmailUser = Depends(get_session_user)) -> SessionValidateResponse:
     """Validate the current session and report its expiry, source, and config hints.
 
     Args:
@@ -509,7 +536,7 @@ async def validate_session(request: Request, current_user: EmailUser = Depends(g
 
 
 @auth_router.post("/refresh", response_model=SessionRefreshResponse)
-async def refresh_session(request: Request, current_user: EmailUser = Depends(get_current_user)) -> Response:
+async def refresh_session(request: Request, current_user: EmailUser = Depends(get_session_user)) -> Response:
     """Refresh the current session by issuing a new JWT with extended expiry.
 
     Args:

--- a/mcpgateway/routers/auth.py
+++ b/mcpgateway/routers/auth.py
@@ -9,6 +9,7 @@ It serves as the primary entry point for authentication workflows.
 """
 
 # Standard
+import asyncio
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 import uuid
@@ -33,7 +34,7 @@ from mcpgateway.services.email_auth_service import EmailAuthService
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.token_blocklist_service import get_token_blocklist_service
 from mcpgateway.utils.security_cookies import set_auth_cookie
-from mcpgateway.utils.verify_credentials import get_auth_header_value
+from mcpgateway.utils.verify_credentials import get_auth_header_value, verify_jwt_token_cached
 
 # Initialize logging
 logging_service = LoggingService()
@@ -383,7 +384,7 @@ def _extract_raw_token(request: Request) -> tuple[Optional[str], bool]:
 
 
 def _decode_token_unverified(raw_token: str) -> Dict[str, Any]:
-    """Decode a JWT payload without re-verifying the signature (claims already verified by auth).
+    """Decode a JWT payload without verifying the signature (only for tokens this gateway just minted).
 
     Args:
         raw_token: Raw JWT string
@@ -395,6 +396,50 @@ def _decode_token_unverified(raw_token: str) -> Dict[str, Any]:
         return jwt.decode(raw_token, options={"verify_signature": False})
     except jwt.DecodeError:
         return {}
+
+
+async def _verify_session_token(raw_token: str, request: Request, current_user: EmailUser) -> Dict[str, Any]:
+    """Verify the request's session token and bind it to the authenticated user.
+
+    Full signature/expiry verification plus revocation and subject checks, so
+    claims are never trusted from a token that was not verified by the gateway
+    (the auth dependency may have authenticated via a non-JWT mechanism).
+
+    Args:
+        raw_token: Raw JWT string extracted from the request
+        request: FastAPI request object
+        current_user: Currently authenticated user
+
+    Returns:
+        Verified JWT payload
+
+    Raises:
+        HTTPException: 401 if the token is invalid, expired, revoked, or its
+            subject does not match the authenticated user
+    """
+    try:
+        payload = await verify_jwt_token_cached(raw_token, request)
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid session token")
+
+    jti = payload.get("jti")
+    if jti:
+        blocklist_service = get_token_blocklist_service()
+        if await asyncio.to_thread(blocklist_service.is_token_revoked, jti):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Session token has been revoked")
+
+    subject = str(payload.get("sub") or "")
+    if subject not in (str(current_user.id), str(current_user.email)):
+        logger.warning(
+            "Session token subject mismatch for %s",
+            SecurityValidator.sanitize_log_message(str(current_user.email)),
+            extra={"security_event": "token_subject_mismatch", "security_severity": "medium", "user_email": current_user.email},
+        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Session token does not match authenticated user")
+
+    return payload
 
 
 def _session_source_from_payload(payload: Dict[str, Any]) -> str:
@@ -442,7 +487,9 @@ async def validate_session(request: Request, current_user: EmailUser = Depends(g
         SessionValidateResponse: Session expiry, user profile, session source, and config hints
     """
     raw_token, _ = _extract_raw_token(request)
-    payload = _decode_token_unverified(raw_token) if raw_token else {}
+    if not raw_token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="No session token to validate")
+    payload = await _verify_session_token(raw_token, request, current_user)
 
     expires_at: Optional[str] = None
     expires_in: Optional[int] = None
@@ -481,9 +528,7 @@ async def refresh_session(request: Request, current_user: EmailUser = Depends(ge
         # Non-JWT auth (basic/proxy) has no session token to refresh
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="No session token to refresh")
 
-    payload = _decode_token_unverified(raw_token)
-    if not payload:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid session token")
+    payload = await _verify_session_token(raw_token, request, current_user)
 
     if payload.get("token_use") != "session":  # nosec B105 - Not a password; token_use is a JWT claim type
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only session tokens can be refreshed. API tokens have their own expiry and revocation lifecycle.")

--- a/mcpgateway/routers/auth.py
+++ b/mcpgateway/routers/auth.py
@@ -9,10 +9,14 @@ It serves as the primary entry point for authentication workflows.
 """
 
 # Standard
-from typing import Optional
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+import uuid
 
 # Third-Party
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi.responses import JSONResponse
+import jwt
 from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 
@@ -23,8 +27,12 @@ from mcpgateway.config import settings
 from mcpgateway.db import EmailUser, SessionLocal
 from mcpgateway.routers.email_auth import create_access_token, get_client_ip, get_user_agent
 from mcpgateway.schemas import AuthenticationResponse, EmailUserResponse
+from mcpgateway.services.audit_trail_service import get_audit_trail_service
+from mcpgateway.services.csrf_service import generate_csrf_token, set_csrf_cookie
 from mcpgateway.services.email_auth_service import EmailAuthService
 from mcpgateway.services.logging_service import LoggingService
+from mcpgateway.services.token_blocklist_service import get_token_blocklist_service
+from mcpgateway.utils.security_cookies import set_auth_cookie
 from mcpgateway.utils.verify_credentials import get_auth_header_value
 
 # Initialize logging
@@ -143,13 +151,6 @@ async def get_csrf_token(request: Request, current_user: "EmailUser" = Depends(g
         >>> # Headers: Authorization: Bearer <token>
         >>> # Response: {"csrf_token": "abc123..."}
     """
-    # Third-Party
-    from fastapi.responses import JSONResponse
-
-    # First-Party
-    from mcpgateway.config import settings
-    from mcpgateway.services.csrf_service import generate_csrf_token, set_csrf_cookie
-
     try:
         session_id = getattr(request.state, "jti", None)
         if not session_id:
@@ -227,13 +228,6 @@ async def login(login_request: LoginRequest, request: Request, db: Session = Dep
         # Generate CSRF token for session (rotate on login)
         if settings.csrf_rotate_on_login:
             try:
-                # Third-Party
-                from fastapi.responses import JSONResponse
-                import jwt
-
-                # First-Party
-                from mcpgateway.services.csrf_service import generate_csrf_token, set_csrf_cookie
-
                 # Decode JWT to get jti (don't verify since we just created it)
                 payload = jwt.decode(access_token, options={"verify_signature": False})
                 session_id = payload.get("jti", "")
@@ -287,9 +281,6 @@ async def logout(request: Request, current_user: EmailUser = Depends(get_current
         - Token cannot be reused after logout
         - Supports audit trail for security monitoring
     """
-    # First-Party
-    from mcpgateway.services.token_blocklist_service import get_token_blocklist_service
-
     try:
         # User is already authenticated via dependency injection
         user = current_user
@@ -306,12 +297,6 @@ async def logout(request: Request, current_user: EmailUser = Depends(get_current
         token = raw_token.strip()
 
         # Decode token to get JTI and expiry
-        # Third-Party
-        import jwt
-
-        # First-Party
-        from mcpgateway.config import settings
-
         try:
             # Handle both SecretStr and string types for jwt_secret_key
             secret_key = settings.jwt_secret_key
@@ -328,9 +313,6 @@ async def logout(request: Request, current_user: EmailUser = Depends(get_current
                 raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Token does not support revocation (missing JTI)")
 
             # Convert timestamps to datetime
-            # Standard
-            from datetime import datetime, timezone
-
             token_expiry = datetime.fromtimestamp(exp, tz=timezone.utc) if exp else None
             last_activity_dt = datetime.fromtimestamp(last_activity, tz=timezone.utc) if last_activity else None
 
@@ -353,3 +335,208 @@ async def logout(request: Request, current_user: EmailUser = Depends(get_current
     except Exception as e:
         logger.error(f"Logout error: {e}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Logout service error")
+
+
+# ---------------------------------------------------------------------------
+# Session refresh & validation
+# ---------------------------------------------------------------------------
+
+
+class SessionRefreshResponse(BaseModel):
+    """Response payload for POST /auth/refresh."""
+
+    access_token: str
+    token_type: str = "bearer"  # nosec B105 - OAuth2 token type, not a password
+    expires_in: int
+    expires_at: str
+    csrf_token: Optional[str] = None
+
+
+class SessionValidateResponse(BaseModel):
+    """Response payload for GET /auth/validate."""
+
+    valid: bool
+    expires_at: Optional[str] = None
+    expires_in: Optional[int] = None
+    user: EmailUserResponse
+    session_source: str
+    config: Dict[str, Any]
+
+
+def _extract_raw_token(request: Request) -> tuple[Optional[str], bool]:
+    """Extract the raw JWT from the auth header or cookie.
+
+    Args:
+        request: FastAPI request object
+
+    Returns:
+        Tuple of (raw token or None, True when the token came from a cookie)
+    """
+    auth_header = get_auth_header_value(request.headers) or ""
+    scheme, _, header_token = auth_header.partition(" ")
+    if scheme.lower() == "bearer" and header_token.strip():
+        return header_token.strip(), False
+    cookie_token = request.cookies.get("jwt_token") or request.cookies.get("access_token")
+    if cookie_token:
+        return cookie_token, True
+    return None, False
+
+
+def _decode_token_unverified(raw_token: str) -> Dict[str, Any]:
+    """Decode a JWT payload without re-verifying the signature (claims already verified by auth).
+
+    Args:
+        raw_token: Raw JWT string
+
+    Returns:
+        Decoded payload dict, or an empty dict if the token cannot be decoded
+    """
+    try:
+        return jwt.decode(raw_token, options={"verify_signature": False})
+    except jwt.DecodeError:
+        return {}
+
+
+def _session_source_from_payload(payload: Dict[str, Any]) -> str:
+    """Classify how the session was established from JWT claims.
+
+    Args:
+        payload: Decoded JWT payload
+
+    Returns:
+        One of "local", "sso", or "api_token"
+    """
+    if payload.get("token_use") == "api":
+        return "api_token"
+    if payload.get("source") == "external_idp":
+        return "sso"
+    provider = str(payload.get("auth_provider") or "local").strip().lower()
+    return "local" if provider in ("", "local", "basic") else "sso"
+
+
+def _session_config_hints() -> Dict[str, Any]:
+    """Build the session-lifecycle config block for UI clients (durations in seconds).
+
+    Returns:
+        Dict of session-lifecycle hints
+    """
+    return {
+        "token_expiry": settings.token_expiry * 60,
+        "idle_timeout": settings.token_idle_timeout * 60,
+        "max_lifetime": settings.session_max_lifetime * 60,
+        "warning_time": settings.session_warning_time,
+        "refresh_buffer": settings.session_refresh_buffer,
+        "activity_tracking": settings.session_activity_tracking,
+    }
+
+
+@auth_router.get("/validate", response_model=SessionValidateResponse)
+async def validate_session(request: Request, current_user: EmailUser = Depends(get_current_user)) -> SessionValidateResponse:
+    """Validate the current session and report its expiry, source, and config hints.
+
+    Args:
+        request: FastAPI request object
+        current_user: Currently authenticated user
+
+    Returns:
+        SessionValidateResponse: Session expiry, user profile, session source, and config hints
+    """
+    raw_token, _ = _extract_raw_token(request)
+    payload = _decode_token_unverified(raw_token) if raw_token else {}
+
+    expires_at: Optional[str] = None
+    expires_in: Optional[int] = None
+    exp_ts = payload.get("exp")
+    if exp_ts:
+        expires_at = datetime.fromtimestamp(exp_ts, tz=timezone.utc).isoformat()
+        expires_in = max(0, int(exp_ts - datetime.now(tz=timezone.utc).timestamp()))
+
+    return SessionValidateResponse(
+        valid=True,
+        expires_at=expires_at,
+        expires_in=expires_in,
+        user=EmailUserResponse.from_email_user(current_user),
+        session_source=_session_source_from_payload(payload),
+        config=_session_config_hints(),
+    )
+
+
+@auth_router.post("/refresh", response_model=SessionRefreshResponse)
+async def refresh_session(request: Request, current_user: EmailUser = Depends(get_current_user)) -> Response:
+    """Refresh the current session by issuing a new JWT with extended expiry.
+
+    Args:
+        request: FastAPI request object
+        current_user: Currently authenticated user
+
+    Returns:
+        SessionRefreshResponse: New access token, expiry, and rotated CSRF token
+
+    Raises:
+        HTTPException: 401 if the session token is missing, malformed, or past
+            the absolute lifetime cap; 403 for non-session tokens
+    """
+    raw_token, from_cookie = _extract_raw_token(request)
+    if not raw_token:
+        # Non-JWT auth (basic/proxy) has no session token to refresh
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="No session token to refresh")
+
+    payload = _decode_token_unverified(raw_token)
+    if not payload:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid session token")
+
+    if payload.get("token_use") != "session":  # nosec B105 - Not a password; token_use is a JWT claim type
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only session tokens can be refreshed. API tokens have their own expiry and revocation lifecycle.")
+
+    session_source = _session_source_from_payload(payload)
+    now_ts = int(datetime.now(tz=timezone.utc).timestamp())
+
+    # session_start is stamped at first login and carried across refreshes
+    session_start = int(payload.get("session_start") or payload.get("iat") or now_ts)
+    if settings.session_max_lifetime > 0 and (now_ts - session_start) >= settings.session_max_lifetime * 60:
+        logger.warning(
+            "Session refresh refused: absolute lifetime exceeded for %s",
+            SecurityValidator.sanitize_log_message(current_user.email),
+            extra={"security_event": "session_max_lifetime", "security_severity": "medium", "user_email": current_user.email},
+        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=f"Session exceeded maximum lifetime ({settings.session_max_lifetime} minutes). Please log in again.")
+
+    old_jti = payload.get("jti")
+    new_jti = str(uuid.uuid4())
+    # Preserve the old token's scope narrowing; teams are resolved server-side from the DB
+    access_token, expires_in = await create_access_token(current_user, token_scopes=payload.get("scopes"), jti=new_jti, extra_claims={"session_start": session_start})
+    new_exp_ts = _decode_token_unverified(access_token).get("exp", now_ts + expires_in)
+    expires_at = datetime.fromtimestamp(new_exp_ts, tz=timezone.utc).isoformat()
+
+    # Rotate the CSRF token (CSRF tokens are HMAC-bound to the jti, which changed)
+    csrf_token: Optional[str] = None
+    try:
+        csrf_token = generate_csrf_token(user_id=current_user.email, session_id=new_jti, secret=settings.csrf_secret_key.get_secret_value(), expiry=settings.csrf_token_expiry)
+    except Exception as e:
+        logger.warning(f"Failed to rotate CSRF token on refresh for {current_user.email}: {e}")
+
+    refresh_response = SessionRefreshResponse(access_token=access_token, token_type="bearer", expires_in=expires_in, expires_at=expires_at, csrf_token=csrf_token)  # nosec B106 - OAuth2 token type
+    response = JSONResponse(content=refresh_response.model_dump(mode="json"))
+    if csrf_token:
+        set_csrf_cookie(response, csrf_token, settings)
+    if from_cookie:
+        set_auth_cookie(response, access_token)
+
+    audit_trail = get_audit_trail_service()
+    audit_trail.log_action(
+        user_id=current_user.email,
+        action="session_refresh",
+        resource_type="session",
+        resource_id=new_jti,
+        user_email=current_user.email,
+        client_ip=get_client_ip(request),
+        user_agent=get_user_agent(request),
+        context={"old_jti": old_jti, "session_source": session_source},
+    )
+
+    logger.info(
+        "Session refreshed for %s",
+        SecurityValidator.sanitize_log_message(current_user.email),
+        extra={"security_event": "session_refresh", "user_email": current_user.email, "jti": new_jti},
+    )
+    return response

--- a/mcpgateway/routers/auth.py
+++ b/mcpgateway/routers/auth.py
@@ -547,8 +547,9 @@ async def refresh_session(request: Request, current_user: EmailUser = Depends(ge
         SessionRefreshResponse: New access token, expiry, and rotated CSRF token
 
     Raises:
-        HTTPException: 401 if the session token is missing, malformed, or past
-            the absolute lifetime cap; 403 for non-session tokens
+        HTTPException: 401 if the session token is missing, malformed, past the
+            absolute lifetime cap, or cannot be rotated (already refreshed or
+            revocation not persisted); 403 for non-session tokens
     """
     raw_token, from_cookie = _extract_raw_token(request)
     if not raw_token:
@@ -574,6 +575,31 @@ async def refresh_session(request: Request, current_user: EmailUser = Depends(ge
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=f"Session exceeded maximum lifetime ({settings.session_max_lifetime} minutes). Please log in again.")
 
     old_jti = payload.get("jti")
+    if not old_jti:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Session token does not support rotation (missing jti)")
+
+    # Single-use rotation: revoke the predecessor before minting so the old token
+    # cannot be replayed to mint further tokens. fail_if_already_revoked makes the
+    # revocation compare-and-set — concurrent refreshes race and exactly one wins.
+    # Fail closed when revocation cannot be persisted.
+    old_exp_ts = payload.get("exp")
+    blocklist_service = get_token_blocklist_service()
+    rotated = await asyncio.to_thread(
+        blocklist_service.revoke_token,
+        jti=old_jti,
+        revoked_by=current_user.email,
+        reason="token_refresh",
+        token_expiry=datetime.fromtimestamp(old_exp_ts, tz=timezone.utc) if old_exp_ts else None,
+        fail_if_already_revoked=True,
+    )
+    if not rotated:
+        logger.warning(
+            "Session refresh refused: predecessor token could not be revoked for %s",
+            SecurityValidator.sanitize_log_message(current_user.email),
+            extra={"security_event": "session_rotation_failed", "security_severity": "medium", "user_email": current_user.email, "jti": old_jti},
+        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Session token already rotated or revocation failed. Please log in again.")
+
     new_jti = str(uuid.uuid4())
     # Preserve the old token's scope narrowing; teams are resolved server-side from the DB
     access_token, expires_in = await create_access_token(current_user, token_scopes=payload.get("scopes"), jti=new_jti, extra_claims={"session_start": session_start})

--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -128,13 +128,15 @@ def get_user_agent(request: Request) -> str:
     return request.headers.get("User-Agent", "unknown")
 
 
-async def create_access_token(user: EmailUser, token_scopes: Optional[dict] = None, jti: Optional[str] = None) -> tuple[str, int]:
+async def create_access_token(user: EmailUser, token_scopes: Optional[dict] = None, jti: Optional[str] = None, extra_claims: Optional[dict] = None) -> tuple[str, int]:
     """Create JWT access token for user with enhanced scoping.
 
     Args:
         user: EmailUser instance
         token_scopes: Optional token scoping information
         jti: Optional JWT ID for revocation tracking
+        extra_claims: Optional additional claims merged into the payload; cannot
+            override the reserved claims set by this function (sub, exp, jti, ...)
 
     Returns:
         Tuple of (token_string, expires_in_seconds)
@@ -146,6 +148,7 @@ async def create_access_token(user: EmailUser, token_scopes: Optional[dict] = No
     issued_at = int(now.timestamp())
     # Create JWT payload — session token (teams resolved server-side at request time)
     payload = {
+        **(extra_claims or {}),
         # Standard JWT claims
         "sub": str(user.id),
         "iss": settings.jwt_issuer,

--- a/mcpgateway/services/token_blocklist_service.py
+++ b/mcpgateway/services/token_blocklist_service.py
@@ -79,7 +79,9 @@ class TokenBlocklistService:
 
         return self._redis_client if self._redis_client is not False else None
 
-    def revoke_token(self, jti: str, revoked_by: str, reason: str = "logout", token_expiry: Optional[datetime] = None, last_activity: Optional[datetime] = None) -> bool:
+    def revoke_token(
+        self, jti: str, revoked_by: str, reason: str = "logout", token_expiry: Optional[datetime] = None, last_activity: Optional[datetime] = None, fail_if_already_revoked: bool = False
+    ) -> bool:
         """Revoke a token by adding it to the blocklist.
 
         Args:
@@ -88,6 +90,8 @@ class TokenBlocklistService:
             reason: Reason for revocation (logout, idle_timeout, security, token_refresh, etc.)
             token_expiry: Original token expiry for cleanup scheduling
             last_activity: Last activity timestamp for audit trail
+            fail_if_already_revoked: When True, an already-revoked jti returns False
+                instead of True (single-use/compare-and-set semantics for rotation)
 
         Returns:
             True if token was revoked successfully, False otherwise.
@@ -106,7 +110,7 @@ class TokenBlocklistService:
 
                 if existing:
                     logger.debug("Token %s already revoked", jti)
-                    return True
+                    return not fail_if_already_revoked
 
                 # Create revocation record
                 revocation = TokenRevocation(jti=jti, revoked_by=revoked_by, reason=reason, token_expiry=token_expiry, last_activity=last_activity or utc_now())
@@ -121,7 +125,7 @@ class TokenBlocklistService:
 
                     if existing:
                         logger.debug("Token %s already revoked", jti)
-                        return True
+                        return not fail_if_already_revoked
 
                     # Create revocation record
                     revocation = TokenRevocation(jti=jti, revoked_by=revoked_by, reason=reason, token_expiry=token_expiry, last_activity=last_activity or utc_now())

--- a/tests/unit/mcpgateway/middleware/test_csrf_fixes.py
+++ b/tests/unit/mcpgateway/middleware/test_csrf_fixes.py
@@ -295,10 +295,9 @@ async def test_token_rotation_on_login():
         patch("mcpgateway.routers.auth.create_access_token") as mock_create_token,
         patch("mcpgateway.routers.auth.settings") as mock_settings,
         patch("jwt.decode") as mock_jwt_decode,
-        patch("mcpgateway.services.csrf_service.generate_csrf_token") as mock_gen_csrf,
-        patch("mcpgateway.services.csrf_service.set_csrf_cookie") as mock_set_cookie,
+        patch("mcpgateway.routers.auth.generate_csrf_token") as mock_gen_csrf,
+        patch("mcpgateway.routers.auth.set_csrf_cookie") as mock_set_cookie,
     ):
-
         # Setup mocks
         mock_settings.csrf_rotate_on_login = True
         mock_settings.csrf_secret_key = SecretStr("test-secret")  # pragma: allowlist secret

--- a/tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py
@@ -466,7 +466,10 @@ class TestRateLimitMiddlewareTiers:
         mock_script = MagicMock()
         mock_client.register_script.return_value = mock_script
 
-        with patch("mcpgateway.middleware.rate_limit_middleware.settings") as mock_settings, patch("mcpgateway.middleware.rate_limit_middleware.auth._get_ratelimiter_redis_client", return_value=mock_client):
+        with (
+            patch("mcpgateway.middleware.rate_limit_middleware.settings") as mock_settings,
+            patch("mcpgateway.middleware.rate_limit_middleware.auth._get_ratelimiter_redis_client", return_value=mock_client),
+        ):
             mock_settings.rate_limiting_enabled = True
             mock_settings.rate_limiting_redis_enabled = True
             mock_settings.trust_proxy_auth = True

--- a/tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py
@@ -105,6 +105,7 @@ class TestRateLimitMiddlewareTiers:
             mock_settings.rate_limit_lockout_enabled = True
             mock_settings.rate_limit_lockout_threshold = 5
             mock_settings.rate_limit_lockout_duration_minutes = 15
+            mock_settings.session_refresh_rate_limit = 10
 
             from mcpgateway.middleware.rate_limit_middleware import RateLimitMiddleware
 
@@ -150,6 +151,12 @@ class TestRateLimitMiddlewareTiers:
         tier = middleware.get_endpoint_tier("/auth/email/login")
         assert tier["limit"] == 10
         assert tier["burst"] == 0
+
+    def test_endpoint_tier_session_refresh(self, middleware):
+        """Test SESSION_REFRESH tier detection for /auth/refresh on both mounts."""
+        assert middleware.get_endpoint_tier("/auth/refresh")["limit"] == 10
+        assert middleware.get_endpoint_tier("/v1/auth/refresh")["limit"] == 10
+        assert middleware._get_tier_name("/auth/refresh") == "SESSION_REFRESH"
 
     def test_endpoint_tier_critical_for_team_invitations(self, middleware):
         """Only SMTP-producing POST invitation requests use the strict tier."""
@@ -474,6 +481,7 @@ class TestRateLimitMiddlewareTiers:
             mock_settings.rate_limit_lockout_enabled = True
             mock_settings.rate_limit_lockout_threshold = 5
             mock_settings.rate_limit_lockout_duration_minutes = 15
+            mock_settings.session_refresh_rate_limit = 10
 
             from mcpgateway.middleware.rate_limit_middleware import RateLimitMiddleware
 
@@ -504,6 +512,7 @@ class TestRateLimitMiddlewareTiers:
             mock_settings.rate_limit_lockout_enabled = True
             mock_settings.rate_limit_lockout_threshold = 5
             mock_settings.rate_limit_lockout_duration_minutes = 15
+            mock_settings.session_refresh_rate_limit = 10
 
             from mcpgateway.middleware.rate_limit_middleware import RateLimitMiddleware
 
@@ -541,6 +550,7 @@ class TestRateLimitMiddlewareTiers:
             mock_settings.rate_limit_lockout_enabled = True
             mock_settings.rate_limit_lockout_threshold = 5
             mock_settings.rate_limit_lockout_duration_minutes = 15
+            mock_settings.session_refresh_rate_limit = 10
 
             from mcpgateway.middleware.rate_limit_middleware import RateLimitMiddleware
 
@@ -1154,6 +1164,7 @@ class TestRateLimitMiddlewareTiers:
             mock_settings.rate_limit_lockout_enabled = True
             mock_settings.rate_limit_lockout_threshold = 5
             mock_settings.rate_limit_lockout_duration_minutes = 15
+            mock_settings.session_refresh_rate_limit = 10
 
             from mcpgateway.middleware.rate_limit_middleware import RateLimitMiddleware
 

--- a/tests/unit/mcpgateway/routers/test_auth.py
+++ b/tests/unit/mcpgateway/routers/test_auth.py
@@ -494,6 +494,7 @@ class TestSessionRefreshAndValidate:
         issued = jwt_lib.encode({"jti": "new-jti", "exp": now + expires_in}, self.SECRET, algorithm="HS256")
         blocklist = MagicMock()
         blocklist.is_token_revoked.return_value = False
+        blocklist.revoke_token.return_value = True
         return {
             "verify": patch("mcpgateway.routers.auth.verify_jwt_token_cached", new_callable=AsyncMock, return_value=payload),
             "blocklist": patch("mcpgateway.routers.auth.get_token_blocklist_service", return_value=blocklist),
@@ -536,6 +537,11 @@ class TestSessionRefreshAndValidate:
         assert "db" not in audit_kwargs
         # session_start carried into the new token
         assert "session_start" in mocks["create_token"].call_args.kwargs["extra_claims"]
+        # Predecessor token revoked single-use (compare-and-set) before minting
+        revoke_kwargs = mocks["blocklist"].return_value.revoke_token.call_args.kwargs
+        assert revoke_kwargs["jti"] == "old-jti"
+        assert revoke_kwargs["reason"] == "token_refresh"
+        assert revoke_kwargs["fail_if_already_revoked"] is True
 
     @pytest.mark.asyncio
     async def test_refresh_success_cookie_sets_auth_cookie(self, mock_user):
@@ -685,6 +691,44 @@ class TestSessionRefreshAndValidate:
 
         assert exc_info.value.status_code == 401
         assert "maximum lifetime" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_refresh_fails_closed_when_rotation_not_persisted(self, mock_user):
+        """If the predecessor token cannot be revoked (already rotated or store failure): 401."""
+        # First-Party
+        from mcpgateway.routers.auth import refresh_session
+
+        token, payload = self._make_token()
+        request = self._make_request(token)
+        patches = self._patch_stack(payload)
+
+        blocklist = MagicMock()
+        blocklist.is_token_revoked.return_value = False
+        blocklist.revoke_token.return_value = False  # CAS lost or persistence failure
+        with patches["verify"], patch("mcpgateway.routers.auth.get_token_blocklist_service", return_value=blocklist):
+            with pytest.raises(HTTPException) as exc_info:
+                await refresh_session(request, mock_user)
+
+        assert exc_info.value.status_code == 401
+        assert "rotated" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_refresh_refuses_token_without_jti(self, mock_user):
+        """A session token without a jti cannot be rotated: 401."""
+        # First-Party
+        from mcpgateway.routers.auth import refresh_session
+
+        token, payload = self._make_token(jti=None)
+        request = self._make_request(token)
+
+        with ExitStack() as stack:
+            for name in ("verify", "blocklist"):
+                stack.enter_context(self._patch_stack(payload)[name])
+            with pytest.raises(HTTPException) as exc_info:
+                await refresh_session(request, mock_user)
+
+        assert exc_info.value.status_code == 401
+        assert "jti" in exc_info.value.detail
 
     # ------------------------------------------------------------------
     # GET /auth/validate
@@ -897,6 +941,7 @@ class TestCookieOnlySessionSmoke:
         stack.enter_context(patch("mcpgateway.utils.verify_credentials.verify_jwt_token", new_callable=AsyncMock, return_value=payload))
         blocklist = MagicMock()
         blocklist.is_token_revoked.return_value = False
+        blocklist.revoke_token.return_value = True
         blocklist.get_last_activity.return_value = None
         stack.enter_context(patch("mcpgateway.routers.auth.get_token_blocklist_service", return_value=blocklist))
         stack.enter_context(patch("mcpgateway.services.token_blocklist_service.get_token_blocklist_service", return_value=blocklist))

--- a/tests/unit/mcpgateway/routers/test_auth.py
+++ b/tests/unit/mcpgateway/routers/test_auth.py
@@ -16,7 +16,7 @@ from pydantic import SecretStr
 import pytest
 
 # First-Party
-from mcpgateway.routers.auth import LoginRequest, get_csrf_token, get_db, login
+from mcpgateway.routers.auth import get_csrf_token, get_db, login, LoginRequest
 
 
 class TestLoginRequest:
@@ -256,8 +256,8 @@ class TestLogin:
             patch("mcpgateway.routers.auth.create_access_token", new_callable=AsyncMock) as mock_create_token,
             patch("mcpgateway.routers.auth.settings") as mock_settings,
             patch("jwt.decode", return_value={"jti": "session-123"}),
-            patch("mcpgateway.services.csrf_service.generate_csrf_token", return_value="csrf-token-123") as mock_generate,
-            patch("mcpgateway.services.csrf_service.set_csrf_cookie") as mock_set_cookie,
+            patch("mcpgateway.routers.auth.generate_csrf_token", return_value="csrf-token-123") as mock_generate,
+            patch("mcpgateway.routers.auth.set_csrf_cookie") as mock_set_cookie,
         ):
             mock_service = MagicMock()
             mock_service.authenticate_user = AsyncMock(return_value=mock_user)
@@ -285,9 +285,9 @@ class TestLogin:
         current_user = SimpleNamespace(email="test@example.com")
 
         with (
-            patch("mcpgateway.config.settings") as mock_settings,
-            patch("mcpgateway.services.csrf_service.generate_csrf_token", return_value="csrf-token-123") as mock_generate,
-            patch("mcpgateway.services.csrf_service.set_csrf_cookie") as mock_set_cookie,
+            patch("mcpgateway.routers.auth.settings") as mock_settings,
+            patch("mcpgateway.routers.auth.generate_csrf_token", return_value="csrf-token-123") as mock_generate,
+            patch("mcpgateway.routers.auth.set_csrf_cookie") as mock_set_cookie,
         ):
             mock_settings.csrf_secret_key = SecretStr("secret")  # pragma: allowlist secret
             mock_settings.csrf_token_expiry = 60
@@ -320,7 +320,7 @@ class TestLogin:
 
         with (
             patch("mcpgateway.routers.auth.settings") as mock_settings,
-            patch("mcpgateway.services.csrf_service.generate_csrf_token", side_effect=Exception("boom")),
+            patch("mcpgateway.routers.auth.generate_csrf_token", side_effect=Exception("boom")),
         ):
             mock_settings.csrf_secret_key = SecretStr("secret")  # pragma: allowlist secret
             mock_settings.csrf_token_expiry = 60
@@ -393,6 +393,7 @@ class TestLogout:
     @pytest.mark.asyncio
     async def test_logout_with_secret_str_jwt_key(self, mock_request, mock_db, mock_current_user):
         """Test logout when jwt_secret_key is a SecretStr type (covers line 239)."""
+        # First-Party
         from mcpgateway.routers.auth import logout
 
         # Create a mock SecretStr
@@ -400,8 +401,8 @@ class TestLogout:
         mock_secret_str.get_secret_value.return_value = "test-secret-key"
 
         with (
-            patch("mcpgateway.services.token_blocklist_service.get_token_blocklist_service") as mock_blocklist_service,
-            patch("mcpgateway.config.settings") as mock_settings,
+            patch("mcpgateway.routers.auth.get_token_blocklist_service") as mock_blocklist_service,
+            patch("mcpgateway.routers.auth.settings") as mock_settings,
         ):
             # Setup settings with SecretStr
             mock_settings.jwt_secret_key = mock_secret_str
@@ -426,3 +427,257 @@ class TestLogout:
                 assert response["revoked_token"] == "test-jti-123"
                 mock_secret_str.get_secret_value.assert_called_once()
                 mock_service.revoke_token.assert_called_once()
+
+
+class TestSessionRefreshAndValidate:
+    """Tests for POST /auth/refresh and GET /auth/validate."""
+
+    SECRET = "test-secret-key"  # pragma: allowlist secret
+
+    @pytest.fixture
+    def mock_user(self):
+        """Create a mock authenticated user."""
+        user = MagicMock()
+        user.id = "test-user-id"
+        user.email = "test@example.com"
+        user.full_name = "Test User"
+        user.is_active = True
+        user.is_admin = False
+        user.auth_provider = "local"
+        return user
+
+    def _make_token(self, **overrides):
+        """Build a real session JWT so unverified claim decoding works."""
+        # Standard
+        import time as time_mod
+
+        # Third-Party
+        import jwt as jwt_lib
+
+        now = int(time_mod.time())
+        payload = {
+            "sub": "test-user-id",
+            "jti": "old-jti",
+            "iat": now,
+            "exp": now + 1200,
+            "token_use": "session",
+            "auth_provider": "local",
+            "scopes": {"server_id": None, "permissions": ["*"], "ip_restrictions": [], "time_restrictions": {}},
+        }
+        payload.update(overrides)
+        payload = {k: v for k, v in payload.items() if v is not None}
+        return jwt_lib.encode(payload, self.SECRET, algorithm="HS256"), payload
+
+    def _make_request(self, token, via_cookie=False):
+        """Create a mock request carrying the JWT in header or cookie."""
+        request = MagicMock()
+        request.client = MagicMock()
+        request.client.host = "127.0.0.1"
+        if via_cookie:
+            request.headers = {"user-agent": "test-agent"}
+            request.cookies = {"jwt_token": token}
+        else:
+            request.headers = {"authorization": f"Bearer {token}", "user-agent": "test-agent"}
+            request.cookies = {}
+        return request
+
+    def _patch_stack(self, new_token="newtok", expires_in=1200):
+        """Patch collaborators of refresh_session; returns the context managers dict."""
+        # Standard
+        # Real JWT for the newly issued token so its exp can be decoded
+        import time as time_mod
+
+        # Third-Party
+        import jwt as jwt_lib
+
+        now = int(time_mod.time())
+        issued = jwt_lib.encode({"jti": "new-jti", "exp": now + expires_in}, self.SECRET, algorithm="HS256")
+        return {
+            "create_token": patch("mcpgateway.routers.auth.create_access_token", new_callable=AsyncMock, return_value=(issued, expires_in)),
+            "csrf": patch("mcpgateway.routers.auth.generate_csrf_token", return_value="csrf-rotated"),
+            "set_csrf": patch("mcpgateway.routers.auth.set_csrf_cookie"),
+            "set_auth": patch("mcpgateway.routers.auth.set_auth_cookie"),
+            "audit": patch("mcpgateway.routers.auth.get_audit_trail_service"),
+        }
+
+    # ------------------------------------------------------------------
+    # POST /auth/refresh
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_refresh_success_bearer(self, mock_user):
+        """A valid local session refreshes: new token issued, CSRF rotated, audit logged, no auth cookie set."""
+        # Standard
+        import json
+
+        # First-Party
+        from mcpgateway.routers.auth import refresh_session
+
+        token, _ = self._make_token()
+        request = self._make_request(token)
+        patches = self._patch_stack()
+        with patches["create_token"] as mock_create, patches["csrf"], patches["set_csrf"], patches["set_auth"] as mock_set_auth, patches["audit"] as mock_audit:
+            response = await refresh_session(request, mock_user)
+
+        body = json.loads(response.body)
+        assert body["token_type"] == "bearer"
+        assert body["expires_in"] == 1200
+        assert body["expires_at"]
+        assert body["csrf_token"] == "csrf-rotated"
+        # Header-authenticated request must NOT receive an auth cookie
+        mock_set_auth.assert_not_called()
+        mock_audit.return_value.log_action.assert_called_once()
+        audit_kwargs = mock_audit.return_value.log_action.call_args.kwargs
+        assert audit_kwargs["action"] == "session_refresh"
+        assert "db" not in audit_kwargs
+        # session_start carried into the new token
+        create_kwargs = mock_create.call_args.kwargs
+        assert "session_start" in create_kwargs["extra_claims"]
+
+    @pytest.mark.asyncio
+    async def test_refresh_success_cookie_sets_auth_cookie(self, mock_user):
+        """A cookie-authenticated refresh re-sets the jwt_token cookie."""
+        # First-Party
+        from mcpgateway.routers.auth import refresh_session
+
+        token, _ = self._make_token()
+        request = self._make_request(token, via_cookie=True)
+        patches = self._patch_stack()
+        with patches["create_token"], patches["csrf"], patches["set_csrf"], patches["set_auth"] as mock_set_auth, patches["audit"]:
+            await refresh_session(request, mock_user)
+
+        mock_set_auth.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_refresh_preserves_session_start_claim(self, mock_user):
+        """session_start from the old token is carried over, not re-stamped."""
+        # First-Party
+        from mcpgateway.routers.auth import refresh_session
+
+        token, _ = self._make_token(session_start=1000000000, iat=1000000000)
+        request = self._make_request(token)
+        patches = self._patch_stack()
+        with patch("mcpgateway.routers.auth.settings") as mock_settings, patches["create_token"] as mock_create, patches["csrf"], patches["set_csrf"], patches["set_auth"], patches["audit"]:
+            mock_settings.session_max_lifetime = 0  # disable the cap for this test
+            mock_settings.csrf_secret_key = SecretStr(self.SECRET)
+            mock_settings.csrf_token_expiry = 3600
+            await refresh_session(request, mock_user)
+
+        assert mock_create.call_args.kwargs["extra_claims"]["session_start"] == 1000000000
+
+    @pytest.mark.asyncio
+    async def test_refresh_refuses_api_token(self, mock_user):
+        """API tokens (token_use=api) are refused with 403."""
+        # First-Party
+        from mcpgateway.routers.auth import refresh_session
+
+        token, _ = self._make_token(token_use="api")
+        request = self._make_request(token)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await refresh_session(request, mock_user)
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_refresh_refuses_token_without_token_use(self, mock_user):
+        """Legacy tokens without token_use are refused with 403 (fail-closed)."""
+        # First-Party
+        from mcpgateway.routers.auth import refresh_session
+
+        token, _ = self._make_token(token_use=None)
+        request = self._make_request(token)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await refresh_session(request, mock_user)
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_refresh_refuses_when_no_token_present(self, mock_user):
+        """Non-JWT auth (basic/proxy) has no session token to refresh: 401."""
+        # First-Party
+        from mcpgateway.routers.auth import refresh_session
+
+        request = MagicMock()
+        request.headers = {"user-agent": "test-agent"}
+        request.cookies = {}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await refresh_session(request, mock_user)
+
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_refresh_enforces_max_lifetime(self, mock_user):
+        """A session older than SESSION_MAX_LIFETIME cannot be refreshed: 401."""
+        # First-Party
+        from mcpgateway.routers.auth import refresh_session
+
+        token, _ = self._make_token(session_start=1000000000)  # ancient session
+        request = self._make_request(token)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await refresh_session(request, mock_user)
+
+        assert exc_info.value.status_code == 401
+        assert "maximum lifetime" in exc_info.value.detail
+
+    # ------------------------------------------------------------------
+    # GET /auth/validate
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_validate_local_session(self, mock_user):
+        """A local session reports valid=True with accurate expiry and source."""
+        # First-Party
+        from mcpgateway.routers.auth import validate_session
+
+        token, payload = self._make_token()
+        request = self._make_request(token)
+
+        result = await validate_session(request, mock_user)
+
+        assert result.valid is True
+        assert result.session_source == "local"
+        assert result.expires_in is not None and 0 < result.expires_in <= 1200
+        assert result.expires_at is not None
+        assert result.user.email == "test@example.com"
+        for key in ("token_expiry", "idle_timeout", "max_lifetime", "warning_time", "refresh_buffer", "activity_tracking"):
+            assert key in result.config
+
+    @pytest.mark.asyncio
+    async def test_validate_sso_session(self, mock_user):
+        """An SSO-provisioned session reports session_source=sso."""
+        # First-Party
+        from mcpgateway.routers.auth import validate_session
+
+        token, _ = self._make_token(auth_provider="github")
+        request = self._make_request(token)
+
+        result = await validate_session(request, mock_user)
+
+        assert result.session_source == "sso"
+
+    @pytest.mark.asyncio
+    async def test_validate_api_token_session(self, mock_user):
+        """An API-token session reports session_source=api_token."""
+        # First-Party
+        from mcpgateway.routers.auth import validate_session
+
+        token, _ = self._make_token(token_use="api")
+        request = self._make_request(token)
+
+        result = await validate_session(request, mock_user)
+
+        assert result.session_source == "api_token"
+
+    def test_session_source_external_idp(self):
+        """Tokens minted for external-IdP identities classify as sso."""
+        # First-Party
+        from mcpgateway.routers.auth import _session_source_from_payload
+
+        assert _session_source_from_payload({"token_use": "session", "source": "external_idp"}) == "sso"
+        assert _session_source_from_payload({"token_use": "session", "auth_provider": "local"}) == "local"
+        assert _session_source_from_payload({"token_use": "api"}) == "api_token"
+        assert _session_source_from_payload({}) == "local"

--- a/tests/unit/mcpgateway/routers/test_auth.py
+++ b/tests/unit/mcpgateway/routers/test_auth.py
@@ -783,3 +783,203 @@ class TestSessionRefreshAndValidate:
         assert _session_source_from_payload({"token_use": "session", "auth_provider": "local"}) == "local"
         assert _session_source_from_payload({"token_use": "api"}) == "api_token"
         assert _session_source_from_payload({}) == "local"
+
+
+class TestGetSessionUser:
+    """Tests for the get_session_user dependency."""
+
+    def _request(self, cookies=None):
+        """Create a mock request with the given cookies."""
+        request = MagicMock()
+        request.cookies = cookies or {}
+        return request
+
+    @pytest.mark.asyncio
+    async def test_bearer_header_delegates_to_get_current_user(self):
+        """A bearer header authenticates through get_current_user."""
+        # Third-Party
+        from fastapi.security import HTTPAuthorizationCredentials
+
+        # First-Party
+        from mcpgateway.routers.auth import get_session_user
+
+        creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="tok")  # pragma: allowlist secret
+        with patch("mcpgateway.routers.auth.get_current_user", new_callable=AsyncMock, return_value="user") as mock_gcu:
+            result = await get_session_user(self._request(), creds)
+
+        assert result == "user"
+        mock_gcu.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cookie_fallback_uses_validate_token_user(self):
+        """Without a bearer header, the jwt_token cookie authenticates via validate_token_user."""
+        # First-Party
+        from mcpgateway.routers.auth import get_session_user
+
+        with patch("mcpgateway.routers.auth.validate_token_user", new_callable=AsyncMock, return_value="user") as mock_vtu:
+            result = await get_session_user(self._request({"jwt_token": "cookie-tok"}), None)
+
+        assert result == "user"
+        assert mock_vtu.call_args.args[1] == "cookie-tok"
+
+    @pytest.mark.asyncio
+    async def test_no_credentials_rejected(self):
+        """Neither header nor cookie: 401."""
+        # First-Party
+        from mcpgateway.routers.auth import get_session_user
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_session_user(self._request(), None)
+
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_invalid_cookie_rejected(self):
+        """An invalid session cookie is rejected with the validator's status."""
+        # First-Party
+        from mcpgateway.auth import TokenValidationError
+        from mcpgateway.routers.auth import get_session_user
+
+        with patch("mcpgateway.routers.auth.validate_token_user", new_callable=AsyncMock, side_effect=TokenValidationError("bad", status_code=401)):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_session_user(self._request({"jwt_token": "bad-tok"}), None)
+
+        assert exc_info.value.status_code == 401
+
+
+class TestCookieOnlySessionSmoke:
+    """Cookie-only requests reach the session endpoints through the full route path."""
+
+    SECRET = "test-secret-key"  # pragma: allowlist secret
+
+    def _payload(self):
+        """Session JWT payload whose subject matches the smoke user."""
+        # Standard
+        import time as time_mod
+
+        now = int(time_mod.time())
+        return {
+            "sub": "smoke@example.com",
+            "email": "smoke@example.com",
+            "jti": "smoke-jti",
+            "iat": now,
+            "exp": now + 1200,
+            "token_use": "session",
+            "auth_provider": "local",
+        }
+
+    def _user(self):
+        """Mock user satisfying EmailUserResponse.from_email_user."""
+        # Standard
+        from datetime import datetime as dt
+        from datetime import timezone as tz
+
+        user = MagicMock()
+        user.id = "smoke-user-id"
+        user.email = "smoke@example.com"
+        user.full_name = "Smoke User"
+        user.is_admin = False
+        user.is_active = True
+        user.auth_provider = "local"
+        user.created_at = dt.now(tz.utc)
+        user.last_login = None
+        user.password_change_required = False
+        user.failed_login_attempts = 0
+        user.locked_until = None
+        user.is_account_locked.return_value = False
+        user.is_email_verified.return_value = True
+        return user
+
+    def _smoke_patches(self, stack, payload):
+        """Enter the boundary patches shared by the smoke tests (no real DB in unit runs)."""
+        user = self._user()
+        stack.enter_context(patch("mcpgateway.routers.auth.validate_token_user", new_callable=AsyncMock, return_value=user))
+        stack.enter_context(patch("mcpgateway.utils.verify_credentials.verify_jwt_token", new_callable=AsyncMock, return_value=payload))
+        blocklist = MagicMock()
+        blocklist.is_token_revoked.return_value = False
+        blocklist.get_last_activity.return_value = None
+        stack.enter_context(patch("mcpgateway.routers.auth.get_token_blocklist_service", return_value=blocklist))
+        stack.enter_context(patch("mcpgateway.services.token_blocklist_service.get_token_blocklist_service", return_value=blocklist))
+        stack.enter_context(patch("mcpgateway.routers.auth.get_audit_trail_service"))
+        # Middleware-level auth helpers that would otherwise hit the (absent) unit-test DB
+        stack.enter_context(patch("mcpgateway.auth._check_token_revoked_sync", return_value=False))
+        stack.enter_context(patch("mcpgateway.auth._get_user_by_email_sync", return_value=user))
+        stack.enter_context(patch("mcpgateway.auth._is_api_token_jti_sync", return_value=False))
+        stack.enter_context(patch("mcpgateway.auth.resolve_session_teams", new_callable=AsyncMock, return_value=[]))
+        stack.enter_context(patch("mcpgateway.middleware.token_scoping.resolve_session_teams", new_callable=AsyncMock, return_value=[]))
+
+    def test_validate_with_cookie_only(self):
+        """GET /auth/validate succeeds with only the jwt_token cookie (no auth header)."""
+        # Third-Party
+        from fastapi.testclient import TestClient
+        import jwt as jwt_lib
+
+        # First-Party
+        from mcpgateway.main import app
+
+        payload = self._payload()
+        token = jwt_lib.encode(payload, self.SECRET, algorithm="HS256")
+
+        with ExitStack() as stack:
+            self._smoke_patches(stack, payload)
+            client = TestClient(app)
+            client.cookies.set("jwt_token", token)
+            response = client.get("/auth/validate")
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["valid"] is True
+        assert body["session_source"] == "local"
+        assert body["user"]["email"] == "smoke@example.com"
+
+    def test_refresh_with_cookie_only_and_csrf(self):
+        """POST /auth/refresh succeeds cookie-only (with same-origin CSRF token) and re-sets the auth cookie."""
+        # Standard
+        from urllib.parse import urlparse
+
+        # Third-Party
+        from fastapi.testclient import TestClient
+        import jwt as jwt_lib
+
+        # First-Party
+        from mcpgateway.config import settings
+        from mcpgateway.main import app
+        from mcpgateway.services.csrf_service import get_csrf_service
+
+        payload = self._payload()
+        token = jwt_lib.encode(payload, self.SECRET, algorithm="HS256")
+        csrf_token = get_csrf_service().generate_csrf_token(user_id="smoke@example.com", session_id="smoke-jti")
+        parsed_app = urlparse(str(settings.app_domain))
+        app_origin = f"{parsed_app.scheme}://{parsed_app.netloc}"
+
+        with ExitStack() as stack:
+            self._smoke_patches(stack, payload)
+            client = TestClient(app)
+            client.cookies.set("jwt_token", token)
+            client.cookies.set("mcpgateway_csrf_token", csrf_token)
+            response = client.post("/auth/refresh", headers={"X-CSRF-Token": csrf_token, "Origin": app_origin})
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["access_token"]
+        assert "jwt_token" in response.cookies
+
+    def test_refresh_with_cookie_only_without_csrf_rejected(self):
+        """POST /auth/refresh cookie-only without a CSRF token is rejected (path not exempt)."""
+        # Third-Party
+        from fastapi.testclient import TestClient
+        import jwt as jwt_lib
+
+        # First-Party
+        from mcpgateway.main import app
+
+        payload = self._payload()
+        token = jwt_lib.encode(payload, self.SECRET, algorithm="HS256")
+
+        with ExitStack() as stack:
+            self._smoke_patches(stack, payload)
+            client = TestClient(app)
+            client.cookies.set("jwt_token", token)
+            response = client.post("/auth/refresh")
+
+        assert response.status_code == 403

--- a/tests/unit/mcpgateway/routers/test_auth.py
+++ b/tests/unit/mcpgateway/routers/test_auth.py
@@ -7,6 +7,7 @@ Tests for the auth router module.
 """
 
 # Standard
+from contextlib import ExitStack
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -481,10 +482,9 @@ class TestSessionRefreshAndValidate:
             request.cookies = {}
         return request
 
-    def _patch_stack(self, new_token="newtok", expires_in=1200):
-        """Patch collaborators of refresh_session; returns the context managers dict."""
+    def _patch_stack(self, payload, expires_in=1200):
+        """Patch session-endpoint collaborators for the given verified payload."""
         # Standard
-        # Real JWT for the newly issued token so its exp can be decoded
         import time as time_mod
 
         # Third-Party
@@ -492,7 +492,11 @@ class TestSessionRefreshAndValidate:
 
         now = int(time_mod.time())
         issued = jwt_lib.encode({"jti": "new-jti", "exp": now + expires_in}, self.SECRET, algorithm="HS256")
+        blocklist = MagicMock()
+        blocklist.is_token_revoked.return_value = False
         return {
+            "verify": patch("mcpgateway.routers.auth.verify_jwt_token_cached", new_callable=AsyncMock, return_value=payload),
+            "blocklist": patch("mcpgateway.routers.auth.get_token_blocklist_service", return_value=blocklist),
             "create_token": patch("mcpgateway.routers.auth.create_access_token", new_callable=AsyncMock, return_value=(issued, expires_in)),
             "csrf": patch("mcpgateway.routers.auth.generate_csrf_token", return_value="csrf-rotated"),
             "set_csrf": patch("mcpgateway.routers.auth.set_csrf_cookie"),
@@ -513,10 +517,10 @@ class TestSessionRefreshAndValidate:
         # First-Party
         from mcpgateway.routers.auth import refresh_session
 
-        token, _ = self._make_token()
+        token, payload = self._make_token()
         request = self._make_request(token)
-        patches = self._patch_stack()
-        with patches["create_token"] as mock_create, patches["csrf"], patches["set_csrf"], patches["set_auth"] as mock_set_auth, patches["audit"] as mock_audit:
+        with ExitStack() as stack:
+            mocks = {name: stack.enter_context(p) for name, p in self._patch_stack(payload).items()}
             response = await refresh_session(request, mock_user)
 
         body = json.loads(response.body)
@@ -525,14 +529,13 @@ class TestSessionRefreshAndValidate:
         assert body["expires_at"]
         assert body["csrf_token"] == "csrf-rotated"
         # Header-authenticated request must NOT receive an auth cookie
-        mock_set_auth.assert_not_called()
-        mock_audit.return_value.log_action.assert_called_once()
-        audit_kwargs = mock_audit.return_value.log_action.call_args.kwargs
+        mocks["set_auth"].assert_not_called()
+        mocks["audit"].return_value.log_action.assert_called_once()
+        audit_kwargs = mocks["audit"].return_value.log_action.call_args.kwargs
         assert audit_kwargs["action"] == "session_refresh"
         assert "db" not in audit_kwargs
         # session_start carried into the new token
-        create_kwargs = mock_create.call_args.kwargs
-        assert "session_start" in create_kwargs["extra_claims"]
+        assert "session_start" in mocks["create_token"].call_args.kwargs["extra_claims"]
 
     @pytest.mark.asyncio
     async def test_refresh_success_cookie_sets_auth_cookie(self, mock_user):
@@ -540,13 +543,13 @@ class TestSessionRefreshAndValidate:
         # First-Party
         from mcpgateway.routers.auth import refresh_session
 
-        token, _ = self._make_token()
+        token, payload = self._make_token()
         request = self._make_request(token, via_cookie=True)
-        patches = self._patch_stack()
-        with patches["create_token"], patches["csrf"], patches["set_csrf"], patches["set_auth"] as mock_set_auth, patches["audit"]:
+        with ExitStack() as stack:
+            mocks = {name: stack.enter_context(p) for name, p in self._patch_stack(payload).items()}
             await refresh_session(request, mock_user)
 
-        mock_set_auth.assert_called_once()
+        mocks["set_auth"].assert_called_once()
 
     @pytest.mark.asyncio
     async def test_refresh_preserves_session_start_claim(self, mock_user):
@@ -554,16 +557,17 @@ class TestSessionRefreshAndValidate:
         # First-Party
         from mcpgateway.routers.auth import refresh_session
 
-        token, _ = self._make_token(session_start=1000000000, iat=1000000000)
+        token, payload = self._make_token(session_start=1000000000, iat=1000000000)
         request = self._make_request(token)
-        patches = self._patch_stack()
-        with patch("mcpgateway.routers.auth.settings") as mock_settings, patches["create_token"] as mock_create, patches["csrf"], patches["set_csrf"], patches["set_auth"], patches["audit"]:
+        with ExitStack() as stack:
+            mock_settings = stack.enter_context(patch("mcpgateway.routers.auth.settings"))
             mock_settings.session_max_lifetime = 0  # disable the cap for this test
             mock_settings.csrf_secret_key = SecretStr(self.SECRET)
             mock_settings.csrf_token_expiry = 3600
+            mocks = {name: stack.enter_context(p) for name, p in self._patch_stack(payload).items()}
             await refresh_session(request, mock_user)
 
-        assert mock_create.call_args.kwargs["extra_claims"]["session_start"] == 1000000000
+        assert mocks["create_token"].call_args.kwargs["extra_claims"]["session_start"] == 1000000000
 
     @pytest.mark.asyncio
     async def test_refresh_refuses_api_token(self, mock_user):
@@ -571,11 +575,14 @@ class TestSessionRefreshAndValidate:
         # First-Party
         from mcpgateway.routers.auth import refresh_session
 
-        token, _ = self._make_token(token_use="api")
+        token, payload = self._make_token(token_use="api")
         request = self._make_request(token)
 
-        with pytest.raises(HTTPException) as exc_info:
-            await refresh_session(request, mock_user)
+        with ExitStack() as stack:
+            for name in ("verify", "blocklist"):
+                stack.enter_context(self._patch_stack(payload)[name])
+            with pytest.raises(HTTPException) as exc_info:
+                await refresh_session(request, mock_user)
 
         assert exc_info.value.status_code == 403
 
@@ -585,11 +592,14 @@ class TestSessionRefreshAndValidate:
         # First-Party
         from mcpgateway.routers.auth import refresh_session
 
-        token, _ = self._make_token(token_use=None)
+        token, payload = self._make_token(token_use=None)
         request = self._make_request(token)
 
-        with pytest.raises(HTTPException) as exc_info:
-            await refresh_session(request, mock_user)
+        with ExitStack() as stack:
+            for name in ("verify", "blocklist"):
+                stack.enter_context(self._patch_stack(payload)[name])
+            with pytest.raises(HTTPException) as exc_info:
+                await refresh_session(request, mock_user)
 
         assert exc_info.value.status_code == 403
 
@@ -609,16 +619,69 @@ class TestSessionRefreshAndValidate:
         assert exc_info.value.status_code == 401
 
     @pytest.mark.asyncio
+    async def test_refresh_refuses_forged_token(self, mock_user):
+        """A token that fails signature verification is rejected with 401."""
+        # First-Party
+        from mcpgateway.routers.auth import refresh_session
+
+        token, _ = self._make_token()
+        request = self._make_request(token)
+
+        with patch("mcpgateway.routers.auth.verify_jwt_token_cached", new_callable=AsyncMock, side_effect=Exception("bad signature")):
+            with pytest.raises(HTTPException) as exc_info:
+                await refresh_session(request, mock_user)
+
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_refresh_refuses_revoked_token(self, mock_user):
+        """A revoked (blocklisted) token cannot refresh: 401."""
+        # First-Party
+        from mcpgateway.routers.auth import refresh_session
+
+        token, payload = self._make_token()
+        request = self._make_request(token)
+        patches = self._patch_stack(payload)
+
+        blocklist = MagicMock()
+        blocklist.is_token_revoked.return_value = True
+        with patches["verify"], patch("mcpgateway.routers.auth.get_token_blocklist_service", return_value=blocklist):
+            with pytest.raises(HTTPException) as exc_info:
+                await refresh_session(request, mock_user)
+
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_refresh_refuses_subject_mismatch(self, mock_user):
+        """A verified token whose subject is a different user is rejected with 401."""
+        # First-Party
+        from mcpgateway.routers.auth import refresh_session
+
+        token, payload = self._make_token(sub="another-user-id")
+        request = self._make_request(token)
+
+        with ExitStack() as stack:
+            for name in ("verify", "blocklist"):
+                stack.enter_context(self._patch_stack(payload)[name])
+            with pytest.raises(HTTPException) as exc_info:
+                await refresh_session(request, mock_user)
+
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
     async def test_refresh_enforces_max_lifetime(self, mock_user):
         """A session older than SESSION_MAX_LIFETIME cannot be refreshed: 401."""
         # First-Party
         from mcpgateway.routers.auth import refresh_session
 
-        token, _ = self._make_token(session_start=1000000000)  # ancient session
+        token, payload = self._make_token(session_start=1000000000)  # ancient session
         request = self._make_request(token)
 
-        with pytest.raises(HTTPException) as exc_info:
-            await refresh_session(request, mock_user)
+        with ExitStack() as stack:
+            for name in ("verify", "blocklist"):
+                stack.enter_context(self._patch_stack(payload)[name])
+            with pytest.raises(HTTPException) as exc_info:
+                await refresh_session(request, mock_user)
 
         assert exc_info.value.status_code == 401
         assert "maximum lifetime" in exc_info.value.detail
@@ -636,7 +699,10 @@ class TestSessionRefreshAndValidate:
         token, payload = self._make_token()
         request = self._make_request(token)
 
-        result = await validate_session(request, mock_user)
+        with ExitStack() as stack:
+            for name in ("verify", "blocklist"):
+                stack.enter_context(self._patch_stack(payload)[name])
+            result = await validate_session(request, mock_user)
 
         assert result.valid is True
         assert result.session_source == "local"
@@ -652,10 +718,13 @@ class TestSessionRefreshAndValidate:
         # First-Party
         from mcpgateway.routers.auth import validate_session
 
-        token, _ = self._make_token(auth_provider="github")
+        token, payload = self._make_token(auth_provider="github")
         request = self._make_request(token)
 
-        result = await validate_session(request, mock_user)
+        with ExitStack() as stack:
+            for name in ("verify", "blocklist"):
+                stack.enter_context(self._patch_stack(payload)[name])
+            result = await validate_session(request, mock_user)
 
         assert result.session_source == "sso"
 
@@ -665,12 +734,45 @@ class TestSessionRefreshAndValidate:
         # First-Party
         from mcpgateway.routers.auth import validate_session
 
-        token, _ = self._make_token(token_use="api")
+        token, payload = self._make_token(token_use="api")
         request = self._make_request(token)
 
-        result = await validate_session(request, mock_user)
+        with ExitStack() as stack:
+            for name in ("verify", "blocklist"):
+                stack.enter_context(self._patch_stack(payload)[name])
+            result = await validate_session(request, mock_user)
 
         assert result.session_source == "api_token"
+
+    @pytest.mark.asyncio
+    async def test_validate_refuses_forged_token(self, mock_user):
+        """A token that fails signature verification is rejected with 401."""
+        # First-Party
+        from mcpgateway.routers.auth import validate_session
+
+        token, _ = self._make_token()
+        request = self._make_request(token)
+
+        with patch("mcpgateway.routers.auth.verify_jwt_token_cached", new_callable=AsyncMock, side_effect=Exception("bad signature")):
+            with pytest.raises(HTTPException) as exc_info:
+                await validate_session(request, mock_user)
+
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_validate_refuses_when_no_token_present(self, mock_user):
+        """Non-JWT auth has no session token to validate: 401."""
+        # First-Party
+        from mcpgateway.routers.auth import validate_session
+
+        request = MagicMock()
+        request.headers = {"user-agent": "test-agent"}
+        request.cookies = {}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await validate_session(request, mock_user)
+
+        assert exc_info.value.status_code == 401
 
     def test_session_source_external_idp(self):
         """Tokens minted for external-IdP identities classify as sso."""

--- a/tests/unit/mcpgateway/test_auth_logout.py
+++ b/tests/unit/mcpgateway/test_auth_logout.py
@@ -71,7 +71,7 @@ class TestLogoutEndpoint:
         app.dependency_overrides[get_db] = lambda: mock_db
 
         try:
-            with patch("mcpgateway.services.token_blocklist_service.get_token_blocklist_service") as mock_service:
+            with patch("mcpgateway.routers.auth.get_token_blocklist_service") as mock_service:
                 mock_blocklist = MagicMock()
                 mock_blocklist.revoke_token.return_value = True
                 mock_service.return_value = mock_blocklist
@@ -181,7 +181,7 @@ class TestLogoutEndpoint:
         app.dependency_overrides[get_db] = lambda: mock_db
 
         try:
-            with patch("mcpgateway.services.token_blocklist_service.get_token_blocklist_service") as mock_service:
+            with patch("mcpgateway.routers.auth.get_token_blocklist_service") as mock_service:
                 mock_blocklist = MagicMock()
                 mock_blocklist.revoke_token.return_value = False
                 mock_service.return_value = mock_blocklist
@@ -200,7 +200,7 @@ class TestLogoutEndpoint:
         app.dependency_overrides[get_db] = lambda: mock_db
 
         try:
-            with patch("mcpgateway.services.token_blocklist_service.get_token_blocklist_service") as mock_service:
+            with patch("mcpgateway.routers.auth.get_token_blocklist_service") as mock_service:
                 mock_service.side_effect = Exception("Database error")
 
                 client = TestClient(app)
@@ -229,7 +229,7 @@ class TestLogoutEndpoint:
                 mock_settings.jwt_secret_key = SecretStr(real_settings.jwt_secret_key.get_secret_value() if hasattr(real_settings.jwt_secret_key, "get_secret_value") else real_settings.jwt_secret_key)
                 mock_settings.jwt_algorithm = real_settings.jwt_algorithm
 
-                with patch("mcpgateway.services.token_blocklist_service.get_token_blocklist_service") as mock_service:
+                with patch("mcpgateway.routers.auth.get_token_blocklist_service") as mock_service:
                     mock_blocklist = MagicMock()
                     mock_blocklist.revoke_token.return_value = True
                     mock_service.return_value = mock_blocklist

--- a/tests/unit/mcpgateway/test_token_blocklist_service.py
+++ b/tests/unit/mcpgateway/test_token_blocklist_service.py
@@ -98,6 +98,19 @@ class TestTokenRevocation:
 
         assert result is True
 
+    def test_revoke_token_fail_if_already_revoked(self, blocklist_service, test_db):
+        """Single-use semantics: an already-revoked jti returns False with fail_if_already_revoked."""
+        jti = str(uuid.uuid4())
+
+        # First revocation wins
+        assert blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="token_refresh", fail_if_already_revoked=True) is True
+
+        # Second attempt loses the compare-and-set
+        assert blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="token_refresh", fail_if_already_revoked=True) is False
+
+        # Default behavior stays idempotent
+        assert blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout") is True
+
     def test_revoke_token_duplicate_without_db_session(self, test_db):
         """Test revoking an already revoked token without db session."""
         # Create service without db to test fresh_db_session path


### PR DESCRIPTION
## 🔗 Related Issue

Closes #6011

---

## 📝 Summary

Adds session-lifecycle endpoints so UI clients can implement silent refresh and idle detection now that `TOKEN_EXPIRY` defaults to 20 minutes:

- **`POST /auth/refresh`** — issues a new session JWT for a valid session. Preserves the old token's scope narrowing, rotates the CSRF token (CSRF tokens are HMAC-bound to the JWT `jti`, which changes on refresh), and re-sets the `jwt_token` cookie when the request authenticated via cookie. Refuses API tokens and any token without `token_use="session"` with 403 (fail-closed) — long-lived API tokens have their own expiry/revocation lifecycle. Refresh events are audit-logged via `AuditTrailService`.
- **`GET /auth/validate`** — reports `valid`, `expires_at` / `expires_in`, the user profile, `session_source` (`local | sso | api_token`, derived from the `token_use` / `auth_provider` / `source` claims), and a `config` block of session-lifecycle values (normalized to seconds) so clients don't hardcode them.

Both endpoints live in `mcpgateway/routers/auth.py` and are exposed at `/v1/auth/*` (canonical) plus the unversioned legacy shim, same as the sibling `/auth/login` / `/auth/logout`. The issue's `/api/auth/*` paths don't exist in the codebase; the implemented paths match the actual v1/legacy mounts and the pre-existing manual test case (AUTH-004) and CSRF config references.

**Supporting changes:**

- `SESSION_MAX_LIFETIME` (default 480 min, `0` disables): absolute session-age cap enforced at refresh via a `session_start` claim carried across refreshes — silent refresh cannot extend a session forever. No `SESSION_IDLE_TIMEOUT` was added: server-side idle enforcement already exists as `TOKEN_IDLE_TIMEOUT` (revocation-backed, in `mcpgateway/auth.py`); `/auth/validate` surfaces it to clients instead of duplicating the knob.
- `SESSION_WARNING_TIME`, `SESSION_REFRESH_BUFFER`, `SESSION_ACTIVITY_TRACKING`: client-behavior hints surfaced via `/auth/validate`.
- **Rate limiting** via a new `SESSION_REFRESH` tier in `RateLimitMiddleware` (pattern covers both `/auth/refresh` and `/v1/auth/refresh`), configured by `SESSION_REFRESH_RATE_LIMIT` (default 10/min). Reuses the existing Redis-backed, multi-dimensional (IP / user / team) infrastructure rather than adding a bespoke limiter.
- **`/auth/refresh` removed from default `CSRF_EXEMPT_PATHS`**: the entry predated the endpoint; a cookie-authenticated, CSRF-exempt refresh would let a cross-site request silently keep a victim's session alive. Bearer requests skip CSRF by design, so API clients are unaffected.
- `create_access_token()` accepts an optional `extra_claims` dict (reserved claims cannot be overridden) for the `session_start` carry-over.
- Refresh is **single-use rotation**: the predecessor token is revoked (blocklisted with `reason=token_refresh` and its original expiry) before the new token is minted, with compare-and-set semantics so concurrent refreshes cannot both succeed; refresh fails closed (401) if the revocation cannot be persisted.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Feature / Enhancement

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint (changed files)      | `ruff check`, `isort --check-only`, `pylint` (9.96), `bandit` (0 issues), `interrogate` (100%) | ✅ |
| Unit tests (affected)     | `pytest tests/unit/mcpgateway/routers/ tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py tests/unit/mcpgateway/middleware/test_csrf_middleware.py tests/unit/mcpgateway/test_config.py` — 1586 passed, 5 skipped (pre-existing) | ✅ |
| mypy (changed files)      | `mypy mcpgateway/routers/auth.py` — 4 errors, identical to pre-change baseline (pre-existing debt, none introduced) | ✅ |
| Full `make lint` / `make test` / `make coverage` | pending CI | ⏳ |

New test coverage (13 tests in `test_auth.py`, 1 in `test_rate_limit_middleware.py`), including the deny paths: API-token refresh refused (403), missing-`token_use` token refused (403), no session token (401), max-lifetime exceeded (401), `session_start` carried over on refresh, SSO / external-IdP / api_token `session_source` classification, cookie-vs-bearer cookie behavior, and `SESSION_REFRESH` tier matching on both mounts.

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

- **Design decisions not specified by the issue:** SSO-established sessions may refresh locally in this phase (the delegated SSO refresh flow is a later phase of #5804); unauthenticated `/auth/validate` returns 401 (consistent with the auth dependency) rather than `{valid: false}`; enforced durations follow the repo's minutes convention (`TOKEN_EXPIRY`-style) while client hints are in seconds — `/auth/validate` normalizes everything to seconds.
- `tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py` includes isort normalization of pre-existing import-heading debt (comment-only hunks) — the file was non-compliant before this change; touching it triggered the standard formatter cleanup.
- Deployments that set `CSRF_EXEMPT_PATHS` explicitly in `.env` should drop `/auth/refresh` from their list to pick up the secure default.

