### PR TITLE
docs: require live black-box tests where applicable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,6 +487,7 @@ exempt.
 - **Conventional Commits**: `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`
 - **Link issues**: `Closes #123`
 - Include tests for behavior changes
+- Every PR whose behavior can be exercised through a live gateway must include a full black-box test against a running gateway
 - Require green lint and tests before PR
 - Don't push until asked.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,7 +487,7 @@ exempt.
 - **Conventional Commits**: `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`
 - **Link issues**: `Closes #123`
 - Include tests for behavior changes
-- Every PR whose behavior can be exercised through a live gateway must include a full black-box test against a running gateway
+- Every PR whose behavior can be exercised through a live gateway must include a full black-box test against a running gateway; see [`tests/live_gateway/`](tests/live_gateway/) for examples
 - Require green lint and tests before PR
 - Don't push until asked.
 


### PR DESCRIPTION
## Summary

- Require a full black-box test against a running gateway whenever a PR’s behavior can be exercised through a live gateway.