### PR TITLE
chore: bump dependency-review-action from v4.9.0 to v5.0.0

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -69,7 +69,7 @@ jobs:
       # -----------------------------------------------------------
       - name: 🔍  Dependency Review
         id: dep-scan
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           # ───────── Vulnerability policy ─────────
           fail-on-severity: moderate # MODERATE, HIGH, CRITICAL ⇒ ❌


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #6155

---

## 📝 Summary

Bumps `actions/dependency-review-action` from `v4.9.0` (SHA `2031cfc080254a8a887f58cffee85186f0e49e48`, Node 20) to `v5.0.0` (SHA `a1d282b36b6f3519aa1f3fc636f609c47dddb294`, Node 24) in `.github/workflows/dependency-review.yml`.

Every `dependency-review` CI run was emitting a Node 20 deprecation warning because the pinned action targets the now-deprecated Node 20 runtime. GitHub Actions forces it onto Node 24 and will hard-fail once the compatibility shim is dropped. v5 is a runtime-only major bump — no input API changes — so all configured policy (vulnerability severity gate, license deny-list, PR comment behaviour) is fully preserved.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Chore (deps, CI, tooling)

---

## 🧪 Verification

This is a workflow-only change (one line, one file). No application code, Python, or Rust is touched, so lint/unit/coverage suites are not applicable.

| Check | Command / Evidence | Status |
|---|---|---|
| YAML syntax valid | `uv tool run yamllint .github/workflows/dependency-review.yml` | ✅ exits 0, no errors |
| Old SHA fully removed | `grep -rn "2031cfc..." .github/` | ✅ no matches |
| New SHA is the only reference | `grep -rn "dependency-review-action" .github/workflows/` | ✅ one hit, correct file |
| Tag `v5.0.0` resolves to pinned SHA | `gh api repos/actions/dependency-review-action/git/ref/tags/v5.0.0` | ✅ SHA matches exactly |
| Commit confirmed | `gh api repos/actions/dependency-review-action/git/commits/a1d282b3...` | ✅ "v5.0.0 release branch", 2026-05-08 |
| Diff scope | `git diff --stat` | ✅ 1 file changed, 1 insertion(+), 1 deletion(-) |

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`) — N/A, workflow file only
- [x] Tests added/updated for changes — N/A, no logic changed
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

- `v5.0.0` is a **runtime-only** major bump (Node 20 → Node 24). The [upstream release notes](https://github.com/actions/dependency-review-action/releases/tag/v5.0.0) confirm no input/output API changes.
- All configured inputs are unchanged: `fail-on-severity: moderate`, `deny-licenses` (GPL-1.0/2.0/3.0, AGPL-3.0, SSPL-1.0, RPL-1.5, OSL-3.0, CPAL-1.0), `license-check: true`, `warn-only: false`, `comment-summary-in-pr: on-failure`.
- Requires Actions Runner ≥ v2.327.1; GitHub-hosted runners already satisfy this.
- The `.cache/pre-commit-home` tree contains a stale `v4` reference in a pre-commit cache artefact — this is not a tracked workflow file and does not affect CI.