### PR TITLE
feat: add post-OAuth redirect allowlist (redirect_uri_after_oauth)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1435,6 +1435,9 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # to validate `aud`. See docs/docs/manage/oauth-resource-configuration.md.
 # OAUTH_REQUIRE_CONFIGURED_RESOURCE=false
 
+# Exact external HTTPS origin permitted for redirect_uri_after_oauth.
+# OAUTH_REDIRECT_ALLOWED_ORIGIN=https://app.example.com
+
 # =============================================================================
 # OAuth Token Storage Backend
 # =============================================================================

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-28T13:19:47Z",
+  "generated_at": "2026-09-02T09:47:39Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -3998,7 +3998,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4713,
+        "line_number": 4788,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-28T12:59:35Z",
+  "generated_at": "2026-08-28T13:19:47Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -3998,7 +3998,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4781,
+        "line_number": 4713,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-28T11:36:23Z",
+  "generated_at": "2026-08-28T12:59:35Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4828,7 +4828,7 @@
         "hashed_secret": "a24a9eab46fcd2eb51c24d7e647a1e398c2c4b26",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2252,
+        "line_number": 2276,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-28T11:05:13Z",
+  "generated_at": "2026-08-28T11:36:23Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -2233,14 +2233,6 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "cfac92b56e517a2186d60c9f812878a82a8c210c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 108,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "c92ae7357b37d02896900f57e76d315173fbf715",
         "is_secret": false,
         "is_verified": false,
@@ -2261,6 +2253,14 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 317,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cfac92b56e517a2186d60c9f812878a82a8c210c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 363,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-31T14:51:49Z",
+  "generated_at": "2026-08-28T11:05:13Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -148,7 +148,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1567,
+        "line_number": 1570,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1572,
+        "line_number": 1575,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1577,
+        "line_number": 1580,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1583,
+        "line_number": 1586,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1595,
+        "line_number": 1598,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1613,
+        "line_number": 1616,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1674,
+        "line_number": 1677,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4026,7 +4026,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14956,
+        "line_number": 15003,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/manage/oauth.md
+++ b/docs/docs/manage/oauth.md
@@ -323,6 +323,92 @@ sequenceDiagram
 
 ---
 
