### PR TITLE
fix(validators): don't flag quoted URL schemes (://) as polyglot attacks

### DIFF
--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -97,7 +97,10 @@ _CONTROL_CHARS_RE: Pattern[str] = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\
 _POLYGLOT_PATTERNS: List[Pattern[str]] = [
     re.compile(r"['\"];.*alert\s*\(", re.IGNORECASE),
     re.compile(r"-->\s*<[^>]+>", re.IGNORECASE),
-    re.compile(r"['\"].*//['\"]", re.IGNORECASE),
+    # `(?<!:)` excludes URL-scheme separators (`://`): legitimate quoted URLs in display
+    # text (e.g. connection-string examples "postgresql://") must not be flagged as
+    # polyglots. A bare `//` before a quote (JS line-comment polyglot) is still caught.
+    re.compile(r"['\"].*(?<!:)//['\"]", re.IGNORECASE),
     re.compile(r"<<[A-Z]+>", re.IGNORECASE),
     re.compile(r"String\.fromCharCode", re.IGNORECASE),
     re.compile(r"javascript:.*\(", re.IGNORECASE),

--- a/tests/unit/mcpgateway/validation/test_validators.py
+++ b/tests/unit/mcpgateway/validation/test_validators.py
@@ -106,6 +106,19 @@ def test_sanitize_display_text_js(patch_logger):
         SecurityValidator.sanitize_display_text("data:text/html;script", "desc")
 
 
+def test_sanitize_display_text_url_scheme_allowed(patch_logger):
+    # Quoted URL schemes in descriptions must not be flagged as polyglots: connection-string
+    # examples like "postgresql://" previously tripped the ['"].*//['"] pattern.
+    assert SecurityValidator.sanitize_display_text('Examples: "postgresql://" or "mysql://"', "desc")
+    assert SecurityValidator.sanitize_display_text('DSN: "postgresql://user:pass@host/db"', "desc")
+
+
+def test_sanitize_display_text_polyglot_double_slash_still_blocked(patch_logger):
+    # A bare `//` before a closing quote (not a URL scheme) is still treated as a polyglot.
+    with pytest.raises(ValueError):
+        SecurityValidator.sanitize_display_text('x "a//" y', "desc")
+
+
 def test_validate_name_valid():
     assert SecurityValidator.validate_name("ValidName", "Name") == "ValidName"
 


### PR DESCRIPTION
## 📌 Summary

`SecurityValidator.sanitize_display_text` rejects any display text in which a quoted string contains `//` (via the `_POLYGLOT_PATTERNS` entry `["'].*//["']`). Legitimate URLs get caught: a tool whose description enumerates connection-string examples such as `"postgresql://"` / `"mysql://"` fails validation with `<field> contains potentially dangerous character sequences`, which blocks tool registration.

## 🔁 Reproduction Steps

Closes #6419

```python
from mcpgateway.common.validators import SecurityValidator
SecurityValidator.sanitize_display_text('Examples: "postgresql://" or "mysql://"', "desc")
# ValueError: desc contains potentially dangerous character sequences
```

Observed in practice with a Superset "create connection" tool whose description lists the supported DB URL schemes.

## 🐞 Root Cause

The `//` of a URL scheme separator (`://`) is treated as a JS line-comment polyglot by `["'].*//["']` in `mcpgateway/common/validators.py`.

## 💡 Fix Description

Add a negative lookbehind so a scheme `://` is not matched, while a bare `//` before a closing quote (a genuine JS line-comment polyglot) is still caught:

```
["'].*//["']   ->   ["'].*(?<!:)//["']
```

The HTML/JS patterns and the other polyglot patterns are unchanged, so real XSS/polyglot payloads remain blocked.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

Two regression tests added in `tests/unit/mcpgateway/validation/test_validators.py`:
- `test_sanitize_display_text_url_scheme_allowed` — quoted URL schemes are accepted;
- `test_sanitize_display_text_polyglot_double_slash_still_blocked` — a bare `//` before a quote is still rejected.

| Check | Command | Status |
|---|---|---|
| Lint suite | `make lint` | not run in submitter environment |
| Unit tests | `make test` | not run in submitter environment |
| Coverage ≥ 80 % | `make coverage` | not run in submitter environment |
| Manual regression | standalone `re` check | verified `"postgresql://"`/`"mysql://"` no longer flagged and `"a//"` still flagged; existing HTML/JS/polyglot checks unaffected — relying on project CI for the full suite |

## 📐 MCP Compliance (if relevant)

N/A — input-validation refinement, no change to the MCP protocol or client behavior.

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`) — not run locally; change is a 1-line regex + tests (formatting-neutral)
- [x] No secrets/credentials committed