### PR TITLE
Add 2 new paths as versioned API aliases

### DIFF
--- a/mcpgateway/api/v1/__init__.py
+++ b/mcpgateway/api/v1/__init__.py
@@ -371,8 +371,6 @@ def build_v1_router(
     )
 
     # Product-language aliases for the existing gateway and virtual-server APIs.
-    # These are v1-only additions; the unversioned compatibility routes retain
-    # their established /gateways and /servers paths.
     v1_router.include_router(gateway_router, prefix="/mcp-servers")
     v1_router.include_router(server_router, prefix="/virtual-servers")
 

--- a/mcpgateway/api/v1/__init__.py
+++ b/mcpgateway/api/v1/__init__.py
@@ -68,9 +68,9 @@ def _assemble_routers(  # noqa: C901 — deliberate single-function assembly, co
         tool_router: Inline tools router from main.py.
         resource_router: Inline resources router from main.py.
         prompt_router: Inline prompts router from main.py.
-        gateway_router: Inline gateways router from main.py.
+        gateway_router: Prefix-free inline gateways router from main.py.
         root_router: Inline roots router from main.py.
-        server_router: Inline servers router from main.py.
+        server_router: Prefix-free inline servers router from main.py.
         metrics_router: Inline metrics router from main.py.
         tag_router: Inline tags router from main.py.
         export_import_router: Inline export/import router from main.py.
@@ -84,9 +84,9 @@ def _assemble_routers(  # noqa: C901 — deliberate single-function assembly, co
     target_router.include_router(tool_router)
     target_router.include_router(resource_router)
     target_router.include_router(prompt_router)
-    target_router.include_router(gateway_router)
+    target_router.include_router(gateway_router, prefix="/gateways")
     target_router.include_router(root_router)
-    target_router.include_router(server_router)
+    target_router.include_router(server_router, prefix="/servers")
     target_router.include_router(metrics_router)
     target_router.include_router(tag_router)
     target_router.include_router(export_import_router)
@@ -369,6 +369,12 @@ def build_v1_router(
         export_import_router=export_import_router,
         a2a_router=a2a_router,
     )
+
+    # Product-language aliases for the existing gateway and virtual-server APIs.
+    # These are v1-only additions; the unversioned compatibility routes retain
+    # their established /gateways and /servers paths.
+    v1_router.include_router(gateway_router, prefix="/mcp-servers")
+    v1_router.include_router(server_router, prefix="/virtual-servers")
 
     # First-Party
     from mcpgateway.routers.catalog import router as catalog_router  # pylint: disable=import-outside-toplevel

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3069,6 +3069,9 @@ class AdminAuthMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
+_SERVER_MCP_PATH_RE = re.compile(r"/servers/([^/]+)/mcp/?")
+
+
 class MCPPathRewriteMiddleware:
     """
     Middleware that rewrites paths ending with '/mcp' to '/mcp/', after performing authentication.
@@ -3242,7 +3245,7 @@ class MCPPathRewriteMiddleware:
                     # Validate that a non-empty server_id segment is present.
                     # Without this check, paths like /servers//mcp (empty ID)
                     # would be rewritten and silently fall through (#3891).
-                    _srv_match = re.fullmatch(r"/servers/([^/]+)/mcp/?", internal_app_path)
+                    _srv_match = _SERVER_MCP_PATH_RE.fullmatch(internal_app_path)
                 else:
                     # Not a recognised server-scoped path — do not rewrite.
                     await self.application(scope, receive, send)

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3212,21 +3212,10 @@ class MCPPathRewriteMiddleware:
         app_path = _normalize_scope_path(original_path, root_path)
         internal_app_path = replace_api_path_alias(app_path)
 
-        # streamable_http_auth() only extracts the server ID from "/servers/{id}/mcp";
-        # present the alias in that shape here, then restore it.
-        auth_path = original_path
-        internal_mcp_match = re.fullmatch(r"/servers/([^/]+)/mcp/?", internal_app_path)
-        if internal_app_path != app_path and internal_mcp_match:
-            auth_path = internal_app_path
-
-        if auth_path != original_path:
-            scope["path"] = auth_path
-            try:
-                auth_ok = await streamable_http_auth(scope, receive, send)
-            finally:
-                scope["path"] = original_path
-        else:
-            auth_ok = await streamable_http_auth(scope, receive, send)
+        # Authenticate against the app-relative internal path without changing
+        # the shared ASGI scope. The original scope remains available for
+        # headers, root_path, and response URL construction.
+        auth_ok = await streamable_http_auth(scope, receive, send, request_path=internal_app_path)
         if not auth_ok:
             return
 

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -4610,7 +4610,12 @@ async def sse_endpoint(request: Request, server_id: str, db: Session = Depends(g
 
 @server_router.post("/{server_id}/message")
 @require_permission("servers.use")
-async def message_endpoint(request: Request, server_id: str = Depends(require_valid_server), user=Depends(get_current_user_with_permissions)):
+async def message_endpoint(
+    request: Request,
+    server_id: str,
+    user=Depends(get_current_user_with_permissions),
+    _server_exists: str = Depends(require_valid_server),
+):
     """
     Handles incoming messages for a specific server.
 

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3074,7 +3074,8 @@ class MCPPathRewriteMiddleware:
     Middleware that rewrites paths ending with '/mcp' to '/mcp/', after performing authentication.
 
     - Rewrites exact '/mcp' to '/mcp/' so Starlette's mount does not emit a 307 redirect.
-    - Rewrites paths like '/servers/<server_id>/mcp' to '/mcp/'.
+    - Rewrites '/servers/<server_id>/mcp' and
+      '/v1/virtual-servers/<server_id>/mcp' to '/mcp/'.
     - Keeps ASGI ``raw_path`` aligned with rewritten paths when present.
     - Only exact '/mcp' and server-scoped MCP transport paths are rewritten.
     - Authentication is performed before any path rewriting.
@@ -3212,7 +3213,7 @@ class MCPPathRewriteMiddleware:
         # Strip root_path prefix before pattern matching.
         # In reverse proxy deployments, scope["path"] may contain the full path
         # including the proxy prefix (e.g., "/dev/mcp-gateway/service/gateway/servers/123/mcp").
-        # We need to strip this prefix to correctly match the /servers/ pattern.
+        # We need to strip this prefix to correctly match server-scoped patterns.
         root_path = (scope.get("root_path") or settings.app_root_path or "").rstrip("/")
         app_path = _normalize_scope_path(original_path, root_path)
 
@@ -3228,7 +3229,9 @@ class MCPPathRewriteMiddleware:
                 await self.application(scope, receive, send)
                 return
             if app_path.endswith("/mcp") or (app_path.endswith("/mcp/") and app_path != "/mcp/"):
-                # SECURITY: Only rewrite recognised MCP paths — /servers/{id}/mcp.
+                # SECURITY: Only rewrite recognised MCP paths — /servers/{id}/mcp
+                # and its versioned product-language alias
+                # /v1/virtual-servers/{id}/mcp.
                 # Arbitrary prefixes (e.g. /foo/mcp) must NOT be rewritten to
                 # /mcp/ as that would expose the global MCP transport under
                 # undocumented aliases, broadening the externally reachable
@@ -3237,15 +3240,26 @@ class MCPPathRewriteMiddleware:
                     # Validate that a non-empty server_id segment is present.
                     # Without this check, paths like /servers//mcp (empty ID)
                     # would be rewritten and silently fall through (#3891).
-                    _srv_match = re.match(r"/servers/([^/]+)/mcp", app_path)
-                    if not _srv_match:
-                        response = ORJSONResponse({"detail": "Invalid server identifier"}, status_code=404)
-                        await response(scope, receive, send)
-                        return
+                    _srv_match = re.fullmatch(r"/servers/([^/]+)/mcp/?", app_path)
+                elif app_path.startswith("/v1/virtual-servers/"):
+                    _srv_match = re.fullmatch(r"/v1/virtual-servers/([^/]+)/mcp/?", app_path)
                 else:
-                    # Not a /servers/ path — do not rewrite, pass through
+                    # Not a recognised server-scoped path — do not rewrite.
                     await self.application(scope, receive, send)
                     return
+
+                if not _srv_match:
+                    response = ORJSONResponse({"detail": "Invalid server identifier"}, status_code=404)
+                    await response(scope, receive, send)
+                    return
+
+                if app_path.startswith("/v1/virtual-servers/"):
+                    # Downstream Python and Rust MCP transports extract the
+                    # server ID from the canonical /servers/{id}/mcp shape.
+                    # Preserve that scoped identity while rewriting the public
+                    # alias to the shared /mcp/ mount.
+                    trailing_slash = "/" if app_path.endswith("/") else ""
+                    scope["modified_path"] = f"/servers/{_srv_match.group(1)}/mcp{trailing_slash}"
                 # Rewrite to /mcp/ and continue through middleware (lets CORSMiddleware handle preflight)
                 # Preserve root_path prefix when rewriting
                 self._apply_mcp_rewrite(scope, root_path)
@@ -3558,10 +3572,10 @@ protocol_router = APIRouter(prefix="/protocol", tags=["Protocol"])
 tool_router = APIRouter(prefix="/tools", tags=["Tools"])
 resource_router = APIRouter(prefix="/resources", tags=["Resources"])
 prompt_router = APIRouter(prefix="/prompts", tags=["Prompts"])
-gateway_router = APIRouter(prefix="/gateways", tags=["Gateways"])
+gateway_router = APIRouter(tags=["Gateways"])
 root_router = APIRouter(prefix="/roots", tags=["Roots"])
 utility_router = APIRouter(tags=["Utilities"])
-server_router = APIRouter(prefix="/servers", tags=["Servers"])
+server_router = APIRouter(tags=["Servers"])
 metrics_router = APIRouter(prefix="/metrics", tags=["Metrics"])
 tag_router = APIRouter(prefix="/tags", tags=["Tags"])
 export_import_router = APIRouter(tags=["Export/Import"])
@@ -12875,8 +12889,9 @@ app.include_router(utility_router)
 # RFC well-known endpoints (/.well-known/*)
 app.include_router(well_known_router)
 
-# Per-server well-known endpoints (/servers/{id}/.well-known/*)
+# Per-server well-known endpoints and their versioned product-language aliases.
 app.include_router(server_well_known_router, prefix="/servers")
+app.include_router(server_well_known_router, prefix="/v1/virtual-servers")
 
 # OpenAPI schema generation (/v1/tools/generate-schemas-from-openapi)
 # prefix="/v1/tools" is hardcoded in the router — not versioned via v1_router to avoid /v1/v1/tools

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -4627,8 +4627,8 @@ async def sse_endpoint(request: Request, server_id: str, db: Session = Depends(g
 async def message_endpoint(
     request: Request,
     server_id: str,
-    user=Depends(get_current_user_with_permissions),
     _server_exists: str = Depends(require_valid_server),
+    user=Depends(get_current_user_with_permissions),
 ):
     """
     Handles incoming messages for a specific server.

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -223,7 +223,7 @@ from mcpgateway.utils.jq_runner import shutdown_jq_pool, start_jq_pool
 from mcpgateway.utils.metadata_capture import MetadataCapture
 from mcpgateway.utils.orjson_response import ORJSONResponse
 from mcpgateway.utils.passthrough_headers import set_global_passthrough_headers
-from mcpgateway.utils.paths import resolve_root_path
+from mcpgateway.utils.paths import replace_api_path_alias, resolve_root_path
 from mcpgateway.utils.redis_client import close_redis_client, get_redis_client, is_redis_available
 from mcpgateway.utils.redis_isready import wait_for_redis_ready
 from mcpgateway.utils.retry_manager import ResilientHttpClient
@@ -3210,15 +3210,14 @@ class MCPPathRewriteMiddleware:
         # We need to strip this prefix to correctly match server-scoped patterns.
         root_path = (scope.get("root_path") or settings.app_root_path or "").rstrip("/")
         app_path = _normalize_scope_path(original_path, root_path)
+        internal_app_path = replace_api_path_alias(app_path)
 
         # streamable_http_auth() only extracts the server ID from "/servers/{id}/mcp";
         # present the alias in that shape here, then restore it.
         auth_path = original_path
-        if not app_path.startswith("/.well-known/") and app_path.startswith("/v1/virtual-servers/"):
-            _alias_auth_match = re.fullmatch(r"/v1/virtual-servers/([^/]+)/mcp/?", app_path)
-            if _alias_auth_match:
-                trailing_slash = "/" if app_path.endswith("/") else ""
-                auth_path = f"/servers/{_alias_auth_match.group(1)}/mcp{trailing_slash}"
+        internal_mcp_match = re.fullmatch(r"/servers/([^/]+)/mcp/?", internal_app_path)
+        if internal_app_path != app_path and internal_mcp_match:
+            auth_path = internal_app_path
 
         if auth_path != original_path:
             scope["path"] = auth_path
@@ -3250,13 +3249,11 @@ class MCPPathRewriteMiddleware:
                 # /mcp/ as that would expose the global MCP transport under
                 # undocumented aliases, broadening the externally reachable
                 # route surface.
-                if app_path.startswith("/servers/"):
+                if internal_app_path.startswith("/servers/"):
                     # Validate that a non-empty server_id segment is present.
                     # Without this check, paths like /servers//mcp (empty ID)
                     # would be rewritten and silently fall through (#3891).
-                    _srv_match = re.fullmatch(r"/servers/([^/]+)/mcp/?", app_path)
-                elif app_path.startswith("/v1/virtual-servers/"):
-                    _srv_match = re.fullmatch(r"/v1/virtual-servers/([^/]+)/mcp/?", app_path)
+                    _srv_match = re.fullmatch(r"/servers/([^/]+)/mcp/?", internal_app_path)
                 else:
                     # Not a recognised server-scoped path — do not rewrite.
                     await self.application(scope, receive, send)
@@ -3267,13 +3264,12 @@ class MCPPathRewriteMiddleware:
                     await response(scope, receive, send)
                     return
 
-                if app_path.startswith("/v1/virtual-servers/"):
+                if internal_app_path != app_path:
                     # Downstream Python and Rust MCP transports extract the
                     # server ID from the canonical /servers/{id}/mcp shape.
                     # Preserve that scoped identity while rewriting the public
                     # alias to the shared /mcp/ mount.
-                    trailing_slash = "/" if app_path.endswith("/") else ""
-                    scope["modified_path"] = f"/servers/{_srv_match.group(1)}/mcp{trailing_slash}"
+                    scope["modified_path"] = internal_app_path
                 # Rewrite to /mcp/ and continue through middleware (lets CORSMiddleware handle preflight)
                 # Preserve root_path prefix when rewriting
                 self._apply_mcp_rewrite(scope, root_path)

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3202,13 +3202,7 @@ class MCPPathRewriteMiddleware:
             >>> scope["path"]
             '/mcp/'
         """
-        # Auth check first
-        auth_ok = await streamable_http_auth(scope, receive, send)
-        if not auth_ok:
-            return
-
         original_path = scope.get("path", "")
-        scope["modified_path"] = original_path
 
         # Strip root_path prefix before pattern matching.
         # In reverse proxy deployments, scope["path"] may contain the full path
@@ -3216,6 +3210,26 @@ class MCPPathRewriteMiddleware:
         # We need to strip this prefix to correctly match server-scoped patterns.
         root_path = (scope.get("root_path") or settings.app_root_path or "").rstrip("/")
         app_path = _normalize_scope_path(original_path, root_path)
+
+        # streamable_http_auth() only extracts the server ID from "/servers/{id}/mcp";
+        # present the alias in that shape here, then restore it.
+        auth_path = original_path
+        if not app_path.startswith("/.well-known/") and app_path.startswith("/v1/virtual-servers/"):
+            _alias_auth_match = re.fullmatch(r"/v1/virtual-servers/([^/]+)/mcp/?", app_path)
+            if _alias_auth_match:
+                trailing_slash = "/" if app_path.endswith("/") else ""
+                auth_path = f"/servers/{_alias_auth_match.group(1)}/mcp{trailing_slash}"
+
+        if auth_path != original_path:
+            scope["path"] = auth_path
+            try:
+                auth_ok = await streamable_http_auth(scope, receive, send)
+            finally:
+                scope["path"] = original_path
+        else:
+            auth_ok = await streamable_http_auth(scope, receive, send)
+        if not auth_ok:
+            return
 
         # Update modified_path to the app-relative path (without root_path prefix).
         # This ensures streamablehttp_transport can extract server_id via regex (#4266).

--- a/mcpgateway/middleware/client_disconnect.py
+++ b/mcpgateway/middleware/client_disconnect.py
@@ -29,9 +29,28 @@ from contextlib import suppress
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 # First-Party
+from mcpgateway.config import settings
 from mcpgateway.services.logging_service import LoggingService
 
 logger = LoggingService().get_logger(__name__)
+
+
+def _normalize_scope_path(path: str, root_path: str) -> str:
+    """Strip a configured reverse-proxy root path from an ASGI request path.
+
+    Args:
+        path: Request path observed by the outer middleware.
+        root_path: ASGI or application root path prefix.
+
+    Returns:
+        The application-relative path used for endpoint classification.
+    """
+    normalized_root = root_path.rstrip("/")
+    if normalized_root and normalized_root != "/" and path.startswith(normalized_root):
+        remainder = path[len(normalized_root) :]
+        if not remainder or remainder.startswith("/"):
+            return remainder or "/"
+    return path
 
 
 def _is_server_streaming_path(path: str) -> bool:
@@ -91,7 +110,9 @@ class ClientDisconnectMiddleware:
 
         # Skip paths that handle disconnect internally
         path: str = scope.get("path", "")
-        if any(path == prefix or path.startswith(prefix + "/") for prefix in _SELF_MANAGED_PREFIXES) or _is_server_streaming_path(path):
+        root_path: str = scope.get("root_path") or settings.app_root_path or ""
+        application_path = _normalize_scope_path(path, root_path)
+        if any(application_path == prefix or application_path.startswith(prefix + "/") for prefix in _SELF_MANAGED_PREFIXES) or _is_server_streaming_path(application_path):
             await self.app(scope, receive, send)
             return
 

--- a/mcpgateway/middleware/client_disconnect.py
+++ b/mcpgateway/middleware/client_disconnect.py
@@ -37,13 +37,16 @@ logger = LoggingService().get_logger(__name__)
 def _is_server_streaming_path(path: str) -> bool:
     """Return whether path is a server-scoped SSE or MCP streaming endpoint.
 
-    Matches ``/servers/{id}/sse`` and ``/servers/{id}/mcp`` (with or without
-    trailing slash) while NOT matching regular REST endpoints like
-    ``/servers/{id}`` or ``/servers/{id}/tools``.
+    Matches ``/servers/{id}/sse``, ``/servers/{id}/mcp``, and their
+    ``/v1/virtual-servers`` aliases (with or without trailing slash) while NOT
+    matching regular REST endpoints like ``/servers/{id}`` or
+    ``/v1/virtual-servers/{id}/tools``.
     """
     normalized = path.rstrip("/")
     parts = normalized.split("/")
-    return len(parts) == 4 and parts[1] == "servers" and parts[3] in ("sse", "mcp")
+    if len(parts) == 4:
+        return parts[1] == "servers" and parts[3] in ("sse", "mcp")
+    return len(parts) == 5 and parts[1:3] == ["v1", "virtual-servers"] and parts[4] in ("sse", "mcp")
 
 
 # Paths that manage their own disconnect handling (SSE, WebSocket, streaming)

--- a/mcpgateway/middleware/client_disconnect.py
+++ b/mcpgateway/middleware/client_disconnect.py
@@ -31,6 +31,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 # First-Party
 from mcpgateway.config import settings
 from mcpgateway.services.logging_service import LoggingService
+from mcpgateway.utils.paths import replace_api_path_alias
 
 logger = LoggingService().get_logger(__name__)
 
@@ -61,11 +62,9 @@ def _is_server_streaming_path(path: str) -> bool:
     matching regular REST endpoints like ``/servers/{id}`` or
     ``/v1/virtual-servers/{id}/tools``.
     """
-    normalized = path.rstrip("/")
+    normalized = replace_api_path_alias(path).rstrip("/")
     parts = normalized.split("/")
-    if len(parts) == 4:
-        return parts[1] == "servers" and parts[3] in ("sse", "mcp")
-    return len(parts) == 5 and parts[1:3] == ["v1", "virtual-servers"] and parts[4] in ("sse", "mcp")
+    return len(parts) == 4 and parts[1] == "servers" and bool(parts[2]) and parts[3] in ("sse", "mcp")
 
 
 # Paths that manage their own disconnect handling (SSE, WebSocket, streaming)

--- a/mcpgateway/middleware/protocol_version.py
+++ b/mcpgateway/middleware/protocol_version.py
@@ -18,6 +18,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 # First-Party
 from mcpgateway.utils.orjson_response import ORJSONResponse
+from mcpgateway.utils.paths import replace_api_path_alias
 
 logger = logging.getLogger(__name__)
 
@@ -152,12 +153,14 @@ class MCPProtocolVersionMiddleware(BaseHTTPMiddleware):
         Returns:
             bool: True if path is an MCP protocol endpoint, False otherwise
         """
+        path = replace_api_path_alias(path)
+
         # Exact match for main RPC endpoint
         if path in ("/mcp", "/mcp/", "/rpc", "/rpc/"):
             return True
 
         # Prefix matches for SSE/WebSocket/Server endpoints
-        if path.startswith(("/servers/", "/v1/virtual-servers/")) and (path.endswith("/sse") or path.endswith("/ws")):
+        if path.startswith("/servers/") and (path.endswith("/sse") or path.endswith("/ws")):
             return True
 
         return False

--- a/mcpgateway/middleware/protocol_version.py
+++ b/mcpgateway/middleware/protocol_version.py
@@ -141,6 +141,8 @@ class MCPProtocolVersionMiddleware(BaseHTTPMiddleware):
         - /rpc and /rpc/ (gateway JSON-RPC endpoint)
         - /servers/*/sse (SSE transport)
         - /servers/*/ws (WebSocket transport)
+        - /v1/virtual-servers/*/sse (versioned SSE transport alias)
+        - /v1/virtual-servers/*/ws (versioned WebSocket transport alias)
 
         Non-MCP endpoints (admin, health, openapi, etc.) are excluded.
 
@@ -155,7 +157,7 @@ class MCPProtocolVersionMiddleware(BaseHTTPMiddleware):
             return True
 
         # Prefix matches for SSE/WebSocket/Server endpoints
-        if path.startswith("/servers/") and (path.endswith("/sse") or path.endswith("/ws")):
+        if path.startswith(("/servers/", "/v1/virtual-servers/")) and (path.endswith("/sse") or path.endswith("/ws")):
             return True
 
         return False

--- a/mcpgateway/middleware/security_headers.py
+++ b/mcpgateway/middleware/security_headers.py
@@ -21,6 +21,7 @@ from starlette.responses import Response
 
 # First-Party
 from mcpgateway.config import settings
+from mcpgateway.utils.paths import replace_api_path_alias
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
@@ -107,10 +108,8 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     PROTECTED_PATH_PATTERNS: Set[str] = {
         r"^/tools(/.*)?$",
         r"^/servers(/.*)?$",
-        r"^/v1/virtual-servers(/.*)?$",
         r"^/resources(/.*)?$",
         r"^/gateways(/.*)?$",
-        r"^/v1/mcp-servers(/.*)?$",
         r"^/prompts(/.*)?$",
         r"^/tags(/.*)?$",
         r"^/roots(/.*)?$",
@@ -141,7 +140,6 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         r"^/ready$",
         r"^/\.well-known/.*$",
         r"^/servers/[^/]+/\.well-known/.*$",
-        r"^/v1/virtual-servers/[^/]+/\.well-known/.*$",
     }
 
     def __init__(self, app: Any) -> None:
@@ -161,6 +159,8 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         Returns:
             True if the path should have no-cache headers, False otherwise
         """
+        path = replace_api_path_alias(path)
+
         # First check if path is exempted (can be cached)
         for pattern in self._exempted_patterns:
             if pattern.match(path):

--- a/mcpgateway/middleware/security_headers.py
+++ b/mcpgateway/middleware/security_headers.py
@@ -107,8 +107,10 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     PROTECTED_PATH_PATTERNS: Set[str] = {
         r"^/tools(/.*)?$",
         r"^/servers(/.*)?$",
+        r"^/v1/virtual-servers(/.*)?$",
         r"^/resources(/.*)?$",
         r"^/gateways(/.*)?$",
+        r"^/v1/mcp-servers(/.*)?$",
         r"^/prompts(/.*)?$",
         r"^/tags(/.*)?$",
         r"^/roots(/.*)?$",
@@ -139,6 +141,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         r"^/ready$",
         r"^/\.well-known/.*$",
         r"^/servers/[^/]+/\.well-known/.*$",
+        r"^/v1/virtual-servers/[^/]+/\.well-known/.*$",
     }
 
     def __init__(self, app: Any) -> None:

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -51,7 +51,6 @@ logger = logging_service.get_logger(__name__)
 # Server path extraction patterns
 _SERVER_PATH_PATTERNS: List[Pattern[str]] = [
     re.compile(r"^/servers/([^/]+)(?:$|/)"),
-    # /v1 is optional because request paths are normalized before matching.
     re.compile(r"^/(?:v1/)?virtual-servers/([^/]+)(?:$|/)"),
     re.compile(r"^/sse/([^/?]+)(?:$|\?)"),
     re.compile(r"^/ws/([^/?]+)(?:$|\?)"),
@@ -78,7 +77,7 @@ class ResourceOwnershipResult(Enum):
     DENIED = auto()
 
 
-_TARGETED_MISSING_DELETE_PATTERN = re.compile(r"^/(?:servers|gateways)/(?:[a-f0-9]{32}|[a-f0-9]{8}-(?:[a-f0-9]{4}-){3}[a-f0-9]{12})/?$")
+_TARGETED_MISSING_DELETE_PATTERN = re.compile(r"^/(?:servers|virtual-servers|gateways|mcp-servers)/(?:[a-f0-9]{32}|[a-f0-9]{8}-(?:[a-f0-9]{4}-){3}[a-f0-9]{12})/?$")
 
 # Permission map with precompiled patterns
 # Maps (HTTP method, path pattern) to required permission
@@ -1374,8 +1373,7 @@ class TokenScopingMiddleware:
             if any(normalized_path.startswith(path) for path in skip_paths):
                 return await call_next(request)
 
-            # Skip server-specific well-known endpoints (RFC 9728), including
-            # the versioned product-language alias.
+            # Skip server-specific well-known endpoints (RFC 9728)
             if re.match(r"^/(?:servers|v1/virtual-servers)/[^/]+/\.well-known/", normalized_path):
                 return await call_next(request)
 

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -51,7 +51,7 @@ logger = logging_service.get_logger(__name__)
 # Server path extraction patterns
 _SERVER_PATH_PATTERNS: List[Pattern[str]] = [
     re.compile(r"^/servers/([^/]+)(?:$|/)"),
-    re.compile(r"^/(?:v1/)?virtual-servers/([^/]+)(?:$|/)"),
+    re.compile(r"^/virtual-servers/([^/]+)(?:$|/)"),
     re.compile(r"^/sse/([^/?]+)(?:$|\?)"),
     re.compile(r"^/ws/([^/?]+)(?:$|\?)"),
 ]
@@ -59,12 +59,12 @@ _SERVER_PATH_PATTERNS: List[Pattern[str]] = [
 # Resource ID extraction patterns (IDs are UUID hex strings)
 _RESOURCE_PATTERNS: List[Tuple[Pattern[str], str]] = [
     (re.compile(r"/servers/?([a-f0-9\-]+)"), "server"),
-    (re.compile(r"/(?:v1/)?virtual-servers/?([a-f0-9\-]+)"), "server"),
+    (re.compile(r"/virtual-servers/?([a-f0-9\-]+)"), "server"),
     (re.compile(r"/tools/?([a-f0-9\-]+)"), "tool"),
     (re.compile(r"/resources/?([a-f0-9\-]+)"), "resource"),
     (re.compile(r"/prompts/?([a-f0-9\-]+)"), "prompt"),
     (re.compile(r"/gateways/?([a-f0-9\-]+)"), "gateway"),
-    (re.compile(r"/(?:v1/)?mcp-servers/?([a-f0-9\-]+)"), "gateway"),
+    (re.compile(r"/mcp-servers/?([a-f0-9\-]+)"), "gateway"),
 ]
 _AUTH_COOKIE_NAMES = ("jwt_token", "access_token")
 
@@ -93,8 +93,8 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("DELETE", re.compile(r"^/tools/[^/]+(?:$|/)"), Permissions.TOOLS_DELETE),
     ("GET", re.compile(r"^/servers/[^/]+/tools(?:$|/)"), Permissions.TOOLS_READ),
     ("POST", re.compile(r"^/servers/[^/]+/tools/[^/]+/call(?:$|/)"), Permissions.TOOLS_EXECUTE),
-    ("GET", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+/tools(?:$|/)"), Permissions.TOOLS_READ),
-    ("POST", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+/tools/[^/]+/call(?:$|/)"), Permissions.TOOLS_EXECUTE),
+    ("GET", re.compile(r"^/virtual-servers/[^/]+/tools(?:$|/)"), Permissions.TOOLS_READ),
+    ("POST", re.compile(r"^/virtual-servers/[^/]+/tools/[^/]+/call(?:$|/)"), Permissions.TOOLS_EXECUTE),
     # JSON-RPC endpoint — multiplexes tools/call, resources/list, initialize, etc.
     # Fine-grained per-method RBAC is enforced downstream by _ensure_rpc_permission();
     # the middleware only gates transport-level access via servers.use.
@@ -114,7 +114,7 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("PUT", re.compile(r"^/resources/[^/]+(?:$|/)"), Permissions.RESOURCES_UPDATE),
     ("DELETE", re.compile(r"^/resources/[^/]+(?:$|/)"), Permissions.RESOURCES_DELETE),
     ("GET", re.compile(r"^/servers/[^/]+/resources(?:$|/)"), Permissions.RESOURCES_READ),
-    ("GET", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+/resources(?:$|/)"), Permissions.RESOURCES_READ),
+    ("GET", re.compile(r"^/virtual-servers/[^/]+/resources(?:$|/)"), Permissions.RESOURCES_READ),
     # Prompts permissions
     ("GET", re.compile(r"^/prompts(?:$|/)"), Permissions.PROMPTS_READ),
     ("POST", re.compile(r"^/prompts/?$"), Permissions.PROMPTS_CREATE),  # Only exact /prompts or /prompts/
@@ -122,7 +122,7 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("POST", re.compile(r"^/prompts/[^/]+$"), Permissions.PROMPTS_READ),  # MCP spec prompt retrieval (POST /prompts/{id})
     ("PUT", re.compile(r"^/prompts/[^/]+(?:$|/)"), Permissions.PROMPTS_UPDATE),
     ("DELETE", re.compile(r"^/prompts/[^/]+(?:$|/)"), Permissions.PROMPTS_DELETE),
-    ("GET", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+/prompts(?:$|/)"), Permissions.SERVERS_READ),
+    ("GET", re.compile(r"^/virtual-servers/[^/]+/prompts(?:$|/)"), Permissions.SERVERS_READ),
     # Server management permissions
     ("GET", re.compile(r"^/servers/[^/]+/sse(?:$|/)"), Permissions.SERVERS_USE),  # Server SSE access endpoint
     ("GET", re.compile(r"^/servers(?:$|/)"), Permissions.SERVERS_READ),
@@ -133,14 +133,14 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("PUT", re.compile(r"^/servers/[^/]+(?:$|/)"), Permissions.SERVERS_UPDATE),
     ("DELETE", re.compile(r"^/servers/[^/]+(?:$|/)"), Permissions.SERVERS_DELETE),
     # Versioned virtual-server aliases (/v1 is stripped during request normalization).
-    ("GET", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+/sse(?:$|/)"), Permissions.SERVERS_USE),
-    ("GET", re.compile(r"^/(?:v1/)?virtual-servers(?:$|/)"), Permissions.SERVERS_READ),
-    ("POST", re.compile(r"^/(?:v1/)?virtual-servers/?$"), Permissions.SERVERS_CREATE),
-    ("POST", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+/(?:state|toggle)(?:$|/)"), Permissions.SERVERS_UPDATE),
-    ("POST", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+/message(?:$|/)"), Permissions.SERVERS_USE),
-    ("POST", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+/mcp(?:$|/)"), Permissions.SERVERS_USE),
-    ("PUT", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+(?:$|/)"), Permissions.SERVERS_UPDATE),
-    ("DELETE", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+(?:$|/)"), Permissions.SERVERS_DELETE),
+    ("GET", re.compile(r"^/virtual-servers/[^/]+/sse(?:$|/)"), Permissions.SERVERS_USE),
+    ("GET", re.compile(r"^/virtual-servers(?:$|/)"), Permissions.SERVERS_READ),
+    ("POST", re.compile(r"^/virtual-servers/?$"), Permissions.SERVERS_CREATE),
+    ("POST", re.compile(r"^/virtual-servers/[^/]+/(?:state|toggle)(?:$|/)"), Permissions.SERVERS_UPDATE),
+    ("POST", re.compile(r"^/virtual-servers/[^/]+/message(?:$|/)"), Permissions.SERVERS_USE),
+    ("POST", re.compile(r"^/virtual-servers/[^/]+/mcp(?:$|/)"), Permissions.SERVERS_USE),
+    ("PUT", re.compile(r"^/virtual-servers/[^/]+(?:$|/)"), Permissions.SERVERS_UPDATE),
+    ("DELETE", re.compile(r"^/virtual-servers/[^/]+(?:$|/)"), Permissions.SERVERS_DELETE),
     # Gateway permissions
     ("GET", re.compile(r"^/gateways(?:$|/)"), Permissions.GATEWAYS_READ),
     ("POST", re.compile(r"^/gateways/?$"), Permissions.GATEWAYS_CREATE),  # Only exact /gateways or /gateways/
@@ -165,11 +165,11 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("POST", re.compile(r"^/mcp-servers/test(?:$|/)"), Permissions.GATEWAYS_READ),
     ("POST", re.compile(r"^/mcp-servers/test-handshake(?:$|/)"), Permissions.GATEWAYS_READ),
     # Versioned MCP-server aliases (/v1 is stripped during request normalization).
-    ("GET", re.compile(r"^/(?:v1/)?mcp-servers(?:$|/)"), Permissions.GATEWAYS_READ),
-    ("POST", re.compile(r"^/(?:v1/)?mcp-servers/?$"), Permissions.GATEWAYS_CREATE),
-    ("POST", re.compile(r"^/(?:v1/)?mcp-servers/[^/]+/"), Permissions.GATEWAYS_UPDATE),  # POST to sub-resources (state, toggle, refresh)
-    ("PUT", re.compile(r"^/(?:v1/)?mcp-servers/[^/]+(?:$|/)"), Permissions.GATEWAYS_UPDATE),
-    ("DELETE", re.compile(r"^/(?:v1/)?mcp-servers/[^/]+(?:$|/)"), Permissions.GATEWAYS_DELETE),
+    ("GET", re.compile(r"^/mcp-servers(?:$|/)"), Permissions.GATEWAYS_READ),
+    ("POST", re.compile(r"^/mcp-servers/?$"), Permissions.GATEWAYS_CREATE),
+    ("POST", re.compile(r"^/mcp-servers/[^/]+/"), Permissions.GATEWAYS_UPDATE),  # POST to sub-resources (state, toggle, refresh)
+    ("PUT", re.compile(r"^/mcp-servers/[^/]+(?:$|/)"), Permissions.GATEWAYS_UPDATE),
+    ("DELETE", re.compile(r"^/mcp-servers/[^/]+(?:$|/)"), Permissions.GATEWAYS_DELETE),
     # MCP registry catalog (v1 prefix stripped by middleware before matching)
     ("GET", re.compile(r"^/catalog(?:$|/)"), Permissions.SERVERS_READ),
     ("POST", re.compile(r"^/catalog/[^/]+/register(?:$|/)"), Permissions.SERVERS_CREATE),

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -1374,8 +1374,9 @@ class TokenScopingMiddleware:
             if any(normalized_path.startswith(path) for path in skip_paths):
                 return await call_next(request)
 
-            # Skip server-specific well-known endpoints (RFC 9728)
-            if re.match(r"^/servers/[^/]+/\.well-known/", normalized_path):
+            # Skip server-specific well-known endpoints (RFC 9728), including
+            # the versioned product-language alias.
+            if re.match(r"^/(?:servers|v1/virtual-servers)/[^/]+/\.well-known/", normalized_path):
                 return await call_next(request)
 
             # Extract full token payload (not just scopes)

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -51,6 +51,8 @@ logger = logging_service.get_logger(__name__)
 # Server path extraction patterns
 _SERVER_PATH_PATTERNS: List[Pattern[str]] = [
     re.compile(r"^/servers/([^/]+)(?:$|/)"),
+    # /v1 is optional because request paths are normalized before matching.
+    re.compile(r"^/(?:v1/)?virtual-servers/([^/]+)(?:$|/)"),
     re.compile(r"^/sse/([^/?]+)(?:$|\?)"),
     re.compile(r"^/ws/([^/?]+)(?:$|\?)"),
 ]
@@ -58,10 +60,12 @@ _SERVER_PATH_PATTERNS: List[Pattern[str]] = [
 # Resource ID extraction patterns (IDs are UUID hex strings)
 _RESOURCE_PATTERNS: List[Tuple[Pattern[str], str]] = [
     (re.compile(r"/servers/?([a-f0-9\-]+)"), "server"),
+    (re.compile(r"/(?:v1/)?virtual-servers/?([a-f0-9\-]+)"), "server"),
     (re.compile(r"/tools/?([a-f0-9\-]+)"), "tool"),
     (re.compile(r"/resources/?([a-f0-9\-]+)"), "resource"),
     (re.compile(r"/prompts/?([a-f0-9\-]+)"), "prompt"),
     (re.compile(r"/gateways/?([a-f0-9\-]+)"), "gateway"),
+    (re.compile(r"/(?:v1/)?mcp-servers/?([a-f0-9\-]+)"), "gateway"),
 ]
 _AUTH_COOKIE_NAMES = ("jwt_token", "access_token")
 
@@ -90,6 +94,8 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("DELETE", re.compile(r"^/tools/[^/]+(?:$|/)"), Permissions.TOOLS_DELETE),
     ("GET", re.compile(r"^/servers/[^/]+/tools(?:$|/)"), Permissions.TOOLS_READ),
     ("POST", re.compile(r"^/servers/[^/]+/tools/[^/]+/call(?:$|/)"), Permissions.TOOLS_EXECUTE),
+    ("GET", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+/tools(?:$|/)"), Permissions.TOOLS_READ),
+    ("POST", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+/tools/[^/]+/call(?:$|/)"), Permissions.TOOLS_EXECUTE),
     # JSON-RPC endpoint — multiplexes tools/call, resources/list, initialize, etc.
     # Fine-grained per-method RBAC is enforced downstream by _ensure_rpc_permission();
     # the middleware only gates transport-level access via servers.use.
@@ -109,6 +115,7 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("PUT", re.compile(r"^/resources/[^/]+(?:$|/)"), Permissions.RESOURCES_UPDATE),
     ("DELETE", re.compile(r"^/resources/[^/]+(?:$|/)"), Permissions.RESOURCES_DELETE),
     ("GET", re.compile(r"^/servers/[^/]+/resources(?:$|/)"), Permissions.RESOURCES_READ),
+    ("GET", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+/resources(?:$|/)"), Permissions.RESOURCES_READ),
     # Prompts permissions
     ("GET", re.compile(r"^/prompts(?:$|/)"), Permissions.PROMPTS_READ),
     ("POST", re.compile(r"^/prompts/?$"), Permissions.PROMPTS_CREATE),  # Only exact /prompts or /prompts/
@@ -116,6 +123,7 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("POST", re.compile(r"^/prompts/[^/]+$"), Permissions.PROMPTS_READ),  # MCP spec prompt retrieval (POST /prompts/{id})
     ("PUT", re.compile(r"^/prompts/[^/]+(?:$|/)"), Permissions.PROMPTS_UPDATE),
     ("DELETE", re.compile(r"^/prompts/[^/]+(?:$|/)"), Permissions.PROMPTS_DELETE),
+    ("GET", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+/prompts(?:$|/)"), Permissions.SERVERS_READ),
     # Server management permissions
     ("GET", re.compile(r"^/servers/[^/]+/sse(?:$|/)"), Permissions.SERVERS_USE),  # Server SSE access endpoint
     ("GET", re.compile(r"^/servers(?:$|/)"), Permissions.SERVERS_READ),
@@ -125,6 +133,15 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("POST", re.compile(r"^/servers/[^/]+/mcp(?:$|/)"), Permissions.SERVERS_USE),  # Server MCP access endpoint
     ("PUT", re.compile(r"^/servers/[^/]+(?:$|/)"), Permissions.SERVERS_UPDATE),
     ("DELETE", re.compile(r"^/servers/[^/]+(?:$|/)"), Permissions.SERVERS_DELETE),
+    # Versioned virtual-server aliases (/v1 is stripped during request normalization).
+    ("GET", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+/sse(?:$|/)"), Permissions.SERVERS_USE),
+    ("GET", re.compile(r"^/(?:v1/)?virtual-servers(?:$|/)"), Permissions.SERVERS_READ),
+    ("POST", re.compile(r"^/(?:v1/)?virtual-servers/?$"), Permissions.SERVERS_CREATE),
+    ("POST", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+/(?:state|toggle)(?:$|/)"), Permissions.SERVERS_UPDATE),
+    ("POST", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+/message(?:$|/)"), Permissions.SERVERS_USE),
+    ("POST", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+/mcp(?:$|/)"), Permissions.SERVERS_USE),
+    ("PUT", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+(?:$|/)"), Permissions.SERVERS_UPDATE),
+    ("DELETE", re.compile(r"^/(?:v1/)?virtual-servers/[^/]+(?:$|/)"), Permissions.SERVERS_DELETE),
     # Gateway permissions
     ("GET", re.compile(r"^/gateways(?:$|/)"), Permissions.GATEWAYS_READ),
     ("POST", re.compile(r"^/gateways/?$"), Permissions.GATEWAYS_CREATE),  # Only exact /gateways or /gateways/
@@ -148,6 +165,12 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     # MCP Servers REST API (v1 prefix stripped by middleware before matching)
     ("POST", re.compile(r"^/mcp-servers/test(?:$|/)"), Permissions.GATEWAYS_READ),
     ("POST", re.compile(r"^/mcp-servers/test-handshake(?:$|/)"), Permissions.GATEWAYS_READ),
+    # Versioned MCP-server aliases (/v1 is stripped during request normalization).
+    ("GET", re.compile(r"^/(?:v1/)?mcp-servers(?:$|/)"), Permissions.GATEWAYS_READ),
+    ("POST", re.compile(r"^/(?:v1/)?mcp-servers/?$"), Permissions.GATEWAYS_CREATE),
+    ("POST", re.compile(r"^/(?:v1/)?mcp-servers/[^/]+/"), Permissions.GATEWAYS_UPDATE),  # POST to sub-resources (state, toggle, refresh)
+    ("PUT", re.compile(r"^/(?:v1/)?mcp-servers/[^/]+(?:$|/)"), Permissions.GATEWAYS_UPDATE),
+    ("DELETE", re.compile(r"^/(?:v1/)?mcp-servers/[^/]+(?:$|/)"), Permissions.GATEWAYS_DELETE),
     # MCP registry catalog (v1 prefix stripped by middleware before matching)
     ("GET", re.compile(r"^/catalog(?:$|/)"), Permissions.SERVERS_READ),
     ("POST", re.compile(r"^/catalog/[^/]+/register(?:$|/)"), Permissions.SERVERS_CREATE),

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -31,6 +31,7 @@ from mcpgateway.db import Permissions
 from mcpgateway.middleware.rbac import _ACCESS_DENIED_MSG, _ALL_PERMISSIONS_SCOPE, token_scope_grants
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.utils.orjson_response import ORJSONResponse
+from mcpgateway.utils.paths import replace_api_path_alias
 from mcpgateway.utils.verify_credentials import (
     ConfigurableHTTPBearer,
     get_auth_bearer_token_from_request,
@@ -51,7 +52,6 @@ logger = logging_service.get_logger(__name__)
 # Server path extraction patterns
 _SERVER_PATH_PATTERNS: List[Pattern[str]] = [
     re.compile(r"^/servers/([^/]+)(?:$|/)"),
-    re.compile(r"^/virtual-servers/([^/]+)(?:$|/)"),
     re.compile(r"^/sse/([^/?]+)(?:$|\?)"),
     re.compile(r"^/ws/([^/?]+)(?:$|\?)"),
 ]
@@ -59,12 +59,10 @@ _SERVER_PATH_PATTERNS: List[Pattern[str]] = [
 # Resource ID extraction patterns (IDs are UUID hex strings)
 _RESOURCE_PATTERNS: List[Tuple[Pattern[str], str]] = [
     (re.compile(r"/servers/?([a-f0-9\-]+)"), "server"),
-    (re.compile(r"/virtual-servers/?([a-f0-9\-]+)"), "server"),
     (re.compile(r"/tools/?([a-f0-9\-]+)"), "tool"),
     (re.compile(r"/resources/?([a-f0-9\-]+)"), "resource"),
     (re.compile(r"/prompts/?([a-f0-9\-]+)"), "prompt"),
     (re.compile(r"/gateways/?([a-f0-9\-]+)"), "gateway"),
-    (re.compile(r"/mcp-servers/?([a-f0-9\-]+)"), "gateway"),
 ]
 _AUTH_COOKIE_NAMES = ("jwt_token", "access_token")
 
@@ -77,7 +75,7 @@ class ResourceOwnershipResult(Enum):
     DENIED = auto()
 
 
-_TARGETED_MISSING_DELETE_PATTERN = re.compile(r"^/(?:servers|virtual-servers|gateways|mcp-servers)/(?:[a-f0-9]{32}|[a-f0-9]{8}-(?:[a-f0-9]{4}-){3}[a-f0-9]{12})/?$")
+_TARGETED_MISSING_DELETE_PATTERN = re.compile(r"^/(?:servers|gateways)/(?:[a-f0-9]{32}|[a-f0-9]{8}-(?:[a-f0-9]{4}-){3}[a-f0-9]{12})/?$")
 
 # Permission map with precompiled patterns
 # Maps (HTTP method, path pattern) to required permission
@@ -93,8 +91,6 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("DELETE", re.compile(r"^/tools/[^/]+(?:$|/)"), Permissions.TOOLS_DELETE),
     ("GET", re.compile(r"^/servers/[^/]+/tools(?:$|/)"), Permissions.TOOLS_READ),
     ("POST", re.compile(r"^/servers/[^/]+/tools/[^/]+/call(?:$|/)"), Permissions.TOOLS_EXECUTE),
-    ("GET", re.compile(r"^/virtual-servers/[^/]+/tools(?:$|/)"), Permissions.TOOLS_READ),
-    ("POST", re.compile(r"^/virtual-servers/[^/]+/tools/[^/]+/call(?:$|/)"), Permissions.TOOLS_EXECUTE),
     # JSON-RPC endpoint — multiplexes tools/call, resources/list, initialize, etc.
     # Fine-grained per-method RBAC is enforced downstream by _ensure_rpc_permission();
     # the middleware only gates transport-level access via servers.use.
@@ -114,7 +110,6 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("PUT", re.compile(r"^/resources/[^/]+(?:$|/)"), Permissions.RESOURCES_UPDATE),
     ("DELETE", re.compile(r"^/resources/[^/]+(?:$|/)"), Permissions.RESOURCES_DELETE),
     ("GET", re.compile(r"^/servers/[^/]+/resources(?:$|/)"), Permissions.RESOURCES_READ),
-    ("GET", re.compile(r"^/virtual-servers/[^/]+/resources(?:$|/)"), Permissions.RESOURCES_READ),
     # Prompts permissions
     ("GET", re.compile(r"^/prompts(?:$|/)"), Permissions.PROMPTS_READ),
     ("POST", re.compile(r"^/prompts/?$"), Permissions.PROMPTS_CREATE),  # Only exact /prompts or /prompts/
@@ -122,7 +117,6 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("POST", re.compile(r"^/prompts/[^/]+$"), Permissions.PROMPTS_READ),  # MCP spec prompt retrieval (POST /prompts/{id})
     ("PUT", re.compile(r"^/prompts/[^/]+(?:$|/)"), Permissions.PROMPTS_UPDATE),
     ("DELETE", re.compile(r"^/prompts/[^/]+(?:$|/)"), Permissions.PROMPTS_DELETE),
-    ("GET", re.compile(r"^/virtual-servers/[^/]+/prompts(?:$|/)"), Permissions.SERVERS_READ),
     # Server management permissions
     ("GET", re.compile(r"^/servers/[^/]+/sse(?:$|/)"), Permissions.SERVERS_USE),  # Server SSE access endpoint
     ("GET", re.compile(r"^/servers(?:$|/)"), Permissions.SERVERS_READ),
@@ -132,16 +126,11 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("POST", re.compile(r"^/servers/[^/]+/mcp(?:$|/)"), Permissions.SERVERS_USE),  # Server MCP access endpoint
     ("PUT", re.compile(r"^/servers/[^/]+(?:$|/)"), Permissions.SERVERS_UPDATE),
     ("DELETE", re.compile(r"^/servers/[^/]+(?:$|/)"), Permissions.SERVERS_DELETE),
-    # Versioned virtual-server aliases (/v1 is stripped during request normalization).
-    ("GET", re.compile(r"^/virtual-servers/[^/]+/sse(?:$|/)"), Permissions.SERVERS_USE),
-    ("GET", re.compile(r"^/virtual-servers(?:$|/)"), Permissions.SERVERS_READ),
-    ("POST", re.compile(r"^/virtual-servers/?$"), Permissions.SERVERS_CREATE),
-    ("POST", re.compile(r"^/virtual-servers/[^/]+/(?:state|toggle)(?:$|/)"), Permissions.SERVERS_UPDATE),
-    ("POST", re.compile(r"^/virtual-servers/[^/]+/message(?:$|/)"), Permissions.SERVERS_USE),
-    ("POST", re.compile(r"^/virtual-servers/[^/]+/mcp(?:$|/)"), Permissions.SERVERS_USE),
-    ("PUT", re.compile(r"^/virtual-servers/[^/]+(?:$|/)"), Permissions.SERVERS_UPDATE),
-    ("DELETE", re.compile(r"^/virtual-servers/[^/]+(?:$|/)"), Permissions.SERVERS_DELETE),
     # Gateway permissions
+    # Connectivity test and handshake probe exposed through the /v1/mcp-servers product alias.
+    # They must precede the generic POST sub-resource rule below.
+    ("POST", re.compile(r"^/gateways/test(?:$|/)"), Permissions.GATEWAYS_READ),
+    ("POST", re.compile(r"^/gateways/test-handshake(?:$|/)"), Permissions.GATEWAYS_READ),
     ("GET", re.compile(r"^/gateways(?:$|/)"), Permissions.GATEWAYS_READ),
     ("POST", re.compile(r"^/gateways/?$"), Permissions.GATEWAYS_CREATE),  # Only exact /gateways or /gateways/
     ("POST", re.compile(r"^/gateways/[^/]+/"), Permissions.GATEWAYS_UPDATE),  # POST to sub-resources (state, toggle, refresh)
@@ -161,15 +150,6 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     # un-narrowed admin token (see _require_unnarrowed_admin).
     ("GET", re.compile(r"^/oauth/registered-clients(?:$|/)"), Permissions.ADMIN_OAUTH_CLIENTS_READ),
     ("DELETE", re.compile(r"^/oauth/registered-clients/[^/]+(?:$|/)"), Permissions.ADMIN_OAUTH_CLIENTS_DELETE),
-    # MCP Servers REST API (v1 prefix stripped by middleware before matching)
-    ("POST", re.compile(r"^/mcp-servers/test(?:$|/)"), Permissions.GATEWAYS_READ),
-    ("POST", re.compile(r"^/mcp-servers/test-handshake(?:$|/)"), Permissions.GATEWAYS_READ),
-    # Versioned MCP-server aliases (/v1 is stripped during request normalization).
-    ("GET", re.compile(r"^/mcp-servers(?:$|/)"), Permissions.GATEWAYS_READ),
-    ("POST", re.compile(r"^/mcp-servers/?$"), Permissions.GATEWAYS_CREATE),
-    ("POST", re.compile(r"^/mcp-servers/[^/]+/"), Permissions.GATEWAYS_UPDATE),  # POST to sub-resources (state, toggle, refresh)
-    ("PUT", re.compile(r"^/mcp-servers/[^/]+(?:$|/)"), Permissions.GATEWAYS_UPDATE),
-    ("DELETE", re.compile(r"^/mcp-servers/[^/]+(?:$|/)"), Permissions.GATEWAYS_DELETE),
     # MCP registry catalog (v1 prefix stripped by middleware before matching)
     ("GET", re.compile(r"^/catalog(?:$|/)"), Permissions.SERVERS_READ),
     ("POST", re.compile(r"^/catalog/[^/]+/register(?:$|/)"), Permissions.SERVERS_CREATE),
@@ -456,6 +436,7 @@ class TokenScopingMiddleware:
         normalized = _normalize_scope_path(request_path or "/", settings.app_root_path or "")
         if not normalized.startswith("/"):
             normalized = f"/{normalized}"
+        normalized = replace_api_path_alias(normalized)
         # Strip the /v1 API version prefix so all patterns match unversioned paths.
         # This ensures scope patterns work identically for /tools and /v1/tools.
         return _strip_v1_prefix(normalized)
@@ -476,8 +457,8 @@ class TokenScopingMiddleware:
         root_path = scope.get("root_path") or settings.app_root_path or ""
         normalized = _normalize_scope_path(scope_path, root_path)
         if not normalized.startswith("/"):
-            return f"/{normalized}"
-        return normalized
+            normalized = f"/{normalized}"
+        return replace_api_path_alias(normalized)
 
     def _extract_jwt_token_from_request(self, request: Request) -> Optional[str]:
         """Extract JWT token from supported cookie names or Bearer auth header.
@@ -1374,7 +1355,7 @@ class TokenScopingMiddleware:
                 return await call_next(request)
 
             # Skip server-specific well-known endpoints (RFC 9728)
-            if re.match(r"^/(?:servers|v1/virtual-servers)/[^/]+/\.well-known/", normalized_path):
+            if re.match(r"^/servers/[^/]+/\.well-known/", normalized_path):
                 return await call_next(request)
 
             # Extract full token payload (not just scopes)

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -4916,12 +4916,23 @@ class _StreamableHttpAuthHandler:
     can send error responses without threading these values through every call.
     """
 
-    __slots__ = ("scope", "receive", "send")
+    __slots__ = ("scope", "receive", "send", "request_path")
 
-    def __init__(self, scope: Any, receive: Any, send: Any) -> None:
+    def __init__(self, scope: Any, receive: Any, send: Any, *, request_path: str | None = None) -> None:
+        """Initialize the authentication handler.
+
+        Args:
+            scope: Original ASGI request scope.
+            receive: ASGI receive callable.
+            send: ASGI send callable.
+            request_path: Optional app-relative path used only for route checks.
+                The original scope remains unchanged.
+        """
         self.scope = scope
         self.receive = receive
         self.send = send
+        scope_path = scope.get("path", "")
+        self.request_path = request_path if request_path is not None else scope_path
 
     async def _send_error(self, *, detail: str, status_code: int = HTTP_401_UNAUTHORIZED, headers: dict[str, str] | None = None) -> bool:
         """Send an error response and return False (auth rejected).
@@ -4959,7 +4970,7 @@ class _StreamableHttpAuthHandler:
             True if authentication passes or is skipped.
             False if authentication fails and a 401 response is sent.
         """
-        path = self.scope.get("path", "")
+        path = self.request_path
         # Normalize trailing slash for consistent matching
         normalized = path.rstrip("/")
         # Check if this is an MCP-related path that requires authentication.
@@ -5465,7 +5476,7 @@ class _StreamableHttpAuthHandler:
             except jwt.DecodeError:
                 return OAuthAuthResult.NOT_APPLICABLE
 
-        path = self.scope.get("path", "")
+        path = self.request_path
         match = _SERVER_ID_RE.search(path)
         if not match:
             return OAuthAuthResult.NOT_APPLICABLE
@@ -5648,7 +5659,7 @@ class _StreamableHttpAuthHandler:
         return OAuthAuthResult.SUCCESS
 
 
-async def streamable_http_auth(scope: Any, receive: Any, send: Any) -> bool:
+async def streamable_http_auth(scope: Any, receive: Any, send: Any, *, request_path: str | None = None) -> bool:
     """Perform authentication check in middleware context (ASGI scope).
 
     Delegates to :class:`_StreamableHttpAuthHandler` which encapsulates the
@@ -5658,6 +5669,8 @@ async def streamable_http_auth(scope: Any, receive: Any, send: Any) -> bool:
         scope: The ASGI scope dictionary, which includes request metadata.
         receive: ASGI receive callable used to receive events.
         send: ASGI send callable used to send events (e.g. a 401 response).
+        request_path: Optional app-relative path used for authentication route
+            checks without changing ``scope["path"]``.
 
     Returns:
         bool: True if authentication passes or is skipped.
@@ -5672,6 +5685,6 @@ async def streamable_http_auth(scope: Any, receive: Any, send: Any) -> bool:
         >>> import inspect
         >>> sig = inspect.signature(streamable_http_auth)
         >>> list(sig.parameters.keys())
-        ['scope', 'receive', 'send']
+        ['scope', 'receive', 'send', 'request_path']
     """
-    return await _StreamableHttpAuthHandler(scope, receive, send).authenticate()
+    return await _StreamableHttpAuthHandler(scope, receive, send, request_path=request_path).authenticate()

--- a/mcpgateway/utils/paths.py
+++ b/mcpgateway/utils/paths.py
@@ -3,7 +3,7 @@
 Copyright contributors to the MCP-CONTEXT-FORGE project
 SPDX-License-Identifier: Apache-2.0
 
-Shared root-path resolution utility for ContextForge.
+Shared request-path utilities for ContextForge.
 
 Some embedded/proxy deployments do not populate ``scope["root_path"]``
 consistently.  This module provides a single canonical helper that checks
@@ -31,6 +31,43 @@ logger = logging.getLogger(__name__)
 # scheme markers, query/fragment delimiters, and whitespace other than
 # leading/trailing (which is stripped before this check).
 _UNSAFE_ROOT_PATH_RE: re.Pattern[str] = re.compile(r"[\x00-\x1f\x7f?#]|://")
+
+# Public product-language aliases map to the established internal route names.
+# Keep this as the single source of truth so security and transport middleware
+# cannot drift when aliases are added or renamed.
+_API_PATH_ALIASES: tuple[tuple[str, str], ...] = (
+    ("/v1/virtual-servers", "/servers"),
+    ("/v1/mcp-servers", "/gateways"),
+)
+
+
+def replace_api_path_alias(path: str) -> str:
+    """Replace a public API path alias with its internal route name.
+
+    Only complete path segments are translated. The suffix, including a
+    trailing slash, is preserved so callers can continue to apply their own
+    endpoint-specific matching rules.
+
+    Args:
+        path: Application-relative request path.
+
+    Returns:
+        Internal path for a known alias, otherwise ``path`` unchanged.
+
+    Examples:
+        >>> replace_api_path_alias("/v1/virtual-servers/server-1/prompts")
+        '/servers/server-1/prompts'
+        >>> replace_api_path_alias("/v1/mcp-servers/gateway-1")
+        '/gateways/gateway-1'
+        >>> replace_api_path_alias("/v1/virtual-servers-extra")
+        '/v1/virtual-servers-extra'
+    """
+    for alias_prefix, canonical_prefix in _API_PATH_ALIASES:
+        if path == alias_prefix:
+            return canonical_prefix
+        if path.startswith(f"{alias_prefix}/"):
+            return f"{canonical_prefix}{path[len(alias_prefix) :]}"
+    return path
 
 
 def _validate_root_path(value: str) -> str:

--- a/tests/integration/test_api_versioning_security.py
+++ b/tests/integration/test_api_versioning_security.py
@@ -77,6 +77,22 @@ class TestUnauthenticatedDenied:
             f"Expected 401 for unauthenticated GET {path}, got {response.status_code}"
         )
 
+    @pytest.mark.parametrize(
+        ("method", "path"),
+        [
+            ("GET", "/v1/virtual-servers"),
+            ("GET", "/v1/mcp-servers"),
+            ("POST", "/v1/virtual-servers/server-123/mcp"),
+        ],
+    )
+    def test_product_alias_unauthenticated(self, client: TestClient, method: str, path: str) -> None:
+        """Product aliases must authenticate before reaching handlers or rewriting."""
+        response = client.request(method, path, content=b"{}", follow_redirects=False)
+
+        assert response.status_code == 401, (
+            f"Expected 401 for unauthenticated {method} {path}, got {response.status_code}"
+        )
+
     @pytest.mark.parametrize("path", ADMIN_V1_ROUTES)
     def test_admin_route_unauthenticated(self, client: TestClient, path: str) -> None:
         response = client.get(path, follow_redirects=False)

--- a/tests/integration/test_api_versioning_security.py
+++ b/tests/integration/test_api_versioning_security.py
@@ -33,6 +33,9 @@ import mcpgateway.transports.streamablehttp_transport as streamable_transport_mo
 from mcpgateway.config import settings
 from mcpgateway.main import app
 
+# Local
+from tests.helpers.auth import make_auth_header_for_email
+
 
 @pytest.fixture
 def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
@@ -51,6 +54,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.setattr(db_mod, "SessionLocal", TestSessionLocal, raising=False)
     monkeypatch.setattr(main_mod, "SessionLocal", TestSessionLocal, raising=False)
     monkeypatch.setattr(streamable_transport_mod, "SessionLocal", TestSessionLocal, raising=False)
+    monkeypatch.setattr(settings, "require_user_in_db", False)
 
     try:
         yield TestClient(app, raise_server_exceptions=False)
@@ -61,8 +65,8 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
 
 
 @pytest.fixture
-def valid_auth() -> tuple[str, str]:
-    return (settings.basic_auth_user, settings.basic_auth_password)
+def valid_auth_headers() -> dict[str, str]:
+    return make_auth_header_for_email(settings.platform_admin_email, is_admin=True, teams=None)
 
 
 @pytest.fixture
@@ -172,15 +176,15 @@ class TestValidCredentialsPassAuth:
     AUTH_PASS_CODES = {200, 201, 204, 404, 405, 422}
 
     @pytest.mark.parametrize("path", ALWAYS_ON_V1_ROUTES)
-    def test_always_on_route_valid_auth_passes(self, client: TestClient, path: str, valid_auth: tuple) -> None:
-        response = client.get(path, auth=valid_auth, follow_redirects=False)
+    def test_always_on_route_valid_auth_passes(self, client: TestClient, path: str, valid_auth_headers: dict[str, str]) -> None:
+        response = client.get(path, headers=valid_auth_headers, follow_redirects=False)
         assert response.status_code not in [401, 403], (
             f"Valid credentials were rejected on GET {path}: {response.status_code}"
         )
 
     @pytest.mark.parametrize("path", ADMIN_V1_ROUTES)
-    def test_admin_route_valid_admin_auth_passes(self, client: TestClient, path: str, valid_auth: tuple) -> None:
-        response = client.get(path, auth=valid_auth, follow_redirects=False)
+    def test_admin_route_valid_admin_auth_passes(self, client: TestClient, path: str, valid_auth_headers: dict[str, str]) -> None:
+        response = client.get(path, headers=valid_auth_headers, follow_redirects=False)
         assert response.status_code not in [401], (
             f"Valid admin credentials were rejected on GET {path}: {response.status_code}"
         )
@@ -212,9 +216,9 @@ class TestV1LegacyAuthParity:
         )
 
     @pytest.mark.parametrize("legacy,versioned", ROUTE_PAIRS)
-    def test_valid_auth_parity(self, client: TestClient, legacy: str, versioned: str, valid_auth: tuple) -> None:
-        legacy_status = client.get(legacy, auth=valid_auth, follow_redirects=False).status_code
-        v1_status = client.get(versioned, auth=valid_auth, follow_redirects=False).status_code
+    def test_valid_auth_parity(self, client: TestClient, legacy: str, versioned: str, valid_auth_headers: dict[str, str]) -> None:
+        legacy_status = client.get(legacy, headers=valid_auth_headers, follow_redirects=False).status_code
+        v1_status = client.get(versioned, headers=valid_auth_headers, follow_redirects=False).status_code
         assert legacy_status == v1_status, (
             f"Auth parity failure (valid creds): {legacy} → {legacy_status}, {versioned} → {v1_status}"
         )

--- a/tests/integration/test_api_versioning_security.py
+++ b/tests/integration/test_api_versioning_security.py
@@ -18,16 +18,46 @@ For every protected /v1 route family we verify:
 
 from __future__ import annotations
 
+import os
+import tempfile
+
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
+import mcpgateway.db as db_mod
+import mcpgateway.main as main_mod
+import mcpgateway.transports.streamablehttp_transport as streamable_transport_mod
 from mcpgateway.config import settings
 from mcpgateway.main import app
 
 
 @pytest.fixture
-def client() -> TestClient:
-    return TestClient(app, raise_server_exceptions=False)
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """TestClient backed by a real (schema-created) SQLite DB.
+
+    Some deny-path checks (e.g. per-server OAuth enforcement) query the DB
+    even for unauthenticated requests, so the default schema-less in-memory
+    DB used elsewhere in the suite isn't sufficient here.
+    """
+    fd, path = tempfile.mkstemp(suffix=".db")
+    engine = create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db_mod.Base.metadata.create_all(bind=engine)
+
+    monkeypatch.setattr(db_mod, "engine", engine, raising=False)
+    monkeypatch.setattr(db_mod, "SessionLocal", TestSessionLocal, raising=False)
+    monkeypatch.setattr(main_mod, "SessionLocal", TestSessionLocal, raising=False)
+    monkeypatch.setattr(streamable_transport_mod, "SessionLocal", TestSessionLocal, raising=False)
+
+    try:
+        yield TestClient(app, raise_server_exceptions=False)
+    finally:
+        engine.dispose()
+        os.close(fd)
+        os.unlink(path)
 
 
 @pytest.fixture
@@ -89,9 +119,7 @@ class TestUnauthenticatedDenied:
         """Product aliases must authenticate before reaching handlers or rewriting."""
         response = client.request(method, path, content=b"{}", follow_redirects=False)
 
-        assert response.status_code == 401, (
-            f"Expected 401 for unauthenticated {method} {path}, got {response.status_code}"
-        )
+        assert response.status_code == 401, f"Expected 401 for unauthenticated {method} {path}, got {response.status_code}"
 
     @pytest.mark.parametrize("path", ADMIN_V1_ROUTES)
     def test_admin_route_unauthenticated(self, client: TestClient, path: str) -> None:

--- a/tests/integration/test_openapi_spec.py
+++ b/tests/integration/test_openapi_spec.py
@@ -72,6 +72,9 @@ def test_v1_routes_in_openapi_spec(app_with_temp_db):
         "/v1/resources",
         "/v1/prompts",
         "/v1/gateways",
+        "/v1/mcp-servers",
+        "/v1/virtual-servers",
+        "/v1/virtual-servers/{server_id}/.well-known/oauth-protected-resource",
     ]
 
     missing = [route for route in expected_core_routes if route not in v1_paths]

--- a/tests/unit/mcpgateway/middleware/test_client_disconnect_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_client_disconnect_middleware.py
@@ -139,6 +139,8 @@ async def test_lifespan_passes_through():
         "/mcp/",
         "/servers/abc/sse",
         "/servers/abc/mcp",
+        "/v1/virtual-servers/abc/sse",
+        "/v1/virtual-servers/abc/mcp",
         "/_internal/mcp/transport",
         "/_internal/mcp/transport/",
     ],
@@ -194,6 +196,41 @@ async def test_regular_server_paths_not_skipped():
         receive = await _receive_messages([{"type": "http.request", "body": b"", "more_body": False}])
         await middleware(scope, receive, send)
         assert len(messages) == 2, f"Expected middleware to process {path}, not skip it"
+
+
+@pytest.mark.parametrize(
+    ("path", "root_path", "expect_passthrough"),
+    [
+        ("/dev/mcp-gateway/servers/abc/mcp", "/dev/mcp-gateway", True),
+        ("/dev/mcp-gateway/v1/virtual-servers/abc/mcp", "/dev/mcp-gateway", True),
+        ("/dev/mcp-gateway/v1/virtual-servers/abc/tools", "/dev/mcp-gateway", False),
+        ("/developer/v1/virtual-servers/abc/mcp", "/dev", False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_app_root_path_streaming_classification(path, root_path, expect_passthrough, monkeypatch):
+    """Root-prefixed streams bypass wrapping without broadening REST matches."""
+    # First-Party
+    from mcpgateway.config import settings
+
+    monkeypatch.setattr(settings, "app_root_path", root_path)
+    original_receive = await _receive_messages([{"type": "http.request", "body": b"", "more_body": False}])
+    messages: list[dict] = []
+
+    async def original_send(message):  # type: ignore[no-untyped-def]
+        messages.append(message)
+
+    async def tracking_app(scope, receive, send):  # type: ignore[no-untyped-def]
+        assert (receive is original_receive) is expect_passthrough
+        assert (send is original_send) is expect_passthrough
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    middleware = ClientDisconnectMiddleware(tracking_app)
+    scope = {"type": "http", "path": path}
+    await middleware(scope, original_receive, original_send)
+
+    assert len(messages) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/middleware/test_client_disconnect_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_client_disconnect_middleware.py
@@ -13,7 +13,7 @@ import asyncio
 import pytest
 
 # First-Party
-from mcpgateway.middleware.client_disconnect import ClientDisconnectMiddleware
+from mcpgateway.middleware.client_disconnect import _is_server_streaming_path, ClientDisconnectMiddleware
 
 
 async def _ok_app(scope, receive, send):  # type: ignore[no-untyped-def]
@@ -56,6 +56,23 @@ async def _receive_messages(messages):  # type: ignore[no-untyped-def]
         return {"type": "http.disconnect"}  # pragma: no cover
 
     return receive
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/servers/abc/mcp", True),
+        ("/v1/virtual-servers/abc/mcp", True),
+        ("/v1/virtual-servers/abc/mcp/", True),
+        ("/v1/virtual-servers/abc/sse", True),
+        ("/v1/virtual-servers/abc/tools", False),
+        ("/v1/virtual-servers//mcp", False),
+        ("/v1/virtual-servers/abc/mcp/extra", False),
+    ],
+)
+def test_is_server_streaming_path_replaces_alias(path: str, expected: bool) -> None:
+    """The virtual-server alias follows the standard streaming-path rules."""
+    assert _is_server_streaming_path(path) is expected
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/middleware/test_protocol_version.py
+++ b/tests/unit/mcpgateway/middleware/test_protocol_version.py
@@ -33,6 +33,21 @@ def _make_request(path: str, headers: Iterable[Tuple[bytes, bytes]] | None = Non
     return Request(scope, receive)
 
 
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/servers/server-1/sse", True),
+        ("/v1/virtual-servers/server-1/sse", True),
+        ("/v1/virtual-servers/server-1/ws", True),
+        ("/v1/virtual-servers/server-1/tools", False),
+    ],
+)
+def test_mcp_endpoint_classification_handles_alias(path: str, expected: bool) -> None:
+    """Versioned virtual servers share the standard transport classification."""
+    middleware = MCPProtocolVersionMiddleware(app=None)
+    assert middleware._is_mcp_endpoint(path) is expected
+
+
 @pytest.mark.asyncio
 async def test_non_mcp_endpoint_skips_validation():
     middleware = MCPProtocolVersionMiddleware(app=None)

--- a/tests/unit/mcpgateway/middleware/test_rbac_endpoint_coverage.py
+++ b/tests/unit/mcpgateway/middleware/test_rbac_endpoint_coverage.py
@@ -23,6 +23,11 @@ from unittest.mock import AsyncMock, MagicMock
 from fastapi import HTTPException
 import pytest
 
+# First-Party
+from mcpgateway.db import Permissions
+from mcpgateway.main import app
+from tests.helpers.router_helpers import collect_routes
+
 # ---------------------------------------------------------------------------
 # Helper: invoke a decorated function and assert 403
 # ---------------------------------------------------------------------------
@@ -83,6 +88,13 @@ async def _assert_permission_granted(func, user_ctx=None, mock_perm_service=None
         pass
 
 
+def _find_route_endpoint(path: str, method: str):
+    """Return the endpoint registered for an exact path and HTTP method."""
+    matches = [route for route_path, route, _ in collect_routes(app.router) if route_path == path and method in getattr(route, "methods", set())]
+    assert len(matches) == 1, f"Expected one {method} route for {path}, found {len(matches)}"
+    return matches[0].endpoint
+
+
 # ---------------------------------------------------------------------------
 # D6.1: Main endpoint permissions (main.py)
 # ---------------------------------------------------------------------------
@@ -118,6 +130,33 @@ class TestMainEndpointPermissions:
             return {"status": "ok"}
 
         await _assert_permission_granted(dummy_endpoint, mock_perm_service=mock_permission_service)
+
+
+class TestV1ServerAliasPermissions:
+    """Verify the product-language v1 aliases retain CRUD RBAC enforcement."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "method,path,permission",
+        [
+            ("POST", "/v1/virtual-servers", Permissions.SERVERS_CREATE),
+            ("GET", "/v1/virtual-servers/{server_id}", Permissions.SERVERS_READ),
+            ("PUT", "/v1/virtual-servers/{server_id}", Permissions.SERVERS_UPDATE),
+            ("DELETE", "/v1/virtual-servers/{server_id}", Permissions.SERVERS_DELETE),
+            ("POST", "/v1/mcp-servers", Permissions.GATEWAYS_CREATE),
+            ("GET", "/v1/mcp-servers/{gateway_id}", Permissions.GATEWAYS_READ),
+            ("PUT", "/v1/mcp-servers/{gateway_id}", Permissions.GATEWAYS_UPDATE),
+            ("DELETE", "/v1/mcp-servers/{gateway_id}", Permissions.GATEWAYS_DELETE),
+        ],
+    )
+    async def test_v1_alias_crud_route_enforces_permission(self, mock_permission_service, method, path, permission):
+        """Each aliased route must reject a caller denied its declared permission."""
+        mock_permission_service.check_permission = AsyncMock(return_value=False)
+        endpoint = _find_route_endpoint(path, method)
+
+        assert getattr(endpoint, "_required_permission", None) == permission
+        await _assert_permission_denied(endpoint)
+        assert mock_permission_service.check_permission.await_args.kwargs["permission"] == permission
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/middleware/test_security_headers_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_security_headers_middleware.py
@@ -32,6 +32,20 @@ async def _call_next(request):
     return Response("ok")
 
 
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/v1/virtual-servers/server-1/tools", True),
+        ("/v1/mcp-servers/gateway-1", True),
+        ("/v1/virtual-servers/server-1/.well-known/oauth-protected-resource", False),
+    ],
+)
+def test_protected_path_classification_handles_alias(path: str, expected: bool) -> None:
+    """Product aliases inherit the standard cache-protection rules."""
+    middleware = SecurityHeadersMiddleware(app=None)
+    assert middleware._is_protected_path(path) is expected
+
+
 def _mock_settings():
     """Create base mock settings."""
     mock = patch("mcpgateway.middleware.security_headers.settings")

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -250,6 +250,73 @@ class TestTokenScopingMiddleware:
         result = middleware._check_permission_restrictions("/tools", "POST", ["tools.write"])
         assert result == False, "Should reject non-canonical 'tools.write' permission"
 
+    def test_versioned_virtual_server_restriction_checks_alias_id(self, middleware):
+        """Server-scoped tokens must enforce the ID in versioned virtual-server paths."""
+        path = "/v1/virtual-servers/server-123/tools"
+
+        assert middleware._check_server_restriction(path, "server-123") is True
+        assert middleware._check_server_restriction(path, "server-456") is False
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v1/virtual-servers/a1b2c3d4-e5f6-0000-1111-222233334444",
+            "/v1/mcp-servers/a1b2c3d4-e5f6-0000-1111-222233334444",
+        ],
+    )
+    def test_versioned_server_aliases_enforce_resource_ownership(self, middleware, path):
+        """Versioned aliases must resolve to an owned server or gateway resource."""
+        db = MagicMock()
+        resource = MagicMock()
+        resource.visibility = "team"
+        resource.team_id = "team-1"
+        db.execute.return_value.scalar_one_or_none.return_value = resource
+
+        allowed = middleware._check_resource_team_ownership(path, ["team-1"], db=db, _user_email="user@example.com")
+        denied = middleware._check_resource_team_ownership(path, ["team-2"], db=db, _user_email="user@example.com")
+
+        assert allowed is ResourceOwnershipResult.ALLOWED
+        assert denied is ResourceOwnershipResult.DENIED
+        assert db.execute.call_count == 2
+
+    @pytest.mark.parametrize(
+        "method,path,permission",
+        [
+            ("GET", "/v1/virtual-servers", Permissions.SERVERS_READ),
+            ("POST", "/v1/virtual-servers", Permissions.SERVERS_CREATE),
+            ("GET", "/v1/virtual-servers/server-1", Permissions.SERVERS_READ),
+            ("PUT", "/v1/virtual-servers/server-1", Permissions.SERVERS_UPDATE),
+            ("DELETE", "/v1/virtual-servers/server-1", Permissions.SERVERS_DELETE),
+            ("GET", "/v1/virtual-servers/server-1/tools", Permissions.TOOLS_READ),
+            ("POST", "/v1/virtual-servers/server-1/tools/tool-1/call", Permissions.TOOLS_EXECUTE),
+            ("GET", "/v1/virtual-servers/server-1/resources", Permissions.RESOURCES_READ),
+            ("GET", "/v1/virtual-servers/server-1/prompts", Permissions.SERVERS_READ),
+            ("GET", "/v1/virtual-servers/server-1/sse", Permissions.SERVERS_USE),
+            ("POST", "/v1/virtual-servers/server-1/message", Permissions.SERVERS_USE),
+            ("POST", "/v1/virtual-servers/server-1/mcp", Permissions.SERVERS_USE),
+            ("POST", "/v1/virtual-servers/server-1/state", Permissions.SERVERS_UPDATE),
+            ("POST", "/v1/virtual-servers/server-1/toggle", Permissions.SERVERS_UPDATE),
+            ("GET", "/v1/mcp-servers", Permissions.GATEWAYS_READ),
+            ("POST", "/v1/mcp-servers", Permissions.GATEWAYS_CREATE),
+            ("GET", "/v1/mcp-servers/gateway-1", Permissions.GATEWAYS_READ),
+            ("PUT", "/v1/mcp-servers/gateway-1", Permissions.GATEWAYS_UPDATE),
+            ("DELETE", "/v1/mcp-servers/gateway-1", Permissions.GATEWAYS_DELETE),
+            ("POST", "/v1/mcp-servers/gateway-1/state", Permissions.GATEWAYS_UPDATE),
+            ("POST", "/v1/mcp-servers/gateway-1/toggle", Permissions.GATEWAYS_UPDATE),
+            ("POST", "/v1/mcp-servers/gateway-1/tools/refresh", Permissions.GATEWAYS_UPDATE),
+        ],
+    )
+    def test_versioned_server_aliases_require_matching_permission(self, middleware, method, path, permission):
+        """Versioned server aliases must mirror the legacy route permission mapping."""
+        assert middleware._check_permission_restrictions(path, method, [permission]) is True
+        assert middleware._check_permission_restrictions(path, method, [Permissions.TOKENS_READ]) is False
+
+    @pytest.mark.parametrize("path", ["/v1/mcp-servers/test", "/v1/mcp-servers/test/"])
+    def test_versioned_mcp_server_test_route_keeps_read_permission(self, middleware, path):
+        """The connectivity test route must not be classified as an update sub-resource."""
+        assert middleware._check_permission_restrictions(path, "POST", [Permissions.GATEWAYS_READ]) is True
+        assert middleware._check_permission_restrictions(path, "POST", [Permissions.GATEWAYS_UPDATE]) is False
+
     def test_plugin_discovery_requires_plugins_read(self, middleware):
         """Versioned plugin discovery uses explicit least-privilege permission."""
         assert middleware._check_permission_restrictions("/v1/plugins", "GET", [Permissions.PLUGINS_READ]) is True

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -2267,6 +2267,8 @@ async def test_team_scoped_resource_denied(monkeypatch):
         ("/gateways/aabbccdd-eeff-0011-2233-445566778899", []),
         ("/v1/servers/aabbccddeeff00112233445566778899", ["team-1"]),
         ("/v1/gateways/aabbccddeeff00112233445566778899", []),
