### PR TITLE
fix: bound SQLite observability metric scans

### DIFF
--- a/mcpgateway/cache/admin_stats_cache.py
+++ b/mcpgateway/cache/admin_stats_cache.py
@@ -260,11 +260,13 @@ class AdminStatsCache:
         with self._lock:
             self._cache[cache_key] = CacheEntry(value=stats, expiry=time.time() + self._system_ttl)
 
-    async def get_observability_stats(self, hours: int = 24) -> Optional[Dict[str, Any]]:
+    async def get_observability_stats(self, hours: int = 24, cache_key: Optional[str] = None) -> Optional[Dict[str, Any]]:
         """Get cached observability statistics.
 
         Args:
             hours: Time range in hours for stats
+            cache_key: Optional query-specific identifier. When omitted, the
+                legacy hours-based key is used.
 
         Returns:
             Cached observability stats or None on cache miss
@@ -279,7 +281,8 @@ class AdminStatsCache:
         if not self._enabled:
             return None
 
-        cache_key = self._get_redis_key("observability", str(hours))
+        identifier = cache_key if cache_key is not None else str(hours)
+        cache_key = self._get_redis_key("observability", identifier)
 
         # Try Redis first
         redis = await self._get_redis_client()
@@ -307,12 +310,14 @@ class AdminStatsCache:
         self._miss_count += 1
         return None
 
-    async def set_observability_stats(self, stats: Dict[str, Any], hours: int = 24) -> None:
+    async def set_observability_stats(self, stats: Dict[str, Any], hours: int = 24, cache_key: Optional[str] = None) -> None:
         """Store observability statistics in cache.
 
         Args:
             stats: Observability statistics dictionary
             hours: Time range in hours for stats
+            cache_key: Optional query-specific identifier. When omitted, the
+                legacy hours-based key is used.
 
         Examples:
             >>> import asyncio
@@ -322,7 +327,8 @@ class AdminStatsCache:
         if not self._enabled:
             return
 
-        cache_key = self._get_redis_key("observability", str(hours))
+        identifier = cache_key if cache_key is not None else str(hours)
+        cache_key = self._get_redis_key("observability", identifier)
 
         # Store in Redis
         redis = await self._get_redis_client()

--- a/mcpgateway/middleware/rate_limit_middleware.py
+++ b/mcpgateway/middleware/rate_limit_middleware.py
@@ -131,6 +131,11 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
                 "limit": settings.rate_limit_medium_rpm,
                 "burst": settings.rate_limit_medium_burst,
             },
