### PR TITLE
fix(admin): stop hiding other teams' public rows when filtering by team

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -161,6 +161,7 @@ from mcpgateway.services.a2a_agent_plugin_binding_service import A2AAgentPluginB
 from mcpgateway.services.a2a_service import A2AAgentError, A2AAgentNameConflictError, A2AAgentNotFoundError, A2AAgentService
 from mcpgateway.services.argon2_service import Argon2PasswordService
 from mcpgateway.services.audit_trail_service import get_audit_trail_service
+from mcpgateway.services.base_service import team_scoped_conditions
 from mcpgateway.services.catalog_service import catalog_service, CatalogRegistrationPermissionError
 from mcpgateway.services.content_security import ContentSizeError, ContentTypeError, TemplateValidationError
 from mcpgateway.services.csrf_service import get_csrf_service
@@ -2955,11 +2956,7 @@ async def admin_servers_partial_html(
         # Team-specific view: only show servers from the specified team
         if team_id in team_ids:
             # Apply visibility check: team/public resources + user's own resources (including private)
-            team_access = [
-                and_(DbServer.team_id == team_id, DbServer.visibility.in_(["team", "public"])),
-                and_(DbServer.team_id == team_id, DbServer.owner_email == user_email),
-            ]
-            query = query.where(or_(*team_access))
+            query = query.where(or_(*team_scoped_conditions(DbServer, team_id, owner_email=user_email)))
             LOGGER.debug(f"Filtering servers by team_id: {team_id}")
         else:
             # User is not a member of this team, return no results using SQLAlchemy's false()
@@ -8857,7 +8854,7 @@ async def admin_tools_partial_html(
     render: QueryRenderModeControls = None,
     gateway_id: QueryGatewayIdList = None,
     team_id: Optional[str] = Depends(_validated_team_id_param),
-    include_public: bool = False,
+    include_public: Optional[bool] = None,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
 ):
@@ -8876,7 +8873,8 @@ async def admin_tools_partial_html(
         include_inactive (bool): Whether to include inactive tools in the results.
         gateway_id (Optional[str]): Filter by gateway ID(s), comma-separated.
         team_id (Optional[str]): Filter by team ID.
-        include_public (bool): Whether to include all public tools in the results.
+        include_public (Optional[bool]): Pass False to suppress globally-public rows from
+            other teams when filtering by team. Defaults to including them.
         render (str): Render mode - 'controls' returns only pagination controls.
         db (Session): Database session dependency.
         user (str): Authenticated user dependency.
@@ -8926,17 +8924,8 @@ async def admin_tools_partial_html(
         # Team-specific view: only show tools from the specified team if user is a member
         if team_id in team_ids:
             # Apply visibility check: team/public resources + user's own resources (including private)
-            team_access = [
-                and_(DbTool.team_id == team_id, DbTool.visibility.in_(["team", "public"])),
-                and_(DbTool.team_id == team_id, DbTool.owner_email == user_email),
-            ]
-            if include_public:
-                # Include all globally public items from any team.
-                # Items with visibility='team' or 'private' from other teams are
-                # blocked by the other conditions (which require team_id == selected team).
-                team_access.append(DbTool.visibility == "public")
-            query = query.where(or_(*team_access))
-            LOGGER.debug(f"Filtering tools by team_id: {team_id}{' (include_public)' if include_public else ''}")
+            query = query.where(or_(*team_scoped_conditions(DbTool, team_id, owner_email=user_email, include_public=include_public is not False)))
+            LOGGER.debug(f"Filtering tools by team_id: {team_id}{' (team-only)' if include_public is False else ''}")
         else:
             # User is not a member of this team, return no results
             LOGGER.warning(f"User {user_email} attempted to filter by team {team_id} but is not a member")
@@ -9150,11 +9139,7 @@ async def admin_tool_ops_partial(
 
     if team_id:
         if team_id in team_ids:
-            team_access = [
-                and_(DbTool.team_id == team_id, DbTool.visibility.in_(["team", "public"])),
-                and_(DbTool.team_id == team_id, DbTool.owner_email == user_email),
-            ]
-            query = query.where(or_(*team_access))
+            query = query.where(or_(*team_scoped_conditions(DbTool, team_id, owner_email=user_email)))
             LOGGER.debug(f"Filtering tools by team_id: {team_id}")
         else:
             LOGGER.warning(f"User {user_email} attempted to filter by team {team_id} but is not a member")
@@ -9221,7 +9206,7 @@ async def admin_get_all_tool_ids(
     include_inactive: bool = False,
     gateway_id: QueryGatewayIdList = None,
     team_id: Optional[str] = Depends(_validated_team_id_param),
-    include_public: bool = False,
+    include_public: Optional[bool] = None,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
 ):
@@ -9235,7 +9220,8 @@ async def admin_get_all_tool_ids(
         include_inactive (bool): Whether to include inactive tools in the results
         gateway_id (Optional[str]): Filter by gateway ID(s), comma-separated. Accepts the literal value 'null' to indicate NULL gateway_id (local tools).
         team_id (Optional[str]): Filter by team ID.
-        include_public (bool): Whether to include all platform-public tools when filtering by team.
+        include_public (Optional[bool]): Pass False to suppress globally-public rows from
+            other teams when filtering by team. Defaults to including them.
         db (Session): Database session dependency
         user: Current user making the request
 
@@ -9290,14 +9276,8 @@ async def admin_get_all_tool_ids(
     # Otherwise, show all accessible items (All Teams view).
     if team_id:
         if team_id in team_ids:
-            team_access = [
-                and_(DbTool.team_id == team_id, DbTool.visibility.in_(["team", "public"])),
-                and_(DbTool.team_id == team_id, DbTool.owner_email == user_email),
-            ]
-            if include_public:
-                team_access.append(DbTool.visibility == "public")
-            query = query.where(or_(*team_access))
-            LOGGER.debug(f"Filtering tool IDs by team_id: {team_id}{' (include_public)' if include_public else ''}")
+            query = query.where(or_(*team_scoped_conditions(DbTool, team_id, owner_email=user_email, include_public=include_public is not False)))
+            LOGGER.debug(f"Filtering tool IDs by team_id: {team_id}{' (team-only)' if include_public is False else ''}")
         else:
             LOGGER.warning(f"User {user_email} attempted to filter tool IDs by team {team_id} but is not a member")
             query = query.where(false())
@@ -9325,7 +9305,7 @@ async def admin_search_tools(
     limit: int = Query(settings.pagination_default_page_size, ge=1, le=settings.pagination_max_page_size, description="Maximum number of results to return"),
     gateway_id: QueryGatewayIdList = None,
     team_id: Optional[str] = Depends(_validated_team_id_param),
-    include_public: bool = False,
+    include_public: Optional[bool] = None,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
 ):
@@ -9342,7 +9322,8 @@ async def admin_search_tools(
         limit (int): Maximum number of results to return.
         gateway_id (Optional[str]): Filter by gateway ID(s), comma-separated.
         team_id (Optional[str]): Filter by team ID.
-        include_public (bool): Whether to include all public tools in the results.
+        include_public (Optional[bool]): Pass False to suppress globally-public rows from
+            other teams when filtering by team. Defaults to including them.
         db (Session): Database session.
         user: Current user with permissions.
 
@@ -9390,14 +9371,8 @@ async def admin_search_tools(
     if team_id:
         if team_id in team_ids:
             # Apply visibility check: team/public resources + user's own resources (including private)
-            team_access = [
-                and_(DbTool.team_id == team_id, DbTool.visibility.in_(["team", "public"])),
-                and_(DbTool.team_id == team_id, DbTool.owner_email == user_email),
-            ]
-            if include_public:
-                team_access.append(DbTool.visibility == "public")
-            query = query.where(or_(*team_access))
-            LOGGER.debug(f"Filtering tool search by team_id: {team_id}{' (include_public)' if include_public else ''}")
+            query = query.where(or_(*team_scoped_conditions(DbTool, team_id, owner_email=user_email, include_public=include_public is not False)))
+            LOGGER.debug(f"Filtering tool search by team_id: {team_id}{' (team-only)' if include_public is False else ''}")
         else:
             LOGGER.warning(f"User {user_email} attempted to filter tool search by team {team_id} but is not a member")
             query = query.where(false())
@@ -9463,7 +9438,7 @@ async def admin_prompts_partial_html(
     render: QueryRenderMode = None,
     gateway_id: QueryGatewayIdList = None,
     team_id: Optional[str] = Depends(_validated_team_id_param),
-    include_public: bool = False,
+    include_public: Optional[bool] = None,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
 ):
@@ -9486,7 +9461,8 @@ async def admin_prompts_partial_html(
         render (Optional[str]): Render mode; one of None, "controls", "selector".
         gateway_id (Optional[str]): Filter by gateway ID(s), comma-separated.
         team_id (Optional[str]): Filter by team ID.
-        include_public (bool): Whether to include all public prompts in the results.
+        include_public (Optional[bool]): Pass False to suppress globally-public rows from
+            other teams when filtering by team. Defaults to including them.
         db (Session): Database session (dependency-injected).
         user: Authenticated user object from dependency injection.
 
@@ -9540,17 +9516,8 @@ async def admin_prompts_partial_html(
         # Team-specific view: only show prompts from the specified team
         if team_id in team_ids:
             # Apply visibility check: team/public resources + user's own resources (including private)
-            team_access = [
-                and_(DbPrompt.team_id == team_id, DbPrompt.visibility.in_(["team", "public"])),
-                and_(DbPrompt.team_id == team_id, DbPrompt.owner_email == user_email),
-            ]
-            if include_public:
-                # Include all globally public items from any team.
-                # Items with visibility='team' or 'private' from other teams are
-                # blocked by the other conditions (which require team_id == selected team).
-                team_access.append(DbPrompt.visibility == "public")
-            query = query.where(or_(*team_access))
-            LOGGER.debug(f"Filtering prompts by team_id: {team_id}{' (include_public)' if include_public else ''}")
+            query = query.where(or_(*team_scoped_conditions(DbPrompt, team_id, owner_email=user_email, include_public=include_public is not False)))
+            LOGGER.debug(f"Filtering prompts by team_id: {team_id}{' (team-only)' if include_public is False else ''}")
         else:
             # User is not a member of this team, return no results using SQLAlchemy's false()
             LOGGER.warning(f"User {user_email} attempted to filter by team {team_id} but is not a member")
@@ -9700,7 +9667,7 @@ async def admin_gateways_partial_html(
     include_inactive: bool = True,
     render: QueryRenderMode = None,
     team_id: Optional[str] = Depends(_validated_team_id_param),
-    include_public: bool = False,
+    include_public: Optional[bool] = None,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
 ):
@@ -9722,7 +9689,8 @@ async def admin_gateways_partial_html(
         include_inactive (bool): If True, include inactive gateways in results.
         render (Optional[str]): Render mode; one of None, "controls", "selector".
         team_id (Optional[str]): Filter by team ID.
-        include_public (bool): Whether to include all public gateways in the results.
+        include_public (Optional[bool]): Pass False to suppress globally-public rows from
+            other teams when filtering by team. Defaults to including them.
         db (Session): Database session (dependency-injected).
         user: Authenticated user object from dependency injection.
 
@@ -9757,17 +9725,8 @@ async def admin_gateways_partial_html(
         # Team-specific view: only show gateways from the specified team if user is a member
         if team_id in team_ids:
             # Apply visibility check: team/public resources + user's own resources (including private)
-            team_access = [
-                and_(DbGateway.team_id == team_id, DbGateway.visibility.in_(["team", "public"])),
-                and_(DbGateway.team_id == team_id, DbGateway.owner_email == user_email),
-            ]
-            if include_public:
-                # Include all globally public items from any team.
-                # Items with visibility='team' or 'private' from other teams are
-                # blocked by the other conditions (which require team_id == selected team).
-                team_access.append(DbGateway.visibility == "public")
-            query = query.where(or_(*team_access))
-            LOGGER.debug(f"Filtering gateways by team_id: {team_id}{' (include_public)' if include_public else ''}")
+            query = query.where(or_(*team_scoped_conditions(DbGateway, team_id, owner_email=user_email, include_public=include_public is not False)))
+            LOGGER.debug(f"Filtering gateways by team_id: {team_id}{' (team-only)' if include_public is False else ''}")
         else:
             # User is not a member of this team, return no results
             LOGGER.warning(f"User {user_email} attempted to filter by team {team_id} but is not a member")
@@ -9892,7 +9851,7 @@ async def admin_gateways_partial_html(
 async def admin_get_all_gateways_ids(
     include_inactive: bool = False,
     team_id: Optional[str] = Depends(_validated_team_id_param),
-    include_public: bool = False,
+    include_public: Optional[bool] = None,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
 ):
@@ -9904,7 +9863,8 @@ async def admin_get_all_gateways_ids(
     Args:
         include_inactive (bool): When True include prompts that are inactive.
         team_id (Optional[str]): Filter by team ID.
-        include_public (bool): Whether to include all public gateways in the results.
+        include_public (Optional[bool]): Pass False to suppress globally-public rows from
+            other teams when filtering by team. Defaults to including them.
         db (Session): Database session (injected dependency).
         user: Authenticated user object from dependency injection.
 
@@ -9928,14 +9888,8 @@ async def admin_get_all_gateways_ids(
     if team_id:
         if team_id in team_ids:
             # Apply visibility check: team/public resources + user's own resources (including private)
-            team_access = [
-                and_(DbGateway.team_id == team_id, DbGateway.visibility.in_(["team", "public"])),
-                and_(DbGateway.team_id == team_id, DbGateway.owner_email == user_email),
-            ]
-            if include_public:
-                team_access.append(DbGateway.visibility == "public")
-            query = query.where(or_(*team_access))
-            LOGGER.debug(f"Filtering gateway IDs by team_id: {team_id}{' (include_public)' if include_public else ''}")
+            query = query.where(or_(*team_scoped_conditions(DbGateway, team_id, owner_email=user_email, include_public=include_public is not False)))
+            LOGGER.debug(f"Filtering gateway IDs by team_id: {team_id}{' (team-only)' if include_public is False else ''}")
         else:
             LOGGER.warning(f"User {user_email} attempted to filter gateway IDs by team {team_id} but is not a member")
             query = query.where(false())
@@ -9960,7 +9914,7 @@ async def admin_search_gateways(
     include_inactive: bool = False,
     limit: int = Query(settings.pagination_default_page_size, ge=1, le=settings.pagination_max_page_size),
     team_id: Optional[str] = Depends(_validated_team_id_param),
-    include_public: bool = False,
+    include_public: Optional[bool] = None,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
 ):
@@ -9976,7 +9930,8 @@ async def admin_search_gateways(
         include_inactive (bool): When True include gateways that are inactive.
         limit (int): Maximum number of results to return (bounded by the query parameter).
         team_id (Optional[str]): Filter by team ID.
-        include_public (bool): Whether to include all public gateways in the results.
+        include_public (Optional[bool]): Pass False to suppress globally-public rows from
+            other teams when filtering by team. Defaults to including them.
         db (Session): Database session (injected dependency).
         user: Authenticated user object from dependency injection.
 
@@ -10006,14 +9961,8 @@ async def admin_search_gateways(
     if team_id:
         if team_id in team_ids:
             # Apply visibility check: team/public resources + user's own resources (including private)
-            team_access = [
-                and_(DbGateway.team_id == team_id, DbGateway.visibility.in_(["team", "public"])),
-                and_(DbGateway.team_id == team_id, DbGateway.owner_email == user_email),
-            ]
-            if include_public:
-                team_access.append(DbGateway.visibility == "public")
-            query = query.where(or_(*team_access))
-            LOGGER.debug(f"Filtering gateway search by team_id: {team_id}{' (include_public)' if include_public else ''}")
+            query = query.where(or_(*team_scoped_conditions(DbGateway, team_id, owner_email=user_email, include_public=include_public is not False)))
+            LOGGER.debug(f"Filtering gateway search by team_id: {team_id}{' (team-only)' if include_public is False else ''}")
         else:
             LOGGER.warning(f"User {user_email} attempted to filter gateway search by team {team_id} but is not a member")
             query = query.where(false())
@@ -10104,11 +10053,7 @@ async def admin_get_all_server_ids(
         # Team-specific view: only show servers from the specified team
         if team_id in team_ids:
             # Apply visibility check: team/public resources + user's own resources (including private)
-            team_access = [
-                and_(DbServer.team_id == team_id, DbServer.visibility.in_(["team", "public"])),
-                and_(DbServer.team_id == team_id, DbServer.owner_email == user_email),
-            ]
-            query = query.where(or_(*team_access))
+            query = query.where(or_(*team_scoped_conditions(DbServer, team_id, owner_email=user_email)))
             LOGGER.debug(f"Filtering server IDs by team_id: {team_id}")
         else:
             # User is not a member of this team, return no results using SQLAlchemy's false()
@@ -10179,11 +10124,7 @@ async def admin_search_servers(
         # Team-specific view: only show servers from the specified team
         if team_id in team_ids:
             # Apply visibility check: team/public resources + user's own resources (including private)
-            team_access = [
-                and_(DbServer.team_id == team_id, DbServer.visibility.in_(["team", "public"])),
-                and_(DbServer.team_id == team_id, DbServer.owner_email == user_email),
-            ]
-            query = query.where(or_(*team_access))
+            query = query.where(or_(*team_scoped_conditions(DbServer, team_id, owner_email=user_email)))
             LOGGER.debug(f"Filtering server search by team_id: {team_id}")
         else:
             # User is not a member of this team, return no results using SQLAlchemy's false()
@@ -10246,7 +10187,7 @@ async def admin_resources_partial_html(
     render: QueryRenderModeControls = None,
     gateway_id: QueryGatewayIdList = None,
     team_id: Optional[str] = Depends(_validated_team_id_param),
-    include_public: bool = False,
+    include_public: Optional[bool] = None,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
 ):
@@ -10268,7 +10209,8 @@ async def admin_resources_partial_html(
             items used by infinite scroll selectors.
         gateway_id (Optional[str]): Filter by gateway ID(s), comma-separated.
         team_id (Optional[str]): Filter by team ID.
-        include_public (bool): Whether to include all public resources in the results.
+        include_public (Optional[bool]): Pass False to suppress globally-public rows from
+            other teams when filtering by team. Defaults to including them.
         db (Session): Database session (dependency-injected).
         user: Authenticated user object from dependency injection.
 
@@ -10326,17 +10268,8 @@ async def admin_resources_partial_html(
         # Team-specific view: only show resources from the specified team
         if team_id in team_ids:
             # Apply visibility check: team/public resources + user's own resources (including private)
-            team_access = [
-                and_(DbResource.team_id == team_id, DbResource.visibility.in_(["team", "public"])),
-                and_(DbResource.team_id == team_id, DbResource.owner_email == user_email),
-            ]
-            if include_public:
-                # Include all globally public items from any team.
-                # Items with visibility='team' or 'private' from other teams are
-                # blocked by the other conditions (which require team_id == selected team).
-                team_access.append(DbResource.visibility == "public")
-            query = query.where(or_(*team_access))
-            LOGGER.debug(f"Filtering resources by team_id: {team_id}{' (include_public)' if include_public else ''}")
+            query = query.where(or_(*team_scoped_conditions(DbResource, team_id, owner_email=user_email, include_public=include_public is not False)))
+            LOGGER.debug(f"Filtering resources by team_id: {team_id}{' (team-only)' if include_public is False else ''}")
         else:
             # User is not a member of this team, return no results using SQLAlchemy's false()
             LOGGER.warning(f"User {user_email} attempted to filter by team {team_id} but is not a member")
@@ -10481,7 +10414,7 @@ async def admin_get_all_prompt_ids(
     include_inactive: bool = False,
     gateway_id: QueryGatewayIdList = None,
     team_id: Optional[str] = Depends(_validated_team_id_param),
-    include_public: bool = False,
+    include_public: Optional[bool] = None,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
 ):
@@ -10495,7 +10428,8 @@ async def admin_get_all_prompt_ids(
         include_inactive (bool): When True include prompts that are inactive.
         gateway_id (Optional[str]): Filter by gateway ID(s), comma-separated. Accepts the literal value 'null' to indicate NULL gateway_id (local prompts).
         team_id (Optional[str]): Filter by team ID.
-        include_public (bool): Whether to include all platform-public prompts when filtering by team.
+        include_public (Optional[bool]): Pass False to suppress globally-public rows from
+            other teams when filtering by team. Defaults to including them.
         db (Session): Database session (injected dependency).
         user: Authenticated user object from dependency injection.
 
@@ -10547,14 +10481,8 @@ async def admin_get_all_prompt_ids(
     # Otherwise, show all accessible items (All Teams view).
     if team_id:
         if team_id in team_ids:
-            team_access = [
-                and_(DbPrompt.team_id == team_id, DbPrompt.visibility.in_(["team", "public"])),
-                and_(DbPrompt.team_id == team_id, DbPrompt.owner_email == user_email),
-            ]
-            if include_public:
-                team_access.append(DbPrompt.visibility == "public")
-            query = query.where(or_(*team_access))
-            LOGGER.debug(f"Filtering prompt IDs by team_id: {team_id}{' (include_public)' if include_public else ''}")
+            query = query.where(or_(*team_scoped_conditions(DbPrompt, team_id, owner_email=user_email, include_public=include_public is not False)))
+            LOGGER.debug(f"Filtering prompt IDs by team_id: {team_id}{' (team-only)' if include_public is False else ''}")
         else:
             # User is not a member of this team, return no results using SQLAlchemy's false()
             LOGGER.warning(f"User {user_email} attempted to filter prompt IDs by team {team_id} but is not a member")
@@ -10579,7 +10507,7 @@ async def admin_get_all_resource_ids(
     include_inactive: bool = False,
     gateway_id: QueryGatewayIdList = None,
     team_id: Optional[str] = Depends(_validated_team_id_param),
-    include_public: bool = False,
+    include_public: Optional[bool] = None,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
 ):
@@ -10593,7 +10521,8 @@ async def admin_get_all_resource_ids(
         include_inactive (bool): Whether to include inactive resources in the results.
         gateway_id (Optional[str]): Filter by gateway ID(s), comma-separated. Accepts the literal value 'null' to indicate NULL gateway_id (local resources).
         team_id (Optional[str]): Filter by team ID.
-        include_public (bool): Whether to include all platform-public resources when filtering by team.
+        include_public (Optional[bool]): Pass False to suppress globally-public rows from
+            other teams when filtering by team. Defaults to including them.
         db (Session): Database session dependency.
         user: Authenticated user object from dependency injection.
 
@@ -10645,14 +10574,8 @@ async def admin_get_all_resource_ids(
     # Otherwise, show all accessible items (All Teams view).
     if team_id:
         if team_id in team_ids:
-            team_access = [
-                and_(DbResource.team_id == team_id, DbResource.visibility.in_(["team", "public"])),
-                and_(DbResource.team_id == team_id, DbResource.owner_email == user_email),
-            ]
-            if include_public:
-                team_access.append(DbResource.visibility == "public")
-            query = query.where(or_(*team_access))
-            LOGGER.debug(f"Filtering resource IDs by team_id: {team_id}{' (include_public)' if include_public else ''}")
+            query = query.where(or_(*team_scoped_conditions(DbResource, team_id, owner_email=user_email, include_public=include_public is not False)))
+            LOGGER.debug(f"Filtering resource IDs by team_id: {team_id}{' (team-only)' if include_public is False else ''}")
         else:
             # User is not a member of this team, return no results using SQLAlchemy's false()
             LOGGER.warning(f"User {user_email} attempted to filter resource IDs by team {team_id} but is not a member")
@@ -10679,7 +10602,7 @@ async def admin_search_resources(
     limit: int = Query(settings.pagination_default_page_size, ge=1, le=settings.pagination_max_page_size),
     gateway_id: QueryGatewayIdList = None,
     team_id: Optional[str] = Depends(_validated_team_id_param),
-    include_public: bool = False,
+    include_public: Optional[bool] = None,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
 ):
@@ -10696,7 +10619,8 @@ async def admin_search_resources(
         limit (int): Maximum number of results to return (bounded by the query parameter).
         gateway_id (Optional[str]): Filter by gateway ID(s), comma-separated.
         team_id (Optional[str]): Filter by team ID.
-        include_public (bool): Whether to include all public resources in the results.
+        include_public (Optional[bool]): Pass False to suppress globally-public rows from
+            other teams when filtering by team. Defaults to including them.
         db (Session): Database session (injected dependency).
         user: Authenticated user object from dependency injection.
 
@@ -10743,14 +10667,8 @@ async def admin_search_resources(
         # Team-specific view: only show resources from the specified team
         if team_id in team_ids:
             # Apply visibility check: team/public resources + user's own resources (including private)
-            team_access = [
-                and_(DbResource.team_id == team_id, DbResource.visibility.in_(["team", "public"])),
-                and_(DbResource.team_id == team_id, DbResource.owner_email == user_email),
-            ]
-            if include_public:
-                team_access.append(DbResource.visibility == "public")
-            query = query.where(or_(*team_access))
-            LOGGER.debug(f"Filtering resource search by team_id: {team_id}{' (include_public)' if include_public else ''}")
+            query = query.where(or_(*team_scoped_conditions(DbResource, team_id, owner_email=user_email, include_public=include_public is not False)))
+            LOGGER.debug(f"Filtering resource search by team_id: {team_id}{' (team-only)' if include_public is False else ''}")
         else:
             # User is not a member of this team, return no results using SQLAlchemy's false()
             LOGGER.warning(f"User {user_email} attempted to filter resource search by team {team_id} but is not a member")
@@ -10804,7 +10722,7 @@ async def admin_search_prompts(
     limit: int = Query(settings.pagination_default_page_size, ge=1, le=settings.pagination_max_page_size),
     gateway_id: QueryGatewayIdList = None,
     team_id: Optional[str] = Depends(_validated_team_id_param),
-    include_public: bool = False,
+    include_public: Optional[bool] = None,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
 ):
@@ -10821,7 +10739,8 @@ async def admin_search_prompts(
         limit (int): Maximum number of results to return (bounded by the query parameter).
         gateway_id (Optional[str]): Filter by gateway ID(s), comma-separated.
         team_id (Optional[str]): Filter by team ID.
-        include_public (bool): Whether to include all public prompts in the results.
+        include_public (Optional[bool]): Pass False to suppress globally-public rows from
+            other teams when filtering by team. Defaults to including them.
         db (Session): Database session (injected dependency).
         user: Authenticated user object from dependency injection.
 
@@ -10868,14 +10787,8 @@ async def admin_search_prompts(
         # Team-specific view: only show prompts from the specified team
         if team_id in team_ids:
             # Apply visibility check: team/public resources + user's own resources (including private)
-            team_access = [
-                and_(DbPrompt.team_id == team_id, DbPrompt.visibility.in_(["team", "public"])),
-                and_(DbPrompt.team_id == team_id, DbPrompt.owner_email == user_email),
-            ]
-            if include_public:
-                team_access.append(DbPrompt.visibility == "public")
-            query = query.where(or_(*team_access))
-            LOGGER.debug(f"Filtering prompt search by team_id: {team_id}{' (include_public)' if include_public else ''}")
+            query = query.where(or_(*team_scoped_conditions(DbPrompt, team_id, owner_email=user_email, include_public=include_public is not False)))
+            LOGGER.debug(f"Filtering prompt search by team_id: {team_id}{' (team-only)' if include_public is False else ''}")
         else:
             # User is not a member of this team, return no results using SQLAlchemy's false()
             LOGGER.warning(f"User {user_email} attempted to filter prompt search by team {team_id} but is not a member")
@@ -11272,11 +11185,7 @@ async def admin_a2a_partial_html(
         # Team-specific view: only show a2a agents from the specified team
         if team_id in team_ids:
             # Apply visibility check: team/public resources + user's own resources (including private)
-            team_access = [
-                and_(DbA2AAgent.team_id == team_id, DbA2AAgent.visibility.in_(["team", "public"])),
-                and_(DbA2AAgent.team_id == team_id, DbA2AAgent.owner_email == user_email),
-            ]
-            query = query.where(or_(*team_access))
+            query = query.where(or_(*team_scoped_conditions(DbA2AAgent, team_id, owner_email=user_email)))
             LOGGER.debug(f"Filtering a2a agents by team_id: {team_id}")
         else:
             # User is not a member of this team, return no results using SQLAlchemy's false()
@@ -11451,11 +11360,7 @@ async def admin_get_all_agent_ids(
     if team_id:
         if team_id in team_ids:
             # Apply visibility check: team/public resources + user's own resources (including private)
-            team_access = [
-                and_(DbA2AAgent.team_id == team_id, DbA2AAgent.visibility.in_(["team", "public"])),
-                and_(DbA2AAgent.team_id == team_id, DbA2AAgent.owner_email == user_email),
-            ]
-            query = query.where(or_(*team_access))
+            query = query.where(or_(*team_scoped_conditions(DbA2AAgent, team_id, owner_email=user_email)))
             LOGGER.debug(f"Filtering A2A agent IDs by team_id: {team_id}")
         else:
             LOGGER.warning(f"User {user_email} attempted to filter A2A agent IDs by team {team_id} but is not a member")
@@ -11524,11 +11429,7 @@ async def admin_search_a2a_agents(
     if team_id:
         if team_id in team_ids:
             # Apply visibility check: team/public resources + user's own resources (including private)
-            team_access = [
-                and_(DbA2AAgent.team_id == team_id, DbA2AAgent.visibility.in_(["team", "public"])),
-                and_(DbA2AAgent.team_id == team_id, DbA2AAgent.owner_email == user_email),
-            ]
-            query = query.where(or_(*team_access))
+            query = query.where(or_(*team_scoped_conditions(DbA2AAgent, team_id, owner_email=user_email)))
             LOGGER.debug(f"Filtering A2A agent search by team_id: {team_id}")
         else:
             LOGGER.warning(f"User {user_email} attempted to filter A2A agent search by team {team_id} but is not a member")

--- a/mcpgateway/admin_ui/filters.js
+++ b/mcpgateway/admin_ui/filters.js
@@ -382,20 +382,13 @@ export const toggleViewPublic = function (checkboxId, containerIds, teamId) {
       let url = container.getAttribute("hx-get");
       if (!url) return;
 
-      if (includePublic) {
-        // Keep team_id to maintain team scope, add include_public to also show public items
-        if (!url.includes("team_id=")) {
-          url += `&team_id=${encodeURIComponent(teamId)}`;
-        }
-        url = url.replace(/&include_public=[^&]*/, "");
-        url += "&include_public=true";
-      } else {
-        // Remove include_public param and ensure team_id is set
-        url = url.replace(/&include_public=[^&]*/, "");
-        if (!url.includes("team_id=")) {
-          url += `&team_id=${encodeURIComponent(teamId)}`;
-        }
+      // Team filtering includes globally-public items by default, so the
+      // unchecked state must say so explicitly rather than omit the param.
+      url = url.replace(/&include_public=[^&]*/, "");
+      if (!url.includes("team_id=")) {
+        url += `&team_id=${encodeURIComponent(teamId)}`;
       }
+      url += includePublic ? "&include_public=true" : "&include_public=false";
 
       // Preserve active gateway filter so toggling View Public
       // does not drop the user's gateway selection

--- a/mcpgateway/admin_ui/gateways.js
+++ b/mcpgateway/admin_ui/gateways.js
@@ -810,8 +810,10 @@ export const initGatewaySelect = function (
         if (selectedTeamId) {
           params.set("team_id", selectedTeamId);
         }
-        if (vpCb && vpCb.checked) {
-          params.set("include_public", "true");
+        if (vpCb) {
+          // Team filtering includes public items by default; send the
+          // unchecked state explicitly so it still narrows.
+          params.set("include_public", vpCb.checked ? "true" : "false");
         }
         const queryString = params.toString();
         const response = await fetch(
@@ -1107,8 +1109,11 @@ const reloadAssociatedItems = function () {
   let teamIdSuffix = urlTeamId
     ? `&team_id=${encodeURIComponent(urlTeamId)}`
     : "";
-  if (vpCheckbox && vpCheckbox.checked) {
-    teamIdSuffix += "&include_public=true";
+  if (vpCheckbox) {
+    // Send the unchecked state explicitly: public rows are included by default.
+    teamIdSuffix += vpCheckbox.checked
+      ? "&include_public=true"
+      : "&include_public=false";
   }
 
   // Reload tools

--- a/mcpgateway/admin_ui/prompts.js
+++ b/mcpgateway/admin_ui/prompts.js
@@ -769,8 +769,10 @@ export const initPromptSelect = function (
               ? "edit-server-view-public"
               : "add-server-view-public";
           const viewPublicCb = document.getElementById(viewPublicId);
-          if (viewPublicCb && viewPublicCb.checked) {
-            params.set("include_public", "true");
+          if (viewPublicCb) {
+            // Team filtering includes public items by default; send the
+            // unchecked state explicitly so it still narrows.
+            params.set("include_public", viewPublicCb.checked ? "true" : "false");
           }
           const queryString = params.toString();
           const resp = await fetch(

--- a/mcpgateway/admin_ui/resources.js
+++ b/mcpgateway/admin_ui/resources.js
@@ -1016,8 +1016,10 @@ export const initResourceSelect = function (
               ? "edit-server-view-public"
               : "add-server-view-public";
           const viewPublicCb = document.getElementById(viewPublicId);
-          if (viewPublicCb && viewPublicCb.checked) {
-            params.set("include_public", "true");
+          if (viewPublicCb) {
+            // Team filtering includes public items by default; send the
+            // unchecked state explicitly so it still narrows.
+            params.set("include_public", viewPublicCb.checked ? "true" : "false");
           }
           const queryString = params.toString();
           const resp = await fetch(

--- a/mcpgateway/admin_ui/search.js
+++ b/mcpgateway/admin_ui/search.js
@@ -491,8 +491,11 @@ export const serverSideSearch = async function (config, searchTerm) {
       if (urlTeamId) {
         url += `&team_id=${encodeURIComponent(urlTeamId)}`;
       }
-      if (viewPublicCb && viewPublicCb.checked) {
-        url += "&include_public=true";
+      if (viewPublicCb) {
+        // Send the unchecked state explicitly: public rows are included by default.
+        url += viewPublicCb.checked
+          ? "&include_public=true"
+          : "&include_public=false";
       }
 
       console.log(`[${config.logPrefix}] Loading defaults with URL: ${url}`);
@@ -610,8 +613,10 @@ export const serverSideSearch = async function (config, searchTerm) {
     if (selectedTeamId) {
       params.set("team_id", selectedTeamId);
     }
-    if (viewPublicCb && viewPublicCb.checked) {
-      params.set("include_public", "true");
+    if (viewPublicCb) {
+      // Team filtering includes public items by default; send the
+      // unchecked state explicitly so it still narrows.
+      params.set("include_public", viewPublicCb.checked ? "true" : "false");
     }
 
     const searchUrl = `${window.ROOT_PATH}${config.apiEndpoint}?${params.toString()}`;

--- a/mcpgateway/admin_ui/tools.js
+++ b/mcpgateway/admin_ui/tools.js
@@ -1219,8 +1219,10 @@ export const initToolSelect = function (
               ? "edit-server-view-public"
               : "add-server-view-public";
           const viewPublicCb = document.getElementById(viewPublicId);
-          if (viewPublicCb && viewPublicCb.checked) {
-            params.set("include_public", "true");
+          if (viewPublicCb) {
+            // Team filtering includes public items by default; send the
+            // unchecked state explicitly so it still narrows.
+            params.set("include_public", viewPublicCb.checked ? "true" : "false");
           }
           const queryString = params.toString();
           const response = await fetch(

--- a/mcpgateway/services/base_service.py
+++ b/mcpgateway/services/base_service.py
@@ -26,6 +26,38 @@ from mcpgateway.services.team_management_service import TeamManagementService
 from mcpgateway.utils.admin_check import is_user_admin
 
 
+def team_scoped_conditions(model_cls: Any, team_id: str, owner_email: Optional[str] = None, include_public: bool = True) -> List[Any]:
+    """Build the OR-conditions selecting rows for an explicit ``team_id`` filter.
+
+    Single definition of what ``?team_id=`` means. Used by :class:`BaseService`
+    for every service-layer list endpoint, and directly by the hand-built admin
+    queries in ``mcpgateway.admin`` so both agree on the semantics.
+
+    Globally-public rows owned by *other* teams stay visible (issue #4732, fixed
+    in PR #4773): ``team_id`` narrows team-scoped rows, it does not suppress
+    platform-public ones.
+
+    Args:
+        model_cls: SQLAlchemy model to build conditions against.
+        team_id: Team to narrow to.
+        owner_email: When set, the caller's own private rows within that team are
+            included. ``None`` suppresses owner access.
+        include_public: Whether globally-public rows from other teams are
+            included. Defaults to ``True``, which is the documented behaviour;
+            callers pass ``False`` only to honour an explicit user request for a
+            team-only view (the admin UI's "View Public" toggle).
+
+    Returns:
+        List of conditions intended to be combined with :func:`sqlalchemy.or_`.
+    """
+    conditions = [and_(model_cls.team_id == team_id, model_cls.visibility.in_(["team", "public"]))]
+    if include_public:
+        conditions.append(model_cls.visibility == "public")  # globally public items from any team
+    if owner_email:
+        conditions.append(and_(model_cls.team_id == team_id, model_cls.visibility == "private", model_cls.owner_email == owner_email))
+    return conditions
+
+
 class BaseService(ABC):
     """Abstract base class for services with visibility-filtered listing."""
 
@@ -147,14 +179,9 @@ class BaseService(ABC):
     def _team_scoped_conditions(self, team_id: str, owner_email: Optional[str] = None) -> List[Any]:
         """Build the OR-conditions selecting rows for an explicit ``team_id`` filter.
 
-        Single definition of what ``?team_id=`` means, shared by the admin and
-        anonymous bypass branches of :meth:`_apply_access_control` and by the
-        team-scoped branch of :meth:`_apply_visibility_filter`, so that adding a
-        visibility tier only requires updating one place.
-
-        Globally-public rows owned by *other* teams stay visible (issue #4732,
-        fixed in PR #4773): ``team_id`` narrows team-scoped rows, it does not
-        suppress platform-public ones.
+        Thin wrapper over :func:`team_scoped_conditions` bound to this service's
+        model. Service-layer listing never suppresses platform-public rows, so no
+        ``include_public`` opt-out is exposed here.
 
         Args:
             team_id: Team to narrow to.
@@ -164,14 +191,7 @@ class BaseService(ABC):
         Returns:
             List of conditions intended to be combined with :func:`sqlalchemy.or_`.
         """
-        model_cls = self._visibility_model_cls
-        conditions = [
-            and_(model_cls.team_id == team_id, model_cls.visibility.in_(["team", "public"])),
-            model_cls.visibility == "public",  # globally public items from any team are always visible
-        ]
-        if owner_email:
-            conditions.append(and_(model_cls.team_id == team_id, model_cls.visibility == "private", model_cls.owner_email == owner_email))
-        return conditions
+        return team_scoped_conditions(self._visibility_model_cls, team_id, owner_email=owner_email)
 
     def _apply_visibility_filter(
         self,

--- a/mcpgateway/templates/gateways_selector_items.html
+++ b/mcpgateway/templates/gateways_selector_items.html
@@ -37,7 +37,7 @@
 <!-- Infinite scroll trigger element -->
 <div
   id="gateways-scroll-trigger-{{ pagination.page }}"
-  hx-get="{{ root_path }}/admin/gateways/partial?page={{ pagination.page + 1 }}&per_page={{ pagination.per_page }}&render=selector{% if gateway_id %}&gateway_id={{ gateway_id }}{% endif %}{% if team_id %}&team_id={{ team_id }}{% endif %}{% if include_public %}&include_public=true{% endif %}"
+  hx-get="{{ root_path }}/admin/gateways/partial?page={{ pagination.page + 1 }}&per_page={{ pagination.per_page }}&render=selector{% if gateway_id %}&gateway_id={{ gateway_id }}{% endif %}{% if team_id %}&team_id={{ team_id }}{% endif %}{% if include_public is not none %}&include_public={{ 'true' if include_public else 'false' }}{% endif %}"
   hx-trigger="intersect once"
   hx-swap="outerHTML"
   class="text-center py-2 text-xs text-gray-500 dark:text-gray-400"

--- a/mcpgateway/templates/prompts_selector_items.html
+++ b/mcpgateway/templates/prompts_selector_items.html
@@ -22,7 +22,7 @@
 <!-- Infinite scroll trigger element -->
 <div
   id="prompts-scroll-trigger-{{ pagination.page }}"
-  hx-get="{{ root_path }}/admin/prompts/partial?page={{ pagination.page + 1 }}&per_page={{ pagination.per_page }}&render=selector{% if gateway_id %}&gateway_id={{ gateway_id }}{% endif %}{% if team_id %}&team_id={{ team_id }}{% endif %}{% if include_public %}&include_public=true{% endif %}"
+  hx-get="{{ root_path }}/admin/prompts/partial?page={{ pagination.page + 1 }}&per_page={{ pagination.per_page }}&render=selector{% if gateway_id %}&gateway_id={{ gateway_id }}{% endif %}{% if team_id %}&team_id={{ team_id }}{% endif %}{% if include_public is not none %}&include_public={{ 'true' if include_public else 'false' }}{% endif %}"
   hx-trigger="intersect once"
   hx-swap="outerHTML"
   class="text-center py-2 text-xs text-gray-500 dark:text-gray-400"

--- a/mcpgateway/templates/resources_selector_items.html
+++ b/mcpgateway/templates/resources_selector_items.html
@@ -21,7 +21,7 @@
 <!-- Infinite scroll trigger element -->
 <div
   id="resources-scroll-trigger-{{ pagination.page }}"
-  hx-get="{{ root_path }}/admin/resources/partial?page={{ pagination.page + 1 }}&per_page={{ pagination.per_page }}&render=selector{% if gateway_id %}&gateway_id={{ gateway_id }}{% endif %}{% if team_id %}&team_id={{ team_id }}{% endif %}{% if include_public %}&include_public=true{% endif %}"
+  hx-get="{{ root_path }}/admin/resources/partial?page={{ pagination.page + 1 }}&per_page={{ pagination.per_page }}&render=selector{% if gateway_id %}&gateway_id={{ gateway_id }}{% endif %}{% if team_id %}&team_id={{ team_id }}{% endif %}{% if include_public is not none %}&include_public={{ 'true' if include_public else 'false' }}{% endif %}"
   hx-trigger="intersect once"
   hx-swap="outerHTML"
   class="text-center py-2 text-xs text-gray-500 dark:text-gray-400"

--- a/mcpgateway/templates/tools_selector_items.html
+++ b/mcpgateway/templates/tools_selector_items.html
@@ -21,7 +21,7 @@
 <!-- Infinite scroll trigger element -->
 <div
   id="tools-scroll-trigger-{{ pagination.page }}"
-  hx-get="{{ root_path }}/admin/tools/partial?page={{ pagination.page + 1 }}&per_page={{ pagination.per_page }}&render=selector{% if gateway_id %}&gateway_id={{ gateway_id }}{% endif %}{% if team_id %}&team_id={{ team_id }}{% endif %}{% if include_public %}&include_public=true{% endif %}"
+  hx-get="{{ root_path }}/admin/tools/partial?page={{ pagination.page + 1 }}&per_page={{ pagination.per_page }}&render=selector{% if gateway_id %}&gateway_id={{ gateway_id }}{% endif %}{% if team_id %}&team_id={{ team_id }}{% endif %}{% if include_public is not none %}&include_public={{ 'true' if include_public else 'false' }}{% endif %}"
   hx-trigger="intersect once"
   hx-swap="outerHTML"
   class="text-center py-2 text-xs text-gray-500 dark:text-gray-400"

--- a/tests/unit/mcpgateway/test_admin_team_filter_public_rows.py
+++ b/tests/unit/mcpgateway/test_admin_team_filter_public_rows.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_admin_team_filter_public_rows.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Admin list endpoints must not suppress globally-public rows when filtering by team.
+
+The hand-built queries in ``mcpgateway.admin`` used to gate the globally-public
+condition behind ``include_public``, which nothing on the main resource tables
+ever set - so selecting a team hid other teams' public rows, contradicting the
+service-layer semantics. These tests pin the two halves of the contract:
+
+* the shared rule itself (:func:`team_scoped_conditions`), in both modes, and
+* that every admin call site actually routes through it rather than
+  re-implementing the conditions inline.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import pathlib
+import re
+
+# Third-Party
+import pytest
+from sqlalchemy import or_, select
+
+# First-Party
+from mcpgateway.db import A2AAgent as DbA2AAgent
+from mcpgateway.db import Gateway as DbGateway
+from mcpgateway.db import Prompt as DbPrompt
+from mcpgateway.db import Resource as DbResource
+from mcpgateway.db import Server as DbServer
+from mcpgateway.db import Tool as DbTool
+from mcpgateway.services.base_service import team_scoped_conditions
+
+MODELS = [DbTool, DbGateway, DbResource, DbPrompt, DbServer, DbA2AAgent]
+ADMIN_SRC = pathlib.Path(__file__).resolve().parents[3] / "mcpgateway" / "admin.py"
+
+
+def _where(model, **kwargs) -> str:
+    """Compile the WHERE clause produced by the shared conditions.
+
+    Args:
+        model: SQLAlchemy model to build against.
+        **kwargs: Passed through to :func:`team_scoped_conditions`.
+
+    Returns:
+        The compiled WHERE clause as a string.
+    """
+    query = select(model).where(or_(*team_scoped_conditions(model, "team-1", **kwargs)))
+    return str(query.compile(compile_kwargs={"literal_binds": True})).split("WHERE", 1)[1]
+
+
+@pytest.mark.parametrize("model", MODELS, ids=[m.__name__ for m in MODELS])
+def test_public_rows_included_by_default(model):
+    """Filtering by team keeps globally-public rows from other teams.
+
+    Args:
+        model: SQLAlchemy model under test.
+    """
+    where = _where(model, owner_email="me@example.com")
+    table = model.__tablename__
+    assert f"{table}.team_id = 'team-1'" in where, "should still narrow to the requested team"
+    assert f"OR {table}.visibility = 'public'" in where, "globally-public rows must not be suppressed"
+
+
+@pytest.mark.parametrize("model", MODELS, ids=[m.__name__ for m in MODELS])
+def test_public_rows_suppressed_only_on_explicit_opt_out(model):
+    """include_public=False narrows to the team, for the UI's team-only toggle.
+
+    Args:
+        model: SQLAlchemy model under test.
+    """
+    where = _where(model, owner_email="me@example.com", include_public=False)
+    table = model.__tablename__
+    assert f"{table}.team_id = 'team-1'" in where
+    assert f"OR {table}.visibility = 'public'" not in where, "explicit opt-out must drop the standalone public condition"
+
+
+def test_no_admin_endpoint_rebuilds_the_conditions_inline():
+    """Admin queries must route through the shared helper, not hand-rolled lists.
+
+    The inline ``team_access = [...]`` blocks are what drifted from the service
+    layer in the first place; re-introducing one would silently reopen the bug.
+    """
+    src = ADMIN_SRC.read_text()
+    assert "team_access = [" not in src, "found a hand-rolled team-access block; use team_scoped_conditions() instead"
+    assert src.count("team_scoped_conditions(") >= 19, "expected every team-filtered admin query to use the shared helper"
+
+
+def test_opt_out_is_only_honoured_where_the_ui_exposes_it():
+    """Only endpoints declaring include_public may pass the opt-out through.
+
+    Endpoints without the parameter must always include public rows, so a
+    stray ``include_public=`` there would be reading an undefined name.
+    """
+    src = ADMIN_SRC.read_text()
+    declaring = src.count("include_public: Optional[bool] = None")
+    passing = len(re.findall(r"team_scoped_conditions\([^)]*include_public=", src))
+    assert declaring == passing, f"{declaring} endpoints declare include_public but {passing} pass it through"


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #6193

---

## 📝 Summary

Admin list endpoints hid globally-public rows owned by other teams when filtering by team. These queries are hand-built in `admin.py` rather than going through `BaseService`, and gated the globally-public condition behind `include_public` — which the main resource tables never set.

All of them now route through a shared `team_scoped_conditions()` helper, extracted to module scope in `base_service.py` so `admin.py` and the service layer use one definition. Team filtering includes globally-public rows by default; callers pass `include_public=false` to opt out.

**Scope is 19 endpoints, not the 12 in the issue.** `/admin/servers/*`, `/admin/a2a/*` and `/admin/tool-ops/partial` have the same bug and are worse — no `include_public` parameter at all, so public rows were suppressed with no way to see them.

**On the fix the issue suggests:** it proposes dropping the `include_public` gate, on the basis that nothing in the UI sets it. The "View Public" toggle in the server add/edit modals does set it (`filters.js`, `gateways.js`, `tools.js`, `prompts.js`, `resources.js`, `search.js`), and dropping the gate would have made that checkbox a no-op. Instead the default is flipped and the modals send the negative explicitly, so the toggle keeps working with no user-visible change.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

Manual check in the Admin UI, two builds against the same database — `main` on one port, this branch on another. Four gateways seeded: one team-scoped in team alpha, one team-scoped in team beta, one public owned by beta, one public with no team. Selecting team alpha, then MCP Servers:

| Row | main | this branch |
| --- | --- | --- |
| alpha, team-visibility | visible | visible |
| beta, team-visibility | hidden | hidden |
| beta, **public** | hidden | **visible** |
| no team, **public** | hidden | **visible** |

Same result on the Tools tab. Other teams' team-scoped rows stay hidden, so nothing widened beyond public.

New tests mutation-checked: making the helper stop including public rows fails 6 of 14; reverting a single endpoint to an inline condition list fails 1.

| Check | Command | Status |
| --- | --- | --- |
| Lint suite | `make lint` | not run — `ruff` clean on changed files |
| Unit tests | `make test` | not run — 1333 passed across admin + services + new tests; 2333 passed in the JS suite |
| Coverage ≥ 80% | `make coverage` | not run |

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

`tests/js/admin-view-public.test.js` covers this toggle but is not collected — `tests/js/**` has been commented out in `vitest.config.js` since #3137 split `admin.js` into modules. Three of its assertions encode the previous contract and would need updating if that suite is re-enabled. Left alone here rather than expanding this change.