### PR TITLE
fix: harden local A2A egress handling

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-24T15:09:48Z",
+  "generated_at": "2026-08-25T12:48:17Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -3936,7 +3936,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 776,
+        "line_number": 785,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -66,6 +66,15 @@ from mcpgateway.config import settings
 
 logger = logging.getLogger(__name__)
 
+
+def pin_url_to_resolved_ip(url: str, resolved_ip: str) -> str:
+    """Return ``url`` with only its network location replaced by ``resolved_ip``."""
+    parsed = urlparse(url)
+    pinned_host = f"[{resolved_ip}]" if ":" in resolved_ip else resolved_ip
+    pinned_netloc = f"{pinned_host}:{parsed.port}" if parsed.port is not None else pinned_host
+    return parsed._replace(netloc=pinned_netloc).geturl()
+
+
 # ============================================================================
 # Precompiled regex patterns (compiled once at module load for performance)
 # ============================================================================

--- a/mcpgateway/services/a2a_protocol.py
+++ b/mcpgateway/services/a2a_protocol.py
@@ -21,6 +21,8 @@ from cryptography.exceptions import InvalidTag
 import orjson
 
 # First-Party
+from mcpgateway.common.validators import pin_url_to_resolved_ip, SecurityValidator
+from mcpgateway.config import settings
 from mcpgateway.utils.services_auth import decode_auth
 from mcpgateway.utils.url_auth import apply_query_param_auth, sanitize_url_for_logging
 
@@ -77,7 +79,12 @@ _V1_TASK_STATE_TO_LEGACY = {
 
 @dataclass(frozen=True)
 class PreparedA2AInvocation:
-    """Prepared outbound A2A invocation payload."""
+    """Prepared outbound A2A invocation payload.
+
+    ``endpoint_url`` is the logical target after auth/query preparation. Do not
+    post it directly; local A2A egress must pass through
+    ``prepare_pinned_a2a_invocation`` immediately before outbound I/O.
+    """
 
     endpoint_url: str
     sanitized_endpoint_url: str
@@ -90,6 +97,53 @@ class PreparedA2AInvocation:
     base_endpoint_url: Optional[str] = None
     auth_value_encrypted: Optional[str] = None
     auth_query_params_encrypted: Optional[Dict[str, str]] = None
+
+
+@dataclass(frozen=True)
+class PinnedA2AInvocation:
+    """A prepared A2A invocation target after connection-time URL pinning."""
+
+    endpoint_url: str
+    headers: Dict[str, str]
+    extensions: Dict[str, str]
+
+
+async def prepare_pinned_a2a_invocation(prepared: PreparedA2AInvocation, field_name: str = "A2A agent URL") -> PinnedA2AInvocation:
+    """Validate and IP-pin a prepared A2A invocation immediately before I/O.
+
+    Args:
+        prepared: Prepared A2A invocation containing the final logical URL.
+        field_name: Human-readable URL field name for validator errors.
+
+    Returns:
+        Pinned outbound URL, headers, and HTTPX request extensions.
+
+    Raises:
+        ValueError: If the outbound A2A target is blocked by URL policy.
+    """
+    try:
+        validated_target = await SecurityValidator.validate_url_for_connection_pinning(prepared.endpoint_url, field_name)
+    except ValueError as exc:
+        raise ValueError("Outbound A2A URL blocked by URL policy") from exc
+
+    resolved_ip = validated_target.get("resolved_ip")
+    original_hostname = validated_target.get("hostname")
+    original_authority = validated_target.get("original_authority")
+    if settings.ssrf_protection_enabled and not (resolved_ip and original_hostname and original_authority):
+        raise ValueError("Outbound A2A URL blocked by URL policy")
+
+    if not (resolved_ip and original_hostname and original_authority):
+        return PinnedA2AInvocation(endpoint_url=prepared.endpoint_url, headers=dict(prepared.headers), extensions={})
+
+    headers = {key: value for key, value in prepared.headers.items() if key.lower() != "host"}
+    # HTTPX/httpcore maps Host to HTTP/2 :authority, so keep the original
+    # authority here even when the pinned URL uses the resolved IP.
+    headers["Host"] = original_authority
+    return PinnedA2AInvocation(
+        endpoint_url=pin_url_to_resolved_ip(prepared.endpoint_url, resolved_ip),
+        headers=headers,
+        extensions={"sni_hostname": original_hostname},
+    )
 
 
 def _strip_version_prefix(version: str) -> str:

--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -28,6 +28,7 @@ from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.cache.a2a_stats_cache import a2a_stats_cache
+from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.db import A2AAgent as DbA2AAgent
 from mcpgateway.db import A2AAgentMetric, A2AAgentMetricsHourly, A2ATask, EmailTeam
@@ -37,9 +38,10 @@ from mcpgateway.db import Tool as DbTool
 from mcpgateway.observability import create_span, set_span_attribute, set_span_error
 from mcpgateway.plugins.utils import build_request_extensions, record_plugin_metrics
 from mcpgateway.schemas import A2AAgentAggregateMetrics, A2AAgentCreate, A2AAgentMetrics, A2AAgentRead, A2AAgentUpdate
-from mcpgateway.services.a2a_protocol import prepare_a2a_invocation
+from mcpgateway.services.a2a_protocol import prepare_a2a_invocation, prepare_pinned_a2a_invocation
 from mcpgateway.services.base_service import BaseService
 from mcpgateway.services.encryption_service import protect_oauth_config_for_storage
+from mcpgateway.services.http_client_service import get_isolated_http_client
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.metrics_cleanup_service import delete_metrics_in_batches, pause_rollup_during_purge
 from mcpgateway.services.observability_service import current_trace_id, ObservabilityService
@@ -2423,12 +2425,24 @@ class A2AAgentService(BaseService):
                     },
                 )
 