+            "OBSERVABILITY_METRICS": {
+                "pattern": r"^/(?:v1/)?observability/metrics(/|$)",
+                "limit": settings.rate_limit_low_rpm,
+                "burst": settings.rate_limit_low_burst,
+            },
             "LOW": {
                 "pattern": r"^/(health|metrics|docs|openapi)(/|$)",
                 "limit": settings.rate_limit_low_rpm,

--- a/mcpgateway/routers/observability.py
+++ b/mcpgateway/routers/observability.py
@@ -30,6 +30,7 @@ from mcpgateway.common.query_params import (
     QueryUserIdentifier,
 )
 from mcpgateway.config import settings
+from mcpgateway.cache.admin_stats_cache import admin_stats_cache
 from mcpgateway.db import SessionLocal
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
 from mcpgateway.schemas import ObservabilitySpanRead, ObservabilityTraceRead, ObservabilityTraceWithSpans
@@ -909,9 +910,15 @@ async def get_metrics_timeseries(
         return TimeseriesResponse(buckets=[], values=[])
 
     try:
+        cache_key = f"metrics:timeseries:{hours}:{interval_minutes}"
+        cached = await admin_stats_cache.get_observability_stats(hours, cache_key=cache_key)
+        if cached is not None:
+            return TimeseriesResponse(**cached)
+
         service = ObservabilityService()
         cutoff_time = datetime.now(timezone.utc) - timedelta(hours=hours)
         data = service.get_execution_timeseries(db, cutoff_time, interval_minutes)
+        await admin_stats_cache.set_observability_stats(data, hours, cache_key=cache_key)
         return TimeseriesResponse(**data)
     except Exception as e:
         logger.error(f"Failed to calculate timeseries metrics: {e}", exc_info=True)
@@ -947,9 +954,15 @@ async def get_metrics_percentiles(
         return PercentilesResponse(buckets=[], p50=[], p95=[], p99=[])
 
     try:
+        cache_key = f"metrics:percentiles:{hours}:{interval_minutes}"
+        cached = await admin_stats_cache.get_observability_stats(hours, cache_key=cache_key)
+        if cached is not None:
+            return PercentilesResponse(**cached)
+
         service = ObservabilityService()
         cutoff_time = datetime.now(timezone.utc) - timedelta(hours=hours)
         data = service.get_latency_percentiles(db, cutoff_time, interval_minutes)
+        await admin_stats_cache.set_observability_stats(data, hours, cache_key=cache_key)
         return PercentilesResponse(**data)
     except Exception as e:
         logger.error(f"Failed to calculate latency percentiles: {e}", exc_info=True)

--- a/mcpgateway/services/observability_service.py
+++ b/mcpgateway/services/observability_service.py
@@ -1861,14 +1861,14 @@ def _execution_timeseries_postgresql(db: Session, cutoff_time: datetime, interva
 def _execution_timeseries_sqlite(db: Session, cutoff_time: datetime, interval_minutes: int) -> Dict[str, List[Any]]:
     """Count executions per time bucket using SQLite aggregation.
 
-    SQLite's ``unixepoch`` keeps the time filter indexable while moving the
+    SQLite's built-in ``strftime`` keeps the time filter indexable while moving the
     grouping work into the database, so process memory is independent of the
     number of traces in the requested window.
     """
     stats_sql = text(
         """
         SELECT
-            CAST(unixepoch(start_time) / :interval_seconds AS INTEGER) * :interval_seconds AS bucket_epoch,
+            CAST(CAST(strftime('%s', start_time) AS INTEGER) / :interval_seconds AS INTEGER) * :interval_seconds AS bucket_epoch,
             COUNT(*) AS total
         FROM observability_traces
         WHERE start_time >= :cutoff_time
@@ -1974,7 +1974,7 @@ def _latency_percentiles_sqlite(db: Session, cutoff_time: datetime, interval_min
         """
         WITH bucketed AS (
             SELECT
-                CAST(unixepoch(start_time) / :interval_seconds AS INTEGER) * :interval_seconds AS bucket_epoch,
+                CAST(CAST(strftime('%s', start_time) AS INTEGER) / :interval_seconds AS INTEGER) * :interval_seconds AS bucket_epoch,
                 duration_ms
             FROM observability_traces
             WHERE start_time >= :cutoff_time AND duration_ms IS NOT NULL

--- a/mcpgateway/services/observability_service.py
+++ b/mcpgateway/services/observability_service.py
@@ -1797,6 +1797,8 @@ class ObservabilityService:
         """
         if db.get_bind().dialect.name == "postgresql":
             return _execution_timeseries_postgresql(db, cutoff_time, interval_minutes)
+        if db.get_bind().dialect.name == "sqlite":
+            return _execution_timeseries_sqlite(db, cutoff_time, interval_minutes)
         return _execution_timeseries_python(db, cutoff_time, interval_minutes)
 
     def get_latency_percentiles(self, db: Session, cutoff_time: datetime, interval_minutes: int) -> Dict[str, List[Any]]:
@@ -1813,6 +1815,8 @@ class ObservabilityService:
         """
         if db.get_bind().dialect.name == "postgresql":
             return _latency_percentiles_postgresql(db, cutoff_time, interval_minutes)
+        if db.get_bind().dialect.name == "sqlite":
+            return _latency_percentiles_sqlite(db, cutoff_time, interval_minutes)
         return _latency_percentiles_python(db, cutoff_time, interval_minutes)
 
 
@@ -1854,8 +1858,38 @@ def _execution_timeseries_postgresql(db: Session, cutoff_time: datetime, interva
     return {"buckets": buckets, "values": values}
 
 
+def _execution_timeseries_sqlite(db: Session, cutoff_time: datetime, interval_minutes: int) -> Dict[str, List[Any]]:
+    """Count executions per time bucket using SQLite aggregation.
+
+    SQLite's ``unixepoch`` keeps the time filter indexable while moving the
+    grouping work into the database, so process memory is independent of the
+    number of traces in the requested window.
+    """
+    stats_sql = text(
+        """
+        SELECT
+            CAST(unixepoch(start_time) / :interval_seconds AS INTEGER) * :interval_seconds AS bucket_epoch,
+            COUNT(*) AS total
+        FROM observability_traces
+        WHERE start_time >= :cutoff_time
+        GROUP BY bucket_epoch
+        ORDER BY bucket_epoch
+        """
+    )
+
+    interval_seconds = interval_minutes * 60
+    results = db.execute(stats_sql, {"cutoff_time": cutoff_time, "interval_seconds": interval_seconds}).fetchall()
+    if not results:
+        return {"buckets": [], "values": []}
+
+    return {
+        "buckets": [datetime.fromtimestamp(int(row.bucket_epoch), tz=timezone.utc).isoformat() for row in results],
+        "values": [int(row.total) for row in results],
+    }
+
+
 def _execution_timeseries_python(db: Session, cutoff_time: datetime, interval_minutes: int) -> Dict[str, List[Any]]:
-    """Count executions per time bucket in Python (fallback for SQLite).
+    """Count executions per time bucket in Python for unsupported dialects.
 
     Args:
         db: Database session
@@ -1928,8 +1962,81 @@ def _latency_percentiles_postgresql(db: Session, cutoff_time: datetime, interval
     return {"buckets": buckets, "p50": p50_values, "p95": p95_values, "p99": p99_values}
 
 
+def _latency_percentiles_sqlite(db: Session, cutoff_time: datetime, interval_minutes: int) -> Dict[str, List[Any]]:
+    """Compute time-bucketed latency percentiles using SQLite window functions.
+
+    The ranking and interpolation happen in SQLite, matching PostgreSQL's
+    ``percentile_cont`` semantics without materializing every duration in
+    Python. SQLite versions bundled with supported runtimes provide window
+    functions; the Python implementation remains available for other dialects.
+    """
+    stats_sql = text(
+        """
+        WITH bucketed AS (
+            SELECT
+                CAST(unixepoch(start_time) / :interval_seconds AS INTEGER) * :interval_seconds AS bucket_epoch,
+                duration_ms
+            FROM observability_traces
+            WHERE start_time >= :cutoff_time AND duration_ms IS NOT NULL
+        ),
+        ranked AS (
+            SELECT
+                bucket_epoch,
+                duration_ms,
+                ROW_NUMBER() OVER (PARTITION BY bucket_epoch ORDER BY duration_ms) - 1 AS row_idx,
+                COUNT(*) OVER (PARTITION BY bucket_epoch) AS bucket_count
+            FROM bucketed
+        ),
+        percentiles(p) AS (VALUES (0.50), (0.95), (0.99)),
+        positions AS (
+            SELECT
+                bucket_epoch,
+                p,
+                duration_ms,
+                row_idx,
+                CAST(p * (bucket_count - 1) AS INTEGER) AS lower_idx,
+                MIN(CAST(p * (bucket_count - 1) AS INTEGER) + 1, bucket_count - 1) AS upper_idx,
+                p * (bucket_count - 1) - CAST(p * (bucket_count - 1) AS INTEGER) AS fraction
+            FROM ranked
+            CROSS JOIN percentiles
+        )
+        SELECT
+            bucket_epoch,
+            p,
+            ROUND(
+                MAX(CASE WHEN row_idx = lower_idx THEN duration_ms END)
+                + fraction * (
+                    MAX(CASE WHEN row_idx = upper_idx THEN duration_ms END)
+                    - MAX(CASE WHEN row_idx = lower_idx THEN duration_ms END)
+                ),
+                2
+            ) AS value
+        FROM positions
+        GROUP BY bucket_epoch, p, fraction
+        ORDER BY bucket_epoch, p
+        """
+    )
+
+    interval_seconds = interval_minutes * 60
+    results = db.execute(stats_sql, {"cutoff_time": cutoff_time, "interval_seconds": interval_seconds}).fetchall()
+    if not results:
+        return {"buckets": [], "p50": [], "p95": [], "p99": []}
+
+    values_by_bucket: Dict[int, Dict[float, float]] = defaultdict(dict)
+    for row in results:
+        values_by_bucket[int(row.bucket_epoch)][float(row.p)] = float(row.value)
+
+    bucket_epochs = sorted(values_by_bucket)
+    return {
+        "buckets": [datetime.fromtimestamp(bucket_epoch, tz=timezone.utc).isoformat() for bucket_epoch in bucket_epochs],
+        "p50": [values_by_bucket[bucket_epoch].get(0.50, 0.0) for bucket_epoch in bucket_epochs],
+        "p95": [values_by_bucket[bucket_epoch].get(0.95, 0.0) for bucket_epoch in bucket_epochs],
+        "p99": [values_by_bucket[bucket_epoch].get(0.99, 0.0) for bucket_epoch in bucket_epochs],
+    }
+
+
 def _latency_percentiles_python(db: Session, cutoff_time: datetime, interval_minutes: int) -> Dict[str, List[Any]]:
-    """Compute time-bucketed latency percentiles in Python (fallback for SQLite).
+    """Compute time-bucketed latency percentiles for unsupported dialects.
 
     Args:
         db: Database session

--- a/tests/unit/mcpgateway/cache/test_admin_stats_cache.py
+++ b/tests/unit/mcpgateway/cache/test_admin_stats_cache.py
@@ -28,6 +28,9 @@ async def test_admin_stats_cache_in_memory_paths(monkeypatch):
     await cache.set_observability_stats({"spans": 2}, hours=12)
     assert await cache.get_observability_stats(12) == {"spans": 2}
 
+    await cache.set_observability_stats({"values": [1]}, hours=24, cache_key="metrics:timeseries:24:60")
+    assert await cache.get_observability_stats(24, cache_key="metrics:timeseries:24:60") == {"values": [1]}
+
     await cache.set_users_list(["u1"], limit=5, offset=0)
     assert await cache.get_users_list(limit=5, offset=0) == ["u1"]
 

--- a/tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py
@@ -203,6 +203,13 @@ class TestRateLimitMiddlewareTiers:
         tier = middleware.get_endpoint_tier("/health")
         assert tier["limit"] == 500
 
+    def test_endpoint_tier_observability_metrics(self, middleware):
+        """Expensive metrics aggregation has an explicit tier on both mounts."""
+        for path in ("/observability/metrics/timeseries", "/v1/observability/metrics/percentiles"):
+            tier = middleware.get_endpoint_tier(path)
+            assert tier["limit"] == 500
+            assert middleware._get_tier_name(path) == "OBSERVABILITY_METRICS"
+
     def test_get_client_ip_forwarded(self, middleware, mock_request):
         """Test IP extraction from X-Forwarded-For."""
         mock_request.headers["X-Forwarded-For"] = "10.0.0.1, 192.168.1.1"

--- a/tests/unit/mcpgateway/routers/test_observability_metrics.py
+++ b/tests/unit/mcpgateway/routers/test_observability_metrics.py
@@ -23,8 +23,8 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 # First-Party
-from mcpgateway.config import settings
 from mcpgateway.cache.admin_stats_cache import AdminStatsCache
+from mcpgateway.config import settings
 from mcpgateway.db import Base, ObservabilityTrace
 from mcpgateway.middleware import rbac as rbac_module
 from mcpgateway.middleware.rbac import get_current_user_with_permissions
@@ -197,6 +197,29 @@ async def test_percentiles_linear_interpolation_and_null_exclusion(db_session, g
     assert response.p50 == [150.0]
     assert response.p95 == [195.0]
     assert response.p99 == [199.0]
+
+
+@pytest.mark.parametrize(
+    "service_method,trace_kwargs,expected_values",
+    [
+        ("get_execution_timeseries", {}, {"values": [1]}),
+        ("get_latency_percentiles", {"duration_ms": 100.0}, {"p50": [100.0], "p95": [100.0], "p99": [100.0]}),
+    ],
+)
+def test_sqlite_metric_queries_do_not_require_unixepoch(db_session, service_method, trace_kwargs, expected_values):
+    """SQLite metrics keep working when the newer unixepoch function is unavailable."""
+
+    def unavailable_unixepoch(_):
+        raise AssertionError("unixepoch must not be called")
+
+    db_session.connection().connection.create_function("unixepoch", 1, unavailable_unixepoch)
+    make_trace(db_session, offset_seconds=300, **trace_kwargs)
+
+    result = getattr(ObservabilityService(), service_method)(db_session, BASE_TIME - timedelta(hours=24), 60)
+
+    assert result["buckets"] == ["2025-01-01T12:00:00+00:00"]
+    for key, value in expected_values.items():
+        assert result[key] == value
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/routers/test_observability_metrics.py
+++ b/tests/unit/mcpgateway/routers/test_observability_metrics.py
@@ -12,7 +12,7 @@ bucketing and percentile math run as actual queries rather than mocked results.
 # Standard
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 # Third-Party
 from fastapi import FastAPI, HTTPException
@@ -24,6 +24,7 @@ from sqlalchemy.pool import StaticPool
 
 # First-Party
 from mcpgateway.config import settings
+from mcpgateway.cache.admin_stats_cache import AdminStatsCache
 from mcpgateway.db import Base, ObservabilityTrace
 from mcpgateway.middleware import rbac as rbac_module
 from mcpgateway.middleware.rbac import get_current_user_with_permissions
@@ -82,6 +83,12 @@ def no_plugin_manager(monkeypatch: pytest.MonkeyPatch):
         return None
 
     monkeypatch.setattr("mcpgateway.plugins.get_plugin_manager", _no_plugin_manager)
+
+
+@pytest.fixture(autouse=True)
+def no_metrics_cache(monkeypatch: pytest.MonkeyPatch):
+    """Keep result caching from leaking data between endpoint tests."""
+    monkeypatch.setattr(observability_module, "admin_stats_cache", AdminStatsCache(enabled=False))
 
 
 @pytest.fixture
@@ -190,6 +197,27 @@ async def test_percentiles_linear_interpolation_and_null_exclusion(db_session, g
     assert response.p50 == [150.0]
     assert response.p95 == [195.0]
     assert response.p99 == [199.0]
+
+
+@pytest.mark.asyncio
+async def test_metrics_cache_isolated_by_metric_and_interval(db_session, grant_permissions, monkeypatch):
+    """Timeseries and percentile queries use distinct cache identities."""
+    grant_permissions()
+    monkeypatch.setattr(observability_module, "datetime", _FrozenDatetime)
+    cache = AdminStatsCache(enabled=True)
+    monkeypatch.setattr(cache, "_get_redis_client", AsyncMock(return_value=None))
+    monkeypatch.setattr(observability_module, "admin_stats_cache", cache)
+
+    make_trace(db_session, offset_seconds=300)
+    first = await call_timeseries(db_session)
+    make_trace(db_session, offset_seconds=5400)
+    cached = await call_timeseries(db_session)
+    percentiles = await call_percentiles(db_session)
+
+    assert cached == first
+    assert percentiles.buckets == []
+    assert cache._get_redis_key("observability", "metrics:timeseries:24:60") in cache._cache
+    assert cache._get_redis_key("observability", "metrics:percentiles:24:60") in cache._cache
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The public observability metrics endpoints currently use a Python fallback on SQLite that calls `.all()` for every trace in the requested window. A 168-hour request can therefore materialize the full raw window in the API process.

This change:

- Aggregates SQLite execution counts in SQL while preserving the existing UTC bucket contract.
- Computes SQLite p50/p95/p99 with window functions and linear interpolation equivalent to PostgreSQL `percentile_cont`, without loading every duration into Python.
- Reuses the existing observability TTL cache with query-specific keys for metric type, look-back window, and interval.
- Assigns `/observability/metrics/*` and `/v1/observability/metrics/*` to an explicit rate-limit tier instead of the default fallback.

The PostgreSQL path and the unsupported-dialect Python fallback remain unchanged.

Closes #6286

## Verification

- `make test` with proxy environment variables cleared: 22533 passed, 870 skipped, 2 xfailed.
- Focused observability, cache, and rate-limit tests: 100% passed.
- Observability service/router SQL tests: 114 passed.
- Admin observability SQL tests: 27 passed.
- `ruff check` on changed production and focused test files: passed.
- `ruff format --check` on changed files: passed.
- `git diff --check`: passed.
- SQLite query-plan check confirmed the `start_time` index is used for the bounded time filter.