### PR TITLE
feat(python): MCP server OAuth form quick wins (read-only redirect URI, drop password grant)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-19T09:48:01Z",
+  "generated_at": "2026-08-20T10:03:23Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -3972,7 +3972,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 888,
+        "line_number": 933,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3982,7 +3982,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4661,
+        "line_number": 4669,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4010,7 +4010,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14959,
+        "line_number": 14956,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/alembic/versions/db41939315aa_add_redirect_uri_to_oauth_states.py
+++ b/mcpgateway/alembic/versions/db41939315aa_add_redirect_uri_to_oauth_states.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/alembic/versions/db41939315aa_add_redirect_uri_to_oauth_states.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Add redirect_uri column to oauth_states.
+
+Revision ID: db41939315aa
+Revises: e4f5a6b7c8d9
+Create Date: 2026-08-14 12:47:18.662212
+"""
+
+# Standard
+from typing import Sequence, Union
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "db41939315aa"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "e4f5a6b7c8d9"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add redirect_uri to oauth_states when missing."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "oauth_states" not in inspector.get_table_names():
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("oauth_states")}
+    if "redirect_uri" in columns:
+        return
+
+    op.add_column("oauth_states", sa.Column("redirect_uri", sa.String(length=2048), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop redirect_uri from oauth_states when present."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "oauth_states" not in inspector.get_table_names():
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("oauth_states")}
+    if "redirect_uri" not in columns:
+        return
+
+    op.drop_column("oauth_states", "redirect_uri")

--- a/mcpgateway/alembic/versions/db41939315aa_add_redirect_uri_to_oauth_states.py
+++ b/mcpgateway/alembic/versions/db41939315aa_add_redirect_uri_to_oauth_states.py
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 Add redirect_uri column to oauth_states.
 
 Revision ID: db41939315aa
-Revises: e4f5a6b7c8d9
+Revises: 9935d863930b
 Create Date: 2026-08-14 12:47:18.662212
 """
 
@@ -19,7 +19,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "db41939315aa"  # pragma: allowlist secret
-down_revision: Union[str, Sequence[str], None] = "e4f5a6b7c8d9"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "9935d863930b"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -5377,6 +5377,7 @@ class OAuthState(Base):
     state: Mapped[str] = mapped_column(String(500), nullable=False, unique=True)  # The state parameter
     code_verifier: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)  # PKCE code verifier (RFC 7636)
     app_user_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)  # Requesting user context for token association
+    redirect_uri: Mapped[Optional[str]] = mapped_column(String(2048), nullable=True)  # Pinned at authorize time; reused at callback (RFC 6749 §4.1.3)
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     used: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -106,6 +106,20 @@ async def enforce_fetch_tools_csrf(request: Request) -> None:
         raise HTTPException(status_code=403, detail="CSRF validation failed")
 
 
+def _default_redirect_uri() -> str:
+    """Build the gateway's own global OAuth callback URL from the configured app domain.
+
+    Used when a gateway's stored ``oauth_config`` carries no ``redirect_uri`` (API-created
+    or legacy rows), so the authorization-code paths never hand an incomplete credentials
+    dict to :class:`~mcpgateway.services.oauth_manager.OAuthManager`.
+
+    Returns:
+        Absolute callback URL, e.g. ``https://gateway.example.com/oauth/callback``.
+    """
+    # str() of a pydantic HttpUrl appends a trailing slash; rstrip keeps the path single-slashed.
+    return f"{str(settings.app_domain).rstrip('/')}/oauth/callback"
+
+
 def _is_well_formed_audience(value: Any) -> bool:
     """Return True if *value* is a usable audience claim shape.
 
@@ -521,6 +535,12 @@ async def initiate_oauth_flow(
             if origin:
                 oauth_config["resource"] = origin
 
+        # API-created and legacy configs may carry no redirect_uri; OAuthManager's PKCE
+        # paths index it directly, so default it here (before DCR, so registration and
+        # the authorization request agree on the callback).
+        if not oauth_config.get("redirect_uri"):
+            oauth_config["redirect_uri"] = _default_redirect_uri()
+
         # Phase 1.4: Auto-trigger DCR if credentials are missing
         # Check if gateway has issuer but no client_id (DCR scenario)
         issuer = oauth_config.get("issuer")
@@ -793,6 +813,11 @@ async def oauth_callback(
             origin = derive_resource_origin(gateway.url)
             if origin:
                 oauth_config_with_resource["resource"] = origin
+
+        # Mirror the authorize-side default so the token exchange sends the same
+        # redirect_uri the authorization request used (RFC 6749 §4.1.3 requires the match).
+        if not oauth_config_with_resource.get("redirect_uri"):
+            oauth_config_with_resource["redirect_uri"] = _default_redirect_uri()
 
         result = await oauth_manager.complete_authorization_code_flow(
             gateway_id, code, state, oauth_config_with_resource, ca_certificate=gateway.ca_certificate, client_cert=gateway.client_cert, client_key=gateway.client_key

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -106,18 +106,29 @@ async def enforce_fetch_tools_csrf(request: Request) -> None:
         raise HTTPException(status_code=403, detail="CSRF validation failed")
 
 
-def _default_redirect_uri() -> str:
+def _default_redirect_uri(request: Optional[Request] = None) -> str:
     """Build the gateway's own global OAuth callback URL from the configured app domain.
 
