### PR TITLE
feat: publish tool schemas to dataplane

### DIFF
--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -10,6 +10,7 @@ Be careful not to overfit production-grade assumptions onto the design.
 
 # Standard
 import asyncio
+from collections.abc import Sequence
 from collections import defaultdict
 import logging
 import os
@@ -67,9 +68,21 @@ class BackendConfig(TypedDict):
     remove_headers: list[str]
     capabilities: dict[str, Any]
     allowed_tool_names: list[str]
+    tool_schemas: dict[str, dict[str, Any]]
     allowed_resource_names: list[str]
     allowed_resource_uris: list[str]
     allowed_prompt_names: list[str]
+
+
+class GatewayBaseConfig(TypedDict):
+    """Gateway connection fields shared by every virtual-host backend."""
+
+    name: str
+    url: str
+    passthrough_headers: list[str]
+    add_headers: dict[str, str]
+    remove_headers: list[str]
+    capabilities: dict[str, Any]
 
 
 class VirtualHostConfig(TypedDict):
@@ -84,7 +97,27 @@ class UserConfig(TypedDict):
     virtual_hosts: dict[str, VirtualHostConfig]
 
 
-BackendItems = dict[str, list[str]]
+class BackendItems(TypedDict):
+    """Database identifiers associated with one server backend."""
+
+    tools: list[str]
+    resources: list[str]
+    prompts: list[str]
+
+
+class PublishedBackendItems(BackendItems):
+    """User-filtered backend items enriched with tool input schemas."""
+
+    tool_schemas: dict[str, dict[str, Any]]
+
+
+class ToolMetadata(TypedDict):
+    """Tool fields needed to publish dataplane routing configuration."""
+
+    name: str
+    input_schema: dict[str, Any]
+
+
 BackendItemsByServer = dict[str, dict[str, BackendItems]]
 
 
@@ -129,7 +162,7 @@ class DataplanePublisherService:
         self.task = None
         logger.info("Dataplane publisher stopped.")
 
-    async def fetch_payload(self) -> dict[str, dict[str, dict[str, Any]]] | None:
+    async def fetch_payload(self) -> dict[str, UserConfig] | None:
         """Fetch the payload to publish to Redis. Returns None on error."""
         user_data = await self.get_data_from_db()
         if user_data is None:
@@ -231,7 +264,7 @@ class DataplanePublisherService:
             # The dataplane proxies streamable-HTTP upstreams only. Exclude
             # every other transport before building its transport-agnostic
             # backend config.
