### PR TITLE
docs: fix IBM Cloud Code Engine deployment guide missing env secret

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-09T13:44:53Z",
+  "generated_at": "2026-09-09T14:20:06Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -346,7 +346,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6651,
+        "line_number": 6652,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -354,7 +354,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6663,
+        "line_number": 6664,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -362,7 +362,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6735,
+        "line_number": 6736,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -370,7 +370,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7151,
+        "line_number": 7152,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -378,7 +378,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7841,
+        "line_number": 7842,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-09T08:35:26Z",
+  "generated_at": "2026-09-09T13:44:53Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -346,7 +346,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6639,
+        "line_number": 6651,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -354,7 +354,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6651,
+        "line_number": 6663,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -362,7 +362,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6723,
+        "line_number": 6735,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -370,7 +370,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7139,
+        "line_number": 7151,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -378,7 +378,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7829,
+        "line_number": 7841,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1722,7 +1722,7 @@
         "hashed_secret": "60ef47f289f32388d377100aec5a69a39bbdd087",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 70,
+        "line_number": 71,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -1730,7 +1730,7 @@
         "hashed_secret": "a095f277a165b357774752331635b3693745d048",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 106,
+        "line_number": 107,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1738,7 +1738,7 @@
         "hashed_secret": "aa91e9f973a0fc76e4c2c303ec788f7b6c22a318",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 113,
+        "line_number": 114,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/Makefile
+++ b/Makefile
@@ -6253,6 +6253,7 @@ ibmcloud-push:
 
 .PHONY: ibmcloud-deploy
 ibmcloud-deploy:
+	@test -f .env || { echo "❌ Missing .env — run: cp .env.example .env"; exit 1; }
 	@echo "🚀 Deploying image to Code Engine as '$(IBMCLOUD_CODE_ENGINE_APP)' using registry secret $(IBMCLOUD_REGISTRY_SECRET)..."
 	@# Create the runtime env secret from .env if it does not exist yet
 	@if ! ibmcloud ce secret get --name $(IBMCLOUD_CODE_ENGINE_APP)-env > /dev/null 2>&1; then \

--- a/Makefile
+++ b/Makefile
@@ -6112,7 +6112,7 @@ compose-test-hardened: compose-validate
 # help: ibmcloud-deploy             - Deploy (or update) container image in Code Engine
 # help: ibmcloud-ce-logs            - Stream logs for the deployed application
 # help: ibmcloud-ce-status          - Get deployment status
-# help: ibmcloud-ce-rm              - Delete the Code Engine application
+# help: ibmcloud-ce-rm              - Delete the Code Engine application and its env secret
 
 .PHONY: ibmcloud-check-env ibmcloud-cli-install ibmcloud-login ibmcloud-ce-login \
 	ibmcloud-list-containers ibmcloud-tag ibmcloud-push ibmcloud-deploy \
@@ -6293,6 +6293,8 @@ ibmcloud-ce-status:
 ibmcloud-ce-rm:
 	@echo "🗑️  Deleting Code Engine app: $(IBMCLOUD_CODE_ENGINE_APP)..."
 	@ibmcloud ce application delete --name $(IBMCLOUD_CODE_ENGINE_APP) -f
+	@echo "🗑️  Deleting runtime env secret: $(IBMCLOUD_CODE_ENGINE_APP)-env..."
+	@ibmcloud ce secret delete --name $(IBMCLOUD_CODE_ENGINE_APP)-env -f 2>/dev/null || true
 
 
 # =============================================================================

--- a/Makefile
+++ b/Makefile
@@ -6254,19 +6254,29 @@ ibmcloud-push:
 .PHONY: ibmcloud-deploy
 ibmcloud-deploy:
 	@echo "🚀 Deploying image to Code Engine as '$(IBMCLOUD_CODE_ENGINE_APP)' using registry secret $(IBMCLOUD_REGISTRY_SECRET)..."
+	@# Create the runtime env secret from .env if it does not exist yet
+	@if ! ibmcloud ce secret get --name mcpgw-env > /dev/null 2>&1; then \
+		echo "🔐 Creating runtime env secret from .env..."; \
+		ibmcloud ce secret create --name mcpgw-env --from-env-file .env; \
+	else \
+		echo "🔐 Updating runtime env secret from .env..."; \
+		ibmcloud ce secret update --name mcpgw-env --from-env-file .env; \
+	fi
 	@if ibmcloud ce application get --name $(IBMCLOUD_CODE_ENGINE_APP) > /dev/null 2>&1; then \
 		echo "🔁 Updating existing app..."; \
 		ibmcloud ce application update --name $(IBMCLOUD_CODE_ENGINE_APP) \
 			--image $(IBMCLOUD_IMAGE_NAME) \
 			--cpu $(IBMCLOUD_CPU) --memory $(IBMCLOUD_MEMORY) \
