### PR TITLE
fix: [BUG]: ContextForge Unable to Start in HTTPS Mode

### DIFF
--- a/infra/nginx/nginx-performance.conf
+++ b/infra/nginx/nginx-performance.conf
@@ -158,7 +158,9 @@ http {
         least_conn;
         zone gateway_backend 64k;
 
-        server gateway:4444 resolve max_fails=0;  # Re-resolve Docker DNS for replica-aware balancing
+        # No `resolve` parameter: it requires nginx 1.27.3+, while
+        # infra/nginx/Dockerfile ships nginx 1.26.
+        server gateway:4444 max_fails=0;
 
         # Keepalive pool sizing for 10,000 capacity:
         # - Each nginx worker maintains its own pool

--- a/infra/nginx/nginx-tls.conf
+++ b/infra/nginx/nginx-tls.conf
@@ -143,34 +143,22 @@ http {
                      inactive=24h
                      use_temp_path=off;
 
-    # Docker DNS resolver for dynamic upstream resolution
-    # valid=5s forces re-resolution every 5 seconds for load balancing across replicas
+    # Docker DNS resolver for dynamic upstream resolution.
+    # Nginx 1.26 (shipped by infra/nginx/Dockerfile) rejects the `resolve`
+    # parameter on an upstream `server` - it requires nginx 1.27.3+ - and does not
+    # re-resolve hostnames used in upstream server blocks after startup, which
+    # leaves stale container IPs behind after gateway rebuilds.
+    # Keep the resolver here and route gateway traffic through resolver-backed
+    # proxy_pass variables instead of static upstream IP lists.
     resolver 127.0.0.11 valid=5s ipv6=off;
 
-    # ============================================================
-    # Upstream Definition - Tuned for 4000 capacity (3000 nginx cap)
-    # ============================================================
-    # IMPORTANT: max_fails must be high enough to survive load spikes
-    # Without this, nginx marks backends dead after just 3 timeouts
-    upstream gateway_backend {
-        # Load balancing: least_conn distributes to backend with fewest active connections
-        # Fixes imbalance caused by keepalive connections sticking to one backend
-        least_conn;
-        zone gateway_backend 64k;
-
-        server gateway:4444 resolve max_fails=0;  # Re-resolve Docker DNS for replica-aware balancing
-
-        # Keepalive pool sizing for 4000 capacity:
-        # - Each nginx worker maintains its own pool
-        # - With 4 workers: 512 × 4 = 2048 reusable connections
-        # - Remaining connections use short-lived TCP
-        keepalive 512;                    # Connections per worker (was 256)
-        keepalive_requests 100000;        # Requests per connection (was 10000)
-        keepalive_timeout 60s;            # Connection idle timeout
+    # Dynamic backend URL. Using a variable keeps Docker DNS re-resolution active
+    # across gateway container churn.
+    map "" $gateway_backend_url {
+        default "http://gateway:4444";
     }
 
-    # Cache bypass conditions
-    map $request_method $skip_cache {
+    # Cache bypass conditions    map $request_method $skip_cache {
         default 0;
         POST 1;
         PUT 1;
@@ -242,11 +230,10 @@ http {
 
         # Health Check - No rate limiting (for monitoring during load tests)
         location = /health {
-            proxy_pass http://gateway_backend;
+            proxy_pass $gateway_backend_url;
             proxy_set_header Host $http_host;
             proxy_set_header Connection "";
-            proxy_http_version 1.1;
-            proxy_connect_timeout 5s;
+            proxy_http_version 1.1;            proxy_connect_timeout 5s;
             proxy_read_timeout 5s;
         }
 
@@ -255,11 +242,10 @@ http {
             limit_req zone=api_limit burst=20000 nodelay;
             limit_conn conn_limit 20000;
 
-            proxy_pass http://gateway_backend;
+            proxy_pass $gateway_backend_url;
             proxy_cache off;
 
-            proxy_next_upstream error timeout http_502 http_503 http_504;
-            proxy_next_upstream_tries 2;
+            proxy_next_upstream error timeout http_502 http_503 http_504;            proxy_next_upstream_tries 2;
             proxy_next_upstream_timeout 10s;
 
             proxy_set_header Host $http_host;
@@ -328,11 +314,10 @@ http {
         # Health Check - No rate limiting (for monitoring during load tests)
         # ============================================================
         location = /health {
-            proxy_pass http://gateway_backend;
+            proxy_pass $gateway_backend_url;
             proxy_set_header Host $http_host;
             proxy_set_header Connection "";
-            proxy_http_version 1.1;
-            # No rate limiting - health checks must always succeed
+            proxy_http_version 1.1;            # No rate limiting - health checks must always succeed
             proxy_connect_timeout 5s;
             proxy_read_timeout 5s;
         }
@@ -341,11 +326,10 @@ http {
         # Static Assets - Aggressive Caching (30 days)
         # ============================================================
         location ~* \.(css|js|jpg|jpeg|png|gif|ico|svg|woff|woff2|ttf|eot|otf|webp|avif)$ {
-            proxy_pass http://gateway_backend;
+            proxy_pass $gateway_backend_url;
 
             proxy_cache static_cache;
-            proxy_cache_valid 200 30d;
-            proxy_cache_valid 404 10m;
+            proxy_cache_valid 200 30d;            proxy_cache_valid 404 10m;
             proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
             proxy_cache_background_update on;
             proxy_cache_lock on;
@@ -373,11 +357,10 @@ http {
         # OpenAPI/Schema - Moderate Caching (24 hours)
         # ============================================================
         location ~ ^/(openapi\.json|docs|redoc)$ {
-            proxy_pass http://gateway_backend;
+            proxy_pass $gateway_backend_url;
 
             # SECURITY: docs/openapi/redoc are auth-protected endpoints.
-            # Shared proxy cache here can leak authenticated responses to
-            # unauthenticated callers on cache hits.
+            # Shared proxy cache here can leak authenticated responses to            # unauthenticated callers on cache hits.
             proxy_cache off;
             proxy_cache_bypass 1;
             proxy_no_cache 1;
@@ -405,11 +388,10 @@ http {
             limit_req zone=api_limit burst=20000 nodelay;
             limit_conn conn_limit 20000;
 
-            proxy_pass http://gateway_backend;
+            proxy_pass $gateway_backend_url;
 
             proxy_cache api_cache;
-            proxy_cache_valid 200 5m;
-            proxy_cache_valid 404 1m;
+            proxy_cache_valid 200 5m;            proxy_cache_valid 404 1m;
             proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
             proxy_cache_background_update on;
             proxy_cache_lock on;
@@ -453,11 +435,10 @@ http {
         # ============================================================
         location = /admin/events {
             # SSE stream: disable caching/buffering and allow long-lived connections
-            proxy_pass http://gateway_backend;
+            proxy_pass $gateway_backend_url;
 
             proxy_cache off;
             proxy_buffering off;
-
             proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -474,11 +455,10 @@ http {
             limit_req zone=api_limit burst=20000 nodelay;
             limit_conn conn_limit 20000;
 
-            proxy_pass http://gateway_backend;
+            proxy_pass $gateway_backend_url;
 
             proxy_cache api_cache;
-            proxy_cache_valid 200 5s;
-            proxy_cache_valid 404 1s;
+            proxy_cache_valid 200 5s;            proxy_cache_valid 404 1s;
             proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
             proxy_cache_background_update on;
             proxy_cache_lock on;
@@ -513,11 +493,10 @@ http {
         # SSE/WebSocket - No Caching
         # ============================================================
         location ~ ^/servers/.*/sse$ {
-            proxy_pass http://gateway_backend;
+            proxy_pass $gateway_backend_url;
 
             # SSE-specific headers
-            proxy_set_header Connection '';
-            proxy_http_version 1.1;
+            proxy_set_header Connection '';            proxy_http_version 1.1;
             chunked_transfer_encoding off;
             proxy_buffering off;
             proxy_cache off;
@@ -535,11 +514,10 @@ http {
         }
 
         location ~ ^/servers/.*/ws$ {
-            proxy_pass http://gateway_backend;
+            proxy_pass $gateway_backend_url;
 
             # WebSocket upgrade
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
+            proxy_http_version 1.1;            proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
             proxy_cache off;
 
@@ -557,11 +535,10 @@ http {
 
         # MCP Streamable HTTP transport
         location ~ ^(/mcp/?|/servers/.*/mcp/?)$ {
-            proxy_pass https://gateway_backend;
+            proxy_pass $gateway_backend_url;
 
             # MCP GET /mcp can be a long-lived SSE stream; disable buffering.
-            proxy_http_version 1.1;
-            proxy_set_header Connection '';
+            proxy_http_version 1.1;            proxy_set_header Connection '';
             proxy_request_buffering off;
             proxy_buffering off;
             proxy_cache off;
@@ -587,10 +564,9 @@ http {
             limit_req zone=api_limit burst=20000 nodelay;
             limit_conn conn_limit 20000;
 
-            proxy_pass http://gateway_backend;
+            proxy_pass $gateway_backend_url;
 
             proxy_cache off;
-
             proxy_next_upstream error timeout http_502 http_503 http_504;
             proxy_next_upstream_tries 2;
             proxy_next_upstream_timeout 10s;
@@ -614,10 +590,9 @@ http {
             limit_req zone=api_limit burst=20000 nodelay;
             limit_conn conn_limit 20000;
 
-            proxy_pass http://gateway_backend;
+            proxy_pass $gateway_backend_url;
 
             proxy_cache off;
-
             proxy_next_upstream error timeout http_502 http_503 http_504;
             proxy_next_upstream_tries 2;
             proxy_next_upstream_timeout 10s;


### PR DESCRIPTION
Fixes #5359

## Root cause

nginx 1.26 rejects `resolve` on upstream server in nginx-tls.conf

## Changes

- Removed the nginx 1.27.3+ `resolve` upstream parameter from the TLS and performance configs. nginx-tls.conf now follows the pattern already proven in nginx.conf: the `gateway_backend` upstream is replaced by a resolver-backed `map "" $gateway_backend_url` and every `proxy_pass` targets that variable, which keeps Docker DNS re-resolution across gateway rebuilds. The MCP location's `proxy_pass https://gateway_backend` was folded into the same http backend URL, matching the compose gateway (plain HTTP on 4444, `SSL=true` commented out) and every other location in the file. nginx-performance.conf keeps its tuned upstream/keepalive pool and only drops the invalid parameter. Added a stdlib-only regression test asserting no config uses `resolve` on an upstream server and that no `proxy_pass` names an undefined upstream.