+        ("/v1/virtual-servers/aabbccddeeff00112233445566778899", ["team-1"]),  # pragma: allowlist secret
+        ("/v1/mcp-servers/aabbccddeeff00112233445566778899", []),
     ],
 )
 async def test_missing_targeted_delete_returns_404(monkeypatch, path, token_teams):

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -317,6 +317,67 @@ class TestTokenScopingMiddleware:
         assert middleware._check_permission_restrictions(path, "POST", [Permissions.GATEWAYS_READ]) is True
         assert middleware._check_permission_restrictions(path, "POST", [Permissions.GATEWAYS_UPDATE]) is False
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v1/virtual-servers/a1b2c3d4-e5f6-0000-1111-222233334444/mcp",
+            "/v1/mcp-servers/a1b2c3d4-e5f6-0000-1111-222233334444",
+        ],
+    )
+    async def test_versioned_server_aliases_deny_wrong_team(self, middleware, mock_request, monkeypatch, path):
+        """A team-scoped token must not access either v1 alias for another team."""
+        mock_request.url.path = path
+        mock_request.scope["path"] = path
+        mock_request.method = "POST" if path.endswith("/mcp") else "GET"
+        mock_request.headers = {"Authorization": "Bearer token"}
+        payload = {"sub": "user@example.com", "teams": ["team-1"], "scopes": {"permissions": ["*"]}}
+        db = MagicMock()
+        resource = MagicMock(visibility="team", team_id="team-2", owner_email="owner@example.com")
+        db.execute.return_value.scalar_one_or_none.return_value = resource
+        monkeypatch.setattr("mcpgateway.db.get_db", lambda: iter([db]))
+
+        with (
+            patch.object(middleware, "_extract_token_scopes", new=AsyncMock(return_value=payload)),
+            patch.object(middleware, "_check_team_membership", return_value=True),
+            patch.object(middleware, "_check_resource_team_ownership", wraps=middleware._check_resource_team_ownership) as ownership_check,
+        ):
+            call_next = AsyncMock()
+            response = await middleware(mock_request, call_next)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        ownership_check.assert_called_once_with(path, ["team-1"], db=db, _user_email="user@example.com")
+        call_next.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method", "path"),
+        [
+            ("POST", "/v1/virtual-servers"),
+            ("POST", "/v1/virtual-servers/server-123/mcp"),
+            ("POST", "/v1/mcp-servers"),
+        ],
+    )
+    async def test_versioned_server_aliases_deny_insufficient_permissions(self, middleware, mock_request, method, path):
+        """An unrelated token permission must not reach a v1 alias handler."""
+        mock_request.url.path = path
+        mock_request.scope["path"] = path
+        mock_request.method = method
+        mock_request.headers = {"Authorization": "Bearer token"}
+        payload = {
+            "sub": "admin@example.com",
+            "teams": None,
+            "is_admin": True,
+            "scopes": {"permissions": [Permissions.TOKENS_READ]},
+        }
+
+        with patch.object(middleware, "_extract_token_scopes", new=AsyncMock(return_value=payload)):
+            call_next = AsyncMock()
+            response = await middleware(mock_request, call_next)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        call_next.assert_not_called()
+
     def test_plugin_discovery_requires_plugins_read(self, middleware):
         """Versioned plugin discovery uses explicit least-privilege permission."""
         assert middleware._check_permission_restrictions("/v1/plugins", "GET", [Permissions.PLUGINS_READ]) is True

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -24,6 +24,7 @@ import pytest
 from mcpgateway.config import settings
 from mcpgateway.db import Permissions
 from mcpgateway.middleware.token_scoping import ResourceOwnershipResult, _get_llm_permission_patterns, TokenScopingMiddleware
