### PR TITLE
[Feature]: SSL/TLS exposed for gateway pods

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -618,7 +618,7 @@
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 979,
+        "line_number": 1021,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -626,7 +626,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1083,
+        "line_number": 1125,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -634,7 +634,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1086,
+        "line_number": 1128,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1253,
+        "line_number": 1295,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1292,
+        "line_number": 1334,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1346,
+        "line_number": 1388,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1442,
+        "line_number": 1484,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1813,
+        "line_number": 1855,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-25T12:48:17Z",
+  "generated_at": "2026-08-26T09:08:27Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -615,10 +615,18 @@
     ],
     "charts/mcp-stack/values.yaml": [
       {
+        "hashed_secret": "7bbf4d709be627d062b1e760bf712e132f62e839",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 217,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 979,
+        "line_number": 1015,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -626,7 +634,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1083,
+        "line_number": 1119,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -634,7 +642,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1086,
+        "line_number": 1122,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +650,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1253,
+        "line_number": 1289,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +658,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1292,
+        "line_number": 1328,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +666,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1346,
+        "line_number": 1382,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +674,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1442,
+        "line_number": 1478,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +682,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1813,
+        "line_number": 1849,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -618,7 +618,7 @@
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1021,
+        "line_number": 979,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -626,7 +626,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1125,
+        "line_number": 1083,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -634,7 +634,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1128,
+        "line_number": 1086,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1295,
+        "line_number": 1253,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1334,
+        "line_number": 1292,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1388,
+        "line_number": 1346,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1484,
+        "line_number": 1442,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1855,
+        "line_number": 1813,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/charts/mcp-stack/templates/_helpers.tpl
+++ b/charts/mcp-stack/templates/_helpers.tpl
@@ -106,3 +106,20 @@ timeoutSeconds:      {{ $p.timeoutSeconds      | default 1 }}
 successThreshold:    {{ $p.successThreshold    | default 1 }}
 failureThreshold:    {{ $p.failureThreshold    | default 3 }}
 {{- end }}
+
+{{- /* --------------------------------------------------------------------
+     Helper: helpers.renderProbeWithTLS
+     Wraps helpers.renderProbe, merging scheme: HTTPS when tlsEnabled=true
+     and the probe type is "http". exec and tcp probes are passed through
+     unchanged — scheme is meaningless for those types.
+     Usage:
+       {{- include "helpers.renderProbeWithTLS" (dict "probe" . "tlsEnabled" $.Values.mcpContextForge.tls.enabled "root" $) | nindent 12 }}
+     -------------------------------------------------------------------- */}}
+{{- define "helpers.renderProbeWithTLS" -}}
+{{- $p := .probe -}}
+{{- if and .tlsEnabled (eq $p.type "http") }}
+{{- include "helpers.renderProbe" (dict "probe" (merge (dict "scheme" "HTTPS") $p) "root" .root) }}
+{{- else }}
+{{- include "helpers.renderProbe" (dict "probe" $p "root" .root) }}
+{{- end }}
+{{- end }}

--- a/charts/mcp-stack/templates/_helpers.tpl
+++ b/charts/mcp-stack/templates/_helpers.tpl
@@ -90,7 +90,9 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 httpGet:
   path: {{ $p.path }}
   port: {{ $p.port }}
-  {{- if $p.scheme }}scheme: {{ $p.scheme }}{{ end }}
+  {{- if $p.scheme }}
+  scheme: {{ $p.scheme }}
+  {{- end }}
 {{- else if eq $p.type "tcp" }}
 tcpSocket:
   port: {{ $p.port }}

--- a/charts/mcp-stack/templates/deployment-mcpgateway.yaml
+++ b/charts/mcp-stack/templates/deployment-mcpgateway.yaml
@@ -199,6 +199,28 @@ spec:
               value: ""
               {{- end }}
 
+            # ---------- GATEWAY TLS (direct HTTPS on pod) ----------
+            {{- if .Values.mcpContextForge.tls.enabled }}
+            - name: SSL
+              value: "true"
+            - name: CERT_FILE
+              value: {{ .Values.mcpContextForge.tls.certFile | quote }}
+            - name: KEY_FILE
+              value: {{ .Values.mcpContextForge.tls.keyFile | quote }}
+            {{- if .Values.mcpContextForge.tls.keyFilePassword }}
+            - name: KEY_FILE_PASSWORD
+              value: {{ .Values.mcpContextForge.tls.keyFilePassword | quote }}
+            {{- end }}
+            {{- if .Values.mcpContextForge.tls.caCerts }}
+            - name: CA_CERTS
+              value: {{ .Values.mcpContextForge.tls.caCerts | quote }}
+            {{- end }}
+            {{- if .Values.mcpContextForge.tls.certReqs }}
+            - name: CERT_REQS
+              value: {{ .Values.mcpContextForge.tls.certReqs | quote }}
+            {{- end }}
+            {{- end }}
+
             # ---------- EXTRA ENV (user-defined) ----------
 
             # ---------- RATE LIMITER REDIS (Optional) ----------
@@ -303,14 +325,15 @@ spec:
           {{- end }}
           {{- end }}
 
+          {{- $probeScheme := ternary "HTTPS" "HTTP" .Values.mcpContextForge.tls.enabled -}}
           {{- with .Values.mcpContextForge.probes.readiness }}
           readinessProbe:
-{{- include "helpers.renderProbe" (dict "probe" . "root" $) | nindent 12 }}
+{{- include "helpers.renderProbe" (dict "probe" (merge (dict "scheme" $probeScheme) .) "root" $) | nindent 12 }}
           {{- end }}
 
           {{- with .Values.mcpContextForge.probes.liveness }}
           livenessProbe:
-{{- include "helpers.renderProbe" (dict "probe" . "root" $) | nindent 12 }}
+{{- include "helpers.renderProbe" (dict "probe" (merge (dict "scheme" $probeScheme) .) "root" $) | nindent 12 }}
           {{- end }}
 
           # Resource requests / limits
@@ -325,6 +348,11 @@ spec:
               mountPath: /app/{{ $pluginsConfigFile }}
               subPath: config.yaml
           {{- end }}
+          {{- if .Values.mcpContextForge.tls.enabled }}
+            - name: gateway-tls-certs
+              mountPath: {{ .Values.mcpContextForge.tls.mountPath | quote }}
+              readOnly: true
+          {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
@@ -335,4 +363,9 @@ spec:
             items:
               - key: config.yaml
                 path: config.yaml
+      {{- end }}
+      {{- if .Values.mcpContextForge.tls.enabled }}
+        - name: gateway-tls-certs
+          secret:
+            secretName: {{ required "mcpContextForge.tls.secretName is required when mcpContextForge.tls.enabled=true" .Values.mcpContextForge.tls.secretName }}
       {{- end }}

--- a/charts/mcp-stack/templates/deployment-mcpgateway.yaml
+++ b/charts/mcp-stack/templates/deployment-mcpgateway.yaml
@@ -207,17 +207,12 @@ spec:
               value: {{ .Values.mcpContextForge.tls.certFile | quote }}
             - name: KEY_FILE
               value: {{ .Values.mcpContextForge.tls.keyFile | quote }}
-            {{- if .Values.mcpContextForge.tls.keyFilePassword }}
+            {{- with .Values.mcpContextForge.tls.keyFilePasswordSecret }}
             - name: KEY_FILE_PASSWORD
-              value: {{ .Values.mcpContextForge.tls.keyFilePassword | quote }}
-            {{- end }}
-            {{- if .Values.mcpContextForge.tls.caCerts }}
-            - name: CA_CERTS
-              value: {{ .Values.mcpContextForge.tls.caCerts | quote }}
-            {{- end }}
-            {{- if .Values.mcpContextForge.tls.certReqs }}
-            - name: CERT_REQS
-              value: {{ .Values.mcpContextForge.tls.certReqs | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "mcpContextForge.tls.keyFilePasswordSecret.name is required" .name }}
+                  key: {{ .key | default "keyFilePassword" }}
             {{- end }}
             {{- end }}
 

--- a/charts/mcp-stack/templates/deployment-mcpgateway.yaml
+++ b/charts/mcp-stack/templates/deployment-mcpgateway.yaml
@@ -325,15 +325,22 @@ spec:
           {{- end }}
           {{- end }}
 
-          {{- $probeScheme := ternary "HTTPS" "HTTP" .Values.mcpContextForge.tls.enabled -}}
           {{- with .Values.mcpContextForge.probes.readiness }}
           readinessProbe:
-{{- include "helpers.renderProbe" (dict "probe" (merge (dict "scheme" $probeScheme) .) "root" $) | nindent 12 }}
+{{- if $.Values.mcpContextForge.tls.enabled }}
+{{- include "helpers.renderProbe" (dict "probe" (merge (dict "scheme" "HTTPS") .) "root" $) | nindent 12 }}
+{{- else }}
+{{- include "helpers.renderProbe" (dict "probe" . "root" $) | nindent 12 }}
+{{- end }}
           {{- end }}
 
           {{- with .Values.mcpContextForge.probes.liveness }}
           livenessProbe:
-{{- include "helpers.renderProbe" (dict "probe" (merge (dict "scheme" $probeScheme) .) "root" $) | nindent 12 }}
+{{- if $.Values.mcpContextForge.tls.enabled }}
+{{- include "helpers.renderProbe" (dict "probe" (merge (dict "scheme" "HTTPS") .) "root" $) | nindent 12 }}
+{{- else }}
+{{- include "helpers.renderProbe" (dict "probe" . "root" $) | nindent 12 }}
+{{- end }}
           {{- end }}
 
           # Resource requests / limits

--- a/charts/mcp-stack/templates/deployment-mcpgateway.yaml
+++ b/charts/mcp-stack/templates/deployment-mcpgateway.yaml
@@ -61,6 +61,7 @@ spec:
           image: "{{ .Values.mcpContextForge.image.repository }}:{{ .Values.mcpContextForge.image.tag }}"
           imagePullPolicy: {{ .Values.mcpContextForge.image.pullPolicy }}
           {{- $pluginsConfigFile := default "plugins/config.yaml" .Values.mcpContextForge.config.PLUGINS_CONFIG_FILE }}
+          {{- $tls := default dict .Values.mcpContextForge.tls }}
 
           # Gateway's internal port
           ports:
@@ -200,14 +201,14 @@ spec:
               {{- end }}
 
             # ---------- GATEWAY TLS (direct HTTPS on pod) ----------
-            {{- if .Values.mcpContextForge.tls.enabled }}
+            {{- if $tls.enabled }}
             - name: SSL
               value: "true"
             - name: CERT_FILE
-              value: {{ .Values.mcpContextForge.tls.certFile | quote }}
+              value: {{ $tls.certFile | quote }}
             - name: KEY_FILE
-              value: {{ .Values.mcpContextForge.tls.keyFile | quote }}
-            {{- with .Values.mcpContextForge.tls.keyFilePasswordSecret }}
+              value: {{ $tls.keyFile | quote }}
+            {{- with $tls.keyFilePasswordSecret }}
             - name: KEY_FILE_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -316,26 +317,18 @@ spec:
           {{- else }}
           {{- with .Values.mcpContextForge.probes.startup }}
           startupProbe:
-{{- include "helpers.renderProbe" (dict "probe" . "root" $) | nindent 12 }}
+{{- include "helpers.renderProbeWithTLS" (dict "probe" . "tlsEnabled" $tls.enabled "root" $) | nindent 12 }}
           {{- end }}
           {{- end }}
 
           {{- with .Values.mcpContextForge.probes.readiness }}
           readinessProbe:
-{{- if $.Values.mcpContextForge.tls.enabled }}
-{{- include "helpers.renderProbe" (dict "probe" (merge (dict "scheme" "HTTPS") .) "root" $) | nindent 12 }}
-{{- else }}
-{{- include "helpers.renderProbe" (dict "probe" . "root" $) | nindent 12 }}
-{{- end }}
+{{- include "helpers.renderProbeWithTLS" (dict "probe" . "tlsEnabled" $tls.enabled "root" $) | nindent 12 }}
           {{- end }}
 
           {{- with .Values.mcpContextForge.probes.liveness }}
           livenessProbe:
-{{- if $.Values.mcpContextForge.tls.enabled }}
-{{- include "helpers.renderProbe" (dict "probe" (merge (dict "scheme" "HTTPS") .) "root" $) | nindent 12 }}
-{{- else }}
-{{- include "helpers.renderProbe" (dict "probe" . "root" $) | nindent 12 }}
-{{- end }}
+{{- include "helpers.renderProbeWithTLS" (dict "probe" . "tlsEnabled" $tls.enabled "root" $) | nindent 12 }}
           {{- end }}
 
           # Resource requests / limits
@@ -350,9 +343,9 @@ spec:
               mountPath: /app/{{ $pluginsConfigFile }}
               subPath: config.yaml
           {{- end }}
-          {{- if .Values.mcpContextForge.tls.enabled }}
+          {{- if $tls.enabled }}
             - name: gateway-tls-certs
-              mountPath: {{ .Values.mcpContextForge.tls.mountPath | quote }}
+              mountPath: {{ $tls.mountPath | quote }}
               readOnly: true
           {{- end }}
       volumes:
@@ -366,8 +359,8 @@ spec:
               - key: config.yaml
                 path: config.yaml
       {{- end }}
-      {{- if .Values.mcpContextForge.tls.enabled }}
+      {{- if $tls.enabled }}
         - name: gateway-tls-certs
           secret:
-            secretName: {{ required "mcpContextForge.tls.secretName is required when mcpContextForge.tls.enabled=true" .Values.mcpContextForge.tls.secretName }}
+            secretName: {{ required "mcpContextForge.tls.secretName is required when mcpContextForge.tls.enabled=true" $tls.secretName }}
       {{- end }}

--- a/charts/mcp-stack/tests/deployment_mcpgateway_tls_test.yaml
+++ b/charts/mcp-stack/tests/deployment_mcpgateway_tls_test.yaml
@@ -1,0 +1,188 @@
+suite: mcpgateway deployment - gateway TLS
+templates:
+  - templates/deployment-mcpgateway.yaml
+
+tests:
+
+  # ── Default (tls.enabled=false) ──────────────────────────────────────────────
+
+  - it: no TLS env vars are present when tls.enabled=false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SSL
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CERT_FILE
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KEY_FILE
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KEY_FILE_PASSWORD
+
+  - it: no gateway-tls-certs volumeMount when tls.enabled=false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: gateway-tls-certs
+
+  - it: no gateway-tls-certs volume when tls.enabled=false
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: gateway-tls-certs
+
+  - it: readiness probe has no scheme when tls.enabled=false
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+
+  - it: liveness probe has no scheme when tls.enabled=false
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+
+  # ── tls.enabled=true ─────────────────────────────────────────────────────────
+
+  - it: SSL env var is true when tls.enabled=true
+    set:
+      mcpContextForge.tls.enabled: true
+      mcpContextForge.tls.secretName: my-gateway-tls
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SSL
+            value: "true"
+
+  - it: CERT_FILE env var uses certFile value
+    set:
+      mcpContextForge.tls.enabled: true
+      mcpContextForge.tls.secretName: my-gateway-tls
+      mcpContextForge.tls.certFile: /app/certs/tls/tls.crt
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CERT_FILE
+            value: /app/certs/tls/tls.crt
+
+  - it: KEY_FILE env var uses keyFile value
+    set:
+      mcpContextForge.tls.enabled: true
+      mcpContextForge.tls.secretName: my-gateway-tls
+      mcpContextForge.tls.keyFile: /app/certs/tls/tls.key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KEY_FILE
+            value: /app/certs/tls/tls.key
+
+  - it: KEY_FILE_PASSWORD uses secretKeyRef when keyFilePasswordSecret is set
+    set:
+      mcpContextForge.tls.enabled: true
+      mcpContextForge.tls.secretName: my-gateway-tls
+      mcpContextForge.tls.keyFilePasswordSecret.name: my-pass-secret
+      mcpContextForge.tls.keyFilePasswordSecret.key: passphrase
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KEY_FILE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-pass-secret
+                key: passphrase
+
+  - it: KEY_FILE_PASSWORD is absent when keyFilePasswordSecret is not set
+    set:
+      mcpContextForge.tls.enabled: true
+      mcpContextForge.tls.secretName: my-gateway-tls
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KEY_FILE_PASSWORD
+
+  - it: gateway-tls-certs volumeMount is read-only at mountPath
+    set:
+      mcpContextForge.tls.enabled: true
+      mcpContextForge.tls.secretName: my-gateway-tls
+      mcpContextForge.tls.mountPath: /app/certs/tls
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: gateway-tls-certs
+            mountPath: /app/certs/tls
+            readOnly: true
+
+  - it: gateway-tls-certs volume references the secretName
+    set:
+      mcpContextForge.tls.enabled: true
+      mcpContextForge.tls.secretName: my-gateway-tls
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: gateway-tls-certs
+            secret:
+              secretName: my-gateway-tls
+
+  - it: readiness probe scheme is HTTPS when tls.enabled=true
+    set:
+      mcpContextForge.tls.enabled: true
+      mcpContextForge.tls.secretName: my-gateway-tls
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTPS
+
+  - it: liveness probe scheme is HTTPS when tls.enabled=true
+    set:
+      mcpContextForge.tls.enabled: true
+      mcpContextForge.tls.secretName: my-gateway-tls
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+          value: HTTPS
+
+  - it: startup probe scheme is HTTPS when tls.enabled=true and probe type is http
+    set:
+      mcpContextForge.tls.enabled: true
+      mcpContextForge.tls.secretName: my-gateway-tls
+      migration.enabled: false
+      mcpContextForge.probes.startup.type: http
+      mcpContextForge.probes.startup.path: /ready
+      mcpContextForge.probes.startup.port: 4444
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.scheme
+          value: HTTPS
+
+  - it: exec startup probe is unaffected by tls.enabled=true
+    set:
+      mcpContextForge.tls.enabled: true
+      mcpContextForge.tls.secretName: my-gateway-tls
+      migration.enabled: false
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0].startupProbe.exec
+      - isNull:
+          path: spec.template.spec.containers[0].startupProbe.httpGet
+
+  - it: required guard fails render when secretName is empty and tls.enabled=true
+    set:
+      mcpContextForge.tls.enabled: true
+      mcpContextForge.tls.secretName: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "mcpContextForge.tls.secretName is required when mcpContextForge.tls.enabled=true"

--- a/charts/mcp-stack/values.schema.json
+++ b/charts/mcp-stack/values.schema.json
@@ -1576,6 +1576,20 @@
           },
           "description": "Ingress configuration"
         },
