### PR TITLE
fix(mcp): preserve structured-only federated tool results

### DIFF
--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -1929,7 +1929,7 @@ async def call_tool(
                 meta_data=meta_data,
                 require_model_visible=True,
             )
-            if not result or not result.content:
+            if not result or (not result.content and not getattr(result, "structured_content", None)):
                 logger.warning("No content returned by tool: %s", name)
                 return []
 

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -566,6 +566,63 @@ async def test_call_tool_with_structured_content(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_call_tool_preserves_structured_only_result(monkeypatch):
+    """A spec-valid structured-only result must not be discarded as empty.
+
+    MCP makes unstructured ``content`` a SHOULD—not a MUST—when
+    ``structuredContent`` is present. The early empty-content guard therefore
+    has to consider both representations.
+    """
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import call_tool, tool_service
+
+    mock_db = MagicMock()
+    mock_result = MagicMock()
+    mock_result.content = []
+    mock_structured = {"id": "widget-42", "name": "Reproduction Widget", "price": 9.99}
+    mock_result.structured_content = mock_structured
+    mock_result.model_dump = lambda by_alias=True: {"content": [], "structuredContent": mock_structured}
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+    monkeypatch.setattr(tool_service, "invoke_tool", AsyncMock(return_value=mock_result))
+
+    result = await call_tool("widget", {})
+
+    assert isinstance(result, tuple)
+    unstructured, structured = result
+    assert unstructured == []
+    assert structured == mock_structured
+
+
+@pytest.mark.asyncio
+async def test_call_tool_returns_empty_when_neither_representation_exists(monkeypatch):
+    """The early return remains for results with neither content representation."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import call_tool, tool_service
+
+    mock_db = MagicMock()
+    mock_result = MagicMock()
+    mock_result.content = []
+    mock_result.structured_content = None
+    mock_result.model_dump = lambda by_alias=True: {"content": [], "structuredContent": None}
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+    monkeypatch.setattr(tool_service, "invoke_tool", AsyncMock(return_value=mock_result))
+
+    result = await call_tool("empty", {})
+
+    assert result == []
+
+
+@pytest.mark.asyncio
 async def test_call_tool_preserves_is_error_for_egress(monkeypatch):
     """Egress regression guard for ContextForge #4202 — local (non-pooled) branch.
 
@@ -9580,10 +9637,6 @@ async def test_local_affinity_post_routes_to_rpc(monkeypatch):
 
     await wrapper.shutdown()
     assert messages[0]["status"] == 200
-
-
-
-
 @pytest.mark.asyncio
 async def test_http_affinity_forwarded_path_dispatches_via_post_rpc_in_process(monkeypatch):
     """``[HTTP_AFFINITY_FORWARDED]`` re-entry also goes through ``post_rpc_in_process`` (PR #4987).


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

A successful federated `tools/call` result may carry all of its data in `structuredContent` while `content` is empty. The MCP Tools specification makes unstructured content a **SHOULD**, not a **MUST**, when structured content is present. ContextForge's streamable-HTTP transport treated that valid shape as an empty result and returned before reaching the structured-content handler.

For tools declaring an `outputSchema`, the MCP SDK then substituted:

```text
Output validation error: outputSchema defined but no structured output returned
```

The real structured payload never reached the client.

Closes #5472

## 🔁 Reproduction Steps

1. Federate an upstream MCP tool that declares an `outputSchema`.
2. Return `{ "content": [], "structuredContent": { ... } }` from its `tools/call` result.
3. Invoke the tool through ContextForge's `/mcp` streamable-HTTP endpoint.
4. Current main returns the validation-error text instead of forwarding the structured payload.

The issue includes a standalone reproduction repository and before/after output.

## 🐞 Root Cause

After `invoke_tool()` returned successfully, the early guard was:

```python
if not result or not result.content:
    return []
```

It ignored `result.structured_content`. Structured-only results therefore returned `[]` before the later handler could assemble `(unstructured, structured)` for SDK validation.

## 💡 Fix Description

Treat the result as empty only when both representations are absent:

```python
if not result or (not result.content and not getattr(result, "structured_content", None)):
```

Structured-only results now fall through to the existing handler and return `(unstructured, structured)`. Results with neither representation continue to return `[]`.

This is intentionally separate from #6182/#6274: those track preservation of an empty dict (`structuredContent: {}`) in the service layer. This fix handles non-empty structured payloads whose unstructured `content` array is empty.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

Pre-fix: the new structured-only test failed with `result == []`.

Post-fix on this branch:

```bash
python -m pytest -q tests/unit/mcpgateway/transports/test_streamablehttp_transport.py -k 'call_tool_success or with_structured_content or structured_only_result or neither_representation or preserves_is_error_for_egress'
# 5 passed
```

Additional checks:

```bash
uvx ruff@0.16.1 check mcpgateway/transports/streamablehttp_transport.py
# All checks passed
```

Full project lint/test/coverage were not duplicated locally due to the large dependency set; CI will provide that result.

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Changed source lint                   | Ruff 0.16.1          | Pass |
| Targeted regression                   | 5 tests              | Pass |
| Pre-fix regression                    | Current-main behavior | Fail as expected |
| Full lint / test / coverage           | `make lint` / CI     | Pending CI |

## 📐 MCP Compliance (if relevant)

- [x] Matches current MCP spec — unstructured `content` is a SHOULD when `structuredContent` is present
- [x] No breaking change to MCP clients
- [x] Existing genuinely-empty results still return `[]`

## ✅ Checklist

- [x] Code formatted
- [x] No secrets/credentials committed