+from mcpgateway.utils.paths import replace_api_path_alias
 
 
 def _trusted_internal_runtime_headers() -> dict[str, str]:
@@ -346,7 +347,7 @@ class TestTokenScopingMiddleware:
             response = await middleware(mock_request, call_next)
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
-        ownership_check.assert_called_once_with(path, ["team-1"], db=db, _user_email="user@example.com")
+        ownership_check.assert_called_once_with(replace_api_path_alias(path), ["team-1"], db=db, _user_email="user@example.com")
         call_next.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/middleware/test_token_scoping_normalization.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping_normalization.py
@@ -39,6 +39,8 @@ from mcpgateway.middleware.token_scoping import TokenScopingMiddleware, _normali
         # Complex paths
         ("/v1/servers/abc/tools", "/servers/abc/tools"),
         ("/v1/teams/123/members", "/teams/123/members"),
+        ("/v1/virtual-servers/abc/prompts", "/servers/abc/prompts"),
+        ("/v1/mcp-servers/abc/tools/refresh", "/gateways/abc/tools/refresh"),
     ],
 )
 def test_normalize_path_for_matching(input_path, expected):

--- a/tests/unit/mcpgateway/test_api_v1.py
+++ b/tests/unit/mcpgateway/test_api_v1.py
@@ -139,13 +139,17 @@ class TestBuildV1RouterGroupA:
         settings = _settings()
         kwargs = _required_kwargs()
         v1 = build_v1_router(settings, **kwargs)
