### PR TITLE
feat(sso): auto-provision routed OAuth users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1596,7 +1596,7 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # SSO_KEYCLOAK_MAP_REALM_ROLES=true
 # SSO_KEYCLOAK_MAP_CLIENT_ROLES=false
 # SSO_KEYCLOAK_USERNAME_CLAIM=preferred_username
-# SSO_KEYCLOAK_EMAIL_CLAIM=email
+# SSO_KEYCLOAK_EMAIL_CLAIM=email  # Claim used as the local ContextForge user email
 # SSO_KEYCLOAK_GROUPS_CLAIM=groups
 # Optional: map Keycloak realm roles/groups to Gateway RBAC roles
 # Example: {"gateway-admin":"platform_admin","gateway-developer":"developer","gateway-viewer":"viewer"}

--- a/docs/docs/manage/sso.md
+++ b/docs/docs/manage/sso.md
@@ -802,6 +802,44 @@ When `trusted_for_api_auth=true`, `api_audience` **must** also be set — the re
 5. The token's identity is JIT-provisioned/looked up as a local user (the same provisioning path used by browser SSO).
 6. The resulting principal is a **session-semantics** identity (`token_use="session"`): `is_admin` is read from the persisted local user record, and `teams` are resolved via `resolve_session_teams()` — both are DB-authoritative, never derived directly from the external token's claims.
 
+### OAuth-enabled virtual-server MCP calls
+
+An OAuth-enabled virtual server validates access tokens against its own issuer
+and audience configuration. If the verified principal does not yet exist in
+ContextForge, it can use the same SSO JIT-provisioning path described above.
+This requires all of the following:
+
+- `SSO_API_TOKEN_AUTH_ENABLED=true`
+- the verified token issuer matches an enabled provider with
+  `trusted_for_api_auth=true`
+- that provider has `auto_create_users=true`
+- the provider's email-verification, trusted-domain, admin-approval,
+  account-linking, role, and team rules accept the identity
+
+Existing users continue through a direct local lookup. Provisioning failures
+are denied, and disabled local users remain denied.
+
+The local user key is selected through the SSO provider's existing
+`provider_metadata.email_claim` setting. Keycloak providers populated from the
+environment use `SSO_KEYCLOAK_EMAIL_CLAIM` (default `email`). Generic OIDC
+providers can configure the same metadata explicitly:
+
+```json
+{
+  "provider_metadata": {
+    "email_claim": "principal_email",
+    "username_claim": "preferred_username"
+  }
+}
+```
+
+The selected claim must contain an email-shaped value (including `@`) because
+ContextForge uses email as the local user key. When a trusted provider has an
+explicit mapping, a missing or invalid mapped claim fails closed instead of
+falling back to another claim such as a contact email. Browser SSO and MCP token
+authentication use the same mapping, preventing one IdP subject from resolving
+to different local users across authentication flows.
+
 ### Role and group mapping
 
 Role/group → team mapping for externally-authenticated principals reuses the same provider configuration as browser SSO (e.g. `SSO_KEYCLOAK_ROLE_MAPPINGS`, `SSO_ENTRA_ROLE_MAPPINGS`, `SSO_GENERIC_ROLE_MAPPINGS`). If role-sync is enabled for the provider, teams and admin status are re-derived from the token's claims into the local DB on each provisioning pass — see the role-sync caveat below.

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -1774,6 +1774,21 @@ class SSOService:
             normalized.update(extra)
         return normalized
 
