### PR TITLE
fix(oauth): return HTML guidance page on DCR failure instead of raw JSON

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-19T09:48:01Z",
+  "generated_at": "2026-08-20T07:01:39Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -3972,7 +3972,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 888,
+        "line_number": 915,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -451,7 +451,7 @@ async def _enforce_gateway_access(
     raise HTTPException(status_code=403, detail="You don't have access to this gateway")
 
 
-@oauth_router.get("/authorize/{gateway_id}")
+@oauth_router.get("/authorize/{gateway_id}", response_model=None)
 async def initiate_oauth_flow(
     gateway_id: str,
     request: Request,
@@ -461,7 +461,7 @@ async def initiate_oauth_flow(
         default=False,
         description="Set by the React UI when opening OAuth in a popup window; encodes a popup. prefix in the state token so the callback responds with postMessage instead of a full HTML page",
     ),
-) -> RedirectResponse:  # noqa: ARG001
+) -> RedirectResponse | HTMLResponse:  # noqa: ARG001
     """Initiates the OAuth 2.0 Authorization Code flow for a specified gateway.
 
     This endpoint retrieves the OAuth configuration for the given gateway, validates that
@@ -593,9 +593,36 @@ async def initiate_oauth_flow(
 
                 except DcrError as dcr_err:
                     logger.error(f"DCR failed for gateway {SecurityValidator.sanitize_log_message(gateway_id)}: {dcr_err}")
-                    raise HTTPException(
-                        status_code=500,
-                        detail="Dynamic Client Registration failed. Please configure client_id and client_secret manually or check your OAuth server supports RFC 7591.",
+                    root_path = resolve_root_path(request) if request else ""
+                    safe_root_path = escape(str(root_path), quote=True)
+                    safe_err = escape(str(dcr_err))
+                    return HTMLResponse(
+                        content=f"""<!DOCTYPE html>
+<html>
+<head><title>OAuth Setup Required</title></head>
+<body>
+    <h1>🔐 Manual OAuth Credentials Required</h1>
+    <p>
+        Dynamic Client Registration (DCR) could not be completed for this gateway.
+        This provider does not support automatic client registration (RFC 7591).
+    </p>
+    <p><strong>Details:</strong> {safe_err}</p>
+    <h2>Next Steps</h2>
+    <ol>
+        <li>Register an OAuth application manually with your provider's developer portal
+            (for example, <a href="https://developer.atlassian.com/console/myapps/" target="_blank" rel="noopener noreferrer">Atlassian App Console</a>).</li>
+        <li>Copy the <strong>Client ID</strong> and <strong>Client Secret</strong> provided by your OAuth provider.</li>
+        <li>
+            <a href="{safe_root_path}/admin#gateways">Return to the Admin Panel</a>,
+            open the gateway edit form, and enter the credentials in the
+            <em>Client ID</em> and <em>Client Secret</em> fields.
+        </li>
+        <li>Click <strong>🔐 Authorize</strong> again once the credentials are saved.</li>
+    </ol>
+    <p><a href="{safe_root_path}/admin#gateways">← Return to Admin Panel</a></p>
+</body>
+</html>""",
+                        status_code=400,
                     )
                 except Exception as dcr_ex:
                     logger.error(f"Unexpected error during DCR for gateway {SecurityValidator.sanitize_log_message(gateway_id)}: {dcr_ex}")

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -577,6 +577,58 @@ class TestOAuthRouter:
         assert "Failed to register OAuth client" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
+    async def test_initiate_oauth_flow_dcr_no_registration_endpoint_returns_html(self, mock_db, mock_request, mock_current_user):
+        """Test DCR path returns a helpful HTML page (not raw JSON) when AS lacks registration_endpoint.
+
+        This covers the Atlassian scenario: issuer is set, DCR is enabled, but the AS
+        does not expose a registration_endpoint in its OIDC metadata, so DcrError is
+        raised.  The endpoint must redirect the user to an HTML guidance page instead
+        of surfacing a raw 500 JSON error.
+        """
+        mock_gateway = Mock(spec=Gateway)
+        mock_gateway.id = "gateway123"
+        mock_gateway.name = "Test Gateway"
+        mock_gateway.url = "https://mcp.atlassian.net"
+        mock_gateway.visibility = "public"
+        mock_gateway.team_id = None
+        mock_gateway.oauth_config = {
+            "grant_type": "authorization_code",
+            "issuer": "https://auth.atlassian.com",
+            "redirect_uri": "https://gateway.example.com/oauth/callback",
+        }
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        with (
+            patch("mcpgateway.routers.oauth_router.settings") as mock_settings,
+            patch("mcpgateway.routers.oauth_router.DcrService") as mock_dcr_class,
+        ):
+            mock_settings.dcr_enabled = True
+            mock_settings.dcr_auto_register_on_missing_credentials = True
+            mock_settings.dcr_default_scopes = ["openid"]
+            mock_settings.auth_encryption_secret = "secret"  # pragma: allowlist secret
+
+            from mcpgateway.services.dcr_service import DcrError
+
+            mock_dcr = Mock()
+            mock_dcr.get_or_register_client = AsyncMock(
+                side_effect=DcrError("AS https://auth.atlassian.com does not support Dynamic Client Registration (no registration_endpoint)")
+            )
+            mock_dcr_class.return_value = mock_dcr
+
+            from mcpgateway.routers.oauth_router import initiate_oauth_flow
+
+            result = await initiate_oauth_flow("gateway123", mock_request, mock_current_user, mock_db)
+
+        # Must be an HTML response, not a raised HTTPException
+        assert result.status_code == 400
+        body = result.body.decode()
+        assert "Manual OAuth Credentials Required" in body
+        assert "registration_endpoint" in body
+        assert "Next Steps" in body
+        assert "admin#gateways" in body
+
+
+    @pytest.mark.asyncio
     async def test_initiate_oauth_flow_oauth_manager_error(self, mock_db, mock_request, mock_gateway, mock_current_user):
         """Test OAuth flow initiation when OAuth manager throws error."""
         # Setup
@@ -2011,7 +2063,7 @@ class TestOAuthRouterAdditionalCoverage:
 
     @pytest.mark.asyncio
     async def test_initiate_oauth_flow_dcr_error(self, mock_db, mock_request, mock_current_user):
-        """Test DCR error handling path."""
+        """Test DCR error handling path returns HTML guidance page (not raw JSON)."""
         mock_gateway = Mock(spec=Gateway)
         mock_gateway.id = "gateway123"
         mock_gateway.name = "Gateway"
@@ -2038,10 +2090,10 @@ class TestOAuthRouterAdditionalCoverage:
                 mock_settings.dcr_enabled = True
                 mock_settings.dcr_auto_register_on_missing_credentials = True
 
-                with pytest.raises(HTTPException) as exc_info:
-                    await initiate_oauth_flow("gateway123", mock_request, mock_current_user, mock_db)
+                result = await initiate_oauth_flow("gateway123", mock_request, mock_current_user, mock_db)
 
-        assert exc_info.value.status_code == 500
+        assert result.status_code == 400
+        assert "Manual OAuth Credentials Required" in result.body.decode()
 
     @pytest.mark.asyncio
     async def test_get_oauth_status_team_access_denied(self, mock_db, mock_request):


### PR DESCRIPTION
## Summary

When a user clicks **🔐 Authorize** on a gateway whose Authorization Server doesn't support Dynamic Client Registration (e.g. Atlassian's `https://auth.atlassian.com`), DCR auto-registration fails mid-flow. Previously the user landed on a raw `{"detail": "..."}` JSON error page with no path back to the Admin UI.

This PR implements **Option B (graceful mid-flow fallback)** from issue #4586: when `DcrError` is raised inside `initiate_oauth_flow` we now return a 400 `HTMLResponse` with:
- A clear explanation that this provider does not support RFC 7591 DCR
- Step-by-step instructions to register an app at the provider's developer portal, copy the credentials, and paste them into the gateway edit form
- A **← Return to Admin Panel** link that navigates back to `/admin#gateways`

## Changes

- **[`mcpgateway/routers/oauth_router.py`](mcpgateway/routers/oauth_router.py)**: catch `DcrError` in `initiate_oauth_flow` and return `HTMLResponse(status=400)` instead of raising `HTTPException(500)`; add `response_model=None` to the route decorator so FastAPI accepts the `RedirectResponse | HTMLResponse` return type
- **[`tests/unit/mcpgateway/routers/test_oauth_router.py`](tests/unit/mcpgateway/routers/test_oauth_router.py)**: update two existing tests that expected `HTTPException(500)` to assert the new HTML response; add a new targeted test for the Atlassian `no registration_endpoint` scenario

Closes #4586