### PR TITLE
fix(security): audit active gateway/tool/agent URLs against scheme allowlist on startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3148,7 +3148,20 @@ PLUGINS_CLI_MARKUP_MODE=rich
 # Allowed URL schemes for external requests
 # Controls which URL schemes are permitted for gateway operations
 # Default: ["http://", "https://", "ws://", "wss://"]
+# NOTE: this is read once into a class-level constant at process start, so a
+# change here needs a full process restart to take effect -- a Gunicorn
+# worker reload (SIGHUP) is NOT sufficient. It is also enforced only at
+# registration time; existing gateway/tool/agent records already in the
+# database keep using whatever scheme they were created with (see
+# STRICT_SCHEME_ENFORCEMENT below to audit those on startup).
 # VALIDATION_ALLOWED_URL_SCHEMES=["http://", "https://", "ws://", "wss://"]
+
+# If true, fail startup when an active gateway/tool/agent record's URL uses a
+# scheme outside VALIDATION_ALLOWED_URL_SCHEMES (e.g. a leftover http:// record
+# after tightening the allowlist to https-only). Default false: such records
+# are logged as a WARNING instead, so upgrading to a stricter allowlist never
+# breaks an existing deployment outright.
+# STRICT_SCHEME_ENFORCEMENT=false
 
 # Character validation patterns (regex)
 # Used to validate various input fields

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -162,15 +162,58 @@ def alembic_at_head(conn: Connection, cfg: Config) -> bool:
         return False
 
 
+def audit_url_schemes(conn: Connection) -> None:
+    """Audit active gateway/tool/A2A-agent URLs against the configured scheme allowlist.
+
+    ``SecurityValidator.ALLOWED_URL_SCHEMES`` is enforced only at registration
+    time (the Pydantic field validators on create/update schemas), so a record
+    that was registered before the allowlist was tightened — e.g. an
+    ``http://`` gateway created before ``VALIDATION_ALLOWED_URL_SCHEMES`` was
+    narrowed to ``https://`` only — keeps being used by health checks, tool
+    invocation, and federation regardless of the current setting. This makes
+    that gap visible on every startup instead of leaving it undetected.
+
+    Read-only by design: this only logs (or, under ``strict_scheme_enforcement``,
+    raises) — it never mutates or disables an offending record, since deciding
+    what to do about a live integration is an operator call, not this
+    function's to make silently.
+
+    Args:
+        conn: Active SQLAlchemy connection.
+
+    Raises:
+        RuntimeError: If ``settings.strict_scheme_enforcement`` is True and at
+            least one active record uses a scheme outside the allowlist.
+    """
+    violations: list[str] = []
+    with Session(bind=conn) as session:
+        for model, url_attr, label in ((Gateway, "url", "gateway"), (Tool, "url", "tool"), (A2AAgent, "endpoint_url", "a2a_agent")):
+            records = session.query(model).filter(model.enabled.is_(True)).all()
+            for record in records:
+                url = getattr(record, url_attr, None)
+                if not url:
+                    continue
+                if not SecurityValidator.has_allowed_scheme(url):
+                    violations.append(f"{label} '{record.name}' (id={record.id}): {url}")
+
+    if not violations:
+        return
+
+    message = f"{len(violations)} active record(s) use a URL scheme outside " f"VALIDATION_ALLOWED_URL_SCHEMES ({', '.join(SecurityValidator.ALLOWED_URL_SCHEMES)}): " + "; ".join(violations)
+    if settings.strict_scheme_enforcement:
+        raise RuntimeError(f"{message}. Refusing to start (STRICT_SCHEME_ENFORCEMENT=true).")
+    logger.warning(message)
+
+
 async def _run_post_migration_bootstrap(conn: Connection) -> None:
     """Run the idempotent post-migration bootstrap steps.
 
     These steps (team-visibility normalization, admin user, default roles,
-    orphaned-resource assignment) are designed to be safe to re-run on
-    every startup — each checks for existing state and skips if already
-    populated. They must run on replicas that take the fast-path so that a
-    prior replica crashing mid-bootstrap doesn't leave downstream state
-    unpopulated.
+    orphaned-resource assignment, URL-scheme audit) are designed to be safe
+    to re-run on every startup — each checks for existing state and skips if
+    already populated (or, for the scheme audit, is read-only). They must run
+    on replicas that take the fast-path so that a prior replica crashing
+    mid-bootstrap doesn't leave downstream state unpopulated.
 
     Args:
         conn: Active SQLAlchemy connection (locked on the slow path,
@@ -183,6 +226,7 @@ async def _run_post_migration_bootstrap(conn: Connection) -> None:
     await bootstrap_admin_user(conn)
     await bootstrap_default_roles(conn)
     await bootstrap_resource_assignments(conn)
+    audit_url_schemes(conn)
 
 
 @contextmanager

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -381,6 +381,29 @@ class SecurityValidator:
     MAX_URL_LENGTH = settings.validation_max_url_length  # Default: 2048
 
     @classmethod
+    def has_allowed_scheme(cls, value: str) -> bool:
+        """Check whether a URL starts with one of the configured allowed schemes.
+
+        Shared by validate_url (registration-time) and the startup scheme
+        audit in bootstrap_db (existing-record time) so both enforce the
+        exact same rule.
+
+        Args:
+            value: URL to check
+
+        Returns:
+            bool: True if value starts with one of cls.ALLOWED_URL_SCHEMES (case-insensitive)
+
+        Examples:
+            >>> SecurityValidator.has_allowed_scheme("https://example.com")
+            True
+            >>> SecurityValidator.has_allowed_scheme("javascript:alert(1)")
+            False
+        """
+        value_lower = value.lower()
+        return any(value_lower.startswith(scheme.lower()) for scheme in cls.ALLOWED_URL_SCHEMES)
+
+    @classmethod
     def sanitize_display_text(cls, value: str, field_name: str) -> str:
         """Ensure text is safe for display in UI by escaping special characters
 
