### PR TITLE
feat: add gateway-side TLS override for end-to-end HTTPS (closes #6266)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3388,6 +3388,12 @@ PLUGINS_CLI_MARKUP_MODE=rich
 # the TLS handshake. Generate a test pair with: make certs-client
 # LOOPBACK_CLIENT_CERT=certs/client/client-cert.pem
 # LOOPBACK_CLIENT_KEY=certs/client/client-key.pem
+# Docker Compose gateway TLS override values.
+# Leave these unset to use the defaults from docker-compose.gateway-tls.yml:
+# SSL=true
+# CERT_FILE=/app/certs/cert.pem
+# KEY_FILE=/app/certs/key.pem
+# KEY_FILE_PASSWORD=
 
 # --- Direct env reads (application code) -------------------------------------
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-28T12:29:08Z",
+  "generated_at": "2026-08-31T08:30:58Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6115,
+        "line_number": 6141,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6612,
+        "line_number": 6638,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6624,
+        "line_number": 6650,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6696,
+        "line_number": 6722,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7112,
+        "line_number": 7138,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7802,
+        "line_number": 7828,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -846,7 +846,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1821,
+        "line_number": 1846,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -854,7 +854,7 @@
         "hashed_secret": "afba9d98073dfb79fba7b21516c4d4d676c72935",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2251,
+        "line_number": 2276,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -862,7 +862,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2351,
+        "line_number": 2376,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -870,7 +870,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2351,
+        "line_number": 2376,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -878,7 +878,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2364,
+        "line_number": 2389,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -886,7 +886,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2512,
+        "line_number": 2539,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -894,7 +894,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2533,
+        "line_number": 2560,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -902,7 +902,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2541,
+        "line_number": 2568,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -910,7 +910,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2546,
+        "line_number": 2573,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -715,6 +715,24 @@
         "verified_result": null
       }
     ],
