### PR TITLE
docs: fix star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1075,7 +1075,7 @@ Special thanks to our contributors for helping us improve ContextForge:
 
 ## Star History and Project Activity
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ibm/mcp-context-forge&type=Date)](https://www.star-history.com/#ibm/mcp-context-forge&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ibm/mcp-context-forge&type=Date)](https://star-history.dera.page/#ibm/mcp-context-forge&Date)
 
 <!-- === Usage Stats === -->
 [![PyPi Downloads](https://static.pepy.tech/badge/mcp-contextforge-gateway/month)](https://pepy.tech/project/mcp-contextforge-gateway)&nbsp;


### PR DESCRIPTION
The Star History chart in the README was broken due to GitHub stargazer API restrictions. Update the chart image and its wrapping link to use the replacement endpoint so the chart renders correctly.