+## Post-OAuth Redirect to an External Application
+
+By default, after a successful Authorization Code flow the browser lands on the gateway's
+built-in success page. If you embed ContextForge's OAuth flow inside your own application
+and need the user brought back to your UI automatically, set `redirect_uri_after_oauth` on
+the gateway's `oauth_config`.
+
+### Prerequisites
+
+Set the allowed HTTPS origin in your environment **before** configuring any gateway with
+this field. The value is validated at startup:
+
+```bash
+# .env
+OAUTH_REDIRECT_ALLOWED_ORIGIN=https://app.example.com
+```
+
+Rules enforced at startup (startup fails if violated):
+
+- Must be an exact HTTPS origin — `https://hostname` or `https://hostname:port`
+- No path, query string, fragment, or credentials (`user:pass@host`)
+- Wildcards (`*`) are rejected
+- HTTP origins are rejected
+
+### Configure a Gateway (API)
+
+Add `redirect_uri_after_oauth` to the gateway's `oauth_config`. The URL must share the
+same origin as `OAUTH_REDIRECT_ALLOWED_ORIGIN`:
+
+```json
+{
+  "name": "GitHub MCP",
+  "url": "https://github-mcp.example.com/sse",
+  "auth_type": "oauth",
+  "oauth_config": {
+    "grant_type": "authorization_code",
+    "client_id": "your_github_app_id",
+    "client_secret": "your_github_app_secret",
+    "authorization_url": "https://github.com/login/oauth/authorize",
+    "token_url": "https://github.com/login/oauth/access_token",
+    "redirect_uri": "https://gateway.example.com/oauth/callback",
+    "scopes": ["repo", "read:user"],
+    "redirect_uri_after_oauth": "https://app.example.com/oauth-complete"
+  }
+}
+```
+
+When the user completes authorization, the gateway issues a `302` to
+`https://app.example.com/oauth-complete`. No tokens or codes appear in the redirect URL.
+
+The Admin UI exposes this setting as the optional **Post-OAuth Redirect URL** field when
+`OAUTH_REDIRECT_ALLOWED_ORIGIN` is configured. Leave it blank to use the built-in success page.
+
+### Security model and why there is no per-request `post_login_redirect_uri`
+
+A common pattern is to pass the destination URL as a query parameter when starting the
+OAuth flow (`GET /oauth/authorize?post_login_redirect_uri=...`), encode it into `state`,
+and read it back on callback.
+
+ContextForge does **not** implement this pattern because it creates an open-redirect
+surface. An attacker who sends a victim a crafted login link with a malicious
+`post_login_redirect_uri` value can redirect the browser to an attacker-controlled page
+immediately after authentication — leaking the session context via the `Referer` header or
+URL bar. This is documented in [RFC 6819 §4.2.4](https://datatracker.ietf.org/doc/html/rfc6819#section-4.2.4).
+
+The static allowlist approach eliminates this surface: the destination is set by an admin
+at configuration time and cannot be influenced by request parameters.
+
+**Current limitation:** one external origin per gateway deployment
+(`OAUTH_REDIRECT_ALLOWED_ORIGIN` is a single value). Multi-app deployments that need
+different post-login destinations per app are not yet supported.
+
+### Validation behaviour
+
+| Location | When checked | Effect on failure |
+|---|---|---|
+| `OAUTH_REDIRECT_ALLOWED_ORIGIN` at startup | App boot | Startup error — gateway will not start |
+| Pydantic schema (`GatewayCreate` / `GatewayUpdate`) | Every API write | `422 Unprocessable Entity` |
+| Admin form assembler (`_assemble_oauth_config_from_fields`) | Admin UI save | `400` form error |
+| Callback (`custom_redirect_after_callback`) | Runtime redirect | `400` — state is **not** consumed, user can retry |
+
+The runtime re-check at callback time covers gateway rows written before validation was
+introduced (e.g., direct database imports).
+
+---
+
 ## Token Storage and Refresh
 
 OAuth tokens are stored per gateway and user for the Authorization Code flow to ensure proper security isolation:

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -213,6 +213,7 @@ from mcpgateway.utils.security_cookies import clear_auth_cookie, CookieTooLargeE
 from mcpgateway.utils.services_auth import encode_auth
 from mcpgateway.utils.sqlalchemy_modifier import json_contains_tag_expr
 from mcpgateway.utils.validate_signature import sign_data
+from mcpgateway.utils.origin import is_allowed_redirect, normalize_origin_parts, origin_from_url
 from mcpgateway.utils.verify_credentials import verify_jwt_token_cached
 
 # Conditional imports for gRPC support (only if grpcio is installed)
@@ -985,6 +986,7 @@ async def _assemble_oauth_config_from_fields(fields: Any, *, encrypt_secret: boo
     oauth_token_url = str(fields.get("oauth_token_url", ""))
     oauth_authorization_url = str(fields.get("oauth_authorization_url", ""))
     oauth_redirect_uri = str(fields.get("oauth_redirect_uri", ""))
+    oauth_redirect_uri_after_oauth = str(fields.get("redirect_uri_after_success", "")).strip()
     oauth_client_id = str(fields.get("oauth_client_id", ""))
     oauth_client_secret = str(fields.get("oauth_client_secret", ""))
     oauth_username = str(fields.get("oauth_username", ""))
@@ -1007,6 +1009,10 @@ async def _assemble_oauth_config_from_fields(fields: Any, *, encrypt_secret: boo
         oauth_config["authorization_url"] = oauth_authorization_url
     if oauth_redirect_uri:
         oauth_config["redirect_uri"] = oauth_redirect_uri
+    if oauth_redirect_uri_after_oauth:
+        if not is_allowed_redirect(oauth_redirect_uri_after_oauth, str(settings.app_domain), settings.oauth_redirect_allowed_origin):
+            raise ValueError(f"redirect_uri_after_oauth must use this gateway origin ({origin_from_url(str(settings.app_domain))}) or the origin in OAUTH_REDIRECT_ALLOWED_ORIGIN")
+        oauth_config["redirect_uri_after_oauth"] = oauth_redirect_uri_after_oauth
     if oauth_client_id:
         oauth_config["client_id"] = oauth_client_id
     if oauth_client_secret:
@@ -1712,25 +1718,6 @@ def _admin_cookie_path(request: Request) -> str:
     return root_path or "/"
 
 
-def _normalize_origin_parts(scheme: str, netloc: str) -> tuple[str, str, int]:
-    """Normalize origin components for exact same-origin comparisons.
-
-    Args:
-        scheme: URL scheme (for example ``http`` or ``https``).
-        netloc: URL authority component (host and optional port).
-
-    Returns:
-        Tuple of normalized scheme, hostname, and resolved port.
-    """
-    parsed = urllib.parse.urlparse(f"{scheme}://{netloc}")
-    normalized_scheme = (parsed.scheme or scheme or "http").lower()
-    normalized_host = (parsed.hostname or "").lower()
-    normalized_port = parsed.port
-    if normalized_port is None:
-        normalized_port = 443 if normalized_scheme == "https" else 80
-    return normalized_scheme, normalized_host, normalized_port
-
-
 def _request_origin_matches(request: Request) -> bool:
     """Return ``True`` when Origin/Referer matches this request origin.
 
@@ -1773,8 +1760,8 @@ def _request_origin_matches(request: Request) -> bool:
     request_scheme = (forwarded_proto.split(",")[0].strip() if forwarded_proto else request.url.scheme) or "http"
     request_netloc = (forwarded_host.split(",")[0].strip() if forwarded_host else request.headers.get("host")) or request.url.netloc
 
-    candidate_parts = _normalize_origin_parts(parsed_candidate.scheme, parsed_candidate.netloc)
-    request_parts = _normalize_origin_parts(request_scheme, request_netloc)
+    candidate_parts = normalize_origin_parts(parsed_candidate.scheme, parsed_candidate.netloc)
+    request_parts = normalize_origin_parts(request_scheme, request_netloc)
     if candidate_parts == request_parts:
         return True
 
@@ -1792,7 +1779,7 @@ def _request_origin_matches(request: Request) -> bool:
             allowed_parsed = urllib.parse.urlparse(allowed_normalized if "://" in allowed_normalized else f"https://{allowed_normalized}")
             if not allowed_parsed.scheme or not allowed_parsed.netloc:
                 continue
-            if candidate_parts == _normalize_origin_parts(allowed_parsed.scheme, allowed_parsed.netloc):
+            if candidate_parts == normalize_origin_parts(allowed_parsed.scheme, allowed_parsed.netloc):
                 return True
         except Exception:  # nosec B112 - malformed allowed_origins entry should not crash
             continue
@@ -4285,6 +4272,7 @@ async def admin_ui(
             "require_token_expiration": getattr(settings, "require_token_expiration", True),
             "sri_hashes": load_sri_hashes(),
             "max_members_per_team": settings.max_members_per_team,
+            "oauth_redirect_allowed_origin": settings.oauth_redirect_allowed_origin,
         },
     )
 
@@ -13256,14 +13244,24 @@ async def admin_edit_gateway(
                 LOGGER.info(f"✅ Assembled OAuth config from UI form fields (edit): grant_type={oauth_config.get('grant_type')}, issuer={oauth_config.get('issuer')}")
 
         user_email = get_user_email(user)
+        # Fetch existing gateway once to preserve team_id and any oauth_config fields that
+        # the UI edit form does not expose (e.g. redirect_uri_after_oauth).
+        existing_gateway = db.get(DbGateway, gateway_id)
+
         # Preserve existing gateway's team_id when no explicit team_id is provided.
         # Without this guard, verify_team_for_user() falls back to the user's
         # personal team, silently reassigning the gateway on every edit.
         if not team_id:
-            existing_gateway = db.get(DbGateway, gateway_id)
             existing_team = getattr(existing_gateway, "team_id", None) if existing_gateway else None
             if isinstance(existing_team, str) and existing_team:
                 team_id = existing_team
+
+        # Preserve redirect_uri_after_oauth when this deployment does not render the
+        # field. A rendered but blank field explicitly disables the redirect.
+        if oauth_config is not None and existing_gateway is not None:
+            existing_oauth: dict = existing_gateway.oauth_config or {}
+            if "redirect_uri_after_success" not in form and "redirect_uri_after_oauth" not in oauth_config and "redirect_uri_after_oauth" in existing_oauth:
+                oauth_config["redirect_uri_after_oauth"] = existing_oauth["redirect_uri_after_oauth"]
 
         team_service = TeamManagementService(db)
         team_id = await team_service.verify_team_for_user(user_email, team_id)

--- a/mcpgateway/admin_ui/gateways.js
+++ b/mcpgateway/admin_ui/gateways.js
@@ -398,6 +398,9 @@ export const editGateway = async function (gatewayId) {
     const oauthTokenUrlField = safeGetElement("oauth-token-url-gw-edit");
     const oauthAuthUrlField = safeGetElement("oauth-authorization-url-gw-edit");
     const oauthRedirectUriField = safeGetElement("oauth-redirect-uri-gw-edit");
+    const oauthRedirectAfterSuccessField = safeGetElement(
+      "oauth-redirect-after-success-gw-edit"
+    );
     const oauthIssuerField = safeGetElement("oauth-issuer-gw-edit");
     const oauthResourceField = safeGetElement("oauth-resource-gw-edit");
     const oauthScopesField = safeGetElement("oauth-scopes-gw-edit");
@@ -521,6 +524,10 @@ export const editGateway = async function (gatewayId) {
           }
           if (oauthRedirectUriField) {
             oauthRedirectUriField.value = config.redirect_uri || "";
+          }
+          if (oauthRedirectAfterSuccessField) {
+            oauthRedirectAfterSuccessField.value =
+              config.redirect_uri_after_oauth || "";
           }
           if (oauthScopesField) {
             oauthScopesField.value = Array.isArray(config.scopes)

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -69,6 +69,7 @@ from mcpgateway._security_constants import MIN_ENTROPY as _MIN_ENTROPY
 from mcpgateway._security_constants import MIN_SECRET_LENGTH as _MIN_SECRET_LENGTH
 from mcpgateway._security_constants import WEAK_VALUES as _CANONICAL_WEAK_VALUES
 from mcpgateway._security_constants import calculate_entropy
+from mcpgateway.utils.origin import is_exact_https_origin
 
 # Only configure basic logging if no handlers exist yet
 # This prevents conflicts with LoggingService while ensuring config logging works
@@ -999,6 +1000,28 @@ class Settings(BaseSettings):
             "the upstream MCP server to validate ``aud``."
         ),
     )
+    oauth_redirect_allowed_origin: Optional[str] = Field(
+        default=None,
+        description="Exact HTTPS origin allowed for post-OAuth redirects outside APP_DOMAIN.",
+    )
+
+    @field_validator("oauth_redirect_allowed_origin")
+    @classmethod
+    def validate_oauth_redirect_allowed_origin(cls, origin: Optional[str]) -> Optional[str]:
+        """Require the external post-OAuth redirect entry to be an exact HTTPS origin.
+
+        Args:
+            origin: Configured external redirect origin.
+
+        Returns:
+            Validated origin.
+
+        Raises:
+            ValueError: If the entry is not an exact HTTPS origin.
+        """
+        if origin is not None and not is_exact_https_origin(origin):
+            raise ValueError(f"OAuth redirect allowlist entry must be an exact HTTPS origin: {origin}")
+        return origin
 
     # ===================================
     # Dynamic Client Registration (DCR) - Client Mode

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -45,6 +45,7 @@ from mcpgateway.services.token_storage_service import TokenStorageService
 from mcpgateway.utils.csp_nonce import get_csp_nonce_from_request
 from mcpgateway.utils.log_sanitizer import sanitize_for_log
 from mcpgateway.utils.oauth_resource import derive_resource_origin
+from mcpgateway.utils.origin import is_allowed_redirect, origin_from_url
 from mcpgateway.utils.paths import resolve_root_path
 from mcpgateway.utils.verify_credentials import get_auth_header_value
 
@@ -929,6 +930,9 @@ async def oauth_callback(
         no_storage_oauth_manager = OAuthManager(token_storage=None)
 
         oauth_config_with_resource = gateway.oauth_config.copy()
+        post_oauth_redirect_response = None
+        if not is_popup and "redirect_uri_after_oauth" in oauth_config_with_resource:
+            post_oauth_redirect_response = custom_redirect_after_callback(oauth_config_with_resource["redirect_uri_after_oauth"], 302)
 
         # RFC 8707: Set resource parameter for the token exchange request.
         # If resource was previously learned from the IdP's token aud claim, use it as-is.
@@ -1204,6 +1208,9 @@ async def oauth_callback(
             samesite="strict",
         )
 
+        if post_oauth_redirect_response is not None:
+            response = post_oauth_redirect_response
+
         return response
 
     except OAuthError as e:
@@ -1291,6 +1298,36 @@ async def oauth_callback(
         """,
             status_code=500,
         )
+
+
+def _validate_post_oauth_redirect(url: str) -> None:
+    """Reject an untrusted post-OAuth redirect target.
+
+    Args:
+        url: Target URL.
+
+    Raises:
+        OAuthError: When the URL matches neither the app origin nor configured external origin.
+    """
+    if not is_allowed_redirect(url, str(settings.app_domain), settings.oauth_redirect_allowed_origin):
+        raise OAuthError(f"redirect_uri_after_oauth must use this gateway origin ({origin_from_url(str(settings.app_domain))}) or the origin in OAUTH_REDIRECT_ALLOWED_ORIGIN")
+
+
+def custom_redirect_after_callback(url: str, status_code: int) -> RedirectResponse:
+    """Validate *url* against trusted redirect origins then return a redirect.
+
+    Args:
+        url: Target URL
+        status_code: HTTP status code for the redirect response.
+
+    Returns:
+        RedirectResponse to url.
+
+    Raises:
+        OAuthError: When an absolute URL matches neither the app origin nor the external allowlist.
+    """
+    _validate_post_oauth_redirect(url)
+    return RedirectResponse(url=url, status_code=status_code, headers={"Referrer-Policy": "no-referrer"})
 
 
 @oauth_router.get("/status/{gateway_id}")

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -43,6 +43,7 @@ from mcpgateway.common.validators import SecurityValidator, validate_core_url
 from mcpgateway.config import settings
 from mcpgateway.utils.base_models import BaseModelWithConfigDict
 from mcpgateway.utils.jq_guard import assert_safe_jq_filter
+from mcpgateway.utils.origin import is_allowed_redirect, origin_from_url
 from mcpgateway.utils.services_auth import decode_auth, encode_auth
 from mcpgateway.validation.tags import validate_tags_field
 
@@ -154,6 +155,12 @@ def _validate_oauth_config_urls(v: Optional[Dict[str, Any]]) -> Optional[Dict[st
         if not isinstance(raw_value, str):
             raise ValueError(f"oauth_config.{field_name} must be a string URL")
         validate_core_url(raw_value, f"OAuth config {field_name}")
+    if "redirect_uri_after_oauth" in v:
+        redirect_after_oauth = v["redirect_uri_after_oauth"]
+        if not isinstance(redirect_after_oauth, str) or not redirect_after_oauth.strip():
+            raise ValueError("oauth_config.redirect_uri_after_oauth must be a non-empty string URL")
+        if not is_allowed_redirect(redirect_after_oauth, str(settings.app_domain), settings.oauth_redirect_allowed_origin):
+            raise ValueError(f"oauth_config.redirect_uri_after_oauth must use this gateway origin ({origin_from_url(str(settings.app_domain))}) or the origin in OAUTH_REDIRECT_ALLOWED_ORIGIN")
     raw_servers = v.get("authorization_servers")
     if raw_servers in (None, ""):
         return v

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -10294,7 +10294,7 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                             type="url"
                             name="redirect_uri_after_success"
                             id="oauth-redirect-after-success-gw-edit"
-                            class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                            class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300 dark:border-gray-70"
                             placeholder="{{ oauth_redirect_allowed_origin }}/oauth-complete"
                           />
                             <p class="mt-1 text-sm text-gray-500">

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -5682,7 +5682,29 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                         >
                       </p>
                     </div>
-
+                    {% if oauth_redirect_allowed_origin %}
+                      <div>
+                      <label
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                      >
+                        Post-OAuth Redirect URL
+                      </label>
+                      <input
+                        type="url"
+                        name="redirect_uri_after_success"
+                        class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                        placeholder="{{ oauth_redirect_allowed_origin }}"
+                      />
+                      <p class="mt-1 text-sm text-gray-500">
+                        Optional. After authorization, redirect the browser to
+                        this URL. Leave blank to use the built-in success page.
+                      </p>
+                      <p class="mt-1 text-sm text-blue-600 font-medium">
+                        Must use the origin configured by
+                        <code class="bg-blue-100 px-1 rounded font-mono">OAUTH_REDIRECT_ALLOWED_ORIGIN</code>
+                      </p>
+                      </div>
+                    {% endif %}
                     <div>
                       <label
                         class="block text-sm font-medium text-gray-700 dark:text-gray-300"
@@ -10260,6 +10282,31 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                               >
                             </p>
                           </div>
+
+                          {% if oauth_redirect_allowed_origin %}
+                           <div>
+                          <label
+                            class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                          >
+                            Post-OAuth Redirect URL
+                          </label>
+                          <input
+                            type="url"
+                            name="redirect_uri_after_success"
+                            id="oauth-redirect-after-success-gw-edit"
+                            class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                            placeholder="{{ oauth_redirect_allowed_origin }}/oauth-complete"
+                          />
+                            <p class="mt-1 text-sm text-gray-500">
+                              Optional. After authorization, redirect the browser
+                              to this URL. Leave blank to use the built-in success page.
+                            </p>
+                            <p class="mt-1 text-sm text-blue-600 font-medium">
+                              Must use the origin configured by
+                              <code class="bg-blue-100 px-1 rounded font-mono">OAUTH_REDIRECT_ALLOWED_ORIGIN</code>
+                            </p>
+                          </div>
+                          {% endif %}
 
                           <div>
                             <label

--- a/mcpgateway/utils/origin.py
+++ b/mcpgateway/utils/origin.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/utils/origin.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Origin normalization and redirect validation utilities.
+
+Shared by :mod:`mcpgateway.admin` and :mod:`mcpgateway.routers.oauth_router`
+to avoid duplication and circular imports.
+"""
+
+from urllib.parse import urlparse
+
+
+def normalize_origin_parts(scheme: str, netloc: str) -> tuple[str, str, int]:
+    """Normalize origin components for exact same-origin comparisons.
+
+    Resolves default ports so that ``http://host:80`` and ``http://host``
+    compare equal.
+
+    Args:
+        scheme: URL scheme (for example ``http`` or ``https``).
+        netloc: URL authority component (host and optional port).
+
+    Returns:
+        Tuple of normalized scheme, hostname, and resolved port.
+    """
+    parsed = urlparse(f"{scheme}://{netloc}")
+    normalized_scheme = (parsed.scheme or scheme or "http").lower()
+    normalized_host = (parsed.hostname or "").lower()
+    normalized_port = parsed.port
+    if normalized_port is None:
+        normalized_port = 443 if normalized_scheme == "https" else 80
+    return normalized_scheme, normalized_host, normalized_port
+
+
+def origin_from_url(url: str) -> str:
+    """Return the ``scheme://host[:port]`` origin of *url*, with no trailing slash.
+
+    Args:
+        url: Any absolute URL (e.g. a Pydantic ``HttpUrl`` stringified value).
+
+    Returns:
+        Clean origin string such as ``http://localhost:8080``.
+    """
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def is_same_origin(url: str, origin: str) -> bool:
+    """Return True if *url* is absolute and has the same origin as *origin*."""
+    if "\\" in url or "\\" in origin:
+        return False
+
+    try:
+        parsed = urlparse(url)
+        ref = urlparse(origin)
+        if not parsed.scheme or not parsed.netloc or not ref.scheme or not ref.netloc:
+            return False
+        return normalize_origin_parts(parsed.scheme, parsed.netloc) == normalize_origin_parts(ref.scheme, ref.netloc)
+    except (TypeError, ValueError):
+        return False
+
+
+def is_exact_https_origin(origin: str) -> bool:
+    """Return whether origin is an HTTPS origin without URL suffix state.
+
+    Args:
+        origin: Candidate origin.
+
+    Returns:
+        True when the value contains only an HTTPS scheme, host, and optional port.
+    """
+    if "\\" in origin:
+        return False
+    try:
+        parsed = urlparse(origin)
+        port = parsed.port
+        hostname = parsed.hostname
+        username = parsed.username
+        password = parsed.password
+    except (TypeError, ValueError):
+        return False
+    return bool(
+        parsed.scheme.lower() == "https"
+        and hostname
+        and username is None
+        and password is None
+        and parsed.path in ("", "/")
+        and not parsed.query
+        and not parsed.fragment
+        and not (port is None and parsed.netloc.rsplit("@", 1)[-1].endswith(":"))
+    )
+
+
+def is_allowed_redirect(url: str, app_origin: str, allowed_origin: str | None) -> bool:
+    """Return whether a post-OAuth redirect target is trusted.
+
+    Args:
+        url: Redirect target.
+        app_origin: Gateway's trusted application origin.
+        allowed_origin: Exact external HTTPS origin configured by the operator.
+
+    Returns:
+        True for absolute same-origin URLs or allowlisted absolute HTTPS URLs.
+    """
+    try:
+        parsed = urlparse(url)
+        if not parsed.scheme or not parsed.netloc:
+            return False
+        if parsed.username is not None or parsed.password is not None:
+            return False
+        if is_same_origin(url, app_origin):
+            return True
+        if parsed.scheme.lower() != "https":
+            return False
+        return bool(allowed_origin and is_same_origin(url, allowed_origin))
+    except (TypeError, ValueError):
+        return False

--- a/tests/live_gateway/mcp/test_oauth_redirect_validation.py
+++ b/tests/live_gateway/mcp/test_oauth_redirect_validation.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/live_gateway/mcp/test_oauth_redirect_validation.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Black-box validation for gateway post-OAuth redirect configuration.
+"""
+
+# Third-Party
+import httpx
+import pytest
+
+# First-Party
+from tests.helpers.auth import make_test_jwt
+from tests.live_gateway.helpers.mcp_test_helpers import BASE_URL, JWT_SECRET, skip_no_gateway
+
+pytestmark = [pytest.mark.e2e, skip_no_gateway]
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "payload"),
+    [
+        (
+            "POST",
+            "/gateways",
+            {
+                "name": "invalid-oauth-redirect",
+                "url": "https://mcp.example.com",
+                "oauth_config": {"redirect_uri_after_oauth": "/oauth-complete"},
+            },
+        ),
+        (
+            "PUT",
+            "/gateways/nonexistent",
+            {"oauth_config": {"redirect_uri_after_oauth": "/oauth-complete"}},
+        ),
+    ],
+)
+def test_gateway_api_rejects_relative_post_oauth_redirect(method: str, path: str, payload: dict) -> None:
+    """Running gateway rejects relative redirect targets on POST and PUT."""
+    token = make_test_jwt("admin@example.com", is_admin=True, teams=None, secret=JWT_SECRET)
+    response = httpx.request(
+        method,
+        f"{BASE_URL}{path}",
+        headers={"Authorization": f"Bearer {token}"},
+        json=payload,
+        timeout=10.0,
+    )
+
+    assert response.status_code == 422, response.text
+    assert "redirect_uri_after_oauth" in response.text

--- a/tests/live_gateway/mcp/test_oauth_redirect_validation.py
+++ b/tests/live_gateway/mcp/test_oauth_redirect_validation.py
@@ -26,13 +26,13 @@ pytestmark = [pytest.mark.e2e, skip_no_gateway]
             {
                 "name": "invalid-oauth-redirect",
                 "url": "https://mcp.example.com",
-                "oauth_config": {"redirect_uri_after_oauth": "/oauth-complete"},
+                "oauth_config": {"redirect_uri_after_oauth": "/oauth-complete"}, # pragma: allowlist secret
             },
         ),
         (
             "PUT",
             "/gateways/nonexistent",
-            {"oauth_config": {"redirect_uri_after_oauth": "/oauth-complete"}},
+            {"oauth_config": {"redirect_uri_after_oauth": "/oauth-complete"}}, # pragma: allowlist secret
         ),
     ],
 )

