### PR TITLE
fix(security): harden Vault token reader boundaries

### DIFF
--- a/mcpgateway/services/token_backends/vault_backend.py
+++ b/mcpgateway/services/token_backends/vault_backend.py
@@ -604,6 +604,15 @@ class VaultTokenBackend(AbstractTokenBackend):
                 return None
 
             data = result["data"]["data"]
+            token_data = data.get("token")
+            if not isinstance(token_data, dict):
+                logger.debug(
+                    "Vault record for gateway %s, team=%s, user=%s has no 'token' field — not an OAuth record",
+                    SecurityValidator.sanitize_log_message(gateway_id),
+                    SecurityValidator.sanitize_log_message(team_id),
+                    SecurityValidator.sanitize_log_message(app_user_email),
+                )
+                return None
             expires_at_str = data.get("expires_at")
             updated_at_str = data.get("updated_at")
 
@@ -618,7 +627,7 @@ class VaultTokenBackend(AbstractTokenBackend):
                     status = "near_expiry"
 
             return {
-                "scopes": data["token"]["scopes"],
+                "scopes": token_data.get("scopes", []),
                 "expires_at": expires_at_str,
                 "status": status,
                 "updated_at": updated_at_str,

--- a/mcpgateway/services/token_storage_service.py
+++ b/mcpgateway/services/token_storage_service.py
@@ -155,6 +155,13 @@ class TokenStorageService:
         else:
             raise ValueError(f"Unknown OAUTH_TOKEN_BACKEND: {settings.oauth_token_backend}. Expected 'database' or 'vault'.")
 
+    @staticmethod
+    def _require_app_user_email(app_user_email: str) -> str:
+        """Reject missing user identity before it reaches a token backend."""
+        if not app_user_email:
+            raise ValueError("app_user_email is required for token operations")
+        return app_user_email
+
     def _get_team_id(self, gateway_id: str, app_user_email: str) -> Optional[str]:
         """
         Extract team_id from JWT user_context (sole source of truth).
@@ -267,6 +274,7 @@ class TokenStorageService:
         Raises:
             OAuthError: If token storage fails
         """
+        app_user_email = self._require_app_user_email(app_user_email)
         team_id = self._get_team_id(gateway_id, app_user_email)
         return await self._backend.store_tokens(
             gateway_id=gateway_id,
@@ -297,6 +305,7 @@ class TokenStorageService:
         Returns:
             Valid access token or None if no valid token available for this user
         """
+        app_user_email = self._require_app_user_email(app_user_email)
         team_id = self._get_team_id(gateway_id, app_user_email)
         return await self._backend.get_user_token(
             gateway_id=gateway_id,
@@ -325,6 +334,7 @@ class TokenStorageService:
         Returns:
             The ``{header: value}`` dict, or None.
         """
+        app_user_email = self._require_app_user_email(app_user_email)
         team_id = self._get_team_id(gateway_id, app_user_email)
         return await self._backend.get_user_auth_headers(
             gateway_id=gateway_id,
@@ -346,6 +356,7 @@ class TokenStorageService:
         Returns:
             Token information dictionary or None if not found
         """
+        app_user_email = self._require_app_user_email(app_user_email)
         team_id = self._get_team_id(gateway_id, app_user_email)
         return await self._backend.get_token_info(
             gateway_id=gateway_id,
@@ -367,6 +378,7 @@ class TokenStorageService:
         Returns:
             True if tokens were revoked successfully
         """
+        app_user_email = self._require_app_user_email(app_user_email)
         team_id = self._get_team_id(gateway_id, app_user_email)
         return await self._backend.revoke_user_tokens(
             gateway_id=gateway_id,
@@ -410,6 +422,7 @@ class TokenStorageService:
             Tuple of (learned_aud, learned_iss). Either element may be None if
             no token record exists or if the fields were never populated.
         """
+        app_user_email = self._require_app_user_email(app_user_email)
         team_id = self._get_team_id(gateway_id, app_user_email)
         return await self._backend.get_user_learned_audience(gateway_id, team_id, app_user_email)
 

--- a/tests/unit/mcpgateway/services/test_token_storage_service.py
+++ b/tests/unit/mcpgateway/services/test_token_storage_service.py
@@ -340,6 +340,35 @@ async def test_get_token_info_delegates_to_backend(mock_db, mock_settings_databa
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "method, kwargs",
+    [
+        (
+            "store_tokens",
+            {
+                "gateway_id": "gw-1",
+                "user_id": "oauth-user-1",
+                "app_user_email": None,
+                "access_token": "access-token",
+                "refresh_token": None,
+                "expires_in": 3600,
+                "scopes": [],
+            },
+        ),
+        ("get_user_token", {"gateway_id": "gw-1", "app_user_email": None}),
+        ("get_user_auth_headers", {"gateway_id": "gw-1", "app_user_email": None}),
+        ("get_token_info", {"gateway_id": "gw-1", "app_user_email": None}),
+        ("revoke_user_tokens", {"gateway_id": "gw-1", "app_user_email": None}),
+        ("get_user_learned_audience", {"gateway_id": "gw-1", "app_user_email": None}),
+    ],
+)
+async def test_user_scoped_operations_reject_missing_email(service, method, kwargs):
+    """No user-scoped operation may route a missing identity to a backend."""
+    with pytest.raises(ValueError, match="app_user_email is required"):
+        await getattr(service, method)(**kwargs)
+
+
+@pytest.mark.asyncio
 async def test_revoke_user_tokens_delegates_to_backend(mock_db, mock_settings_database):
     """Test revoke_user_tokens delegates to backend with team_id."""
     with patch("mcpgateway.services.token_storage_service.get_settings") as mock_get_settings:

--- a/tests/unit/mcpgateway/services/test_vault_token_backend.py
+++ b/tests/unit/mcpgateway/services/test_vault_token_backend.py
@@ -2330,6 +2330,16 @@ async def test_r7_get_token_info_vault_auth_error():
 
 
 @pytest.mark.asyncio
+async def test_r7_get_token_info_returns_none_for_header_only_record():
+    """get_token_info treats a non-OAuth Vault record as no token."""
+    backend, _ = _make_backend_r7()
+    header_only = {"data": {"data": {"headers": {"X-Api-Key": "abc123"}}}}  # pragma: allowlist secret
+    with patch.object(backend, "_vault_request", new_callable=AsyncMock, return_value=header_only):
+        result = await backend.get_token_info("gw-1", "team-1", "alice@example.com")
+    assert result is None
+
+
+@pytest.mark.asyncio
 async def test_r7_revoke_user_tokens_generic_exception_returns_false():
     """revoke_user_tokens returns False on generic non-Vault exception (line 620)."""
     backend, _ = _make_backend_r7()


### PR DESCRIPTION
## Summary

This is a focused follow-up to #6353. The existing `get_user_token()` header-only record handling is already present on `main`; this PR completes the remaining reader/facade boundary items without expanding into the broader Vault follow-up list.

- Make Vault `get_token_info()` treat a record without an OAuth `token` object, such as an ICA-written header-only record, as no token instead of raising `KeyError`.
- Default missing `scopes` to an empty list for otherwise valid token records.
- Reject a missing or empty `app_user_email` at the `TokenStorageService` facade before team resolution or backend dispatch across store, read, revoke, and learned-audience operations.
- Keep existing Vault paths, OAuth behavior, and the database backend contract unchanged for valid user identities.

The guard preserves the fail-closed behavior described in #6353 while preventing an unhelpful raw exception at the Vault reader boundary.

Related #6353

## Verification

- `make test` with proxy environment variables cleared: 22538 passed, 870 skipped, 2 xfailed.
- Focused Vault token-backend and token-storage-service suites: passed.
- Adjacent Vault coverage, token-storage facade, and Vault router suites: passed.
- `ruff check` on changed source files: passed.
- `ruff format --check` on changed source files: passed.
- `git diff --check`: passed.
- Commit is SSH-signed with the repository-required identity.