-			--registry-secret $(IBMCLOUD_REGISTRY_SECRET); \
+			--registry-secret $(IBMCLOUD_REGISTRY_SECRET) \
+			--env-from-secret mcpgw-env; \
 	else \
 		echo "🆕 Creating new app..."; \
 		ibmcloud ce application create --name $(IBMCLOUD_CODE_ENGINE_APP) \
 			--image $(IBMCLOUD_IMAGE_NAME) \
 			--cpu $(IBMCLOUD_CPU) --memory $(IBMCLOUD_MEMORY) \
 			--port 4444 \
-			--registry-secret $(IBMCLOUD_REGISTRY_SECRET); \
+			--registry-secret $(IBMCLOUD_REGISTRY_SECRET) \
+			--env-from-secret mcpgw-env; \
 	fi
 
 .PHONY: ibmcloud-ce-logs

--- a/Makefile
+++ b/Makefile
@@ -6255,12 +6255,12 @@ ibmcloud-push:
 ibmcloud-deploy:
 	@echo "🚀 Deploying image to Code Engine as '$(IBMCLOUD_CODE_ENGINE_APP)' using registry secret $(IBMCLOUD_REGISTRY_SECRET)..."
 	@# Create the runtime env secret from .env if it does not exist yet
-	@if ! ibmcloud ce secret get --name mcpgw-env > /dev/null 2>&1; then \
+	@if ! ibmcloud ce secret get --name $(IBMCLOUD_CODE_ENGINE_APP)-env > /dev/null 2>&1; then \
 		echo "🔐 Creating runtime env secret from .env..."; \
-		ibmcloud ce secret create --name mcpgw-env --from-env-file .env; \
+		ibmcloud ce secret create --name $(IBMCLOUD_CODE_ENGINE_APP)-env --from-env-file .env; \
 	else \
 		echo "🔐 Updating runtime env secret from .env..."; \
-		ibmcloud ce secret update --name mcpgw-env --from-env-file .env; \
+		ibmcloud ce secret update --name $(IBMCLOUD_CODE_ENGINE_APP)-env --from-env-file .env; \
 	fi
 	@if ibmcloud ce application get --name $(IBMCLOUD_CODE_ENGINE_APP) > /dev/null 2>&1; then \
 		echo "🔁 Updating existing app..."; \
@@ -6268,7 +6268,7 @@ ibmcloud-deploy:
 			--image $(IBMCLOUD_IMAGE_NAME) \
 			--cpu $(IBMCLOUD_CPU) --memory $(IBMCLOUD_MEMORY) \
 			--registry-secret $(IBMCLOUD_REGISTRY_SECRET) \
-			--env-from-secret mcpgw-env; \
+			--env-from-secret $(IBMCLOUD_CODE_ENGINE_APP)-env; \
 	else \
 		echo "🆕 Creating new app..."; \
 		ibmcloud ce application create --name $(IBMCLOUD_CODE_ENGINE_APP) \
@@ -6276,7 +6276,7 @@ ibmcloud-deploy:
 			--cpu $(IBMCLOUD_CPU) --memory $(IBMCLOUD_MEMORY) \
 			--port 4444 \
 			--registry-secret $(IBMCLOUD_REGISTRY_SECRET) \
-			--env-from-secret mcpgw-env; \
+			--env-from-secret $(IBMCLOUD_CODE_ENGINE_APP)-env; \
 	fi
 
 .PHONY: ibmcloud-ce-logs

--- a/docs/docs/howto/ibm-cloud-code-engine.md
+++ b/docs/docs/howto/ibm-cloud-code-engine.md
@@ -15,6 +15,7 @@ This guide covers two supported deployment paths for the **ContextForge**:
 | Docker **or** Podman | Builds the production container image locally                      |
 | IBM Cloud CLI ≥ 2.16 | Installed automatically with `make ibmcloud-cli-install`           |
 | Code Engine project  | Create or select one in the IBM Cloud console                      |
+| IAM permissions      | Editor or higher on Code Engine; Writer or higher on Container Registry in the resource group |
 | `.env` file          | Runtime secrets & config for the gateway                           |
 | `.env.ce` file       | Deployment credentials & metadata for Code Engine / Container Reg. |
 
@@ -153,7 +154,7 @@ grep -q JWT_SECRET_KEY .env && echo "OK: JWT_SECRET_KEY set" || echo "WARNING: J
 | `ibmcloud-deploy`           | Create **or** update the app; syncs `.env` to a Code Engine secret (`<app>-env`), sets CPU/MEM, attaches registry secret, exposes port 4444. |
 | `ibmcloud-ce-status`        | `ibmcloud ce application get` - see route URL, revisions, health.                    |
 | `ibmcloud-ce-logs`          | `ibmcloud ce application logs --follow` - live log stream.                           |
-| `ibmcloud-ce-rm`            | Delete the application entirely.                                                     |
+| `ibmcloud-ce-rm`            | Delete the application and its `<app>-env` runtime secret.                           |
 
 **Typical first deploy**
 
@@ -211,6 +212,12 @@ podman build -t "$IBMCLOUD_IMG_PROD" .
 podman tag "$IBMCLOUD_IMG_PROD" "$IBMCLOUD_IMAGE_NAME"
 
 # 5 - Push image to ICR
