### PR TITLE
fix(llm-proxy): forward tool-calling through the Anthropic chat-completion path

### DIFF
--- a/mcpgateway/services/llm_proxy_service.py
+++ b/mcpgateway/services/llm_proxy_service.py
@@ -12,7 +12,7 @@ formats and handles streaming responses.
 
 # Standard
 import time
-from typing import Any, AsyncGenerator, Dict, Optional, Tuple
+from typing import Any, AsyncGenerator, Dict, Optional, Tuple, Union
 import uuid
 
 # Third-Party
@@ -378,10 +378,48 @@ class LLMProxyService:
         elif provider.default_temperature:
             body["temperature"] = provider.default_temperature
 
+        if request.tools:
+            body["tools"] = [
+                {
+                    "name": t.function.name,
+                    "description": t.function.description or "",
+                    "input_schema": t.function.parameters or {"type": "object", "properties": {}},
+                }
+                for t in request.tools
+            ]
+
+        if request.tool_choice:
+            anthropic_tool_choice = self._map_tool_choice_to_anthropic(request.tool_choice)
+            if anthropic_tool_choice:
+                body["tool_choice"] = anthropic_tool_choice
+
         if request.stream:
             body["stream"] = True
 
         return url, headers, body
+
+    @staticmethod
+    def _map_tool_choice_to_anthropic(tool_choice: Union[str, Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        """Map an OpenAI-shaped ``tool_choice`` to Anthropic's tool-choice object.
+
+        Args:
+            tool_choice: OpenAI-style tool choice ("auto", "required", "none",
+                or {"type": "function", "function": {"name": ...}}).
+
+        Returns:
+            The equivalent Anthropic tool-choice dict, or None when there is no
+            faithful equivalent (OpenAI's "none" cannot be expressed once tools
+            are attached to an Anthropic request; the caller omits the key so
+            Anthropic falls back to its own default of "auto").
+        """
+        if isinstance(tool_choice, dict):
+            name = tool_choice.get("function", {}).get("name")
+            return {"type": "tool", "name": name} if name else None
+        if tool_choice == "required":
+            return {"type": "any"}
+        if tool_choice == "auto":
+            return {"type": "auto"}
+        return None
 
     def _build_ollama_request(
         self,
@@ -710,9 +748,22 @@ class LLMProxyService:
             ChatCompletionResponse in OpenAI format.
         """
         content = ""
+        tool_calls = []
         for block in data.get("content", []):
-            if block.get("type") == "text":
+            block_type = block.get("type")
+            if block_type == "text":
                 content += block.get("text", "")
+            elif block_type == "tool_use":
+                tool_calls.append(
+                    {
+                        "id": block.get("id", f"call_{uuid.uuid4().hex[:24]}"),
+                        "type": "function",
+                        "function": {
+                            "name": block.get("name", ""),
+                            "arguments": orjson.dumps(block.get("input", {})).decode(),
+                        },
+                    }
+                )
 
         usage_data = data.get("usage", {})
 
@@ -723,8 +774,8 @@ class LLMProxyService:
             choices=[
                 ChatChoice(
                     index=0,
-                    message=ChatMessage(role="assistant", content=content),
-                    finish_reason=data.get("stop_reason", "stop"),
+                    message=ChatMessage(role="assistant", content=content, tool_calls=tool_calls or None),
+                    finish_reason=self._map_anthropic_stop_reason(data.get("stop_reason")),
                 )
             ],
             usage=UsageStats(
@@ -733,6 +784,23 @@ class LLMProxyService:
                 total_tokens=usage_data.get("input_tokens", 0) + usage_data.get("output_tokens", 0),
             ),
         )
+
+    @staticmethod
+    def _map_anthropic_stop_reason(stop_reason: Optional[str]) -> str:
+        """Map an Anthropic ``stop_reason`` to an OpenAI-compatible ``finish_reason``.
+
+        Args:
+            stop_reason: Anthropic's stop reason (e.g. "end_turn", "tool_use").
+
+        Returns:
+            The OpenAI-equivalent finish reason string.
+        """
+        return {
+            "end_turn": "stop",
+            "stop_sequence": "stop",
+            "max_tokens": "length",
+            "tool_use": "tool_calls",
+        }.get(stop_reason, stop_reason or "stop")
 
     def _transform_ollama_response(
         self,
@@ -791,9 +859,37 @@ class LLMProxyService:
         """
         event_type = data.get("type")
 
-        if event_type == "content_block_delta":
+        if event_type == "content_block_start":
+            block = data.get("content_block", {})
+            if block.get("type") == "tool_use":
+                chunk = {
+                    "id": response_id,
+                    "object": "chat.completion.chunk",
+                    "created": created,
+                    "model": model_id,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": data.get("index", 0),
+                                        "id": block.get("id", f"call_{uuid.uuid4().hex[:24]}"),
+                                        "type": "function",
+                                        "function": {"name": block.get("name", ""), "arguments": ""},
+                                    }
+                                ]
+                            },
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+                return orjson.dumps(chunk).decode()
+
+        elif event_type == "content_block_delta":
             delta = data.get("delta", {})
-            if delta.get("type") == "text_delta":
+            delta_type = delta.get("type")
+            if delta_type == "text_delta":
                 chunk = {
                     "id": response_id,
                     "object": "chat.completion.chunk",
@@ -808,16 +904,40 @@ class LLMProxyService:
                     ],
                 }
                 return orjson.dumps(chunk).decode()