-    Used when a gateway's stored ``oauth_config`` carries no ``redirect_uri`` (API-created
-    or legacy rows), so the authorization-code paths never hand an incomplete credentials
-    dict to :class:`~mcpgateway.services.oauth_manager.OAuthManager`.
+    Pure computation with no side effects, so it is cheap to call unconditionally. Used when
+    a gateway's stored ``oauth_config`` carries no ``redirect_uri`` (API-created or legacy
+    rows), so the authorization-code paths never hand an incomplete credentials dict to
+    :class:`~mcpgateway.services.oauth_manager.OAuthManager`. Callers that substitute this
+    value into OAuth credentials are responsible for logging that substitution -- the
+    authorize path logs at its call site (it must resolve the default before DCR registration
+    runs); the callback path instead passes this as ``default_redirect_uri`` into
+    ``OAuthManager.complete_authorization_code_flow``, whose single centralized guard
+    (``_apply_default_redirect_uri``) logs only when it actually applies it.
+
+    Args:
+        request: The current request, used to resolve a reverse-proxy ``root_path`` (falls
+            back to ``settings.app_root_path`` when omitted or when the scope carries none).
 
     Returns:
         Absolute callback URL, e.g. ``https://gateway.example.com/oauth/callback``.
     """
+    root_path = resolve_root_path(request) if request is not None else str(settings.app_root_path).rstrip("/")
     # str() of a pydantic HttpUrl appends a trailing slash; rstrip keeps the path single-slashed.
-    return f"{str(settings.app_domain).rstrip('/')}/oauth/callback"
+    return f"{str(settings.app_domain).rstrip('/')}{root_path}/oauth/callback"
 
 
 def _is_well_formed_audience(value: Any) -> bool:
@@ -537,9 +548,12 @@ async def initiate_oauth_flow(
 
         # API-created and legacy configs may carry no redirect_uri; OAuthManager's PKCE
         # paths index it directly, so default it here (before DCR, so registration and
-        # the authorization request agree on the callback).
+        # the authorization request agree on the callback). Resolved eagerly here --
+        # rather than deferred to OAuthManager's centralized guard like the callback path
+        # below -- because DCR registration (a few lines down) needs the concrete value too.
         if not oauth_config.get("redirect_uri"):
-            oauth_config["redirect_uri"] = _default_redirect_uri()
+            oauth_config["redirect_uri"] = _default_redirect_uri(request)
+            logger.info("No redirect_uri configured on gateway OAuth config; defaulting to derived callback %s", oauth_config["redirect_uri"])
 
         # Phase 1.4: Auto-trigger DCR if credentials are missing
         # Check if gateway has issuer but no client_id (DCR scenario)
@@ -814,13 +828,19 @@ async def oauth_callback(
             if origin:
                 oauth_config_with_resource["resource"] = origin
 
-        # Mirror the authorize-side default so the token exchange sends the same
-        # redirect_uri the authorization request used (RFC 6749 §4.1.3 requires the match).
-        if not oauth_config_with_resource.get("redirect_uri"):
-            oauth_config_with_resource["redirect_uri"] = _default_redirect_uri()
-
+        # No inline guard here: complete_authorization_code_flow reuses the redirect_uri
+        # pinned in server-side state at authorize time (RFC 6749 §4.1.3) in preference to
+        # this, and applies this default_redirect_uri itself (logging only if actually used)
+        # when that pinned value is unavailable -- e.g. a state stored before pinning existed.
         result = await oauth_manager.complete_authorization_code_flow(
-            gateway_id, code, state, oauth_config_with_resource, ca_certificate=gateway.ca_certificate, client_cert=gateway.client_cert, client_key=gateway.client_key
+            gateway_id,
+            code,
+            state,
+            oauth_config_with_resource,
+            ca_certificate=gateway.ca_certificate,
+            client_cert=gateway.client_cert,
+            client_key=gateway.client_key,
+            default_redirect_uri=_default_redirect_uri(request),
         )
 
         # Token's aud/iss claims (best-effort, unverified) are persisted per-user by

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -3260,8 +3260,16 @@ class GatewayCreate(BaseModelWithConfigDict):
     @field_validator("oauth_config", mode="before")
     @classmethod
     def validate_oauth_config(cls, v: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
-        """Validate URL-bearing OAuth configuration entries."""
-        return _validate_oauth_config_urls(v)
+        """Validate URL-bearing OAuth configuration entries and reject deprecated grants.
+
+        The OAuth 2.1 resource owner password credentials grant is rejected for
+        new MCP server registrations. Existing records keep working via
+        ``GatewayUpdate`` (backwards compatibility).
+        """
+        v = _validate_oauth_config_urls(v)
+        if isinstance(v, dict) and v.get("grant_type") == "password":
+            raise ValueError("The OAuth 2.1 resource owner password grant is not supported for new MCP servers. Use authorization_code or client_credentials instead.")
+        return v
 
     @field_validator("description")
     @classmethod

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -2862,6 +2862,18 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 # Handle OAuth configuration updates
                 if gateway_update.oauth_config is not None:
                     raw_oauth_update = dict(gateway_update.oauth_config)
+
+                    # GatewayCreate rejects the deprecated password grant for new gateways at
+                    # the schema layer, but GatewayUpdate must accept it so a gateway that
+                    # already uses it keeps working (unrelated field edits re-submit the
+                    # unchanged oauth_config). What must NOT be allowed is using this update
+                    # path to newly adopt password on a gateway that wasn't already using it —
+                    # otherwise the create-time rejection is trivially bypassable.
+                    if raw_oauth_update.get("grant_type") == "password":
+                        original_grant_type = original_oauth_config.get("grant_type") if isinstance(original_oauth_config, dict) else None
+                        if original_grant_type != "password":
+                            raise ValueError("The OAuth 2.1 resource owner password grant is not supported for new MCP servers. Use authorization_code or client_credentials instead.")
+
                     await self._enforce_token_exchange_admin_only(db, raw_oauth_update, user_email)
                     raw_oauth_update = await self._auto_discover_oauth_endpoints(raw_oauth_update)
                     raw_oauth_update = self._validate_token_exchange_config(raw_oauth_update)

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -884,7 +884,36 @@ class OAuthManager:
 
         raise OAuthError("Token exchange failed after all retry attempts")
 
-    async def initiate_authorization_code_flow(self, gateway_id: str, credentials: Dict[str, Any], app_user_email: str = None, popup: bool = False) -> Dict[str, str]:
+    @staticmethod
+    def _apply_default_redirect_uri(credentials: Dict[str, Any], default_redirect_uri: Optional[str] = None) -> Dict[str, Any]:
+        """Fill in ``redirect_uri`` when *credentials* carries none.
+
+        Single point of application -- rather than each caller (currently the two /oauth
+        router endpoints) guarding inline -- so any future caller of the authorization-code
+        flow methods is protected too, since ``_create_authorization_url_with_pkce`` and
+        ``_exchange_code_for_tokens`` both index ``credentials["redirect_uri"]`` directly.
+
+        Args:
+            credentials: OAuth configuration for the flow.
+            default_redirect_uri: Caller-computed default (e.g. request-scoped, root-path-aware)
+                to prefer when present. Falls back to a settings-only default when omitted, so
+                this is still self-protecting even for a caller that supplies none.
+
+        Returns:
+            *credentials* unchanged if it already carries a ``redirect_uri``; otherwise a
+            shallow copy with one filled in.
+        """
+        if credentials.get("redirect_uri"):
+            return credentials
+        settings = get_settings()
+        root_path = str(getattr(settings, "app_root_path", "") or "").rstrip("/")
+        resolved = default_redirect_uri or f"{str(settings.app_domain).rstrip('/')}{root_path}/oauth/callback"
+        logger.info("OAuth credentials carried no redirect_uri; defaulting to %s", resolved)
+        return {**credentials, "redirect_uri": resolved}
+
+    async def initiate_authorization_code_flow(
+        self, gateway_id: str, credentials: Dict[str, Any], app_user_email: str = None, popup: bool = False, default_redirect_uri: Optional[str] = None
+    ) -> Dict[str, str]:
         """Initiate Authorization Code flow with PKCE and return authorization URL.
 
         Args:
@@ -893,10 +922,14 @@ class OAuthManager:
             app_user_email: ContextForge user email to associate with tokens
             popup: When True, the state token is prefixed with ``popup.`` so the
                 callback endpoint knows to respond with postMessage instead of HTML.
+            default_redirect_uri: Fallback used by :meth:`_apply_default_redirect_uri` when
+                *credentials* carries no ``redirect_uri`` (defence-in-depth; today's router
+                caller already resolves one before DCR runs, so this is normally a no-op).
 
         Returns:
             Dict containing authorization_url and state
         """
+        credentials = self._apply_default_redirect_uri(credentials, default_redirect_uri)
 
         # Generate PKCE parameters (RFC 7636)
         pkce_params = self._generate_pkce_params()
@@ -911,6 +944,7 @@ class OAuthManager:
                 state,
                 code_verifier=pkce_params["code_verifier"],
                 app_user_email=app_user_email,
+                redirect_uri=credentials.get("redirect_uri"),
             )
 
         # Generate authorization URL with PKCE
@@ -921,7 +955,15 @@ class OAuthManager:
         return {"authorization_url": auth_url, "state": state, "gateway_id": gateway_id}
 
     async def complete_authorization_code_flow(
-        self, gateway_id: str, code: str, state: str, credentials: Dict[str, Any], ca_certificate: Optional[str] = None, client_cert: Optional[str] = None, client_key: Optional[str] = None
+        self,
+        gateway_id: str,
+        code: str,
+        state: str,
+        credentials: Dict[str, Any],
+        ca_certificate: Optional[str] = None,
+        client_cert: Optional[str] = None,
+        client_key: Optional[str] = None,
+        default_redirect_uri: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Complete Authorization Code flow with PKCE and store tokens.
 
@@ -933,6 +975,9 @@ class OAuthManager:
             ca_certificate: Optional custom CA certificate for SSL verification (PEM format)
             client_cert: Optional client certificate for mTLS (PEM format or file path)
             client_key: Optional client private key for mTLS (PEM format or file path)
+            default_redirect_uri: Fallback used by :meth:`_apply_default_redirect_uri` when
+                neither the state pinned at authorize time nor *credentials* itself carries a
+                ``redirect_uri`` (e.g. a state stored before pinning existed).
 
         Returns:
             Dict containing success status, user_id, and expiration info
@@ -947,6 +992,18 @@ class OAuthManager:
 
         code_verifier = state_data.get("code_verifier")
         app_user_email = state_data.get("app_user_email")
+
+        # Reuse the exact redirect_uri pinned at authorize time (RFC 6749 §4.1.3 requires
+        # the token-exchange redirect_uri to match the one sent in the authorization
+        # request) in preference to the caller-supplied credentials/default, which could
+        # have drifted if the gateway's oauth_config or app_domain changed mid-flow.
+        pinned_redirect_uri = state_data.get("redirect_uri")
+        if pinned_redirect_uri:
+            credentials = {**credentials, "redirect_uri": pinned_redirect_uri}
+        else:
+            # No pinned value (state stored before pinning existed, or token_storage
+            # unavailable) -- fall back to the centralized default.
+            credentials = self._apply_default_redirect_uri(credentials, default_redirect_uri)
 
         # Defence-in-depth: if app_user_email is absent from server-side
         # state (e.g. state stored by an older code path), attempt a
@@ -1164,6 +1221,7 @@ class OAuthManager:
         state: str,
         code_verifier: str = None,
         app_user_email: str = None,
+        redirect_uri: str = None,
     ) -> None:
         """Store authorization state for validation with TTL.
 
@@ -1172,6 +1230,10 @@ class OAuthManager:
             state: State parameter to store
             code_verifier: Optional PKCE code verifier (RFC 7636)
             app_user_email: Requesting user email for token association