+#
+# Note: if you are deploying to a region other than us-south (e.g. eu-de, jp-tok),
+# set the Container Registry region first:
+#   ibmcloud cr region-set <region>   (e.g. ibmcloud cr region-set eu-de)
+# Without this step `ibmcloud cr login` will authenticate to the wrong endpoint
+# and the push will fail with authentication errors.
 ibmcloud cr login
 ibmcloud cr namespaces       # Ensure your namespace exists
 podman push "$IBMCLOUD_IMAGE_NAME"
@@ -227,16 +234,23 @@ ibmcloud cr images --restrict "$(echo "$IBMCLOUD_IMAGE_NAME" | cut -d/ -f2)"
 
 ```bash
 # 6 - Create registry secret (first time)
-ibmcloud ce registry create-secret --name "$IBMCLOUD_REGISTRY_SECRET" \
+ibmcloud ce secret create --name "$IBMCLOUD_REGISTRY_SECRET" \
+    --format registry \
     --server "$(echo "$IBMCLOUD_IMAGE_NAME" | cut -d/ -f1)" \
     --username iamapikey --password "$IBMCLOUD_API_KEY"
 ibmcloud ce secret list # list every secret (generic, registry, SSH, TLS, etc.)
 ibmcloud ce secret get --name "$IBMCLOUD_REGISTRY_SECRET"         # add --decode to see clear-text values
 
-# 6b - Create a runtime environment secret from .env (first time only)
+# 6b - Create a runtime environment secret from .env
 # Code Engine has no access to your local .env file — upload it as a secret.
 # The secret name is derived from the app name to keep naming consistent.
+#
+# First time:
 ibmcloud ce secret create --name "${IBMCLOUD_CODE_ENGINE_APP}-env" --from-env-file .env
+#
+# To update later (e.g. rotating credentials or changing config):
+# ibmcloud ce secret update --name "${IBMCLOUD_CODE_ENGINE_APP}-env" --from-env-file .env
+# ibmcloud ce application update --name "$IBMCLOUD_CODE_ENGINE_APP"
 
 # 7 - Deploy / update (attach the env secret so the container sees your config)
 if ibmcloud ce application get --name "$IBMCLOUD_CODE_ENGINE_APP" >/dev/null 2>&1; then

--- a/docs/docs/howto/ibm-cloud-code-engine.md
+++ b/docs/docs/howto/ibm-cloud-code-engine.md
@@ -26,8 +26,8 @@ Both files are already in **`.gitignore`**.
 Templates named **`.env.example`** and **`.env.ce.example`** are included; copy them:
 
 ```bash
-cp .env.example .env         # runtime settings (inside the container)
-cp .env.ce.example .env.ce   # deployment credentials (CLI only)
+cp .env.example .env         # runtime settings (uploaded to Code Engine as a secret)
+cp .env.ce.example .env.ce   # deployment credentials (CLI only, never reach the container)
 ```
 
 ### `.env` - runtime settings
@@ -150,7 +150,7 @@ grep -q JWT_SECRET_KEY .env && echo "OK: JWT_SECRET_KEY set" || echo "WARNING: J
 | `ibmcloud-list-containers`  | Show ICR images and existing Code Engine apps.                                       |
 | `ibmcloud-tag`              | `podman tag $IBMCLOUD_IMG_PROD $IBMCLOUD_IMAGE_NAME`.                                |
 | `ibmcloud-push`             | `ibmcloud cr login` + `podman push` to ICR.                                          |
-| `ibmcloud-deploy`           | Create **or** update the app; syncs `.env` to a Code Engine secret (`mcpgw-env`), sets CPU/MEM, attaches registry secret, exposes port 4444. |
+| `ibmcloud-deploy`           | Create **or** update the app; syncs `.env` to a Code Engine secret (`<app>-env`), sets CPU/MEM, attaches registry secret, exposes port 4444. |
 | `ibmcloud-ce-status`        | `ibmcloud ce application get` - see route URL, revisions, health.                    |
 | `ibmcloud-ce-logs`          | `ibmcloud ce application logs --follow` - live log stream.                           |
 | `ibmcloud-ce-rm`            | Delete the application entirely.                                                     |
@@ -169,8 +169,9 @@ make ibmcloud-deploy
 ```
 
 !!! info "`make ibmcloud-deploy` handles env injection automatically"
-    The target creates or updates a Code Engine secret named `mcpgw-env` from your local `.env`
-    on every run, then passes `--env-from-secret mcpgw-env` to the app. You do not need a
+    The target creates or updates a Code Engine secret named `<app>-env` (where `<app>` is
+    `$IBMCLOUD_CODE_ENGINE_APP`) from your local `.env` on every run, then passes
+    `--env-from-secret <app>-env` to the app. You do not need a
     separate step — just make sure `.env` is present and populated before running the target.
 
 **Redeploy after code changes**
