### PR TITLE
chore: Tool invoke function refactor

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -18,6 +18,7 @@ import asyncio
 import base64
 import binascii
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import lru_cache
 import json  # NOTE: httpx uses stdlib json, not orjson, so response.json() raises json.JSONDecodeError
@@ -1073,6 +1074,33 @@ def _build_retry_policy_config(raw_cfg: Optional[Dict[str, Any]], tool_name: str
     effective_cfg["max_retries"] = min(effective_cfg["max_retries"], settings.max_tool_retries)
 
     return effective_cfg
+
+
+@dataclass
+class ResolvedTool:
+    """Result of resolving and authorizing a tool name for invocation.
+
+    Shared return type of ``ToolService._resolve_tool_for_invocation``, called by both
+    ``invoke_tool`` (live invocation) and ``preview_tool_invocation`` (dry-run, #5629) so
+    tool lookup, RBAC, and visibility rules can never drift between the two paths.
+
+    Attributes:
+        is_direct_proxy: True when resolved via the X-Context-Forge-Gateway-Id direct-proxy
+            header (no DB tool row involved).
+        tool: ORM Tool row when resolved via a DB/cache-miss lookup; None on a cache hit or
+            in direct-proxy mode.
+        gateway: ORM Gateway row eager-loaded alongside ``tool``; None when the tool has no
+            gateway, on a cache hit, or in direct-proxy mode.
+        tool_payload: Flattened tool fields, from a cache hit, a cache-miss ORM conversion,
+            or direct-proxy synthesis. Always populated.
+        gateway_payload: Flattened gateway fields, or None when the tool has no gateway.
+    """
+
+    is_direct_proxy: bool
+    tool: Optional[DbTool]
+    gateway: Optional[DbGateway]
+    tool_payload: Dict[str, Any]
+    gateway_payload: Optional[Dict[str, Any]]
 
 
 class ToolService(BaseService):
@@ -4819,77 +4847,46 @@ class ToolService(BaseService):
                 retry_attempt=retry_attempt + 1,
             )
 