+    "docker-compose.gateway-tls.yml": [
+      {
+        "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "docker-compose.sso.yml": [
       {
         "hashed_secret": "65724217e73023f759367bcb3375ea4c0a618418",
@@ -1641,10 +1659,18 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 293,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "4729dd879b70a5a3ae4fa180ccbb4bea7b1d4ce2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 725,
+        "line_number": 731,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/Makefile
+++ b/Makefile
@@ -5997,7 +5997,7 @@ compose-tls-ps:
 compose-gateway-tls: compose-validate
 	@echo "🔐 Starting stack with gateway TLS enabled (HTTPS on port 4444)..."
 	@echo "   Run 'make certs' first if ./certs/ is empty."
-	IMAGE_LOCAL=$(call get_image_name) $(COMPOSE_CMD) -f $(COMPOSE_FILE) -f docker-compose.gateway-tls.yml up -d
+	IMAGE_LOCAL=$(call get_image_name) $(COMPOSE_CMD) -f $(COMPOSE_FILE) -f docker-compose.gateway-tls.yml up -d --scale nginx=0 --scale gateway=1
 	@echo "✅ Gateway TLS started. Test: curl -fk https://localhost:4444/health"
 
 compose-tls-e2e: compose-validate

--- a/Makefile
+++ b/Makefile
@@ -5619,6 +5619,10 @@ docker-shell:
 # help: compose-tls-logs      - Tail logs from TLS stack
 # help: compose-test-hardened - 🔒 Test hardened runtime (read_only + cap_drop + runtime/default seccomp)
 # help: compose-tls-ps        - Show TLS stack status
+# help: compose-gateway-tls  - 🔐 Gateway-side TLS only (HTTPS:4444, no nginx TLS)
+# help: compose-tls-e2e      - 🔐 End-to-end TLS: nginx TLS + gateway TLS (HTTPS:8443 → HTTPS:4444)
+# help: compose-tls-e2e-down - Stop end-to-end TLS stack
+# help: compose-tls-e2e-logs - Tail logs from end-to-end TLS stack
 # help: compose-siem-up       - 🛡️  Start stack with local OpenSearch SIEM sink (docker-compose.siem-opensearch.yml)
 # help: compose-siem-down     - 🛑 Stop SIEM test stack and remove SIEM containers
 # help: compose-siem-logs     - 📜 Tail logs for gateway + OpenSearch SIEM services
@@ -5944,7 +5948,7 @@ compose-up-safe: compose-validate compose-up
 # ─────────────────────────────────────────────────────────────────────────────
 # TLS Profile - Zero-config HTTPS via Nginx
 # ─────────────────────────────────────────────────────────────────────────────
-.PHONY: compose-tls compose-tls-https compose-tls-down compose-tls-logs compose-tls-ps
+.PHONY: compose-tls compose-tls-https compose-tls-down compose-tls-logs compose-tls-ps compose-gateway-tls compose-tls-e2e compose-tls-e2e-down compose-tls-e2e-logs
 
 compose-tls: compose-validate
 	@echo "🔐 Starting stack with TLS enabled..."
@@ -5985,6 +5989,28 @@ compose-tls-logs:
 	$(COMPOSE_CMD) -f $(COMPOSE_FILE) --profile tls logs -f
 
 compose-tls-ps:
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Gateway TLS / End-to-End TLS (docker-compose.gateway-tls.yml override)
+# ─────────────────────────────────────────────────────────────────────────────
+
+compose-gateway-tls: compose-validate
+	@echo "🔐 Starting stack with gateway TLS enabled (HTTPS on port 4444)..."
+	@echo "   Run 'make certs' first if ./certs/ is empty."
+	IMAGE_LOCAL=$(call get_image_name) $(COMPOSE_CMD) -f $(COMPOSE_FILE) -f docker-compose.gateway-tls.yml up -d
+	@echo "✅ Gateway TLS started. Test: curl -fk https://localhost:4444/health"
+
+compose-tls-e2e: compose-validate
+	@echo "🔐 Starting end-to-end TLS (nginx HTTPS:8443 → gateway HTTPS:4444)..."
+	@echo "   Run 'make certs' first if ./certs/ is empty."
+	IMAGE_LOCAL=$(call get_image_name) $(COMPOSE_CMD) -f $(COMPOSE_FILE) -f docker-compose.gateway-tls.yml --profile tls up -d --scale nginx=0
+	@echo "✅ End-to-end TLS started. Test: curl -sk https://localhost:8443/health"
+
+compose-tls-e2e-down:
+	$(COMPOSE_CMD) -f $(COMPOSE_FILE) -f docker-compose.gateway-tls.yml --profile tls down --remove-orphans
+
+compose-tls-e2e-logs:
+	$(COMPOSE_CMD) -f $(COMPOSE_FILE) -f docker-compose.gateway-tls.yml --profile tls logs -f
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Hardened Runtime Testing - Verify security constraints work in practice

--- a/Makefile
+++ b/Makefile
@@ -6003,7 +6003,7 @@ compose-gateway-tls: compose-validate
 compose-tls-e2e: compose-validate
 	@echo "🔐 Starting end-to-end TLS (nginx HTTPS:8443 → gateway HTTPS:4444)..."
 	@echo "   Run 'make certs' first if ./certs/ is empty."
-	IMAGE_LOCAL=$(call get_image_name) $(COMPOSE_CMD) -f $(COMPOSE_FILE) -f docker-compose.gateway-tls.yml --profile tls up -d --scale nginx=0
+	IMAGE_LOCAL=$(call get_image_name) $(COMPOSE_CMD) -f $(COMPOSE_FILE) -f docker-compose.gateway-tls.yml --profile tls up -d --scale nginx=0 --scale gateway=1
 	@echo "✅ End-to-end TLS started. Test: curl -sk https://localhost:8443/health"
 
 compose-tls-e2e-down:

--- a/docker-compose.gateway-tls.yml
+++ b/docker-compose.gateway-tls.yml
@@ -1,0 +1,37 @@
+# docker-compose.gateway-tls.yml
+#
+# Docker Compose override for gateway-side TLS (end-to-end encryption).
+# Extends docker-compose.yml so the gateway itself serves HTTPS on port 4444.
+#
+# Usage (gateway TLS only):
+#   docker compose -f docker-compose.yml -f docker-compose.gateway-tls.yml up -d
+#   make compose-gateway-tls
+#
+# Usage (end-to-end TLS — nginx TLS + gateway TLS):
+#   docker compose -f docker-compose.yml -f docker-compose.gateway-tls.yml --profile tls up -d --scale nginx=0
+#   make compose-tls-e2e
+#
+# Prerequisites:
+#   make certs           # generate self-signed certs (or place your own in ./certs/)
+#
+# SSL vars are read from .env; defaults activate TLS when this override is applied:
+#   SSL=true
+#   CERT_FILE=/app/certs/cert.pem
+#   KEY_FILE=/app/certs/key.pem
+#   KEY_FILE_PASSWORD=       # only needed for passphrase-protected keys
+
+services:
+  gateway:
+    environment:
+      - SSL=${SSL:-true}
+      - CERT_FILE=${CERT_FILE:-/app/certs/cert.pem}
+      - KEY_FILE=${KEY_FILE:-/app/certs/key.pem}
+      - KEY_FILE_PASSWORD=${KEY_FILE_PASSWORD:-}
+    volumes:
+      - ./certs:/app/certs:ro
+    healthcheck:
+      test: ["CMD", "curl", "-fk", "https://localhost:4444/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s

--- a/docker-compose.gateway-tls.yml
+++ b/docker-compose.gateway-tls.yml
@@ -38,6 +38,10 @@ services:
       retries: 5
       start_period: 30s
 
+  nginx_tls:
+    environment:
+      - GATEWAY_SCHEME=https
+
   register_fast_time:
     environment:
       - GATEWAY_URL=${GATEWAY_URL:-https://gateway:4444}

--- a/docker-compose.gateway-tls.yml
+++ b/docker-compose.gateway-tls.yml
@@ -29,9 +29,18 @@ services:
       - KEY_FILE_PASSWORD=${KEY_FILE_PASSWORD:-}
     volumes:
       - ./certs:/app/certs:ro
+    ports:
+      - "${GATEWAY_TLS_PORT:-4444}:4444"
     healthcheck:
       test: ["CMD", "curl", "-fk", "https://localhost:4444/health"]
       interval: 30s
       timeout: 10s
       retries: 5
       start_period: 30s
+
+  register_fast_time:
+    environment:
+      - GATEWAY_URL=${GATEWAY_URL:-https://gateway:4444}
+      - GATEWAY_CA_CERT=${GATEWAY_CA_CERT:-/app/certs/cert.pem}
+    volumes:
+      - ./certs:/app/certs:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2451,6 +2451,8 @@ services:
     environment:
       # Set to "true" to force all HTTP requests to redirect to HTTPS
       - NGINX_FORCE_HTTPS=${NGINX_FORCE_HTTPS:-false}
+      # Backend protocol; gateway TLS override changes this to HTTPS.
+      - GATEWAY_SCHEME=${GATEWAY_SCHEME:-http}
     depends_on:
       gateway:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1579,6 +1579,7 @@ services:
     environment:
       - "JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY is not set. Run: make setup (first time) or make init-secrets-patch-env (if .env exists)}"
       - "AUTH_ENCRYPTION_SECRET=${AUTH_ENCRYPTION_SECRET:?AUTH_ENCRYPTION_SECRET is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
+      - "GATEWAY_URL=${GATEWAY_URL:-http://gateway:4444}"
 
     # This is a one-shot container that exits after registration
     restart: "no"
@@ -1592,13 +1593,24 @@ services:
 
         # Wait for gateway to be ready using Python
         python3 -c "
+        import os
+        import ssl
         import time
-        import urllib.request
         import urllib.error
+        import urllib.request
+
+        gateway_url = os.environ.get('GATEWAY_URL', 'http://gateway:4444').rstrip('/')
+        ca_cert = os.environ.get('GATEWAY_CA_CERT')
+        ssl_context = ssl.create_default_context(cafile=ca_cert) if ca_cert else None
+        if ssl_context is not None:
+            ssl_context.check_hostname = False
 
         for i in range(1, 61):
             try:
-                with urllib.request.urlopen('http://gateway:4444/health', timeout=2) as response:
+                request_kwargs = {'timeout': 2}
+                if ssl_context is not None:
+                    request_kwargs['context'] = ssl_context
+                with urllib.request.urlopen(f'{gateway_url}/health', **request_kwargs) as response:
                     if response.status == 200:
                         print('✅ gateway is healthy')
                         break
@@ -1649,24 +1661,37 @@ services:
 
         # Use Python to make HTTP requests
         python3 -c "
-        import urllib.request
-        import urllib.error
         import json
-        import sys
         import os
+        import ssl
+        import sys
         import time
+        import urllib.error
+        import urllib.request
 
         token = os.environ.get('MCPGATEWAY_BEARER_TOKEN', '')
+        gateway_url = os.environ.get('GATEWAY_URL', 'http://gateway:4444').rstrip('/')
+        ca_cert = os.environ.get('GATEWAY_CA_CERT')
+        ssl_context = ssl.create_default_context(cafile=ca_cert) if ca_cert else None
+        if ssl_context is not None:
+            ssl_context.check_hostname = False
+
+        def open_url(request, timeout):
+            request_kwargs = {'timeout': timeout}
+            if ssl_context is not None:
+                request_kwargs['context'] = ssl_context
+            return urllib.request.urlopen(request, **request_kwargs)
+
 
         def api_request(method, path, data=None):
             '''Helper to make authenticated API requests.'''
-            url = f'http://gateway:4444{path}'
+            url = f'{gateway_url}{path}'
             req = urllib.request.Request(url, method=method)
             req.add_header('Authorization', f'Bearer {token}')
             req.add_header('Content-Type', 'application/json')
             if data:
                 req.data = json.dumps(data).encode('utf-8')
-            with urllib.request.urlopen(req, timeout=60) as response:
+            with open_url(req, 60) as response:
                 return json.loads(response.read().decode('utf-8'))
 
         def api_request_with_retry(method, path, data=None, retries=30, delay=2, retry_statuses=(401, 502, 503)):
@@ -2369,7 +2394,7 @@ services:
         apt-get install -y --no-install-recommends openssl
         rm -rf /var/lib/apt/lists/*
         # Check if we have an encrypted key that needs decryption
-        if [ -f /certs/key-encrypted.pem ] && [ -n "${KEY_FILE_PASSWORD}" ]; then
+        if [ -f /certs/key-encrypted.pem ] && [ -n "$${KEY_FILE_PASSWORD}" ]; then
           # Validate: encrypted key requires matching certificate
           if [ ! -f /certs/cert.pem ]; then
             echo "❌ Found key-encrypted.pem but cert.pem is missing"

--- a/docs/docs/deployment/tls-configuration.md
+++ b/docs/docs/deployment/tls-configuration.md
@@ -266,14 +266,40 @@ certs/
 
 ## Step 2: Configure Gateway TLS
 
-### Environment Variables
+### Activation via Override File (Recommended)
 
-Edit `docker-compose.yml` gateway service environment section:
+Do not edit `docker-compose.yml` directly. Use the provided override file instead:
+
+```bash
+# Generate certs if you haven't already
+make certs
+
+# Gateway TLS only (port 4444 serves HTTPS)
+make compose-gateway-tls
+
+# End-to-end TLS: nginx HTTPS:8443 → gateway HTTPS:4444
+make compose-tls-e2e
+```
+
+The override file (`docker-compose.gateway-tls.yml`) sets `SSL=true`, mounts `./certs:/app/certs:ro`,
+and switches the healthcheck to `https://` — no manual edits required.
+
+SSL variables can be overridden in `.env`:
+
+```bash
+SSL=true
+CERT_FILE=/app/certs/cert.pem
+KEY_FILE=/app/certs/key.pem
+KEY_FILE_PASSWORD=        # only for passphrase-protected keys
+```
+
+### Manual Configuration (Advanced)
+
+If composing the override file yourself, the gateway service needs:
 
 ```yaml
 gateway:
   environment:
-    # Enable SSL
     - SSL=true
     - CERT_FILE=/app/certs/cert.pem
     - KEY_FILE=/app/certs/key-encrypted.pem
@@ -408,32 +434,7 @@ Ensure certificates are mounted in the gateway container:
 ```yaml
 gateway:
   volumes:
-    - ./certs:/app/certs:ro   # Read-only mount
-```
-
-### HTTP Server Selection
-
-The gateway uses Gunicorn with a custom Python SSL key manager:
-
-#### Gunicorn (Default)
-```yaml
-environment:
-  # Gunicorn HTTP server (the only supported server)
-  - GUNICORN_WORKERS=4
-```
-
-Gunicorn uses a custom Python SSL key manager that:
-
-- Decrypts passphrase-protected keys at startup
-- Creates temporary unencrypted key files
-- Supports all SSL/TLS configurations
-
-### Update Healthcheck
-
-For HTTPS gateway, update the healthcheck to skip SSL verification for self-signed certificates:
-
-```yaml
-gateway:
+    - ./certs:/app/certs:ro
   healthcheck:
     test: ["CMD", "curl", "-fk", "https://localhost:4444/health"]
     interval: 30s
@@ -441,6 +442,11 @@ gateway:
     retries: 5
     start_period: 30s
 ```
+
+### HTTP Server Selection
+
+The gateway uses Gunicorn with a custom Python SSL key manager that decrypts
+passphrase-protected keys at startup and supports all SSL/TLS configurations.
 
 ### Expose Gateway Port (Optional)
 

--- a/infra/nginx/docker-entrypoint.sh
+++ b/infra/nginx/docker-entrypoint.sh
@@ -4,50 +4,51 @@
 
 set -e
 
-NGINX_CONF="/etc/nginx/nginx.conf"
-NGINX_CONF_ORIG="/etc/nginx/nginx.conf.orig"
+NGINX_CONF_ORIG="/etc/nginx/nginx.conf"
+NGINX_CONF="/tmp/nginx.conf"
+cp "$NGINX_CONF_ORIG" "$NGINX_CONF"
+
+GATEWAY_SCHEME="${GATEWAY_SCHEME:-http}"
+case "$GATEWAY_SCHEME" in
+    http|https) ;;
+    *)
+        echo "❌ GATEWAY_SCHEME must be http or https, got: $GATEWAY_SCHEME"
+        exit 1
+        ;;
+esac
+
+if grep -q "__GATEWAY_SCHEME__" "$NGINX_CONF"; then
+    sed -i "s/__GATEWAY_SCHEME__/$GATEWAY_SCHEME/g" "$NGINX_CONF"
+fi
 
 # If NGINX_FORCE_HTTPS is set to "true", enable the redirect block
 if [ "$NGINX_FORCE_HTTPS" = "true" ]; then
     echo "🔒 NGINX_FORCE_HTTPS=true: Enabling HTTP -> HTTPS redirect"
 
-    # Check if we're using the TLS config (has the commented redirect block)
-    if grep -q "# Uncomment this block to force HTTP -> HTTPS redirect" "$NGINX_CONF"; then
-        # Copy config to a writable location (in case it's mounted read-only)
-        cp "$NGINX_CONF" /tmp/nginx.conf
-
-        # Uncomment the redirect server block
-        sed -i '
-            /# Uncomment this block to force HTTP -> HTTPS redirect/,/# HTTP server block/ {
-                s/^[[:space:]]*# server {/    server {/
-                s/^[[:space:]]*#[[:space:]]*listen 80;/        listen 80;/
-                s/^[[:space:]]*#[[:space:]]*listen \[::\]:80;/        listen [::]:80;/
-                s/^[[:space:]]*#[[:space:]]*server_name localhost;/        server_name localhost;/
-                s/^[[:space:]]*#[[:space:]]*return 301/        return 301/
-                s/^[[:space:]]*# }/    }/
-            }
-        ' /tmp/nginx.conf
-
-        # Comment out the regular HTTP server block listeners to avoid port conflict
-        sed -i '
-            /# HTTP server block (keeps HTTP available alongside HTTPS)/,/^[[:space:]]*server_name localhost;/ {
-                s/^\([[:space:]]*\)listen 80 backlog/\1# listen 80 backlog/
-                s/^\([[:space:]]*\)listen \[::\]:80 backlog/\1# listen [::]:80 backlog/
-            }
-        ' /tmp/nginx.conf
-
-        # Use the modified config
-        cp /tmp/nginx.conf "$NGINX_CONF" 2>/dev/null || {
-            # If we can't write to /etc/nginx, use -c flag to specify config path
-            NGINX_CONF="/tmp/nginx.conf"
+    # The active config is already a writable copy in /tmp.
+    # Uncomment the redirect server block
+    sed -i '
+        /# Uncomment this block to force HTTP -> HTTPS redirect/,/# HTTP server block/ {
+            s/^[[:space:]]*# server {/    server {/
+            s/^[[:space:]]*#[[:space:]]*listen 80;/        listen 80;/
+            s/^[[:space:]]*#[[:space:]]*listen \[::\]:80;/        listen [::]:80;/
+            s/^[[:space:]]*#[[:space:]]*server_name localhost;/        server_name localhost;/
+            s/^[[:space:]]*#[[:space:]]*return 301/        return 301/
+            s/^[[:space:]]*# }/    }/
         }
+    ' "$NGINX_CONF"
 
-        echo "✅ HTTP -> HTTPS redirect enabled (all HTTP requests redirect to HTTPS)"
-    else
-        echo "⚠️  NGINX_FORCE_HTTPS set but redirect block not found in config"
-    fi
+    # Comment out the regular HTTP server block listeners to avoid port conflict
+    sed -i '
+        /# HTTP server block (keeps HTTP available alongside HTTPS)/,/^[[:space:]]*server_name localhost;/ {
+            s/^\([[:space:]]*\)listen 80 backlog/\1# listen 80 backlog/
+            s/^\([[:space:]]*\)listen \[::\]:80 backlog/\1# listen [::]:80 backlog/
+        }
+    ' "$NGINX_CONF"
+
+    echo "✅ HTTP -> HTTPS redirect enabled (all HTTP requests redirect to HTTPS)"
 else
-    echo "ℹ️  NGINX_FORCE_HTTPS not set: Both HTTP and HTTPS available"
+    echo "⚠️  NGINX_FORCE_HTTPS set but redirect block not found in config"
 fi
 
 # Validate nginx configuration

--- a/infra/nginx/nginx-tls.conf
+++ b/infra/nginx/nginx-tls.conf
@@ -143,9 +143,6 @@ http {
                      inactive=24h
                      use_temp_path=off;
 
-    # Docker DNS resolver for dynamic upstream resolution
-    # valid=5s forces re-resolution every 5 seconds for load balancing across replicas
-    resolver 127.0.0.11 valid=5s ipv6=off;
 
     # ============================================================
     # Upstream Definition - Tuned for 4000 capacity (3000 nginx cap)
@@ -158,7 +155,7 @@ http {
         least_conn;
         zone gateway_backend 64k;
 
-        server gateway:4444 max_fails=0;  # Disable failure tracking (always retry)
+        server gateway:4444 max_fails=0;  # `resolve` is unsupported by the bundled nginx image
 
         # Keepalive pool sizing for 4000 capacity:
         # - Each nginx worker maintains its own pool
@@ -242,7 +239,7 @@ http {
 
         # Health Check - No rate limiting (for monitoring during load tests)
         location = /health {
-            proxy_pass https://gateway_backend;
+            proxy_pass __GATEWAY_SCHEME__://gateway_backend;
             proxy_set_header Host $http_host;
             proxy_set_header Connection "";
             proxy_http_version 1.1;
@@ -255,7 +252,7 @@ http {
             limit_req zone=api_limit burst=20000 nodelay;
             limit_conn conn_limit 20000;
 
-            proxy_pass https://gateway_backend;
+            proxy_pass __GATEWAY_SCHEME__://gateway_backend;
             proxy_cache off;
 
             proxy_next_upstream error timeout http_502 http_503 http_504;
@@ -328,7 +325,7 @@ http {
         # Health Check - No rate limiting (for monitoring during load tests)
         # ============================================================
         location = /health {
-            proxy_pass https://gateway_backend;
+            proxy_pass __GATEWAY_SCHEME__://gateway_backend;
             proxy_set_header Host $http_host;
             proxy_set_header Connection "";
             proxy_http_version 1.1;
@@ -341,7 +338,7 @@ http {
         # Static Assets - Aggressive Caching (30 days)
         # ============================================================
         location ~* \.(css|js|jpg|jpeg|png|gif|ico|svg|woff|woff2|ttf|eot|otf|webp|avif)$ {
-            proxy_pass https://gateway_backend;
+            proxy_pass __GATEWAY_SCHEME__://gateway_backend;
 
             proxy_cache static_cache;
             proxy_cache_valid 200 30d;
@@ -373,7 +370,7 @@ http {
         # OpenAPI/Schema - Moderate Caching (24 hours)
         # ============================================================
         location ~ ^/(openapi\.json|docs|redoc)$ {
-            proxy_pass https://gateway_backend;
+            proxy_pass __GATEWAY_SCHEME__://gateway_backend;
 
             # SECURITY: docs/openapi/redoc are auth-protected endpoints.
             # Shared proxy cache here can leak authenticated responses to
@@ -405,7 +402,7 @@ http {
             limit_req zone=api_limit burst=20000 nodelay;
             limit_conn conn_limit 20000;
 
-            proxy_pass https://gateway_backend;
+            proxy_pass __GATEWAY_SCHEME__://gateway_backend;
 
             proxy_cache api_cache;
             proxy_cache_valid 200 5m;
@@ -453,7 +450,7 @@ http {
         # ============================================================
         location = /admin/events {
             # SSE stream: disable caching/buffering and allow long-lived connections
-            proxy_pass https://gateway_backend;
+            proxy_pass __GATEWAY_SCHEME__://gateway_backend;
 
             proxy_cache off;
             proxy_buffering off;
@@ -474,7 +471,7 @@ http {
             limit_req zone=api_limit burst=20000 nodelay;
             limit_conn conn_limit 20000;
 
-            proxy_pass https://gateway_backend;
+            proxy_pass __GATEWAY_SCHEME__://gateway_backend;
 
             proxy_cache api_cache;
             proxy_cache_valid 200 5s;
@@ -513,7 +510,7 @@ http {
         # SSE/WebSocket - No Caching
         # ============================================================
         location ~ ^/servers/.*/sse$ {
-            proxy_pass https://gateway_backend;
+            proxy_pass __GATEWAY_SCHEME__://gateway_backend;
 
             # SSE-specific headers
             proxy_set_header Connection '';
@@ -535,7 +532,7 @@ http {
         }
 
         location ~ ^/servers/.*/ws$ {
-            proxy_pass https://gateway_backend;
+            proxy_pass __GATEWAY_SCHEME__://gateway_backend;
 
             # WebSocket upgrade
             proxy_http_version 1.1;
@@ -557,7 +554,7 @@ http {
 
         # MCP Streamable HTTP transport
         location ~ ^(/mcp/?|/servers/.*/mcp/?)$ {
-            proxy_pass https://gateway_backend;
+            proxy_pass __GATEWAY_SCHEME__://gateway_backend;
 
             # MCP GET /mcp can be a long-lived SSE stream; disable buffering.
             proxy_http_version 1.1;
@@ -587,7 +584,7 @@ http {
             limit_req zone=api_limit burst=20000 nodelay;
             limit_conn conn_limit 20000;
 
-            proxy_pass https://gateway_backend;
+            proxy_pass __GATEWAY_SCHEME__://gateway_backend;
 
             proxy_cache off;
 
@@ -614,7 +611,7 @@ http {
             limit_req zone=api_limit burst=20000 nodelay;
             limit_conn conn_limit 20000;
 
-            proxy_pass https://gateway_backend;
+            proxy_pass __GATEWAY_SCHEME__://gateway_backend;
 
             proxy_cache off;
 

--- a/infra/nginx/nginx-tls.conf
+++ b/infra/nginx/nginx-tls.conf
@@ -158,7 +158,7 @@ http {
         least_conn;
         zone gateway_backend 64k;
 
-        server gateway:4444 resolve max_fails=0;  # Re-resolve Docker DNS for replica-aware balancing
+        server gateway:4444 max_fails=0;  # Disable failure tracking (always retry)
 
         # Keepalive pool sizing for 4000 capacity:
         # - Each nginx worker maintains its own pool
@@ -242,7 +242,7 @@ http {
 
         # Health Check - No rate limiting (for monitoring during load tests)
         location = /health {
-            proxy_pass http://gateway_backend;
+            proxy_pass https://gateway_backend;
             proxy_set_header Host $http_host;
             proxy_set_header Connection "";
             proxy_http_version 1.1;
@@ -255,7 +255,7 @@ http {
             limit_req zone=api_limit burst=20000 nodelay;
             limit_conn conn_limit 20000;
 
-            proxy_pass http://gateway_backend;
+            proxy_pass https://gateway_backend;
             proxy_cache off;
 
             proxy_next_upstream error timeout http_502 http_503 http_504;
@@ -328,7 +328,7 @@ http {
         # Health Check - No rate limiting (for monitoring during load tests)
         # ============================================================
         location = /health {
-            proxy_pass http://gateway_backend;
+            proxy_pass https://gateway_backend;
             proxy_set_header Host $http_host;
             proxy_set_header Connection "";
             proxy_http_version 1.1;
@@ -341,7 +341,7 @@ http {
         # Static Assets - Aggressive Caching (30 days)
         # ============================================================
         location ~* \.(css|js|jpg|jpeg|png|gif|ico|svg|woff|woff2|ttf|eot|otf|webp|avif)$ {
-            proxy_pass http://gateway_backend;
+            proxy_pass https://gateway_backend;
 
             proxy_cache static_cache;
             proxy_cache_valid 200 30d;
@@ -373,7 +373,7 @@ http {
         # OpenAPI/Schema - Moderate Caching (24 hours)
         # ============================================================
         location ~ ^/(openapi\.json|docs|redoc)$ {
-            proxy_pass http://gateway_backend;
+            proxy_pass https://gateway_backend;
 
             # SECURITY: docs/openapi/redoc are auth-protected endpoints.
             # Shared proxy cache here can leak authenticated responses to
@@ -405,7 +405,7 @@ http {
             limit_req zone=api_limit burst=20000 nodelay;
             limit_conn conn_limit 20000;
 
-            proxy_pass http://gateway_backend;
+            proxy_pass https://gateway_backend;
 
             proxy_cache api_cache;
             proxy_cache_valid 200 5m;
@@ -453,7 +453,7 @@ http {
         # ============================================================
         location = /admin/events {
             # SSE stream: disable caching/buffering and allow long-lived connections
-            proxy_pass http://gateway_backend;
+            proxy_pass https://gateway_backend;
 
             proxy_cache off;
             proxy_buffering off;
@@ -474,7 +474,7 @@ http {
             limit_req zone=api_limit burst=20000 nodelay;
             limit_conn conn_limit 20000;
 
-            proxy_pass http://gateway_backend;
+            proxy_pass https://gateway_backend;
 
             proxy_cache api_cache;
             proxy_cache_valid 200 5s;
@@ -513,7 +513,7 @@ http {
         # SSE/WebSocket - No Caching
         # ============================================================
         location ~ ^/servers/.*/sse$ {
-            proxy_pass http://gateway_backend;
+            proxy_pass https://gateway_backend;
 
             # SSE-specific headers
             proxy_set_header Connection '';
@@ -535,7 +535,7 @@ http {
         }
 
         location ~ ^/servers/.*/ws$ {
-            proxy_pass http://gateway_backend;
+            proxy_pass https://gateway_backend;
 
             # WebSocket upgrade
             proxy_http_version 1.1;
@@ -587,7 +587,7 @@ http {
             limit_req zone=api_limit burst=20000 nodelay;
             limit_conn conn_limit 20000;
 
-            proxy_pass http://gateway_backend;
+            proxy_pass https://gateway_backend;
 
             proxy_cache off;
 
@@ -614,7 +614,7 @@ http {
             limit_req zone=api_limit burst=20000 nodelay;
             limit_conn conn_limit 20000;
 
-            proxy_pass http://gateway_backend;
+            proxy_pass https://gateway_backend;
 
             proxy_cache off;
 

--- a/tests/live_gateway/test_tls_compose.py
+++ b/tests/live_gateway/test_tls_compose.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/live_gateway/test_tls_compose.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Black-box smoke test for the end-to-end Compose TLS path.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import ssl
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+import pytest
+
+
+BASE_URL = os.environ.get("TLS_BASE_URL", "https://localhost:8443").rstrip("/")
+
+
+def test_end_to_end_tls_health() -> None:
+    """Verify nginx TLS can reach the gateway's HTTPS health endpoint."""
+    parsed = urlparse(BASE_URL)
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        with socket.create_connection((parsed.hostname, port), timeout=2):
+            pass
+    except OSError:
+        pytest.skip(f"TLS gateway is not reachable at {BASE_URL}")
+
+    context = ssl._create_unverified_context()
+    with urlopen(f"{BASE_URL}/health", context=context, timeout=5) as response:
+        assert response.status == 200

--- a/tests/unit/test_tls_compose.py
+++ b/tests/unit/test_tls_compose.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/test_tls_compose.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Regression tests for the Compose TLS workflows.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _compose_config(*files: str) -> dict:
+    result = subprocess.run(
+        ["docker", "compose", *sum((["-f", file] for file in files), []), "--profile", "tls", "config", "--format", "json"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_nginx_tls_selects_http_or_https_gateway_scheme_per_compose_stack() -> None:
+    nginx_only = _compose_config("docker-compose.yml")
+    end_to_end = _compose_config("docker-compose.yml", "docker-compose.gateway-tls.yml")
+
+    assert nginx_only["services"]["nginx_tls"]["environment"]["GATEWAY_SCHEME"] == "http"
+    assert end_to_end["services"]["nginx_tls"]["environment"]["GATEWAY_SCHEME"] == "https"
+    nginx_config = (REPO_ROOT / "infra/nginx/nginx-tls.conf").read_text(encoding="utf-8")
+    entrypoint = (REPO_ROOT / "infra/nginx/docker-entrypoint.sh").read_text(encoding="utf-8")
+    assert "proxy_pass __GATEWAY_SCHEME__://gateway_backend;" in nginx_config
+    assert 'sed -i "s/__GATEWAY_SCHEME__/$GATEWAY_SCHEME/g" "$NGINX_CONF"' in entrypoint
+
+
+def test_compose_tls_e2e_pins_gateway_to_one_published_port() -> None:
+    result = subprocess.run(
+        ["make", "-n", "compose-tls-e2e"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "--scale nginx=0 --scale gateway=1" in result.stdout
+
+
+def test_nginx_tls_documents_unsupported_dynamic_resolution() -> None:
+    config = (REPO_ROOT / "infra/nginx/nginx-tls.conf").read_text(encoding="utf-8")
+
+    assert "server gateway:4444 max_fails=0;" in config
+    assert "`resolve` is unsupported by the bundled nginx image" in config


### PR DESCRIPTION
## Summary

Operators enabling gateway-side TLS currently have to edit `docker-compose.yml` directly — there is no profile or override that activates it without file edits. This PR fixes that by adding `docker-compose.gateway-tls.yml`, an override file that wires up gateway SSL without touching the base compose file.

## Changes

### `docker-compose.gateway-tls.yml` (new)
Compose override that, when applied, enables gateway-side HTTPS:
- Sets `SSL=true`, `CERT_FILE`, `KEY_FILE`, `KEY_FILE_PASSWORD` (all read from `.env` with safe defaults)
- Unconditionally mounts `./certs:/app/certs:ro` so the cert volume and SSL env vars are never decoupled
- Replaces the gateway healthcheck with `curl -fk https://localhost:4444/health` — no more hardcoded HTTP check breaking when SSL is on

### `Makefile`
Four new targets alongside the existing `compose-tls` family:
| Target | Description |
|---|---|
| `make compose-gateway-tls` | Gateway HTTPS only (port 4444) |
| `make compose-tls-e2e` | End-to-end TLS: nginx HTTPS:8443 → gateway HTTPS:4444 |
| `make compose-tls-e2e-down` | Stop e2e TLS stack |
| `make compose-tls-e2e-logs` | Tail e2e TLS logs |

### `docs/docs/deployment/tls-configuration.md`
Step 2 (Configure Gateway TLS) now leads with the override-file approach instead of instructing operators to edit `docker-compose.yml`. The manual YAML snippet is kept under a collapsible Advanced subsection for reference.

## Activation path (end-to-end TLS)

```bash
make certs          # generate self-signed certs (skip if you have your own)
make compose-tls-e2e
curl -sk https://localhost:8443/health
```

For gateway TLS only (no nginx frontend):
```bash
make compose-gateway-tls
curl -fk https://localhost:4444/health
```

## Acceptance criteria (from #6266)

- [x] Operator can enable gateway-side TLS without editing `docker-compose.yml`
- [x] Cert volume is mounted whenever TLS is activated (override file always includes it)
- [x] Healthcheck uses the correct scheme (`https://` with `-k` for self-signed)
- [x] `docs/docs/deployment/tls-configuration.md` documents the activation path

Closes #6266