### PR TITLE
fix: add MCP handshake test endpoint for virtual servers

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -4510,6 +4510,15 @@ async def test_server_mcp_handshake(
         auth_token = request.cookies.get("jwt_token") or request.cookies.get("access_token")
     if auth_token:
         forwarded_headers["Authorization"] = f"Bearer {auth_token}"
+    elif settings.trust_proxy_auth:
+        # No bearer/cookie credential: this caller may have been authenticated via the
+        # configured trusted-proxy identity header instead (TRUST_PROXY_AUTH_DANGEROUSLY).
+        # Forward that header's *own already-verified value from this request* -- never
+        # anything from the request body -- so the probe reflects the same identity that
+        # got the caller past auth here.
+        proxy_user = request.headers.get(settings.proxy_user_header)
+        if proxy_user:
+            forwarded_headers[settings.proxy_user_header] = proxy_user
 
     return await test_server_handshake(server.id, server.name, server.enabled, body, forwarded_headers)
 

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -145,6 +145,7 @@ from mcpgateway.schemas import (
     CursorPaginatedServersResponse,
     CursorPaginatedToolsResponse,
     GatewayCreate,
+    GatewayHandshakeResponse,
     GatewayImpactPreview,
     GatewayRead,
     GatewayRefreshResponse,
@@ -165,6 +166,7 @@ from mcpgateway.schemas import (
     RootUpdate,
     RPCRequest,
     ServerCreate,
+    ServerHandshakeRequest,
     ServerRead,
     ServerUpdate,
     TaggedEntity,
@@ -189,6 +191,7 @@ from mcpgateway.services.gateway_service import (
     GatewayLookupConflictError,
     GatewayNameConflictError,
     GatewayNotFoundError,
+    test_server_handshake,
 )
 from mcpgateway.services.import_service import ConflictStrategy, ImportConflictError
 from mcpgateway.services.import_service import ImportError as ImportServiceError
@@ -4453,6 +4456,62 @@ async def toggle_server_status(
 
     warnings.warn("The /toggle endpoint is deprecated. Use /state instead.", DeprecationWarning, stacklevel=2)
     return await set_server_state(server_id, activate, db, user)
+
+
+@server_router.post("/{server_id}/test-handshake", response_model=GatewayHandshakeResponse)
+# allow_admin_bypass=False mirrors the analogous /gateways/test-handshake endpoint: this
+# probe makes the gateway itself act as an MCP client, so it goes through the same
+# explicit permission check platform admins get for every other action, not the bypass.
+@require_permission("servers.read", allow_admin_bypass=False)
+async def test_server_mcp_handshake(
+    server_id: str,
+    request: Request,
+    body: ServerHandshakeRequest = Body(default_factory=ServerHandshakeRequest),
+    db: Session = Depends(get_db),
+    user=Depends(get_current_user_with_permissions),
+) -> GatewayHandshakeResponse:
+    """Test whether a virtual server's own MCP endpoint speaks MCP via a protocol handshake.
+
+    Unlike ``POST /gateways/test-handshake``, the target isn't an arbitrary
+    caller-supplied URL — it's this server's own ``/servers/{server_id}/mcp``
+    transport, resolved from a server ID the caller already has read access to.
+    The handshake runs in-process (no outbound network call, no SSRF allowlist),
+    reusing the caller's own forwarded credentials by default so the result
+    reflects what that caller would actually see.
+
+    Args:
+        server_id (str): The ID of the virtual server to test.
+        request (Request): The incoming request, used for scoped access validation and to forward the caller's own credentials.
+        body (ServerHandshakeRequest): Optional header overrides for the handshake.
+        db (Session): The database session used to interact with the data store.
+        user: Authenticated user context.
+
+    Returns:
+        GatewayHandshakeResponse: The handshake outcome, including negotiation path,
+            server identity, capabilities, component counts, and failure classification.
+
+    Raises:
+        HTTPException: If the server is not found or the caller lacks visibility.
+    """
+    auth_user_email, auth_token_teams = get_scoped_resource_access_context(request, user)
+    try:
+        server = await server_service.get_server(db, server_id, user_email=auth_user_email, token_teams=auth_token_teams)
+    except ServerNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    _enforce_scoped_resource_access(request, db, user, f"/servers/{server_id}/test-handshake")
+
+    # Reuse the caller's own credentials for the probe (header or cookie, same precedence
+    # as get_current_user_with_permissions) rather than minting a new token or bypassing
+    # auth: the panel is testing what this caller can actually reach.
+    forwarded_headers: Dict[str, str] = {}
+    auth_header = get_auth_header_value(request.headers) or ""
+    auth_token = auth_header[7:] if auth_header.lower().startswith("bearer ") else None
+    if not auth_token and hasattr(request, "cookies") and request.cookies:
+        auth_token = request.cookies.get("jwt_token") or request.cookies.get("access_token")
+    if auth_token:
+        forwarded_headers["Authorization"] = f"Bearer {auth_token}"
+
+    return await test_server_handshake(server.id, server.name, server.enabled, body, forwarded_headers)
 
 
 @server_router.delete("/{server_id}", response_model=Dict[str, str])

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -4509,7 +4509,12 @@ async def test_server_mcp_handshake(
     if not auth_token and hasattr(request, "cookies") and request.cookies:
         auth_token = request.cookies.get("jwt_token") or request.cookies.get("access_token")
     if auth_token:
-        forwarded_headers["Authorization"] = f"Bearer {auth_token}"
+        # Forward under the *configured* auth header name -- when AUTH_HEADER_NAME is
+        # customized away from the default "Authorization", the nested request's own
+        # auth extraction (get_auth_header_value / _resolve_auth_header_name) only reads
+        # that header, so hardcoding "Authorization" here would make the probe fail auth
+        # even though the outer request succeeded.
+        forwarded_headers[_resolve_auth_header_name(settings)] = f"Bearer {auth_token}"
     elif settings.trust_proxy_auth:
         # No bearer/cookie credential: this caller may have been authenticated via the
         # configured trusted-proxy identity header instead (TRUST_PROXY_AUTH_DANGEROUSLY).

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -121,6 +121,10 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("GET", re.compile(r"^/servers/[^/]+/sse(?:$|/)"), Permissions.SERVERS_USE),  # Server SSE access endpoint
     ("GET", re.compile(r"^/servers(?:$|/)"), Permissions.SERVERS_READ),
     ("POST", re.compile(r"^/servers/?$"), Permissions.SERVERS_CREATE),  # Only exact /servers or /servers/
+    # Handshake probe against the virtual server's own MCP endpoint — read-only, symmetric
+    # with GATEWAYS_READ on the gateway test-handshake endpoint. Must precede the generic
+    # state|toggle sub-resource rule below.
+    ("POST", re.compile(r"^/servers/[^/]+/test-handshake(?:$|/)"), Permissions.SERVERS_READ),
     ("POST", re.compile(r"^/servers/[^/]+/(?:state|toggle)(?:$|/)"), Permissions.SERVERS_UPDATE),  # Server management sub-resources
     ("POST", re.compile(r"^/servers/[^/]+/message(?:$|/)"), Permissions.SERVERS_USE),  # Server message access endpoint
     ("POST", re.compile(r"^/servers/[^/]+/mcp(?:$|/)"), Permissions.SERVERS_USE),  # Server MCP access endpoint

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -4978,7 +4978,13 @@ class ServerHandshakeRequest(BaseModelWithConfigDict):
     an arbitrary caller-supplied URL, so no ``base_url``/``path`` fields exist here.
     """
 
-    headers: Optional[Dict[str, str]] = Field(None, description="Optional headers (e.g. Authorization) overriding the caller's own forwarded credentials")
+    headers: Optional[Dict[str, str]] = Field(
+        None,
+        description=(
+            "Optional header overrides for the handshake's credentials. Only 'Authorization' is honored -- "
+            "any other header (including proxy-identity, client-IP, session, or hop-by-hop headers) is ignored."
+        ),
+    )
 
 
 class TaggedEntity(BaseModelWithConfigDict):

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -4981,8 +4981,9 @@ class ServerHandshakeRequest(BaseModelWithConfigDict):
     headers: Optional[Dict[str, str]] = Field(
         None,
         description=(
-            "Optional header overrides for the handshake's credentials. Only 'Authorization' is honored -- "
-            "any other header (including proxy-identity, client-IP, session, or hop-by-hop headers) is ignored."
+            "Optional header overrides for the handshake's credentials. Only 'Authorization' and the "
+            "configured AUTH_HEADER_NAME (when customized) are honored -- any other header (including "
+            "proxy-identity, client-IP, session, or hop-by-hop headers) is ignored."
         ),
     )
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -4964,10 +4964,21 @@ class GatewayHandshakeResponse(BaseModelWithConfigDict):
     capabilities: Optional[Dict[str, Any]] = None
     component_counts: Optional[Dict[str, int]] = Field(None, description="Counts for tools/resources/prompts; a key is absent when the capability is not advertised")
     counts_partial: bool = Field(False, description="True when any list result had a nextCursor (counts are first-page lower bounds)")
-    credential_source: Literal["stored", "form", "none"] = "none"
+    credential_source: Literal["stored", "form", "none", "session"] = "none"
     failure_class: Optional[Literal["transport", "protocol", "auth", "invalid_response"]] = None
     error: Optional[str] = None
     raw_preview: Optional[str] = Field(None, description="Size-capped JSON preview of the final handshake payload")
+
+
+class ServerHandshakeRequest(BaseModelWithConfigDict):
+    """Request to run an MCP handshake test against a virtual server's own endpoint.
+
+    Unlike :class:`GatewayHandshakeRequest`, the target is derived from the
+    trusted, already-registered virtual server ID (path parameter) rather than
+    an arbitrary caller-supplied URL, so no ``base_url``/``path`` fields exist here.
+    """
+
+    headers: Optional[Dict[str, str]] = Field(None, description="Optional headers (e.g. Authorization) overriding the caller's own forwarded credentials")
 
 
 class TaggedEntity(BaseModelWithConfigDict):

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -7871,6 +7871,60 @@ async def _probe_mcp_session(
     )
 
 
+# Headers that must never reach the in-process handshake probe, regardless of
+# whether they arrived via the caller's own forwarded credentials or an explicit
+# body override: proxy-identity / client-IP headers a caller could otherwise use
+# to impersonate another principal or spoof their source IP against
+# TRUST_PROXY_AUTH_DANGEROUSLY or IP-scoped token checks, ContextForge-internal
+# routing headers, MCP session headers (must be derived fresh by the SDK), and
+# hop-by-hop headers that are never valid to forward manually.
+_HANDSHAKE_HEADER_DENYLIST: frozenset[str] = frozenset(
+    {
+        "host",
+        "x-real-ip",
+        "mcp-session-id",
+        "connection",
+        "keep-alive",
+        "proxy-connection",
+        "te",
+        "trailer",
+        "upgrade",
+        "content-length",
+        "transfer-encoding",
+    }
+)
+
+# The only header an explicit body override is trusted to set: the caller is
+# supplying their own credential for their own probe, so overriding Authorization
+# is safe. Anything else -- in particular the configured trusted-proxy identity
+# header -- must never be settable from arbitrary caller-supplied JSON.
+_HANDSHAKE_FORM_HEADER_ALLOWLIST: frozenset[str] = frozenset({"authorization"})
+
+
+def _is_handshake_header_denied(header_name: str, *, allow_proxy_identity: bool) -> bool:
+    """Whether a header must be dropped before it reaches the in-process handshake probe.
+
+    Args:
+        header_name: The header's name (any case).
+        allow_proxy_identity: Whether the configured trusted-proxy identity header
+            (``settings.proxy_user_header``) is allowed through. Only ``True`` for
+            headers sourced from the caller's own already-authenticated request
+            (see ``test_server_mcp_handshake`` in ``main.py``) -- never for an
+            explicit body override, which is arbitrary caller-supplied JSON.
+
+    Returns:
+        True if the header must be stripped.
+    """
+    lowered = header_name.lower()
+    if lowered in _HANDSHAKE_HEADER_DENYLIST:
+        return True
+    if lowered.startswith("x-forwarded-") or lowered.startswith("x-contextforge-"):
+        return True
+    if lowered == settings.proxy_user_header.lower():
+        return not allow_proxy_identity
+    return False
+
+
 async def test_server_handshake(
     server_id: str,
     server_name: str,
@@ -7920,12 +7974,15 @@ async def test_server_handshake(
             error=f"Virtual server '{server_name}' is disabled. Enable it before testing the connection.",
         )
 
-    # SECURITY: Host is stripped from both sources — it must be derived from the
-    # in-process target, never from caller input, the same rule test_gateway_handshake
-    # applies to gateway-test headers.
-    headers = {key: value for key, value in forwarded_headers.items() if key.lower() != "host"}
+    # SECURITY: forwarded_headers comes from the caller's own already-authenticated
+    # request (Authorization/cookie, or the configured trusted-proxy identity header
+    # -- see test_server_mcp_handshake in main.py) so it may carry that proxy header
+    # through; body.headers is arbitrary caller-supplied JSON and is restricted to a
+    # strict allowlist so it can never be used to inject proxy-identity, client-IP,
+    # session, or hop-by-hop headers into the in-process probe (CWE-287/CWE-807).
+    headers = {key: value for key, value in forwarded_headers.items() if not _is_handshake_header_denied(key, allow_proxy_identity=True)}
     credential_source: Literal["stored", "form", "none", "session"] = "session" if headers else "none"
-    form_headers = {key: value for key, value in (body.headers or {}).items() if key.lower() != "host"}
+    form_headers = {key: value for key, value in (body.headers or {}).items() if key.lower() in _HANDSHAKE_FORM_HEADER_ALLOWLIST}
     if form_headers:
         overridden_keys = {key.lower() for key in form_headers}
         headers = {key: value for key, value in headers.items() if key.lower() not in overridden_keys}

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -110,6 +110,7 @@ from mcpgateway.schemas import (
     GatewayUpdate,
     PromptCreate,
     ResourceCreate,
+    ServerHandshakeRequest,
     ToolCreate,
 )
 
@@ -130,6 +131,7 @@ from mcpgateway.services.token_exchange_cache import TokenExchangeCache
 from mcpgateway.utils.admin_check import is_admin_bypass_granted
 from mcpgateway.utils.create_slug import slugify
 from mcpgateway.utils.display_name import generate_display_name
+from mcpgateway.utils.internal_http import internal_loopback_base_url
 from mcpgateway.utils.pagination import unified_paginate
 from mcpgateway.utils.passthrough_headers import get_passthrough_headers
 from mcpgateway.utils.redis_client import get_redis_client
@@ -7812,6 +7814,184 @@ def _classify_handshake_error(root_cause: BaseException) -> tuple[str, str]:
     return "invalid_response", _HANDSHAKE_INVALID_COPY
 
 
+async def _probe_mcp_session(
+    session: ClientSession,
+    *,
+    credential_source: Literal["stored", "form", "none", "session"],
+    start_time: float,
+    log_context: str,
+) -> GatewayHandshakeResponse:
+    """Run initialize plus first-page component listings on an open MCP session.
+
+    Shared by the gateway-URL handshake and the virtual-server handshake: both
+    open a session by different means (an externally validated, DNS-pinned URL
+    vs. an in-process ASGI call to the gateway's own transport) but negotiate
+    and summarize the result identically.
+
+    Args:
+        session: The connected MCP client session.
+        credential_source: Provenance of the credentials used to open the session.
+        start_time: ``time.monotonic()`` value captured when the handshake attempt began.
+        log_context: Sanitized identifier (URL or server id) used in list-call debug logs.
+
+    Returns:
+        GatewayHandshakeResponse: The successful initialize-path result.
+    """
+    init = await session.initialize()
+    capabilities = init.capabilities.model_dump(by_alias=True, exclude_none=True)
+    component_counts: Dict[str, int] = {}
+    counts_partial = False
+    for capability, list_call, attr in (
+        (init.capabilities.tools, session.list_tools, "tools"),
+        (init.capabilities.resources, session.list_resources, "resources"),
+        (init.capabilities.prompts, session.list_prompts, "prompts"),
+    ):
+        if capability is None:
+            continue
+        try:
+            list_result = await list_call()
+            component_counts[attr] = len(getattr(list_result, attr))
+            if getattr(list_result, "nextCursor", None):
+                counts_partial = True
+        except Exception as list_exc:
+            logger.debug("MCP handshake list_%s failed for %s: %s", attr, log_context, list_exc)
+
+    return GatewayHandshakeResponse(
+        success=True,
+        latency_ms=int((time.monotonic() - start_time) * 1000),
+        negotiation_path="initialize",
+        protocol_version=str(init.protocolVersion),
+        server_name=init.serverInfo.name,
+        server_version=init.serverInfo.version,
+        capabilities=capabilities,
+        component_counts=component_counts or None,
+        counts_partial=counts_partial,
+        credential_source=credential_source,
+        raw_preview=json.dumps(init.model_dump(by_alias=True, exclude_none=True), default=str)[:4096],
+    )
+
+
+async def test_server_handshake(
+    server_id: str,
+    server_name: str,
+    server_enabled: bool,
+    body: ServerHandshakeRequest,
+    forwarded_headers: Dict[str, str],
+) -> GatewayHandshakeResponse:
+    """Test whether a virtual server's own MCP endpoint speaks MCP via a protocol handshake.
+
+    Unlike :func:`test_gateway_handshake`, the target is not an arbitrary
+    caller-supplied URL that must clear the gateway-test SSRF allowlist — it is
+    the gateway's own ``/servers/{server_id}/mcp`` transport endpoint, derived
+    from an ID the caller already had read access to (checked by the router via
+    :meth:`ServerService.get_server` before this is called). Skipping URL
+    validation here is deliberate: that gate exists to keep the process from
+    being used to probe arbitrary/internal hosts, and this target is never
+    anything other than the process's own transport.
+
+    The probe dispatches through an in-process ASGI transport (``httpx.ASGITransport``)
+    rather than a real network round trip, so it works identically behind any
+    reverse proxy/LB and — critically for multi-worker deployments — always lands
+    on this worker rather than being routed to an arbitrary one by the kernel.
+    It still runs the full request through the real ASGI app: auth, RBAC and MCP
+    negotiation are exercised exactly as they would be for a real client, using
+    the caller's own forwarded credentials (or an explicit header override), so
+    the result reflects what an actual client would see.
+
+    Args:
+        server_id: ID of the virtual server to test.
+        server_name: Display name of the virtual server, for error copy.
+        server_enabled: Whether the virtual server is currently enabled.
+        body: Optional header overrides for the handshake request.
+        forwarded_headers: Headers from the caller's original request (typically
+            just ``Authorization``/``Cookie``) to reuse as the handshake's credentials.
+
+    Returns:
+        GatewayHandshakeResponse: The handshake outcome, including negotiation path,
+            server identity, capabilities, component counts, and failure classification.
+    """
+    start_time = time.monotonic()
+
+    if not server_enabled:
+        return GatewayHandshakeResponse(
+            success=False,
+            latency_ms=int((time.monotonic() - start_time) * 1000),
+            failure_class="transport",
+            error=f"Virtual server '{server_name}' is disabled. Enable it before testing the connection.",
+        )
+
+    # SECURITY: Host is stripped from both sources — it must be derived from the
+    # in-process target, never from caller input, the same rule test_gateway_handshake
+    # applies to gateway-test headers.
+    headers = {key: value for key, value in forwarded_headers.items() if key.lower() != "host"}
+    credential_source: Literal["stored", "form", "none", "session"] = "session" if headers else "none"
+    form_headers = {key: value for key, value in (body.headers or {}).items() if key.lower() != "host"}
+    if form_headers:
+        overridden_keys = {key.lower() for key in form_headers}
+        headers = {key: value for key, value in headers.items() if key.lower() not in overridden_keys}
+        headers.update(form_headers)
+        credential_source = "form"
+
+    def _failure(failure_class: Literal["transport", "protocol", "auth", "invalid_response"], error: str) -> GatewayHandshakeResponse:
+        """Build a failed handshake response preserving the resolved credential source."""
+        return GatewayHandshakeResponse(success=False, latency_ms=int((time.monotonic() - start_time) * 1000), credential_source=credential_source, failure_class=failure_class, error=error)
+
+    # Deferred import: `main` imports this module at load time, so importing the
+    # ASGI `app` singleton at module scope here would be circular.
+    from mcpgateway.main import app  # pylint: disable=import-outside-toplevel,cyclic-import
+
+    def get_httpx_client_factory(
+        headers: Optional[Dict[str, str]] = None,
+        timeout: Optional[httpx.Timeout] = None,
+        auth: Optional[httpx.Auth] = None,
+    ) -> httpx.AsyncClient:
+        """Build the SDK's httpx client to dispatch in-process via ASGI transport rather than a real socket.
+
+        Args:
+            headers: Optional headers for the client.
+            timeout: Optional timeout for the client.
+            auth: Optional auth for the client.
+
+        Returns:
+            httpx.AsyncClient: Client wired to the gateway's own ASGI app.
+        """
+        return httpx.AsyncClient(
+            follow_redirects=False,
+            headers=headers,
+            timeout=timeout if timeout else get_http_timeout(),
+            auth=auth,
+            # client=("127.0.0.1", 0) sets scope["client"] to a loopback address, matching
+            # the trust posture of a same-host caller (see post_rpc_in_process precedent).
+            transport=httpx.ASGITransport(app=app, client=("127.0.0.1", 0)),
+        )
+
+    target_url = f"{internal_loopback_base_url()}/servers/{server_id}/mcp"
+
+    try:
+        async with asyncio.timeout(settings.health_check_timeout):
+            try:
+                async with streamablehttp_client(url=target_url, headers=headers, timeout=settings.health_check_timeout, httpx_client_factory=get_httpx_client_factory) as (
+                    read_stream,
+                    write_stream,
+                    _get_session_id,
+                ):
+                    async with ClientSession(read_stream, write_stream) as session:
+                        return await _probe_mcp_session(session, credential_source=credential_source, start_time=start_time, log_context=server_id)
+            except TimeoutError:
+                raise
+            except Exception as e:
+                root_cause: BaseException = e
+                while isinstance(root_cause, BaseExceptionGroup) and root_cause.exceptions:  # pylint: disable=no-member
+                    root_cause = root_cause.exceptions[0]  # pylint: disable=no-member
+                failure_class, copy = _classify_handshake_error(root_cause)
+                if failure_class == "transport":
+                    copy = f"{copy}: {sanitize_exception_message(str(root_cause))}"
+                logger.warning("MCP handshake initialize failed for virtual server %s: %s", server_id, sanitize_exception_message(str(root_cause)))
+                return _failure(failure_class, copy)
+    except TimeoutError:
+        return _failure("transport", _HANDSHAKE_TRANSPORT_COPY)
+
+
 async def test_gateway_connectivity(
     request: GatewayTestRequest,
     team_id: Optional[str],
@@ -8301,38 +8481,7 @@ async def test_gateway_handshake(
                 Returns:
                     GatewayHandshakeResponse: The successful initialize-path result.
                 """
-                init = await session.initialize()
-                capabilities = init.capabilities.model_dump(by_alias=True, exclude_none=True)
-                component_counts: Dict[str, int] = {}
-                counts_partial = False
-                for capability, list_call, attr in (
-                    (init.capabilities.tools, session.list_tools, "tools"),
-                    (init.capabilities.resources, session.list_resources, "resources"),
-                    (init.capabilities.prompts, session.list_prompts, "prompts"),
-                ):
-                    if capability is None:
-                        continue
-                    try:
-                        list_result = await list_call()
-                        component_counts[attr] = len(getattr(list_result, attr))
-                        if getattr(list_result, "nextCursor", None):
-                            counts_partial = True
-                    except Exception as list_exc:
-                        logger.debug("MCP handshake list_%s failed for %s: %s", attr, sanitize_url_for_logging(validated_base_url), list_exc)
-
-                return GatewayHandshakeResponse(
-                    success=True,
-                    latency_ms=_latency_ms(),
-                    negotiation_path="initialize",
-                    protocol_version=str(init.protocolVersion),
-                    server_name=init.serverInfo.name,
-                    server_version=init.serverInfo.version,
-                    capabilities=capabilities,
-                    component_counts=component_counts or None,
-                    counts_partial=counts_partial,
-                    credential_source=credential_source,
-                    raw_preview=json.dumps(init.model_dump(by_alias=True, exclude_none=True), default=str)[:4096],
-                )
+                return await _probe_mcp_session(session, credential_source=credential_source, start_time=start_time, log_context=sanitize_url_for_logging(validated_base_url))
 
             try:
                 # SECURITY: the SDK keeps the validated hostname (it rejects a server-advertised

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -143,6 +143,7 @@ from mcpgateway.utils.subject_token import extract_subject_jwt
 from mcpgateway.utils.token_exchange_audit import audit_token_exchange
 from mcpgateway.utils.url_auth import apply_query_param_auth, sanitize_exception_message, sanitize_url_for_logging
 from mcpgateway.utils.validate_signature import validate_signature
+from mcpgateway.utils.verify_credentials import _resolve_auth_header_name
 from mcpgateway.validation.tags import validate_tags_field
 
 
@@ -7894,11 +7895,22 @@ _HANDSHAKE_HEADER_DENYLIST: frozenset[str] = frozenset(
     }
 )
 
-# The only header an explicit body override is trusted to set: the caller is
-# supplying their own credential for their own probe, so overriding Authorization
-# is safe. Anything else -- in particular the configured trusted-proxy identity
-# header -- must never be settable from arbitrary caller-supplied JSON.
-_HANDSHAKE_FORM_HEADER_ALLOWLIST: frozenset[str] = frozenset({"authorization"})
+
+def _handshake_form_header_allowlist() -> frozenset[str]:
+    """The only header(s) an explicit body override is trusted to set.
+
+    The caller is supplying their own credential for their own probe, so
+    overriding the auth header is safe -- both the literal ``authorization``
+    and, when ``AUTH_HEADER_NAME`` is customized away from the default, the
+    configured auth header name are honored (matching the nested request's
+    own auth extraction, which reads that configured name). Anything else --
+    in particular the configured trusted-proxy identity header -- must never
+    be settable from arbitrary caller-supplied JSON.
+
+    Returns:
+        The set of lowercased header names an explicit body override may set.
+    """
+    return frozenset({"authorization", _resolve_auth_header_name(settings).lower()})
 
 
 def _is_handshake_header_denied(header_name: str, *, allow_proxy_identity: bool) -> bool:
@@ -7982,7 +7994,7 @@ async def test_server_handshake(
     # session, or hop-by-hop headers into the in-process probe (CWE-287/CWE-807).
     headers = {key: value for key, value in forwarded_headers.items() if not _is_handshake_header_denied(key, allow_proxy_identity=True)}
     credential_source: Literal["stored", "form", "none", "session"] = "session" if headers else "none"
-    form_headers = {key: value for key, value in (body.headers or {}).items() if key.lower() in _HANDSHAKE_FORM_HEADER_ALLOWLIST}
+    form_headers = {key: value for key, value in (body.headers or {}).items() if key.lower() in _handshake_form_header_allowlist()}
     if form_headers:
         overridden_keys = {key.lower() for key in form_headers}
         headers = {key: value for key, value in headers.items() if key.lower() not in overridden_keys}

--- a/tests/unit/mcpgateway/services/test_server_handshake.py
+++ b/tests/unit/mcpgateway/services/test_server_handshake.py
@@ -23,8 +23,16 @@ from mcpgateway.schemas import GatewayHandshakeResponse, ServerHandshakeRequest
 from mcpgateway.services.gateway_service import test_server_handshake as run_server_handshake
 
 
-def _mock_sdk_session():
-    """Build mocked streamablehttp_client / ClientSession context managers for a successful initialize."""
+def _mock_sdk_session(init_side_effect=None):
+    """Build mocked streamablehttp_client / ClientSession context managers.
+
+    Args:
+        init_side_effect: Optional exception (or exception instance) for
+            ``session.initialize()`` to raise instead of succeeding.
+
+    Returns:
+        Tuple of (transport context manager, session) mocks.
+    """
     init_result = MagicMock()
     init_result.protocolVersion = "2025-11-25"
     init_result.serverInfo.name = "smoke-test-server"
@@ -40,7 +48,7 @@ def _mock_sdk_session():
     tools_result.nextCursor = None
 
     session = MagicMock()
-    session.initialize = AsyncMock(return_value=init_result)
+    session.initialize = AsyncMock(side_effect=init_side_effect, return_value=init_result) if init_side_effect else AsyncMock(return_value=init_result)
     session.list_tools = AsyncMock(return_value=tools_result)
     session.__aenter__ = AsyncMock(return_value=session)
     session.__aexit__ = AsyncMock(return_value=None)
@@ -158,3 +166,65 @@ async def test_connect_error_is_classified_as_transport_failure():
 
     assert result.success is False
     assert result.failure_class == "transport"
+
+
+@pytest.mark.asyncio
+async def test_initialize_timeout_is_transport_failure():
+    """A TimeoutError from the SDK session re-raises past the inner handler and is caught as a transport failure."""
+    # First-Party
+    from mcpgateway.services.gateway_service import _HANDSHAKE_TRANSPORT_COPY
+
+    transport_cm, session = _mock_sdk_session(init_side_effect=TimeoutError())
+
+    with patch("mcpgateway.main.app", MagicMock()):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm):
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                result = await run_server_handshake("srv-1", "my-server", True, ServerHandshakeRequest(), {})
+
+    assert result.success is False
+    assert result.failure_class == "transport"
+    assert result.error == _HANDSHAKE_TRANSPORT_COPY
+
+
+@pytest.mark.asyncio
+async def test_exception_group_unwraps_root_cause():
+    """A grouped initialize failure is classified from its root cause and keeps the detail suffix."""
+    # Third-Party
+    import httpx
+
+    # First-Party
+    from mcpgateway.services.gateway_service import _HANDSHAKE_TRANSPORT_COPY
+
+    transport_cm, session = _mock_sdk_session(init_side_effect=ExceptionGroup("handshake failed", [httpx.ConnectError("connection refused")]))
+
+    with patch("mcpgateway.main.app", MagicMock()):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm):
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                result = await run_server_handshake("srv-1", "my-server", True, ServerHandshakeRequest(), {})
+
+    assert result.success is False
+    assert result.failure_class == "transport"
+    assert result.error == f"{_HANDSHAKE_TRANSPORT_COPY}: connection refused"
+
+
+@pytest.mark.asyncio
+async def test_httpx_client_factory_builds_asgi_transport_client():
+    """The httpx_client_factory passed to the SDK builds a client wired to the ASGI transport."""
+    # Third-Party
+    import httpx
+
+    transport_cm, session = _mock_sdk_session()
+    fake_app = MagicMock()
+
+    with patch("mcpgateway.main.app", fake_app):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                await run_server_handshake("srv-1", "my-server", True, ServerHandshakeRequest(), {})
+
+    factory = mock_streamable.call_args.kwargs["httpx_client_factory"]
+    client = factory()
+    try:
+        assert isinstance(client, httpx.AsyncClient)
+        assert isinstance(client._transport, httpx.ASGITransport)
+    finally:
+        await client.aclose()

--- a/tests/unit/mcpgateway/services/test_server_handshake.py
+++ b/tests/unit/mcpgateway/services/test_server_handshake.py
@@ -155,6 +155,67 @@ async def test_body_header_override_ignores_host():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "forbidden_header",
+    [
+        "X-Authenticated-User",  # default settings.proxy_user_header -- trusted-proxy identity spoofing
+        "X-Forwarded-For",
+        "X-Forwarded-Host",
+        "X-Real-IP",
+        "X-ContextForge-Internal",
+        "Mcp-Session-Id",
+        "Connection",
+        "Transfer-Encoding",
+    ],
+)
+async def test_body_header_override_drops_forbidden_headers(forbidden_header):
+    """A caller-supplied proxy-identity/client-IP/session/hop-by-hop header in the body override never
+    reaches the in-process probe -- only 'Authorization' is honored from arbitrary body JSON (CWE-287/CWE-807).
+    """
+    transport_cm, session = _mock_sdk_session()
+
+    with patch("mcpgateway.main.app", MagicMock()):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                result = await run_server_handshake(
+                    "srv-1",
+                    "my-server",
+                    True,
+                    ServerHandshakeRequest(headers={forbidden_header: "spoofed-value", "Authorization": "Bearer caller-own-token"}),
+                    {},
+                )
+
+    called_headers = mock_streamable.call_args.kwargs["headers"]
+    assert forbidden_header.lower() not in {k.lower() for k in called_headers}
+    assert called_headers["Authorization"] == "Bearer caller-own-token"
+    assert result.credential_source == "form"
+
+
+@pytest.mark.asyncio
+async def test_forwarded_proxy_identity_header_is_not_overridable_by_body():
+    """Even when the caller's own forwarded credentials legitimately carry the trusted-proxy identity
+    header (TRUST_PROXY_AUTH_DANGEROUSLY), a body override cannot replace it with a different identity --
+    the override key is dropped, not merged in, so the session-derived value stands.
+    """
+    transport_cm, session = _mock_sdk_session()
+
+    with patch("mcpgateway.main.app", MagicMock()):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                result = await run_server_handshake(
+                    "srv-1",
+                    "my-server",
+                    True,
+                    ServerHandshakeRequest(headers={"X-Authenticated-User": "victim@example.com"}),
+                    {"X-Authenticated-User": "caller@example.com"},
+                )
+
+    called_headers = {k.lower(): v for k, v in mock_streamable.call_args.kwargs["headers"].items()}
+    assert called_headers.get("x-authenticated-user") == "caller@example.com"
+    assert result.credential_source == "session"
+
+
+@pytest.mark.asyncio
 async def test_connect_error_is_classified_as_transport_failure():
     """A connection error from the in-process transport is classified the same way as a real gateway handshake."""
     # Third-Party

--- a/tests/unit/mcpgateway/services/test_server_handshake.py
+++ b/tests/unit/mcpgateway/services/test_server_handshake.py
@@ -216,6 +216,62 @@ async def test_forwarded_proxy_identity_header_is_not_overridable_by_body():
 
 
 @pytest.mark.asyncio
+async def test_body_header_override_honors_custom_auth_header_name(monkeypatch):
+    """When AUTH_HEADER_NAME is customized, a body override under that configured header name is
+    honored (not just the literal 'Authorization'), matching the nested request's own auth extraction.
+    """
+    # First-Party
+    from mcpgateway.config import settings
+
+    monkeypatch.setattr(settings, "auth_header_name", "X-MCP-Gateway-Auth")
+
+    transport_cm, session = _mock_sdk_session()
+
+    with patch("mcpgateway.main.app", MagicMock()):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                result = await run_server_handshake(
+                    "srv-1",
+                    "my-server",
+                    True,
+                    ServerHandshakeRequest(headers={"X-MCP-Gateway-Auth": "Bearer custom-header-token"}),
+                    {},
+                )
+
+    called_headers = {k.lower(): v for k, v in mock_streamable.call_args.kwargs["headers"].items()}
+    assert called_headers.get("x-mcp-gateway-auth") == "Bearer custom-header-token"
+    assert result.credential_source == "form"
+
+
+@pytest.mark.asyncio
+async def test_body_header_override_still_drops_spoofed_headers_with_custom_auth_header_name(monkeypatch):
+    """Customizing AUTH_HEADER_NAME widens the allowlist by exactly one entry -- proxy-identity and
+    other spoofed headers in a body override remain dropped.
+    """
+    # First-Party
+    from mcpgateway.config import settings
+
+    monkeypatch.setattr(settings, "auth_header_name", "X-MCP-Gateway-Auth")
+
+    transport_cm, session = _mock_sdk_session()
+
+    with patch("mcpgateway.main.app", MagicMock()):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                await run_server_handshake(
+                    "srv-1",
+                    "my-server",
+                    True,
+                    ServerHandshakeRequest(headers={"X-MCP-Gateway-Auth": "Bearer custom-header-token", "X-Authenticated-User": "spoofed@example.com"}),
+                    {},
+                )
+
+    called_headers = {k.lower(): v for k, v in mock_streamable.call_args.kwargs["headers"].items()}
+    assert called_headers.get("x-mcp-gateway-auth") == "Bearer custom-header-token"
+    assert "x-authenticated-user" not in called_headers
+
+
+@pytest.mark.asyncio
 async def test_connect_error_is_classified_as_transport_failure():
     """A connection error from the in-process transport is classified the same way as a real gateway handshake."""
     # Third-Party

--- a/tests/unit/mcpgateway/services/test_server_handshake.py
+++ b/tests/unit/mcpgateway/services/test_server_handshake.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_server_handshake.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for gateway_service.test_server_handshake (issue #6370).
+
+Unlike test_gateway_handshake, the target is the virtual server's own
+/servers/{id}/mcp transport rather than a caller-supplied URL, so there is no
+SSRF allowlist to clear: these tests focus on the disabled-server short
+circuit, credential-source resolution (session/form/none), the in-process
+ASGI dispatch, and failure classification passthrough.
+"""
+
+# Standard
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.schemas import GatewayHandshakeResponse, ServerHandshakeRequest
+from mcpgateway.services.gateway_service import test_server_handshake as run_server_handshake
+
+
+def _mock_sdk_session():
+    """Build mocked streamablehttp_client / ClientSession context managers for a successful initialize."""
+    init_result = MagicMock()
+    init_result.protocolVersion = "2025-11-25"
+    init_result.serverInfo.name = "smoke-test-server"
+    init_result.serverInfo.version = "1.0"
+    init_result.capabilities.tools = MagicMock()
+    init_result.capabilities.resources = None
+    init_result.capabilities.prompts = None
+    init_result.capabilities.model_dump.return_value = {"tools": {}}
+    init_result.model_dump.return_value = {"protocolVersion": "2025-11-25"}
+
+    tools_result = MagicMock()
+    tools_result.tools = [MagicMock(), MagicMock()]
+    tools_result.nextCursor = None
+
+    session = MagicMock()
+    session.initialize = AsyncMock(return_value=init_result)
+    session.list_tools = AsyncMock(return_value=tools_result)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+
+    transport_cm = MagicMock()
+    transport_cm.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock(), MagicMock()))
+    transport_cm.__aexit__ = AsyncMock(return_value=None)
+
+    return transport_cm, session
+
+
+@pytest.mark.asyncio
+async def test_disabled_server_fails_without_attempting_a_handshake():
+    """A disabled virtual server returns a graceful failure with no outbound dispatch."""
+    with patch("mcpgateway.services.gateway_service.streamablehttp_client") as mock_streamable:
+        result = await run_server_handshake("srv-1", "my-server", False, ServerHandshakeRequest(), {})
+
+    assert isinstance(result, GatewayHandshakeResponse)
+    assert result.success is False
+    assert result.failure_class == "transport"
+    assert "disabled" in result.error
+    mock_streamable.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_successful_handshake_reuses_forwarded_session_credentials():
+    """A successful initialize round-trip reports credential_source='session' when only forwarded headers are present."""
+    transport_cm, session = _mock_sdk_session()
+
+    with patch("mcpgateway.main.app", MagicMock()):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                result = await run_server_handshake("srv-1", "my-server", True, ServerHandshakeRequest(), {"Authorization": "Bearer caller-token"})
+
+    assert result.success is True
+    assert result.negotiation_path == "initialize"
+    assert result.protocol_version == "2025-11-25"
+    assert result.server_name == "smoke-test-server"
+    assert result.component_counts == {"tools": 2}
+    assert result.credential_source == "session"
+
+    # Target is derived from the server ID via a loopback URL, never from caller input.
+    called_url = mock_streamable.call_args.kwargs["url"]
+    assert called_url.endswith("/servers/srv-1/mcp")
+    called_headers = mock_streamable.call_args.kwargs["headers"]
+    assert called_headers["Authorization"] == "Bearer caller-token"
+
+
+@pytest.mark.asyncio
+async def test_no_credentials_reports_none_source():
+    """No forwarded headers and no body override reports credential_source='none'."""
+    transport_cm, session = _mock_sdk_session()
+
+    with patch("mcpgateway.main.app", MagicMock()):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm):
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                result = await run_server_handshake("srv-1", "my-server", True, ServerHandshakeRequest(), {})
+
+    assert result.success is True
+    assert result.credential_source == "none"
+
+
+@pytest.mark.asyncio
+async def test_body_header_override_wins_over_forwarded_credentials():
+    """An explicit header override in the request body replaces the forwarded Authorization and reports credential_source='form'."""
+    transport_cm, session = _mock_sdk_session()
+
+    with patch("mcpgateway.main.app", MagicMock()):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                result = await run_server_handshake(
+                    "srv-1",
+                    "my-server",
+                    True,
+                    ServerHandshakeRequest(headers={"Authorization": "Bearer override-token"}),
+                    {"Authorization": "Bearer caller-token"},
+                )
+
+    assert result.success is True
+    assert result.credential_source == "form"
+    called_headers = mock_streamable.call_args.kwargs["headers"]
+    assert called_headers["Authorization"] == "Bearer override-token"
+
+
+@pytest.mark.asyncio
+async def test_body_header_override_ignores_host():
+    """A caller-supplied Host in the body override is stripped, matching the gateway-handshake rule."""
+    transport_cm, session = _mock_sdk_session()
+
+    with patch("mcpgateway.main.app", MagicMock()):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
+                await run_server_handshake(
+                    "srv-1",
+                    "my-server",
+                    True,
+                    ServerHandshakeRequest(headers={"Host": "evil.example.com"}),
+                    {},
+                )
+
+    called_headers = mock_streamable.call_args.kwargs["headers"]
+    assert "Host" not in called_headers
+    assert "host" not in {k.lower() for k in called_headers}
+
+
+@pytest.mark.asyncio
+async def test_connect_error_is_classified_as_transport_failure():
+    """A connection error from the in-process transport is classified the same way as a real gateway handshake."""
+    # Third-Party
+    import httpx
+
+    with patch("mcpgateway.main.app", MagicMock()):
+        with patch("mcpgateway.services.gateway_service.streamablehttp_client", side_effect=httpx.ConnectError("boom")):
+            result = await run_server_handshake("srv-1", "my-server", True, ServerHandshakeRequest(), {})
+
+    assert result.success is False
+    assert result.failure_class == "transport"

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -1124,6 +1124,111 @@ class TestServerEndpoints:
         mock_list_prompts.assert_called_once()
 
 
+class TestServerHandshakeEndpoint:
+    """Tests for POST /servers/{server_id}/test-handshake (issue #6370).
+
+    Unlike /gateways/test-handshake, the target is the virtual server's own
+    /servers/{id}/mcp transport (derived from the ID, not a caller-supplied
+    URL), so these tests focus on: 404 for an invisible/missing server, the
+    router-level credential-forwarding logic (Authorization header vs. cookie
+    vs. neither), and that both the legacy and /v1/virtual-servers alias
+    paths reach the same handler. The handshake mechanics themselves
+    (in-process ASGI dispatch, MCP negotiation) are covered directly against
+    ``gateway_service.test_server_handshake``.
+    """
+
+    @pytest.mark.parametrize("path_prefix", SERVER_CRUD_PREFIXES)
+    @patch("mcpgateway.main.test_server_handshake")
+    @patch("mcpgateway.main.server_service.get_server")
+    def test_handshake_endpoint_success(self, mock_get_server, mock_handshake, path_prefix, test_client, auth_headers):
+        """A visible, enabled server reaches test_server_handshake and returns its result."""
+        # First-Party
+        from mcpgateway.schemas import GatewayHandshakeResponse
+
+        mock_get_server.return_value = ServerRead(**MOCK_SERVER_READ)
+        mock_handshake.return_value = GatewayHandshakeResponse(
+            success=True,
+            latency_ms=12,
+            negotiation_path="initialize",
+            protocol_version="2025-11-25",
+            server_name="test_server",
+            server_version="1.0",
+            credential_source="session",
+        )
+
+        response = test_client.post(f"{path_prefix}/1/test-handshake", json={}, headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["negotiationPath"] == "initialize"
+        assert data["credentialSource"] == "session"
+        mock_handshake.assert_called_once()
+        call_args = mock_handshake.call_args.args
+        assert call_args[0] == MOCK_SERVER_READ["id"]
+        assert call_args[1] == MOCK_SERVER_READ["name"]
+        assert call_args[2] == MOCK_SERVER_READ["enabled"]
+
+    @patch("mcpgateway.main.server_service.get_server")
+    def test_handshake_endpoint_not_found(self, mock_get_server, test_client, auth_headers):
+        """A missing or invisible server returns 404 without attempting a handshake."""
+        # First-Party
+        from mcpgateway.services.server_service import ServerNotFoundError
+
+        mock_get_server.side_effect = ServerNotFoundError("Server not found: missing")
+
+        response = test_client.post("/servers/missing/test-handshake", json={}, headers=auth_headers)
+
+        assert response.status_code == 404
+
+    @patch("mcpgateway.main.test_server_handshake")
+    @patch("mcpgateway.main.server_service.get_server")
+    def test_handshake_forwards_bearer_token(self, mock_get_server, mock_handshake, test_client, auth_headers):
+        """The caller's own bearer token is forwarded as the handshake's default credentials."""
+        # First-Party
+        from mcpgateway.schemas import GatewayHandshakeResponse
+
+        mock_get_server.return_value = ServerRead(**MOCK_SERVER_READ)
+        mock_handshake.return_value = GatewayHandshakeResponse(success=True, latency_ms=1)
+
+        test_client.post("/servers/1/test-handshake", json={}, headers=auth_headers)
+
+        forwarded_headers = mock_handshake.call_args.args[4]
+        assert forwarded_headers.get("Authorization") == auth_headers["Authorization"]
+
+    @patch("mcpgateway.main.test_server_handshake")
+    @patch("mcpgateway.main.server_service.get_server")
+    def test_handshake_without_credentials_forwards_nothing(self, mock_get_server, mock_handshake, test_client):
+        """A request with no Authorization header and no cookie forwards no credentials."""
+        # First-Party
+        from mcpgateway.schemas import GatewayHandshakeResponse
+
+        mock_get_server.return_value = ServerRead(**MOCK_SERVER_READ)
+        mock_handshake.return_value = GatewayHandshakeResponse(success=True, latency_ms=1)
+
+        # The test_client fixture's dependency overrides bypass auth regardless of headers,
+        # so this exercises the router's own extraction logic in isolation.
+        test_client.post("/servers/1/test-handshake", json={})
+
+        forwarded_headers = mock_handshake.call_args.args[4]
+        assert "Authorization" not in forwarded_headers
+
+    @patch("mcpgateway.main.test_server_handshake")
+    @patch("mcpgateway.main.server_service.get_server")
+    def test_handshake_header_override_reaches_service(self, mock_get_server, mock_handshake, test_client, auth_headers):
+        """An explicit ``headers`` override in the request body is passed through to the service."""
+        # First-Party
+        from mcpgateway.schemas import GatewayHandshakeResponse
+
+        mock_get_server.return_value = ServerRead(**MOCK_SERVER_READ)
+        mock_handshake.return_value = GatewayHandshakeResponse(success=True, latency_ms=1)
+
+        test_client.post("/servers/1/test-handshake", json={"headers": {"X-Custom": "value"}}, headers=auth_headers)
+
+        body = mock_handshake.call_args.args[3]
+        assert body.headers == {"X-Custom": "value"}
+
+
 # ----------------------------------------------------- #
 # Tool Management Tests                                 #
 # ----------------------------------------------------- #

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -1183,6 +1183,25 @@ class TestServerHandshakeEndpoint:
 
     @patch("mcpgateway.main.test_server_handshake")
     @patch("mcpgateway.main.server_service.get_server")
+    def test_handshake_falls_back_to_cookie_when_no_bearer_header(self, mock_get_server, mock_handshake, test_client):
+        """With no Authorization header, a jwt_token cookie is forwarded as the handshake's credentials."""
+        # First-Party
+        from mcpgateway.schemas import GatewayHandshakeResponse
+
+        mock_get_server.return_value = ServerRead(**MOCK_SERVER_READ)
+        mock_handshake.return_value = GatewayHandshakeResponse(success=True, latency_ms=1)
+
+        test_client.cookies.set("jwt_token", "cookie-token")
+        try:
+            test_client.post("/servers/1/test-handshake", json={})
+        finally:
+            test_client.cookies.delete("jwt_token")
+
+        forwarded_headers = mock_handshake.call_args.args[4]
+        assert forwarded_headers.get("Authorization") == "Bearer cookie-token"
+
+    @patch("mcpgateway.main.test_server_handshake")
+    @patch("mcpgateway.main.server_service.get_server")
     def test_handshake_forwards_bearer_token(self, mock_get_server, mock_handshake, test_client, auth_headers):
         """The caller's own bearer token is forwarded as the handshake's default credentials."""
         # First-Party

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -1235,7 +1235,11 @@ class TestServerHandshakeEndpoint:
     @patch("mcpgateway.main.test_server_handshake")
     @patch("mcpgateway.main.server_service.get_server")
     def test_handshake_header_override_reaches_service(self, mock_get_server, mock_handshake, test_client, auth_headers):
-        """An explicit ``headers`` override in the request body is passed through to the service."""
+        """An explicit ``headers`` override in the request body is passed through to the service.
+
+        The service layer (not the router) is responsible for restricting which override
+        headers are actually honored -- see test_server_handshake.py's deny-path coverage.
+        """
         # First-Party
         from mcpgateway.schemas import GatewayHandshakeResponse
 
@@ -1246,6 +1250,48 @@ class TestServerHandshakeEndpoint:
 
         body = mock_handshake.call_args.args[3]
         assert body.headers == {"X-Custom": "value"}
+
+    @patch("mcpgateway.main.test_server_handshake")
+    @patch("mcpgateway.main.server_service.get_server")
+    def test_handshake_forwards_trusted_proxy_identity_header_when_no_bearer_or_cookie(self, mock_get_server, mock_handshake, test_client, monkeypatch):
+        """With TRUST_PROXY_AUTH_DANGEROUSLY enabled and no Authorization header/cookie, the caller's own
+        already-verified trusted-proxy identity header (from this request, not the body) is forwarded under
+        the configured header name -- not hardcoded to 'Authorization'.
+        """
+        # First-Party
+        from mcpgateway.schemas import GatewayHandshakeResponse
+
+        monkeypatch.setattr(settings, "trust_proxy_auth", True)
+        monkeypatch.setattr(settings, "proxy_user_header", "X-Authenticated-User")
+
+        mock_get_server.return_value = ServerRead(**MOCK_SERVER_READ)
+        mock_handshake.return_value = GatewayHandshakeResponse(success=True, latency_ms=1)
+
+        test_client.post("/servers/1/test-handshake", json={}, headers={"X-Authenticated-User": "proxy-user@example.com"})
+
+        forwarded_headers = mock_handshake.call_args.args[4]
+        assert forwarded_headers.get("X-Authenticated-User") == "proxy-user@example.com"
+        assert "Authorization" not in forwarded_headers
+
+    @patch("mcpgateway.main.test_server_handshake")
+    @patch("mcpgateway.main.server_service.get_server")
+    def test_handshake_does_not_forward_proxy_identity_header_when_trust_proxy_auth_disabled(self, mock_get_server, mock_handshake, test_client, monkeypatch):
+        """With TRUST_PROXY_AUTH_DANGEROUSLY disabled (the default), a caller-supplied identity header is
+        never forwarded into the probe, even if it happens to match the configured header name.
+        """
+        # First-Party
+        from mcpgateway.schemas import GatewayHandshakeResponse
+
+        monkeypatch.setattr(settings, "trust_proxy_auth", False)
+        monkeypatch.setattr(settings, "proxy_user_header", "X-Authenticated-User")
+
+        mock_get_server.return_value = ServerRead(**MOCK_SERVER_READ)
+        mock_handshake.return_value = GatewayHandshakeResponse(success=True, latency_ms=1)
+
+        test_client.post("/servers/1/test-handshake", json={}, headers={"X-Authenticated-User": "spoofed@example.com"})
+
+        forwarded_headers = mock_handshake.call_args.args[4]
+        assert "X-Authenticated-User" not in forwarded_headers
 
 
 # ----------------------------------------------------- #

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -1217,6 +1217,27 @@ class TestServerHandshakeEndpoint:
 
     @patch("mcpgateway.main.test_server_handshake")
     @patch("mcpgateway.main.server_service.get_server")
+    def test_handshake_forwards_bearer_under_custom_auth_header_name(self, mock_get_server, mock_handshake, test_client, mock_jwt_token, monkeypatch):
+        """When AUTH_HEADER_NAME is customized, the bearer token is forwarded under that configured
+        header name -- not hardcoded 'Authorization' -- since the nested request's own auth extraction
+        only reads the configured header.
+        """
+        # First-Party
+        from mcpgateway.schemas import GatewayHandshakeResponse
+
+        monkeypatch.setattr(settings, "auth_header_name", "X-MCP-Gateway-Auth")
+
+        mock_get_server.return_value = ServerRead(**MOCK_SERVER_READ)
+        mock_handshake.return_value = GatewayHandshakeResponse(success=True, latency_ms=1)
+
+        test_client.post("/servers/1/test-handshake", json={}, headers={"X-MCP-Gateway-Auth": f"Bearer {mock_jwt_token}"})
+
+        forwarded_headers = mock_handshake.call_args.args[4]
+        assert forwarded_headers.get("X-MCP-Gateway-Auth") == f"Bearer {mock_jwt_token}"
+        assert "Authorization" not in forwarded_headers
+
+    @patch("mcpgateway.main.test_server_handshake")
+    @patch("mcpgateway.main.server_service.get_server")
     def test_handshake_without_credentials_forwards_nothing(self, mock_get_server, mock_handshake, test_client):
         """A request with no Authorization header and no cookie forwards no credentials."""
         # First-Party


### PR DESCRIPTION
Closes #6370

### Summary

  `POST /v1/mcp-servers/test-handshake` is scoped to registered gateways: its SSRF allowlist only ever matches rows in the `gateways` table, so a virtual server's own `/servers/{id}/mcp` endpoint can never pass it. The "Test connection" panel for virtual servers reused that endpoint and could therefore never succeed, regardless of URL, host, or config — the SSRF gate in `SecurityValidator.validate_gateway_test_url` also unconditionally blocks loopback/private targets, so no allowlist workaround was possible either.

  Adds `POST /servers/{server_id}/test-handshake` (aliased at `/v1/servers/...` and `/v1/virtual-servers/...`), scoped to virtual servers instead of arbitrary URLs:

  - Derives the target from the server's own ID rather than validating a caller-supplied URL, so the gateway-test SSRF allowlist doesn't apply — the target is never anything but the process's own transport.
  - Dispatches in-process via `httpx.ASGITransport` rather than a real network round trip, so it works identically behind any reverse proxy/LB and always lands on the worker handling the request.
  - Reuses the caller's own forwarded credentials by default (bearer token or session cookie), with an optional header override in the request body, so auth, RBAC, and MCP negotiation are exercised for real.
  - Adds the `servers.read` permission mapping for the new route (previously unmapped paths default-deny under token scoping).

  The existing gateway `/v1/mcp-servers/test-handshake` endpoint is unchanged.

  ### 🧪 Verification - testing

Tested directly against a running dev server (`make dev`), not just mocks.
  ```bash
  export TOKEN=$(python -m mcpgateway.utils.create_jwt_token \
    --username admin@example.com --exp 60 --secret <JWT_SECRET_KEY>)
  ```

  2. Create a virtual server to test against:
  ```bash
  curl -s -X POST http://localhost:8000/servers \
    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
    -d '{"server": {"name": "smoke-test-server"}}'
  # note the returned "id" as $SERVER_ID
  ```

  3. Run the handshake against all three path forms:
  ```bash
  curl -s -X POST "http://localhost:8000/servers/$SERVER_ID/test-handshake" \
    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{}'
  curl -s -X POST "http://localhost:8000/v1/servers/$SERVER_ID/test-handshake" \
    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{}'
  curl -s -X POST "http://localhost:8000/v1/virtual-servers/$SERVER_ID/test-handshake" \
    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{}'
  ```
  Expected: `"success": true`, a real `negotiationPath`/`protocolVersion`/`serverName`, and `"credentialSource": "session"` on all three.

  4. Failure paths:
     - No `Authorization` header → `401`.
     - Disable the server first (`POST /servers/$SERVER_ID/state?activate=false`), then retest → `200` with `"success": false` and an error naming the server as disabled (not a crash/hang).
     - A token scoped without `servers.read` → `403`.

  5. Regression check — confirm the existing gateway endpoint is unaffected:
  ```bash
  curl -s -X POST "http://localhost:8000/v1/mcp-servers/test-handshake" \
    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
    -d '{"base_url": "http://127.0.0.1:9/"}'
  ```
  Expected: unchanged SSRF-rejection behavior.

  6. Clean up the test server: `DELETE /servers/$SERVER_ID`.