+            if delta_type == "input_json_delta":
+                chunk = {
+                    "id": response_id,
+                    "object": "chat.completion.chunk",
+                    "created": created,
+                    "model": model_id,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": data.get("index", 0),
+                                        "function": {"arguments": delta.get("partial_json", "")},
+                                    }
+                                ]
+                            },
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+                return orjson.dumps(chunk).decode()
 
-        elif event_type == "message_stop":
-            chunk = {
-                "id": response_id,
-                "object": "chat.completion.chunk",
-                "created": created,
-                "model": model_id,
-                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
-            }
-            return orjson.dumps(chunk).decode()
+        elif event_type == "message_delta":
+            stop_reason = data.get("delta", {}).get("stop_reason")
+            if stop_reason:
+                chunk = {
+                    "id": response_id,
+                    "object": "chat.completion.chunk",
+                    "created": created,
+                    "model": model_id,
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": self._map_anthropic_stop_reason(stop_reason)}],
+                }
+                return orjson.dumps(chunk).decode()
 
         return None
 

--- a/tests/unit/mcpgateway/services/test_llm_proxy_service.py
+++ b/tests/unit/mcpgateway/services/test_llm_proxy_service.py
@@ -16,7 +16,7 @@ import pytest
 
 # First-Party
 from mcpgateway.db import LLMProviderType