+            redirect_uri: The redirect_uri sent in the authorization request, pinned here so
+                ``complete_authorization_code_flow`` can reuse the exact same value at token
+                exchange time (RFC 6749 §4.1.3) instead of recomputing it from live gateway
+                state, which could have changed between authorize and callback.
         """
         expires_at = datetime.now(timezone.utc) + timedelta(seconds=STATE_TTL_SECONDS)
         settings = get_settings()
@@ -1188,6 +1250,7 @@ class OAuthManager:
                         "gateway_id": gateway_id,
                         "code_verifier": code_verifier,
                         "app_user_email": app_user_email,
+                        "redirect_uri": redirect_uri,
                         "expires_at": expires_at.isoformat(),
                         "used": False,
                     }
@@ -1221,6 +1284,8 @@ class OAuthManager:
                     }
                     if hasattr(OAuthState, "app_user_email"):
                         oauth_state_kwargs["app_user_email"] = app_user_email
+                    if hasattr(OAuthState, "redirect_uri"):
+                        oauth_state_kwargs["redirect_uri"] = redirect_uri
 
                     oauth_state = OAuthState(**oauth_state_kwargs)
                     db.add(oauth_state)
@@ -1242,6 +1307,7 @@ class OAuthManager:
                 "gateway_id": gateway_id,
                 "code_verifier": code_verifier,
                 "app_user_email": app_user_email,
+                "redirect_uri": redirect_uri,
                 "expires_at": expires_at.isoformat(),
                 "used": False,
             }
@@ -1467,6 +1533,8 @@ class OAuthManager:
                     }
                     if hasattr(oauth_state, "app_user_email"):
                         state_data["app_user_email"] = getattr(oauth_state, "app_user_email", None)
+                    if hasattr(oauth_state, "redirect_uri"):
+                        state_data["redirect_uri"] = getattr(oauth_state, "redirect_uri", None)
 
                     # Mark as used and delete
                     db.delete(oauth_state)

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -5504,9 +5504,6 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                       <option value="client_credentials">
                         Client Credentials (Machine-to-Machine)
                       </option>
-                      <option value="password">
-                        Resource Owner Password Credentials (Keycloak/Legacy)
-                      </option>
                     </select>
                   </div>
 

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -515,6 +515,62 @@ class TestOAuthRouter:
         assert oauth_config_passed["resource"] == ["https://api.example.com", "my-client-id"]
 
     @pytest.mark.asyncio
+    async def test_initiate_oauth_flow_defaults_redirect_uri(self, mock_db, mock_request, mock_current_user):
+        """A config with no redirect_uri gets the gateway's own callback URL (API-created/legacy rows)."""
+        # First-Party
+        from mcpgateway.config import settings
+
+        mock_gateway = Mock(spec=Gateway)
+        mock_gateway.id = "gateway123"
+        mock_gateway.name = "Test Gateway"
+        mock_gateway.url = "https://mcp.example.com"
+        mock_gateway.visibility = "public"
+        mock_gateway.team_id = None
+        mock_gateway.oauth_config = {
+            "grant_type": "authorization_code",
+            "client_id": "client-id",
+            "client_secret": "secret",
+            "authorization_url": "https://auth.example.com/authorize",
+            "token_url": "https://auth.example.com/token",
+        }
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        auth_data = {"authorization_url": "https://auth.example.com/authorize?state=x", "state": "x"}
+
+        with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_manager_class:
+            mock_oauth_manager = Mock()
+            mock_oauth_manager.initiate_authorization_code_flow = AsyncMock(return_value=auth_data)
+            mock_oauth_manager_class.return_value = mock_oauth_manager
+
+            with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                from mcpgateway.routers.oauth_router import initiate_oauth_flow
+
+                await initiate_oauth_flow("gateway123", mock_request, mock_current_user, mock_db)
+
+        oauth_config_passed = mock_oauth_manager.initiate_authorization_code_flow.call_args[0][1]
+        assert oauth_config_passed["redirect_uri"] == f"{str(settings.app_domain).rstrip('/')}/oauth/callback"
+
+    @pytest.mark.asyncio
+    async def test_initiate_oauth_flow_preserves_explicit_redirect_uri(self, mock_db, mock_request, mock_gateway, mock_current_user):
+        """An explicitly configured redirect_uri is passed through untouched."""
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        auth_data = {"authorization_url": "https://oauth.example.com/authorize?state=x", "state": "x"}
+
+        with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_manager_class:
+            mock_oauth_manager = Mock()
+            mock_oauth_manager.initiate_authorization_code_flow = AsyncMock(return_value=auth_data)
+            mock_oauth_manager_class.return_value = mock_oauth_manager
+
+            with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                from mcpgateway.routers.oauth_router import initiate_oauth_flow
+
+                await initiate_oauth_flow("gateway123", mock_request, mock_current_user, mock_db)
+
+        oauth_config_passed = mock_oauth_manager.initiate_authorization_code_flow.call_args[0][1]
+        assert oauth_config_passed["redirect_uri"] == "https://gateway.example.com/oauth/callback"
+
+    @pytest.mark.asyncio
     async def test_initiate_oauth_flow_missing_client_id(self, mock_db, mock_request, mock_current_user):
         """Test OAuth flow missing client_id without DCR issuer."""
         mock_gateway = Mock(spec=Gateway)
@@ -680,6 +736,47 @@ class TestOAuthRouter:
         assert isinstance(result, HTMLResponse)
         oauth_config_passed = mock_oauth_manager.complete_authorization_code_flow.call_args[0][3]
         assert oauth_config_passed["resource"] == "my-client-id-from-idp"
