### PR TITLE
fix: recreate CI venv when cached Python symlink is broken

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-17T13:30:58Z",
+  "generated_at": "2026-08-19T09:48:01Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -334,7 +334,7 @@
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 576,
+        "line_number": 580,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -342,7 +342,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1027,
+        "line_number": 1031,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +350,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1029,
+        "line_number": 1033,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +358,7 @@
         "hashed_secret": "db69d9215c29ae2f2e4ead587890a9f8455059dd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1103,
+        "line_number": 1107,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +366,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1683,
+        "line_number": 1687,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +374,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1902,
+        "line_number": 1906,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6059,
+        "line_number": 6063,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6556,
+        "line_number": 6560,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6568,
+        "line_number": 6572,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6640,
+        "line_number": 6644,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7056,
+        "line_number": 7060,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7746,
+        "line_number": 7750,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,10 @@ DETECT_SECRETS_SPEC     ?= git+https://github.com/ibm/detect-secrets.git@076672a
 
 .PHONY: venv
 venv: uv
+	@if [ -d "$(VENV_DIR)" ] && [ ! -e "$(VENV_DIR)/bin/python3" ]; then \
+		echo "⚠️  Cached virtual env has a broken Python interpreter symlink; recreating."; \
+		rm -rf "$(VENV_DIR)"; \
+	fi
 	@if [ ! -d "$(VENV_DIR)" ]; then \
 		$(UV_BIN) venv "$(VENV_DIR)"; \
 		echo -e "✅  Virtual env created.\n💡  Enter it with:\n    . $(VENV_DIR)/bin/activate\n"; \


### PR DESCRIPTION
## Summary
- `make venv` only checked that `.venv` existed, not that its `bin/python3` symlink still resolved
- The plugin-integration workflow caches `.venv` across runs; when the cached interpreter path no longer matches the runner (e.g. runner image/toolchain update), the symlink dangles and `install-dev` fails with `Broken symlink at .venv/bin/python3`
- Detect a dangling `bin/python3` symlink and wipe the venv before recreating it, so a stale cache self-heals instead of failing the job

Fixes the merge-queue CI failure in https://github.com/IBM/mcp-context-forge/actions/runs/32236429043/job/96017328757

## Test plan
- [x] Simulated a broken `.venv/bin/python3` symlink and ran `make venv` — confirmed it detects, removes, and recreates the venv
- [x] Ran `make venv` against the existing healthy `.venv` — confirmed it still skips recreation (no regression)