@@ -1254,11 +1277,9 @@ class SecurityValidator:
         if "\ufffd" in decoded_value:
             raise ValueError(f"{field_name} contains invalid UTF-8 byte sequences which are not allowed")
 
-        # Check allowed schemes (lowercase value once, not per scheme).
-        allowed_schemes = cls.ALLOWED_URL_SCHEMES
-        value_lower = value.lower()
-        if not any(value_lower.startswith(scheme.lower()) for scheme in allowed_schemes):
-            raise ValueError(f"{field_name} must start with one of: {', '.join(allowed_schemes)}")
+        # Check allowed schemes.
+        if not cls.has_allowed_scheme(value):
+            raise ValueError(f"{field_name} must start with one of: {', '.join(cls.ALLOWED_URL_SCHEMES)}")
 
         # Block dangerous URL patterns anywhere in the decoded URL (defense-in-depth:
         # downstream consumers may extract query/fragment and reuse as URLs elsewhere).

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -3609,6 +3609,16 @@ Disallow: /
 
     validation_allowed_url_schemes: List[str] = ["http://", "https://", "ws://", "wss://"]
 
+    # If True, startup fails when an active gateway/tool/agent record's URL uses
+    # a scheme outside validation_allowed_url_schemes -- e.g. a leftover http://
+    # record after tightening the allowlist to https-only. Registration-time
+    # validation alone does not catch this: it only checks new records, so an
+    # existing record keeps being used by health checks, tool invocation, and
+    # federation regardless of the current allowlist. Default False (warn-only)
+    # so upgrading to a stricter allowlist never breaks an existing deployment
+    # outright.
+    strict_scheme_enforcement: bool = False
+
     # Character validation patterns
     validation_name_pattern: str = r"^[a-zA-Z0-9_.\- ]+$"  # Allow spaces for names (literal space, not \s to reject control chars)
     validation_identifier_pattern: str = r"^[a-zA-Z0-9_\-\.]+$"  # No spaces for IDs