+    def normalize_user_info(self, provider: SSOProvider, user_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize provider claims to the canonical ContextForge user shape.
+
+        Token-authenticated and browser SSO flows call this public entry point
+        so provider claim mappings resolve to the same local principal.
+
+        Args:
+            provider: SSO provider configuration.
+            user_data: Raw, trusted claims or user-info data from the provider.
+
+        Returns:
+            Normalized user information.
+        """
+        return self._normalize_user_info(provider, user_data)
+
     def _normalize_user_info(self, provider: SSOProvider, user_data: Dict[str, Any]) -> Dict[str, Any]:
         """Normalize user info from different providers to common format.
 
@@ -1805,6 +1820,10 @@ class SSOService:
                 normalized["email_verified"] = github_email_verified
             return normalized
 
+        metadata = provider.provider_metadata or {}
+        email_claim = metadata.get("email_claim", "email")
+        username_claim = metadata.get("username_claim", "preferred_username")
+
         # Handle Google provider
         if provider.id == "google":
             return self._build_normalized_user_info(
@@ -1814,7 +1833,6 @@ class SSOService:
                 username=user_data.get("email", "").split("@")[0],
             )
 
-        metadata = provider.provider_metadata or {}
         groups_claim = metadata.get("groups_claim", "groups")
 
         # Handle IBM Verify provider
@@ -1829,9 +1847,6 @@ class SSOService:
 
         # Handle Keycloak provider with role mapping
         if provider.id == "keycloak":
-            username_claim = metadata.get("username_claim", "preferred_username")
-            email_claim = metadata.get("email_claim", "email")
-
             groups: list[str] = []
 
             # Extract realm roles
@@ -1919,7 +1934,14 @@ class SSOService:
 
         # Generic OIDC format for all other providers.
         groups = self._extract_groups_and_roles(user_data, groups_claim)
-        return self._build_normalized_user_info(user_data, provider.id, groups)
+        email = user_data.get(email_claim)
+        return self._build_normalized_user_info(
+            user_data,
+            provider.id,
+            groups,
+            email=email,
+            username=user_data.get(username_claim) or (email.split("@")[0] if isinstance(email, str) and "@" in email else None),
+        )
 
     def _reset_pending_approval(self, pending: PendingUserApproval, incoming_provider: str, user_info: Dict[str, Any]) -> None:
         """Reset a pending approval request to pending state with fresh metadata.
@@ -2105,8 +2127,8 @@ class SSOService:
                 user.auth_provider = incoming_provider
                 current_auth_provider = incoming_provider
 
-            # Persist verification status from provider claims.
-            user.email_verified = self._is_email_verified_claim(user_info)
+            # The verification check above has already accepted this identity.
+            user.email_verified_at = utc_now()
             user.last_login = utc_now()
 
             # Synchronize is_admin status based on current group membership
@@ -2184,6 +2206,11 @@ class SSOService:
             )
             if not user:
                 return None
+
+            # SSO identities accepted by the verification gate above are locally
+            # verified. Persist that state for APIs that inspect the user row.
+            user.email_verified_at = utc_now()
+            self.db.commit()
 
             user_email = getattr(user, "email", None)
             if isinstance(user_email, str) and user_email.strip():

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -94,6 +94,7 @@ from mcpgateway.services.oauth_manager import OAuthEnforcementUnavailableError, 
 from mcpgateway.services.permission_service import PermissionService
 from mcpgateway.services.prompt_service import PromptService
 from mcpgateway.services.resource_service import ResourceError, ResourceNotFoundError, ResourceService
+from mcpgateway.services.sso_service import resolve_trusted_provider_by_issuer, SSOService
 from mcpgateway.services.tool_service import ToolService
 from mcpgateway.transports.context import UserContext
 from mcpgateway.transports.redis_event_store import RedisEventStore
@@ -106,6 +107,7 @@ from mcpgateway.utils.passthrough_headers import compute_passthrough_headers_cac
 from mcpgateway.utils.trace_context import set_trace_context_from_teams, set_trace_session_id
 from mcpgateway.utils.verify_credentials import (
     _resolve_auth_header_name,
+    build_external_identity,
     get_auth_header_value,
     is_proxy_auth_trust_active,
     require_auth_header_first,
@@ -866,6 +868,97 @@ async def get_db() -> AsyncGenerator[Session, Any]:
         raise
     finally:
         db.close()
+
+
+def _legacy_oauth_user_email(claims: Dict[str, Any]) -> Optional[str]:
+    """Return the backwards-compatible OAuth principal from verified claims."""
+    value = claims.get("email") or claims.get("preferred_username") or claims.get("sub")
+    if not isinstance(value, str) or "@" not in value:
+        return None
+    return value.strip().lower()
+
+
+async def _resolve_oauth_user_email(claims: Dict[str, Any]) -> Optional[str]:
+    """Resolve the local principal using trusted SSO provider claim mapping.
+
+    When external SSO token authentication is disabled, or the issuer does not
+    map to an API-trusted provider, this preserves the historical
+    ``email``/``preferred_username``/``sub`` precedence. A matched provider is
+    authoritative: a missing or invalid configured ``email_claim`` fails closed
+    instead of falling back to a different identity claim.
+
+    Args:
+        claims: Claims already verified for the target virtual server.
+
+    Returns:
+        Normalized ContextForge email principal, or ``None`` when invalid.
+    """
+    fallback = _legacy_oauth_user_email(claims)
+    if not settings.sso_api_token_auth_enabled:
+        return fallback
+
+    issuer = claims.get("iss")
+    if not isinstance(issuer, str) or not issuer:
+        return fallback
+
+    async with get_db() as db:
+        provider = resolve_trusted_provider_by_issuer(issuer, db)
+        if provider is None:
+            return fallback
+        user_info = SSOService(db).normalize_user_info(provider, claims)
+
+    value = user_info.get("email")
+    if not isinstance(value, str) or "@" not in value:
+        return None
+    return value.strip().lower()
+
+
+async def _auto_provision_oauth_user(token: str, claims: Dict[str, Any], expected_email: str) -> bool:
+    """Provision a missing virtual-server OAuth user through trusted SSO.
+
+    The token has already passed the virtual server's signature, issuer,
+    expiry, and audience validation. Provisioning additionally requires the
+    global external-token opt-in and an enabled, API-trusted SSO provider with
+    ``auto_create_users`` enabled. The shared SSO service applies the existing
+    email-verification, trusted-domain, approval, account-linking, role, and
+    team rules.
+
+    Args:
+        token: Raw external bearer token.
+        claims: Claims verified for the target virtual server.
+        expected_email: Principal selected through provider claim mapping.
+
+    Returns:
+        ``True`` only when the expected local user exists after provisioning.
+    """
+    if not settings.sso_api_token_auth_enabled:
+        return False
+
+    issuer = claims.get("iss")
+    if not isinstance(issuer, str) or not issuer:
+        return False
+
+    async with get_db() as db:
+        db.info["external_owned"] = True
+        provider = resolve_trusted_provider_by_issuer(issuer, db)
+        if provider is None or not provider.auto_create_users:
+            return False
+
+        identity = await build_external_identity(provider, claims, token, db)
+        if identity is None:
+            return False
+
+        provisioned_email = str(identity.get("email") or "").strip().lower()
+        if provisioned_email != expected_email:
+            logger.warning(
+                "Virtual-server OAuth provisioning identity mismatch: expected=%s actual=%s provider=%s",
+                sanitize_for_log(expected_email),
+                sanitize_for_log(provisioned_email),
+                sanitize_for_log(getattr(provider, "id", "")),
+            )
+            return False
+
+        return True
 
 
 def get_user_email_from_context() -> str:
@@ -1683,9 +1776,7 @@ def _truthy_is_error(result: Any) -> bool:
 
 
 @mcp_app.call_tool(validate_input=False)
-async def call_tool(
-    name: str, arguments: dict
-) -> Union[
+async def call_tool(name: str, arguments: dict) -> Union[
     types.CallToolResult,
     List[Union[types.TextContent, types.ImageContent, types.AudioContent, types.ResourceLink, types.EmbeddedResource]],
     Tuple[List[Union[types.TextContent, types.ImageContent, types.AudioContent, types.ResourceLink, types.EmbeddedResource]], Dict[str, Any]],
@@ -5597,15 +5688,25 @@ class _StreamableHttpAuthHandler:
         except Exception:
             logger.warning("Failed to persist learned audience for server %s (caller guard)", server_id, exc_info=True)
 
-        # Resolve user identity from verified claims
-        user_email = claims.get("email") or claims.get("preferred_username") or claims.get("sub")
-        if not user_email or not isinstance(user_email, str) or "@" not in user_email:
+        # Resolve the local principal through the trusted provider's SSO claim
+        # mapping when configured; preserve the historical fallback otherwise.
+        try:
+            user_email = await _resolve_oauth_user_email(claims)
+        except SQLAlchemyError:
+            logger.exception("DB error resolving SSO identity during OAuth access-token verification")
+            await self._send_error(detail="Service unavailable", status_code=503)
+            return OAuthAuthResult.FAILED
+        except Exception:
+            logger.exception("Unexpected error resolving SSO identity during OAuth access-token verification")
+            await self._send_error(detail="Authentication failed", headers={"WWW-Authenticate": "Bearer"})
+            return OAuthAuthResult.FAILED
+
+        if not user_email:
             await self._send_error(detail="OAuth token missing valid email claim")
             return OAuthAuthResult.FAILED
 
-        user_email = user_email.strip().lower()
-
-        # Look up user in ContextForge DB — user must already exist (no auto-creation)
+        # Look up the local user first. Only a trusted SSO provider may provision
+        # a missing identity, and existing users stay on this fast path.
         # First-Party
         from mcpgateway.auth import _get_user_by_email_sync, _resolve_teams_from_db  # pylint: disable=import-outside-toplevel
 
@@ -5621,8 +5722,22 @@ class _StreamableHttpAuthHandler:
             return OAuthAuthResult.FAILED
 
         if user_record is None:
-            await self._send_error(detail="User not registered in ContextForge. Please log in via SSO first.")
-            return OAuthAuthResult.FAILED
+            try:
+                provisioned = await _auto_provision_oauth_user(token, claims, user_email)
+                if provisioned:
+                    user_record = await asyncio.to_thread(_get_user_by_email_sync, user_email)
+            except SQLAlchemyError:
+                logger.exception("DB error provisioning user %s during OAuth access-token verification", user_email)
+                await self._send_error(detail="Service unavailable", status_code=503)
+                return OAuthAuthResult.FAILED
+            except Exception:
+                logger.exception("Unexpected error provisioning user %s during OAuth access-token verification", user_email)
+                await self._send_error(detail="Authentication failed", headers={"WWW-Authenticate": "Bearer"})
+                return OAuthAuthResult.FAILED
+
+            if user_record is None:
+                await self._send_error(detail="User not registered in ContextForge. Please log in via SSO first.")
+                return OAuthAuthResult.FAILED
         if not user_record.is_active:
             await self._send_error(detail="Account disabled")
             return OAuthAuthResult.FAILED

--- a/tests/unit/mcpgateway/services/test_sso_service.py
+++ b/tests/unit/mcpgateway/services/test_sso_service.py
@@ -754,7 +754,7 @@ class TestTokenExchange:
         # Verify it's valid base64
         import base64
 
-        payload = auth_header[len("Basic "):]
+        payload = auth_header[len("Basic ") :]
         decoded = base64.b64decode(payload).decode("utf-8")
         assert decoded.startswith("test-client-id:")
         assert decoded.count(":") == 1
@@ -810,7 +810,7 @@ class TestTokenExchange:
         assert header.startswith("Basic ")
         import base64
 
-        payload = base64.b64decode(header[len("Basic "):]).decode("utf-8")
+        payload = base64.b64decode(header[len("Basic ") :]).decode("utf-8")
         assert payload == "client%40id:secret%3A%2B%3F"
 
     @pytest.mark.asyncio
@@ -3585,6 +3585,7 @@ class TestAuthenticateOrCreateUser:
         assert result == "jwt-token"
         assert existing_user.full_name == "New Name"
         assert existing_user.auth_provider == "github"
+        assert existing_user.email_verified_at is not None
 
     @pytest.mark.asyncio
     async def test_existing_user_calls_apply_team_mapping(self, sso_service, mock_db):
@@ -4063,6 +4064,7 @@ class TestAuthenticateOrCreateUser:
             )
 
         assert result == "new-jwt"
+        assert sso_service.auth_service.create_user.return_value.email_verified_at is not None
         sso_service._map_groups_to_roles.assert_called_once()
         sso_service._sync_user_roles.assert_called_once()
 

--- a/tests/unit/mcpgateway/services/test_sso_user_normalization.py
+++ b/tests/unit/mcpgateway/services/test_sso_user_normalization.py
@@ -1193,6 +1193,44 @@ class TestGenericOIDCNormalization:
 
         assert normalized["groups"] == ["Engineering"]
 
+    def test_generic_oidc_custom_email_and_username_claims(self, sso_service):
+        """Generic providers may select their stable local identity claims."""
+        provider = SSOProvider(
+            id="custom_oidc",
+            name="custom_oidc",
+            display_name="Custom OIDC",
+            provider_type="oidc",
+            provider_metadata={"email_claim": "principal", "username_claim": "login_name"},
+        )
+        user_data = {
+            "email": "contact@example.com",
+            "principal": "tenant-user@identity.example",
+            "login_name": "tenant-user",
+            "sub": "provider-subject-123",
+        }
+
+        normalized = sso_service.normalize_user_info(provider, user_data)
+
+        assert normalized["email"] == "tenant-user@identity.example"
+        assert normalized["username"] == "tenant-user"
+
+    def test_generic_oidc_missing_configured_email_claim_does_not_fallback(self, sso_service):
+        """An explicit identity mapping fails closed when its claim is absent."""
+        provider = SSOProvider(
+            id="custom_oidc",
+            name="custom_oidc",
+            display_name="Custom OIDC",
+            provider_type="oidc",
+            provider_metadata={"email_claim": "principal"},
+        )
+
+        normalized = sso_service.normalize_user_info(
+            provider,
+            {"email": "contact@example.com", "sub": "provider-subject-123"},
+        )
+
+        assert normalized["email"] is None
+
     def test_generic_oidc_groups_absent_claim(self, sso_service):
         """When no groups claim is present, groups defaults to empty list."""
         provider = SSOProvider(id="custom_oidc", name="custom_oidc", display_name="Custom OIDC", provider_type="oidc")

--- a/tests/unit/mcpgateway/test_auth.py
+++ b/tests/unit/mcpgateway/test_auth.py
@@ -14,12 +14,13 @@ and error handling scenarios.
 from datetime import datetime, timedelta, timezone
 import logging
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 # Third-Party
 from fastapi import HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials
 import pytest
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 # First-Party
@@ -4563,9 +4564,9 @@ class TestTenantIdPropagation:
 
         auth_module._propagate_tenant_id(request)
 
-        assert request.state.plugin_global_context.tenant_id == "team-acme", (
-            "_propagate_tenant_id must fill tenant_id even when middleware has already created plugin_global_context with tenant_id=None"
-        )
+        assert (
+            request.state.plugin_global_context.tenant_id == "team-acme"
+        ), "_propagate_tenant_id must fill tenant_id even when middleware has already created plugin_global_context with tenant_id=None"
 
     def test_propagate_tenant_id_no_overwrite(self):
         """_propagate_tenant_id must not overwrite an already-set tenant_id."""
@@ -6888,6 +6889,333 @@ class TestTryOauthAccessTokenErrorBranches:
 
         assert result is OAuthAuthResult.FAILED
         assert b"not registered in ContextForge" in _response_body(responses)
+
+    @pytest.mark.asyncio
+    async def test_missing_user_is_auto_provisioned(self, _pinned_app_domain, oauth_server_row):
+        """A trusted provider may provision a first-time headless MCP user."""
+        del _pinned_app_domain
+        handler, _responses = _make_handler()
+        token = _make_idp_token()
+        claims = {
+            "iss": IDP_ISSUER,
+            "sub": "provider-user-123",
+            "principal": "new-user@example.com",
+            "email": "contact@example.com",
+            "email_verified": True,
+        }
+        mock_user = MagicMock(is_active=True, is_admin=False)
+
+        async def fake_verify(*_args, **_kwargs):
+            return claims
+
+        lookup = MagicMock(side_effect=[None, mock_user])
+        provision = AsyncMock(return_value=True)
+
+        with (
+            _patched_get_db(oauth_server_row),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.transports.streamablehttp_transport._resolve_oauth_user_email", new_callable=AsyncMock, return_value="new-user@example.com"),
+            patch("mcpgateway.transports.streamablehttp_transport._auto_provision_oauth_user", provision),
+            patch("mcpgateway.auth._get_user_by_email_sync", lookup),
+            patch("mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock, return_value=[]),
+        ):
+            result = await handler._try_oauth_access_token(token, self._GOOD_UNVERIFIED)
+
+        assert result is OAuthAuthResult.SUCCESS
+        provision.assert_awaited_once_with(token, claims, "new-user@example.com")
+        assert lookup.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_existing_user_skips_auto_provision(self, _pinned_app_domain, oauth_server_row):
+        """Existing local users stay on the lookup fast path."""
+        del _pinned_app_domain
+        handler, _responses = _make_handler()
+        mock_user = MagicMock(is_active=True, is_admin=False)
+        provision = AsyncMock()
+
+        async def fake_verify(*_args, **_kwargs):
+            return {"iss": IDP_ISSUER, "email": "user@example.com"}
+
+        with (
+            _patched_get_db(oauth_server_row),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
+            patch("mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock, return_value=[]),
+            patch("mcpgateway.transports.streamablehttp_transport._auto_provision_oauth_user", provision),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token(), self._GOOD_UNVERIFIED)
+
+        assert result is OAuthAuthResult.SUCCESS
+        provision.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_auto_provision_requires_global_opt_in(self, monkeypatch):
+        """Virtual-server token JIT provisioning is disabled by default."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _auto_provision_oauth_user  # pylint: disable=import-outside-toplevel
+
+        monkeypatch.setattr(settings, "sso_api_token_auth_enabled", False)
+        resolve_provider = MagicMock()
+
+        with patch("mcpgateway.transports.streamablehttp_transport.resolve_trusted_provider_by_issuer", resolve_provider):
+            result = await _auto_provision_oauth_user(
+                "token",
+                {"iss": IDP_ISSUER, "email": "user@example.com"},
+                "user@example.com",
+            )
+
+        assert result is False
+        resolve_provider.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_auto_provision_requires_issuer(self, monkeypatch):
+        """Provisioning cannot select a provider without a verified issuer."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _auto_provision_oauth_user  # pylint: disable=import-outside-toplevel
+
+        monkeypatch.setattr(settings, "sso_api_token_auth_enabled", True)
+
+        result = await _auto_provision_oauth_user("token", {"email": "user@example.com"}, "user@example.com")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_oauth_principal_uses_provider_email_claim_mapping(self, monkeypatch):
+        """The MCP OAuth lookup uses the same normalized identity as SSO."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _resolve_oauth_user_email  # pylint: disable=import-outside-toplevel
+
+        monkeypatch.setattr(settings, "sso_api_token_auth_enabled", True)
+        provider = MagicMock(id="custom_oidc")
+        db_mock = MagicMock()
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=db_mock)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        sso_service = MagicMock()
+        sso_service.normalize_user_info.return_value = {"email": "stable-principal@example.com"}
+
+        with (
+            patch("mcpgateway.transports.streamablehttp_transport.get_db", return_value=cm),
+            patch("mcpgateway.transports.streamablehttp_transport.resolve_trusted_provider_by_issuer", return_value=provider),
+            patch("mcpgateway.transports.streamablehttp_transport.SSOService", return_value=sso_service),
+        ):
+            email = await _resolve_oauth_user_email(
+                {
+                    "iss": IDP_ISSUER,
+                    "email": "contact@example.com",
+                    "principal": "stable-principal@example.com",
+                }
+            )
+
+        assert email == "stable-principal@example.com"
+        sso_service.normalize_user_info.assert_called_once_with(provider, ANY)
+
+    @pytest.mark.asyncio
+    async def test_oauth_principal_missing_mapped_claim_fails_closed(self, monkeypatch):
+        """A matched provider cannot silently fall back to the contact email."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _resolve_oauth_user_email  # pylint: disable=import-outside-toplevel
+
+        monkeypatch.setattr(settings, "sso_api_token_auth_enabled", True)
+        provider = MagicMock(id="custom_oidc")
+        db_mock = MagicMock()
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=db_mock)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("mcpgateway.transports.streamablehttp_transport.get_db", return_value=cm),
+            patch("mcpgateway.transports.streamablehttp_transport.resolve_trusted_provider_by_issuer", return_value=provider),
+            patch("mcpgateway.transports.streamablehttp_transport.SSOService") as service_factory,
+        ):
+            service_factory.return_value.normalize_user_info.return_value = {"email": None}
+            email = await _resolve_oauth_user_email({"iss": IDP_ISSUER, "email": "contact@example.com"})
+
+        assert email is None
+
+    @pytest.mark.asyncio
+    async def test_oauth_principal_without_issuer_uses_legacy_claims(self, monkeypatch):
+        """Provider mapping is skipped when verified claims have no issuer."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _resolve_oauth_user_email  # pylint: disable=import-outside-toplevel
+
+        monkeypatch.setattr(settings, "sso_api_token_auth_enabled", True)
+
+        email = await _resolve_oauth_user_email({"email": "Legacy@Example.com"})
+
+        assert email == "legacy@example.com"
+
+    @pytest.mark.asyncio
+    async def test_oauth_principal_without_trusted_provider_uses_legacy_claims(self, monkeypatch):
+        """An unmatched issuer preserves the existing principal precedence."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _resolve_oauth_user_email  # pylint: disable=import-outside-toplevel
+
+        monkeypatch.setattr(settings, "sso_api_token_auth_enabled", True)
+        db_mock = MagicMock()
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=db_mock)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("mcpgateway.transports.streamablehttp_transport.get_db", return_value=cm),
+            patch("mcpgateway.transports.streamablehttp_transport.resolve_trusted_provider_by_issuer", return_value=None),
+        ):
+            email = await _resolve_oauth_user_email({"iss": IDP_ISSUER, "email": "Legacy@Example.com"})
+
+        assert email == "legacy@example.com"
+
+    @pytest.mark.asyncio
+    async def test_auto_provision_requires_provider_opt_in(self, monkeypatch):
+        """An API-trusted provider with auto-create disabled cannot create users."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _auto_provision_oauth_user  # pylint: disable=import-outside-toplevel
+
+        monkeypatch.setattr(settings, "sso_api_token_auth_enabled", True)
+        provider = MagicMock(auto_create_users=False)
+        db_mock = MagicMock()
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=db_mock)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        build = AsyncMock()
+
+        with (
+            patch("mcpgateway.transports.streamablehttp_transport.get_db", return_value=cm),
+            patch("mcpgateway.transports.streamablehttp_transport.resolve_trusted_provider_by_issuer", return_value=provider),
+            patch("mcpgateway.transports.streamablehttp_transport.build_external_identity", build),
+        ):
+            result = await _auto_provision_oauth_user(
+                "token",
+                {"iss": IDP_ISSUER, "email": "user@example.com"},
+                "user@example.com",
+            )
+
+        assert result is False
+        build.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_auto_provision_accepts_matching_normalized_identity(self, monkeypatch):
+        """A trusted auto-create provider provisions the selected local principal."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _auto_provision_oauth_user  # pylint: disable=import-outside-toplevel
+
+        monkeypatch.setattr(settings, "sso_api_token_auth_enabled", True)
+        provider = MagicMock(id="oidc", auto_create_users=True)
+        db_mock = MagicMock()
+        db_mock.info = {}
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=db_mock)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        claims = {"iss": IDP_ISSUER, "principal": "user@example.com"}
+        build = AsyncMock(return_value={"email": "user@example.com"})
+
+        with (
+            patch("mcpgateway.transports.streamablehttp_transport.get_db", return_value=cm),
+            patch("mcpgateway.transports.streamablehttp_transport.resolve_trusted_provider_by_issuer", return_value=provider),
+            patch("mcpgateway.transports.streamablehttp_transport.build_external_identity", build),
+        ):
+            result = await _auto_provision_oauth_user("token", claims, "user@example.com")
+
+        assert result is True
+        assert db_mock.info["external_owned"] is True
+        build.assert_awaited_once_with(provider, claims, "token", db_mock)
+
+    @pytest.mark.asyncio
+    async def test_auto_provision_rejects_unresolved_identity(self, monkeypatch):
+        """A provider that cannot provision the identity fails closed."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _auto_provision_oauth_user  # pylint: disable=import-outside-toplevel
+
+        monkeypatch.setattr(settings, "sso_api_token_auth_enabled", True)
+        provider = MagicMock(id="oidc", auto_create_users=True)
+        db_mock = MagicMock()
+        db_mock.info = {}
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=db_mock)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("mcpgateway.transports.streamablehttp_transport.get_db", return_value=cm),
+            patch("mcpgateway.transports.streamablehttp_transport.resolve_trusted_provider_by_issuer", return_value=provider),
+            patch("mcpgateway.transports.streamablehttp_transport.build_external_identity", new_callable=AsyncMock, return_value=None),
+        ):
+            result = await _auto_provision_oauth_user("token", {"iss": IDP_ISSUER}, "user@example.com")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_auto_provision_rejects_identity_mismatch(self, monkeypatch):
+        """Provisioning cannot switch to a different normalized local principal."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _auto_provision_oauth_user  # pylint: disable=import-outside-toplevel
+
+        monkeypatch.setattr(settings, "sso_api_token_auth_enabled", True)
+        provider = MagicMock(id="oidc", auto_create_users=True)
+        db_mock = MagicMock()
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=db_mock)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("mcpgateway.transports.streamablehttp_transport.get_db", return_value=cm),
+            patch("mcpgateway.transports.streamablehttp_transport.resolve_trusted_provider_by_issuer", return_value=provider),
+            patch(
+                "mcpgateway.transports.streamablehttp_transport.build_external_identity",
+                new_callable=AsyncMock,
+                return_value={"email": "different@example.com"},
+            ),
+        ):
+            result = await _auto_provision_oauth_user(
+                "token",
+                {"iss": IDP_ISSUER, "email": "expected@example.com"},
+                "expected@example.com",
+            )
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("error", "expected_status"), [(SQLAlchemyError("db down"), 503), (RuntimeError("unexpected"), 401)])
+    async def test_oauth_principal_resolution_errors_fail_closed(self, _pinned_app_domain, oauth_server_row, error, expected_status):
+        """Identity-resolution failures return the appropriate closed response."""
+        del _pinned_app_domain
+        handler, responses = _make_handler()
+
+        async def fake_verify(*_args, **_kwargs):
+            return {"iss": IDP_ISSUER, "email": "user@example.com"}
+
+        with (
+            _patched_get_db(oauth_server_row),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.transports.streamablehttp_transport._resolve_oauth_user_email", new_callable=AsyncMock, side_effect=error),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token(), self._GOOD_UNVERIFIED)
+
+        assert result is OAuthAuthResult.FAILED
+        start = next(message for message in responses if message["type"] == "http.response.start")
+        assert start["status"] == expected_status
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("error", "expected_status"), [(SQLAlchemyError("db down"), 503), (RuntimeError("unexpected"), 401)])
+    async def test_oauth_provisioning_errors_fail_closed(self, _pinned_app_domain, oauth_server_row, error, expected_status):
+        """JIT-provisioning failures return the appropriate closed response."""
+        del _pinned_app_domain
+        handler, responses = _make_handler()
+
+        async def fake_verify(*_args, **_kwargs):
+            return {"iss": IDP_ISSUER, "email": "user@example.com"}
+
+        with (
+            _patched_get_db(oauth_server_row),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.transports.streamablehttp_transport._resolve_oauth_user_email", new_callable=AsyncMock, return_value="user@example.com"),
+            patch("mcpgateway.transports.streamablehttp_transport._auto_provision_oauth_user", new_callable=AsyncMock, side_effect=error),
+            patch("mcpgateway.auth._get_user_by_email_sync", return_value=None),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token(), self._GOOD_UNVERIFIED)
+
+        assert result is OAuthAuthResult.FAILED
+        start = next(message for message in responses if message["type"] == "http.response.start")
+        assert start["status"] == expected_status
 
     @pytest.mark.asyncio
     async def test_inactive_user_rejected(self, _pinned_app_domain, oauth_server_row):


### PR DESCRIPTION
## 🔗 Epic / Issue

Closes #5306

---

## 🚀 Summary

JIT-provisions missing users during OAuth-enabled virtual-server MCP authentication by reusing ContextForge's trusted SSO provider path. The provider's existing `email_claim` mapping now selects the same local principal for browser SSO and MCP OAuth flows.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated behavior, including customized permission-error responses, is excluded
- [x] Tests are included with the code they validate

---

## 🧪 Checks

- [x] Affected unit suites pass for OAuth authentication, SSO provisioning, claim normalization, and external IdP authentication
- [x] Changed-line coverage is 100% (`diff-cover`, 79 executable lines)
- [x] Pinned Black, Ruff, Pylint, Bandit, and Interrogate checks pass for changed production code
- [x] `git diff --check` passes
- [ ] Full parallel suite: one pre-existing Hypothesis 200 ms deadline check was timing-sensitive (261 ms initially, 172 ms on replay); it passed when rerun in isolation
- [ ] CHANGELOG not updated; release changelog entries are maintained with release preparation

---

## 📓 Notes

Provisioning remains disabled unless `SSO_API_TOKEN_AUTH_ENABLED=true`. It also requires an enabled provider matched by verified issuer with both `trusted_for_api_auth=true` and `auto_create_users=true`.

The shared SSO path continues to enforce email verification, trusted domains, admin approval, account linking, role mapping, and team mapping. A configured `email_claim` is authoritative and fails closed when missing or invalid rather than falling back to a contact-email claim. Existing and disabled local-user behavior is unchanged.

This also persists `email_verified_at` after the shared SSO verification gate accepts a newly created or linked user.