-                # Make HTTP request to the agent endpoint using shared HTTP client
-                # First-Party
-                from mcpgateway.services.http_client_service import get_http_client  # pylint: disable=import-outside-toplevel
+                try:
+                    pinned = await prepare_pinned_a2a_invocation(prepared)
+                except ValueError as validation_error:
+                    error_message = "Outbound A2A URL blocked by URL policy"
+                    validation_reason = SecurityValidator.sanitize_log_message(str(validation_error.__cause__ or validation_error))
+                    logger.warning(
+                        "A2A outbound URL validation failed for agent %s (%s), url=%s, correlation_id=%s: %s",
+                        SecurityValidator.sanitize_log_message(agent_name),
+                        SecurityValidator.sanitize_log_message(agent_id),
+                        prepared.sanitized_endpoint_url,
+                        correlation_id,
+                        validation_reason,
+                    )
+                    raise A2AAgentError(error_message) from validation_error
 
-                client = await get_http_client()
-                http_response = await client.post(prepared.endpoint_url, json=prepared.request_data, headers=prepared.headers)
+                # Make HTTP request to the agent endpoint using an isolated SSRF-sensitive client.
+                async with get_isolated_http_client(follow_redirects=False) as client:
+                    http_response = await client.post(pinned.endpoint_url, json=prepared.request_data, headers=pinned.headers, extensions=pinned.extensions)
                 status_code = http_response.status_code
                 response_json = http_response.json() if status_code == 200 else None
                 response_text = http_response.text

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -63,7 +63,7 @@ from mcpgateway.common.models import Gateway as PydanticGateway
 from mcpgateway.common.models import TextContent
 from mcpgateway.common.models import Tool as PydanticTool
 from mcpgateway.common.models import ToolResult
-from mcpgateway.common.validators import SecurityValidator
+from mcpgateway.common.validators import pin_url_to_resolved_ip, SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.db import A2AAgent as DbA2AAgent
 from mcpgateway.db import fresh_db_session
@@ -75,11 +75,12 @@ from mcpgateway.observability import create_child_span, create_span, inject_trac
 from mcpgateway.plugins.control_telemetry import ControlTelemetryAccumulator, record_control_telemetry
 from mcpgateway.plugins.utils import build_request_extensions, record_plugin_metrics
 from mcpgateway.schemas import AuthenticationValues, ToolCreate, ToolMetrics, ToolRead, ToolUpdate, TopPerformer
-from mcpgateway.services.a2a_protocol import prepare_a2a_invocation
+from mcpgateway.services.a2a_protocol import prepare_a2a_invocation, prepare_pinned_a2a_invocation
 from mcpgateway.services.audit_trail_service import get_audit_trail_service
 from mcpgateway.services.base_service import BaseService
 from mcpgateway.services.content_security import ContentSecurityService
 from mcpgateway.services.event_service import EventService
+from mcpgateway.services.http_client_service import get_isolated_http_client
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.mcp_apps import is_app_visible_tool, is_model_visible_tool, mcp_apps_enabled, optional_extension_metadata, validate_extension_metadata
 from mcpgateway.services.metrics_buffer_service import get_metrics_buffer_service
@@ -232,14 +233,6 @@ def _sync_meta_traceparent(
     updated_meta = dict(meta_data or {})
     updated_meta["traceparent"] = traceparent
     return updated_meta
-
-
-def _pin_url_to_resolved_ip(url: str, resolved_ip: str) -> str:
-    """Return ``url`` with only its network location replaced by ``resolved_ip``."""
-    parsed = urlparse(url)
-    pinned_host = f"[{resolved_ip}]" if ":" in resolved_ip else resolved_ip
-    pinned_netloc = f"{pinned_host}:{parsed.port}" if parsed.port is not None else pinned_host
-    return parsed._replace(netloc=pinned_netloc).geturl()
 
 
 def _build_pinned_rest_http_client() -> ResilientHttpClient:
@@ -5739,7 +5732,7 @@ class ToolService(BaseService):
                         )
                         raise ToolInvocationError("Outbound URL blocked by URL policy")
                     if resolved_ip and original_hostname and original_authority:
-                        final_url = _pin_url_to_resolved_ip(final_url, resolved_ip)
+                        final_url = pin_url_to_resolved_ip(final_url, resolved_ip)
                         headers = {hk: hv for hk, hv in headers.items() if hk.lower() != "host"}
                         headers["Host"] = original_authority
                         rest_request_extensions["sni_hostname"] = original_hostname
@@ -6701,10 +6694,31 @@ class ToolService(BaseService):
                         logger.info("Calling A2A agent '%s' at %s", a2a_agent_name, prepared.sanitized_endpoint_url)
                         a2a_start_time = time.time()
                         try:
-                            http_response = await asyncio.wait_for(
-                                self._http_client.post(prepared.endpoint_url, json=prepared.request_data, headers=prepared.headers),
-                                timeout=effective_timeout,
-                            )
+                            try:
+                                pinned = await prepare_pinned_a2a_invocation(prepared)
+                            except ValueError as validation_error:
+                                validation_reason = SecurityValidator.sanitize_log_message(str(validation_error.__cause__ or validation_error))
+                                logger.warning(
+                                    "A2A tool outbound URL validation failed for tool %s (%s), agent=%s, url=%s, correlation_id=%s: %s",
+                                    SecurityValidator.sanitize_log_message(name),
+                                    SecurityValidator.sanitize_log_message(tool_id),
+                                    SecurityValidator.sanitize_log_message(a2a_agent_name or ""),
+                                    prepared.sanitized_endpoint_url,
+                                    get_correlation_id(),
+                                    validation_reason,
+                                )
+                                raise ToolInvocationError("Outbound A2A URL blocked by URL policy") from validation_error
+
+                            async with get_isolated_http_client(follow_redirects=False) as client:
+                                http_response = await asyncio.wait_for(
+                                    client.post(
+                                        pinned.endpoint_url,
+                                        json=prepared.request_data,
+                                        headers=pinned.headers,
+                                        extensions=pinned.extensions,
+                                    ),
+                                    timeout=effective_timeout,
+                                )
                             status_code = http_response.status_code
                             response_data = http_response.json() if status_code == 200 else None
                             response_text = http_response.text