@@ -182,7 +183,7 @@ make podman ibmcloud-tag ibmcloud-push ibmcloud-deploy
 **Update runtime config (`.env` changed, no code change)**
 
 ```bash
-ibmcloud ce secret update --name mcpgw-env --from-env-file .env
+ibmcloud ce secret update --name "${IBMCLOUD_CODE_ENGINE_APP}-env" --from-env-file .env
 ibmcloud ce application update --name "$IBMCLOUD_CODE_ENGINE_APP"
 ```
 
@@ -234,7 +235,8 @@ ibmcloud ce secret get --name "$IBMCLOUD_REGISTRY_SECRET"         # add --decode
 
 # 6b - Create a runtime environment secret from .env (first time only)
 # Code Engine has no access to your local .env file — upload it as a secret.
-ibmcloud ce secret create --name mcpgw-env --from-env-file .env
+# The secret name is derived from the app name to keep naming consistent.
+ibmcloud ce secret create --name "${IBMCLOUD_CODE_ENGINE_APP}-env" --from-env-file .env
 
 # 7 - Deploy / update (attach the env secret so the container sees your config)
 if ibmcloud ce application get --name "$IBMCLOUD_CODE_ENGINE_APP" >/dev/null 2>&1; then
@@ -242,14 +244,14 @@ if ibmcloud ce application get --name "$IBMCLOUD_CODE_ENGINE_APP" >/dev/null 2>&
       --image "$IBMCLOUD_IMAGE_NAME" \
       --cpu "$IBMCLOUD_CPU" --memory "$IBMCLOUD_MEMORY" \
       --registry-secret "$IBMCLOUD_REGISTRY_SECRET" \
-      --env-from-secret mcpgw-env
+      --env-from-secret "${IBMCLOUD_CODE_ENGINE_APP}-env"
 else
   ibmcloud ce application create --name "$IBMCLOUD_CODE_ENGINE_APP" \
       --image "$IBMCLOUD_IMAGE_NAME" \
       --cpu "$IBMCLOUD_CPU" --memory "$IBMCLOUD_MEMORY" \
       --port 4444 \
       --registry-secret "$IBMCLOUD_REGISTRY_SECRET" \
-      --env-from-secret mcpgw-env
+      --env-from-secret "${IBMCLOUD_CODE_ENGINE_APP}-env"
 fi
 ```
 
@@ -309,6 +311,9 @@ make ibmcloud-ce-rm
 
 # or directly
 ibmcloud ce application delete --name "$IBMCLOUD_CODE_ENGINE_APP" -f
+
+# Also remove the runtime env secret if you no longer need it
+ibmcloud ce secret delete --name "${IBMCLOUD_CODE_ENGINE_APP}-env" -f
 ```
 
 ---
@@ -316,6 +321,13 @@ ibmcloud ce application delete --name "$IBMCLOUD_CODE_ENGINE_APP" -f
 ## 7 - Using IBM Cloud Databases for PostgreSQL
 
 Need durable data, high availability, and automated backups? Provision **IBM Cloud Databases for PostgreSQL** and connect ContextForge to it.
+
+!!! tip "Already have `DATABASE_URL` in your `.env`?"
+    If you set `DATABASE_URL` in `.env` before running `make ibmcloud-deploy`, it is already
+    present in the `<app>-env` secret and you can skip steps 4–5 below. The separate
+    `mcpgw-db-url` secret approach shown here is useful when you want to manage the database
+    credential independently from the rest of your config — for example, rotating it without
+    re-uploading the entire `.env`.
 
 ```bash
 ###############################################################################
@@ -412,6 +424,12 @@ For production workloads you **must** switch to a managed database or mount a pe
 
 Need a high-performance shared cache? Provision **IBM Cloud Databases for Redis**
 and point ContextForge at it.
+
+!!! tip "Already have `REDIS_URL` in your `.env`?"
+    If you set `REDIS_URL` and `CACHE_TYPE=redis` in `.env` before running `make ibmcloud-deploy`,
+    they are already present in the `<app>-env` secret and you can skip steps 4–5 below. The
+    separate `mcpgw-redis-url` secret approach shown here is useful when you want to manage the
+    Redis credential independently from the rest of your config.
 
 ```bash
 ###############################################################################
@@ -557,7 +575,7 @@ make podman ibmcloud-tag ibmcloud-push ibmcloud-deploy
 |---------|-------|-----|
 | `ibmcloud ce application get` shows "Failed" | Image pull error — wrong registry secret or image path | Verify `IBMCLOUD_IMAGE_NAME` matches the pushed image: `ibmcloud cr images` |
 | Application starts then crashes (OOMKilled) | Insufficient memory for gunicorn workers | Increase `IBMCLOUD_MEMORY` in `.env.ce` or reduce `workers` in `gunicorn.config.py` |