--- a/tests/unit/js/gateway.test.js
+++ b/tests/unit/js/gateway.test.js
@@ -1118,6 +1118,7 @@ describe("editGateway - auth types", () => {
       <input id="oauth-token-url-gw-edit" />
       <input id="oauth-authorization-url-gw-edit" />
       <input id="oauth-redirect-uri-gw-edit" />
+      <input id="oauth-redirect-after-success-gw-edit" />
       <input id="oauth-scopes-gw-edit" />
       <input id="oauth-resource-gw-edit" />
       <div id="oauth-auth-code-fields-gw-edit" style="display:none"></div>
@@ -1200,6 +1201,7 @@ describe("editGateway - auth types", () => {
             client_id: "cid",
             token_url: "http://auth/token",
             scopes: ["api"],
+            redirect_uri_after_oauth: "https://app.example.com/oauth-complete",
           },
           tags: [],
         }),
@@ -1211,6 +1213,9 @@ describe("editGateway - auth types", () => {
     expect(document.getElementById("oauth-client-id-gw-edit").value).toBe("cid");
     expect(document.getElementById("oauth-token-url-gw-edit").value).toBe("http://auth/token");
     expect(document.getElementById("oauth-scopes-gw-edit").value).toBe("api");
+    expect(
+      document.getElementById("oauth-redirect-after-success-gw-edit").value
+    ).toBe("https://app.example.com/oauth-complete");
     expect(document.getElementById("edit-gateway-visibility-private").checked).toBe(true);
   });
 

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -270,6 +270,40 @@ class TestEnforceFetchToolsCsrf:
 class TestOAuthRouter:
     """Test cases for OAuth router endpoints."""
 
+    def test_custom_redirect_after_callback_allows_configured_external_origin(self):
+        """Configured external redirect returns no-referrer response without cookies."""
+        from mcpgateway.routers.oauth_router import custom_redirect_after_callback
+
+        with patch("mcpgateway.routers.oauth_router.settings") as mock_settings:
+            mock_settings.app_domain = "https://gateway.example.com"
+            mock_settings.oauth_redirect_allowed_origin = "https://app.example.org"
+            response = custom_redirect_after_callback("https://app.example.org/oauth-complete?gateway_id=123", 302)
+
+        assert response.headers["location"] == "https://app.example.org/oauth-complete?gateway_id=123"
+        assert response.headers["referrer-policy"] == "no-referrer"
+        assert response.headers.getlist("set-cookie") == []
+
+    def test_custom_redirect_after_callback_rejects_unconfigured_external_origin(self):
+        """Unconfigured external redirect remains fail-closed at callback time."""
+        from mcpgateway.routers.oauth_router import custom_redirect_after_callback
+
+        with patch("mcpgateway.routers.oauth_router.settings") as mock_settings:
+            mock_settings.app_domain = "https://gateway.example.com"
+            mock_settings.oauth_redirect_allowed_origin = "https://app.example.org"
+            with pytest.raises(OAuthError, match="OAUTH_REDIRECT_ALLOWED_ORIGIN"):
+                custom_redirect_after_callback("https://evil.example/oauth-complete", 302)
+
+    @pytest.mark.parametrize("url", ["//evil.example", "///evil.example", "////evil.example", "\\\\evil.example", "https://[::1"])
+    def test_custom_redirect_after_callback_rejects_network_path_bypasses(self, url):
+        """Browser-resolved network paths must not bypass the external allowlist."""
+        from mcpgateway.routers.oauth_router import custom_redirect_after_callback
+
+        with patch("mcpgateway.routers.oauth_router.settings") as mock_settings:
+            mock_settings.app_domain = "https://gateway.example.com"
+            mock_settings.oauth_redirect_allowed_origin = None
+            with pytest.raises(OAuthError, match="OAUTH_REDIRECT_ALLOWED_ORIGIN"):
+                custom_redirect_after_callback(url, 302)
+
     @pytest.fixture
     def mock_db(self):
         """Create mock database session."""
@@ -732,6 +766,66 @@ class TestOAuthRouter:
                 call_args = mock_oauth_manager.complete_authorization_code_flow.call_args
                 oauth_config_passed = call_args[0][3]  # 4th positional arg is credentials
                 assert oauth_config_passed["resource"] == "https://mcp.example.com"  # Normalized URL
+
+    @pytest.mark.asyncio
+    async def test_oauth_callback_redirects_to_allowed_external_origin_without_cookies(self, mock_db, mock_request, mock_gateway):
+        """Successful callback redirects externally without gateway-scoped cookies."""
+        from mcpgateway.routers.oauth_router import oauth_callback
+
+        mock_gateway.oauth_config["redirect_uri_after_oauth"] = "https://app.example.org/oauth-complete?gateway_id=123"
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+        token_result = {
+            "user_id": "oauth_user_123",
+            "expires_at": "2024-01-01T12:00:00",
+            "token_aud": None,
+            "state_data": {"app_user_email": "test@example.com", "team_id": None},
+        }
+
+        with patch("mcpgateway.routers.oauth_router.settings.app_domain", "https://gateway.example.com"), \
+             patch("mcpgateway.routers.oauth_router.settings.oauth_redirect_allowed_origin", "https://app.example.org"), \
+             patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_manager_class, \
+             patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+            mock_oauth_manager = Mock()
+            mock_oauth_manager.resolve_gateway_id_from_state = AsyncMock(return_value="gateway123")
+            mock_oauth_manager.complete_authorization_code_flow = AsyncMock(return_value=token_result)
+            mock_oauth_manager_class.return_value = mock_oauth_manager
+
+            response = await oauth_callback(code="auth_code_123", state="state-token", request=mock_request, db=mock_db)
+
+        assert isinstance(response, RedirectResponse)
+        assert response.status_code == 302
+        assert response.headers["location"] == "https://app.example.org/oauth-complete?gateway_id=123"
+        assert response.headers["referrer-policy"] == "no-referrer"
+        assert response.headers.getlist("set-cookie") == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("redirect", ["/oauth-complete", "/\\evil.example/oauth-complete"])
+    async def test_oauth_callback_rejects_relative_redirect(self, mock_db, mock_request, mock_gateway, redirect):
+        """Callback rejects all relative redirect targets."""
+        from mcpgateway.routers.oauth_router import oauth_callback
+
+        mock_gateway.oauth_config["redirect_uri_after_oauth"] = redirect
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+        token_result = {
+            "user_id": "oauth_user_123",
+            "expires_at": "2024-01-01T12:00:00",
+            "token_aud": None,
+            "state_data": {"app_user_email": "test@example.com", "team_id": None},
+        }
+
+        with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_manager_class, \
+             patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+            mock_oauth_manager = Mock()
+            mock_oauth_manager.resolve_gateway_id_from_state = AsyncMock(return_value="gateway123")
+            mock_oauth_manager.complete_authorization_code_flow = AsyncMock(return_value=token_result)
+            mock_oauth_manager_class.return_value = mock_oauth_manager
+
+            response = await oauth_callback(code="auth_code_123", state="state-token", request=mock_request, db=mock_db)
+
+        assert isinstance(response, HTMLResponse)
+        assert response.status_code == 400
+        assert "OAuth Authorization Failed" in response.body.decode()
+        mock_oauth_manager.complete_authorization_code_flow.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_oauth_callback_resource_string_persisted_as_is(self, mock_db, mock_request):
@@ -3273,7 +3367,8 @@ class TestOAuthRouterPopupMode:
         mock_gateway.oauth_config = {
             "client_id": "test-client",
             "authorization_url": "https://oauth.example.com/authorize",
-            "token_url": "https://oauth.example.com/token"
+            "token_url": "https://oauth.example.com/token",
+            "redirect_uri_after_oauth": "https://app.example.org/oauth-complete",
         }
         mock_gateway.ca_certificate = None
         mock_gateway.client_cert = None
@@ -3321,6 +3416,7 @@ class TestOAuthRouterPopupMode:
 
                     # Verify no legacy admin UI elements
                     assert 'Fetch Tools from MCP Server' not in body
+                    assert "location" not in result.headers
 
     @pytest.mark.asyncio
     async def test_oauth_callback_with_popup_state_provider_error(self, mock_db):

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -24812,7 +24812,7 @@ class TestAdminCsrfProtection:
         # function falls through to return False and CSRF validation fails.
         monkeypatch.setattr("mcpgateway.admin.settings.allowed_origins", {"will-explode://bad"})
 
-        real_normalize = admin_mod._normalize_origin_parts
+        real_normalize = admin_mod.normalize_origin_parts
 
         def _boom_on_bad(scheme, netloc):
             if netloc == "bad":
@@ -24829,7 +24829,7 @@ class TestAdminCsrfProtection:
             cookies={"jwt_token": "jwt", admin_mod.ADMIN_CSRF_COOKIE_NAME: "expected"},
             form_data={admin_mod.ADMIN_CSRF_FORM_FIELD: "expected"},
         )