-        assert "/v1/sentinel-gateway" in _route_paths(v1)
+        paths = _route_paths(v1)
+        assert "/v1/gateways/sentinel-gateway" in paths
+        assert "/v1/mcp-servers/sentinel-gateway" in paths
 
     def test_server_router_included(self):
         settings = _settings()
         kwargs = _required_kwargs()
         v1 = build_v1_router(settings, **kwargs)
-        assert "/v1/sentinel-server" in _route_paths(v1)
+        paths = _route_paths(v1)
+        assert "/v1/servers/sentinel-server" in paths
+        assert "/v1/virtual-servers/sentinel-server" in paths
 
     def test_metrics_router_included(self):
         settings = _settings()

--- a/tests/unit/mcpgateway/test_api_versioning_parity.py
+++ b/tests/unit/mcpgateway/test_api_versioning_parity.py
@@ -55,7 +55,6 @@ def test_legacy_prefixes_match_assembled_routers():
     test_router = APIRouter()
 
     # Create minimal mock routers with at least one route each
-    # Gateway and server prefixes are applied during router assembly.
     mock_routers = {}
     router_prefixes = {
         "protocol": "/protocol",

--- a/tests/unit/mcpgateway/test_api_versioning_parity.py
+++ b/tests/unit/mcpgateway/test_api_versioning_parity.py
@@ -55,16 +55,16 @@ def test_legacy_prefixes_match_assembled_routers():
     test_router = APIRouter()
 
     # Create minimal mock routers with at least one route each
-    # Use the actual prefix names from main.py (plural forms)
+    # Gateway and server prefixes are applied during router assembly.
     mock_routers = {}
     router_prefixes = {
         "protocol": "/protocol",
         "tool": "/tools",           # Note: router name is singular, prefix is plural
         "resource": "/resources",
         "prompt": "/prompts",
-        "gateway": "/gateways",
+        "gateway": "",
         "root": "/roots",
-        "server": "/servers",
+        "server": "",
         "metrics": "/metrics",
         "tag": "/tags",
         "a2a": "/a2a",

--- a/tests/unit/mcpgateway/test_legacy_router.py
+++ b/tests/unit/mcpgateway/test_legacy_router.py
@@ -136,7 +136,9 @@ class TestBuildLegacyRouterGroupA:
 
     def test_gateway_router_at_root(self):
         v = build_legacy_router(_settings(), **_required_kwargs())
-        assert "/sentinel-gateway" in _route_paths(v)
+        paths = _route_paths(v)
+        assert "/gateways/sentinel-gateway" in paths
+        assert "/mcp-servers/sentinel-gateway" not in paths
 
     def test_root_router_at_root(self):
         v = build_legacy_router(_settings(), **_required_kwargs())
@@ -144,7 +146,9 @@ class TestBuildLegacyRouterGroupA:
 
     def test_server_router_at_root(self):
         v = build_legacy_router(_settings(), **_required_kwargs())
-        assert "/sentinel-server" in _route_paths(v)
+        paths = _route_paths(v)
+        assert "/servers/sentinel-server" in paths
+        assert "/virtual-servers/sentinel-server" not in paths
 
     def test_metrics_router_at_root(self):
         v = build_legacy_router(_settings(), **_required_kwargs())

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -3669,6 +3669,28 @@ class TestRealtimeEndpoints:
         assert response.status_code == 404
         assert response.json()["detail"] == "Server not found"
 
+    @pytest.mark.parametrize("path_prefix", SERVER_CRUD_PREFIXES)
+    def test_server_message_endpoint_checks_nonexistent_server_before_auth(self, app_with_temp_db, path_prefix):
+        """Missing servers retain the legacy 404 response before authentication."""
+        # First-Party
+        from mcpgateway.middleware.rbac import get_current_user_with_permissions
+
+        def reject_unauthenticated_request():
+            """Simulate the authentication dependency's unauthenticated response."""
+            raise HTTPException(status_code=401, detail="Not authenticated")
+
+        app_with_temp_db.dependency_overrides[get_current_user_with_permissions] = reject_unauthenticated_request
+        try:
+            client = TestClient(app_with_temp_db, raise_server_exceptions=False)
+            message = {"type": "test", "data": "hello"}
+            with patch("mcpgateway.services.server_service.ServerService.entity_exists", new=AsyncMock(return_value=False)):
+                response = client.post(f"{path_prefix}/nonexistent-id/message?session_id=test-session", json=message)
+        finally:
+            app_with_temp_db.dependency_overrides.pop(get_current_user_with_permissions, None)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Server not found"
+
     def test_server_message_endpoint_returns_503_on_db_error(self, test_client, auth_headers):
         """Server message endpoint returns 503 when database validation fails (fail-closed)."""
         message = {"type": "test", "data": "hello"}

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -195,6 +195,9 @@ MOCK_ROOT = {
     "name": "Test Root",
 }
 
+SERVER_CRUD_PREFIXES = ("/servers", "/v1/virtual-servers")
+GATEWAY_CRUD_PREFIXES = ("/gateways", "/v1/mcp-servers")
+
 
 class _ValidationModel(BaseModel):
     value: int
@@ -906,11 +909,12 @@ class TestServerEndpoints:
         assert len(data) == 1 and data[0]["name"] == "test_server"
         mock_list_servers.assert_called_once()
 
+    @pytest.mark.parametrize("path_prefix", SERVER_CRUD_PREFIXES)
     @patch("mcpgateway.main.server_service.get_server")
-    def test_get_server_endpoint(self, mock_get, test_client, auth_headers):
-        """Test retrieving a specific server."""
+    def test_get_server_endpoint(self, mock_get, path_prefix, test_client, auth_headers):
+        """Test retrieving a specific server through old and new path prefixes."""
         mock_get.return_value = ServerRead(**MOCK_SERVER_READ)
-        response = test_client.get("/servers/1", headers=auth_headers)
+        response = test_client.get(f"{path_prefix}/1", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["name"] == "test_server"
         mock_get.assert_called_once()
@@ -926,12 +930,13 @@ class TestServerEndpoints:
         assert response.status_code == 404
         mock_get.assert_called_once()
 
+    @pytest.mark.parametrize("path_prefix", SERVER_CRUD_PREFIXES)
     @patch("mcpgateway.main.server_service.register_server")
-    def test_create_server_endpoint(self, mock_create, test_client, auth_headers):
-        """Test creating a new server."""
+    def test_create_server_endpoint(self, mock_create, path_prefix, test_client, auth_headers):
+        """Test creating a server through old and new path prefixes."""
         mock_create.return_value = ServerRead(**MOCK_SERVER_READ)
         req = {"server": {"name": "test_server", "description": "A test server"}, "team_id": None, "visibility": "private"}
-        response = test_client.post("/servers/", json=req, headers=auth_headers)
+        response = test_client.post(f"{path_prefix}/", json=req, headers=auth_headers)
         assert response.status_code == 201
         mock_create.assert_called_once()
 
@@ -951,12 +956,13 @@ class TestServerEndpoints:
         detail = response.json()["detail"][0]
         assert "Invalid ID format" in detail["msg"]
 
+    @pytest.mark.parametrize("path_prefix", SERVER_CRUD_PREFIXES)
     @patch("mcpgateway.main.server_service.update_server")
-    def test_update_server_endpoint(self, mock_update, test_client, auth_headers):
-        """Test updating an existing server."""
+    def test_update_server_endpoint(self, mock_update, path_prefix, test_client, auth_headers):
+        """Test updating a server through old and new path prefixes."""
         mock_update.return_value = ServerRead(**MOCK_SERVER_READ)
         req = {"description": "Updated description"}
-        response = test_client.put("/servers/1", json=req, headers=auth_headers)
+        response = test_client.put(f"{path_prefix}/1", json=req, headers=auth_headers)
         assert response.status_code == 200
         mock_update.assert_called_once()
 
@@ -1002,13 +1008,14 @@ class TestServerEndpoints:
         response = test_client.post("/servers/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 404
 
+    @pytest.mark.parametrize("path_prefix", SERVER_CRUD_PREFIXES)
     @patch("mcpgateway.main.server_service.delete_server")
     @patch("mcpgateway.main.server_service.get_server")
-    def test_delete_server_endpoint(self, mock_get, mock_delete, test_client, auth_headers):
-        """Test permanently deleting a server."""
+    def test_delete_server_endpoint(self, mock_get, mock_delete, path_prefix, test_client, auth_headers):
+        """Test deleting a server through old and new path prefixes."""
         mock_get.return_value = ServerRead(**MOCK_SERVER_READ)
         mock_delete.return_value = None
-        response = test_client.delete("/servers/1", headers=auth_headers)
+        response = test_client.delete(f"{path_prefix}/1", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
@@ -2228,12 +2235,13 @@ class TestGatewayEndpoints:
         assert len(data) == 1
         mock_list.assert_called_once()
 
+    @pytest.mark.parametrize("path_prefix", GATEWAY_CRUD_PREFIXES)
     @patch("mcpgateway.main.gateway_service.register_gateway")
-    def test_create_gateway_endpoint(self, mock_create, test_client, auth_headers):
-        """Test registering a new gateway."""
+    def test_create_gateway_endpoint(self, mock_create, path_prefix, test_client, auth_headers):
+        """Test creating a gateway through old and new path prefixes."""
         mock_create.return_value = MOCK_GATEWAY_READ
         req = {"name": "test_gateway", "url": "http://example.com"}
-        response = test_client.post("/gateways/", json=req, headers=auth_headers)
+        response = test_client.post(f"{path_prefix}/", json=req, headers=auth_headers)
         assert response.status_code == 200
         mock_create.assert_called_once()
 
@@ -2263,11 +2271,12 @@ class TestGatewayEndpoints:
         data = response.json()
         assert data["skippedTools"] == skipped
 
+    @pytest.mark.parametrize("path_prefix", GATEWAY_CRUD_PREFIXES)
     @patch("mcpgateway.main.gateway_service.get_gateway")
-    def test_get_gateway_endpoint(self, mock_get, test_client, auth_headers):
-        """Test retrieving a specific gateway."""
+    def test_get_gateway_endpoint(self, mock_get, path_prefix, test_client, auth_headers):
+        """Test retrieving a gateway through old and new path prefixes."""
         mock_get.return_value = MOCK_GATEWAY_READ
-        response = test_client.get("/gateways/1", headers=auth_headers)
+        response = test_client.get(f"{path_prefix}/1", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["name"] == "test_gateway"
         mock_get.assert_called_once()
@@ -2295,12 +2304,13 @@ class TestGatewayEndpoints:
         assert "ambiguous" in response.json()["detail"]
         mock_get.assert_called_once()
 
+    @pytest.mark.parametrize("path_prefix", GATEWAY_CRUD_PREFIXES)
     @patch("mcpgateway.main.gateway_service.update_gateway")
-    def test_update_gateway_endpoint(self, mock_update, test_client, auth_headers):
-        """Test updating an existing gateway."""
+    def test_update_gateway_endpoint(self, mock_update, path_prefix, test_client, auth_headers):
+        """Test updating a gateway through old and new path prefixes."""
         mock_update.return_value = MOCK_GATEWAY_READ
         req = {"description": "Updated description"}
-        response = test_client.put("/gateways/1", json=req, headers=auth_headers)
+        response = test_client.put(f"{path_prefix}/1", json=req, headers=auth_headers)
         assert response.status_code == 200
         mock_update.assert_called_once()
 
@@ -2315,13 +2325,14 @@ class TestGatewayEndpoints:
         assert response.headers["Retry-After"] == "5"
         mock_update.assert_called_once()
 
+    @pytest.mark.parametrize("path_prefix", GATEWAY_CRUD_PREFIXES)
     @patch("mcpgateway.main.gateway_service.delete_gateway")
     @patch("mcpgateway.main.gateway_service.get_gateway")
-    def test_delete_gateway_endpoint(self, mock_get, mock_delete, test_client, auth_headers):
-        """Test deleting a gateway."""
+    def test_delete_gateway_endpoint(self, mock_get, mock_delete, path_prefix, test_client, auth_headers):
+        """Test deleting a gateway through old and new path prefixes."""
         mock_delete.return_value = None
         mock_get.return_value.capabilities = {}
-        response = test_client.delete("/gateways/1", headers=auth_headers)
+        response = test_client.delete(f"{path_prefix}/1", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -197,6 +197,58 @@ MOCK_ROOT = {
 
 SERVER_CRUD_PREFIXES = ("/servers", "/v1/virtual-servers")
 GATEWAY_CRUD_PREFIXES = ("/gateways", "/v1/mcp-servers")
+MISSING_ALIAS_RESOURCE_ID = "cccccccccccccccccccccccccccccccc"
+ALIAS_RESPONSE_CASES = (
+    pytest.param("GET", "/gateways", "/v1/mcp-servers", None, id="list-mcp-servers"),
+    pytest.param("POST", "/gateways", "/v1/mcp-servers", {}, id="create-mcp-server"),
+    pytest.param("GET", f"/gateways/{MISSING_ALIAS_RESOURCE_ID}", f"/v1/mcp-servers/{MISSING_ALIAS_RESOURCE_ID}", None, id="read-mcp-server"),
+    pytest.param("PUT", f"/gateways/{MISSING_ALIAS_RESOURCE_ID}", f"/v1/mcp-servers/{MISSING_ALIAS_RESOURCE_ID}", {}, id="update-mcp-server"),
+    pytest.param("DELETE", f"/gateways/{MISSING_ALIAS_RESOURCE_ID}", f"/v1/mcp-servers/{MISSING_ALIAS_RESOURCE_ID}", None, id="delete-mcp-server"),
+    pytest.param(
+        "POST",
+        f"/gateways/{MISSING_ALIAS_RESOURCE_ID}/state?activate=false",
+        f"/v1/mcp-servers/{MISSING_ALIAS_RESOURCE_ID}/state?activate=false",
+        None,
+        id="set-mcp-server-state",
+    ),
+    pytest.param(
+        "POST",
+        f"/gateways/{MISSING_ALIAS_RESOURCE_ID}/tools/refresh",
+        f"/v1/mcp-servers/{MISSING_ALIAS_RESOURCE_ID}/tools/refresh",
+        None,
+        id="refresh-mcp-server-tools",
+    ),
+    pytest.param("GET", "/servers", "/v1/virtual-servers", None, id="list-virtual-servers"),
+    pytest.param("POST", "/servers", "/v1/virtual-servers", {}, id="create-virtual-server"),
+    pytest.param("GET", f"/servers/{MISSING_ALIAS_RESOURCE_ID}", f"/v1/virtual-servers/{MISSING_ALIAS_RESOURCE_ID}", None, id="read-virtual-server"),
+    pytest.param("PUT", f"/servers/{MISSING_ALIAS_RESOURCE_ID}", f"/v1/virtual-servers/{MISSING_ALIAS_RESOURCE_ID}", {}, id="update-virtual-server"),
+    pytest.param("DELETE", f"/servers/{MISSING_ALIAS_RESOURCE_ID}", f"/v1/virtual-servers/{MISSING_ALIAS_RESOURCE_ID}", None, id="delete-virtual-server"),
+    pytest.param(
+        "POST",
+        f"/servers/{MISSING_ALIAS_RESOURCE_ID}/state?activate=false",
+        f"/v1/virtual-servers/{MISSING_ALIAS_RESOURCE_ID}/state?activate=false",
+        None,
+        id="set-virtual-server-state",
+    ),
+    pytest.param("GET", f"/servers/{MISSING_ALIAS_RESOURCE_ID}/sse", f"/v1/virtual-servers/{MISSING_ALIAS_RESOURCE_ID}/sse", None, id="virtual-server-sse"),
+    pytest.param(
+        "POST",
+        f"/servers/{MISSING_ALIAS_RESOURCE_ID}/message?session_id=alias-parity",
+        f"/v1/virtual-servers/{MISSING_ALIAS_RESOURCE_ID}/message?session_id=alias-parity",
+        {"jsonrpc": "2.0", "method": "ping"},
+        id="virtual-server-message",
+    ),
+    pytest.param("GET", f"/servers/{MISSING_ALIAS_RESOURCE_ID}/tools", f"/v1/virtual-servers/{MISSING_ALIAS_RESOURCE_ID}/tools", None, id="virtual-server-tools"),
+    pytest.param("GET", f"/servers/{MISSING_ALIAS_RESOURCE_ID}/resources", f"/v1/virtual-servers/{MISSING_ALIAS_RESOURCE_ID}/resources", None, id="virtual-server-resources"),
+    pytest.param("GET", f"/servers/{MISSING_ALIAS_RESOURCE_ID}/prompts", f"/v1/virtual-servers/{MISSING_ALIAS_RESOURCE_ID}/prompts", None, id="virtual-server-prompts"),
+    pytest.param(
+        "GET",
+        f"/servers/{MISSING_ALIAS_RESOURCE_ID}/.well-known/robots.txt",
+        f"/v1/virtual-servers/{MISSING_ALIAS_RESOURCE_ID}/.well-known/robots.txt",
+        None,
+        id="virtual-server-well-known",
+    ),
+)
 
 
 class _ValidationModel(BaseModel):
@@ -2356,6 +2408,24 @@ class TestGatewayEndpoints:
         response = test_client.post("/gateways/1/state?activate=false", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["status"] == "success"
+
+
+class TestProductAliasResponseParity:
+    """Verify every product-language alias matches its legacy HTTP response."""
+
+    @pytest.mark.parametrize("method,legacy_path,alias_path,json_body", ALIAS_RESPONSE_CASES)
+    def test_alias_response_matches_legacy(self, method, legacy_path, alias_path, json_body, test_client, auth_headers):
+        """Compare status, body, and content type while ignoring legacy deprecation headers."""
+        request_kwargs = {"headers": auth_headers, "follow_redirects": False}
+        if json_body is not None:
+            request_kwargs["json"] = json_body
+
+        legacy_response = test_client.request(method, legacy_path, **request_kwargs)
+        alias_response = test_client.request(method, alias_path, **request_kwargs)
+
+        assert alias_response.status_code == legacy_response.status_code
+        assert alias_response.content == legacy_response.content
+        assert alias_response.headers.get("content-type") == legacy_response.headers.get("content-type")
 
 
 # ----------------------------------------------------- #

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -120,6 +120,9 @@ from mcpgateway.services.tool_service import ToolError, ToolNotFoundError
 from mcpgateway.transports.streamablehttp_transport import user_context_var
 from mcpgateway.validation.jsonrpc import JSONRPCError
 
+# Local
+from tests.helpers.router_helpers import collect_routes
+
 
 def _make_request(
     path: str,
@@ -3061,6 +3064,13 @@ class TestAdminAuthMiddleware:
 class TestMCPPathRewriteMiddleware:
     """Cover MCPPathRewriteMiddleware branches."""
 
+    def test_versioned_virtual_server_well_known_alias_registered(self):
+        """The per-server well-known router is available under the new v1 alias."""
+        paths = {path for path, *_ in collect_routes(app.router)}
+
+        assert "/v1/virtual-servers/{server_id}/.well-known/oauth-protected-resource" in paths
+        assert "/v1/virtual-servers/{server_id}/.well-known/{filename:path}" in paths
+
     @pytest.mark.asyncio
     async def test_rewrite_exact_mcp_path_prevents_mount_redirect(self):
         """Exact /mcp is internally normalized so Starlette Mount cannot emit 307."""
@@ -3266,6 +3276,28 @@ class TestMCPPathRewriteMiddleware:
         app_mock.assert_called_once_with(scope, receive, send)
 
     @pytest.mark.asyncio
+    async def test_rewrite_virtual_server_alias_preserves_server_id(self):
+        """The v1 alias rewrites to /mcp/ while retaining canonical server scope."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {
+            "type": "http",
+            "path": "/v1/virtual-servers/server-123/mcp",
+            "raw_path": b"/v1/virtual-servers/server-123/mcp",
+            "headers": [],
+        }
+        receive = AsyncMock()
+        send = AsyncMock()
+
+        with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=True)):
+            await middleware._call_streamable_http(scope, receive, send)
+
+        assert scope["modified_path"] == "/servers/server-123/mcp"
+        assert scope["path"] == "/mcp/"
+        assert scope["raw_path"] == b"/mcp/"
+        app_mock.assert_called_once_with(scope, receive, send)
+
+    @pytest.mark.asyncio
     async def test_rewrite_auth_failure(self):
         app_mock = AsyncMock()
         middleware = MCPPathRewriteMiddleware(app_mock)
@@ -3310,11 +3342,12 @@ class TestMCPPathRewriteMiddleware:
         app_mock.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_rewrite_rejects_empty_server_id_segment(self):
-        """Middleware returns 404 for /servers//mcp (empty server ID)."""
+    @pytest.mark.parametrize("path", ["/servers//mcp", "/v1/virtual-servers//mcp"])
+    async def test_rewrite_rejects_empty_server_id_segment(self, path):
+        """Middleware returns 404 for recognised MCP paths with an empty server ID."""
         app_mock = AsyncMock()
         middleware = MCPPathRewriteMiddleware(app_mock)
-        scope = {"type": "http", "path": "/servers//mcp", "headers": []}
+        scope = {"type": "http", "path": path, "headers": []}
         receive = AsyncMock()
         sent = []
 

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -3276,23 +3276,25 @@ class TestMCPPathRewriteMiddleware:
         app_mock.assert_called_once_with(scope, receive, send)
 
     @pytest.mark.asyncio
-    async def test_rewrite_virtual_server_alias_preserves_server_id(self):
-        """The v1 alias rewrites to /mcp/ while retaining canonical server scope."""
+    @pytest.mark.parametrize("trailing_slash", ["", "/"])
+    async def test_rewrite_virtual_server_alias_preserves_server_id(self, trailing_slash):
+        """The public v1 alias rewrites while retaining canonical server scope."""
         app_mock = AsyncMock()
         middleware = MCPPathRewriteMiddleware(app_mock)
+        public_path = f"/v1/virtual-servers/server-123/mcp{trailing_slash}"
         scope = {
             "type": "http",
-            "path": "/v1/virtual-servers/server-123/mcp",
-            "raw_path": b"/v1/virtual-servers/server-123/mcp",
+            "path": public_path,
+            "raw_path": public_path.encode(),
             "headers": [],
         }
         receive = AsyncMock()
         send = AsyncMock()
 
         with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=True)):
-            await middleware._call_streamable_http(scope, receive, send)
+            await middleware(scope, receive, send)
 
-        assert scope["modified_path"] == "/servers/server-123/mcp"
+        assert scope["modified_path"] == f"/servers/server-123/mcp{trailing_slash}"
         assert scope["path"] == "/mcp/"
         assert scope["raw_path"] == b"/mcp/"
         app_mock.assert_called_once_with(scope, receive, send)

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -3312,9 +3312,39 @@ class TestMCPPathRewriteMiddleware:
 
         app_mock.assert_not_called()
 
+    @pytest.mark.parametrize(
+        ("path", "root_path", "expected_request_path"),
+        [
+            ("/v1/virtual-servers/server-123/mcp", "", "/servers/server-123/mcp"),
+            ("/gateway/servers/server-123/mcp", "/gateway", "/servers/server-123/mcp"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_auth_uses_internal_path_without_changing_scope(self, path, root_path, expected_request_path):
+        """Authentication receives the internal path while the ASGI scope stays unchanged."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {"type": "http", "path": path, "root_path": root_path, "headers": []}
+        receive = AsyncMock()
+        send = AsyncMock()
+        observed: dict[str, str] = {}
+
+        async def check_auth_path(auth_scope, _receive, _send, *, request_path=None):
+            observed["scope_path"] = auth_scope["path"]
+            observed["request_path"] = request_path
+            return False
+
+        with patch("mcpgateway.main.streamable_http_auth", side_effect=check_auth_path):
+            await middleware._call_streamable_http(scope, receive, send)
+
+        assert observed == {"scope_path": path, "request_path": expected_request_path}
+        assert scope["path"] == path
+        assert "modified_path" not in scope
+        app_mock.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_exact_mcp_auth_failure_blocks_rewrite(self):
-        """Exact /mcp auth failures return before normalization mutates the scope."""
+        """Exact /mcp auth failures return before rewrite state is added."""
         app_mock = AsyncMock()
         middleware = MCPPathRewriteMiddleware(app_mock)
         scope = {"type": "http", "path": "/mcp", "headers": []}

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -120,9 +120,6 @@ from mcpgateway.services.tool_service import ToolError, ToolNotFoundError
 from mcpgateway.transports.streamablehttp_transport import user_context_var
 from mcpgateway.validation.jsonrpc import JSONRPCError
 
-# Local
-from tests.helpers.router_helpers import collect_routes
-
 
 def _make_request(
     path: str,
@@ -3066,6 +3063,9 @@ class TestMCPPathRewriteMiddleware:
 
     def test_versioned_virtual_server_well_known_alias_registered(self):
         """The per-server well-known router is available under the new v1 alias."""
+        # Local
+        from tests.helpers.router_helpers import collect_routes
+
         paths = {path for path, *_ in collect_routes(app.router)}
 
         assert "/v1/virtual-servers/{server_id}/.well-known/oauth-protected-resource" in paths

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -14027,6 +14027,37 @@ async def test_streamable_http_auth_rejects_unauthenticated_oauth_server(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_streamable_http_auth_uses_request_path_without_changing_scope(monkeypatch):
+    """An app-relative path enforces OAuth without replacing the root-prefixed scope path."""
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_require_auth", False)
+
+    mock_server = MagicMock()
+    mock_server.oauth_enabled = True
+
+    mock_db = MagicMock()
+    mock_db.execute.return_value.scalar_one_or_none.return_value = mock_server
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", _make_fake_get_db(mock_db))
+
+    public_path = "/gateway/servers/abc123def/mcp"
+    scope = _make_scope(public_path)
+    scope["root_path"] = "/gateway"
+    called = []
+
+    async def send(msg):
+        called.append(msg)
+
+    token = tr._oauth_checked_var.set(False)
+    try:
+        result = await streamable_http_auth(scope, None, send, request_path="/servers/abc123def/mcp")
+    finally:
+        tr._oauth_checked_var.reset(token)
+
+    assert result is False
+    assert called and called[0]["status"] == 401
+    assert scope["path"] == public_path
+
+
+@pytest.mark.asyncio
 async def test_streamable_http_auth_rejects_unauthenticated_oauth_server_on_get(monkeypatch):
     """#4205 parity guard: GET to an oauth_enabled server must 401, not 405.
 
@@ -14147,7 +14178,9 @@ async def test_oauth_access_token_context_preserves_exp(monkeypatch):
     monkeypatch.setattr("mcpgateway.auth._get_user_by_email_sync", MagicMock(return_value=mock_user))
     monkeypatch.setattr("mcpgateway.auth._resolve_teams_from_db", AsyncMock(return_value=["team-a"]))
 
-    handler = tr._StreamableHttpAuthHandler(scope=_make_scope("/servers/oauth-server/mcp"), receive=AsyncMock(), send=AsyncMock())
+    scope = _make_scope("/gateway/servers/oauth-server/mcp")
+    scope["root_path"] = "/gateway"
+    handler = tr._StreamableHttpAuthHandler(scope=scope, receive=AsyncMock(), send=AsyncMock(), request_path="/servers/oauth-server/mcp")
 
     result = await handler._try_oauth_access_token(
         "oauth-token",
@@ -14156,6 +14189,7 @@ async def test_oauth_access_token_context_preserves_exp(monkeypatch):
 
     assert result is tr.OAuthAuthResult.SUCCESS
     assert tr.user_context_var.get()["exp"] == token_exp
+    assert scope["path"] == "/gateway/servers/oauth-server/mcp"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/utils/test_paths.py
+++ b/tests/unit/mcpgateway/utils/test_paths.py
@@ -3,7 +3,7 @@
 Copyright contributors to the MCP-CONTEXT-FORGE project
 SPDX-License-Identifier: Apache-2.0
 
-Unit tests for mcpgateway.utils.paths.resolve_root_path.
+Unit tests for shared request-path utilities.
 
 Covers the canonical root-path resolution helper introduced in issue #3298
 to replace the 12 direct ``request.scope.get("root_path", "")`` call sites
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock
 import pytest
 
 # First-Party
-from mcpgateway.utils.paths import resolve_root_path
+from mcpgateway.utils.paths import replace_api_path_alias, resolve_root_path
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -35,6 +35,25 @@ def _make_request(root_path: str | None = "") -> MagicMock:
     else:
         req.scope = {"root_path": root_path}
     return req
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/v1/virtual-servers", "/servers"),
+        ("/v1/virtual-servers/", "/servers/"),
+        ("/v1/virtual-servers/server-1/prompts", "/servers/server-1/prompts"),
+        ("/v1/mcp-servers", "/gateways"),
+        ("/v1/mcp-servers/gateway-1/tools/refresh/", "/gateways/gateway-1/tools/refresh/"),
+        ("/servers/server-1", "/servers/server-1"),
+        ("/v1/tools", "/v1/tools"),
+        ("/v1/virtual-servers-extra/server-1", "/v1/virtual-servers-extra/server-1"),
+        ("/prefix/v1/virtual-servers/server-1", "/prefix/v1/virtual-servers/server-1"),
+    ],
+)
+def test_replace_api_path_alias(path: str, expected: str) -> None:
+    """Known aliases are replaced without broad prefix matches."""
+    assert replace_api_path_alias(path) == expected
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

# Pull Request

## 🔗 Related Issue
Relates to [IBM/mcp-context-forge#4956](https://github.com/IBM/mcp-context-forge/issues/4956)

Closes #

---

## 📝 Summary

_What does this PR do and why?_
Adds `/v1/mcp-servers` and `/v1/virtual-servers` as aliases for the existing `/gateways` and `/servers` APIs.
The new routes apply the same authentication, RBAC, token-scoping, security-header, protocol-version, client-disconnect, and MCP path-rewrite handling as the existing paths. Legacy routes remain unchanged for backward compatibility.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

_List exact commands, screenshots, videos, logs, reproduction steps, or manual validation. If evidence is not feasible, explain why._

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |    YAML warnings and JSON errors that come from unchanged files that are not part of this PR. Focused Ruff checks and `git diff --check` pass for these PR changes.   |
| Unit tests                | `make test`     |   one unrelated local failure caused by NVM login-shell output. The affected test is unchanged by this PR.     |
| Coverage ≥ 80%            | `make coverage` |     98%   |

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

_Screenshots, design decisions, or additional context._
