### PR TITLE
fix(rpc): preserve admin email for private tool owner matching

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -10323,6 +10323,27 @@ async def _execute_rpc_initialize(
     return result
 
 
+def _resolve_tool_execution_auth_context(request: Request, user) -> tuple[Optional[str], Optional[List[str]], bool]:
+    """Resolve the visibility context for tool execution.
+
+    Admin bypass keeps the caller's email so the service can owner-match that
+    admin's own private tools. It must not expose another user's private tool.
+
+    Args:
+        request: Incoming JSON-RPC request.
+        user: Authenticated user payload.
+
+    Returns:
+        ``(user_email, token_teams, is_admin)`` for service-layer visibility.
+    """
+    user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
+    if is_admin and token_teams is None:
+        return user_email, None, True
+    if token_teams is None:
+        return user_email, [], False
+    return user_email, token_teams, is_admin
+
+
 async def _execute_rpc_tools_call(
     request: Request,
     db: Session,
@@ -10359,15 +10380,11 @@ async def _execute_rpc_tools_call(
     if not name:
         raise JSONRPCError(-32602, "Missing tool name in parameters", params)
 
-    # Layer-1 exception: run ownership is captured below from the raw context,
-    # before admin-bypass normalization is applied.
-    auth_user_email, auth_token_teams, auth_is_admin = get_rpc_filter_context(request, user)
+    # Layer-1 exception: run ownership is derived with the raw context; admin
+    # bypass preserves email for owner matching without exposing others' tools.
+    auth_user_email, auth_token_teams, auth_is_admin = _resolve_tool_execution_auth_context(request, user)
     run_owner_email = auth_user_email
     run_owner_team_ids = [] if auth_token_teams is None else list(auth_token_teams)
-    if auth_is_admin and auth_token_teams is None:
-        auth_user_email = None
-    elif auth_token_teams is None:
-        auth_token_teams = []
 
     oauth_user_email = get_user_email(user)
     plugin_context_table = getattr(request.state, "plugin_context_table", None)
@@ -10946,13 +10963,9 @@ async def handle_internal_mcp_tools_call_resolve(request: Request):
         if (get_internal_mcp_auth_context(request) or {}).get("is_authenticated", True) is True:
             await _ensure_rpc_permission(user, db, "tools.execute", "tools/call", request=request)
 
-        # Layer-1 exception: tool-execution authorization, not resource visibility.
-        # Centralizing here would widen admin execution scope to their own private tools.
-        auth_user_email, auth_token_teams, auth_is_admin = get_rpc_filter_context(request, user)
-        if auth_is_admin and auth_token_teams is None:
-            auth_user_email = None
-        elif auth_token_teams is None:
-            auth_token_teams = []
+        # Layer-1 exception: tool-execution authorization preserves the admin's
+        # email for owner matching while retaining the admin-bypass team scope.
+        auth_user_email, auth_token_teams, auth_is_admin = _resolve_tool_execution_auth_context(request, user)
 
         arguments = params.get("arguments") if isinstance(params.get("arguments"), dict) else {}
         plugin_context_table = getattr(request.state, "plugin_context_table", None)
@@ -11714,12 +11727,7 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             # Get authorization context (same as tools/call)
             # Layer-1 exception: tool-execution authorization, not resource visibility.
             # Kept in sync with _execute_rpc_tools_call.
-            auth_user_email, auth_token_teams, auth_is_admin = get_rpc_filter_context(request, user)
-            if auth_is_admin and auth_token_teams is None:
-                auth_user_email = None
-                # auth_token_teams stays None (unrestricted)
-            elif auth_token_teams is None:
-                auth_token_teams = []  # Non-admin without teams = public-only
+            auth_user_email, auth_token_teams, auth_is_admin = _resolve_tool_execution_auth_context(request, user)
 
             # Get user email for OAuth token selection
             oauth_user_email = get_user_email(user)

--- a/tests/unit/mcpgateway/test_rpc_tool_admin_owner_matching.py
+++ b/tests/unit/mcpgateway/test_rpc_tool_admin_owner_matching.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_rpc_tool_admin_owner_matching.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Regression tests for admin-bypass owner matching on RPC tool execution paths.
+"""
+
+# Standard
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+# Third-Party
+import orjson
+import pytest
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway import main as main_mod
+
+
+class FakeRequest:
+    """Minimal request double for direct RPC handler tests."""
+
+    def __init__(self, body: dict | None = None):
+        self.body_value = orjson.dumps(body or {})
+        self.headers: dict[str, str] = {}
+        self.query_params: dict[str, str] = {}
+        self.state = SimpleNamespace()
+
+    async def body(self) -> bytes:
+        """Return the encoded JSON-RPC body."""
+        return self.body_value
+
+
+@pytest.fixture
+def mock_db():
+    """Provide a database-session double."""
+    return MagicMock(spec=Session)
+
+
+def test_resolve_tool_execution_auth_context_preserves_admin_identity(
+    monkeypatch,
+):
+    """Unrestricted admin bypass keeps the email for private-row owner matching."""
+    request = FakeRequest()
+    monkeypatch.setattr(
+        main_mod,
+        "get_rpc_filter_context",
+        lambda _request, _user: ("admin@example.com", None, True),
+    )
+
+    assert main_mod._resolve_tool_execution_auth_context(request, {}) == (
+        "admin@example.com",
+        None,
+        True,
+    )
+
+
+def test_resolve_tool_execution_auth_context_defaults_missing_teams_to_public(
+    monkeypatch,
+):
+    """A non-admin with no team claim remains public-only."""
+    request = FakeRequest()
+    monkeypatch.setattr(
+        main_mod,
+        "get_rpc_filter_context",
+        lambda _request, _user: ("user@example.com", None, False),
+    )
+
+    assert main_mod._resolve_tool_execution_auth_context(request, {}) == (
+        "user@example.com",
+        [],
+        False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_rpc_tools_call_keeps_admin_email_for_owner_matching(monkeypatch, mock_db):
+    """The model-facing tools/call path passes the admin email to visibility."""
+    request = FakeRequest({"name": "private-tool"})
+    request.state.plugin_context_table = None
+    request.state.plugin_global_context = None
+    invoke_tool = AsyncMock(return_value={"content": []})
+
+    monkeypatch.setattr(main_mod.settings, "mcpgateway_tool_cancellation_enabled", False)
+    monkeypatch.setattr(
+        main_mod,
+        "get_rpc_filter_context",
+        lambda _request, _user: ("admin@example.com", None, True),
+    )
+    monkeypatch.setattr(main_mod.tool_service, "invoke_tool", invoke_tool)
+
+    await main_mod._execute_rpc_tools_call(
+        request,
+        mock_db,
+        {"email": "admin@example.com"},
+        req_id="call-1",
+        params={"name": "private-tool", "arguments": {}},
+        lowered_request_headers={},
+        server_id=None,
+    )
+
+    assert invoke_tool.await_args.kwargs["app_user_email"] == "admin@example.com"
+    assert invoke_tool.await_args.kwargs["user_email"] == "admin@example.com"
+    assert invoke_tool.await_args.kwargs["token_teams"] is None
+    assert invoke_tool.await_args.kwargs["require_model_visible"] is True
+
+
+@pytest.mark.asyncio
+async def test_internal_resolve_keeps_admin_email_for_owner_matching(monkeypatch, mock_db):
+    """The Rust resolve path passes the admin email to visibility filtering."""
+    request = FakeRequest(
+        {
+            "jsonrpc": "2.0",
+            "id": "resolve-1",
+            "method": "tools/call",
+            "params": {"name": "private-tool", "arguments": {}},
+        }
+    )
+    request.state.plugin_context_table = None
+    request.state.plugin_global_context = None
+    prepare = AsyncMock(return_value={"plan": {}})
+
+    monkeypatch.setattr(main_mod, "SessionLocal", MagicMock(return_value=mock_db))
+    monkeypatch.setattr(main_mod, "_build_internal_mcp_forwarded_user", lambda _request: {"email": "admin@example.com"})
+    monkeypatch.setattr(main_mod, "get_internal_mcp_auth_context", lambda _request: None)
+    monkeypatch.setattr(main_mod, "_ensure_rpc_permission", AsyncMock())
+    monkeypatch.setattr(
+        main_mod,
+        "get_rpc_filter_context",
+        lambda _request, _user: ("admin@example.com", None, True),
+    )
+    monkeypatch.setattr(main_mod.tool_service, "prepare_rust_mcp_tool_execution", prepare)
+
+    await main_mod.handle_internal_mcp_tools_call_resolve(request)
+
+    assert prepare.await_args.kwargs["app_user_email"] == "admin@example.com"
+    assert prepare.await_args.kwargs["user_email"] == "admin@example.com"
+    assert prepare.await_args.kwargs["token_teams"] is None
+    assert prepare.await_args.kwargs["require_model_visible"] is True
+
+
+@pytest.mark.asyncio
+async def test_legacy_rpc_tool_keeps_admin_email_for_owner_matching(monkeypatch, mock_db):
+    """The backward-compatible RPC tool branch also preserves owner identity."""
+    request = FakeRequest(
+        {
+            "jsonrpc": "2.0",
+            "id": "legacy-1",
+            "method": "private-tool",
+            "params": {},
+        },
+    )
+    request.state.plugin_context_table = None
+    request.state.plugin_global_context = None
+    invoke_tool = AsyncMock(return_value={"content": []})
+
+    monkeypatch.setattr(main_mod.settings, "use_stateful_sessions", False)
+    monkeypatch.setattr(main_mod, "_maybe_forward_affinitized_rpc_request", AsyncMock(return_value=None))
+    monkeypatch.setattr(main_mod, "_ensure_rpc_permission", AsyncMock())
+    monkeypatch.setattr(main_mod, "get_internal_mcp_auth_context", lambda _request: None)
+    monkeypatch.setattr(
+        main_mod,
+        "get_rpc_filter_context",
+        lambda _request, _user: ("admin@example.com", None, True),
+    )
+    monkeypatch.setattr(main_mod.tool_service, "invoke_tool", invoke_tool)
+
+    response = await main_mod._handle_rpc_authenticated(request, mock_db, {"email": "admin@example.com"})
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "result": {"content": []},
+        "id": "legacy-1",
+    }
+    assert invoke_tool.await_args.kwargs["app_user_email"] == "admin@example.com"
+    assert invoke_tool.await_args.kwargs["user_email"] == "admin@example.com"
+    assert invoke_tool.await_args.kwargs["token_teams"] is None
+    assert invoke_tool.await_args.kwargs["require_model_visible"] is True


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Unrestricted admin tokens lost their email while being normalized for tool execution. The service layer therefore could not owner-match an admin's own private tool and returned `Tool not found` through `tools/call`. This preserves the caller email for owner matching while retaining `token_teams=None` admin bypass, so another user's private tool remains inaccessible.

Closes #5566

## 🔁 Reproduction Steps

1. Authenticate as a database admin with unrestricted scope (`token_teams=None`).
2. Register or select a private tool owned by that same admin.
3. Invoke it through JSON-RPC `tools/call` (or the legacy direct-method RPC path).
4. Current main reports the tool as not found even though the same admin owns it.

The issue also traces the regression to `_execute_rpc_tools_call` setting `auth_user_email = None` when admin bypass is active.

## 🐞 Root Cause

Tool-execution paths treated admin bypass as if it required an anonymous email. The canonical visibility contract in `get_scoped_resource_access_context` explicitly preserves email for `(email, None)` so services can match public + team + **own private** rows. Three tool paths diverged from that contract:

- Python `_execute_rpc_tools_call`
- Rust direct execution-plan resolution
- legacy backward-compatible direct-method dispatch

## 💡 Fix Description

Add `_resolve_tool_execution_auth_context` as the single normalization point for these tool paths. It preserves the admin email when `is_admin=True` and `token_teams=None`, converts a missing/non-admin team claim to public-only (`[]`), and leaves team-scoped identities unchanged. Apply the helper consistently to all three execution paths.

This is intentionally narrower than general Layer-1 visibility refactoring: it changes only tool execution authorization context and preserves the existing security invariant that admin bypass never reveals another user's private resources.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

Pre-fix: copied the new tests onto a clean `origin/main` worktree; all 5 failed, including assertions showing `user_email=None` reached all three service boundaries.

Post-fix on this branch:

```bash
.venv/bin/python -m pytest -q tests/unit/mcpgateway/test_rpc_tool_admin_owner_matching.py
# 5 passed

.venv/bin/python -m pytest -q tests/unit/mcpgateway/test_mcp_apps_security.py -k execute_rpc_tools_call
# 1 passed

.venv/bin/python -m pytest -q tests/integration/test_admin_bypass_owner_visibility.py
# 12 passed
```

Formatted with pinned Black 26.5.1; Ruff 0.16.1 reported no issues on changed files. Full project lint/test/coverage were not duplicated locally because the runtime/toolchain dependency set is large; CI will provide the full-suite result.

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Changed-file formatting               | Black 26.5.1         | Pass |
| Changed-file lint                     | Ruff 0.16.1          | Pass |
| Targeted regression                   | 5 new tests          | Pass |
| Existing admin-bypass owner tests     | 12 integration tests | Pass |
| Full lint / test / coverage           | `make lint` / CI     | Pending CI |

## 📐 MCP Compliance (if relevant)

- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist

- [x] Code formatted
- [x] No secrets/credentials committed