-            gateway_base = {
+            gateway_base: dict[str, GatewayBaseConfig] = {
                 gateway["id"]: {
                     "name": gateway["name"],
                     "url": gateway["url"],
@@ -261,8 +294,14 @@ class DataplanePublisherService:
                         continue
 
                     backends[gateway_id] = {
-                        **gateway_config,
+                        "name": gateway_config["name"],
+                        "url": gateway_config["url"],
+                        "passthrough_headers": gateway_config["passthrough_headers"],
+                        "add_headers": gateway_config["add_headers"],
+                        "remove_headers": gateway_config["remove_headers"],
+                        "capabilities": gateway_config["capabilities"],
                         "allowed_tool_names": backend_items["tools"],
+                        "tool_schemas": backend_items.get("tool_schemas", {}),
                         "allowed_resource_names": allowed_resource_names,
                         "allowed_resource_uris": allowed_resource_uris,
                         "allowed_prompt_names": allowed_prompt_names,
@@ -326,7 +365,7 @@ class DataplanePublisherService:
                         DbResource.uri_template.is_(None),
                     )
                 ).all()
-                tool_rows = db.execute(select(DbTool.id, DbTool.original_name, DbTool.owner_email, DbTool.team_id, DbTool.visibility).where(DbTool.enabled.is_(True))).all()
+                tool_rows = db.execute(select(DbTool.id, DbTool.original_name, DbTool.input_schema, DbTool.owner_email, DbTool.team_id, DbTool.visibility).where(DbTool.enabled.is_(True))).all()
                 backend_items_by_server = self._get_backend_items_by_server(db)
 
                 return {
@@ -353,21 +392,23 @@ class DataplanePublisherService:
         user_email: str,
         team_ids: set[str],
         is_admin: bool,
-        server_rows: list[Any],
-        gateway_rows: list[Any],
-        prompt_rows: list[Any],
-        resource_rows: list[Any],
-        tool_rows: list[Any],
+        server_rows: Sequence[Any],
+        gateway_rows: Sequence[Any],
+        prompt_rows: Sequence[Any],
+        resource_rows: Sequence[Any],
+        tool_rows: Sequence[Any],
         backend_items_by_server: BackendItemsByServer,
     ) -> dict[str, Any]:
         """Build already-filtered dataplane data for one user."""
-        tool_name_by_id = {tool.id: tool.original_name for tool in tool_rows if self._filter_for_user(tool, user_email, team_ids, is_admin=is_admin)}
+        tool_by_id: dict[str, ToolMetadata] = {
+            tool.id: {"name": tool.original_name, "input_schema": tool.input_schema} for tool in tool_rows if self._filter_for_user(tool, user_email, team_ids, is_admin=is_admin)
+        }
 
         return {
             "servers": [
                 {
                     "id": server.id,
-                    "backend_items": self._filter_backend_items_for_user(backend_items_by_server.get(server.id, {}), tool_name_by_id),
+                    "backend_items": self._filter_backend_items_for_user(backend_items_by_server.get(server.id, {}), tool_by_id),
                 }
                 for server in server_rows
                 if self._filter_for_user(server, user_email, team_ids, is_admin=is_admin)
@@ -403,11 +444,12 @@ class DataplanePublisherService:
         return row.team_id in team_ids and visibility == "team"
 
     @staticmethod
-    def _filter_backend_items_for_user(backend_items_by_gateway: dict[str, BackendItems], tool_name_by_id: dict[str, str]) -> dict[str, BackendItems]:
-        """Filter backend tool IDs for one user and convert visible tools to names."""
+    def _filter_backend_items_for_user(backend_items_by_gateway: dict[str, BackendItems], tool_by_id: dict[str, ToolMetadata]) -> dict[str, PublishedBackendItems]:
+        """Filter backend tool IDs for one user and publish visible names with schemas."""
         return {
             gateway_id: {
-                "tools": [tool_name_by_id[tool_id] for tool_id in backend_items["tools"] if tool_id in tool_name_by_id],
+                "tools": [tool_by_id[tool_id]["name"] for tool_id in backend_items["tools"] if tool_id in tool_by_id],
+                "tool_schemas": {tool_by_id[tool_id]["name"]: tool_by_id[tool_id]["input_schema"] for tool_id in backend_items["tools"] if tool_id in tool_by_id},
                 "resources": list(backend_items["resources"]),
                 "prompts": list(backend_items["prompts"]),
             }

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -301,7 +301,7 @@ class DataplanePublisherService:
                         "remove_headers": gateway_config["remove_headers"],
                         "capabilities": gateway_config["capabilities"],
                         "allowed_tool_names": backend_items["tools"],
-                        "tool_schemas": backend_items.get("tool_schemas", {}),
+                        "tool_schemas": backend_items["tool_schemas"],
                         "allowed_resource_names": allowed_resource_names,
                         "allowed_resource_uris": allowed_resource_uris,
                         "allowed_prompt_names": allowed_prompt_names,
@@ -401,7 +401,12 @@ class DataplanePublisherService:
     ) -> dict[str, Any]:
         """Build already-filtered dataplane data for one user."""
         tool_by_id: dict[str, ToolMetadata] = {
-            tool.id: {"name": tool.original_name, "input_schema": tool.input_schema} for tool in tool_rows if self._filter_for_user(tool, user_email, team_ids, is_admin=is_admin)
+            tool.id: {
+                "name": tool.original_name,
+                "input_schema": tool.input_schema if isinstance(tool.input_schema, dict) else {},
+            }
+            for tool in tool_rows
+            if self._filter_for_user(tool, user_email, team_ids, is_admin=is_admin)
         }
 
         return {

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -400,13 +400,17 @@ class DataplanePublisherService:
         backend_items_by_server: BackendItemsByServer,
     ) -> dict[str, Any]:
         """Build already-filtered dataplane data for one user."""
+        visible_tools = [tool for tool in tool_rows if self._filter_for_user(tool, user_email, team_ids, is_admin=is_admin)]
+        for tool in visible_tools:
+            if not isinstance(tool.input_schema, dict):
+                raise ValueError(f"Tool {tool.id} has a non-object input schema")
+
         tool_by_id: dict[str, ToolMetadata] = {
             tool.id: {
                 "name": tool.original_name,
-                "input_schema": tool.input_schema if isinstance(tool.input_schema, dict) else {},
+                "input_schema": tool.input_schema,
             }
-            for tool in tool_rows
-            if self._filter_for_user(tool, user_email, team_ids, is_admin=is_admin)
+            for tool in visible_tools
         }
 
         return {

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -400,18 +400,17 @@ class DataplanePublisherService:
         backend_items_by_server: BackendItemsByServer,
     ) -> dict[str, Any]:
         """Build already-filtered dataplane data for one user."""
-        visible_tools = [tool for tool in tool_rows if self._filter_for_user(tool, user_email, team_ids, is_admin=is_admin)]
-        for tool in visible_tools:
+        tool_by_id: dict[str, ToolMetadata] = {}
+        for tool in tool_rows:
+            if not self._filter_for_user(tool, user_email, team_ids, is_admin=is_admin):
+                continue
             if not isinstance(tool.input_schema, dict):
-                raise ValueError(f"Tool {tool.id} has a non-object input schema")
-
-        tool_by_id: dict[str, ToolMetadata] = {
-            tool.id: {
+                logger.warning("Excluding tool %s from the dataplane snapshot because its input schema is not an object", tool.id)
+                continue
+            tool_by_id[tool.id] = {
                 "name": tool.original_name,
                 "input_schema": tool.input_schema,
             }
-            for tool in visible_tools
-        }
 
         return {
             "servers": [

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -226,7 +226,7 @@ async def test_full_payload_generation_with_mock_db():
     tool2.id = "t2"
     tool2.name = "gw1-private_tool"
     tool2.original_name = "private_tool"
-    tool2.input_schema = {"type": "object", "properties": {"text": {"type": "string"}}}
+    tool2.input_schema = None
     tool2.owner_email = "user1@example.com"
     tool2.team_id = "team1"
     tool2.visibility = "private"
@@ -296,7 +296,7 @@ async def test_full_payload_generation_with_mock_db():
             "allowed_tool_names": ["public_tool", "private_tool"],
             "tool_schemas": {
                 "public_tool": tool1.input_schema,
-                "private_tool": tool2.input_schema,
+                "private_tool": {},
             },
             "allowed_resource_names": ["Resource 1"],
             "allowed_resource_uris": ["resource://one"],
@@ -413,7 +413,7 @@ def test_create_payload_filters_empty_backends():
                 {
                     "id": "server1",
                     "backend_items": {
-                        "gateway1": {"tools": [], "resources": [], "prompts": []},
+                        "gateway1": {"tools": [], "tool_schemas": {}, "resources": [], "prompts": []},
                     },
                 }
             ],
@@ -442,7 +442,12 @@ def test_create_payload_excludes_non_streamable_gateways(transport: str):
                 {
                     "id": "server1",
                     "backend_items": {
-                        "gateway_non_streamable": {"tools": ["tool1"], "resources": [], "prompts": []},
+                        "gateway_non_streamable": {
+                            "tools": ["tool1"],
+                            "tool_schemas": {},
+                            "resources": [],
+                            "prompts": [],
+                        },
                     },
                 }
             ],
@@ -469,7 +474,7 @@ def test_create_payload_normalizes_null_passthrough_headers():
                 {
                     "id": "server1",
                     "backend_items": {
-                        "gateway1": {"tools": ["tool1"], "resources": [], "prompts": []},
+                        "gateway1": {"tools": ["tool1"], "tool_schemas": {}, "resources": [], "prompts": []},
                     },
                 }
             ],
@@ -499,7 +504,12 @@ def test_create_payload_handles_missing_references():
                 {
                     "id": "server1",
                     "backend_items": {
-                        "missing_gateway": {"tools": ["tool1"], "resources": ["missing_res"], "prompts": ["missing_prompt"]},
+                        "missing_gateway": {
+                            "tools": ["tool1"],
+                            "tool_schemas": {},
+                            "resources": ["missing_res"],
+                            "prompts": ["missing_prompt"],
+                        },
                     },
                 }
             ],

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -11,7 +11,6 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
-
 USER1_ID = "11111111-1111-1111-1111-111111111111"
 USER2_ID = "22222222-2222-2222-2222-222222222222"
 USER3_ID = "33333333-3333-3333-3333-333333333333"
@@ -214,6 +213,10 @@ async def test_full_payload_generation_with_mock_db():
     tool1.id = "t1"
     tool1.name = "gw1-public_tool"
     tool1.original_name = "public_tool"
+    tool1.input_schema = {
+        "type": "object",
+        "properties": {"region": {"type": "string", "x-mcp-header": "Region"}},
+    }
     tool1.owner_email = "user1@example.com"
     tool1.team_id = "team1"
     tool1.visibility = "public"
@@ -223,6 +226,7 @@ async def test_full_payload_generation_with_mock_db():
     tool2.id = "t2"
     tool2.name = "gw1-private_tool"
     tool2.original_name = "private_tool"
+    tool2.input_schema = {"type": "object", "properties": {"text": {"type": "string"}}}
     tool2.owner_email = "user1@example.com"
     tool2.team_id = "team1"
     tool2.visibility = "private"
@@ -232,6 +236,7 @@ async def test_full_payload_generation_with_mock_db():
     tool3.id = "t3"
     tool3.name = "gw1-team2_tool"
     tool3.original_name = "team2_tool"
+    tool3.input_schema = {"type": "object", "properties": {"count": {"type": "integer"}}}
     tool3.owner_email = "user2@example.com"
     tool3.team_id = "team2"
     tool3.visibility = "team"
@@ -289,6 +294,10 @@ async def test_full_payload_generation_with_mock_db():
             "remove_headers": ["Cookie"],
             "capabilities": {"resources": {"subscribe": True}},
             "allowed_tool_names": ["public_tool", "private_tool"],
+            "tool_schemas": {
+                "public_tool": tool1.input_schema,
+                "private_tool": tool2.input_schema,
+            },
             "allowed_resource_names": ["Resource 1"],
             "allowed_resource_uris": ["resource://one"],
             "allowed_prompt_names": ["Prompt 1"],
@@ -302,6 +311,11 @@ async def test_full_payload_generation_with_mock_db():
         assert "add_headers" in selected_keys, "Gateway SELECT must include add_headers"
         assert "remove_headers" in selected_keys, "Gateway SELECT must include remove_headers"
 
+        tool_execute_call = mock_db.execute.call_args_list[6]
+        tool_stmt = tool_execute_call[0][0]
+        selected_tool_keys = {col.key for col in tool_stmt.selected_columns}
+        assert "input_schema" in selected_tool_keys, "Tool SELECT must include input_schema"
+
         # Verify user2 sees public server but not private server from user1
         user2_config = payload[USER2_ID]
         assert "s1" in user2_config["virtual_hosts"]  # public
@@ -310,6 +324,10 @@ async def test_full_payload_generation_with_mock_db():
         assert "s2" not in user2_config["virtual_hosts"]
         user2_backend = user2_config["virtual_hosts"]["s1"]["backends"]["g1"]
         assert user2_backend["allowed_tool_names"] == ["public_tool", "team2_tool"]
+        assert user2_backend["tool_schemas"] == {
+            "public_tool": tool1.input_schema,
+            "team2_tool": tool3.input_schema,
+        }
 
         # Verify active users with no team membership still get public-only config.
         user3_config = payload[USER3_ID]
@@ -317,6 +335,7 @@ async def test_full_payload_generation_with_mock_db():
         assert "s2" not in user3_config["virtual_hosts"]
         user3_backend = user3_config["virtual_hosts"]["s1"]["backends"]["g1"]
         assert user3_backend["allowed_tool_names"] == ["public_tool"]
+        assert user3_backend["tool_schemas"] == {"public_tool": tool1.input_schema}
 
 
 # ============================================================================

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -242,6 +242,16 @@ async def test_full_payload_generation_with_mock_db():
     tool3.visibility = "team"
     tool3.enabled = True
 
+    malformed_tool = Mock()
+    malformed_tool.id = "bad-tool"
+    malformed_tool.name = "gw1-bad_tool"
+    malformed_tool.original_name = "bad_tool"
+    malformed_tool.input_schema = None
+    malformed_tool.owner_email = "user1@example.com"
+    malformed_tool.team_id = "team1"
+    malformed_tool.visibility = "private"
+    malformed_tool.enabled = True
+
     # Mock active users and user-team memberships
     mock_db.execute.return_value.all.side_effect = [
         # Active users query
@@ -257,9 +267,9 @@ async def test_full_payload_generation_with_mock_db():
         # Resource query
         [resource1],
         # Tool query
-        [tool1, tool2, tool3],
+        [tool1, tool2, tool3, malformed_tool],
         # Tool associations
-        [("s1", "t1", "g1"), ("s1", "t2", "g1"), ("s1", "t3", "g1")],
+        [("s1", "t1", "g1"), ("s1", "t2", "g1"), ("s1", "t3", "g1"), ("s1", "bad-tool", "g1")],
         # Resource associations
         [("s1", "r1", "g1")],
         # Prompt associations
@@ -302,6 +312,8 @@ async def test_full_payload_generation_with_mock_db():
             "allowed_resource_uris": ["resource://one"],
             "allowed_prompt_names": ["Prompt 1"],
         }
+        assert "bad_tool" not in backend["allowed_tool_names"]
+        assert "bad_tool" not in backend["tool_schemas"]
 
         # Verify the gateway SELECT projection actually includes the new columns
         # (guards against getattr-on-Row silently returning None when columns are missing from SELECT)
@@ -338,16 +350,31 @@ async def test_full_payload_generation_with_mock_db():
         assert user3_backend["tool_schemas"] == {"public_tool": tool1.input_schema}
 
 
-def test_build_user_data_rejects_non_object_tool_schema():
-    """Dataplane snapshots fail closed when an enabled tool schema is malformed."""
+def test_build_user_data_excludes_non_object_tool_schema(caplog):
+    """A malformed tool is excluded without dropping valid tools from the snapshot."""
     from unittest.mock import Mock
 
-    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+    from mcpgateway.services.dataplane_publisher import BackendItemsByServer, DataplanePublisherService
 
-    tool = Mock(id="bad-tool", original_name="bad", input_schema=None, visibility="public")
+    bad_tool = Mock(id="bad-tool", original_name="bad", input_schema=None, visibility="public")
+    good_tool = Mock(id="good-tool", original_name="good", input_schema={"type": "object"}, visibility="public")
+    server = Mock(id="server", visibility="public")
+    backend_items_by_server: BackendItemsByServer = {
+        "server": {
+            "gateway": {
+                "tools": ["bad-tool", "good-tool"],
+                "resources": [],
+                "prompts": [],
+            }
+        }
+    }
 
-    with pytest.raises(ValueError, match="Tool bad-tool has a non-object input schema"):
-        DataplanePublisherService()._build_user_data("user@example.com", set(), False, [], [], [], [], [tool], {})
+    result = DataplanePublisherService()._build_user_data("user@example.com", set(), False, [server], [], [], [], [bad_tool, good_tool], backend_items_by_server)
+
+    backend_items = result["servers"][0]["backend_items"]["gateway"]
+    assert backend_items["tools"] == ["good"]
+    assert backend_items["tool_schemas"] == {"good": {"type": "object"}}
+    assert "Excluding tool bad-tool" in caplog.text
 
 
 # ============================================================================

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -226,7 +226,7 @@ async def test_full_payload_generation_with_mock_db():
     tool2.id = "t2"
     tool2.name = "gw1-private_tool"
     tool2.original_name = "private_tool"
-    tool2.input_schema = None
+    tool2.input_schema = {}
     tool2.owner_email = "user1@example.com"
     tool2.team_id = "team1"
     tool2.visibility = "private"
@@ -336,6 +336,18 @@ async def test_full_payload_generation_with_mock_db():
         user3_backend = user3_config["virtual_hosts"]["s1"]["backends"]["g1"]
         assert user3_backend["allowed_tool_names"] == ["public_tool"]
         assert user3_backend["tool_schemas"] == {"public_tool": tool1.input_schema}
+
+
+def test_build_user_data_rejects_non_object_tool_schema():
+    """Dataplane snapshots fail closed when an enabled tool schema is malformed."""
+    from unittest.mock import Mock
+
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    tool = Mock(id="bad-tool", original_name="bad", input_schema=None, visibility="public")
+
+    with pytest.raises(ValueError, match="Tool bad-tool has a non-object input schema"):
+        DataplanePublisherService()._build_user_data("user@example.com", set(), False, [], [], [], [], [tool], {})
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- publish visibility-filtered MCP tool input schemas in the existing per-user Redis snapshot
- key schemas by virtual host, backend, and original upstream tool name
- reject non-object schemas instead of publishing an invalid dataplane contract

This supplies the request-scoped schema source required by contextforge-org/contextforge-data-plane#109. The dataplane validates client-supplied `Mcp-Param-*` headers before forwarding them unchanged; it does not reconstruct headers or call `tools/list` on the request path. The existing periodic control-plane discovery/publisher flow remains the schema producer.

Related: #6147 and #6256.

## Validation

- publisher unit tests: 26 passed
- Ruff and Black
- cross-repo E2E with the official conformance fixture: matching plain/Base64 values pass; mismatched, invalid Base64, and missing headers return HTTP `400` / JSON-RPC `-32020`
