### PR TITLE
fix: enforce component-aware directory confinement on admin log download

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-27T14:59:01Z",
+  "generated_at": "2026-08-28T12:29:08Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -342,7 +342,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1083,
+        "line_number": 1084,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +350,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1085,
+        "line_number": 1086,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +358,7 @@
         "hashed_secret": "db69d9215c29ae2f2e4ead587890a9f8455059dd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1159,
+        "line_number": 1160,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +366,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1738,
+        "line_number": 1739,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +374,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1957,
+        "line_number": 1958,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6114,
+        "line_number": 6115,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6611,
+        "line_number": 6612,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6623,
+        "line_number": 6624,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6695,
+        "line_number": 6696,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7111,
+        "line_number": 7112,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7801,
+        "line_number": 7802,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -756,7 +756,7 @@
         "hashed_secret": "b6f3674b78a02881de33177e6f6fb8b851e0101c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 248,
+        "line_number": 250,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -764,7 +764,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 343,
+        "line_number": 345,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -772,7 +772,7 @@
         "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 393,
+        "line_number": 395,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -780,7 +780,7 @@
         "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 401,
+        "line_number": 403,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -788,7 +788,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 448,
+        "line_number": 450,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -796,7 +796,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 966,
+        "line_number": 968,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -804,7 +804,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1069,
+        "line_number": 1071,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -812,7 +812,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1236,
+        "line_number": 1238,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -820,7 +820,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1271,
+        "line_number": 1273,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -828,7 +828,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1819,
+        "line_number": 1821,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -836,7 +836,7 @@
         "hashed_secret": "afba9d98073dfb79fba7b21516c4d4d676c72935",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2249,
+        "line_number": 2251,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -844,7 +844,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2349,
+        "line_number": 2351,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -852,7 +852,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2349,
+        "line_number": 2351,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -860,7 +860,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2362,
+        "line_number": 2364,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -868,7 +868,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2510,
+        "line_number": 2512,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -876,7 +876,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2531,
+        "line_number": 2533,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -884,7 +884,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2539,
+        "line_number": 2541,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -892,7 +892,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2544,
+        "line_number": 2546,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-27T15:52:01Z",
+  "generated_at": "2026-08-27T14:59:01Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -342,7 +342,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1084,
+        "line_number": 1083,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +350,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1086,
+        "line_number": 1085,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +358,7 @@
         "hashed_secret": "db69d9215c29ae2f2e4ead587890a9f8455059dd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1160,
+        "line_number": 1159,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +366,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1739,
+        "line_number": 1738,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +374,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1958,
+        "line_number": 1957,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6115,
+        "line_number": 6114,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6612,
+        "line_number": 6611,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6624,
+        "line_number": 6623,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6696,
+        "line_number": 6695,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7112,
+        "line_number": 7111,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7802,
+        "line_number": 7801,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -756,7 +756,7 @@
         "hashed_secret": "b6f3674b78a02881de33177e6f6fb8b851e0101c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 250,
+        "line_number": 248,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -764,7 +764,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 345,
+        "line_number": 343,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -772,7 +772,7 @@
         "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 395,
+        "line_number": 393,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -780,7 +780,7 @@
         "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 403,
+        "line_number": 401,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -788,7 +788,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 450,
+        "line_number": 448,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -796,7 +796,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 968,
+        "line_number": 966,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -804,7 +804,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1071,
+        "line_number": 1069,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -812,7 +812,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1238,
+        "line_number": 1236,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -820,7 +820,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1273,
+        "line_number": 1271,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -828,7 +828,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1821,
+        "line_number": 1819,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -836,7 +836,7 @@
         "hashed_secret": "afba9d98073dfb79fba7b21516c4d4d676c72935",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2251,
+        "line_number": 2249,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -844,7 +844,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2351,
+        "line_number": 2349,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -852,7 +852,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2351,
+        "line_number": 2349,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -860,7 +860,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2364,
+        "line_number": 2362,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -868,7 +868,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2512,
+        "line_number": 2510,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -876,7 +876,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2533,
+        "line_number": 2531,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -884,7 +884,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2541,
+        "line_number": 2539,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -892,7 +892,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2546,
+        "line_number": 2544,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3936,7 +3936,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 786,
+        "line_number": 787,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4792,7 +4792,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7272,
+        "line_number": 7273,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -209,7 +209,6 @@ from mcpgateway.utils.pagination import paginate_query
 from mcpgateway.utils.passthrough_headers import PassthroughHeadersError
 from mcpgateway.utils.paths import is_path_within, open_confined
 from mcpgateway.utils.paths import resolve_root_path as _resolve_root_path
-from mcpgateway.utils.paths import UnsupportedPlatformError
 from mcpgateway.utils.security_cookies import clear_auth_cookie, CookieTooLargeError, set_auth_cookie
 from mcpgateway.utils.services_auth import encode_auth
 from mcpgateway.utils.sqlalchemy_modifier import json_contains_tag_expr