-| App running but env vars missing (auth fails, wrong DB, etc.) | `.env` was never uploaded as a Code Engine secret | Run: `ibmcloud ce secret create --name mcpgw-env --from-env-file .env` then `ibmcloud ce application update --name $IBMCLOUD_CODE_ENGINE_APP --env-from-secret mcpgw-env` |
+| App running but env vars missing (auth fails, wrong DB, etc.) | `.env` was never uploaded as a Code Engine secret | Run: `ibmcloud ce secret create --name ${IBMCLOUD_CODE_ENGINE_APP}-env --from-env-file .env` then `ibmcloud ce application update --name $IBMCLOUD_CODE_ENGINE_APP --env-from-secret ${IBMCLOUD_CODE_ENGINE_APP}-env` |
 | App starts but requests never reach it (connection refused / 502) | `HOST=127.0.0.1` in `.env` — app binds to loopback only | Set `HOST=0.0.0.0` in `.env`, update the secret, and trigger a new revision |
 | `connection refused` to PostgreSQL | Database not yet provisioned or wrong hostname | Verify with: `ibmcloud resource service-instance mcpgw-db` and check credentials JSON |
 | `SSL: CERTIFICATE_VERIFY_FAILED` on database connection | Missing `sslmode=require` in `DATABASE_URL` | Ensure `DATABASE_URL` ends with `?sslmode=require` |

--- a/docs/docs/howto/ibm-cloud-code-engine.md
+++ b/docs/docs/howto/ibm-cloud-code-engine.md
@@ -32,7 +32,7 @@ cp .env.ce.example .env.ce   # deployment credentials (CLI only)
 
 ### `.env` - runtime settings
 
-This file is **mounted into the container** (via `--env-file=.env`), so its keys live inside Code Engine at runtime. Treat it as an application secret store.
+This file holds the runtime configuration for the gateway. Locally it is passed to the container via `--env-file=.env`, but **Code Engine has no access to your local filesystem** — you must upload these values as a Code Engine secret (covered in the deploy steps below). Treat this file as an application secret store and never commit it to version control.
 
 ```bash
 # ─────────────────────────────────────────────────────────────────────────────
@@ -125,6 +125,17 @@ grep -q DATABASE_URL .env && echo "OK: DATABASE_URL set" || echo "WARNING: DATAB
 grep -q JWT_SECRET_KEY .env && echo "OK: JWT_SECRET_KEY set" || echo "WARNING: JWT_SECRET_KEY not set in .env"
 ```
 
+!!! warning "Set `HOST=0.0.0.0` in your `.env`"
+    Code Engine routes external traffic into the container. If `HOST` is set to `127.0.0.1`
+    (the application default) the process binds to loopback only and Code Engine's routing
+    cannot reach it — the app will appear to start but all requests will fail.
+
+    Make sure your `.env` contains:
+    ```bash
+    HOST=0.0.0.0
+    PORT=4444
+    ```
+
 ---
 
 ## 3 - Workflow A - Makefile targets
@@ -139,7 +150,7 @@ grep -q JWT_SECRET_KEY .env && echo "OK: JWT_SECRET_KEY set" || echo "WARNING: J
 | `ibmcloud-list-containers`  | Show ICR images and existing Code Engine apps.                                       |
 | `ibmcloud-tag`              | `podman tag $IBMCLOUD_IMG_PROD $IBMCLOUD_IMAGE_NAME`.                                |
 | `ibmcloud-push`             | `ibmcloud cr login` + `podman push` to ICR.                                          |
-| `ibmcloud-deploy`           | Create **or** update the app, set CPU/MEM, attach registry secret, expose port 4444. |
+| `ibmcloud-deploy`           | Create **or** update the app; syncs `.env` to a Code Engine secret (`mcpgw-env`), sets CPU/MEM, attaches registry secret, exposes port 4444. |
 | `ibmcloud-ce-status`        | `ibmcloud ce application get` - see route URL, revisions, health.                    |
 | `ibmcloud-ce-logs`          | `ibmcloud ce application logs --follow` - live log stream.                           |
 | `ibmcloud-ce-rm`            | Delete the application entirely.                                                     |
@@ -157,10 +168,22 @@ make ibmcloud-push
 make ibmcloud-deploy
 ```
 
+!!! info "`make ibmcloud-deploy` handles env injection automatically"
+    The target creates or updates a Code Engine secret named `mcpgw-env` from your local `.env`
+    on every run, then passes `--env-from-secret mcpgw-env` to the app. You do not need a
+    separate step — just make sure `.env` is present and populated before running the target.
+
 **Redeploy after code changes**
 
 ```bash
 make podman ibmcloud-tag ibmcloud-push ibmcloud-deploy
