### PR TITLE
chore: remove temporary min-release-age-exclude pins from .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 min-release-age=10
-min-release-age-exclude=dompurify,js-yaml,nanoid


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #6170

---

## 📝 Summary

Removes the temporary `min-release-age-exclude=dompurify,js-yaml,nanoid` line from `.npmrc`. This bypass was added to unblock a routine npm dependency update cycle while those three packages were still within the 10-day soak window. They have since passed that threshold, so the exclusion is no longer needed. Removing it restores the standard `min-release-age=10` gate for all packages uniformly.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Chore (deps, CI, tooling)

---

## 🧪 Verification

| Check        | Command          | Status |
|--------------|------------------|--------|
| UI build     | `make build-ui`  | ✅ Passes — bundle built successfully in ~2s |
| Lint suite   | `make lint`      | ✅ |
| Unit tests   | `make test`      | ✅ |

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes — N/A (config-only change)
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

Single-line deletion in `.npmrc`. No source code, tests, or documentation were affected. The three packages (`dompurify 3.4.13`, `js-yaml 4.3.1`, `nanoid 3.3.18`) cleared the 10-day soak window shortly after the `cargo-npm-updates-10-08` PR merged. Leaving the exclusion in place permanently would exempt these packages from the soak gate on every future upgrade cycle, undermining the intent of `min-release-age`.