--- a/tests/unit/mcpgateway/test_bootstrap_db.py
+++ b/tests/unit/mcpgateway/test_bootstrap_db.py
@@ -20,6 +20,7 @@ import pytest
 from mcpgateway.bootstrap_db import (
     alembic_at_head,
     advisory_lock,
+    audit_url_schemes,
     bootstrap_admin_user,
     bootstrap_default_roles,
     bootstrap_resource_assignments,
@@ -27,6 +28,7 @@ from mcpgateway.bootstrap_db import (
     normalize_team_visibility,
 )
 from mcpgateway.common.validators import SecurityValidator
+from mcpgateway.db import A2AAgent, Gateway, Tool
 
 
 @pytest.fixture
@@ -1657,6 +1659,121 @@ class TestBootstrapResourceAssignments:
                                                 mock_logger.info.assert_any_call("Successfully assigned 1 orphaned resources to admin team")
 
 
+class TestAuditUrlSchemes:
+    """Test audit_url_schemes: the startup check for #6264 (Gap 2).
+
+    SecurityValidator.ALLOWED_URL_SCHEMES is enforced only at registration
+    time, so an existing enabled gateway/tool/a2a_agent record can carry a
+    scheme the current allowlist no longer permits. These tests guard that
+    the startup audit actually surfaces that gap instead of staying silent.
+    """
+
+    @staticmethod
+    def _record(name, id_, url):
+        record = Mock()
+        record.name = name
+        record.id = id_
+        record.url = url
+        record.endpoint_url = url
+        return record
+
+    @staticmethod
+    def _session_returning(records_by_model):
+        """Build a mock Session whose .query(Model).filter(...).all() returns
+        records_by_model.get(Model, []) for whichever model is queried."""
+        session = MagicMock()
+        session.__enter__ = Mock(return_value=session)
+        session.__exit__ = Mock(return_value=None)
+
+        def query_side_effect(model):
+            query = Mock()
+            query.filter.return_value = query
+            query.all.return_value = records_by_model.get(model, [])
+            return query
+
+        session.query.side_effect = query_side_effect
+        return session
+
+    def test_no_active_records_no_warning(self, mock_settings, mock_conn):
+        """Nothing enabled -> nothing to warn about."""
+        session = self._session_returning({})
+        mock_settings.strict_scheme_enforcement = False
+
+        with patch("mcpgateway.bootstrap_db.settings", mock_settings):
+            with patch("mcpgateway.bootstrap_db.Session", return_value=session):
+                with patch("mcpgateway.bootstrap_db.logger") as mock_logger:
+                    audit_url_schemes(mock_conn)
+
+                    mock_logger.warning.assert_not_called()
+
+    def test_all_schemes_allowed_no_warning(self, mock_settings, mock_conn):
+        """Records whose scheme is still in the (default) allowlist are not flagged."""
+        gateway = self._record("good-gateway", "gw-1", "https://good.example.com")
+        session = self._session_returning({Gateway: [gateway]})
+        mock_settings.strict_scheme_enforcement = False
+
+        with patch("mcpgateway.bootstrap_db.settings", mock_settings):
+            with patch("mcpgateway.bootstrap_db.Session", return_value=session):
+                with patch("mcpgateway.bootstrap_db.logger") as mock_logger:
+                    audit_url_schemes(mock_conn)
+
+                    mock_logger.warning.assert_not_called()
+
+    def test_disallowed_scheme_logs_warning_by_default(self, mock_settings, mock_conn):
+        """An active record outside the allowlist is warned about, and startup does not fail
+        (strict_scheme_enforcement default False keeps upgrades to a stricter allowlist
+        non-breaking)."""
+        offender = self._record("legacy-gateway", "gw-legacy", "http://legacy.example.com")
+        session = self._session_returning({Gateway: [offender]})
+        mock_settings.strict_scheme_enforcement = False
+
+        with patch("mcpgateway.bootstrap_db.settings", mock_settings):
+            with patch("mcpgateway.bootstrap_db.SecurityValidator") as mock_validator:
+                mock_validator.has_allowed_scheme.return_value = False
+                mock_validator.ALLOWED_URL_SCHEMES = ["https://", "wss://"]
+                with patch("mcpgateway.bootstrap_db.Session", return_value=session):
+                    with patch("mcpgateway.bootstrap_db.logger") as mock_logger:
+                        audit_url_schemes(mock_conn)  # must not raise
+
+                        mock_logger.warning.assert_called_once()
+                        warning_text = mock_logger.warning.call_args[0][0]
+                        assert "legacy-gateway" in warning_text
+                        assert "http://legacy.example.com" in warning_text
+
+    def test_disallowed_scheme_raises_under_strict_enforcement(self, mock_settings, mock_conn):
+        """STRICT_SCHEME_ENFORCEMENT=true fails startup instead of warning."""
+        offender = self._record("legacy-tool", "tool-legacy", "http://legacy.example.com")
+        session = self._session_returning({Tool: [offender]})
+        mock_settings.strict_scheme_enforcement = True
+
+        with patch("mcpgateway.bootstrap_db.settings", mock_settings):
+            with patch("mcpgateway.bootstrap_db.SecurityValidator") as mock_validator:
+                mock_validator.has_allowed_scheme.return_value = False
+                mock_validator.ALLOWED_URL_SCHEMES = ["https://", "wss://"]
+                with patch("mcpgateway.bootstrap_db.Session", return_value=session):
+                    with pytest.raises(RuntimeError, match="legacy-tool"):
+                        audit_url_schemes(mock_conn)
+
+    def test_checks_all_three_record_types(self, mock_settings, mock_conn):
+        """Gateway, Tool, and A2AAgent are all covered, keyed by their own URL attribute."""
+        gw = self._record("gw", "gw-1", "http://gw.example.com")
+        tool = self._record("tool", "tool-1", "http://tool.example.com")
+        agent = self._record("agent", "agent-1", "http://agent.example.com")
+        session = self._session_returning({Gateway: [gw], Tool: [tool], A2AAgent: [agent]})
+        mock_settings.strict_scheme_enforcement = False
+
+        with patch("mcpgateway.bootstrap_db.settings", mock_settings):
+            with patch("mcpgateway.bootstrap_db.SecurityValidator") as mock_validator:
+                mock_validator.has_allowed_scheme.return_value = False
+                mock_validator.ALLOWED_URL_SCHEMES = ["https://"]
+                with patch("mcpgateway.bootstrap_db.Session", return_value=session):
+                    with patch("mcpgateway.bootstrap_db.logger") as mock_logger:
+                        audit_url_schemes(mock_conn)
+
+                        warning_text = mock_logger.warning.call_args[0][0]
+                        assert "gw" in warning_text and "tool" in warning_text and "agent" in warning_text
+
+
 class TestMain:
     """Test main function."""
 
@@ -1687,12 +1804,13 @@ class TestMain:
                             with patch("mcpgateway.bootstrap_db.bootstrap_admin_user", new=AsyncMock()):
                                 with patch("mcpgateway.bootstrap_db.bootstrap_default_roles", new=AsyncMock()):
                                     with patch("mcpgateway.bootstrap_db.bootstrap_resource_assignments", new=AsyncMock()):
-                                        with patch("mcpgateway.bootstrap_db.settings", mock_settings):
-                                            with patch("mcpgateway.bootstrap_db.advisory_lock"):
-                                                with patch("mcpgateway.bootstrap_db.logger") as mock_logger:
-                                                    await main()
+                                        with patch("mcpgateway.bootstrap_db.audit_url_schemes"):
+                                            with patch("mcpgateway.bootstrap_db.settings", mock_settings):
+                                                with patch("mcpgateway.bootstrap_db.advisory_lock"):
+                                                    with patch("mcpgateway.bootstrap_db.logger") as mock_logger:
+                                                        await main()
 
-                                                    mock_logger.info.assert_any_call("Normalized 5 team record(s) to supported visibility values")
+                                                        mock_logger.info.assert_any_call("Normalized 5 team record(s) to supported visibility values")
 
     @pytest.mark.asyncio
     async def test_main_complete_flow(self, mock_settings):
@@ -1722,18 +1840,19 @@ class TestMain:
                                 with patch("mcpgateway.bootstrap_db.bootstrap_admin_user", new=AsyncMock()) as mock_admin:
                                     with patch("mcpgateway.bootstrap_db.bootstrap_default_roles", new=AsyncMock()) as mock_roles:
                                         with patch("mcpgateway.bootstrap_db.bootstrap_resource_assignments", new=AsyncMock()) as mock_resources:
-                                            with patch("mcpgateway.bootstrap_db.settings", mock_settings):
-                                                with patch("mcpgateway.bootstrap_db.advisory_lock"):
-                                                    with patch("mcpgateway.bootstrap_db.logger") as mock_logger:
-                                                        await main()
+                                            with patch("mcpgateway.bootstrap_db.audit_url_schemes"):
+                                                with patch("mcpgateway.bootstrap_db.settings", mock_settings):
+                                                    with patch("mcpgateway.bootstrap_db.advisory_lock"):
+                                                        with patch("mcpgateway.bootstrap_db.logger") as mock_logger:
+                                                            await main()
 
-                                                        # Schema at head — upgrade must NOT be called
-                                                        mock_command.upgrade.assert_not_called()
-                                                        # All bootstrap functions were called
-                                                        mock_admin.assert_called_once()
-                                                        mock_roles.assert_called_once()
-                                                        mock_resources.assert_called_once()
-                                                        mock_logger.info.assert_any_call("Database ready")
+                                                            # Schema at head — upgrade must NOT be called
+                                                            mock_command.upgrade.assert_not_called()
+                                                            # All bootstrap functions were called
+                                                            mock_admin.assert_called_once()
+                                                            mock_roles.assert_called_once()
+                                                            mock_resources.assert_called_once()
+                                                            mock_logger.info.assert_any_call("Database ready")
 
     @pytest.mark.asyncio
     async def test_main_skip_migration_fresh_db(self, mock_settings):
@@ -1916,6 +2035,7 @@ class TestMainAdditionalBranches:
             patch("mcpgateway.bootstrap_db.bootstrap_admin_user", new=AsyncMock()),
             patch("mcpgateway.bootstrap_db.bootstrap_default_roles", new=AsyncMock()),
             patch("mcpgateway.bootstrap_db.bootstrap_resource_assignments", new=AsyncMock()),
+            patch("mcpgateway.bootstrap_db.audit_url_schemes"),
             patch("mcpgateway.bootstrap_db.settings", mock_settings),
             patch("mcpgateway.bootstrap_db.logger") as mock_logger,
         ):