-from mcpgateway.llm_schemas import ChatCompletionRequest, ChatMessage
+from mcpgateway.llm_schemas import ChatCompletionRequest, ChatMessage, FunctionDefinition, ToolDefinition
 from mcpgateway.services.llm_proxy_service import (
     LLMModelNotFoundError,
     LLMProxyRequestError,
@@ -217,6 +217,57 @@ def test_build_anthropic_request_with_system_message(service, monkeypatch: pytes
     assert body["messages"][0]["role"] == "user"
 
 
+def test_build_anthropic_request_with_tools(service):
+    """Anthropic request forwards tools in Anthropic's own shape (name/description/input_schema,
+    not OpenAI's type/function wrapper) and maps a function tool_choice by name."""
+    tool = ToolDefinition(function=FunctionDefinition(name="get_weather", description="Get the weather", parameters={"type": "object", "properties": {"city": {"type": "string"}}}))
+    request = ChatCompletionRequest(
+        model="claude-3",
+        messages=[ChatMessage(role="user", content="hi")],
+        tools=[tool],
+        tool_choice={"type": "function", "function": {"name": "get_weather"}},
+    )
+    provider = _make_provider(provider_type=LLMProviderType.ANTHROPIC, api_base="http://anthropic", config={})
+    model = _make_model(model_id="claude-3")
+
+    url, headers, body = service._build_anthropic_request(request, provider, model)
+
+    assert body["tools"] == [
+        {
+            "name": "get_weather",
+            "description": "Get the weather",
+            "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}},
+        }
+    ]
+    assert body["tool_choice"] == {"type": "tool", "name": "get_weather"}
+
+
+def test_build_anthropic_request_no_tools(service):
+    """No tools on the request means neither key is sent (branch coverage for the falsy path)."""
+    request = ChatCompletionRequest(model="claude-3", messages=[ChatMessage(role="user", content="hi")])
+    provider = _make_provider(provider_type=LLMProviderType.ANTHROPIC, api_base="http://anthropic", config={})
+    model = _make_model(model_id="claude-3")
+
+    url, headers, body = service._build_anthropic_request(request, provider, model)
+
+    assert "tools" not in body
+    assert "tool_choice" not in body
+
+
+@pytest.mark.parametrize(
+    "tool_choice,expected",
+    [
+        ("auto", {"type": "auto"}),
+        ("required", {"type": "any"}),
+        ("none", None),
+        ({"type": "function", "function": {"name": "fn"}}, {"type": "tool", "name": "fn"}),
+        ({"type": "function", "function": {}}, None),
+    ],
+)
+def test_map_tool_choice_to_anthropic(service, tool_choice, expected):
+    assert service._map_tool_choice_to_anthropic(tool_choice) == expected
+
+
 def test_build_ollama_request_openai_compat(service):
     request = ChatCompletionRequest(model="llama3", messages=[ChatMessage(role="user", content="hi")], stream=True)
     provider = _make_provider(provider_type=LLMProviderType.OLLAMA, api_base="http://ollama.local/v1", default_temperature=0.3, default_max_tokens=77)
@@ -248,14 +299,55 @@ def test_transform_anthropic_response(service):
         "id": "resp",
         "content": [{"type": "text", "text": "hi"}, {"type": "text", "text": " there"}],
         "usage": {"input_tokens": 1, "output_tokens": 2},
-        "stop_reason": "stop",
+        "stop_reason": "end_turn",
     }
 
     result = service._transform_anthropic_response(data, "claude")
 
     assert result.choices[0].message.content == "hi there"
+    assert result.choices[0].message.tool_calls is None
+    assert result.choices[0].finish_reason == "stop"
     assert result.usage.total_tokens == 3
     assert result.model == "claude"
+
+
+def test_transform_anthropic_response_tool_use(service):
+    """A tool_use content block must surface as an OpenAI-shaped tool_calls entry
+    and the finish_reason must map to 'tool_calls', not the raw Anthropic value."""
+    data = {
+        "id": "resp",
+        "content": [{"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {"city": "SF"}}],
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+        "stop_reason": "tool_use",
+    }
+
+    result = service._transform_anthropic_response(data, "claude")
+
+    message = result.choices[0].message
+    assert message.content == ""
+    assert message.tool_calls == [
+        {
+            "id": "toolu_1",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city":"SF"}'},
+        }
+    ]
+    assert result.choices[0].finish_reason == "tool_calls"
+
+
+@pytest.mark.parametrize(
+    "stop_reason,finish_reason",
+    [
+        ("end_turn", "stop"),
+        ("stop_sequence", "stop"),
+        ("max_tokens", "length"),
+        ("tool_use", "tool_calls"),
+        (None, "stop"),
+        ("pause_turn", "pause_turn"),
+    ],
+)
+def test_map_anthropic_stop_reason(service, stop_reason, finish_reason):
+    assert service._map_anthropic_stop_reason(stop_reason) == finish_reason
 
 
 def test_transform_ollama_response_done(service):
@@ -269,14 +361,52 @@ def test_transform_ollama_response_done(service):
 
 def test_transform_anthropic_stream_chunk(service):
     text_delta = {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "hi"}}
+    # The finish reason now comes from message_delta's stop_reason (message_stop carries
+    # no data of its own in the Anthropic protocol), so message_stop is a no-op.
+    message_delta_stop = {"type": "message_delta", "delta": {"stop_reason": "end_turn"}}
     stop_event = {"type": "message_stop"}
 
     chunk = service._transform_anthropic_stream_chunk(text_delta, "id", 1, "model")
-    stop_chunk = service._transform_anthropic_stream_chunk(stop_event, "id", 1, "model")
+    finish_chunk = service._transform_anthropic_stream_chunk(message_delta_stop, "id", 1, "model")
 
     assert '"content":"hi"' in chunk
-    assert '"finish_reason":"stop"' in stop_chunk
+    assert '"finish_reason":"stop"' in finish_chunk
+    assert service._transform_anthropic_stream_chunk(stop_event, "id", 1, "model") is None
     assert service._transform_anthropic_stream_chunk({"type": "other"}, "id", 1, "model") is None
+    assert service._transform_anthropic_stream_chunk({"type": "message_delta", "delta": {}}, "id", 1, "model") is None
+
+
+def test_transform_anthropic_stream_chunk_tool_use(service):
+    """A tool_use content_block_start opens an OpenAI-shaped tool_calls delta at the
+    Anthropic block's own index, and input_json_delta streams the arguments into it."""
+    start_event = {
+        "type": "content_block_start",
+        "index": 1,
+        "content_block": {"type": "tool_use", "id": "toolu_1", "name": "get_weather"},
+    }
+    arg_delta = {"type": "content_block_delta", "index": 1, "delta": {"type": "input_json_delta", "partial_json": '{"city":'}}
+    tool_use_stop = {"type": "message_delta", "delta": {"stop_reason": "tool_use"}}
+
+    start_chunk = service._transform_anthropic_stream_chunk(start_event, "id", 1, "model")
+    delta_chunk = service._transform_anthropic_stream_chunk(arg_delta, "id", 1, "model")
+    finish_chunk = service._transform_anthropic_stream_chunk(tool_use_stop, "id", 1, "model")
+
+    assert '"index":1' in start_chunk
+    assert '"id":"toolu_1"' in start_chunk
+    assert '"name":"get_weather"' in start_chunk
+    assert '"arguments":""' in start_chunk
+
+    assert '"index":1' in delta_chunk
+    assert '"arguments":"{\\"city\\":"' in delta_chunk
+
+    assert '"finish_reason":"tool_calls"' in finish_chunk
+
+
+def test_transform_anthropic_stream_chunk_content_block_start_text(service):
+    """A text content_block_start (no tool_use) yields no chunk of its own; the text
+    itself arrives via subsequent content_block_delta text_delta events."""
+    start_event = {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
+    assert service._transform_anthropic_stream_chunk(start_event, "id", 1, "model") is None
 
 
 def test_transform_ollama_stream_chunk(service):
@@ -1192,7 +1322,8 @@ def test_build_ollama_openai_compat_no_defaults(service):
 
 
 def test_transform_anthropic_response_non_text_block(service):
-    """Anthropic response with non-text content block (branch 610->609 false)."""
+    """Anthropic response with a tool_use block alongside text: both must surface,
+    the tool_use as a tool_calls entry, the text as message.content."""
     data = {
         "id": "resp",
         "content": [{"type": "tool_use", "id": "t1", "name": "fn"}, {"type": "text", "text": "ok"}],
@@ -1202,15 +1333,17 @@ def test_transform_anthropic_response_non_text_block(service):
     result = service._transform_anthropic_response(data, "claude")
 
     assert result.choices[0].message.content == "ok"
+    assert result.choices[0].message.tool_calls == [{"id": "t1", "type": "function", "function": {"name": "fn", "arguments": "{}"}}]
 
 
 def test_transform_anthropic_stream_chunk_non_text_delta(service):
-    """Anthropic stream chunk with non-text-delta type (branch 692->718 false)."""
-    data = {"type": "content_block_delta", "delta": {"type": "input_json_delta", "partial_json": "{}"}}
+    """input_json_delta streams tool-call arguments rather than being dropped."""
+    data = {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{}"}}
 
     result = service._transform_anthropic_stream_chunk(data, "id", 1, "model")
 
-    assert result is None
+    assert result is not None
+    assert '"arguments":"{}"' in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related Issue

None linked. This repo's own measured pattern (13/13 outside-filed issues with `NONE`
association were fixed by someone other than the filer) means a standalone issue from
this account would sit unfixed, so this is a direct PR with the full repro in the
description below, per that measured shape.

## Summary

The gateway's unified `/v1/chat/completions` proxy is OpenAI-shaped on the client side,
but the Anthropic backend path silently drops tool-calling end to end. A client that
sends `tools`/`tool_choice` against an Anthropic-backed model gets no tools forwarded
upstream at all, and even a tool call Claude makes anyway (tools attached on an earlier
turn) is stripped out of both the non-streaming and streaming response, with
`finish_reason` hardcoded to `"stop"` in both cases. Any agent framework built on this
gateway sees "the model just replied with text" instead of a tool call.

## Root Cause

Three linked gaps in `llm_proxy_service.py`, all on the Anthropic-specific code paths:

- `_build_anthropic_request` builds the outbound body from `request.temperature` /
  `max_tokens` / `stream` only; it never reads `request.tools` or `request.tool_choice`
  (the OpenAI-compatible sibling, `_build_openai_request`, already forwards both).
- `_transform_anthropic_response` iterates Anthropic's `content` blocks and only handles
  `type == "text"`; a `tool_use` block is silently skipped, and `finish_reason` is
  `data.get("stop_reason", "stop")` verbatim, so Anthropic's own `"tool_use"` stop reason
  leaks through unmapped instead of becoming OpenAI's `"tool_calls"`.
- `_transform_anthropic_stream_chunk` only handles `content_block_delta` events of type
  `"text_delta"`; the `content_block_start` event that opens a tool-use block and the
  `input_json_delta` events that stream its arguments are both unhandled, and the
  finish-reason chunk is emitted unconditionally on `message_stop` as a hardcoded
  `"stop"` (Anthropic's own protocol carries the real `stop_reason` on the preceding
  `message_delta` event, not on `message_stop`, which carries no payload).

## Fix

- `_build_anthropic_request` now forwards `tools` in Anthropic's own shape
  (`name`/`description`/`input_schema`, not OpenAI's `type`/`function` wrapper) and maps
  `tool_choice` via a new `_map_tool_choice_to_anthropic` helper (`"auto"` -> `{"type":
  "auto"}`, `"required"` -> `{"type": "any"}`, `{"function": {"name": ...}}` -> `{"type":
  "tool", "name": ...}`). OpenAI's `"none"` has no faithful Anthropic equivalent once
  tools are attached, so that case sends no `tool_choice` key and falls back to
  Anthropic's own default (`auto`) rather than sending something misleading.
- `_transform_anthropic_response` now collects `tool_use` blocks into OpenAI-shaped
  `tool_calls` entries and maps `stop_reason` through a new `_map_anthropic_stop_reason`
  helper (`tool_use` -> `tool_calls`, `max_tokens` -> `length`, `end_turn`/
  `stop_sequence` -> `stop`, anything else passed through as-is).
- `_transform_anthropic_stream_chunk` now emits an OpenAI-shaped `tool_calls` delta on
  `content_block_start` (when the block is `tool_use`) and on `input_json_delta`, using
  Anthropic's own block `index` so multiple concurrent tool calls stay distinguishable.
  The finish-reason chunk moved to `message_delta`'s `stop_reason` (mapped through the
  same helper); `message_stop` is now a no-op, since by Anthropic's own event ordering
  `message_delta` always precedes it and always carries the real `stop_reason`.

## Verification

- New/updated unit tests fail against unmodified `main` (`18 failed, 69 passed`) and
  pass on this branch. Full `tests/unit/mcpgateway/services/test_llm_proxy_service.py`
  on the branch: 87 passed; branch coverage on the changed module is 99% (359/360
  lines), the one uncovered line a pre-existing, untouched Ollama JSON-decode branch.
- `pylint --rcfile=.pylintrc.mcpgateway` on the changed module: 10.00/10. Could not run
  this repo's pinned `ruff` (0.15.1, per `lint.yml`): `pyproject.toml`'s
  `[tool.ruff.lint] ignore` list contains `"PLW0717"`, which that version rejects as an
  unknown rule selector, reproducing identically on unmodified `main`; a newer `ruff`,
  informational only, reports the changed files clean.
- Not verified: a live call against the real Anthropic API. This is a request/response/
  stream-transform change checked against Anthropic's documented Messages API event
  shapes and this repo's own existing test fixtures for the same functions; I do not
  have an Anthropic API key in this environment.

Signed-off-by: Amir Fathi <amirfathi.me@gmail.com>