+```
+
+**Update runtime config (`.env` changed, no code change)**
+
+```bash
+ibmcloud ce secret update --name mcpgw-env --from-env-file .env
+ibmcloud ce application update --name "$IBMCLOUD_CODE_ENGINE_APP"
 ```
 
 ---
@@ -209,18 +232,24 @@ ibmcloud ce registry create-secret --name "$IBMCLOUD_REGISTRY_SECRET" \
 ibmcloud ce secret list # list every secret (generic, registry, SSH, TLS, etc.)
 ibmcloud ce secret get --name "$IBMCLOUD_REGISTRY_SECRET"         # add --decode to see clear-text values
 
-# 7 - Deploy / update
+# 6b - Create a runtime environment secret from .env (first time only)
+# Code Engine has no access to your local .env file — upload it as a secret.
+ibmcloud ce secret create --name mcpgw-env --from-env-file .env
+
+# 7 - Deploy / update (attach the env secret so the container sees your config)
 if ibmcloud ce application get --name "$IBMCLOUD_CODE_ENGINE_APP" >/dev/null 2>&1; then
   ibmcloud ce application update --name "$IBMCLOUD_CODE_ENGINE_APP" \
       --image "$IBMCLOUD_IMAGE_NAME" \
       --cpu "$IBMCLOUD_CPU" --memory "$IBMCLOUD_MEMORY" \
-      --registry-secret "$IBMCLOUD_REGISTRY_SECRET"
+      --registry-secret "$IBMCLOUD_REGISTRY_SECRET" \
+      --env-from-secret mcpgw-env
 else
   ibmcloud ce application create --name "$IBMCLOUD_CODE_ENGINE_APP" \
       --image "$IBMCLOUD_IMAGE_NAME" \
       --cpu "$IBMCLOUD_CPU" --memory "$IBMCLOUD_MEMORY" \
       --port 4444 \
-      --registry-secret "$IBMCLOUD_REGISTRY_SECRET"
+      --registry-secret "$IBMCLOUD_REGISTRY_SECRET" \
+      --env-from-secret mcpgw-env
 fi
 ```
 
@@ -528,6 +557,8 @@ make podman ibmcloud-tag ibmcloud-push ibmcloud-deploy
 |---------|-------|-----|
 | `ibmcloud ce application get` shows "Failed" | Image pull error — wrong registry secret or image path | Verify `IBMCLOUD_IMAGE_NAME` matches the pushed image: `ibmcloud cr images` |
 | Application starts then crashes (OOMKilled) | Insufficient memory for gunicorn workers | Increase `IBMCLOUD_MEMORY` in `.env.ce` or reduce `workers` in `gunicorn.config.py` |
+| App running but env vars missing (auth fails, wrong DB, etc.) | `.env` was never uploaded as a Code Engine secret | Run: `ibmcloud ce secret create --name mcpgw-env --from-env-file .env` then `ibmcloud ce application update --name $IBMCLOUD_CODE_ENGINE_APP --env-from-secret mcpgw-env` |
+| App starts but requests never reach it (connection refused / 502) | `HOST=127.0.0.1` in `.env` — app binds to loopback only | Set `HOST=0.0.0.0` in `.env`, update the secret, and trigger a new revision |
 | `connection refused` to PostgreSQL | Database not yet provisioned or wrong hostname | Verify with: `ibmcloud resource service-instance mcpgw-db` and check credentials JSON |
 | `SSL: CERTIFICATE_VERIFY_FAILED` on database connection | Missing `sslmode=require` in `DATABASE_URL` | Ensure `DATABASE_URL` ends with `?sslmode=require` |
 | Redis connection timeout | Security group or allowlist blocking Code Engine IPs | IBM Cloud Databases allowlist must include Code Engine's outbound IPs, or use private endpoints |

--- a/docs/docs/howto/ibm-cloud-code-engine.md
+++ b/docs/docs/howto/ibm-cloud-code-engine.md
@@ -175,6 +175,19 @@ make ibmcloud-deploy
     `--env-from-secret <app>-env` to the app. You do not need a
     separate step — just make sure `.env` is present and populated before running the target.
 
+!!! warning "`--from-env-file` skips lines with inline comments"
+    The `ibmcloud ce secret` flag used to upload `.env` silently **skips any line that contains
+    an inline comment** (e.g. `KEY=value  # comment`).  If you copied `.env.example` verbatim,
+    strip all inline comments before running `make ibmcloud-deploy`:
+
+    ```bash
+    # Remove inline comments from .env before uploading (non-destructive — edits in place)
+    sed -i.bak 's/[[:space:]]*#.*$//' .env && grep -v '^[[:space:]]*$' .env > .env.clean && mv .env.clean .env
+    ```
+
+    Affected variables will be uploaded as **empty strings**, causing silent misconfiguration
+    that is difficult to diagnose at runtime.
+
 **Redeploy after code changes**
 
 ```bash
@@ -234,6 +247,7 @@ ibmcloud cr images --restrict "$(echo "$IBMCLOUD_IMAGE_NAME" | cut -d/ -f2)"
 
 ```bash
 # 6 - Create registry secret (first time)
+# Note: 'ibmcloud ce registry create-secret' is deprecated — use the form below.
 ibmcloud ce secret create --name "$IBMCLOUD_REGISTRY_SECRET" \
     --format registry \
     --server "$(echo "$IBMCLOUD_IMAGE_NAME" | cut -d/ -f1)" \