@@ -8000,12 +8014,22 @@ class ToolService(BaseService):
         )
         logger.info("invoke tool request_data prepared: %s", prepared.request_data)
 
-        # Make HTTP request to the agent endpoint using shared HTTP client
-        # First-Party
-        from mcpgateway.services.http_client_service import get_http_client  # pylint: disable=import-outside-toplevel
+        try:
+            pinned = await prepare_pinned_a2a_invocation(prepared)
+        except ValueError as validation_error:
+            validation_reason = SecurityValidator.sanitize_log_message(str(validation_error.__cause__ or validation_error))
+            logger.warning(
+                "A2A helper outbound URL validation failed for agent %s, url=%s, correlation_id=%s: %s",
+                SecurityValidator.sanitize_log_message(agent.name),
+                prepared.sanitized_endpoint_url,
+                get_correlation_id(),
+                validation_reason,
+            )
+            raise ToolInvocationError("Outbound A2A URL blocked by URL policy") from validation_error
 
-        client = await get_http_client()
-        http_response = await client.post(prepared.endpoint_url, json=prepared.request_data, headers=prepared.headers)
+        # Make HTTP request to the agent endpoint using an isolated SSRF-sensitive client.
+        async with get_isolated_http_client(follow_redirects=False) as client:
+            http_response = await client.post(pinned.endpoint_url, json=prepared.request_data, headers=pinned.headers, extensions=pinned.extensions)
 
         if http_response.status_code == 200:
             return http_response.json()

--- a/tests/unit/mcpgateway/services/test_a2a_agent_invoke_hooks.py
+++ b/tests/unit/mcpgateway/services/test_a2a_agent_invoke_hooks.py
@@ -39,6 +39,23 @@ def service():
     return A2AAgentService()
 
 
+@pytest.fixture(autouse=True)
+def route_isolated_clients_to_patched_shared_client(monkeypatch):
+    """Route isolated A2A HTTP clients through tests' patched shared client."""
+
+    class IsolatedClientCtx:
+        async def __aenter__(self):
+            # First-Party
+            from mcpgateway.services.http_client_service import get_http_client
+
+            return await get_http_client()
+
+        async def __aexit__(self, *_exc):
+            return None
+
+    monkeypatch.setattr("mcpgateway.services.a2a_service.get_isolated_http_client", lambda **_kwargs: IsolatedClientCtx())
+
+
 @pytest.fixture
 def mock_db():
     return MagicMock()