+
+    @pytest.mark.asyncio
+    async def test_oauth_callback_defaults_redirect_uri(self, mock_db, mock_request):
+        """The token exchange gets the gateway's own callback URL when the config omits redirect_uri."""
+        # First-Party
+        from mcpgateway.config import settings
+
+        state_data = {"gateway_id": "gateway123", "app_user_email": "test@example.com"}
+        payload = json.dumps(state_data).encode()
+        signature = b"x" * 32
+        state = base64.urlsafe_b64encode(payload + signature).decode()
+
+        mock_gateway = Mock(spec=Gateway)
+        mock_gateway.id = "gateway123"
+        mock_gateway.name = "Test Gateway"
+        mock_gateway.url = "https://mcp.example.com"
+        mock_gateway.oauth_config = {
+            "grant_type": "authorization_code",
+            "client_id": "client-id",
+            "client_secret": "secret",
+            "authorization_url": "https://auth.example.com/authorize",
+            "token_url": "https://auth.example.com/token",
+        }
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        token_result = {"user_id": "oauth_user_123", "app_user_email": "test@example.com", "expires_at": "2024-01-01T12:00:00", "token_aud": None}
+
+        with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_manager_class:
+            mock_oauth_manager = Mock()
+            mock_oauth_manager.resolve_gateway_id_from_state = AsyncMock(return_value="gateway123")
+            mock_oauth_manager.complete_authorization_code_flow = AsyncMock(return_value=token_result)
+            mock_oauth_manager_class.return_value = mock_oauth_manager
+
+            with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                from mcpgateway.routers.oauth_router import oauth_callback
+
+                result = await oauth_callback(code="auth_code_123", state=state, request=mock_request, db=mock_db)
+
+        assert isinstance(result, HTMLResponse)
+        oauth_config_passed = mock_oauth_manager.complete_authorization_code_flow.call_args[0][3]
+        assert oauth_config_passed["redirect_uri"] == f"{str(settings.app_domain).rstrip('/')}/oauth/callback"
 
     @pytest.mark.asyncio
     async def test_oauth_callback_legacy_state_format(self, mock_db, mock_request, mock_gateway):

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -551,6 +551,45 @@ class TestOAuthRouter:
         assert oauth_config_passed["redirect_uri"] == f"{str(settings.app_domain).rstrip('/')}/oauth/callback"
 
     @pytest.mark.asyncio
+    async def test_initiate_oauth_flow_defaults_redirect_uri_includes_root_path(self, mock_db, mock_request, mock_current_user):
+        """Behind a reverse proxy with a non-empty root_path, the derived callback must
+        include it -- otherwise the URL sent to the IdP 404s once past the proxy."""
+        # First-Party
+        from mcpgateway.config import settings
+
+        mock_request.scope = {"root_path": "/proxy/mcp"}
+
+        mock_gateway = Mock(spec=Gateway)
+        mock_gateway.id = "gateway123"
+        mock_gateway.name = "Test Gateway"
+        mock_gateway.url = "https://mcp.example.com"
+        mock_gateway.visibility = "public"
+        mock_gateway.team_id = None
+        mock_gateway.oauth_config = {
+            "grant_type": "authorization_code",
+            "client_id": "client-id",
+            "client_secret": "secret",
+            "authorization_url": "https://auth.example.com/authorize",
+            "token_url": "https://auth.example.com/token",
+        }
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        auth_data = {"authorization_url": "https://auth.example.com/authorize?state=x", "state": "x"}
+
+        with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_manager_class:
+            mock_oauth_manager = Mock()
+            mock_oauth_manager.initiate_authorization_code_flow = AsyncMock(return_value=auth_data)
+            mock_oauth_manager_class.return_value = mock_oauth_manager
+
+            with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                from mcpgateway.routers.oauth_router import initiate_oauth_flow
+
+                await initiate_oauth_flow("gateway123", mock_request, mock_current_user, mock_db)
+
+        oauth_config_passed = mock_oauth_manager.initiate_authorization_code_flow.call_args[0][1]
+        assert oauth_config_passed["redirect_uri"] == f"{str(settings.app_domain).rstrip('/')}/proxy/mcp/oauth/callback"
+
+    @pytest.mark.asyncio
     async def test_initiate_oauth_flow_preserves_explicit_redirect_uri(self, mock_db, mock_request, mock_gateway, mock_current_user):
         """An explicitly configured redirect_uri is passed through untouched."""
         mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
@@ -739,7 +778,10 @@ class TestOAuthRouter:
 
     @pytest.mark.asyncio
     async def test_oauth_callback_defaults_redirect_uri(self, mock_db, mock_request):
-        """The token exchange gets the gateway's own callback URL when the config omits redirect_uri."""
+        """The callback passes OAuthManager the gateway's own callback URL as its
+        default_redirect_uri fallback -- OAuthManager applies it only if the state pinned
+        at authorize time carries none (see TestRedirectUriPinning in test_oauth_manager.py
+        for the actual application/pinning-precedence logic, which lives there now)."""
         # First-Party
         from mcpgateway.config import settings
 
@@ -775,8 +817,8 @@ class TestOAuthRouter:
                 result = await oauth_callback(code="auth_code_123", state=state, request=mock_request, db=mock_db)
 
         assert isinstance(result, HTMLResponse)
-        oauth_config_passed = mock_oauth_manager.complete_authorization_code_flow.call_args[0][3]
-        assert oauth_config_passed["redirect_uri"] == f"{str(settings.app_domain).rstrip('/')}/oauth/callback"
+        default_redirect_uri_passed = mock_oauth_manager.complete_authorization_code_flow.call_args.kwargs["default_redirect_uri"]
+        assert default_redirect_uri_passed == f"{str(settings.app_domain).rstrip('/')}/oauth/callback"
 
     @pytest.mark.asyncio
     async def test_oauth_callback_legacy_state_format(self, mock_db, mock_request, mock_gateway):

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -889,12 +889,10 @@ class TestGatewayService:
             description="OAuth gateway",
             auth_type="oauth",
             oauth_config={
-                "grant_type": "password",
+                "grant_type": "client_credentials",
                 "client_id": "cid",
                 "client_secret": "super-secret",  # pragma: allowlist secret
-                "password": "p@ssw0rd",  # pragma: allowlist secret
                 "token_url": "https://auth.example.com/token",
-                "username": "svc-user",
             },
         )
 
