### PR TITLE
docs: note the pango dependency needed to build the docs

### DIFF
--- a/docs/docs/development/documentation.md
+++ b/docs/docs/development/documentation.md
@@ -10,6 +10,14 @@ Follow this guide when you need to add or update markdown pages under `docs/` an
 * `make` (GNU Make 4+)
 * (First-time only) **[`mkdocs-material`](https://squidfunk.github.io/mkdocs-material/)** and plugins are installed automatically by the *docs* `Makefile`.
 * One-time GitHub setup, e.g. [gitconfig setup](./github.md#16-personal-git-configuration-recommended)
+* **Pango and its GLib dependencies**, required by WeasyPrint, which the PDF export plugin loads on every build:
+
+    ```bash
+    brew install pango                      # macOS
+    sudo apt install libpango-1.0-0 libpangoft2-1.0-0   # Debian/Ubuntu
+    ```
+
+    Without them, `make serve` and `make build` stop while loading the plugin, with an error such as `cannot load library 'libgobject-2.0-0'` or `cannot load library 'libpango-1.0-0'`. WeasyPrint documents the platform packages in its [installation guide](https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#installation).
 
 ---
 


### PR DESCRIPTION
Closes #5882.

The docs build loads the `with-pdf` plugin, which imports WeasyPrint, which dlopens the Pango/GLib libraries. Those are system packages, not pip dependencies, so on a machine without them `make serve` and `make build` fail during plugin load — the error in the issue.

Reproduced on a clean macOS arm64 machine with no Homebrew:

```
$ python3 -m venv v && v/bin/pip install weasyprint && v/bin/python -c 'import weasyprint'
  File ".../weasyprint/text/ffi.py", line 475, in <module>
    gobject = _dlopen(
OSError: cannot load library 'libgobject-2.0-0': dlopen(libgobject-2.0-0, 0x0002): tried: ...
Additionally, ctypes.util.find_library() did not manage to locate a library called 'libgobject-2.0-0'
```

The library named in the error depends on which one WeasyPrint reaches first, hence `libpango-1.0-0` in the issue and `libgobject-2.0-0` here; `brew install pango` pulls in both. On a second macOS arm64 machine that already had it, `make venv && mkdocs build` completed in 46 seconds without any change.

Adds the dependency to the prerequisites of the documentation guide, with the macOS and Debian package names and a pointer to WeasyPrint's own installation page.