--- a/tests/unit/mcpgateway/services/test_a2a_protocol.py
+++ b/tests/unit/mcpgateway/services/test_a2a_protocol.py
@@ -7,7 +7,7 @@ Tests for mcpgateway.services.a2a_protocol.
 """
 
 # Standard
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 # Third-Party
 import pytest
@@ -28,6 +28,7 @@ from mcpgateway.services.a2a_protocol import (
     normalize_a2a_params,
     normalize_a2a_version_header,
     prepare_a2a_invocation,
+    prepare_pinned_a2a_invocation,
 )
 
 # ── is_v1_a2a_protocol ──────────────────────────────────────────────────────
@@ -883,3 +884,143 @@ def test_prepare_a2a_invocation_preserves_encrypted_auth_value(monkeypatch):
     )
 
     assert prepared.auth_value_encrypted == "encrypted_blob"
+
+
+# ── prepare_pinned_a2a_invocation ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_prepare_pinned_a2a_invocation_pins_url_and_sets_host_sni(monkeypatch):
+    """Pinned A2A calls use the resolved IP while preserving Host and SNI."""
+    monkeypatch.setattr("mcpgateway.services.a2a_protocol.settings.ssrf_protection_enabled", True)
+    validate = AsyncMock(
+        return_value={
+            "validated_url": "https://agent.example.com:8443/a2a",
+            "hostname": "agent.example.com",
+            "original_authority": "agent.example.com:8443",
+            "resolved_ip": "203.0.113.10",
+        }
+    )
+    monkeypatch.setattr("mcpgateway.services.a2a_protocol.SecurityValidator.validate_url_for_connection_pinning", validate)
+
+    prepared = prepare_a2a_invocation(
+        agent_type="generic",
+        endpoint_url="https://agent.example.com:8443/a2a",
+        protocol_version="1.0",
+        parameters={"query": "hello"},
+        interaction_type="query",
+        base_headers={"host": "attacker.example", "X-Test": "1"},
+    )
+
+    pinned = await prepare_pinned_a2a_invocation(prepared)
+
+    assert pinned.endpoint_url == "https://203.0.113.10:8443/a2a"
+    assert pinned.headers["Host"] == "agent.example.com:8443"
+    assert pinned.headers["X-Test"] == "1"
+    assert "host" not in pinned.headers
+    assert pinned.extensions == {"sni_hostname": "agent.example.com"}
+    validate.assert_awaited_once_with(prepared.endpoint_url, "A2A agent URL")
+
+
+@pytest.mark.asyncio
+async def test_prepare_pinned_a2a_invocation_brackets_ipv6(monkeypatch):
+    """IPv6 resolved addresses are bracketed when rewriting the URL netloc."""
+    monkeypatch.setattr("mcpgateway.services.a2a_protocol.settings.ssrf_protection_enabled", True)
+    monkeypatch.setattr(
+        "mcpgateway.services.a2a_protocol.SecurityValidator.validate_url_for_connection_pinning",
+        AsyncMock(
+            return_value={
+                "validated_url": "https://agent.example.com:8443/a2a",
+                "hostname": "agent.example.com",
+                "original_authority": "agent.example.com:8443",
+                "resolved_ip": "2001:4860:4860::8888",
+            }
+        ),
+    )
+    prepared = prepare_a2a_invocation(
+        agent_type="generic",
+        endpoint_url="https://agent.example.com:8443/a2a",
+        protocol_version="1.0",
+        parameters={"query": "hello"},
+        interaction_type="query",
+    )
+
+    pinned = await prepare_pinned_a2a_invocation(prepared)
+
+    assert pinned.endpoint_url == "https://[2001:4860:4860::8888]:8443/a2a"
+    assert pinned.headers["Host"] == "agent.example.com:8443"
+    assert pinned.extensions == {"sni_hostname": "agent.example.com"}
+
+
+@pytest.mark.asyncio
+async def test_prepare_pinned_a2a_invocation_validates_query_param_auth_final_url(monkeypatch):
+    """Query-param auth is applied before the final URL is pinned."""
+    monkeypatch.setattr("mcpgateway.services.a2a_protocol.settings.ssrf_protection_enabled", True)
+    monkeypatch.setattr("mcpgateway.services.a2a_protocol.decode_auth", lambda _value: {"api_key": "real-key"})  # pragma: allowlist secret
+    monkeypatch.setattr("mcpgateway.services.a2a_protocol.apply_query_param_auth", lambda url, _params: f"{url}?api_key=real-key")  # pragma: allowlist secret
+    validate = AsyncMock(
+        return_value={
+            "validated_url": "http://agent.example.com/a2a?api_key=real-key",  # pragma: allowlist secret
+            "hostname": "agent.example.com",
+            "original_authority": "agent.example.com",
+            "resolved_ip": "203.0.113.10",
+        }
+    )
+    monkeypatch.setattr("mcpgateway.services.a2a_protocol.SecurityValidator.validate_url_for_connection_pinning", validate)
+    prepared = prepare_a2a_invocation(
+        agent_type="generic",
+        endpoint_url="http://agent.example.com/a2a",
+        protocol_version="1.0",
+        parameters={"query": "hello"},
+        interaction_type="query",
+        auth_type="query_param",
+        auth_query_params={"api_key": "encrypted"},  # pragma: allowlist secret
+    )
+
+    pinned = await prepare_pinned_a2a_invocation(prepared)
+
+    validate.assert_awaited_once_with("http://agent.example.com/a2a?api_key=real-key", "A2A agent URL")  # pragma: allowlist secret
+    assert pinned.endpoint_url == "http://203.0.113.10/a2a?api_key=real-key"  # pragma: allowlist secret
+    assert prepared.sanitized_endpoint_url == "http://agent.example.com/a2a?api_key=REDACTED"
+
+
+@pytest.mark.asyncio
+async def test_prepare_pinned_a2a_invocation_fails_closed_without_pin_metadata(monkeypatch):
+    """SSRF-enabled A2A calls fail closed when validation returns no pinned target."""
+    monkeypatch.setattr("mcpgateway.services.a2a_protocol.settings.ssrf_protection_enabled", True)
+    monkeypatch.setattr(
+        "mcpgateway.services.a2a_protocol.SecurityValidator.validate_url_for_connection_pinning",
+        AsyncMock(return_value={"validated_url": "https://agent.example.com/a2a", "hostname": "agent.example.com", "original_authority": "agent.example.com", "resolved_ip": None}),
+    )
+    prepared = prepare_a2a_invocation(
+        agent_type="generic",
+        endpoint_url="https://agent.example.com/a2a",
+        protocol_version="1.0",
+        parameters={"query": "hello"},
+        interaction_type="query",
+    )
+
+    with pytest.raises(ValueError, match="Outbound A2A URL blocked by URL policy"):
+        await prepare_pinned_a2a_invocation(prepared)
+
+
+@pytest.mark.asyncio
+async def test_prepare_pinned_a2a_invocation_wraps_validation_detail(monkeypatch):
+    """Validation details remain in the cause, not the public exception message."""
+    monkeypatch.setattr("mcpgateway.services.a2a_protocol.settings.ssrf_protection_enabled", True)
+    monkeypatch.setattr(
+        "mcpgateway.services.a2a_protocol.SecurityValidator.validate_url_for_connection_pinning",
+        AsyncMock(side_effect=ValueError("A2A agent URL contains private network address")),
+    )
+    prepared = prepare_a2a_invocation(
+        agent_type="generic",
+        endpoint_url="https://agent.example.com/a2a",
+        protocol_version="1.0",
+        parameters={"query": "hello"},
+        interaction_type="query",
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        await prepare_pinned_a2a_invocation(prepared)
+
+    assert str(exc_info.value) == "Outbound A2A URL blocked by URL policy"

--- a/tests/unit/mcpgateway/services/test_a2a_service.py
+++ b/tests/unit/mcpgateway/services/test_a2a_service.py
@@ -69,6 +69,43 @@ def bypass_uaid_security_for_tests(monkeypatch):
     monkeypatch.setattr("mcpgateway.services.a2a_service.settings.mcpgateway_a2a_default_timeout", 30)
 
 
+@pytest.fixture(autouse=True)
+def mock_local_a2a_pinning_for_existing_tests(monkeypatch):
+    """Route isolated local A2A clients through existing shared-client mocks."""
+
+    async def passthrough_pinning(prepared, *_args, **_kwargs):
+        return SimpleNamespace(endpoint_url=prepared.endpoint_url, headers=dict(prepared.headers), extensions={})
+
+    class ClientAdapter:
+        def __init__(self, client):
+            self._client = client
+
+        def __getattr__(self, name):
+            return getattr(self._client, name)
+
+        async def post(self, url, **kwargs):
+            try:
+                return await self._client.post(url, **kwargs)
+            except TypeError as exc:
+                if "extensions" not in str(exc):
+                    raise
+                kwargs.pop("extensions", None)
+                return await self._client.post(url, **kwargs)
+
+    class IsolatedClientCtx:
+        async def __aenter__(self):
+            # First-Party
+            from mcpgateway.services.http_client_service import get_http_client
+
+            return ClientAdapter(await get_http_client())
+
+        async def __aexit__(self, *_exc):
+            return None
+
+    monkeypatch.setattr("mcpgateway.services.a2a_service.prepare_pinned_a2a_invocation", passthrough_pinning)
+    monkeypatch.setattr("mcpgateway.services.a2a_service.get_isolated_http_client", lambda **_kwargs: IsolatedClientCtx())
+
+
 class TestA2AAgentService:
     """Test suite for A2A Agent Service."""
 
@@ -625,6 +662,131 @@ class TestA2AAgentService:
         mock_metrics_buffer.record_a2a_agent_metric_with_duration.assert_called_once()
         # last_interaction updated via fresh_db_session
         mock_ts_db.commit.assert_called()
+
+    @patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service")
+    @patch("mcpgateway.services.a2a_service.fresh_db_session")
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    async def test_invoke_agent_uses_pinned_target_and_isolated_client(
+        self,
+        mock_get_for_update,
+        mock_fresh_db,
+        mock_metrics_buffer_fn,
+        service,
+        mock_db,
+        sample_db_agent,
+        monkeypatch,
+    ):
+        """Direct A2A invocation posts only to the pinned outbound target."""
+        mock_db.execute.return_value.scalar_one_or_none.return_value = sample_db_agent.id
+
+        mock_agent = MagicMock()
+        mock_agent.id = sample_db_agent.id
+        mock_agent.name = sample_db_agent.name
+        mock_agent.enabled = True
+        mock_agent.endpoint_url = "https://agent.example.com/a2a"
+        mock_agent.auth_type = None
+        mock_agent.auth_value = None
+        mock_agent.auth_query_params = None
+        mock_agent.protocol_version = sample_db_agent.protocol_version
+        mock_agent.agent_type = "generic"
+        mock_agent.visibility = "public"
+        mock_agent.team_id = None
+        mock_agent.owner_email = None
+        mock_get_for_update.return_value = mock_agent
+
+        mock_ts_db = MagicMock()
+        mock_ts_db.execute.return_value.scalar_one_or_none.return_value = sample_db_agent
+        mock_fresh_db.return_value.__enter__.return_value = mock_ts_db
+        mock_fresh_db.return_value.__exit__.return_value = None
+        mock_metrics_buffer_fn.return_value = MagicMock()
+
+        pinned = SimpleNamespace(endpoint_url="https://203.0.113.10/a2a", headers={"Host": "agent.example.com"}, extensions={"sni_hostname": "agent.example.com"})
+        pinning = AsyncMock(return_value=pinned)
+        factory_kwargs = {}
+        post_kwargs = {}
+
+        class Client:
+            async def post(self, url, **kwargs):
+                post_kwargs["url"] = url
+                post_kwargs.update(kwargs)
+                response = MagicMock()
+                response.status_code = 200
+                response.json.return_value = {"response": "Pinned response"}
+                response.text = '{"response":"Pinned response"}'
+                return response
+
+        class IsolatedClientCtx:
+            async def __aenter__(self):
+                return Client()
+
+            async def __aexit__(self, *_exc):
+                return None
+
+        def isolated_client_factory(**kwargs):
+            factory_kwargs.update(kwargs)
+            return IsolatedClientCtx()
+
+        monkeypatch.setattr("mcpgateway.services.a2a_service.prepare_pinned_a2a_invocation", pinning)
+        monkeypatch.setattr("mcpgateway.services.a2a_service.get_isolated_http_client", isolated_client_factory)
+
+        result = await service.invoke_agent(mock_db, sample_db_agent.name, {"test": "data"})
+
+        assert result["response"] == "Pinned response"
+        pinning.assert_awaited_once()
+        assert factory_kwargs == {"follow_redirects": False}
+        assert "verify" not in factory_kwargs
+        assert post_kwargs["url"] == "https://203.0.113.10/a2a"
+        assert post_kwargs["headers"] == {"Host": "agent.example.com"}
+        assert post_kwargs["extensions"] == {"sni_hostname": "agent.example.com"}
+
+    @patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service")
+    @patch("mcpgateway.services.a2a_service.fresh_db_session")
+    @patch("mcpgateway.services.http_client_service.get_http_client", new_callable=AsyncMock)
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    async def test_invoke_agent_blocks_when_pinning_fails(
+        self,
+        mock_get_for_update,
+        mock_get_client,
+        mock_fresh_db,
+        mock_metrics_buffer_fn,
+        service,
+        mock_db,
+        sample_db_agent,
+        monkeypatch,
+    ):
+        """Invocation-time URL policy failures happen before HTTP I/O."""
+        mock_db.execute.return_value.scalar_one_or_none.return_value = sample_db_agent.id
+
+        mock_agent = MagicMock()
+        mock_agent.id = sample_db_agent.id
+        mock_agent.name = sample_db_agent.name
+        mock_agent.enabled = True
+        mock_agent.endpoint_url = sample_db_agent.endpoint_url
+        mock_agent.auth_type = None
+        mock_agent.auth_value = None
+        mock_agent.auth_query_params = None
+        mock_agent.protocol_version = sample_db_agent.protocol_version
+        mock_agent.agent_type = "generic"
+        mock_agent.visibility = "public"
+        mock_agent.team_id = None
+        mock_agent.owner_email = None
+        mock_get_for_update.return_value = mock_agent
+
+        mock_ts_db = MagicMock()
+        mock_fresh_db.return_value.__enter__.return_value = mock_ts_db
+        mock_fresh_db.return_value.__exit__.return_value = None
+        mock_metrics_buffer = MagicMock()
+        mock_metrics_buffer_fn.return_value = mock_metrics_buffer
+
+        pinning = AsyncMock(side_effect=ValueError("private address"))
+        monkeypatch.setattr("mcpgateway.services.a2a_service.prepare_pinned_a2a_invocation", pinning)
+
+        with pytest.raises(A2AAgentError, match="Outbound A2A URL blocked by URL policy"):
+            await service.invoke_agent(mock_db, sample_db_agent.name, {"test": "data"})
+
+        pinning.assert_awaited_once()
+        mock_get_client.assert_not_awaited()
+        mock_metrics_buffer.record_a2a_agent_metric_with_duration.assert_called_once()
 
     async def test_invoke_agent_disabled(self, service, mock_db, sample_db_agent):
         """Test invoking disabled agent."""
@@ -2754,8 +2916,6 @@ class TestInvokeAgentEdgeCases:
 
         with pytest.raises(A2AAgentError, match="Failed to prepare A2A invocation"):
             await service.invoke_agent(mock_db, "ag", {})
-
-
 
 
 class TestA2AInvalidationBestEffort:
@@ -5232,7 +5392,6 @@ class TestCrossGatewayRoutingCoverage:
         )
 
         assert captured_headers.get("X-Contextforge-UAID-Hop") == "2", f"local-agent outbound must stamp hop+1; headers={captured_headers!r}"
-
 
     async def test_federation_chain_increments_hop_and_rejects_at_max(self, service, mock_db, monkeypatch):
         """Three-hop chain locks in the stamp-N+1 vs reject-at-max

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -30,6 +30,7 @@ from sqlalchemy.exc import IntegrityError
 # First-Party
 from mcpgateway.cache.global_config_cache import global_config_cache
 from mcpgateway.cache.tool_lookup_cache import tool_lookup_cache
