### PR TITLE
chore: bump pinned UBI10 base image tags

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -45,9 +45,9 @@ ARG ENABLE_PROFILING=false
 #     --build-arg NODEJS_IMAGE=<internal-registry>/ubi9/nodejs-20:latest \
 #     --build-arg UBI_MINIMAL=<internal-registry>/ubi9/ubi-minimal:latest \
 #     .
-ARG UBI_BASE=registry.access.redhat.com/ubi10:10.2-1786928703
-ARG NODEJS_IMAGE=registry.access.redhat.com/ubi10/nodejs-24:10.2-1786927268
-ARG UBI_MINIMAL=registry.access.redhat.com/ubi10/ubi-minimal:10.2-1786928543
+ARG UBI_BASE=registry.access.redhat.com/ubi10:10.2-1787684095
+ARG NODEJS_IMAGE=registry.access.redhat.com/ubi10/nodejs-24:10.2-1787666083
+ARG UBI_MINIMAL=registry.access.redhat.com/ubi10/ubi-minimal:10.2-1787688243
 # Wheel closure stage — used only for s390x and ppc64le where PyPI manylinux
 # binary wheels are unavailable (tiktoken/psycopg/cryptography require native
 # compilation, and psycopg-binary has no s390x wheel at all).


### PR DESCRIPTION
## What
Bumps the pinned UBI_BASE/NODEJS_IMAGE/UBI_MINIMAL defaults in Containerfile to the latest available UBI 10.2 build tags.

## Why
The merge-queue Docker Security Scan gate started failing on a high-severity vulnerability in a base-image package that has since been fixed upstream. The CI Docker layer cache kept serving a pre-fix layer built from the older pinned base digest, so the scanned image never picked up the fix even on reruns.

Bumping the FROM tags changes the base-stage digest, busting the stale cached layer and forcing a fresh package install against current repo content.

## Verification
Built the runtime target locally from the updated pins and confirmed the previously-flagged packages now install at patched versions. Also checked the FedRAMP (UBI9) build path in the same workflow — it uses floating tags plus a digest pin that already resolves patched packages live, and runs report-only (non-blocking), so no change needed there.

No application code, schema, or Alembic changes.