@@ -1957,6 +2077,7 @@ class TestMainAdditionalBranches:
             patch("mcpgateway.bootstrap_db.bootstrap_admin_user", new=AsyncMock()) as mock_admin,
             patch("mcpgateway.bootstrap_db.bootstrap_default_roles", new=AsyncMock()) as mock_roles,
             patch("mcpgateway.bootstrap_db.bootstrap_resource_assignments", new=AsyncMock()) as mock_resources,
+            patch("mcpgateway.bootstrap_db.audit_url_schemes"),
             patch("mcpgateway.bootstrap_db.settings", mock_settings),
             patch("mcpgateway.bootstrap_db.logger") as mock_logger,
         ):
@@ -1985,6 +2106,7 @@ class TestMainAdditionalBranches:
             patch("mcpgateway.bootstrap_db.bootstrap_admin_user", new=AsyncMock()),
             patch("mcpgateway.bootstrap_db.bootstrap_default_roles", new=AsyncMock()),
             patch("mcpgateway.bootstrap_db.bootstrap_resource_assignments", new=AsyncMock()),
+            patch("mcpgateway.bootstrap_db.audit_url_schemes"),
             patch("mcpgateway.bootstrap_db.settings", mock_settings),
             patch("mcpgateway.bootstrap_db.logger") as mock_logger,
         ):