@@ -904,8 +902,7 @@ class TestGatewayService:
         assert stored_gateway is not None
         encryption = get_encryption_service(settings.auth_encryption_secret)
         assert encryption.is_encrypted(stored_gateway.oauth_config["client_secret"])
-        assert encryption.is_encrypted(stored_gateway.oauth_config["password"])
-        assert stored_gateway.oauth_config["grant_type"] == "password"
+        assert stored_gateway.oauth_config["grant_type"] == "client_credentials"
         assert stored_gateway.oauth_config["client_id"] == "cid"
 
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -7635,7 +7635,15 @@ class TestUpdateGatewayAdvanced:
         mock_gateway.auth_query_params = None
         mock_gateway.version = 1
         mock_gateway.tags = []
-        mock_gateway.oauth_config = None
+        # Already a password-grant gateway (deprecated grant, kept working for existing
+        # records only) so the update below is re-saving it, not newly adopting password.
+        mock_gateway.oauth_config = {
+            "grant_type": "password",
+            "client_id": "cid",
+            "client_secret": "old-secret",  # pragma: allowlist secret
+            "password": "old-pw",  # pragma: allowlist secret
+            "token_url": "https://auth.example.com/token",
+        }
 
         update_data = _make_gateway(
             auth_type=None,
@@ -7669,6 +7677,61 @@ class TestUpdateGatewayAdvanced:
         assert encryption.is_encrypted(mock_gateway.oauth_config["client_secret"])
         assert encryption.is_encrypted(mock_gateway.oauth_config["password"])
         assert mock_gateway.oauth_config["grant_type"] == "password"
+
+    @pytest.mark.asyncio
+    async def test_update_oauth_config_rejects_new_password_grant(self, gateway_service, mock_gateway, monkeypatch):
+        """update_gateway must not let a non-password gateway be flipped to the deprecated
+        password grant. GatewayCreate rejects it at the schema layer for new gateways, but
+        GatewayUpdate has to accept it for gateways that already use it (backwards
+        compatibility) -- so the "already password" check has to happen here, comparing
+        against the gateway's current oauth_config, not in the schema layer.
+        """
+        db = MagicMock()
+        db.execute.return_value = _make_execute_result(scalar=mock_gateway)
+        mock_gateway.auth_type = "oauth"
+        mock_gateway.auth_value = {}
+        mock_gateway.auth_query_params = None
+        mock_gateway.version = 1
+        mock_gateway.tags = []
+        mock_gateway.oauth_config = {
+            "grant_type": "client_credentials",
+            "client_id": "cid",
+            "client_secret": "secret",  # pragma: allowlist secret
+            "token_url": "https://auth.example.com/token",
+        }
+
+        update_data = _make_gateway(
+            auth_type=None,
+            auth_value=None,
+            url="http://example.com/gateway",
+            passthrough_headers=None,
+            visibility=None,
+            oauth_config={
+                "grant_type": "password",
+                "client_id": "cid",
+                "client_secret": "secret",  # pragma: allowlist secret
+                "password": "pw",  # pragma: allowlist secret
+                "username": "svc-user",
+                "token_url": "https://auth.example.com/token",
+            },
+        )
+        update_data.auth_token = None
+        update_data.auth_password = None
+        update_data.auth_header_value = None
+        update_data.auth_query_param_key = None
+        update_data.auth_query_param_value = None
+
+        monkeypatch.setattr("mcpgateway.services.gateway_service.get_for_update", MagicMock(side_effect=[mock_gateway, None]))
+        monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: MagicMock(invalidate_gateways=AsyncMock()))
+        monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: MagicMock(invalidate_gateway=AsyncMock()))
+        monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", MagicMock(invalidate_tags=AsyncMock()))
+        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [], [])))
+
+        with pytest.raises(GatewayError, match="password grant"):
+            await gateway_service.update_gateway(db, mock_gateway.id, update_data)
+
+        # The gateway's stored config must be untouched by the rejected attempt.
+        assert mock_gateway.oauth_config["grant_type"] == "client_credentials"
 
     @pytest.mark.asyncio
     async def test_update_oauth_config_preserves_masked_secret_placeholder(self, gateway_service, mock_gateway, monkeypatch):

--- a/tests/unit/mcpgateway/services/test_oauth_manager.py
+++ b/tests/unit/mcpgateway/services/test_oauth_manager.py
@@ -1461,6 +1461,133 @@ async def test_complete_authorization_code_flow_scope_mixed_types(oauth_manager)
     assert call_kwargs["scopes"] == ["read", "write"]
 
 