@@ -244,6 +258,10 @@ ibmcloud ce secret get --name "$IBMCLOUD_REGISTRY_SECRET"         # add --decode
 # 6b - Create a runtime environment secret from .env
 # Code Engine has no access to your local .env file — upload it as a secret.
 # The secret name is derived from the app name to keep naming consistent.
+#
+# WARNING: --from-env-file skips lines with inline comments (KEY=value  # comment).
+# Strip inline comments from .env before running this command to avoid silent data loss:
+#   sed -i.bak 's/[[:space:]]*#.*$//' .env && grep -v '^[[:space:]]*$' .env > .env.clean && mv .env.clean .env
 #
 # First time:
 ibmcloud ce secret create --name "${IBMCLOUD_CODE_ENGINE_APP}-env" --from-env-file .env
@@ -589,7 +607,7 @@ make podman ibmcloud-tag ibmcloud-push ibmcloud-deploy
 |---------|-------|-----|
 | `ibmcloud ce application get` shows "Failed" | Image pull error — wrong registry secret or image path | Verify `IBMCLOUD_IMAGE_NAME` matches the pushed image: `ibmcloud cr images` |
 | Application starts then crashes (OOMKilled) | Insufficient memory for gunicorn workers | Increase `IBMCLOUD_MEMORY` in `.env.ce` or reduce `workers` in `gunicorn.config.py` |
-| App running but env vars missing (auth fails, wrong DB, etc.) | `.env` was never uploaded as a Code Engine secret | Run: `ibmcloud ce secret create --name ${IBMCLOUD_CODE_ENGINE_APP}-env --from-env-file .env` then `ibmcloud ce application update --name $IBMCLOUD_CODE_ENGINE_APP --env-from-secret ${IBMCLOUD_CODE_ENGINE_APP}-env` |
+| App running but env vars missing (auth fails, wrong DB, etc.) | `.env` was never uploaded as a Code Engine secret, or contained inline comments that caused keys to be skipped | Strip inline comments from `.env` first (`sed -i.bak 's/[[:space:]]*#.*$//' .env`), then run: <br>`ibmcloud ce secret create --name "${IBMCLOUD_CODE_ENGINE_APP}-env" --from-env-file .env`<br>`ibmcloud ce application update --name "$IBMCLOUD_CODE_ENGINE_APP" --env-from-secret "${IBMCLOUD_CODE_ENGINE_APP}-env"` |
 | App starts but requests never reach it (connection refused / 502) | `HOST=127.0.0.1` in `.env` — app binds to loopback only | Set `HOST=0.0.0.0` in `.env`, update the secret, and trigger a new revision |
 | `connection refused` to PostgreSQL | Database not yet provisioned or wrong hostname | Verify with: `ibmcloud resource service-instance mcpgw-db` and check credentials JSON |
 | `SSL: CERTIFICATE_VERIFY_FAILED` on database connection | Missing `sslmode=require` in `DATABASE_URL` | Ensure `DATABASE_URL` ends with `?sslmode=require` |

--- a/docs/docs/howto/ibm-cloud-code-engine.md
+++ b/docs/docs/howto/ibm-cloud-code-engine.md
@@ -177,16 +177,13 @@ make ibmcloud-deploy
 
 !!! warning "`--from-env-file` skips lines with inline comments"
     The `ibmcloud ce secret` flag used to upload `.env` silently **skips any line that contains
-    an inline comment** (e.g. `KEY=value  # comment`).  If you copied `.env.example` verbatim,
-    strip all inline comments before running `make ibmcloud-deploy`:
+    an inline comment** (e.g. `KEY=value  # comment`).  Before running `make ibmcloud-deploy`,
+    check your `.env` for lines of the form `KEY=value  # comment` and move the comment to its
+    own line above the key.
 
-    ```bash
-    # Remove inline comments from .env before uploading (non-destructive — edits in place)
-    sed -i.bak 's/[[:space:]]*#.*$//' .env && grep -v '^[[:space:]]*$' .env > .env.clean && mv .env.clean .env
-    ```
-
-    Affected variables will be uploaded as **empty strings**, causing silent misconfiguration
-    that is difficult to diagnose at runtime.
+    Do **not** use a blanket `sed` stripper — values such as `DATABASE_URL` or `REDIS_URL`
+    pasted from the IBM Cloud console can legitimately contain `#`, and stripping would silently
+    truncate them.
 
 **Redeploy after code changes**
 
@@ -259,9 +256,9 @@ ibmcloud ce secret get --name "$IBMCLOUD_REGISTRY_SECRET"         # add --decode
 # Code Engine has no access to your local .env file — upload it as a secret.
 # The secret name is derived from the app name to keep naming consistent.
 #
-# WARNING: --from-env-file skips lines with inline comments (KEY=value  # comment).
-# Strip inline comments from .env before running this command to avoid silent data loss:
-#   sed -i.bak 's/[[:space:]]*#.*$//' .env && grep -v '^[[:space:]]*$' .env > .env.clean && mv .env.clean .env
+# NOTE: --from-env-file skips lines with inline comments (KEY=value  # comment).
+# Check your .env for such lines and move comments to their own line before running.
+# See the warning in Workflow A above for details.
 #
 # First time:
 ibmcloud ce secret create --name "${IBMCLOUD_CODE_ENGINE_APP}-env" --from-env-file .env