+from mcpgateway.common.validators import pin_url_to_resolved_ip
 from mcpgateway.config import settings
 from mcpgateway.db import Gateway as DbGateway
 from mcpgateway.db import Tool as DbTool
@@ -42,7 +43,6 @@ from mcpgateway.services.tool_service import (
     _encrypt_tool_header_value,
     _get_validator_class_and_check,
     _is_sensitive_tool_header_name,
-    _pin_url_to_resolved_ip,
     _protect_tool_headers_for_storage,
     _sync_meta_traceparent,
     _validate_header_mapping_targets,
@@ -431,6 +431,17 @@ def tool_service(monkeypatch):
     service.get_plugin_manager = AsyncMock()
     # service._plugin_manager = False  # Disable plugin manager to avoid real plugin execution in tests
 
+    class IsolatedClientCtx:
+        async def __aenter__(self):
+            # First-Party
+            from mcpgateway.services.http_client_service import get_http_client
+
+            return await get_http_client()
+
+        async def __aexit__(self, *_exc):
+            return None
+
+    monkeypatch.setattr("mcpgateway.services.tool_service.get_isolated_http_client", lambda **_kwargs: IsolatedClientCtx())
     return service
 
 
@@ -2444,7 +2455,7 @@ class TestToolService:
 
     def test_pin_url_to_resolved_ip_brackets_ipv6_and_preserves_query(self):
         """Pinned IPv6 netlocs must be bracketed without losing URL parts."""
-        assert _pin_url_to_resolved_ip("https://api.example.com:8443/path?sig=abc", "2001:4860:4860::8888") == "https://[2001:4860:4860::8888]:8443/path?sig=abc"
+        assert pin_url_to_resolved_ip("https://api.example.com:8443/path?sig=abc", "2001:4860:4860::8888") == "https://[2001:4860:4860::8888]:8443/path?sig=abc"
 
     @pytest.mark.asyncio
     async def test_build_pinned_rest_http_client_disables_connection_reuse(self):

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -110,6 +110,51 @@ def tool_service(monkeypatch):
     monkeypatch.setattr("mcpgateway.services.tool_service.settings.ssrf_protection_enabled", False)
     service = ToolService()
     service._http_client = AsyncMock()
+
+    async def passthrough_pinning(prepared, *_args, **_kwargs):
+        return SimpleNamespace(endpoint_url=prepared.endpoint_url, headers=dict(prepared.headers), extensions={})
+
+    def service_http_client_is_configured():
+        post = getattr(service._http_client, "post", None)
+        if post is None:
+            return False
+        if not isinstance(post, AsyncMock):
+            return True
+        if post.side_effect is not None:
+            return True
+        return not isinstance(post.return_value, AsyncMock)
+
+    class ClientAdapter:
+        def __init__(self, client):
+            self._client = client
+
+        def __getattr__(self, name):
+            return getattr(self._client, name)
+
+        async def post(self, url, **kwargs):
+            try:
+                return await self._client.post(url, **kwargs)
+            except TypeError as exc:
+                if "extensions" not in str(exc):
+                    raise
+                kwargs.pop("extensions", None)
+                return await self._client.post(url, **kwargs)
+
+    class IsolatedClientCtx:
+        async def __aenter__(self):
+            if service_http_client_is_configured():
+                return ClientAdapter(service._http_client)
+
+            # First-Party
+            from mcpgateway.services.http_client_service import get_http_client
+
+            return ClientAdapter(await get_http_client())
+
+        async def __aexit__(self, *_exc):
+            return None
+
+    monkeypatch.setattr("mcpgateway.services.tool_service.prepare_pinned_a2a_invocation", passthrough_pinning)
+    monkeypatch.setattr("mcpgateway.services.tool_service.get_isolated_http_client", lambda **_kwargs: IsolatedClientCtx())
     return service
 
 
@@ -3281,9 +3326,41 @@ class TestInvokeA2AToolCoverage:
     """Tests for _invoke_a2a_tool (lines 4449-4510)."""
 
     @pytest.fixture
-    def tool_service(self):
+    def tool_service(self, monkeypatch):
         svc = ToolService()
         svc._event_service = AsyncMock()
+
+        async def passthrough_pinning(prepared, *_args, **_kwargs):
+            return SimpleNamespace(endpoint_url=prepared.endpoint_url, headers=dict(prepared.headers), extensions={})
+
+        class ClientAdapter:
+            def __init__(self, client):
+                self._client = client
+
+            def __getattr__(self, name):
+                return getattr(self._client, name)
+
+            async def post(self, url, **kwargs):
+                try:
+                    return await self._client.post(url, **kwargs)
+                except TypeError as exc:
+                    if "extensions" not in str(exc):
+                        raise
+                    kwargs.pop("extensions", None)
+                    return await self._client.post(url, **kwargs)
+
+        class IsolatedClientCtx:
+            async def __aenter__(self):
+                # First-Party
+                from mcpgateway.services.http_client_service import get_http_client
+
+                return ClientAdapter(await get_http_client())
+
+            async def __aexit__(self, *_exc):
+                return None
+
+        monkeypatch.setattr("mcpgateway.services.tool_service.prepare_pinned_a2a_invocation", passthrough_pinning)
+        monkeypatch.setattr("mcpgateway.services.tool_service.get_isolated_http_client", lambda **_kwargs: IsolatedClientCtx())
         return svc
 
     def _make_a2a_tool(self, agent_id="agent-1"):
@@ -3509,9 +3586,41 @@ class TestCallA2AAgentCoverage:
     """Tests for _call_a2a_agent (lines 4512-4598)."""
 
     @pytest.fixture
-    def tool_service(self):
+    def tool_service(self, monkeypatch):
         svc = ToolService()
         svc._event_service = AsyncMock()
+
+        async def passthrough_pinning(prepared, *_args, **_kwargs):
+            return SimpleNamespace(endpoint_url=prepared.endpoint_url, headers=dict(prepared.headers), extensions={})
+
+        class ClientAdapter:
+            def __init__(self, client):
+                self._client = client
+
+            def __getattr__(self, name):
+                return getattr(self._client, name)
+
+            async def post(self, url, **kwargs):
+                try:
+                    return await self._client.post(url, **kwargs)
+                except TypeError as exc:
+                    if "extensions" not in str(exc):
+                        raise
+                    kwargs.pop("extensions", None)
+                    return await self._client.post(url, **kwargs)
+
+        class IsolatedClientCtx:
+            async def __aenter__(self):
+                # First-Party
+                from mcpgateway.services.http_client_service import get_http_client
+
+                return ClientAdapter(await get_http_client())
+
+            async def __aexit__(self, *_exc):
+                return None
+
+        monkeypatch.setattr("mcpgateway.services.tool_service.prepare_pinned_a2a_invocation", passthrough_pinning)
+        monkeypatch.setattr("mcpgateway.services.tool_service.get_isolated_http_client", lambda **_kwargs: IsolatedClientCtx())
         return svc
 
     def _make_agent(self, **overrides):
@@ -3558,6 +3667,60 @@ class TestCallA2AAgentCoverage:
 
             with pytest.raises(RuntimeError, match="logger boom"):
                 await tool_service._call_a2a_agent(agent, {"query": "hello"})
+
+    @pytest.mark.asyncio
+    async def test_validation_failure_blocks_before_http(self, tool_service, monkeypatch):
+        """A2A URL policy failures stop before an outbound HTTP client is requested."""
+        agent = self._make_agent()
+        pinning = AsyncMock(side_effect=ValueError("private address"))
+        monkeypatch.setattr("mcpgateway.services.tool_service.prepare_pinned_a2a_invocation", pinning)
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", new_callable=AsyncMock) as mock_get_client:
+            with pytest.raises(ToolInvocationError, match="Outbound A2A URL blocked by URL policy"):
+                await tool_service._call_a2a_agent(agent, {"query": "hello"})
+
+        pinning.assert_awaited_once()
+        mock_get_client.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pinned_call_disables_redirects_and_preserves_tls_verification(self, tool_service, monkeypatch):
+        """Pinned A2A calls disable redirects without overriding TLS verification."""
+        agent = self._make_agent(endpoint_url="https://agent.example.com/a2a")
+        pinned = SimpleNamespace(endpoint_url="https://203.0.113.10/a2a", headers={"Host": "agent.example.com"}, extensions={"sni_hostname": "agent.example.com"})
+        monkeypatch.setattr("mcpgateway.services.tool_service.prepare_pinned_a2a_invocation", AsyncMock(return_value=pinned))
+        factory_kwargs = {}
+        post_kwargs = {}
+
+        class Client:
+            async def post(self, url, **kwargs):
+                post_kwargs["url"] = url
+                post_kwargs.update(kwargs)
+                response = MagicMock()
+                response.status_code = 200
+                response.json.return_value = {"result": "ok"}
+                return response
+
+        class IsolatedClientCtx:
+            async def __aenter__(self):
+                return Client()
+
+            async def __aexit__(self, *_exc):
+                return None
+
+        def isolated_client_factory(**kwargs):
+            factory_kwargs.update(kwargs)
+            return IsolatedClientCtx()
+
+        monkeypatch.setattr("mcpgateway.services.tool_service.get_isolated_http_client", isolated_client_factory)
+
+        result = await tool_service._call_a2a_agent(agent, {"query": "hello"})
+
+        assert result == {"result": "ok"}
+        assert factory_kwargs == {"follow_redirects": False}
+        assert "verify" not in factory_kwargs
+        assert post_kwargs["url"] == "https://203.0.113.10/a2a"
+        assert post_kwargs["headers"] == {"Host": "agent.example.com"}
+        assert post_kwargs["extensions"] == {"sni_hostname": "agent.example.com"}
 
     @pytest.mark.asyncio
     async def test_custom_agent_format(self, tool_service):
@@ -7941,6 +8104,75 @@ class TestInvokeToolA2A:
         assert result is not None
         assert result.is_error is False
         assert "Hello from A2A" in result.content[0].text
+
+    @pytest.mark.asyncio
+    async def test_a2a_jsonrpc_uses_pinned_target_and_isolated_client(self, tool_service, monkeypatch):
+        """Tool-mediated A2A invocation posts only to the pinned outbound target."""
+        tp = _make_tool_payload(
+            integration_type="A2A",
+            request_type="POST",
+            annotations={"a2a_agent_id": "agent-uuid-1"},
+        )
+        db = MagicMock()
+        a2a_agent = _make_a2a_agent()
+        a2a_agent.endpoint_url = "https://agent.example.com/a2a"
+        db.execute = MagicMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=a2a_agent)))
+
+        pinned = SimpleNamespace(endpoint_url="https://203.0.113.10/a2a", headers={"Host": "agent.example.com"}, extensions={"sni_hostname": "agent.example.com"})
+        pinning = AsyncMock(return_value=pinned)
+        factory_kwargs = {}
+        post_kwargs = {}
+
+        class Client:
+            async def post(self, url, **kwargs):
+                post_kwargs["url"] = url
+                post_kwargs.update(kwargs)
+                response = MagicMock()
+                response.status_code = 200
+                response.json.return_value = {"response": "Pinned response"}
+                response.text = '{"response":"Pinned response"}'
+                return response
+
+        class IsolatedClientCtx:
+            async def __aenter__(self):
+                return Client()
+
+            async def __aexit__(self, *_exc):
+                return None
+
+        def isolated_client_factory(**kwargs):
+            factory_kwargs.update(kwargs)
+            return IsolatedClientCtx()
+
+        monkeypatch.setattr("mcpgateway.services.tool_service.prepare_pinned_a2a_invocation", pinning)
+        monkeypatch.setattr("mcpgateway.services.tool_service.get_isolated_http_client", isolated_client_factory)
+
+        with (
+            _setup_cache_for_invoke(tp),
+            patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
+            patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
+            patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service") as mock_mbuf,
+            patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={}),
+        ):
+            mock_gcc.get_passthrough_headers = MagicMock(return_value=[])
+            mock_trace.get = MagicMock(return_value=None)
+            mock_span_ctx.return_value.__enter__ = MagicMock(return_value=MagicMock())
+            mock_span_ctx.return_value.__exit__ = MagicMock(return_value=False)
+            mock_mbuf.return_value = MagicMock()
+
+            result = await tool_service.invoke_tool(db, "test_tool", {"query": "What is A2A?"})
+
+        assert result is not None
+        assert result.is_error is False
+        assert "Pinned response" in result.content[0].text
+        pinning.assert_awaited_once()
+        assert factory_kwargs == {"follow_redirects": False}
+        assert "verify" not in factory_kwargs
+        assert post_kwargs["url"] == "https://203.0.113.10/a2a"
+        assert post_kwargs["headers"] == {"Host": "agent.example.com"}
+        assert post_kwargs["extensions"] == {"sni_hostname": "agent.example.com"}
 
     async def _invoke_a2a_tool_via_invoke_tool(self, tool_service, response_json):
         """Helper: invoke an A2A tool through invoke_tool with a given HTTP 200 JSON response."""