@@ -15544,21 +15543,21 @@ async def admin_get_log_file(
         if not (file_path.suffix in [".log", ".jsonl", ".json"] or file_path.stem.startswith(Path(settings.log_file).stem)):
             raise HTTPException(403, "Not a log file")
 
-        # Open the verified fd directly via an openat()/O_NOFOLLOW chain instead of
-        # handing a pathname to FileResponse, which reopens the path when it streams.
-        # A process able to write into log_dir_resolved could otherwise rename the
-        # checked file away and put a symlink in its place between the confinement
+        # Open the verified fd directly via a component-by-component confined open
+        # instead of handing a pathname to FileResponse, which reopens the path when it
+        # streams. A process able to write into log_dir_resolved could otherwise rename
+        # the checked file away and put a symlink in its place between the confinement
         # check above and that later reopen (TOCTOU), causing this privileged endpoint
-        # to stream an attacker-chosen target. open_confined() resolves and opens each
-        # path component with O_NOFOLLOW relative to its already-open parent, so the fd
-        # it returns refers to exactly the inode that was validated.
+        # to stream an attacker-chosen target. On POSIX, open_confined() resolves and
+        # opens each path component with O_NOFOLLOW relative to its already-open
+        # parent, so the fd it returns refers to exactly the inode that was validated.
+        # On platforms without that atomic chaining (Windows), it falls back to a
+        # per-component symlink/reparse-point rejection that is not atomic but still
+        # rejects every reparse point present at check time.
         try:
             file_fd, file_stat = open_confined(log_dir_resolved, candidate)
         except FileNotFoundError:
             raise HTTPException(404, f"Log file not found: {filename}")
-        except UnsupportedPlatformError as e:
-            LOGGER.error("Log file download unavailable on this platform: %s", sanitize_for_log(e))
-            raise HTTPException(501, "Log file download is not supported on this platform")
         except (OSError, ValueError) as e:
             LOGGER.warning("Log file access denied for %s: %s", sanitize_for_log(filename), sanitize_for_log(e))
             raise HTTPException(403, _ACCESS_DENIED_MSG)

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -201,6 +201,7 @@ from mcpgateway.services.token_catalog_service import TokenCatalogService
 from mcpgateway.services.tool_service import ToolError, ToolLockConflictError, ToolNameConflictError, ToolNotFoundError, ToolService
 from mcpgateway.utils.create_jwt_token import create_jwt_token, get_jwt_token
 from mcpgateway.utils.error_formatter import ErrorFormatter, sanitize_validation_error_for_log
+from mcpgateway.utils.log_sanitizer import sanitize_for_log
 from mcpgateway.utils.metadata_capture import MetadataCapture
 from mcpgateway.utils.oauth_resource import parse_oauth_resource_form
 from mcpgateway.utils.orjson_response import ORJSONResponse
@@ -208,6 +209,7 @@ from mcpgateway.utils.pagination import paginate_query
 from mcpgateway.utils.passthrough_headers import PassthroughHeadersError
 from mcpgateway.utils.paths import is_path_within, open_confined
 from mcpgateway.utils.paths import resolve_root_path as _resolve_root_path
+from mcpgateway.utils.paths import UnsupportedPlatformError
 from mcpgateway.utils.security_cookies import clear_auth_cookie, CookieTooLargeError, set_auth_cookie
 from mcpgateway.utils.services_auth import encode_auth
 from mcpgateway.utils.sqlalchemy_modifier import json_contains_tag_expr
@@ -15554,11 +15556,14 @@ async def admin_get_log_file(
             file_fd, file_stat = open_confined(log_dir_resolved, candidate)
         except FileNotFoundError:
             raise HTTPException(404, f"Log file not found: {filename}")
+        except UnsupportedPlatformError as e:
+            LOGGER.error("Log file download unavailable on this platform: %s", sanitize_for_log(e))
+            raise HTTPException(501, "Log file download is not supported on this platform")
         except (OSError, ValueError) as e:
-            LOGGER.warning(f"Log file access denied for {filename}: {e}")
+            LOGGER.warning("Log file access denied for %s: %s", sanitize_for_log(filename), sanitize_for_log(e))
             raise HTTPException(403, _ACCESS_DENIED_MSG)
         except Exception as e:
-            LOGGER.error(f"Error opening log file for download: {e}")
+            LOGGER.error("Error opening log file for download: %s", sanitize_for_log(e))
             raise HTTPException(500, f"Error reading file for download: {e}")
 
         LOGGER.info(f"Serving log file download: {file_path.name} ({file_stat.st_size} bytes)")
@@ -15592,24 +15597,43 @@ async def admin_get_log_file(
         start, end = 0, file_size
         status_code = 200
         if range_header and (if_range is None or if_range in (etag, last_modified)):
-            range_match = re.fullmatch(r"bytes=(\d*)-(\d*)", range_header.strip())
-            if not range_match or not (range_match.group(1) or range_match.group(2)):
+            range_spec = range_header.strip()
+            if not range_spec.startswith("bytes="):
                 handle.close()
                 raise HTTPException(400, "Malformed Range header")
-            range_start, range_end = range_match.group(1), range_match.group(2)
-            if range_start:
-                start = int(range_start)
-                end = int(range_end) + 1 if range_end else file_size
+            spec_value = range_spec[len("bytes=") :]
+            if "," in spec_value:
+                # Multiple ranges (e.g. "bytes=0-1,4-5"): multipart/byteranges responses
+                # aren't implemented here. Per RFC 7233 SS3.1, a server may ignore a Range
+                # header it can't satisfy the way the client wants and return the full
+                # entity instead of erroring, so fall through and serve start/end as set
+                # above (0, file_size) rather than rejecting the request outright.
+                pass
             else:
-                # Suffix range (e.g. "bytes=-500"): last N bytes of the file.
-                start = max(file_size - int(range_end), 0)
-                end = file_size
-            if start >= file_size or start >= end:
-                handle.close()
-                raise HTTPException(416, "Requested range not satisfiable", headers={"Content-Range": f"bytes */{file_size}"})
-            end = min(end, file_size)
-            status_code = 206
-            headers["Content-Range"] = f"bytes {start}-{end - 1}/{file_size}"
+                range_match = re.fullmatch(r"(\d*)-(\d*)", spec_value)
+                if not range_match or not (range_match.group(1) or range_match.group(2)):
+                    handle.close()
+                    raise HTTPException(400, "Malformed Range header")
+                range_start, range_end = range_match.group(1), range_match.group(2)
+                try:
+                    if range_start:
+                        start = int(range_start)
+                        end = int(range_end) + 1 if range_end else file_size
+                    else:
+                        # Suffix range (e.g. "bytes=-500"): last N bytes of the file.
+                        start = max(file_size - int(range_end), 0)
+                        end = file_size
+                except ValueError:
+                    # int() enforces sys.get_int_max_str_digits(); an oversized numeric
+                    # range value hits that limit and must not surface as a 500.
+                    handle.close()
+                    raise HTTPException(400, "Malformed Range header")
+                if start >= file_size or start >= end:
+                    handle.close()
+                    raise HTTPException(416, "Requested range not satisfiable", headers={"Content-Range": f"bytes */{file_size}"})
+                end = min(end, file_size)
+                status_code = 206
+                headers["Content-Range"] = f"bytes {start}-{end - 1}/{file_size}"
 
         headers["Content-Length"] = str(end - start)
         handle.seek(start)

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -23,7 +23,9 @@ import binascii
 from collections import defaultdict
 import csv
 from datetime import datetime, timedelta, timezone
+from email.utils import formatdate
 from functools import lru_cache, wraps
+import hashlib
 import html
 import inspect
 import io
@@ -15479,6 +15481,7 @@ async def admin_stream_logs(
 @admin_router.get("/logs/file")
 @require_permission("admin.system_config", allow_admin_bypass=False)
 async def admin_get_log_file(
+    request: Request,
     filename: Optional[str] = None,
     user=Depends(get_current_user_with_permissions),  # pylint: disable=unused-argument
     _db: Session = Depends(get_db),
@@ -15486,6 +15489,7 @@ async def admin_get_log_file(
     """Download log file.
 
     Args:
+        request: Incoming request, used to read a conditional/range header for resumable downloads.
         filename: Specific log file to download (optional)
         user: Authenticated user
         _db: Database session for permission checks.
@@ -15563,18 +15567,73 @@ async def admin_get_log_file(
         quoted_name = urllib.parse.quote(file_path.name)
         content_disposition = f"attachment; filename*=utf-8''{quoted_name}" if quoted_name != file_path.name else f'attachment; filename="{file_path.name}"'
 
+        file_size = file_stat.st_size
+        last_modified = formatdate(file_stat.st_mtime, usegmt=True)
+        etag = f'"{hashlib.md5(f"{file_stat.st_mtime}-{file_size}".encode(), usedforsecurity=False).hexdigest()}"'  # nosec B324 - cache validator, not a security control
+
+        # file_fd was validated and opened by open_confined() above (see the comment on that
+        # call); wrap it in a Python file object now, outside the generator, so a single owner
+        # (this handle) exists regardless of whether the generator body ever runs. Starlette can
+        # cancel a StreamingResponse before its body generator is first iterated (e.g. the client
+        # disconnects immediately) -- in that case the generator's own `finally` never executes,
+        # so the BackgroundTask below is the fallback that guarantees the fd is closed. handle.close()
+        # is idempotent, so running both paths is safe.
+        handle = os.fdopen(file_fd, "rb")
+
+        headers = {
+            "Content-Disposition": content_disposition,
+            "Accept-Ranges": "bytes",
+            "Last-Modified": last_modified,
+            "ETag": etag,
+        }
+
+        range_header = request.headers.get("range")
+        if_range = request.headers.get("if-range")
+        start, end = 0, file_size
+        status_code = 200
+        if range_header and (if_range is None or if_range in (etag, last_modified)):
+            range_match = re.fullmatch(r"bytes=(\d*)-(\d*)", range_header.strip())
+            if not range_match or not (range_match.group(1) or range_match.group(2)):
+                handle.close()
+                raise HTTPException(400, "Malformed Range header")
+            range_start, range_end = range_match.group(1), range_match.group(2)
+            if range_start:
+                start = int(range_start)
+                end = int(range_end) + 1 if range_end else file_size
+            else:
+                # Suffix range (e.g. "bytes=-500"): last N bytes of the file.
+                start = max(file_size - int(range_end), 0)
+                end = file_size
+            if start >= file_size or start >= end:
+                handle.close()
+                raise HTTPException(416, "Requested range not satisfiable", headers={"Content-Range": f"bytes */{file_size}"})
+            end = min(end, file_size)
+            status_code = 206
+            headers["Content-Range"] = f"bytes {start}-{end - 1}/{file_size}"
+
+        headers["Content-Length"] = str(end - start)
+        handle.seek(start)
+        remaining = end - start
+
         def _iter_log_file():
-            with os.fdopen(file_fd, "rb") as handle:
-                while chunk := handle.read(chunk_size):
+            """Yield the requested byte range in chunks, closing the fd when done."""
+            nonlocal remaining
+            try:
+                while remaining > 0:
+                    chunk = handle.read(min(chunk_size, remaining))
+                    if not chunk:
+                        break
+                    remaining -= len(chunk)
                     yield chunk
+            finally:
+                handle.close()
 
         return StreamingResponse(
             _iter_log_file(),
+            status_code=status_code,
             media_type="application/octet-stream",
-            headers={
-                "Content-Disposition": content_disposition,
-                "Content-Length": str(file_stat.st_size),
-            },
+            headers=headers,
+            background=BackgroundTask(handle.close),
         )
 
     # List available log files

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -204,6 +204,7 @@ from mcpgateway.utils.oauth_resource import parse_oauth_resource_form
 from mcpgateway.utils.orjson_response import ORJSONResponse
 from mcpgateway.utils.pagination import paginate_query
 from mcpgateway.utils.passthrough_headers import PassthroughHeadersError
+from mcpgateway.utils.paths import is_path_within
 from mcpgateway.utils.paths import resolve_root_path as _resolve_root_path
 from mcpgateway.utils.security_cookies import clear_auth_cookie, CookieTooLargeError, set_auth_cookie
 from mcpgateway.utils.services_auth import encode_auth
@@ -15503,17 +15504,35 @@ async def admin_get_log_file(
     log_dir = Path(settings.log_folder) if settings.log_folder else Path(".")
 
     if filename:
-        # Download specific file
-        file_path = log_dir / filename
-
-        # Security: Ensure file is within log directory
-        try:
-            file_path = file_path.resolve()
-            log_dir_resolved = log_dir.resolve()
-            if not str(file_path).startswith(str(log_dir_resolved)):
-                raise HTTPException(403, _ACCESS_DENIED_MSG)
-        except Exception:
+        # Download specific file.
+        #
+        # Security: the download is confined to LOG_FOLDER by two independent checks.
+        #
+        #   1. Reject obviously hostile input *before* joining it onto the log
+        #      directory: absolute paths and drive/UNC anchors would make ``/`` discard
+        #      log_dir entirely, ``..`` segments walk upwards, and a NUL byte can
+        #      truncate the path at the OS layer.
+        #   2. Resolve the joined path (collapsing symlinks and any remaining relative
+        #      segments) and require it to stay inside the resolved log directory.
+        #
+        # Check 2 is the real control; ``is_path_within`` compares whole path
+        # components, so a sibling directory that merely shares a textual prefix with
+        # LOG_FOLDER is rejected.
+        if "\x00" in filename:
             raise HTTPException(400, "Invalid file path")
+
+        candidate = Path(filename)
+        if candidate.is_absolute() or candidate.drive or candidate.root or ".." in candidate.parts:
+            raise HTTPException(400, "Invalid file path")
+
+        try:
+            file_path = (log_dir / candidate).resolve()
+            log_dir_resolved = log_dir.resolve()
+        except (OSError, ValueError, RuntimeError):
+            raise HTTPException(400, "Invalid file path")
+
+        if not is_path_within(file_path, log_dir_resolved):
+            raise HTTPException(403, _ACCESS_DENIED_MSG)
 
         # Check if file exists
         if not file_path.exists() or not file_path.is_file():

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -204,7 +204,7 @@ from mcpgateway.utils.oauth_resource import parse_oauth_resource_form
 from mcpgateway.utils.orjson_response import ORJSONResponse
 from mcpgateway.utils.pagination import paginate_query
 from mcpgateway.utils.passthrough_headers import PassthroughHeadersError
-from mcpgateway.utils.paths import is_path_within
+from mcpgateway.utils.paths import is_path_within, open_confined
 from mcpgateway.utils.paths import resolve_root_path as _resolve_root_path
 from mcpgateway.utils.security_cookies import clear_auth_cookie, CookieTooLargeError, set_auth_cookie
 from mcpgateway.utils.services_auth import encode_auth
@@ -15534,31 +15534,48 @@ async def admin_get_log_file(
         if not is_path_within(file_path, log_dir_resolved):
             raise HTTPException(403, _ACCESS_DENIED_MSG)
 
-        # Check if file exists
-        if not file_path.exists() or not file_path.is_file():
-            raise HTTPException(404, f"Log file not found: {filename}")
-
-        # Check if it's a log file
+        # Check if it's a log file (name check only; no filesystem access yet)
         if not (file_path.suffix in [".log", ".jsonl", ".json"] or file_path.stem.startswith(Path(settings.log_file).stem)):
             raise HTTPException(403, "Not a log file")
 
-        # Return file for download using FileResponse (streams asynchronously)
-        # Pre-stat the file to catch issues early and provide Content-Length
+        # Open the verified fd directly via an openat()/O_NOFOLLOW chain instead of
+        # handing a pathname to FileResponse, which reopens the path when it streams.
+        # A process able to write into log_dir_resolved could otherwise rename the
+        # checked file away and put a symlink in its place between the confinement
+        # check above and that later reopen (TOCTOU), causing this privileged endpoint
+        # to stream an attacker-chosen target. open_confined() resolves and opens each
+        # path component with O_NOFOLLOW relative to its already-open parent, so the fd
+        # it returns refers to exactly the inode that was validated.
         try:
-            file_stat = file_path.stat()
-            LOGGER.info(f"Serving log file download: {file_path.name} ({file_stat.st_size} bytes)")
-            return FileResponse(
-                path=file_path,
-                media_type="application/octet-stream",
-                filename=file_path.name,
-                stat_result=file_stat,
-            )
+            file_fd, file_stat = open_confined(log_dir_resolved, candidate)
         except FileNotFoundError:
-            LOGGER.error(f"Log file disappeared before streaming: {filename}")
             raise HTTPException(404, f"Log file not found: {filename}")
+        except (OSError, ValueError) as e:
+            LOGGER.warning(f"Log file access denied for {filename}: {e}")
+            raise HTTPException(403, _ACCESS_DENIED_MSG)
         except Exception as e:
-            LOGGER.error(f"Error preparing file for download: {e}")
+            LOGGER.error(f"Error opening log file for download: {e}")
             raise HTTPException(500, f"Error reading file for download: {e}")
+
+        LOGGER.info(f"Serving log file download: {file_path.name} ({file_stat.st_size} bytes)")
+
+        chunk_size = 64 * 1024
+        quoted_name = urllib.parse.quote(file_path.name)
+        content_disposition = f"attachment; filename*=utf-8''{quoted_name}" if quoted_name != file_path.name else f'attachment; filename="{file_path.name}"'
+
+        def _iter_log_file():
+            with os.fdopen(file_fd, "rb") as handle:
+                while chunk := handle.read(chunk_size):
+                    yield chunk
+
+        return StreamingResponse(
+            _iter_log_file(),
+            media_type="application/octet-stream",
+            headers={
+                "Content-Disposition": content_disposition,
+                "Content-Length": str(file_stat.st_size),
+            },
+        )
 
     # List available log files
     log_files = []

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -15597,11 +15597,10 @@ async def admin_get_log_file(
         start, end = 0, file_size
         status_code = 200
         if range_header and (if_range is None or if_range in (etag, last_modified)):
-            range_spec = range_header.strip()
-            if not range_spec.startswith("bytes="):
+            range_unit, has_value, spec_value = range_header.strip().partition("=")
+            if not has_value or range_unit.strip().lower() != "bytes":
                 handle.close()
                 raise HTTPException(400, "Malformed Range header")
-            spec_value = range_spec[len("bytes=") :]
             if "," in spec_value:
                 # Multiple ranges (e.g. "bytes=0-1,4-5"): multipart/byteranges responses
                 # aren't implemented here. Per RFC 7233 SS3.1, a server may ignore a Range

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -64,6 +64,7 @@ import uuid
 
 # First-Party
 from mcpgateway.config import settings
+from mcpgateway.utils.paths import is_path_within
 
 logger = logging.getLogger(__name__)
 
@@ -2279,7 +2280,9 @@ class SecurityValidator:
 
             # Check against allowed roots
             if allowed_roots:
-                allowed = any(str(resolved_path).startswith(str(Path(root).resolve())) for root in allowed_roots)
+                # Component-aware confinement: a plain string prefix would let a sibling
+                # directory such as /srv/data_secret pass a /srv/data root.
+                allowed = any(is_path_within(resolved_path, Path(root).resolve()) for root in allowed_roots)
                 if not allowed:
                     raise ValueError("Path outside allowed roots")
 

--- a/mcpgateway/middleware/validation_middleware.py
+++ b/mcpgateway/middleware/validation_middleware.py
@@ -30,6 +30,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 # First-Party
 from mcpgateway.config import settings
 from mcpgateway.deprecations import VALIDATION_MIDDLEWARE_DEPRECATION_MESSAGE
+from mcpgateway.utils.paths import is_path_within
 
 logger = logging.getLogger(__name__)
 _VALIDATION_MIDDLEWARE_DEPRECATION_LOGGED = False
@@ -241,7 +242,9 @@ class ValidationMiddleware(BaseHTTPMiddleware):
 
             # Check against allowed roots
             if self.allowed_roots:
-                allowed = any(str(resolved_path).startswith(str(root)) for root in self.allowed_roots)
+                # Component-aware confinement: a plain string prefix would let a sibling
+                # directory such as /srv/data_secret pass a /srv/data root.
+                allowed = any(is_path_within(resolved_path, root) for root in self.allowed_roots)
                 if not allowed:
                     raise HTTPException(status_code=400, detail="invalid_path: Path outside allowed roots")
 

--- a/mcpgateway/utils/paths.py
+++ b/mcpgateway/utils/paths.py
@@ -35,6 +35,11 @@ logger = logging.getLogger(__name__)
 # ``dir_fd`` and neither ``os.O_DIRECTORY`` nor ``os.O_NOFOLLOW`` exist there.
 _SUPPORTS_CONFINED_OPENAT = hasattr(os, "O_DIRECTORY") and hasattr(os, "O_NOFOLLOW") and os.open in os.supports_dir_fd
 
+# Windows ``FILE_ATTRIBUTE_REPARSE_POINT``: set on NTFS symlinks *and* junctions.
+# ``stat.S_ISLNK`` alone misses junctions, which Windows does not report as a
+# symlink via ``lstat()`` but does mark with this attribute bit.
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+
 # Characters that must never appear in a root path — control chars, URL
 # scheme markers, query/fragment delimiters, and whitespace other than
 # leading/trailing (which is stripped before this check).
@@ -201,13 +206,15 @@ def open_confined(root: Path, relative: Path) -> "tuple[int, os.stat_result]":
     returns.
 
     On platforms without that support (Windows lacks ``dir_fd``/``O_NOFOLLOW``), this
-    function fails closed: it raises :class:`UnsupportedPlatformError` rather than
-    falling back to a per-component ``os.path.islink()`` check. An islink-then-open
-    fallback is not atomic — a process able to write into *root* can still swap the
-    checked component for a symlink between the check and the ``open()`` call — so it
-    does not actually close the TOCTOU window this function exists to close; a caller
-    that streams the returned fd under the assumption that it is TOCTOU-safe would be
-    silently wrong on those platforms.
+    falls back to :func:`_open_confined_fallback`, which rejects a symlink or NTFS
+    reparse point (junction) at any path component — including the final one — before
+    it is traversed or opened. That check and the following open are two separate
+    syscalls rather than one atomic ``openat()`` chain, so it does not close the TOCTOU
+    window the POSIX path closes: a process able to write into *root* could in
+    principle swap a checked component for a symlink/junction in the gap between them.
+    It does close the gap the previous ``resolve()`` + string-prefix check left wide
+    open (no per-component check at all), and is the best guarantee available on a
+    platform without atomic no-follow traversal.
 
     Args:
         root: Resolved, trusted directory that confines the lookup.
@@ -221,10 +228,9 @@ def open_confined(root: Path, relative: Path) -> "tuple[int, os.stat_result]":
     Raises:
         ValueError: *relative* is absolute, escapes *root*, is empty, or resolves to
             something other than a regular file.
-        OSError: A path component does not exist, is a symlink, or cannot be opened
-            (including a symlink rejected by ``O_NOFOLLOW``).
-        UnsupportedPlatformError: The current platform lacks the ``dir_fd``/``O_NOFOLLOW``
-            support this function's TOCTOU guarantee depends on.
+        OSError: A path component does not exist, is a symlink/reparse point, or
+            cannot be opened (including a symlink rejected by ``O_NOFOLLOW`` on the
+            POSIX path).
     """
     if relative.is_absolute() or relative.drive or relative.root or ".." in relative.parts:
         raise ValueError("path escapes confinement root")
@@ -232,10 +238,7 @@ def open_confined(root: Path, relative: Path) -> "tuple[int, os.stat_result]":
     if not parts:
         raise ValueError("empty path")
 
-    if not _SUPPORTS_CONFINED_OPENAT:
-        raise UnsupportedPlatformError("this platform lacks dir_fd/O_NOFOLLOW support required for TOCTOU-safe confined opens")
-
-    file_fd = _open_confined_posix(root, parts)
+    file_fd = _open_confined_posix(root, parts) if _SUPPORTS_CONFINED_OPENAT else _open_confined_fallback(root, parts)
 
     try:
         file_stat = os.fstat(file_fd)
@@ -269,10 +272,26 @@ def _open_confined_posix(root: Path, parts: "tuple[str, ...]") -> int:
         os.close(dir_fd)
 
 
-class UnsupportedPlatformError(OSError):
-    """Raised by :func:`open_confined` on platforms without atomic no-follow traversal.
+def _open_confined_fallback(root: Path, parts: "tuple[str, ...]") -> int:
+    """Open the final path component with a per-component reparse-point check.
 
-    Distinguishing this from a generic :class:`OSError` lets callers surface a
-    "not supported on this platform" response instead of conflating it with an
-    access-denied outcome (a rejected symlink, a missing file, etc.).
+    Used on platforms without ``dir_fd``/``O_NOFOLLOW`` support (Windows, and any
+    other platform where ``os.open()`` cannot chain ``openat()``-style). Each
+    component, walked from *root* down, is ``lstat()``-ed and rejected if it is a
+    symlink or — on Windows, where a junction is not reported as a symlink by
+    ``lstat()`` — a reparse point, before the next component is joined onto it or the
+    final component is opened.
+
+    This is not atomic: the check and the following join/open are separate syscalls,
+    so a process able to write into *root* could still swap a checked component for a
+    symlink/junction in the gap between them (TOCTOU). It rejects every reparse point
+    that exists at the time each component is checked, which is strictly more than the
+    single post-resolve string-prefix check this replaced ever did.
     """
+    current = root
+    for part in parts:
+        current = current / part
+        component_stat = os.lstat(current)
+        if stat_module.S_ISLNK(component_stat.st_mode) or (getattr(component_stat, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT):
+            raise OSError(f"path component is a symlink or reparse point: {part!r}")
+    return os.open(str(current), os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NONBLOCK", 0))

--- a/mcpgateway/utils/paths.py
+++ b/mcpgateway/utils/paths.py
@@ -200,11 +200,14 @@ def open_confined(root: Path, relative: Path) -> "tuple[int, os.stat_result]":
     that was validated — nothing can be swapped out from under it after this call
     returns.
 
-    On platforms without that support (Windows), :func:`_open_confined_fallback` is used
-    instead: each component is checked with ``os.path.islink()`` before descending, then
-    the final component is opened by path. This still rejects symlinks but leaves a
-    narrower race between the last ``islink()`` check and the final ``open()`` — the
-    POSIX path's atomicity guarantee does not carry over.
+    On platforms without that support (Windows lacks ``dir_fd``/``O_NOFOLLOW``), this
+    function fails closed: it raises :class:`UnsupportedPlatformError` rather than
+    falling back to a per-component ``os.path.islink()`` check. An islink-then-open
+    fallback is not atomic — a process able to write into *root* can still swap the
+    checked component for a symlink between the check and the ``open()`` call — so it
+    does not actually close the TOCTOU window this function exists to close; a caller
+    that streams the returned fd under the assumption that it is TOCTOU-safe would be
+    silently wrong on those platforms.
 
     Args:
         root: Resolved, trusted directory that confines the lookup.
@@ -220,6 +223,8 @@ def open_confined(root: Path, relative: Path) -> "tuple[int, os.stat_result]":
             something other than a regular file.
         OSError: A path component does not exist, is a symlink, or cannot be opened
             (including a symlink rejected by ``O_NOFOLLOW``).
+        UnsupportedPlatformError: The current platform lacks the ``dir_fd``/``O_NOFOLLOW``
+            support this function's TOCTOU guarantee depends on.
     """
     if relative.is_absolute() or relative.drive or relative.root or ".." in relative.parts:
         raise ValueError("path escapes confinement root")
@@ -227,10 +232,10 @@ def open_confined(root: Path, relative: Path) -> "tuple[int, os.stat_result]":
     if not parts:
         raise ValueError("empty path")
 
-    if _SUPPORTS_CONFINED_OPENAT:
-        file_fd = _open_confined_posix(root, parts)
-    else:
-        file_fd = _open_confined_fallback(root, parts)
+    if not _SUPPORTS_CONFINED_OPENAT:
+        raise UnsupportedPlatformError("this platform lacks dir_fd/O_NOFOLLOW support required for TOCTOU-safe confined opens")
+
+    file_fd = _open_confined_posix(root, parts)
 
     try:
         file_stat = os.fstat(file_fd)
@@ -255,22 +260,10 @@ def _open_confined_posix(root: Path, parts: "tuple[str, ...]") -> int:
         os.close(dir_fd)
 
 
-def _open_confined_fallback(root: Path, parts: "tuple[str, ...]") -> int:
-    """Open the final path component with a per-component symlink check. Non-POSIX fallback.
+class UnsupportedPlatformError(OSError):
+    """Raised by :func:`open_confined` on platforms without atomic no-follow traversal.
 
-    Used when the platform lacks ``dir_fd``/``O_NOFOLLOW`` support (Windows). Each
-    intermediate component is required to be a real directory, not a symlink, before
-    descending into it; the final component is required not to be a symlink before it is
-    opened by path. This is a narrower guarantee than :func:`_open_confined_posix`: a
-    rename-and-symlink race between the last check and the ``open()`` call is still
-    possible, since the checks and the open are not atomic with each other.
+    Distinguishing this from a generic :class:`OSError` lets callers surface a
+    "not supported on this platform" response instead of conflating it with an
+    access-denied outcome (a rejected symlink, a missing file, etc.).
     """
-    current = root
-    for part in parts[:-1]:
-        current = current / part
-        if os.path.islink(current) or not current.is_dir():
-            raise OSError(f"refusing to descend through non-directory or symlink: {current}")
-    final = current / parts[-1]
-    if os.path.islink(final):
-        raise OSError(f"refusing to follow symlink: {final}")
-    return os.open(str(final), os.O_RDONLY)

--- a/mcpgateway/utils/paths.py
+++ b/mcpgateway/utils/paths.py
@@ -248,14 +248,23 @@ def open_confined(root: Path, relative: Path) -> "tuple[int, os.stat_result]":
 
 
 def _open_confined_posix(root: Path, parts: "tuple[str, ...]") -> int:
-    """Open the final path component via an ``openat``/``O_NOFOLLOW`` chain. POSIX only."""
+    """Open the final path component via an ``openat``/``O_NOFOLLOW`` chain. POSIX only.
+
+    The final component is opened with ``O_NONBLOCK`` in addition to ``O_NOFOLLOW``.
+    Without it, a FIFO planted at that path would block this call — and the calling
+    event loop, since ``open_confined()`` runs synchronously — until a writer connects,
+    since a read-only open of a FIFO blocks by default. ``O_NONBLOCK`` makes that open
+    return immediately instead, and the caller's ``fstat`` check (which requires a
+    regular file) rejects the FIFO. Regular-file opens and reads are unaffected:
+    ``O_NONBLOCK`` has no effect on them.
+    """
     dir_fd = os.open(str(root), os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
     try:
         for part in parts[:-1]:
             next_fd = os.open(part, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=dir_fd)
             os.close(dir_fd)
             dir_fd = next_fd
-        return os.open(parts[-1], os.O_RDONLY | os.O_NOFOLLOW, dir_fd=dir_fd)
+        return os.open(parts[-1], os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=dir_fd)
     finally:
         os.close(dir_fd)
 

--- a/mcpgateway/utils/paths.py
+++ b/mcpgateway/utils/paths.py
@@ -3,7 +3,7 @@
 Copyright contributors to the MCP-CONTEXT-FORGE project
 SPDX-License-Identifier: Apache-2.0
 
-Shared request-path utilities for ContextForge.
+Shared request-path and filesystem-path utilities for ContextForge.
 
 Some embedded/proxy deployments do not populate ``scope["root_path"]``
 consistently.  This module provides a single canonical helper that checks
@@ -17,6 +17,7 @@ directly should use :func:`resolve_root_path` instead.
 
 # Standard
 import logging
+from pathlib import Path
 import re
 
 # Third-Party
@@ -130,3 +131,45 @@ def resolve_root_path(request: Request, *, fallback: str | None = None) -> str:
     if root_path:
         root_path = "/" + root_path.lstrip("/")
     return root_path.rstrip("/")
+
+
+def is_path_within(candidate: Path, root: Path) -> bool:
+    """Report whether *candidate* is confined to the directory tree rooted at *root*.
+
+    This is the canonical directory-confinement check for ContextForge.  It must be
+    used instead of ``str(candidate).startswith(str(root))``: a plain string prefix
+    comparison has no notion of a path-component boundary, so a *sibling* directory
+    that merely shares a textual prefix (``/srv/logs_secret`` vs. root ``/srv/logs``)
+    passes the prefix test while living entirely outside the intended tree.
+
+    Both arguments are expected to be already resolved (``Path.resolve()``) by the
+    caller, so that symlinks and ``..`` segments have been collapsed before the
+    comparison.  The check itself is purely lexical and touches no filesystem.
+
+    Args:
+        candidate: Resolved path to test.
+        root: Resolved directory that *candidate* must not escape.
+
+    Returns:
+        ``True`` when *candidate* is *root* itself or lives beneath it, else ``False``.
+
+    Examples:
+        >>> from pathlib import Path
+        >>> is_path_within(Path("/srv/logs/app.log"), Path("/srv/logs"))
+        True
+        >>> is_path_within(Path("/srv/logs"), Path("/srv/logs"))
+        True
+        >>> is_path_within(Path("/srv/logs/sub/app.log"), Path("/srv/logs"))
+        True
+
+        A sibling directory sharing a textual prefix is correctly rejected, where a
+        ``startswith`` check would wrongly allow it:
+
+        >>> str(Path("/srv/logs_secret/creds.json")).startswith(str(Path("/srv/logs")))
+        True
+        >>> is_path_within(Path("/srv/logs_secret/creds.json"), Path("/srv/logs"))
+        False
+        >>> is_path_within(Path("/etc/passwd"), Path("/srv/logs"))
+        False
+    """
+    return candidate == root or candidate.is_relative_to(root)

--- a/mcpgateway/utils/paths.py
+++ b/mcpgateway/utils/paths.py
@@ -30,6 +30,11 @@ from mcpgateway.config import settings
 
 logger = logging.getLogger(__name__)
 
+# ``dir_fd``/``O_NOFOLLOW``-based ``openat`` chaining (the TOCTOU-proof path in
+# ``open_confined()``) is POSIX-only: Windows' ``os.open()`` does not accept
+# ``dir_fd`` and neither ``os.O_DIRECTORY`` nor ``os.O_NOFOLLOW`` exist there.
+_SUPPORTS_CONFINED_OPENAT = hasattr(os, "O_DIRECTORY") and hasattr(os, "O_NOFOLLOW") and os.open in os.supports_dir_fd
+
 # Characters that must never appear in a root path — control chars, URL
 # scheme markers, query/fragment delimiters, and whitespace other than
 # leading/trailing (which is stripped before this check).
@@ -178,7 +183,7 @@ def is_path_within(candidate: Path, root: Path) -> bool:
 
 
 def open_confined(root: Path, relative: Path) -> "tuple[int, os.stat_result]":
-    """Open *relative* under *root* via an ``openat``/``O_NOFOLLOW`` chain, returning a live fd.
+    """Open *relative* under *root* confined to that tree, returning a live fd.
 
     A confinement check performed with ``Path.resolve()`` followed by a *separate*
     ``open()`` call (or, worse, a path handed to something like Starlette's
@@ -187,12 +192,19 @@ def open_confined(root: Path, relative: Path) -> "tuple[int, os.stat_result]":
     between the check and the actual open, causing the eventual read to follow the
     symlink to an arbitrary target.
 
-    This helper closes that window by resolving and opening each path component with
-    ``dir_fd`` relative to its already-open parent, with ``O_NOFOLLOW`` on every hop
-    (including the final component). A symlink anywhere along the chain raises
+    On POSIX (where ``os.open()`` supports ``dir_fd`` and ``O_DIRECTORY``/``O_NOFOLLOW``
+    exist), this closes that window completely by resolving and opening each path
+    component with ``dir_fd`` relative to its already-open parent, ``O_NOFOLLOW`` on
+    every hop including the final component. A symlink anywhere along the chain raises
     ``OSError`` instead of being followed, and the returned fd refers to the exact inode
     that was validated — nothing can be swapped out from under it after this call
     returns.
+
+    On platforms without that support (Windows), :func:`_open_confined_fallback` is used
+    instead: each component is checked with ``os.path.islink()`` before descending, then
+    the final component is opened by path. This still rejects symlinks but leaves a
+    narrower race between the last ``islink()`` check and the final ``open()`` — the
+    POSIX path's atomicity guarantee does not carry over.
 
     Args:
         root: Resolved, trusted directory that confines the lookup.
@@ -215,16 +227,10 @@ def open_confined(root: Path, relative: Path) -> "tuple[int, os.stat_result]":
     if not parts:
         raise ValueError("empty path")
 
-    nofollow = getattr(os, "O_NOFOLLOW", 0)
-    dir_fd = os.open(str(root), os.O_RDONLY | os.O_DIRECTORY | nofollow)
-    try:
-        for part in parts[:-1]:
-            next_fd = os.open(part, os.O_RDONLY | os.O_DIRECTORY | nofollow, dir_fd=dir_fd)
-            os.close(dir_fd)
-            dir_fd = next_fd
-        file_fd = os.open(parts[-1], os.O_RDONLY | nofollow, dir_fd=dir_fd)
-    finally:
-        os.close(dir_fd)
+    if _SUPPORTS_CONFINED_OPENAT:
+        file_fd = _open_confined_posix(root, parts)
+    else:
+        file_fd = _open_confined_fallback(root, parts)
 
     try:
         file_stat = os.fstat(file_fd)
@@ -234,3 +240,37 @@ def open_confined(root: Path, relative: Path) -> "tuple[int, os.stat_result]":
         os.close(file_fd)
         raise
     return file_fd, file_stat
+
+
+def _open_confined_posix(root: Path, parts: "tuple[str, ...]") -> int:
+    """Open the final path component via an ``openat``/``O_NOFOLLOW`` chain. POSIX only."""
+    dir_fd = os.open(str(root), os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        for part in parts[:-1]:
+            next_fd = os.open(part, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=dir_fd)
+            os.close(dir_fd)
+            dir_fd = next_fd
+        return os.open(parts[-1], os.O_RDONLY | os.O_NOFOLLOW, dir_fd=dir_fd)
+    finally:
+        os.close(dir_fd)
+
+
+def _open_confined_fallback(root: Path, parts: "tuple[str, ...]") -> int:
+    """Open the final path component with a per-component symlink check. Non-POSIX fallback.
+
+    Used when the platform lacks ``dir_fd``/``O_NOFOLLOW`` support (Windows). Each
+    intermediate component is required to be a real directory, not a symlink, before
+    descending into it; the final component is required not to be a symlink before it is
+    opened by path. This is a narrower guarantee than :func:`_open_confined_posix`: a
+    rename-and-symlink race between the last check and the ``open()`` call is still
+    possible, since the checks and the open are not atomic with each other.
+    """
+    current = root
+    for part in parts[:-1]:
+        current = current / part
+        if os.path.islink(current) or not current.is_dir():
+            raise OSError(f"refusing to descend through non-directory or symlink: {current}")
+    final = current / parts[-1]
+    if os.path.islink(final):
+        raise OSError(f"refusing to follow symlink: {final}")
+    return os.open(str(final), os.O_RDONLY)

--- a/mcpgateway/utils/paths.py
+++ b/mcpgateway/utils/paths.py
@@ -17,8 +17,10 @@ directly should use :func:`resolve_root_path` instead.
 
 # Standard
 import logging
+import os
 from pathlib import Path
 import re
+import stat as stat_module
 
 # Third-Party
 from fastapi import Request
@@ -173,3 +175,62 @@ def is_path_within(candidate: Path, root: Path) -> bool:
         False
     """
     return candidate == root or candidate.is_relative_to(root)
+
+
+def open_confined(root: Path, relative: Path) -> "tuple[int, os.stat_result]":
+    """Open *relative* under *root* via an ``openat``/``O_NOFOLLOW`` chain, returning a live fd.
+
+    A confinement check performed with ``Path.resolve()`` followed by a *separate*
+    ``open()`` call (or, worse, a path handed to something like Starlette's
+    ``FileResponse`` that reopens it later) is subject to a TOCTOU race: a process able
+    to write into *root* can rename the checked file away and put a symlink in its place
+    between the check and the actual open, causing the eventual read to follow the
+    symlink to an arbitrary target.
+
+    This helper closes that window by resolving and opening each path component with
+    ``dir_fd`` relative to its already-open parent, with ``O_NOFOLLOW`` on every hop
+    (including the final component). A symlink anywhere along the chain raises
+    ``OSError`` instead of being followed, and the returned fd refers to the exact inode
+    that was validated — nothing can be swapped out from under it after this call
+    returns.
+
+    Args:
+        root: Resolved, trusted directory that confines the lookup.
+        relative: Path relative to *root* to open. Must not be absolute, escape *root*
+            via ``..``, or be empty.
+
+    Returns:
+        A ``(fd, stat_result)`` tuple for the opened regular file. Callers own the fd
+        and must close it (e.g. via ``os.fdopen(fd, "rb")`` as a context manager).
+
+    Raises:
+        ValueError: *relative* is absolute, escapes *root*, is empty, or resolves to
+            something other than a regular file.
+        OSError: A path component does not exist, is a symlink, or cannot be opened
+            (including a symlink rejected by ``O_NOFOLLOW``).
+    """
+    if relative.is_absolute() or relative.drive or relative.root or ".." in relative.parts:
+        raise ValueError("path escapes confinement root")
+    parts = relative.parts
+    if not parts:
+        raise ValueError("empty path")
+
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    dir_fd = os.open(str(root), os.O_RDONLY | os.O_DIRECTORY | nofollow)
+    try:
+        for part in parts[:-1]:
+            next_fd = os.open(part, os.O_RDONLY | os.O_DIRECTORY | nofollow, dir_fd=dir_fd)
+            os.close(dir_fd)
+            dir_fd = next_fd
+        file_fd = os.open(parts[-1], os.O_RDONLY | nofollow, dir_fd=dir_fd)
+    finally:
+        os.close(dir_fd)
+
+    try:
+        file_stat = os.fstat(file_fd)
+        if not stat_module.S_ISREG(file_stat.st_mode):
+            raise ValueError("not a regular file")
+    except BaseException:
+        os.close(file_fd)
+        raise
+    return file_fd, file_stat

--- a/tests/unit/mcpgateway/middleware/test_validation_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_validation_middleware.py
@@ -444,6 +444,29 @@ class TestValidationMiddleware:
             assert exc_info.value.status_code == 400
             assert "Path outside allowed roots" in exc_info.value.detail
 
+    def test_validate_resource_path_rejects_sibling_prefix_root(self):
+        """A sibling directory sharing an allowed root's textual prefix is rejected.
+
+        ``/safe_secret`` shares a string prefix with the ``/safe`` root, so a
+        ``startswith`` confinement check would wrongly allow it.
+        """
+        with patch("mcpgateway.middleware.validation_middleware.settings") as mock_settings:
+            mock_settings.experimental_validate_io = True
+            mock_settings.validation_strict = True
+            mock_settings.sanitize_output = False
+            mock_settings.allowed_roots = ["/safe"]
+            mock_settings.dangerous_patterns = []
+            mock_settings.max_path_depth = 100
+
+            middleware = ValidationMiddleware(app=None)
+
+            for candidate in ("/safe_secret/creds.json", "/safex", "/safe-backup/file.txt"):
+                with pytest.raises(HTTPException) as exc_info:
+                    middleware.validate_resource_path(candidate)
+
+                assert exc_info.value.status_code == 400
+                assert "Path outside allowed roots" in exc_info.value.detail
+
     def test_validate_resource_path_allowed_root_returns_resolved_path(self, tmp_path):
         """Test valid paths under allowed roots return resolved path."""
         with patch("mcpgateway.middleware.validation_middleware.settings") as mock_settings:

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -14949,12 +14949,9 @@ class TestAdminAdditionalCoverage:
         assert excinfo.value.status_code == 403
 
     @patch("mcpgateway.admin.settings")
-    async def test_admin_get_log_file_unsupported_platform_returns_501(self, mock_settings, tmp_path, mock_db):
-        """A platform without dir_fd/O_NOFOLLOW support must surface as 501, not 403/500,
-        so it's distinguishable from an access-denied or unexpected-error outcome."""
-        # First-Party
-        from mcpgateway.utils.paths import UnsupportedPlatformError
-
+    async def test_admin_get_log_file_falls_back_without_dir_fd_support(self, mock_settings, tmp_path, mock_db):
+        """On a platform without dir_fd/O_NOFOLLOW support (e.g. Windows), the download must
+        still succeed via the per-component reparse-point-checking fallback rather than fail."""
         log_dir = tmp_path
         (log_dir / "app.log").write_text("main")
 
@@ -14963,10 +14960,27 @@ class TestAdminAdditionalCoverage:
         mock_settings.log_folder = str(log_dir)
         mock_settings.log_rotation_enabled = False
 
-        with patch("mcpgateway.admin.open_confined", side_effect=UnsupportedPlatformError("no dir_fd support")):
+        with patch("mcpgateway.utils.paths._SUPPORTS_CONFINED_OPENAT", False):
+            response = await admin_get_log_file(request=SimpleNamespace(headers={}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+        assert response.status_code == 200
+
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_fallback_rejects_symlinked_file(self, mock_settings, tmp_path, mock_db):
+        """The non-atomic fallback used without dir_fd/O_NOFOLLOW support must still reject a
+        symlink at the final path component, even though the check isn't atomic with the open."""
+        log_dir = tmp_path
+        (log_dir / "real.log").write_text("main")
+        (log_dir / "app.log").symlink_to(log_dir / "real.log")
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        with patch("mcpgateway.utils.paths._SUPPORTS_CONFINED_OPENAT", False):
             with pytest.raises(HTTPException) as excinfo:
                 await admin_get_log_file(request=SimpleNamespace(headers={}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
-        assert excinfo.value.status_code == 501
+        assert excinfo.value.status_code == 403
 
     @patch("mcpgateway.admin.settings")
     async def test_admin_get_log_file_multi_range_falls_back_to_full_response(self, mock_settings, tmp_path, mock_db):

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -8647,7 +8647,7 @@ class TestAdminNonMemberTeamBanner:
 class TestSetLoggingService:
     """Test the logging service setup functionality."""
 
-    def test_set_logging_service(self):
+    def test_set_logging_service(self, monkeypatch):
         """Test setting the logging service."""
         # First-Party
         from mcpgateway.admin import set_logging_service
@@ -8657,13 +8657,20 @@ class TestSetLoggingService:
         mock_logger = MagicMock()
         mock_service.get_logger.return_value = mock_logger
 
+        # First-Party
+        from mcpgateway import admin
+
+        # admin.LOGGER/admin.logging_service are module globals; set_logging_service()
+        # reassigns them directly rather than through a fixture, so without monkeypatch
+        # restoring them, every test running later in this session would keep seeing
+        # this MagicMock logger instead of a real one.
+        monkeypatch.setattr(admin, "logging_service", admin.logging_service, raising=False)
+        monkeypatch.setattr(admin, "LOGGER", admin.LOGGER, raising=False)
+
         # Set the logging service
         set_logging_service(mock_service)
 
         # Verify global variables were updated
-        # First-Party
-        from mcpgateway import admin
-
         assert admin.logging_service == mock_service
         assert admin.LOGGER == mock_logger
         mock_service.get_logger.assert_called_with("mcpgateway.admin")
@@ -14708,6 +14715,23 @@ class TestAdminAdditionalCoverage:
             await admin_get_log_file(request=SimpleNamespace(headers={"range": "not-a-range"}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
         assert excinfo.value.status_code == 400
 
+    @pytest.mark.parametrize("unit", ["Bytes", "BYTES", "  bytes  "])
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_range_unit_is_case_insensitive(self, mock_settings, unit, tmp_path, mock_db):
+        """The range-unit token is case-insensitive per RFC 7233; the FileResponse
+        parser this handler replaced accepted ``Bytes=``/``BYTES=`` and so must this one."""
+        log_dir = tmp_path
+        (log_dir / "app.log").write_text("0123456789")
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        response = await admin_get_log_file(request=SimpleNamespace(headers={"range": f"{unit}=2-5"}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+        assert response.status_code == 206
+        assert response.headers.get("content-range") == "bytes 2-5/10"
+
     @patch("mcpgateway.admin.settings")
     async def test_admin_get_log_file_rejects_unsatisfiable_range(self, mock_settings, tmp_path, mock_db):
         """A range starting beyond EOF is rejected with 416 and a Content-Range header."""
@@ -14981,10 +15005,17 @@ class TestAdminAdditionalCoverage:
     @patch("mcpgateway.admin.settings")
     async def test_admin_get_log_file_access_denied_log_is_sanitized(self, mock_settings, tmp_path, mock_db, caplog):
         """Filename and exception text logged on access-denied must have CR/LF stripped so
-        a crafted filename can't forge additional log lines."""
+        a crafted filename can't forge additional log lines.
+
+        The filename itself carries the CR/LF payload (a real symlink is created on disk
+        using that literal name), so this test actually exercises sanitize_for_log(): it
+        would fail if sanitization were removed, unlike asserting against a plain filename
+        that never contained a control character to begin with.
+        """
         log_dir = tmp_path
         (log_dir / "real.log").write_text("main")
-        (log_dir / "app.log").symlink_to(log_dir / "real.log")
+        crlf_name = "app.log\r\nCRITICAL:root:INJECTED-FAKE-LOG-LINE"
+        (log_dir / crlf_name).symlink_to(log_dir / "real.log")
 
         mock_settings.log_to_file = True
         mock_settings.log_file = "app.log"
@@ -14993,11 +15024,14 @@ class TestAdminAdditionalCoverage:
 
         with caplog.at_level(logging.WARNING, logger="mcpgateway.admin"):
             with pytest.raises(HTTPException):
-                await admin_get_log_file(request=SimpleNamespace(headers={}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+                await admin_get_log_file(request=SimpleNamespace(headers={}), filename=crlf_name, user={"email": "admin@example.com", "db": mock_db})
 
+        assert caplog.records
         for record in caplog.records:
-            assert "\n" not in record.getMessage()
-            assert "\r" not in record.getMessage()
+            message = record.getMessage()
+            assert "\n" not in message
+            assert "\r" not in message
+            assert "INJECTED-FAKE-LOG-LINE" in message
 
     async def test_admin_export_logs_json_csv(self, mock_db, monkeypatch):
         """Export logs in JSON and CSV formats."""

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -14746,7 +14746,7 @@ class TestAdminAdditionalCoverage:
 
     @patch("mcpgateway.admin.settings")
     async def test_admin_get_log_file_download_stat_filenotfound(self, mock_settings, tmp_path, mock_db):
-        """Cover FileNotFoundError handling when preparing the FileResponse."""
+        """Cover FileNotFoundError handling when opening the verified fd."""
         log_dir = tmp_path
         (log_dir / "app.log").write_text("main")
 
@@ -14755,14 +14755,14 @@ class TestAdminAdditionalCoverage:
         mock_settings.log_folder = str(log_dir)
         mock_settings.log_rotation_enabled = False
 
-        with patch("mcpgateway.admin.FileResponse", side_effect=FileNotFoundError("gone")):
+        with patch("mcpgateway.admin.open_confined", side_effect=FileNotFoundError("gone")):
             with pytest.raises(HTTPException) as excinfo:
                 await admin_get_log_file(filename="app.log", user={"email": "admin@example.com", "db": mock_db})
         assert excinfo.value.status_code == 404
 
     @patch("mcpgateway.admin.settings")
     async def test_admin_get_log_file_download_stat_generic_error(self, mock_settings, tmp_path, mock_db):
-        """Cover generic exception handling when preparing the FileResponse."""
+        """Cover generic exception handling when opening the verified fd."""
         log_dir = tmp_path
         (log_dir / "app.log").write_text("main")
 
@@ -14771,10 +14771,26 @@ class TestAdminAdditionalCoverage:
         mock_settings.log_folder = str(log_dir)
         mock_settings.log_rotation_enabled = False
 
-        with patch("mcpgateway.admin.FileResponse", side_effect=RuntimeError("boom")):
+        with patch("mcpgateway.admin.open_confined", side_effect=RuntimeError("boom")):
             with pytest.raises(HTTPException) as excinfo:
                 await admin_get_log_file(filename="app.log", user={"email": "admin@example.com", "db": mock_db})
         assert excinfo.value.status_code == 500
+
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_rejects_symlinked_file(self, mock_settings, tmp_path, mock_db):
+        """A symlink at the final path component must be rejected even when its target is inside the log dir."""
+        log_dir = tmp_path
+        (log_dir / "real.log").write_text("main")
+        (log_dir / "app.log").symlink_to(log_dir / "real.log")
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        with pytest.raises(HTTPException) as excinfo:
+            await admin_get_log_file(filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+        assert excinfo.value.status_code == 403
 
     async def test_admin_export_logs_json_csv(self, mock_db, monkeypatch):
         """Export logs in JSON and CSV formats."""

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -6807,7 +6807,7 @@ class TestLoggingEndpoints:
         # Mock file exists and reading
         with patch("pathlib.Path.exists", return_value=True), patch("pathlib.Path.stat") as mock_stat, patch("builtins.open", mock_open(read_data=b"test log content")):
             mock_stat.return_value.st_size = 16
-            result = await admin_get_log_file(filename=None, user={"email": "test-user", "db": mock_db})
+            result = await admin_get_log_file(request=SimpleNamespace(headers={}), filename=None, user={"email": "test-user", "db": mock_db})
 
             assert isinstance(result, Response)
             assert result.media_type == "application/octet-stream"
@@ -6823,7 +6823,7 @@ class TestLoggingEndpoints:
         mock_settings.log_file = None
 
         with pytest.raises(HTTPException) as excinfo:
-            await admin_get_log_file(filename=None, user={"email": "test-user@example.com", "db": mock_db})
+            await admin_get_log_file(request=SimpleNamespace(headers={}), filename=None, user={"email": "test-user@example.com", "db": mock_db})
 
         assert excinfo.value.status_code == 404
         assert "File logging is not enabled" in str(excinfo.value.detail)
@@ -14562,7 +14562,7 @@ class TestAdminAdditionalCoverage:
         mock_settings.log_folder = str(log_dir)
         mock_settings.log_rotation_enabled = True
 
-        result = await admin_get_log_file(filename=None, user={"email": "admin@example.com", "db": mock_db})
+        result = await admin_get_log_file(request=SimpleNamespace(headers={}), filename=None, user={"email": "admin@example.com", "db": mock_db})
 
         assert result["total"] >= 2
         types = {entry["type"] for entry in result["files"]}
@@ -14585,7 +14585,7 @@ class TestAdminAdditionalCoverage:
         monkeypatch.setattr("mcpgateway.admin.Path.glob", _boom, raising=True)
 
         with pytest.raises(HTTPException) as excinfo:
-            await admin_get_log_file(filename=None, user={"email": "admin@example.com", "db": mock_db})
+            await admin_get_log_file(request=SimpleNamespace(headers={}), filename=None, user={"email": "admin@example.com", "db": mock_db})
         assert excinfo.value.status_code == 500
 
     @patch("mcpgateway.admin.settings")
@@ -14600,7 +14600,7 @@ class TestAdminAdditionalCoverage:
         mock_settings.log_folder = str(log_dir)
         mock_settings.log_rotation_enabled = False
 
-        result = await admin_get_log_file(filename=None, user={"email": "admin@example.com", "db": mock_db})
+        result = await admin_get_log_file(request=SimpleNamespace(headers={}), filename=None, user={"email": "admin@example.com", "db": mock_db})
         types = {entry["type"] for entry in result["files"]}
         assert "main" in types
         assert "storage" in types
@@ -14618,7 +14618,7 @@ class TestAdminAdditionalCoverage:
         mock_settings.log_folder = str(log_dir)
         mock_settings.log_rotation_enabled = False
 
-        response = await admin_get_log_file(filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+        response = await admin_get_log_file(request=SimpleNamespace(headers={}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
         assert isinstance(response, Response)
         assert "app.log" in response.headers.get("content-disposition", "")
 
@@ -14628,16 +14628,143 @@ class TestAdminAdditionalCoverage:
 
         # Rejected by the pre-join input filter (".." component), before any path join.
         with pytest.raises(HTTPException) as excinfo:
-            await admin_get_log_file(filename="../secret.log", user={"email": "admin@example.com", "db": mock_db})
+            await admin_get_log_file(request=SimpleNamespace(headers={}), filename="../secret.log", user={"email": "admin@example.com", "db": mock_db})
         assert excinfo.value.status_code == 400
 
         with pytest.raises(HTTPException) as excinfo:
-            await admin_get_log_file(filename="missing.log", user={"email": "admin@example.com", "db": mock_db})
+            await admin_get_log_file(request=SimpleNamespace(headers={}), filename="missing.log", user={"email": "admin@example.com", "db": mock_db})
         assert excinfo.value.status_code == 404
 
         with pytest.raises(HTTPException) as excinfo:
-            await admin_get_log_file(filename="random.txt", user={"email": "admin@example.com", "db": mock_db})
+            await admin_get_log_file(request=SimpleNamespace(headers={}), filename="random.txt", user={"email": "admin@example.com", "db": mock_db})
         assert excinfo.value.status_code == 403
+
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_sets_cache_validator_headers(self, mock_settings, tmp_path, mock_db):
+        """A full download must carry Accept-Ranges/ETag/Last-Modified like the FileResponse it replaced."""
+        log_dir = tmp_path
+        (log_dir / "app.log").write_text("main")
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        response = await admin_get_log_file(request=SimpleNamespace(headers={}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+        assert response.status_code == 200
+        assert response.headers.get("accept-ranges") == "bytes"
+        assert response.headers.get("etag", "").startswith('"')
+        assert response.headers.get("last-modified")
+        assert response.headers.get("content-length") == "4"
+
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_serves_single_range(self, mock_settings, tmp_path, mock_db):
+        """A Range request returns a 206 partial response with the requested byte span."""
+        log_dir = tmp_path
+        (log_dir / "app.log").write_text("0123456789")
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        response = await admin_get_log_file(request=SimpleNamespace(headers={"range": "bytes=2-5"}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+        assert response.status_code == 206
+        assert response.headers.get("content-range") == "bytes 2-5/10"
+        assert response.headers.get("content-length") == "4"
+        body = b"".join([chunk async for chunk in response.body_iterator])
+        assert body == b"2345"
+
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_serves_suffix_range(self, mock_settings, tmp_path, mock_db):
+        """A suffix range (``bytes=-N``) returns the last N bytes of the file."""
+        log_dir = tmp_path
+        (log_dir / "app.log").write_text("0123456789")
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        response = await admin_get_log_file(request=SimpleNamespace(headers={"range": "bytes=-3"}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+        assert response.status_code == 206
+        assert response.headers.get("content-range") == "bytes 7-9/10"
+        body = b"".join([chunk async for chunk in response.body_iterator])
+        assert body == b"789"
+
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_rejects_malformed_range(self, mock_settings, tmp_path, mock_db):
+        """A syntactically invalid Range header is rejected with 400, not silently ignored."""
+        log_dir = tmp_path
+        (log_dir / "app.log").write_text("0123456789")
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        with pytest.raises(HTTPException) as excinfo:
+            await admin_get_log_file(request=SimpleNamespace(headers={"range": "not-a-range"}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+        assert excinfo.value.status_code == 400
+
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_rejects_unsatisfiable_range(self, mock_settings, tmp_path, mock_db):
+        """A range starting beyond EOF is rejected with 416 and a Content-Range header."""
+        log_dir = tmp_path
+        (log_dir / "app.log").write_text("0123456789")
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        with pytest.raises(HTTPException) as excinfo:
+            await admin_get_log_file(request=SimpleNamespace(headers={"range": "bytes=100-200"}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+        assert excinfo.value.status_code == 416
+        assert excinfo.value.headers.get("Content-Range") == "bytes */10"
+
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_ignores_stale_if_range(self, mock_settings, tmp_path, mock_db):
+        """An If-Range validator that doesn't match the current ETag/Last-Modified falls back to a full 200 response."""
+        log_dir = tmp_path
+        (log_dir / "app.log").write_text("0123456789")
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        response = await admin_get_log_file(
+            request=SimpleNamespace(headers={"range": "bytes=2-5", "if-range": '"stale-etag"'}), filename="app.log", user={"email": "admin@example.com", "db": mock_db}
+        )
+        assert response.status_code == 200
+        body = b"".join([chunk async for chunk in response.body_iterator])
+        assert body == b"0123456789"
+
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_background_task_closes_fd_if_never_streamed(self, mock_settings, tmp_path, mock_db):
+        """The fd opened by open_confined() must be closed even if the StreamingResponse
+        body generator is cancelled before it is ever iterated (e.g. an immediate client
+        disconnect) — this is what the BackgroundTask fallback covers."""
+        log_dir = tmp_path
+        (log_dir / "app.log").write_text("main")
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        response = await admin_get_log_file(request=SimpleNamespace(headers={}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+
+        # Simulate Starlette cancelling the response before the generator is ever advanced:
+        # the background task is the only thing that runs.
+        assert response.background is not None
+        await response.background()
+
+        with pytest.raises(ValueError):
+            # The underlying fd is closed; reading through the (now-closed) handle raises.
+            async for _ in response.body_iterator:
+                pass
 
     @patch("mcpgateway.admin.settings")
     async def test_admin_get_log_file_rejects_sibling_prefix_directory(self, mock_settings, tmp_path, mock_db):
@@ -14662,7 +14789,7 @@ class TestAdminAdditionalCoverage:
 
         for payload in ("../logs_secret/creds.json", "sub/../../logs_secret/creds.json", "./../logs_secret/creds.json"):
             with pytest.raises(HTTPException) as excinfo:
-                await admin_get_log_file(filename=payload, user={"email": "admin@example.com", "db": mock_db})
+                await admin_get_log_file(request=SimpleNamespace(headers={}), filename=payload, user={"email": "admin@example.com", "db": mock_db})
             assert excinfo.value.status_code == 400
             assert canary not in str(excinfo.value.detail)
 
@@ -14694,7 +14821,7 @@ class TestAdminAdditionalCoverage:
         mock_settings.log_rotation_enabled = False
 
         with pytest.raises(HTTPException) as excinfo:
-            await admin_get_log_file(filename="escape.json", user={"email": "admin@example.com", "db": mock_db})
+            await admin_get_log_file(request=SimpleNamespace(headers={}), filename="escape.json", user={"email": "admin@example.com", "db": mock_db})
         assert excinfo.value.status_code == 403
 
     @patch("mcpgateway.admin.settings")
@@ -14711,7 +14838,7 @@ class TestAdminAdditionalCoverage:
 
         for payload in ("/etc/passwd", "/var/log/syslog.log", "app.log\x00.png"):
             with pytest.raises(HTTPException) as excinfo:
-                await admin_get_log_file(filename=payload, user={"email": "admin@example.com", "db": mock_db})
+                await admin_get_log_file(request=SimpleNamespace(headers={}), filename=payload, user={"email": "admin@example.com", "db": mock_db})
             assert excinfo.value.status_code == 400
 
     @patch("mcpgateway.admin.settings")
@@ -14728,7 +14855,7 @@ class TestAdminAdditionalCoverage:
 
         with patch("mcpgateway.admin.Path.resolve", side_effect=OSError("ELOOP")):
             with pytest.raises(HTTPException) as excinfo:
-                await admin_get_log_file(filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+                await admin_get_log_file(request=SimpleNamespace(headers={}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
         assert excinfo.value.status_code == 400
 
     @patch("mcpgateway.admin.settings")
@@ -14744,7 +14871,7 @@ class TestAdminAdditionalCoverage:
         mock_settings.log_folder = str(log_dir)
         mock_settings.log_rotation_enabled = False
 
-        response = await admin_get_log_file(filename="archive/app.log", user={"email": "admin@example.com", "db": mock_db})
+        response = await admin_get_log_file(request=SimpleNamespace(headers={}), filename="archive/app.log", user={"email": "admin@example.com", "db": mock_db})
         assert isinstance(response, Response)
         assert "app.log" in response.headers.get("content-disposition", "")
 
@@ -14761,7 +14888,7 @@ class TestAdminAdditionalCoverage:
 
         with patch("mcpgateway.admin.open_confined", side_effect=FileNotFoundError("gone")):
             with pytest.raises(HTTPException) as excinfo:
-                await admin_get_log_file(filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+                await admin_get_log_file(request=SimpleNamespace(headers={}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
         assert excinfo.value.status_code == 404
 
     @patch("mcpgateway.admin.settings")
@@ -14777,7 +14904,7 @@ class TestAdminAdditionalCoverage:
 
         with patch("mcpgateway.admin.open_confined", side_effect=RuntimeError("boom")):
             with pytest.raises(HTTPException) as excinfo:
-                await admin_get_log_file(filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+                await admin_get_log_file(request=SimpleNamespace(headers={}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
         assert excinfo.value.status_code == 500
 
     @patch("mcpgateway.admin.settings")
@@ -14793,7 +14920,7 @@ class TestAdminAdditionalCoverage:
         mock_settings.log_rotation_enabled = False
 
         with pytest.raises(HTTPException) as excinfo:
-            await admin_get_log_file(filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+            await admin_get_log_file(request=SimpleNamespace(headers={}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
         assert excinfo.value.status_code == 403
 
     async def test_admin_export_logs_json_csv(self, mock_db, monkeypatch):

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -14622,6 +14622,7 @@ class TestAdminAdditionalCoverage:
         assert isinstance(response, Response)
         assert "app.log" in response.headers.get("content-disposition", "")
 
+        # Rejected by the pre-join input filter (".." component), before any path join.
         with pytest.raises(HTTPException) as excinfo:
             await admin_get_log_file(filename="../secret.log", user={"email": "admin@example.com", "db": mock_db})
         assert excinfo.value.status_code == 400
@@ -14633,6 +14634,115 @@ class TestAdminAdditionalCoverage:
         with pytest.raises(HTTPException) as excinfo:
             await admin_get_log_file(filename="random.txt", user={"email": "admin@example.com", "db": mock_db})
         assert excinfo.value.status_code == 403
+
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_rejects_sibling_prefix_directory(self, mock_settings, tmp_path, mock_db):
+        """A sibling directory sharing LOG_FOLDER's textual prefix must not be readable.
+
+        ``/tmp/.../logs_secret`` shares a string prefix with the ``/tmp/.../logs`` log
+        directory, so a ``startswith`` confinement check would wrongly allow it.
+        """
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        (log_dir / "app.log").write_text("main")
+
+        secret_dir = tmp_path / "logs_secret"
+        secret_dir.mkdir()
+        canary = "CANARY-SIBLING-PREFIX-MUST-NOT-LEAK"
+        (secret_dir / "creds.json").write_text('{"secret": "%s"}' % canary)  # pragma: allowlist secret
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        for payload in ("../logs_secret/creds.json", "sub/../../logs_secret/creds.json", "./../logs_secret/creds.json"):
+            with pytest.raises(HTTPException) as excinfo:
+                await admin_get_log_file(filename=payload, user={"email": "admin@example.com", "db": mock_db})
+            assert excinfo.value.status_code == 400
+            assert canary not in str(excinfo.value.detail)
+
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_rejects_symlink_escaping_log_dir(self, mock_settings, tmp_path, mock_db):
+        """A symlink planted inside LOG_FOLDER must not read outside it.
+
+        This payload contains no ``..`` component, so it reaches the post-resolve
+        confinement check — the primary control — rather than the input filter.
+        """
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        (log_dir / "app.log").write_text("main")
+
+        secret_dir = tmp_path / "logs_secret"
+        secret_dir.mkdir()
+        secret_file = secret_dir / "creds.json"
+        secret_file.write_text('{"secret": "CANARY-SYMLINK-MUST-NOT-LEAK"}')  # pragma: allowlist secret
+
+        link = log_dir / "escape.json"
+        try:
+            link.symlink_to(secret_file)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform")
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        with pytest.raises(HTTPException) as excinfo:
+            await admin_get_log_file(filename="escape.json", user={"email": "admin@example.com", "db": mock_db})
+        assert excinfo.value.status_code == 403
+
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_rejects_absolute_and_nul_filenames(self, mock_settings, tmp_path, mock_db):
+        """Absolute paths and NUL bytes are rejected before the path join."""
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        (log_dir / "app.log").write_text("main")
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        for payload in ("/etc/passwd", "/var/log/syslog.log", "app.log\x00.png"):
+            with pytest.raises(HTTPException) as excinfo:
+                await admin_get_log_file(filename=payload, user={"email": "admin@example.com", "db": mock_db})
+            assert excinfo.value.status_code == 400
+
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_resolve_failure_is_rejected(self, mock_settings, tmp_path, mock_db):
+        """An OS-level failure while resolving the path is rejected, never allowed through."""
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        (log_dir / "app.log").write_text("main")
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        with patch("mcpgateway.admin.Path.resolve", side_effect=OSError("ELOOP")):
+            with pytest.raises(HTTPException) as excinfo:
+                await admin_get_log_file(filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+        assert excinfo.value.status_code == 400
+
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_allows_nested_file_inside_log_dir(self, mock_settings, tmp_path, mock_db):
+        """Confinement must not be so tight that legitimate nested log files break."""
+        log_dir = tmp_path / "logs"
+        (log_dir / "archive").mkdir(parents=True)
+        (log_dir / "app.log").write_text("main")
+        (log_dir / "archive" / "app.log").write_text("rotated")
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        response = await admin_get_log_file(filename="archive/app.log", user={"email": "admin@example.com", "db": mock_db})
+        assert isinstance(response, Response)
+        assert "app.log" in response.headers.get("content-disposition", "")
 
     @patch("mcpgateway.admin.settings")
     async def test_admin_get_log_file_download_stat_filenotfound(self, mock_settings, tmp_path, mock_db):

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -12,6 +12,7 @@ Enhanced with additional test cases for better coverage.
 # Standard
 from datetime import datetime, timedelta, timezone
 import json
+import logging
 from pathlib import Path
 import socket
 from types import SimpleNamespace
@@ -14922,6 +14923,81 @@ class TestAdminAdditionalCoverage:
         with pytest.raises(HTTPException) as excinfo:
             await admin_get_log_file(request=SimpleNamespace(headers={}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
         assert excinfo.value.status_code == 403
+
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_unsupported_platform_returns_501(self, mock_settings, tmp_path, mock_db):
+        """A platform without dir_fd/O_NOFOLLOW support must surface as 501, not 403/500,
+        so it's distinguishable from an access-denied or unexpected-error outcome."""
+        # First-Party
+        from mcpgateway.utils.paths import UnsupportedPlatformError
+
+        log_dir = tmp_path
+        (log_dir / "app.log").write_text("main")
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        with patch("mcpgateway.admin.open_confined", side_effect=UnsupportedPlatformError("no dir_fd support")):
+            with pytest.raises(HTTPException) as excinfo:
+                await admin_get_log_file(request=SimpleNamespace(headers={}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+        assert excinfo.value.status_code == 501
+
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_multi_range_falls_back_to_full_response(self, mock_settings, tmp_path, mock_db):
+        """A multi-range Range header (multipart/byteranges) isn't implemented; the handler
+        must serve the full entity as 200 rather than reject it with 400."""
+        log_dir = tmp_path
+        (log_dir / "app.log").write_text("0123456789")
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        response = await admin_get_log_file(request=SimpleNamespace(headers={"range": "bytes=0-1,4-5"}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+        assert response.status_code == 200
+        body = b"".join([chunk async for chunk in response.body_iterator])
+        assert body == b"0123456789"
+
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_rejects_oversized_range_value(self, mock_settings, tmp_path, mock_db):
+        """A Range value with more digits than Python's int/str conversion limit allows
+        must be rejected with 400, not escape as an uncaught 500 with the fd left open."""
+        log_dir = tmp_path
+        (log_dir / "app.log").write_text("0123456789")
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        oversized = "9" * 5000
+        with pytest.raises(HTTPException) as excinfo:
+            await admin_get_log_file(request=SimpleNamespace(headers={"range": f"bytes={oversized}-"}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+        assert excinfo.value.status_code == 400
+
+    @patch("mcpgateway.admin.settings")
+    async def test_admin_get_log_file_access_denied_log_is_sanitized(self, mock_settings, tmp_path, mock_db, caplog):
+        """Filename and exception text logged on access-denied must have CR/LF stripped so
+        a crafted filename can't forge additional log lines."""
+        log_dir = tmp_path
+        (log_dir / "real.log").write_text("main")
+        (log_dir / "app.log").symlink_to(log_dir / "real.log")
+
+        mock_settings.log_to_file = True
+        mock_settings.log_file = "app.log"
+        mock_settings.log_folder = str(log_dir)
+        mock_settings.log_rotation_enabled = False
+
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.admin"):
+            with pytest.raises(HTTPException):
+                await admin_get_log_file(request=SimpleNamespace(headers={}), filename="app.log", user={"email": "admin@example.com", "db": mock_db})
+
+        for record in caplog.records:
+            assert "\n" not in record.getMessage()
+            assert "\r" not in record.getMessage()
 
     async def test_admin_export_logs_json_csv(self, mock_db, monkeypatch):
         """Export logs in JSON and CSV formats."""

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -14622,6 +14622,10 @@ class TestAdminAdditionalCoverage:
         assert isinstance(response, Response)
         assert "app.log" in response.headers.get("content-disposition", "")
 
+        # Consume the streamed body to exercise the fd-backed generator itself.
+        body = b"".join([chunk async for chunk in response.body_iterator])
+        assert body == b"main"
+
         # Rejected by the pre-join input filter (".." component), before any path join.
         with pytest.raises(HTTPException) as excinfo:
             await admin_get_log_file(filename="../secret.log", user={"email": "admin@example.com", "db": mock_db})

--- a/tests/unit/mcpgateway/utils/test_paths.py
+++ b/tests/unit/mcpgateway/utils/test_paths.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock
 import pytest
 
 # First-Party
-from mcpgateway.utils.paths import is_path_within, open_confined, replace_api_path_alias, resolve_root_path
+from mcpgateway.utils.paths import is_path_within, open_confined, replace_api_path_alias, resolve_root_path, UnsupportedPlatformError
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -403,62 +403,34 @@ def test_open_confined_rejects_directory_as_final_component(tmp_path: Path) -> N
 
 
 # ---------------------------------------------------------------------------
-# open_confined — non-POSIX fallback (platforms without dir_fd/O_NOFOLLOW, e.g. Windows)
+# open_confined — fails closed on platforms without dir_fd/O_NOFOLLOW (e.g. Windows)
 # ---------------------------------------------------------------------------
 
 
-def test_open_confined_dispatches_to_fallback_when_dir_fd_unsupported(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """When the platform lacks dir_fd/O_NOFOLLOW support, open_confined() must not raise
-    AttributeError from os.O_DIRECTORY/os.O_NOFOLLOW — it should use the fallback opener."""
+def test_open_confined_fails_closed_when_dir_fd_unsupported(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the platform lacks dir_fd/O_NOFOLLOW support, open_confined() must raise
+    UnsupportedPlatformError rather than fall back to a non-atomic islink()-then-open
+    check, which would silently reintroduce the TOCTOU race this function exists to close."""
     monkeypatch.setattr("mcpgateway.utils.paths._SUPPORTS_CONFINED_OPENAT", False)
     (tmp_path / "app.log").write_text("hello")
 
-    fd, st = open_confined(tmp_path, Path("app.log"))
-    try:
-        assert os.read(fd, 5) == b"hello"
-        assert st.st_size == 5
-    finally:
-        os.close(fd)
+    with pytest.raises(UnsupportedPlatformError):
+        open_confined(tmp_path, Path("app.log"))
 
 
-def test_open_confined_fallback_opens_nested_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Fallback opener walks intermediate directory components too."""
+def test_open_confined_unsupported_platform_error_is_an_os_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """UnsupportedPlatformError must subclass OSError so existing broad `except OSError`
+    call sites still catch it, even though admin.py distinguishes it for a 501 response."""
     monkeypatch.setattr("mcpgateway.utils.paths._SUPPORTS_CONFINED_OPENAT", False)
-    (tmp_path / "archive").mkdir()
-    (tmp_path / "archive" / "app.log").write_text("rotated")
-
-    fd, st = open_confined(tmp_path, Path("archive/app.log"))
-    try:
-        assert os.read(fd, st.st_size) == b"rotated"
-    finally:
-        os.close(fd)
-
-
-def test_open_confined_fallback_rejects_symlinked_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Fallback opener still rejects a symlink at the final component."""
-    monkeypatch.setattr("mcpgateway.utils.paths._SUPPORTS_CONFINED_OPENAT", False)
-    (tmp_path / "real.log").write_text("main")
-    (tmp_path / "app.log").symlink_to(tmp_path / "real.log")
 
     with pytest.raises(OSError):
         open_confined(tmp_path, Path("app.log"))
 
 
-def test_open_confined_fallback_rejects_symlinked_parent_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Fallback opener still rejects a symlinked intermediate directory component."""
-    monkeypatch.setattr("mcpgateway.utils.paths._SUPPORTS_CONFINED_OPENAT", False)
-    real_dir = tmp_path / "real_archive"
-    real_dir.mkdir()
-    (real_dir / "app.log").write_text("rotated")
-    (tmp_path / "archive").symlink_to(real_dir)
-
-    with pytest.raises(OSError):
-        open_confined(tmp_path, Path("archive/app.log"))
-
-
-def test_open_confined_fallback_rejects_missing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Fallback opener raises FileNotFoundError for a nonexistent file, same as the POSIX path."""
+def test_open_confined_fails_closed_before_touching_filesystem(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The platform check fails closed even for a target that doesn't exist — callers must
+    not be able to distinguish "unsupported platform" from filesystem state via timing/errors."""
     monkeypatch.setattr("mcpgateway.utils.paths._SUPPORTS_CONFINED_OPENAT", False)
 
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(UnsupportedPlatformError):
         open_confined(tmp_path, Path("does-not-exist.log"))

--- a/tests/unit/mcpgateway/utils/test_paths.py
+++ b/tests/unit/mcpgateway/utils/test_paths.py
@@ -3,7 +3,7 @@
 Copyright contributors to the MCP-CONTEXT-FORGE project
 SPDX-License-Identifier: Apache-2.0
 
-Unit tests for shared request-path utilities.
+Unit tests for shared request-path and filesystem-path utilities.
 
 Covers the canonical root-path resolution helper introduced in issue #3298
 to replace the 12 direct ``request.scope.get("root_path", "")`` call sites
@@ -14,13 +14,14 @@ that lacked the ``settings.app_root_path`` fallback.
 from __future__ import annotations
 
 # Standard
+from pathlib import Path
 from unittest.mock import MagicMock
 
 # Third-Party
 import pytest
 
 # First-Party
-from mcpgateway.utils.paths import replace_api_path_alias, resolve_root_path
+from mcpgateway.utils.paths import is_path_within, replace_api_path_alias, resolve_root_path
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -255,3 +256,63 @@ def test_encoded_chars_preserved() -> None:
     """Percent-encoded characters are preserved as-is."""
     req = _make_request("/app%2Fpath")
     assert resolve_root_path(req) == "/app%2Fpath"
+
+
+# ---------------------------------------------------------------------------
+# is_path_within
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        "/srv/logs",
+        "/srv/logs/app.log",
+        "/srv/logs/archive/app.log",
+    ],
+)
+def test_is_path_within_accepts_root_and_descendants(candidate: str) -> None:
+    """The root itself and anything beneath it are confined."""
+    assert is_path_within(Path(candidate), Path("/srv/logs")) is True
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        "/srv/logs_secret/creds.json",
+        "/srv/logsx",
+        "/srv/logs-backup/app.log",
+        "/srv",
+        "/etc/passwd",
+    ],
+)
+def test_is_path_within_rejects_paths_outside_root(candidate: str) -> None:
+    """Anything outside the root tree is rejected, siblings included."""
+    assert is_path_within(Path(candidate), Path("/srv/logs")) is False
+
+
+def test_is_path_within_rejects_sibling_that_startswith_would_allow() -> None:
+    """Regression: the sibling-prefix case a ``startswith`` check gets wrong.
+
+    ``/srv/logs_secret/creds.json`` shares a textual prefix with ``/srv/logs`` but
+    lives outside that directory tree.
+    """
+    candidate = Path("/srv/logs_secret/creds.json")
+    root = Path("/srv/logs")
+
+    # The insecure check this helper replaces would allow it...
+    assert str(candidate).startswith(str(root)) is True
+    # ...while component-aware confinement correctly denies it.
+    assert is_path_within(candidate, root) is False
+
+
+def test_is_path_within_resolves_relative_escape(tmp_path: Path) -> None:
+    """A ``..`` escape collapsed by ``resolve()`` is rejected."""
+    root = (tmp_path / "logs").resolve()
+    root.mkdir()
+    (tmp_path / "logs_secret").mkdir()
+
+    escaped = (root / ".." / "logs_secret" / "creds.json").resolve()
+
+    assert str(escaped).startswith(str(root)) is True
+    assert is_path_within(escaped, root) is False

--- a/tests/unit/mcpgateway/utils/test_paths.py
+++ b/tests/unit/mcpgateway/utils/test_paths.py
@@ -400,3 +400,65 @@ def test_open_confined_rejects_directory_as_final_component(tmp_path: Path) -> N
 
     with pytest.raises(ValueError):
         open_confined(tmp_path, Path("subdir"))
+
+
+# ---------------------------------------------------------------------------
+# open_confined — non-POSIX fallback (platforms without dir_fd/O_NOFOLLOW, e.g. Windows)
+# ---------------------------------------------------------------------------
+
+
+def test_open_confined_dispatches_to_fallback_when_dir_fd_unsupported(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the platform lacks dir_fd/O_NOFOLLOW support, open_confined() must not raise
+    AttributeError from os.O_DIRECTORY/os.O_NOFOLLOW — it should use the fallback opener."""
+    monkeypatch.setattr("mcpgateway.utils.paths._SUPPORTS_CONFINED_OPENAT", False)
+    (tmp_path / "app.log").write_text("hello")
+
+    fd, st = open_confined(tmp_path, Path("app.log"))
+    try:
+        assert os.read(fd, 5) == b"hello"
+        assert st.st_size == 5
+    finally:
+        os.close(fd)
+
+
+def test_open_confined_fallback_opens_nested_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fallback opener walks intermediate directory components too."""
+    monkeypatch.setattr("mcpgateway.utils.paths._SUPPORTS_CONFINED_OPENAT", False)
+    (tmp_path / "archive").mkdir()
+    (tmp_path / "archive" / "app.log").write_text("rotated")
+
+    fd, st = open_confined(tmp_path, Path("archive/app.log"))
+    try:
+        assert os.read(fd, st.st_size) == b"rotated"
+    finally:
+        os.close(fd)
+
+
+def test_open_confined_fallback_rejects_symlinked_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fallback opener still rejects a symlink at the final component."""
+    monkeypatch.setattr("mcpgateway.utils.paths._SUPPORTS_CONFINED_OPENAT", False)
+    (tmp_path / "real.log").write_text("main")
+    (tmp_path / "app.log").symlink_to(tmp_path / "real.log")
+
+    with pytest.raises(OSError):
+        open_confined(tmp_path, Path("app.log"))
+
+
+def test_open_confined_fallback_rejects_symlinked_parent_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fallback opener still rejects a symlinked intermediate directory component."""
+    monkeypatch.setattr("mcpgateway.utils.paths._SUPPORTS_CONFINED_OPENAT", False)
+    real_dir = tmp_path / "real_archive"
+    real_dir.mkdir()
+    (real_dir / "app.log").write_text("rotated")
+    (tmp_path / "archive").symlink_to(real_dir)
+
+    with pytest.raises(OSError):
+        open_confined(tmp_path, Path("archive/app.log"))
+
+
+def test_open_confined_fallback_rejects_missing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fallback opener raises FileNotFoundError for a nonexistent file, same as the POSIX path."""
+    monkeypatch.setattr("mcpgateway.utils.paths._SUPPORTS_CONFINED_OPENAT", False)
+
+    with pytest.raises(FileNotFoundError):
+        open_confined(tmp_path, Path("does-not-exist.log"))

--- a/tests/unit/mcpgateway/utils/test_paths.py
+++ b/tests/unit/mcpgateway/utils/test_paths.py
@@ -388,6 +388,12 @@ def test_open_confined_rejects_dotdot_escape(tmp_path: Path) -> None:
         open_confined(tmp_path, Path("../secret.txt"))
 
 
+def test_open_confined_rejects_empty_path(tmp_path: Path) -> None:
+    """An empty relative path (no components at all) is rejected before any open()."""
+    with pytest.raises(ValueError):
+        open_confined(tmp_path, Path(""))
+
+
 def test_open_confined_rejects_directory_as_final_component(tmp_path: Path) -> None:
     """The final component must be a regular file, not a directory."""
     (tmp_path / "subdir").mkdir()

--- a/tests/unit/mcpgateway/utils/test_paths.py
+++ b/tests/unit/mcpgateway/utils/test_paths.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock
 import pytest
 
 # First-Party
-from mcpgateway.utils.paths import is_path_within, open_confined, replace_api_path_alias, resolve_root_path, UnsupportedPlatformError
+from mcpgateway.utils.paths import is_path_within, open_confined, replace_api_path_alias, resolve_root_path
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -423,34 +423,56 @@ def test_open_confined_rejects_fifo_without_blocking(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# open_confined — fails closed on platforms without dir_fd/O_NOFOLLOW (e.g. Windows)
+# open_confined — fallback path used on platforms without dir_fd/O_NOFOLLOW (e.g. Windows)
 # ---------------------------------------------------------------------------
 
 
-def test_open_confined_fails_closed_when_dir_fd_unsupported(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """When the platform lacks dir_fd/O_NOFOLLOW support, open_confined() must raise
-    UnsupportedPlatformError rather than fall back to a non-atomic islink()-then-open
-    check, which would silently reintroduce the TOCTOU race this function exists to close."""
+def test_open_confined_fallback_opens_regular_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without dir_fd/O_NOFOLLOW support, open_confined() must still succeed for a
+    legitimate file via the per-component reparse-point-checking fallback."""
     monkeypatch.setattr("mcpgateway.utils.paths._SUPPORTS_CONFINED_OPENAT", False)
     (tmp_path / "app.log").write_text("hello")
 
-    with pytest.raises(UnsupportedPlatformError):
-        open_confined(tmp_path, Path("app.log"))
+    fd, file_stat = open_confined(tmp_path, Path("app.log"))
+    try:
+        assert os.pread(fd, file_stat.st_size, 0) == b"hello"
+    finally:
+        os.close(fd)
 
 
-def test_open_confined_unsupported_platform_error_is_an_os_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """UnsupportedPlatformError must subclass OSError so existing broad `except OSError`
-    call sites still catch it, even though admin.py distinguishes it for a 501 response."""
+def test_open_confined_fallback_opens_nested_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The fallback must walk and open intermediate directory components too, not just
+    the final one."""
     monkeypatch.setattr("mcpgateway.utils.paths._SUPPORTS_CONFINED_OPENAT", False)
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "app.log").write_text("nested")
+
+    fd, file_stat = open_confined(tmp_path, Path("sub/app.log"))
+    try:
+        assert os.pread(fd, file_stat.st_size, 0) == b"nested"
+    finally:
+        os.close(fd)
+
+
+def test_open_confined_fallback_rejects_symlinked_final_component(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The fallback is not atomic, but it must still reject a symlink at the final
+    path component checked at open time."""
+    monkeypatch.setattr("mcpgateway.utils.paths._SUPPORTS_CONFINED_OPENAT", False)
+    (tmp_path / "real.log").write_text("hello")
+    (tmp_path / "app.log").symlink_to(tmp_path / "real.log")
 
     with pytest.raises(OSError):
         open_confined(tmp_path, Path("app.log"))
 
 
-def test_open_confined_fails_closed_before_touching_filesystem(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """The platform check fails closed even for a target that doesn't exist — callers must
-    not be able to distinguish "unsupported platform" from filesystem state via timing/errors."""
+def test_open_confined_fallback_rejects_symlinked_intermediate_component(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A symlinked intermediate directory component must be rejected too, not just the
+    final component."""
     monkeypatch.setattr("mcpgateway.utils.paths._SUPPORTS_CONFINED_OPENAT", False)
+    outside = tmp_path.with_name(tmp_path.name + "_outside")
+    outside.mkdir()
+    (outside / "app.log").write_text("secret")
+    (tmp_path / "sub").symlink_to(outside)
 
-    with pytest.raises(UnsupportedPlatformError):
-        open_confined(tmp_path, Path("does-not-exist.log"))
+    with pytest.raises(OSError):
+        open_confined(tmp_path, Path("sub/app.log"))

--- a/tests/unit/mcpgateway/utils/test_paths.py
+++ b/tests/unit/mcpgateway/utils/test_paths.py
@@ -402,6 +402,26 @@ def test_open_confined_rejects_directory_as_final_component(tmp_path: Path) -> N
         open_confined(tmp_path, Path("subdir"))
 
 
+@pytest.mark.timeout(5)
+def test_open_confined_rejects_fifo_without_blocking(tmp_path: Path) -> None:
+    """A FIFO at the final component must be rejected, not block the caller.
+
+    A plain ``O_RDONLY`` open of a FIFO blocks until a writer connects. Since
+    open_confined() runs synchronously from an async admin handler, that would hang
+    the event loop indefinitely; ``O_NONBLOCK`` on the final open must prevent it.
+    This test has no writer for the FIFO, so it would hang (and time out) if that
+    flag regressed.
+    """
+    if not hasattr(os, "mkfifo"):
+        pytest.skip("FIFOs are not supported on this platform")
+
+    fifo_path = tmp_path / "blocked.log"
+    os.mkfifo(fifo_path)
+
+    with pytest.raises(ValueError):
+        open_confined(tmp_path, Path("blocked.log"))
+
+
 # ---------------------------------------------------------------------------
 # open_confined — fails closed on platforms without dir_fd/O_NOFOLLOW (e.g. Windows)
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/utils/test_paths.py
+++ b/tests/unit/mcpgateway/utils/test_paths.py
@@ -14,6 +14,7 @@ that lacked the ``settings.app_root_path`` fallback.
 from __future__ import annotations
 
 # Standard
+import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -21,7 +22,7 @@ from unittest.mock import MagicMock
 import pytest
 
 # First-Party
-from mcpgateway.utils.paths import is_path_within, replace_api_path_alias, resolve_root_path
+from mcpgateway.utils.paths import is_path_within, open_confined, replace_api_path_alias, resolve_root_path
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -316,3 +317,80 @@ def test_is_path_within_resolves_relative_escape(tmp_path: Path) -> None:
 
     assert str(escaped).startswith(str(root)) is True
     assert is_path_within(escaped, root) is False
+
+
+# ---------------------------------------------------------------------------
+# open_confined
+# ---------------------------------------------------------------------------
+
+
+def test_open_confined_opens_regular_file(tmp_path: Path) -> None:
+    """A regular file directly under root is opened and its fd/stat returned."""
+    (tmp_path / "app.log").write_text("hello")
+
+    fd, st = open_confined(tmp_path, Path("app.log"))
+    try:
+        assert os.read(fd, 5) == b"hello"
+        assert st.st_size == 5
+    finally:
+        os.close(fd)
+
+
+def test_open_confined_opens_nested_file(tmp_path: Path) -> None:
+    """Intermediate directory components are walked via dir_fd, not string joins."""
+    (tmp_path / "archive").mkdir()
+    (tmp_path / "archive" / "app.log").write_text("rotated")
+
+    fd, st = open_confined(tmp_path, Path("archive/app.log"))
+    try:
+        assert os.read(fd, st.st_size) == b"rotated"
+    finally:
+        os.close(fd)
+
+
+def test_open_confined_rejects_missing_file(tmp_path: Path) -> None:
+    """A nonexistent file raises FileNotFoundError, not a generic OSError."""
+    with pytest.raises(FileNotFoundError):
+        open_confined(tmp_path, Path("does-not-exist.log"))
+
+
+def test_open_confined_rejects_symlinked_file(tmp_path: Path) -> None:
+    """The final component is opened with O_NOFOLLOW: a symlink is rejected even
+    when its target is inside root, closing the TOCTOU window a resolve()-then-open()
+    check leaves open (target can be swapped between the check and the reopen)."""
+    (tmp_path / "real.log").write_text("main")
+    (tmp_path / "app.log").symlink_to(tmp_path / "real.log")
+
+    with pytest.raises(OSError):
+        open_confined(tmp_path, Path("app.log"))
+
+
+def test_open_confined_rejects_symlinked_parent_dir(tmp_path: Path) -> None:
+    """A symlinked intermediate directory component is rejected too, not just the leaf."""
+    real_dir = tmp_path / "real_archive"
+    real_dir.mkdir()
+    (real_dir / "app.log").write_text("rotated")
+    (tmp_path / "archive").symlink_to(real_dir)
+
+    with pytest.raises(OSError):
+        open_confined(tmp_path, Path("archive/app.log"))
+
+
+def test_open_confined_rejects_absolute_path(tmp_path: Path) -> None:
+    """Absolute input is rejected before any filesystem access."""
+    with pytest.raises(ValueError):
+        open_confined(tmp_path, Path("/etc/passwd"))
+
+
+def test_open_confined_rejects_dotdot_escape(tmp_path: Path) -> None:
+    """A ``..`` component is rejected before any filesystem access."""
+    with pytest.raises(ValueError):
+        open_confined(tmp_path, Path("../secret.txt"))
+
+
+def test_open_confined_rejects_directory_as_final_component(tmp_path: Path) -> None:
+    """The final component must be a regular file, not a directory."""
+    (tmp_path / "subdir").mkdir()
+
+    with pytest.raises(ValueError):
+        open_confined(tmp_path, Path("subdir"))

--- a/tests/unit/mcpgateway/validation/test_validators_advanced.py
+++ b/tests/unit/mcpgateway/validation/test_validators_advanced.py
@@ -961,6 +961,21 @@ class TestValidatePath:
         with pytest.raises(ValueError, match="outside allowed roots"):
             SecurityValidator.validate_path("/tmp/file", allowed_roots=["/nonexistent/root"])
 
+    def test_allowed_roots_rejects_sibling_prefix_directory(self):
+        """A sibling directory sharing an allowed root's textual prefix is rejected.
+
+        ``/tmp/data_secret`` shares a string prefix with the ``/tmp/data`` root, so a
+        ``startswith`` confinement check would wrongly allow it.
+        """
+        for candidate in ("/tmp/data_secret/creds.json", "/tmp/datax", "/tmp/data-backup/file.txt"):
+            with pytest.raises(ValueError, match="outside allowed roots"):
+                SecurityValidator.validate_path(candidate, allowed_roots=["/tmp/data"])
+
+    def test_allowed_roots_permits_root_and_descendants(self):
+        """The allowed root itself and paths beneath it remain valid."""
+        assert SecurityValidator.validate_path("/tmp/data", allowed_roots=["/tmp/data"])
+        assert SecurityValidator.validate_path("/tmp/data/sub/file.txt", allowed_roots=["/tmp/data"])
+
     def test_valid_path(self):
         result = SecurityValidator.validate_path("/tmp")
         assert result  # Returns resolved path


### PR DESCRIPTION
The admin log-download handler (`GET /admin/logs/file`) confined the requested file to `LOG_FOLDER` using `str(file_path).startswith(str(log_dir))`. A string prefix comparison has no notion of a path-component boundary, so a sibling directory that merely shares a textual prefix with the log directory — `/srv/logs_secret` against a `/srv/logs` root — passes the check while living entirely outside the intended tree.

## Changes

- Adds `is_path_within()` to `mcpgateway/utils/paths.py` as the canonical directory-confinement check, and uses it in `admin_get_log_file`. Absolute paths, drive/UNC anchors, NUL bytes and `..` components are now rejected before the path join as defence-in-depth; the post-resolve `is_path_within` check is the actual control.
- Moves the 403 raise out of the surrounding `try` block. A bare `except Exception` was catching the `HTTPException` and rewriting every denial into a 400, leaving the 403 branch unreachable.
- Two other call sites carried the same prefix-comparison pattern and now use the shared helper: `ValidationMiddleware.validate_resource_path` and `SecurityValidator.validate_path`. Both apply only when `allowed_roots` is configured, and the change is deny-only.

Happy to split the two validator call sites into their own PR if reviewers would rather keep this one scoped to `admin.py`.

## Tests

New regression coverage in `tests/unit/mcpgateway/test_admin.py`, `tests/unit/mcpgateway/utils/test_paths.py`, `tests/unit/mcpgateway/middleware/test_validation_middleware.py` and `tests/unit/mcpgateway/validation/test_validators_advanced.py`:

- sibling-prefix directory (`logs` vs `logs_secret`) — the case a `startswith` check gets wrong
- symlink inside the log directory pointing outside it, which contains no `..` and so exercises the post-resolve check rather than the input filter
- absolute paths and NUL bytes
- resolve failure surfaces as a rejection rather than falling through
- nested legitimate log files still download, so confinement is not over-tight
- deny-path tests for both validator call sites with an absolute sibling-prefix root

Each new deny-path test was confirmed to fail against the unpatched code before the fix was applied.
