### PR TITLE
chore: add Gateway UX port to `testing-up` output

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-31T10:37:33Z",
+  "generated_at": "2026-09-01T10:51:38Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-01T10:51:38Z",
+  "generated_at": "2026-09-01T11:13:01Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -374,7 +374,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1958,
+        "line_number": 1959,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6141,
+        "line_number": 6142,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6638,
+        "line_number": 6639,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6650,
+        "line_number": 6651,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6722,
+        "line_number": 6723,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7138,
+        "line_number": 7139,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7828,
+        "line_number": 7829,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/Makefile
+++ b/Makefile
@@ -1786,7 +1786,7 @@ testing-up:                                ## Start testing stack (Locust + Fast
 	@echo "Service              URL                           Purpose"
 	@echo "──────────────────────────────────────────────────────────────────────────"
 	@echo "Gateway (nginx)      http://localhost:8080         API proxy"
-	@echo "Gateway UX (nginx)   http://localhost:3100         Gateway Supported UX"
+	@echo "Gateway UX (nginx)   http://localhost:$${WEB_UI_PORT:-3001}         Gateway Supported UX"
 	@echo "Locust Web UI        http://localhost:8089         Load testing (master+workers)"
 	@echo "Fast Time Server     http://localhost:8888         MCP benchmark target"
 	@echo "A2A Echo Agent       http://localhost:9100         A2A protocol target"

--- a/Makefile
+++ b/Makefile
@@ -1786,6 +1786,7 @@ testing-up:                                ## Start testing stack (Locust + Fast
 	@echo "Service              URL                           Purpose"
 	@echo "──────────────────────────────────────────────────────────────────────────"
 	@echo "Gateway (nginx)      http://localhost:8080         API proxy"
+	@echo "Gateway UX (nginx)   http://localhost:3100         Gateway Supported UX"
 	@echo "Locust Web UI        http://localhost:8089         Load testing (master+workers)"
 	@echo "Fast Time Server     http://localhost:8888         MCP benchmark target"
 	@echo "A2A Echo Agent       http://localhost:9100         A2A protocol target"


### PR DESCRIPTION
## Summary

Adds a one-line reminder for the Gateway UX URL to the `make testing-up` service table.

PR #6320 exposed the experimental web UI at `http://localhost:3100` (configurable via `WEB_UI_PORT`), but the `testing-up` startup summary table wasn't updated to include it. Operators had to know the port out-of-band.

## Change

```diff
+	@echo "Gateway UX (nginx)   http://localhost:3100         Gateway Supported UX"
```

One `@echo` line in the `Makefile` — no logic changes.

## Testing

Running `make testing-up` now prints:
```
Service              URL                           Purpose
──────────────────────────────────────────────────────────────────────────
Gateway (nginx)      http://localhost:8080         API proxy
Gateway UX (nginx)   http://localhost:3100         Gateway Supported UX
Locust Web UI        http://localhost:8089         Load testing (master+workers)
...
```

Closes #6414