-        with patch.object(admin_mod, "_normalize_origin_parts", side_effect=_boom_on_bad):
+        with patch.object(admin_mod, "normalize_origin_parts", side_effect=_boom_on_bad):
             with pytest.raises(HTTPException, match="CSRF origin validation failed"):
                 await admin_mod.enforce_admin_csrf(request)
 

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -52,6 +52,30 @@ def test_parse_allowed_origins_json_and_csv():
     assert s_csv.allowed_origins == {"https://x.com", "https://y.com"}
 
 
+def test_oauth_redirect_allowed_origin_accepts_exact_https_origin():
+    """OAuth redirect allowlist accepts one exact HTTPS origin."""
+    settings = Settings(oauth_redirect_allowed_origin="https://a.com:8443", environment="development", _env_file=None)
+    assert settings.oauth_redirect_allowed_origin == "https://a.com:8443"
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "*",
+        "http://app.example.com",
+        "https://user@app.example.com",
+        "https://app.example.com/path",
+        "https://app.example.com?query=value",
+        "https://app.example.com\\path",
+        "https://[::1",
+    ],
+)
+def test_oauth_redirect_allowed_origin_rejects_non_origins(origin):
+    """OAuth redirect allowlist rejects unsafe or non-origin entries."""
+    with pytest.raises(ValueError, match="OAuth redirect"):
+        Settings(oauth_redirect_allowed_origin=origin, environment="development", _env_file=None)
+
+
 @pytest.mark.parametrize(
     ("url", "message"),
     [

--- a/tests/unit/mcpgateway/test_schemas.py
+++ b/tests/unit/mcpgateway/test_schemas.py
@@ -1740,6 +1740,47 @@ class TestAuthValidationErrors:
             GatewayUpdate(auth_type="invalid_type")
         assert "Invalid 'auth_type'" in str(exc_info.value)
 
+    @pytest.mark.parametrize(
+        ("model_name", "base_fields"),
+        [
+            ("create", {"name": "test", "url": "https://mcp.example.com"}),
+            ("update", {}),
+        ],
+    )
+    def test_gateway_oauth_config_accepts_allowed_post_oauth_redirect(self, model_name, base_fields):
+        """Gateway POST and PUT schemas accept trusted post-OAuth redirects."""
+        from mcpgateway.schemas import GatewayCreate, GatewayUpdate
+
+        model = GatewayCreate if model_name == "create" else GatewayUpdate
+        with patch("mcpgateway.schemas.settings") as mock_settings:
+            mock_settings.app_domain = "https://gateway.example.com"
+            mock_settings.oauth_redirect_allowed_origin = "https://app.example.org"
+            gateway = model(
+                **base_fields,
+                oauth_config={"redirect_uri_after_oauth": "https://app.example.org/oauth-complete"},
+            )
+
+        assert gateway.oauth_config["redirect_uri_after_oauth"] == "https://app.example.org/oauth-complete"
+
+    @pytest.mark.parametrize(
+        ("model_name", "base_fields"),
+        [
+            ("create", {"name": "test", "url": "https://mcp.example.com"}),
+            ("update", {}),
+        ],
+    )
+    @pytest.mark.parametrize("redirect", ["", " ", None, "https://evil.example/oauth-complete", "/oauth-complete", "/\\evil.example/oauth-complete", 123])
+    def test_gateway_oauth_config_rejects_invalid_post_oauth_redirect(self, model_name, base_fields, redirect):
+        """Gateway POST and PUT schemas reject untrusted or malformed redirects."""
+        from mcpgateway.schemas import GatewayCreate, GatewayUpdate
+
+        model = GatewayCreate if model_name == "create" else GatewayUpdate
+        with patch("mcpgateway.schemas.settings") as mock_settings:
+            mock_settings.app_domain = "https://gateway.example.com"
+            mock_settings.oauth_redirect_allowed_origin = "https://app.example.org"
+            with pytest.raises(ValidationError, match="redirect_uri_after_oauth"):
+                model(**base_fields, oauth_config={"redirect_uri_after_oauth": redirect})
+
     def test_a2a_agent_create_invalid_auth_type(self):
         """Test A2AAgentCreate rejects invalid auth_type."""
         # First-Party

--- a/tests/unit/mcpgateway/utils/test_small_utils.py
+++ b/tests/unit/mcpgateway/utils/test_small_utils.py
@@ -8,10 +8,12 @@ Unit tests for small utility modules that had low coverage.
 
 # Third-Party
 from pydantic import BaseModel
+import pytest
 
 # First-Party
 from mcpgateway.utils.base_models import BaseModelWithConfigDict
 from mcpgateway.utils.display_name import generate_display_name
+from mcpgateway.utils.origin import is_allowed_redirect, is_exact_https_origin, is_same_origin, normalize_origin_parts, origin_from_url
 
 
 def test_generate_display_name_empty_string() -> None:
@@ -47,3 +49,79 @@ def test_base_model_to_dict_recurses_like_model_dump() -> None:
 
     # Ensure we call through to model_dump and preserve nested structure
     assert obj.to_dict(use_alias=False) == {"child": {"child_field": "x"}}
+
+
+def test_normalize_origin_parts_normalizes_case_and_default_ports() -> None:
+    assert normalize_origin_parts("HTTP", "Example.COM") == ("http", "example.com", 80)
+    assert normalize_origin_parts("https", "example.com:443") == ("https", "example.com", 443)
+
+
+def test_origin_from_url_removes_path_query_and_fragment() -> None:
+    assert origin_from_url("https://example.com:8443/path?query=value#fragment") == "https://example.com:8443"
+
+
+def test_is_same_origin_requires_matching_absolute_origin() -> None:
+    origin = "https://example.com"
+
+    assert not is_same_origin("/dashboard", origin)
+    assert is_same_origin("https://EXAMPLE.com:443/dashboard", origin)
+    assert not is_same_origin("//evil.example/dashboard", origin)
+    assert not is_same_origin("http://example.com/dashboard", origin)
+    assert not is_same_origin("https://example.com:8443/dashboard", origin)
+
+
+@pytest.mark.parametrize("url", ["/\\evil.example/dashboard", " /\\evil.example/dashboard", "\\evil.example/dashboard"])
+def test_is_same_origin_rejects_browser_normalized_backslashes(url: str) -> None:
+    assert not is_same_origin(url, "https://example.com")
+
+
+def test_is_same_origin_rejects_backslash_in_reference_origin() -> None:
+    assert not is_same_origin("https://example.com/dashboard", "https://example.com\\path")
+
+
+def test_is_exact_https_origin_rejects_url_suffix_state() -> None:
+    assert is_exact_https_origin("https://example.com:8443")
+    assert not is_exact_https_origin("http://example.com")
+    assert not is_exact_https_origin("https://user@example.com")
+    assert not is_exact_https_origin("https://example.com/path")
+    assert not is_exact_https_origin("https://example.com?query=value")
+    assert not is_exact_https_origin("https://example.com:bad")
+    assert not is_exact_https_origin("https://example.com\\path")
+    assert not is_exact_https_origin("https://[::1")
+
+
+def test_is_allowed_redirect_accepts_configured_external_https_origin() -> None:
+    assert is_allowed_redirect(
+        "https://app.example.org/oauth-complete?gateway_id=123",
+        "https://gateway.example.com",
+        "https://app.example.org",
+    )
+
+
+def test_is_allowed_redirect_accepts_absolute_app_origin_without_external_origin() -> None:
+    assert is_allowed_redirect(
+        "https://gateway.example.com/oauth-complete",
+        "https://gateway.example.com",
+        None,
+    )
+
+
+def test_is_allowed_redirect_rejects_untrusted_or_insecure_external_url() -> None:
+    app_origin = "https://gateway.example.com"
+    allowed_origin = "https://app.example.org"
+
+    assert not is_allowed_redirect("https://evil.example/oauth-complete", app_origin, allowed_origin)
+    assert not is_allowed_redirect("http://app.example.org/oauth-complete", app_origin, allowed_origin)
+    assert not is_allowed_redirect("https://user@app.example.org/oauth-complete", app_origin, allowed_origin)
+    assert not is_allowed_redirect("https://app.example.org:bad/oauth-complete", app_origin, allowed_origin)
+    assert not is_allowed_redirect("https://[::1", app_origin, allowed_origin)
+
+
+@pytest.mark.parametrize("url", ["//evil.example", "///evil.example", "////evil.example", "\\\\evil.example", "/\\evil.example"])
+def test_is_allowed_redirect_rejects_network_path_bypasses(url: str) -> None:
+    assert not is_allowed_redirect(url, "https://gateway.example.com", None)
+
+
+@pytest.mark.parametrize("url", ["", " ", "/oauth-complete", "oauth-complete"])
+def test_is_allowed_redirect_rejects_relative_targets(url: str) -> None:
+    assert not is_allowed_redirect(url, "https://gateway.example.com", None)


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Partially addresses https://github.com/IBM/mcp-context-forge/issues/6309

---

## 📝 Summary

Adds `redirect_uri_after_oauth` — an optional field in a gateway's `oauth_config` that causes the browser to be sent to an operator-configured external URL after a successful Authorization Code OAuth callback, instead of landing on the gateway's built-in success page.

```json
{
  "oauth_config": {
    "grant_type": "authorization_code",
    "redirect_uri_after_oauth": "https://app.example.com/oauth-complete"
  }
}
```

The destination must be within the single HTTPS origin declared by the new `OAUTH_REDIRECT_ALLOWED_ORIGIN` environment variable, which is validated at startup.

Flow: register MCP OAuth → user logs in → callback → `302` to `redirect_uri_after_oauth`

---

## ⚠️ Design note — divergence from issue #6309

Issue #6309 proposed a **per-flow, dynamic** mechanism: a `post_login_redirect_uri` query parameter passed at `GET /oauth/authorize`, encoded into the OAuth `state`, and decoded on callback.

This PR deliberately implements a **static, per-gateway allowlist** instead. The reason is security:

- The per-flow design gives every request an opportunity to inject an attacker-controlled redirect destination. A malicious login link (`?post_login_redirect_uri=https://evil.com`) would send the victim to an attacker-controlled page after authentication — a classic open-redirect / token-leakage vector documented in [RFC 6819 §4.2.4](https://datatracker.ietf.org/doc/html/rfc6819#section-4.2.4).
- A static allowlist has **zero per-request surface**: the destination is set by an admin at configuration time, not by a caller at runtime.

Trade-off: multi-app deployments are currently capped at one external origin per gateway deployment. This covers the common single-app case (the reporter's stated need: "bring the user back to our own UI"). The per-flow dynamic mechanism from the issue remains unimplemented and is out of scope for this PR.

**Admin UI field**: Adding the field to the Admin UI is intentionally deferred to a follow-up — the feature is fully usable via the REST API today.

---

## What changed

**`mcpgateway/utils/origin.py`** (new) — shared origin utilities extracted from `admin.py`:
- `normalize_origin_parts()` — normalises scheme/host/port for exact same-origin comparison (moved from `admin._normalize_origin_parts`)
- `origin_from_url()` — extracts `scheme://host[:port]` from any URL
- `is_same_origin()` — absolute URL same-origin check with backslash rejection
- `is_exact_https_origin()` — strict HTTPS-only origin validator (no path/query/fragment/credentials)
- `is_allowed_redirect()` — gate used at every enforcement point

**`mcpgateway/config.py`** — new `oauth_redirect_allowed_origin` field validated at startup by `is_exact_https_origin()`; rejects wildcards, HTTP, paths, credentials.

**`mcpgateway/schemas.py`** — `_validate_oauth_config_urls` enforces `redirect_uri_after_oauth` must be absolute and within allowed origins at schema validation time (Pydantic layer).

**`mcpgateway/admin.py`** — `_assemble_oauth_config_from_fields` enforces the same check for the admin form path (non-Pydantic path). `_normalize_origin_parts` removed in favour of the shared import.

**`mcpgateway/routers/oauth_router.py`** — `custom_redirect_after_callback()` validates and issues the `302` redirect with `Referrer-Policy: no-referrer` after a successful non-popup OAuth flow.

---

## Security invariants

- Fail-closed at three layers: Pydantic schema validation, admin form assembler, and again at redirect time (covering legacy rows written before validation existed).
- Redirect-time validation runs before `complete_authorization_code_flow`, so a misconfigured URL does not burn the one-time state.
- Relative URLs rejected (no scheme/netloc → fail-closed).
- Backslash-normalised paths (`/\\evil.example`) rejected.
- HTTP external origins rejected (HTTPS-only).
- Credentials in URLs (`user@host`) rejected.
- Popup mode unaffected — redirect skipped when `is_popup=True`.
- No tokens in the redirect URL; `Referrer-Policy: no-referrer` prevents leaking the consumed code/state to the external origin.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

<img width="1122" height="259" alt="image" src="https://github.com/user-attachments/assets/498a408f-51cb-4d63-82dd-2e1ae115c6f7" />

new field added to UI