### PR TITLE
fix(vault): inject tokens for A2A-backed tools invoked via MCP

### DIFF
--- a/plugins/vault/vault_plugin.py
+++ b/plugins/vault/vault_plugin.py
@@ -396,7 +396,20 @@ class Vault(Plugin):
         system_key: str | None = None
         auth_header: str | None = None
         if self._sconfig.system_handling == SystemHandling.TAG:
-            system_key, auth_header = self._resolve_system_and_auth_from_tags(gateway_metadata)
+            # When an A2A agent is wrapped as an MCP tool (annotations carry
+            # ``a2a_agent_id``), the tool metadata replicates the agent's tags
+            # (e.g. ``system:<host>``) which the gateway metadata may not have.
+            # Resolve the system from the tool metadata in that case so vault
+            # token injection works regardless of the invocation path.
+            tool_metadata = context.global_context.metadata.get("tool")
+            if tool_metadata is not None:
+                annotations = get_attr(tool_metadata, "annotations", None) or {}
+                is_a2a_backed = "a2a_agent_id" in annotations
+                if is_a2a_backed:
+                    system_key, auth_header = self._resolve_system_and_auth_from_tags(tool_metadata)
+
+            if system_key is None:
+                system_key, auth_header = self._resolve_system_and_auth_from_tags(gateway_metadata)
         elif self._sconfig.system_handling == SystemHandling.OAUTH2_CONFIG:
             system_key = await self._resolve_system_from_oauth2_config(context.global_context.server_id)
 

--- a/tests/unit/mcpgateway/plugins/plugins/vault/test_vault_plugin.py
+++ b/tests/unit/mcpgateway/plugins/plugins/vault/test_vault_plugin.py
@@ -327,7 +327,9 @@ class TestVaultPluginFunctionality:
         vault_tokens = {"github.com": "ghp_root_access_test"}
 
         # Create payload with vault header
-        payload = ToolPreInvokePayload(name="test_tool", arguments={}, headers=HttpHeaderPayload(root={"Content-Type": "application/json", "X-Vault-Tokens": json.dumps(vault_tokens), "X-Custom-Header": "custom_value"}))
+        payload = ToolPreInvokePayload(
+            name="test_tool", arguments={}, headers=HttpHeaderPayload(root={"Content-Type": "application/json", "X-Vault-Tokens": json.dumps(vault_tokens), "X-Custom-Header": "custom_value"})
+        )
 
         # Verify .root contains actual headers (the correct access pattern)
         assert len(payload.headers.root) == 3, "Headers.root should contain all headers"
@@ -889,6 +891,74 @@ class TestVaultPluginMcpServerBinding:
 
         assert result.modified_payload is not None
         assert "authorization" not in result.modified_payload.headers.root
+
+    @pytest.mark.asyncio
+    async def test_a2a_backed_tool_injects_token_from_tool_metadata(self, plugin_config):
+        """A2A-backed tools resolve the vault system from tool metadata tags (#6394)."""
+        plugin = Vault(plugin_config)
+
+        gateway_metadata = type("obj", (object,), {"tags": []})()
+        tool_metadata = type(
+            "obj",
+            (object,),
+            {
+                "tags": [{"id": "1", "label": "system:echo.local"}],
+                "annotations": {"title": "A2A Agent: echo", "a2a_agent_id": "agent-1"},
+            },
+        )()
+        context = PluginContext(
+            global_context=GlobalContext(
+                request_id="a2a-tool-1",
+                metadata={"gateway": gateway_metadata, "tool": tool_metadata},
+            )
+        )
+
+        vault_tokens = {"echo.local": "tok-secret"}
+        payload = ToolPreInvokePayload(
+            name="a2a_echo",
+            arguments={},
+            headers=HttpHeaderPayload(root={"content-type": "application/json", "x-vault-tokens": json.dumps(vault_tokens)}),
+        )
+
+        result = await plugin.tool_pre_invoke(payload, context)
+
+        assert result.modified_payload is not None
+        assert result.modified_payload.headers.root["authorization"] == "Bearer tok-secret"
+        assert "x-vault-tokens" not in result.modified_payload.headers.root
+
+    @pytest.mark.asyncio
+    async def test_regular_tool_ignores_tool_metadata(self, plugin_config):
+        """Non-A2A tools keep resolving the system from gateway metadata only."""
+        plugin = Vault(plugin_config)
+
+        gateway_metadata = type("obj", (object,), {"tags": [{"id": "1", "label": "system:github.com"}]})()
+        tool_metadata = type(
+            "obj",
+            (object,),
+            {
+                "tags": [{"id": "1", "label": "system:echo.local"}],
+                "annotations": {"title": "regular tool"},
+            },
+        )()
+        context = PluginContext(
+            global_context=GlobalContext(
+                request_id="regular-tool-1",
+                metadata={"gateway": gateway_metadata, "tool": tool_metadata},
+            )
+        )
+
+        vault_tokens = {"github.com": "tok-github", "echo.local": "tok-echo"}
+        payload = ToolPreInvokePayload(
+            name="regular_tool",
+            arguments={},
+            headers=HttpHeaderPayload(root={"content-type": "application/json", "x-vault-tokens": json.dumps(vault_tokens)}),
+        )
+
+        result = await plugin.tool_pre_invoke(payload, context)
+
+        assert result.modified_payload is not None
+        assert result.modified_payload.headers.root["authorization"] == "Bearer tok-github"
+        assert "x-vault-tokens" not in result.modified_payload.headers.root
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 ## 📋 Summary
  Fixes #6394 — the Vault plugin did not inject vault tokens when an A2A agent wrapped as an MCP tool was invoked
  through the MCP protocol (`tools/call`). Token injection only worked via the direct `/a2a/{name}/invoke` path
  (`agent_pre_invoke`).

  Root cause: `tool_pre_invoke` resolved the system tag only from the gateway metadata. A2A-backed tools carry an
  `a2a_agent_id` annotation (and replicate the agent's tags, e.g. `system:<host>`), but that metadata was never
  consulted.

  ## 🔧 Changes
  - `plugins/vault/vault_plugin.py`: in `tool_pre_invoke`, when the tool metadata carries the `a2a_agent_id` annotation,
  the system/auth-header tags are resolved from the tool metadata (which carries the agent's tags) instead of the
  gateway metadata. Non-A2A tools keep the existing gateway-metadata resolution behavior.

  ## ✅ Tests
  Added 2 unit tests in `tests/unit/.../test_vault_plugin.py`:
  - `test_a2a_backed_tool_injects_token_from_tool_metadata` — A2A-backed tool with a `system:` tag on the tool metadata
  gets the Bearer token injected (fails on the unpatched code).
  - `test_regular_tool_ignores_tool_metadata` — non-A2A tools still resolve from the gateway metadata only (regression
  guard).

  All 39 unit tests pass; `ruff check` and `ruff format` clean.