-    async def invoke_tool(
+    async def _resolve_tool_for_invocation(
         self,
         db: Session,
         name: str,
-        arguments: Dict[str, Any],
-        request_headers: Optional[Dict[str, str]] = None,
-        app_user_email: Optional[str] = None,
-        user_email: Optional[str] = None,
-        token_teams: Optional[List[str]] = None,
-        server_id: Optional[str] = None,
-        plugin_context_table: Optional[PluginContextTable] = None,
-        plugin_global_context: Optional[GlobalContext] = None,
-        meta_data: Optional[Dict[str, Any]] = None,
-        skip_pre_invoke: bool = False,
-        require_app_visible: bool = False,
-        require_model_visible: bool = False,
-        retry_attempt: int = 0,
-    ) -> ToolResult:
-        """
-        Invoke a registered tool and record execution metrics.
+        request_headers: Optional[Dict[str, str]],
+        user_email: Optional[str],
+        token_teams: Optional[List[str]],
+        server_id: Optional[str],
+        require_app_visible: bool,
+        require_model_visible: bool,
+    ) -> ResolvedTool:
+        """Resolve a tool name to an authorized, invocable target.
+
+        Side-effect-free (beyond cache reads/writes and the read-only DB queries already
+        required to answer "is this tool invocable by this caller"): no network call, no
+        plugin hook, no dispatch. Extracted from ``invoke_tool`` (#5629) so the live
+        invocation path and the dry-run preview path (``preview_tool_invocation``) share
+        one resolution/RBAC implementation and cannot silently drift apart.
 
         Args:
             db: Database session.
-            name: Name of tool to invoke.
-            arguments: Tool arguments.
-            request_headers (Optional[Dict[str, str]], optional): Headers from the request to pass through.
-                Defaults to None.
-            app_user_email (Optional[str], optional): ContextForge user email for OAuth token retrieval.
-                Required for OAuth-protected gateways.
-            user_email (Optional[str], optional): User email for authorization checks.
-                None = unauthenticated request.
-            token_teams (Optional[List[str]], optional): Team IDs from JWT token for authorization.
-                None = unrestricted admin, [] = public-only, [...] = team-scoped.
-            server_id (Optional[str], optional): Virtual server ID for server scoping enforcement.
-                If provided, tool must be attached to this server.
-            plugin_context_table: Optional plugin context table from previous hooks for cross-hook state sharing.
-            plugin_global_context: Optional global context from middleware for consistency across hooks.
-            meta_data: Optional metadata dictionary for additional context (e.g., request ID).
-            skip_pre_invoke: When True, skip TOOL_PRE_INVOKE hooks (used by trusted Rust fallback path).
-            require_app_visible: When True, deny execution unless the resolved tool is MCP Apps app-visible.
-            require_model_visible: When True, deny execution unless the resolved tool is model-visible.
-            retry_attempt: Zero-based retry counter; 0 = original call.  Incremented by the retry
-                loop and compared against ``settings.max_tool_retries``.
+            name: Name of tool to resolve.
+            request_headers: Headers from the request (used for X-Context-Forge-Gateway-Id
+                direct-proxy detection).
+            user_email: User email for authorization checks. None = unauthenticated request.
+            token_teams: Team IDs from JWT token for authorization. None = unrestricted admin,
+                [] = public-only, [...] = team-scoped.
+            server_id: Virtual server ID for server scoping enforcement. If provided, tool
+                must be attached to this server.
+            require_app_visible: When True, deny resolution unless the tool is MCP Apps
+                app-visible.
+            require_model_visible: When True, deny resolution unless the tool is model-visible.
 
         Returns:
-            Tool invocation result.
+            ResolvedTool: The resolved, authorized tool (or direct-proxy target).
 
         Raises:
-            ToolNotFoundError: If tool not found or access denied.
-            ToolInvocationError: If invocation fails or A2A authentication decryption fails.
-            ToolTimeoutError: If tool invocation times out.
-            PluginViolationError: If plugin blocks tool invocation.
-            PluginError: If encounters issue with plugin.
-
-        Examples:
-            >>> # Note: This method requires extensive mocking of SQLAlchemy models,
-            >>> # database relationships, and caching infrastructure, which is not
-            >>> # suitable for doctests. See tests/unit/mcpgateway/services/test_tool_service.py
-            >>> pass  # doctest: +SKIP
+            ToolNotFoundError: If tool not found, inaccessible, or fails a visibility gate.
+            ToolInvocationError: If the tool name is ambiguous or the tool is deprecated.
         """
-        # pylint: disable=comparison-with-callable
-        logger.info("Invoking tool: %s with arguments: %s and headers: %s, server_id=%s", name, arguments.keys() if arguments else None, request_headers.keys() if request_headers else None, server_id)
-        # ═══════════════════════════════════════════════════════════════════════════
-        # PHASE 0: Set request_headers_var ContextVar so downstream_session_id_from_request_context() can access it
-        # This is needed for upstream session registry to work correctly
-        # ═══════════════════════════════════════════════════════════════════════════
-        # First-Party
-        from mcpgateway.transports.context import request_headers_var  # pylint: disable=import-outside-toplevel
-
-        if request_headers:
-            request_headers_var.set(request_headers)
         # ═══════════════════════════════════════════════════════════════════════════
         # PHASE 1: Check for X-Context-Forge-Gateway-Id header for direct_proxy mode (no DB lookup)
         # ═══════════════════════════════════════════════════════════════════════════
@@ -5064,6 +5061,91 @@ class ToolService(BaseService):
                 raise ToolNotFoundError(f"Tool not found: {name}")
         elif require_model_visible and not is_direct_proxy and not is_model_visible_tool(tool_payload):
             raise ToolNotFoundError(f"Tool not found: {name}")
+
+        return ResolvedTool(is_direct_proxy=is_direct_proxy, tool=tool, gateway=gateway, tool_payload=tool_payload, gateway_payload=gateway_payload)
+
+    async def invoke_tool(
+        self,
+        db: Session,
+        name: str,
+        arguments: Dict[str, Any],
+        request_headers: Optional[Dict[str, str]] = None,
+        app_user_email: Optional[str] = None,
+        user_email: Optional[str] = None,
+        token_teams: Optional[List[str]] = None,
+        server_id: Optional[str] = None,
+        plugin_context_table: Optional[PluginContextTable] = None,
+        plugin_global_context: Optional[GlobalContext] = None,
+        meta_data: Optional[Dict[str, Any]] = None,
+        skip_pre_invoke: bool = False,
+        require_app_visible: bool = False,
+        require_model_visible: bool = False,
+        retry_attempt: int = 0,
+    ) -> ToolResult:
+        """
+        Invoke a registered tool and record execution metrics.
+
+        Args:
+            db: Database session.
+            name: Name of tool to invoke.
+            arguments: Tool arguments.
+            request_headers (Optional[Dict[str, str]], optional): Headers from the request to pass through.
+                Defaults to None.
+            app_user_email (Optional[str], optional): ContextForge user email for OAuth token retrieval.
+                Required for OAuth-protected gateways.
+            user_email (Optional[str], optional): User email for authorization checks.
+                None = unauthenticated request.
+            token_teams (Optional[List[str]], optional): Team IDs from JWT token for authorization.
+                None = unrestricted admin, [] = public-only, [...] = team-scoped.
+            server_id (Optional[str], optional): Virtual server ID for server scoping enforcement.
+                If provided, tool must be attached to this server.
+            plugin_context_table: Optional plugin context table from previous hooks for cross-hook state sharing.
+            plugin_global_context: Optional global context from middleware for consistency across hooks.
+            meta_data: Optional metadata dictionary for additional context (e.g., request ID).
+            skip_pre_invoke: When True, skip TOOL_PRE_INVOKE hooks (used by trusted Rust fallback path).
+            require_app_visible: When True, deny execution unless the resolved tool is MCP Apps app-visible.
+            require_model_visible: When True, deny execution unless the resolved tool is model-visible.
+            retry_attempt: Zero-based retry counter; 0 = original call.  Incremented by the retry
+                loop and compared against ``settings.max_tool_retries``.
+
+        Returns:
+            Tool invocation result.
+
+        Raises:
+            ToolNotFoundError: If tool not found or access denied.
+            ToolInvocationError: If invocation fails or A2A authentication decryption fails.
+            ToolTimeoutError: If tool invocation times out.
+            PluginViolationError: If plugin blocks tool invocation.
+            PluginError: If encounters issue with plugin.
+
+        Examples:
+            >>> # Note: This method requires extensive mocking of SQLAlchemy models,
+            >>> # database relationships, and caching infrastructure, which is not
+            >>> # suitable for doctests. See tests/unit/mcpgateway/services/test_tool_service.py
+            >>> pass  # doctest: +SKIP
+        """
+        # pylint: disable=comparison-with-callable
+        logger.info("Invoking tool: %s with arguments: %s and headers: %s, server_id=%s", name, arguments.keys() if arguments else None, request_headers.keys() if request_headers else None, server_id)
+        # ═══════════════════════════════════════════════════════════════════════════
+        # PHASE 0: Set request_headers_var ContextVar so downstream_session_id_from_request_context() can access it
+        # This is needed for upstream session registry to work correctly
+        # ═══════════════════════════════════════════════════════════════════════════
+        # First-Party
+        from mcpgateway.transports.context import request_headers_var  # pylint: disable=import-outside-toplevel
+
+        if request_headers:
+            request_headers_var.set(request_headers)
+        # ═══════════════════════════════════════════════════════════════════════════
+        # PHASE 1: Resolve tool name to an authorized, invocable target.
+        # Shared with preview_tool_invocation (#5629) via _resolve_tool_for_invocation
+        # so tool lookup, RBAC, and visibility rules cannot drift between the two paths.
+        # ═══════════════════════════════════════════════════════════════════════════
+        resolved = await self._resolve_tool_for_invocation(db, name, request_headers, user_email, token_teams, server_id, require_app_visible, require_model_visible)
+        is_direct_proxy = resolved.is_direct_proxy
+        tool = resolved.tool
+        gateway = resolved.gateway
+        tool_payload = resolved.tool_payload
+        gateway_payload = resolved.gateway_payload
 
         # Extract A2A-related data from annotations (will be used after db.close() if A2A tool)
         tool_annotations = tool_payload.get("annotations") or {}


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue

Relates to #5629

---

## 🚀 Summary (1-2 sentences)

Extracts the tool-lookup/RBAC/visibility-gate prefix of `ToolService.invoke_tool` into a new `_resolve_tool_for_invocation` helper (returning a `ResolvedTool` dataclass), with zero behavior change. This isolates the riskiest part of a larger refactor into its own small diff and is the shared resolution path a later PR's dry-run preview endpoint will call, so tool lookup/RBAC/visibility rules can't drift between live invocation and preview.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate — none needed; see Checks below for why
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🧪 Checks

- [x] `make ruff interrogate pylint` — clean (ruff: all checks passed; interrogate: 100.0% docstring coverage; pylint: 10.00/10, no change)
- [x] `make test` on the full `test_tool_service*.py` family — passes unmodified, **zero test files edited**, which is the actual proof of no behavior change (if the extraction had altered anything, some existing assertion would have broken)
- [x] Cross-checked 10 other test files that exercise `invoke_tool` indirectly (RPC handlers, streamable HTTP transport, identity propagation, token exchange, deprecated-tool path, RBAC authorization) — one failure (`test_rest_tool_runtime_url_validation.py::test_invocation_rejects_disallowed_runtime_target`) reproduces identically on pre-refactor code run in the same file order (verified via `git stash`) — pre-existing test-isolation/ordering issue, not a regression from this change
- [x] `mypy` on the changed file — two pre-existing findings land on the new call site (untyped `_get_tool_lookup_cache()`, cpex-import-derived `Any` typing on `invoke_tool`'s own signature); both existed before this change under the old line numbers, nothing new introduced
- [x] `make detect-secrets-scan` — clean, no new findings
- [ ] CHANGELOG updated (if user-facing) — not applicable; internal refactor, no observable behavior change

---

## 📓 Notes (optional)

Second of a 4-PR sequence implementing #5629:

1. RBAC permission plumbing (`tools.preview` permission, default-role seed data, backfill migration, `TokenScopingMiddleware` mapping) - https://github.com/IBM/mcp-context-forge/pull/6321/
2. **This PR** - pure refactor extracting `_resolve_tool_for_invocation`
3. New `ToolService.preview_tool_invocation` business logic, unit-tested, not yet reachable via HTTP
4. `POST /tools/preview/{name}` route + feature flag + integration tests

Extraction boundary was scoped narrower than originally planned: it stops right after the `require_app_visible`/`require_model_visible` checks rather than the later `db.commit()`/`db.close()` point deeper in `invoke_tool`. Everything past that boundary (URL/auth/header flattening, gateway cert extraction, A2A agent lookup) is dispatch-only plumbing that the upcoming preview endpoint will never touch, so pulling it in would have widened this diff and the shared-code surface for no benefit to either caller.

`invoke_tool` itself is otherwise byte-for-byte unchanged past the new call site — it unpacks `ResolvedTool` into the same local variable names (`is_direct_proxy`, `tool`, `gateway`, `tool_payload`, `gateway_payload`) it always used, so the ~1900 remaining lines of dispatch/hook/retry/metrics logic needed no edits at all.