@@ -607,7 +604,7 @@ make podman ibmcloud-tag ibmcloud-push ibmcloud-deploy
 |---------|-------|-----|
 | `ibmcloud ce application get` shows "Failed" | Image pull error — wrong registry secret or image path | Verify `IBMCLOUD_IMAGE_NAME` matches the pushed image: `ibmcloud cr images` |
 | Application starts then crashes (OOMKilled) | Insufficient memory for gunicorn workers | Increase `IBMCLOUD_MEMORY` in `.env.ce` or reduce `workers` in `gunicorn.config.py` |
-| App running but env vars missing (auth fails, wrong DB, etc.) | `.env` was never uploaded as a Code Engine secret, or contained inline comments that caused keys to be skipped | Strip inline comments from `.env` first (`sed -i.bak 's/[[:space:]]*#.*$//' .env`), then run: <br>`ibmcloud ce secret create --name "${IBMCLOUD_CODE_ENGINE_APP}-env" --from-env-file .env`<br>`ibmcloud ce application update --name "$IBMCLOUD_CODE_ENGINE_APP" --env-from-secret "${IBMCLOUD_CODE_ENGINE_APP}-env"` |
+| App running but env vars missing (auth fails, wrong DB, etc.) | `.env` was never uploaded as a Code Engine secret, or has lines with inline comments that `--from-env-file` skips (see warning in Workflow A) | Check `.env` for `KEY=value  # comment` lines and move comments to their own line, then run:<br>`ibmcloud ce secret create --name "${IBMCLOUD_CODE_ENGINE_APP}-env" --from-env-file .env`<br>`ibmcloud ce application update --name "$IBMCLOUD_CODE_ENGINE_APP" --env-from-secret "${IBMCLOUD_CODE_ENGINE_APP}-env"` |
 | App starts but requests never reach it (connection refused / 502) | `HOST=127.0.0.1` in `.env` — app binds to loopback only | Set `HOST=0.0.0.0` in `.env`, update the secret, and trigger a new revision |
 | `connection refused` to PostgreSQL | Database not yet provisioned or wrong hostname | Verify with: `ibmcloud resource service-instance mcpgw-db` and check credentials JSON |
 | `SSL: CERTIFICATE_VERIFY_FAILED` on database connection | Missing `sslmode=require` in `DATABASE_URL` | Ensure `DATABASE_URL` ends with `?sslmode=require` |


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #6289 

---

## 📝 Summary

The IBM Cloud Code Engine deployment guide was missing the step to inject `.env` runtime settings into the running container. Users following the guide ended up with a deployed but unconfigured application — none of the values from `.env` (JWT secret, database URL, auth settings, etc.) were present inside the container.

Two root causes:

1. `make ibmcloud-deploy` called `ibmcloud ce application create/update` without passing any environment variables — the `--env-file=.env` flag used by local `docker`/`podman run` does not apply to Code Engine, which pulls the image remotely and has no access to the local filesystem.
2. Neither Workflow A (Makefile) nor Workflow B (manual CLI) in the guide mentioned creating a Code Engine secret from `.env` or attaching it to the app.

**Changes:**
- `make ibmcloud-deploy` now automatically creates or updates a Code Engine secret named `mcpgw-env` from the local `.env` on every run, and passes `--env-from-secret mcpgw-env` to both `application create` and `application update`
- Workflow B manual CLI steps gain step 6b (secret creation) and `--env-from-secret mcpgw-env` on step 7
- Corrected the false claim in Section 2 that `.env` is "mounted via `--env-file`" on Code Engine
- Added a `HOST=0.0.0.0` warning callout — if left as `127.0.0.1`, the app binds to loopback only and Code Engine routing cannot reach it
- Added a "update runtime config" snippet for the case where `.env` changes without a code change
- Added two new troubleshooting rows: missing env vars and `HOST=127.0.0.1` causing 502s

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [x] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [x] Other — Makefile tooling fix alongside docs

---

## 🧪 Verification

This is a documentation and Makefile tooling fix. The Makefile change can be verified by running `make ibmcloud-deploy` against a real Code Engine project and confirming:
1. The `mcpgw-env` secret is created/updated from `.env`
2. `ibmcloud ce application get --name <app>` shows the secret listed under environment references
3. Env vars are present inside the container

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | N/A — docs + Makefile only |
| Unit tests                | `make test`     | N/A — no Python changes |
| Coverage ≥ 80%            | `make coverage` | N/A — no Python changes |

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

The `--from-env-file` flag on `ibmcloud ce secret` skips lines with inline comments (e.g. `KEY=value  # comment`). Users copying `.env.example` verbatim should strip inline comments before running `make ibmcloud-deploy`. This is a pre-existing `.env.example` formatting issue tracked separately.