### PR DESCRIPTION
## Summary

Fixes #6264.

`SecurityValidator.ALLOWED_URL_SCHEMES` is enforced only at registration time (the Pydantic field validators on `GatewayCreate`/`GatewayUpdate` and equivalents). A record registered before the allowlist was tightened — e.g. an `http://` gateway created before `VALIDATION_ALLOWED_URL_SCHEMES` was narrowed to `https://` only — silently keeps being used by the health-check loop, tool invocation, and the federation layer, regardless of the current setting. Setting `VALIDATION_ALLOWED_URL_SCHEMES='["https://","wss://"]'` on an existing deployment therefore does *not* enforce HTTPS-only connectivity — it only prevents new registrations.

This addresses **Gap 2** from the issue (the substantive security gap) and documents **Gap 1** (the class-level-constant restart requirement) as the issue's own proposed changes suggested — making Gap 1 dynamically re-readable was flagged as "optional" in the issue and is left out of scope here to keep this reviewable.

### Changes

- `mcpgateway/common/validators.py` — extracted the scheme check into `SecurityValidator.has_allowed_scheme()` so `validate_url` (registration-time) and the new startup audit (existing-record time) enforce the exact same rule instead of two copies drifting apart.
- `mcpgateway/bootstrap_db.py` — added `audit_url_schemes()`, run from `_run_post_migration_bootstrap` on every startup (alongside the other idempotent bootstrap steps). It queries active (`enabled=True`) `Gateway`, `Tool`, and `A2AAgent` records and checks each against the current allowlist.
  - **Read-only by design**: it never mutates or disables an offending record — deciding what to do about a live integration is an operator call, not this function's to make silently.
  - **Warn-only by default**: logs one `WARNING` naming every offending record (type, name, id, URL), so upgrading to a stricter allowlist never breaks an existing deployment outright.
