### PR TITLE
fix(ci): raise clippy large-error-threshold for mcp_runtime

### DIFF
--- a/crates/mcp_runtime/clippy.toml
+++ b/crates/mcp_runtime/clippy.toml
@@ -1,2 +1,15 @@
 too-many-lines-threshold = 1000
 max-struct-bools = 10
+
+# `result_large_err` defaults to a 128-byte threshold and fires at >=. Both error
+# types returned across this crate measure exactly 128 bytes:
+#
+#   axum::response::Response  = 128
+#   ResolveToolsCallError     = 128  (serde_json::Value 32 + reqwest HeaderMap 96)
+#
+# Sitting precisely on the boundary, they trip the lint on newer toolchains while
+# passing on older ones, with no change to this crate. Satisfying it would mean
+# boxing the error type on ~25 signatures in the request path, adding an allocation
+# to every error return for no measurable gain. Raising the threshold keeps the
+# lint active for error types that are genuinely oversized.
+large-error-threshold = 256


### PR DESCRIPTION
## Summary

Rust CI's clippy gate is failing on any PR that touches the Rust path filter, with 25 `result_large_err` errors in `crates/mcp_runtime`. No Rust code changed to cause it. This raises `large-error-threshold` so the gate passes again.

## What's happening

`rust-toolchain.toml` pins `channel = "stable"` without a version, so CI follows whatever stable is current. A newer clippy started flagging error types this crate has returned for a long time.

Verified against identical source at `origin/main`:

| Toolchain | `cargo clippy --workspace --all-targets -- -D warnings` |
|---|---|
| rustc 1.93.1 | exit 0, clean |
| rustc 1.98.0 | 25 errors, exit 101 |

Every error is the same lint, all reporting the same size:

```
error: the `Err`-variant returned from this function is very large
  --> crates/mcp_runtime/src/lib.rs:8269:6
   |  ) -> Result<reqwest::Response, Response> {
   |       ^^^^^^ the `Err`-variant is at least 128 bytes
```

## Why the threshold rather than boxing

Both error types measure exactly 128 bytes:

```
axum::response::Response  = 128
ResolveToolsCallError     = 128   (serde_json::Value 32 + reqwest HeaderMap 96)
```

Clippy's default `large-error-threshold` is 128 and the lint fires at `>=`, so both sit precisely on the boundary. Satisfying it properly would mean boxing the error type across ~25 signatures in the request path, which adds an allocation to every error return to satisfy a performance lint. Raising the threshold to 256 leaves the lint active for error types that are genuinely oversized.

Note the file lives in the crate directory rather than the workspace root, since clippy resolves `clippy.toml` relative to the crate manifest directory. The crate already had one, so this is an addition to it and leaves `too-many-lines-threshold` and `max-struct-bools` untouched.

## Verification

Run against `origin/main` plus this commit, on rustc 1.98.0:

- `cargo clippy --workspace --all-targets -- -D warnings -A clippy::multiple_crate_versions` — exit 0, 0 errors (was 25)
- `cargo fmt --check` — clean
- `cargo test -p contextforge_mcp_runtime` — 107 passed, 2 passed, 0 failed
- Re-checked on rustc 1.93.1 — still clean, so the change is not toolchain-specific

## Follow-ups, not in this PR

- `.github/workflows/rust.yml` triggers on `pull_request` only, with no `push` to `main`. Clippy therefore never runs on `main`, which is why this stayed invisible until it surfaced on an unrelated PR. Worth adding a push trigger so breakage is attributed to `main` rather than to whoever opens the next PR.
- Unblocks #6321, which hit this because the Rust path filter includes `mcpgateway/db.py` and `mcpgateway/alembic/**`.