+        "tls": {
+          "type": "object",
+          "description": "Direct TLS configuration for the gateway pod (end-to-end HTTPS)",
+          "properties": {
+            "enabled":         { "type": "boolean", "default": false },
+            "secretName":      { "type": "string",  "default": "" },
+            "mountPath":       { "type": "string",  "default": "/app/certs/tls" },
+            "certFile":        { "type": "string",  "default": "/app/certs/tls/tls.crt" },
+            "keyFile":         { "type": "string",  "default": "/app/certs/tls/tls.key" },
+            "keyFilePassword": { "type": "string",  "default": "" },
+            "caCerts":         { "type": "string",  "default": "" },
+            "certReqs":        { "type": "integer", "default": 0, "enum": [0, 1, 2] }
+          }
+        },
         "metrics": {
           "type": "object",
           "properties": {

--- a/charts/mcp-stack/values.schema.json
+++ b/charts/mcp-stack/values.schema.json
@@ -1580,14 +1580,19 @@
           "type": "object",
           "description": "Direct TLS configuration for the gateway pod (end-to-end HTTPS)",
           "properties": {
-            "enabled":         { "type": "boolean", "default": false },
-            "secretName":      { "type": "string",  "default": "" },
-            "mountPath":       { "type": "string",  "default": "/app/certs/tls" },
-            "certFile":        { "type": "string",  "default": "/app/certs/tls/tls.crt" },
-            "keyFile":         { "type": "string",  "default": "/app/certs/tls/tls.key" },
-            "keyFilePassword": { "type": "string",  "default": "" },
-            "caCerts":         { "type": "string",  "default": "" },
-            "certReqs":        { "type": "integer", "default": 0, "enum": [0, 1, 2] }
+            "enabled":    { "type": "boolean", "default": false },
+            "secretName": { "type": "string",  "default": "" },
+            "mountPath":  { "type": "string",  "default": "/app/certs/tls" },
+            "certFile":   { "type": "string",  "default": "/app/certs/tls/tls.crt" },
+            "keyFile":    { "type": "string",  "default": "/app/certs/tls/tls.key" },
+            "keyFilePasswordSecret": {
+              "type": "object",
+              "description": "Reference to a Kubernetes Secret key holding the private-key passphrase",
+              "properties": {
+                "name": { "type": "string" },
+                "key":  { "type": "string", "default": "keyFilePassword" }
+              }
+            }
           }
         },
         "metrics": {

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -210,18 +210,12 @@ mcpContextForge:
     keyFile: /app/certs/tls/tls.key
 
     # Optional passphrase for an encrypted private key.
-    # Leave empty for unencrypted keys (recommended for Kubernetes Secrets).
-    keyFilePassword: ""
-
-    # ── Inbound mTLS (client-certificate authentication) ─────────────────────
-    # Optional: path to a CA bundle inside the container for verifying client certs.
-    caCerts: ""                 # e.g. /app/certs/tls/ca.crt (add ca.crt to the Secret)
-
-    # Client certificate requirement level (passed as CERT_REQS env var):
-    #   0 = none     (server does not request a client cert)
-    #   1 = optional (client cert accepted but not required)
-    #   2 = required (connection rejected without valid client cert)
-    certReqs: 0
+    # Reference a Kubernetes Secret key rather than inlining the value here —
+    # plain strings end up in helm get values, kubectl get pod -o yaml, and CI logs.
+    # Example:
+    #   kubectl create secret generic my-gateway-tls-pass \
+    #     --from-literal=keyFilePassword=my-passphrase
+    keyFilePasswordSecret: {}   # e.g. { name: my-gateway-tls-pass, key: keyFilePassword }
 
   ####################################################################
   # CORE ENVIRONMENT - injected one-by-one as name/value pairs.

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -181,6 +181,48 @@ mcpContextForge:
       enabled: true             # TLS enabled by default for encrypted ingress traffic
       secretName: ""            # Name of the TLS secret (auto-generated if empty)
 
+  # ── Direct Gateway TLS ──────────────────────────────────────────────────────
+  # Enable this to terminate TLS inside the gateway pod itself (direct HTTPS).
+  # Use together with tls.enabled=true (nginx frontend) for end-to-end TLS, or
+  # standalone when there is no reverse proxy in front of the gateway.
+  #
+  # The cert and key are read from a Kubernetes TLS Secret that you pre-create:
+  #   kubectl create secret tls <secretName> --cert=tls.crt --key=tls.key
+  #
+  # Topologies:
+  #   Ingress TLS only (default):  mcpContextForge.tls.enabled=false — nginx/ingress terminates TLS
+  #   End-to-end TLS:              mcpContextForge.tls.enabled=true  — nginx AND gateway pod use TLS
+  tls:
+    enabled: false              # Set true to enable direct HTTPS on the gateway pod
+
+    # Name of a pre-existing kubernetes.io/tls Secret containing tls.crt and tls.key.
+    # The Secret must be in the same namespace as the release.
+    secretName: ""              # e.g. "my-release-gateway-tls"
+
+    # Mount path inside the container where the cert and key will be placed.
+    # Matches the paths passed to SSL env vars below.
+    mountPath: /app/certs/tls   # read-only; do not write other files here
+
+    # Path inside the container to the TLS certificate file.
+    certFile: /app/certs/tls/tls.crt
+
+    # Path inside the container to the TLS private key file.
+    keyFile: /app/certs/tls/tls.key
+
+    # Optional passphrase for an encrypted private key.
+    # Leave empty for unencrypted keys (recommended for Kubernetes Secrets).
+    keyFilePassword: ""
+
+    # ── Inbound mTLS (client-certificate authentication) ─────────────────────
+    # Optional: path to a CA bundle inside the container for verifying client certs.
+    caCerts: ""                 # e.g. /app/certs/tls/ca.crt (add ca.crt to the Secret)
+
+    # Client certificate requirement level (passed as CERT_REQS env var):
+    #   0 = none     (server does not request a client cert)
+    #   1 = optional (client cert accepted but not required)
+    #   2 = required (connection rejected without valid client cert)
+    certReqs: 0
+
   ####################################################################
   # CORE ENVIRONMENT - injected one-by-one as name/value pairs.
   # Only the DATABASE / CACHE connection points live here; everything

--- a/docs/docs/deployment/helm.md
+++ b/docs/docs/deployment/helm.md
@@ -663,6 +663,8 @@ flowchart TD
     | `pgadmin.enabled`                            | `false`     | Enable PgAdmin for DB UI                         |
     | `redisCommander.enabled`                     | `false`     | Enable Redis Commander for Redis UI              |
     | `rbac.create`                                | `true`      | Automatically create Role/RoleBinding            |
+    | `mcpContextForge.tls.enabled`                | `false`     | Enable direct HTTPS on the gateway pod           |
+    | `mcpContextForge.tls.secretName`             | `""`        | Name of the pre-created `kubernetes.io/tls` Secret |
 
     📝 For all possible options, see the full [`values.yaml`](https://github.com/IBM/mcp-context-forge/blob/main/charts/mcp-stack/values.yaml) file in the chart repository.
 

--- a/docs/docs/deployment/tls-configuration.md
+++ b/docs/docs/deployment/tls-configuration.md
@@ -914,6 +914,105 @@ server {
 }
 ```
 
+---
+
+## Kubernetes / Helm
+
+This section covers end-to-end TLS for the **Helm chart** (`charts/mcp-stack`).
+The chart exposes two independent TLS layers:
+
+| Layer | Values key | What it secures |
+|---|---|---|
+| Ingress / nginx frontend | `mcpContextForge.ingress.tls.enabled` | Client → cluster edge |
+| Gateway pod (direct HTTPS) | `mcpContextForge.tls.enabled` | nginx → gateway pod |
+
+Enable both for a fully encrypted path; enable only the ingress layer (default) for standard deployments where nginx terminates TLS.
+
+### Prerequisites
+
+- A Kubernetes cluster with an ingress controller (nginx recommended)
+- A `kubernetes.io/tls` Secret containing your certificate and private key, created **before** the Helm release:
+
+```bash
+# From a PEM cert/key pair
+kubectl create secret tls my-release-gateway-tls \
+  --cert=tls.crt \
+  --key=tls.key \
+  --namespace=<your-namespace>
+
+# Or via cert-manager (annotate the Ingress and cert-manager creates the Secret automatically)
+```
+
+### Ingress TLS only (default topology)
+
+Nginx terminates TLS at the cluster edge; the gateway pod runs plain HTTP internally.
+No extra values are required beyond the ingress block:
+
+```yaml
+mcpContextForge:
+  ingress:
+    enabled: true
+    host: api.example.com
+    tls:
+      enabled: true
+      secretName: "my-ingress-tls-secret"   # kubernetes.io/tls Secret for nginx
+```
+
+### End-to-end TLS (nginx → HTTPS → gateway pod)
+
+Add `mcpContextForge.tls` to your values override file to also terminate TLS inside the gateway pod:
+
+```yaml
+mcpContextForge:
+  ingress:
+    enabled: true
+    host: api.example.com
+    tls:
+      enabled: true
+      secretName: "my-ingress-tls-secret"
+
+  tls:
+    enabled: true
+    secretName: "my-release-gateway-tls"   # pre-created kubernetes.io/tls Secret
+    mountPath: /app/certs/tls
+    certFile:  /app/certs/tls/tls.crt
+    keyFile:   /app/certs/tls/tls.key
+
+    # Optional: mTLS client-certificate verification
+    # caCerts:  /app/certs/tls/ca.crt       # add ca.crt to the Secret
+    # certReqs: 2                            # 0=none 1=optional 2=required
+```
+
+Apply with:
+
+```bash
+helm upgrade --install my-release charts/mcp-stack \
+  -f my-values.yaml \
+  --namespace <your-namespace>
+```
+
+### Probe scheme
+
+When `mcpContextForge.tls.enabled=true` the chart automatically switches the readiness and liveness probe scheme from `HTTP` to `HTTPS`. No manual probe override is needed.
+
+### mTLS (client-certificate authentication)
+
+To require clients to present a certificate signed by your CA:
+
+1. Add `ca.crt` to the same Secret alongside `tls.crt` / `tls.key`
+2. Set `caCerts` to the path inside the container and `certReqs: 2`:
+
+```yaml
+mcpContextForge:
+  tls:
+    enabled: true
+    secretName: "my-release-gateway-tls"
+    caCerts:  /app/certs/tls/ca.crt
+    certReqs: 2
+```
+
+---
+
 ## Additional Resources
 
 - [OpenSSL Documentation](https://www.openssl.org/docs/)

--- a/docs/docs/deployment/tls-configuration.md
+++ b/docs/docs/deployment/tls-configuration.md
@@ -978,9 +978,10 @@ mcpContextForge:
     certFile:  /app/certs/tls/tls.crt
     keyFile:   /app/certs/tls/tls.key
 
-    # Optional: mTLS client-certificate verification
-    # caCerts:  /app/certs/tls/ca.crt       # add ca.crt to the Secret
-    # certReqs: 2                            # 0=none 1=optional 2=required
+    # Optional: passphrase for an encrypted private key (reference a Secret, not a plain string)
+    # keyFilePasswordSecret:
+    #   name: my-gateway-tls-pass
+    #   key:  keyFilePassword
 ```
 
 Apply with:
@@ -994,22 +995,6 @@ helm upgrade --install my-release charts/mcp-stack \
 ### Probe scheme
 
 When `mcpContextForge.tls.enabled=true` the chart automatically switches the readiness and liveness probe scheme from `HTTP` to `HTTPS`. No manual probe override is needed.
-
-### mTLS (client-certificate authentication)
-
-To require clients to present a certificate signed by your CA:
-
-1. Add `ca.crt` to the same Secret alongside `tls.crt` / `tls.key`
-2. Set `caCerts` to the path inside the container and `certReqs: 2`:
-
-```yaml
-mcpContextForge:
-  tls:
-    enabled: true
-    secretName: "my-release-gateway-tls"
-    caCerts:  /app/certs/tls/ca.crt
-    certReqs: 2
-```
 
 ---
 


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes https://github.com/IBM/mcp-context-forge/issues/6265

---

## 📝 Summary

The Helm chart exposed TLS only at the ingress/nginx layer. Operators who needed end-to-end TLS (nginx → HTTPS → gateway pod) had to manually inject SSL, CERT_FILE, and KEY_FILE via extraEnv and patch the volume mount themselves — no first-class support existed.

This PR adds mcpContextForge.tls to values.yaml and wires it through deployment-mcpgateway.yaml so that env vars, the cert volume mount, and the probe scheme are all handled automatically when mcpContextForge.tls.enabled=true.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [x] Feature / Enhancement
- [x] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

### Template rendering (no cluster required)


Check | Command | Status
-- | -- | --
helm lint --strict | helm lint --strict charts/mcp-stack | ✅ 1 chart linted, 0 failed
helm-unittest | make linting-helm-unittest | ✅ 42/42 tests pass (5 suites)
TLS env vars injected | helm template ... --set mcpContextForge.tls.enabled=true --set mcpContextForge.tls.secretName=my-tls \| grep -E "SSL\|CERT_FILE\|KEY_FILE" | ✅ SSL, CERT_FILE, KEY_FILE present
KEY_FILE_PASSWORD uses secretKeyRef | ... --set mcpContextForge.tls.keyFilePasswordSecret.name=my-pass \| grep -A 4 KEY_FILE_PASSWORD | ✅ valueFrom.secretKeyRef, no plain value:
Volume + volumeMount | ... \| grep -A 3 "gateway-tls-certs" | ✅ Secret volume + read-only mount at /app/certs/tls
All three probes flipped | ... \| grep "scheme:" | ✅ scheme: HTTPS ×2 readiness + liveness; startup probe gets scheme: HTTPS when type: http
Default unchanged | helm template ... \| grep -E "SSL\|CERT_FILE\|gateway-tls-certs" | ✅ No TLS artefacts when tls.enabled=false
required guard | helm template ... --set mcpContextForge.tls.enabled=true (no secretName) | ✅ Clear error at render time
Nil guard | helm template ... --set mcpContextForge.tls=null | ✅ Renders cleanly, no error

### Runtime verification — kind cluster (k8s v1.36.1, Helm v4.1.3)

Runtime verification — kind cluster (k8s v1.36.1, Helm v4.1.3)

# Create self-signed cert Secret
openssl req -x509 -newkey rsa:2048 -nodes \
  -keyout tls.key -out tls.crt -days 365 -subj "/CN=gateway.local"
kubectl create secret tls my-tls-secret --cert=tls.crt --key=tls.key

# Install with TLS enabled
helm install my-release charts/mcp-stack \
  --set mcpContextForge.tls.enabled=true \
  --set mcpContextForge.tls.secretName=my-tls-secret \
  --set mcpContextForge.metrics.serviceMonitor.enabled=false \
  --set mcpContextForge.secret.JWT_SECRET_KEY="$(openssl rand -hex 32)" \
  --set mcpContextForge.secret.AUTH_ENCRYPTION_SECRET="$(openssl rand -hex 32)"

# Port-forward and verify HTTPS
kubectl port-forward \
  pod/$(kubectl get pod -l app=my-release-mcp-stack-mcpgateway \
        -o jsonpath='{.items[0].metadata.name}') 4444:4444 &
curl -k https://localhost:4444/health


Result: {"status":"healthy", …} returned over HTTPS. curl http://localhost:4444/health returns an SSL protocol error, confirming TLS-only mode is active.

---

## ✅ Checklist

- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

Why mcpContextForge.tls and not gateway.tls?
The gateway's entire config lives under mcpContextForge. A top-level tls: key already exists for the nginx frontend TLS profile — a second top-level tls would be ambiguous.

KEY_FILE_PASSWORD uses a Secret reference, not a plain string.
The original proposal had keyFilePassword: "". A plain string surfaces in helm get values, kubectl get pod -o yaml, and any values file committed to git. Replaced with keyFilePasswordSecret: { name, key } which follows the same valueFrom.secretKeyRef pattern already used by POSTGRES_PASSWORD and REDIS_PASSWORD in this template.

No cert generation in the chart.
The operator pre-creates a kubernetes.io/tls Secret (via cert-manager or kubectl create secret tls). Chart-side cert generation is out of scope.

mTLS (CA_CERTS / CERT_REQS) is out of scope.
run-gunicorn.sh has no consumer for those env vars — advertising them would create a silently-ineffective security control. Dropped from this PR; tracked separately.

_helpers.tpl fix.
The pre-existing {{- if $p.scheme }}scheme: {{ $p.scheme }}{{ end }} used {{- which stripped the preceding newline, producing port: 4444scheme: HTTP — invalid YAML as soon as scheme was passed. Fixed to put scheme: on its own line. Also extracted helpers.renderProbeWithTLS so the HTTPS-scheme logic lives in one place and all three probe call sites (startup, readiness, liveness) share it.