+class TestRedirectUriPinning:
+    """The redirect_uri sent to the IdP at authorize time must be the exact value used at
+    token exchange (RFC 6749 §4.1.3) -- so it is pinned into server-side state at authorize
+    time and reused at callback, instead of each side independently recomputing/reading it
+    from possibly-changed live state.
+    """
+
+    @pytest.mark.asyncio
+    async def test_complete_flow_uses_redirect_uri_pinned_at_authorize(self, oauth_manager):
+        """complete_authorization_code_flow must override the caller-supplied credentials'
+        redirect_uri with the value pinned in state at authorize time, when present."""
+        mock_token_response = {"access_token": "test-token", "scope": "read", "expires_in": 3600}
+
+        mock_token_storage = AsyncMock()
+        mock_token_record = MagicMock()
+        mock_token_record.expires_at = None
+        mock_token_storage.store_tokens.return_value = mock_token_record
+        oauth_manager.token_storage = mock_token_storage
+
+        exchange_mock = AsyncMock(return_value=mock_token_response)
+
+        with (
+            patch.object(
+                oauth_manager,
+                "_validate_and_retrieve_state",
+                return_value={"code_verifier": "verifier", "app_user_email": "user@example.com", "redirect_uri": "https://pinned.example.com/oauth/callback"},
+            ),
+            patch.object(oauth_manager, "_exchange_code_for_tokens", exchange_mock),
+            patch.object(oauth_manager, "_extract_user_id", return_value="user-1"),
+            patch.object(oauth_manager, "_extract_aud_and_iss", return_value=(None, None)),
+        ):
+            result = await oauth_manager.complete_authorization_code_flow(
+                gateway_id="gw-123",
+                code="auth-code",
+                state="test-state",
+                # Router-computed value; must be superseded by the pinned one below since
+                # e.g. app_domain or the gateway's oauth_config could have changed since authorize.
+                credentials={"client_id": "cid", "token_url": "https://auth.example.com/token", "redirect_uri": "https://recomputed.example.com/oauth/callback"},
+            )
+
+        assert result["success"] is True
+        exchange_mock.assert_called_once()
+        credentials_used = exchange_mock.call_args[0][0]
+        assert credentials_used["redirect_uri"] == "https://pinned.example.com/oauth/callback"
+
+    @pytest.mark.asyncio
+    async def test_complete_flow_falls_back_when_state_has_no_pinned_redirect_uri(self, oauth_manager):
+        """States stored before pinning existed (no redirect_uri key) fall back to whatever
+        redirect_uri the caller passed in credentials."""
+        mock_token_response = {"access_token": "test-token", "scope": "read", "expires_in": 3600}
+
+        mock_token_storage = AsyncMock()
+        mock_token_record = MagicMock()
+        mock_token_record.expires_at = None
+        mock_token_storage.store_tokens.return_value = mock_token_record
+        oauth_manager.token_storage = mock_token_storage
+
+        exchange_mock = AsyncMock(return_value=mock_token_response)
+
+        with (
+            patch.object(oauth_manager, "_validate_and_retrieve_state", return_value={"code_verifier": "verifier", "app_user_email": "user@example.com"}),
+            patch.object(oauth_manager, "_exchange_code_for_tokens", exchange_mock),
+            patch.object(oauth_manager, "_extract_user_id", return_value="user-1"),
+            patch.object(oauth_manager, "_extract_aud_and_iss", return_value=(None, None)),
+        ):
+            result = await oauth_manager.complete_authorization_code_flow(
+                gateway_id="gw-123",
+                code="auth-code",
+                state="test-state",
+                credentials={"client_id": "cid", "token_url": "https://auth.example.com/token", "redirect_uri": "https://fallback.example.com/oauth/callback"},
+            )
+
+        assert result["success"] is True
+        credentials_used = exchange_mock.call_args[0][0]
+        assert credentials_used["redirect_uri"] == "https://fallback.example.com/oauth/callback"
+
+    @pytest.mark.asyncio
+    async def test_initiate_flow_pins_redirect_uri_into_state(self, oauth_manager):
+        """initiate_authorization_code_flow must store the credentials' redirect_uri
+        alongside the PKCE code_verifier so callback-time can reuse it."""
+        oauth_manager.token_storage = AsyncMock()
+        store_state_mock = AsyncMock()
+
+        with patch.object(oauth_manager, "_store_authorization_state", store_state_mock):
+            await oauth_manager.initiate_authorization_code_flow(
+                "test-gateway",
+                {"client_id": "test-client", "authorization_url": "https://auth.example.com/authorize", "redirect_uri": "https://app.example.com/callback"},
+                app_user_email="user@test.com",
+            )
+
+        store_state_mock.assert_called_once()
+        assert store_state_mock.call_args.kwargs["redirect_uri"] == "https://app.example.com/callback"
+
+
+class TestApplyDefaultRedirectUri:
+    """OAuthManager._apply_default_redirect_uri -- the single centralized guard that both
+    flow entry points call before indexing credentials["redirect_uri"] downstream, so any
+    future caller (not just the two /oauth router endpoints that populate it today) is
+    protected against an incomplete credentials dict.
+    """
+
+    def test_noop_when_already_present(self):
+        """An existing redirect_uri is returned untouched, ignoring any default."""
+        credentials = {"client_id": "cid", "redirect_uri": "https://existing.example.com/callback"}
+        result = OAuthManager._apply_default_redirect_uri(credentials, "https://should-not-be-used.example.com/callback")
+        assert result["redirect_uri"] == "https://existing.example.com/callback"
+        assert result is credentials
+
+    def test_uses_caller_supplied_default_when_missing(self):
+        """A caller-supplied default (e.g. the router's request-scoped, root-path-aware
+        value) is used when credentials carries none."""
+        credentials = {"client_id": "cid"}
+        result = OAuthManager._apply_default_redirect_uri(credentials, "https://caller-default.example.com/callback")
+        assert result["redirect_uri"] == "https://caller-default.example.com/callback"
+        # Original dict is untouched (shallow copy), so callers can't be surprised by aliasing.
+        assert "redirect_uri" not in credentials
+
+    def test_falls_back_to_settings_only_default_when_no_caller_default(self):
+        """With no caller-supplied default at all (e.g. a future call path that bypasses
+        both /oauth router endpoints), it still self-heals from settings instead of leaving
+        credentials incomplete."""
+        with patch("mcpgateway.services.oauth_manager.get_settings") as mock_settings:
+            mock_settings.return_value = MagicMock(app_domain="https://gateway.example.com", app_root_path="")
+            result = OAuthManager._apply_default_redirect_uri({"client_id": "cid"}, None)
+        assert result["redirect_uri"] == "https://gateway.example.com/oauth/callback"
+
+
 class TestIssuerPinningOnAudienceLearning:
     """Issuer pinning at learning time (restores the PR's advertised hardening).
 

--- a/tests/unit/mcpgateway/test_oauth_manager.py
+++ b/tests/unit/mcpgateway/test_oauth_manager.py
@@ -502,7 +502,7 @@ class TestOAuthManager:
             state_with_sig = state_bytes + signature
             state = base64.urlsafe_b64encode(state_with_sig).decode()
 
-            credentials = {"client_id": "test_client"}
+            credentials = {"client_id": "test_client", "redirect_uri": "https://gateway.example.com/oauth/callback"}
 
             token_response = {"access_token": "access123", "refresh_token": "refresh123", "expires_in": 3600}
 

--- a/tests/unit/mcpgateway/test_schemas_validators_extra.py
+++ b/tests/unit/mcpgateway/test_schemas_validators_extra.py
@@ -366,6 +366,36 @@ def test_gateway_create_query_param_allowlist(monkeypatch):
     assert gateway.auth_query_param_key == "api_key"
 
 
+def test_gateway_create_rejects_password_grant():
+    """New MCP servers cannot use the deprecated OAuth password grant (issue #5721)."""
+    with pytest.raises(ValidationError, match="password grant"):
+        GatewayCreate(
+            name="gw",
+            url="https://example.com",
+            auth_type="oauth",
+            oauth_config={"grant_type": "password", "username": "u", "password": "p"},
+        )
+
+    # Non-deprecated grants remain accepted.
+    for grant in ("authorization_code", "client_credentials"):
+        gateway = GatewayCreate(
+            name="gw",
+            url="https://example.com",
+            auth_type="oauth",
+            oauth_config={"grant_type": grant, "client_id": "cid"},
+        )
+        assert gateway.oauth_config["grant_type"] == grant
+
+
+def test_gateway_update_allows_legacy_password_grant():
+    """Existing password-grant MCP servers keep working via update (backwards compat)."""
+    updated = GatewayUpdate(
+        auth_type="oauth",
+        oauth_config={"grant_type": "password", "username": "u", "password": "p"},
+    )
+    assert updated.oauth_config["grant_type"] == "password"
+
+
 def test_gateway_create_query_param_disabled(monkeypatch):
     monkeypatch.setattr(settings, "insecure_allow_queryparam_auth", False)
     with pytest.raises(ValidationError):


### PR DESCRIPTION
# Pull Request

> **Credit:** All code in this PR is the work of @marekdano (both commits, both `Signed-off-by`) and @Altamimi-Dev, who opened and drove the original PR #5786 through review. This PR only exists to carry that already-reviewed, already-approved work past a fork-push permission limit — GitHub doesn't allow reassigning PR authorship, so it shows as opened by me. Please attribute the work to them.

## 🔗 Related Issue

Relates to #5721 (delivers the backend pieces of User Stories 1, 2, and 4; Story 3 — pre-fill from MCP `initialize` — is deferred, see #5719).

Supersedes #5786 — same commits, rebased onto current `main`. That PR's head branch lives on a fork we don't have push access to, so a fresh PR against a branch on this repo was needed to land the already-reviewed and approved rebase.

---

## 📝 Summary

Backend half of the MCP server OAuth form quick wins: closes an OAuth 2.1 foot-gun (deprecated password grant) and hardens `redirect_uri` handling for the authorization-code flow. The React UI half now lives in [contextforge-org/contextforge-web-ui#15](https://github.com/contextforge-org/contextforge-web-ui/pull/15).

- **Deprecated password grant rejected (Story 4):** `GatewayCreate` rejects `grant_type == "password"` at the schema layer, so new MCP server registrations can't use it regardless of how they're created (UI or API). Existing gateways that already use it keep working through `GatewayUpdate` — but `GatewayUpdate` now also rejects *newly adopting* password on a gateway that wasn't already using it, so the create-time restriction can't be bypassed via the update path. The legacy admin UI's gateway *creation* form no longer offers the option either (the edit form still does, for loading/saving existing legacy configs).
- **`redirect_uri` defaulting (Story 1, server-side):** `initiate_oauth_flow` and `oauth_callback` default a missing `redirect_uri` to the gateway's own global callback (`{app_domain}{app_root_path}/oauth/callback`), so API-created and legacy configs can't reach `OAuthManager`'s PKCE paths without one. The default accounts for a reverse-proxy `app_root_path`, logs when it's actually applied, and the substitution logic is centralized in `OAuthManager`.
- **`redirect_uri` pinned across the flow:** the value sent to the IdP at authorize time is now pinned into server-side OAuth state (alongside the PKCE `code_verifier`) and reused at token-exchange time, so a concurrent gateway config change or `app_domain` change between authorize and callback can't cause the two to diverge (RFC 6749 §4.1.3). Adds a `redirect_uri` column to `oauth_states` (migration included).
- **Resource (RFC 8707) — Story 2:** already satisfied server-side; no change needed beyond confirming the behavior.

All review feedback from #5786 (password-grant update loophole, `app_root_path` handling, missing logging, redirect_uri pinning, legacy UI option) is already addressed in these commits, and the PR was approved there before the rebase.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

---

## 🏷️ Type of Change

- [x] Feature / Enhancement

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Schema/gateway tests | `pytest tests/unit/mcpgateway/test_schemas_validators_extra.py tests/unit/mcpgateway/services/test_gateway_service.py -k "oauth or gateway_create or gateway_update or password"` | ✅ |
| OAuth router tests | `pytest tests/unit/mcpgateway/routers/test_oauth_router.py` | ✅ |
| OAuth manager tests | `pytest tests/unit/mcpgateway/services/test_oauth_manager.py` | ✅ |
| Alembic heads | `alembic heads` | ✅ single head |

---

## ✅ Checklist

- [x] Code formatted
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