--- a/tests/unit/mcpgateway/test_a2a_agent.py
+++ b/tests/unit/mcpgateway/test_a2a_agent.py
@@ -57,6 +57,24 @@ def bypass_uaid_security_for_tests(monkeypatch):
     monkeypatch.setattr("mcpgateway.services.a2a_service.settings.mcpgateway_a2a_default_timeout", 30)
 
 
+@pytest.fixture(autouse=True)
+def route_isolated_clients_to_patched_shared_client(monkeypatch):
+    """Route isolated A2A HTTP clients through tests' patched shared client."""
+
+    class IsolatedClientCtx:
+        async def __aenter__(self):
+            # First-Party
+            from mcpgateway.services.http_client_service import get_http_client
+
+            return await get_http_client()
+
+        async def __aexit__(self, *_exc):
+            return None
+
+    monkeypatch.setattr("mcpgateway.services.a2a_service.get_isolated_http_client", lambda **_kwargs: IsolatedClientCtx())
+    monkeypatch.setattr("mcpgateway.services.tool_service.get_isolated_http_client", lambda **_kwargs: IsolatedClientCtx())
+
+
 class TestUserInputForA2AAgentTest:
     """Test suite for Issue #840 - Part 1: A2A agent test endpoint lacks user input field.
 


### PR DESCRIPTION
## Summary
- Harden local A2A invocation egress handling.
- Add focused regression coverage for local A2A invocation paths.