- `mcpgateway/config.py` — added `strict_scheme_enforcement: bool = False`. When `true`, `audit_url_schemes` raises `RuntimeError` instead of warning, so an operator can opt into fail-closed startup once they've reviewed the warnings (matches the issue's acceptance criteria: "A `STRICT_SCHEME_ENFORCEMENT` flag (default `false`) can be set to fail startup instead of warn").
- `.env.example` — documents the restart requirement for `VALIDATION_ALLOWED_URL_SCHEMES` and the new `STRICT_SCHEME_ENFORCEMENT` flag.

### Acceptance criteria (from the issue)

- [x] The restart requirement for `VALIDATION_ALLOWED_URL_SCHEMES` is documented
- [x] On startup, active records with URL schemes not in the allowlist emit a WARNING log entry naming the offending record and URL
- [x] The startup check is implemented in a way that does not break existing deployments (warn-only by default)
- [x] A `STRICT_SCHEME_ENFORCEMENT` flag (default `false`) can be set to fail startup instead of warn

## Test plan

- [x] `pytest tests/unit/mcpgateway/test_bootstrap_db.py` — 73 passed, including 5 new tests in `TestAuditUrlSchemes` covering: no active records, all-allowed (no warning), a disallowed scheme (warns, does not raise), `strict_scheme_enforcement=True` (raises `RuntimeError`), and coverage across all three record types (Gateway/Tool/A2AAgent)
- [x] `pytest tests/unit/mcpgateway/validation/test_validators.py tests/unit/mcpgateway/validation/test_validators_advanced.py` — all pass (`has_allowed_scheme` refactor is behavior-preserving for `validate_url`)
- [x] `ruff check` clean on all touched files
- [x] `black --check` clean on all touched files (pre-existing long-line formatting debt elsewhere in `config.py`/`validators.py` left untouched, out of scope)

## Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5), reviewed and tested by me before submitting.