### PR TITLE
feat: add OrcaRouter as a named LLM provider

### DIFF
--- a/docs/docs/manage/llm-settings.md
+++ b/docs/docs/manage/llm-settings.md
@@ -68,6 +68,7 @@ Run a health check on any provider to verify connectivity and credentials. The r
 | `mistral` | Mistral AI models | `https://api.mistral.ai/v1` | Required |
 | `groq` | Groq high-speed inference | `https://api.groq.com/openai/v1` | Required |
 | `together` | Together AI inference | `https://api.together.xyz/v1` | Required |
+| `orcarouter` | [OrcaRouter](https://www.orcarouter.ai) gateway (150+ models, one endpoint) | `https://api.orcarouter.ai/v1` | Required |
 
 ## Environment Variables
 

--- a/docs/docs/using/clients/llm-chat.md
+++ b/docs/docs/using/clients/llm-chat.md
@@ -35,6 +35,7 @@ All LLM providers are configured via the Admin UI's LLM Settings. Navigate to **
 | `ollama` | Local Ollama | Base URL (default: http://localhost:11434) |
 | `watsonx` | IBM watsonx.ai | API Key, project_id in additional_config |
 | `openai_compatible` | OpenAI-compatible APIs (vLLM, LocalAI, etc.) | Base URL, optional API Key |
+| `orcarouter` | [OrcaRouter](https://www.orcarouter.ai) gateway (150+ models) | API Key, Base URL (default: https://api.orcarouter.ai/v1) |
 
 ### 🗄️ Redis Configurations for Multi Worker Environment
 

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -6336,6 +6336,7 @@ class LLMProviderType:
     MISTRAL = "mistral"
     GROQ = "groq"
     TOGETHER = "together"
+    ORCAROUTER = "orcarouter"
 
     @classmethod
     def get_all_types(cls) -> List[str]:
@@ -6357,6 +6358,7 @@ class LLMProviderType:
             cls.MISTRAL,
             cls.GROQ,
             cls.TOGETHER,
+            cls.ORCAROUTER,
         ]
 
     @classmethod
@@ -6436,6 +6438,14 @@ class LLMProviderType:
                 "models_endpoint": "/models",
                 "requires_api_key": True,
                 "description": "Together AI inference",
+            },
+            cls.ORCAROUTER: {
+                "api_base": "https://api.orcarouter.ai/v1",
+                "default_model": "orcarouter/auto",
+                "supports_model_list": True,
+                "models_endpoint": "/models",
+                "requires_api_key": True,
+                "description": "OrcaRouter gateway (150+ models, one endpoint)",
             },
             cls.BEDROCK: {
                 "api_base": "",

--- a/mcpgateway/llm_provider_configs.py
+++ b/mcpgateway/llm_provider_configs.py
@@ -504,6 +504,18 @@ PROVIDER_CONFIGS: Dict[str, ProviderConfigDefinition] = {
         api_base_default="https://api.together.xyz/v1",
         config_fields=[],
     ),
+    "orcarouter": ProviderConfigDefinition(
+        provider_type="orcarouter",
+        display_name="OrcaRouter",
+        description="OrcaRouter gateway (150+ models, one endpoint)",
+        requires_api_key=True,
+        api_key_label="OrcaRouter API Key",
+        api_key_help="Get your API key from https://www.orcarouter.ai",
+        requires_api_base=True,
+        api_base_default="https://api.orcarouter.ai/v1",
+        api_base_help="Default: https://api.orcarouter.ai/v1",
+        config_fields=[],
+    ),
 }
 
 

--- a/mcpgateway/llm_schemas.py
+++ b/mcpgateway/llm_schemas.py
@@ -45,6 +45,7 @@ class LLMProviderTypeEnum(str, Enum):
     MISTRAL = "mistral"
     GROQ = "groq"
     TOGETHER = "together"
+    ORCAROUTER = "orcarouter"
 
 
 class HealthStatus(str, Enum):

--- a/tests/unit/mcpgateway/routers/test_llm_admin_router.py
+++ b/tests/unit/mcpgateway/routers/test_llm_admin_router.py
@@ -237,6 +237,10 @@ async def test_get_provider_defaults():
     mock_db = MagicMock()
     result = await llm_admin_router.get_provider_defaults(mock_db, current_user_ctx={"email": "user@example.com", "db": mock_db})
     assert isinstance(result, dict)
+    # OrcaRouter is registered as a named provider with gateway defaults.
+    assert result["orcarouter"]["api_base"] == "https://api.orcarouter.ai/v1"
+    assert result["orcarouter"]["default_model"] == "orcarouter/auto"
+    assert result["orcarouter"]["requires_api_key"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

N/A — small, self-contained provider addition; no issue is linked.

---

## 📝 Summary

_What does this PR do and why?_

Registers [OrcaRouter](https://www.orcarouter.ai) as a first-class, named LLM provider in the gateway, alongside the existing `together`, `cohere`, `groq` and `mistral` entries. It adds the provider type to `LLMProviderType` (with gateway defaults: `https://api.orcarouter.ai/v1`, default model `orcarouter/auto`), its `ProviderConfigDefinition` in `PROVIDER_CONFIGS`, the matching enum value, and documents it on both the admin settings and LLM-chat client pages.

The Admin UI populates the provider picker dynamically from `get_provider_defaults()`, so the new entry appears automatically without any frontend change. No DB migration is needed: the provider type is stored as a string column and no seed rows exist.

This registers [OrcaRouter](https://www.orcarouter.ai) the same way the existing named providers (`together`, `cohere`, `groq`, `mistral`) are wired, so the model picker, config reference and docs stay consistent. OrcaRouter is an OpenAI-compatible gateway: one `ORCAROUTER_API_KEY` (keys start with `sk-orca-`) unlocks 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single `https://api.orcarouter.ai/v1` endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [x] Feature / Enhancement
- [x] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

_List exact commands, screenshots, videos, logs, reproduction steps, or manual validation. If evidence is not feasible, explain why._

| Check | Command | Status |
|-------|---------|--------|
| LLM admin router unit tests (incl. new OrcaRouter defaults assertion) | `python -m pytest tests/unit/mcpgateway/routers/test_llm_admin_router.py -q` | ✅ 46 passed |
| LLM proxy + config router unit tests | `python -m pytest tests/unit/mcpgateway/routers/test_llm_proxy_router.py tests/unit/mcpgateway/routers/test_llm_config_router.py -q` | ✅ passed |
| Provider registration scripted asserts (registry + defaults + enum) | `python _work/verify-mcf-orcarouter.py` | ✅ all asserts passed |
| Live models list | `GET https://api.orcarouter.ai/v1/models` | ✅ 200, 205 models |
| Live chat completion | `POST https://api.orcarouter.ai/v1/chat/completions` | ✅ 200 |

Note: the full `make lint` / `make test` / `make coverage` suite was not run in this environment; the three LLM router test modules that cover provider configs, defaults and proxy dispatch all pass, and the live gateway endpoint was exercised directly.

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

_Screenshots, design decisions, or additional context._

- New provider type: `orcarouter` → `https://api.orcarouter.ai/v1`, default model `orcarouter/auto`.
- Chat dispatch needs no changes: OrcaRouter is OpenAI-compatible and flows through the existing default `_build_openai_request` path.
- The docs provider tables in `docs/docs/manage/llm-settings.md` and `docs/docs/using/clients/llm-chat.md` now list the new provider.
