### PR TITLE
fix(auth): wire external-IdP verification into get_current_user()

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -399,6 +399,8 @@ services:
       - SSO_KEYCLOAK_ROLE_MAPPINGS=${SSO_KEYCLOAK_ROLE_MAPPINGS:-{}}
       - SSO_KEYCLOAK_DEFAULT_ROLE=${SSO_KEYCLOAK_DEFAULT_ROLE:-}
       - SSO_KEYCLOAK_RESOLVE_TEAM_SCOPE_TO_PERSONAL_TEAM=${SSO_KEYCLOAK_RESOLVE_TEAM_SCOPE_TO_PERSONAL_TEAM:-false}
+      # Accept bearer tokens from a trusted_for_api_auth SSO provider on API/MCP endpoints (issue #3567)
+      - SSO_API_TOKEN_AUTH_ENABLED=${SSO_API_TOKEN_AUTH_ENABLED:-false}
       - SSO_AUTO_CREATE_USERS=${SSO_AUTO_CREATE_USERS:-true}
       - SSO_PRESERVE_ADMIN_AUTH=${SSO_PRESERVE_ADMIN_AUTH:-true}
       # Security defaults (tokens require expiration and JTI for revocation)

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -103,7 +103,7 @@ from mcpgateway.utils.trace_context import (
 from mcpgateway.utils.verify_credentials import (
     ConfigurableHTTPBearer,
     security,
-    verify_jwt_token_cached,
+    verify_credentials_cached,
 )
 
 __all__ = [
@@ -1625,9 +1625,18 @@ async def get_current_user(
     email = None
 
     try:
-        # Try JWT token first using the centralized verify_jwt_token_cached function
+        # Dispatch to the shared verifier, which tries a trusted external-IdP
+        # bearer token first (SSO_API_TOKEN_AUTH_ENABLED + per-provider
+        # trusted_for_api_auth, see resolve_trusted_provider_by_issuer) and
+        # falls back to internal-only verify_jwt_token_cached() when the
+        # token isn't from a trusted issuer. Without this, every
+        # Depends(get_current_user_with_permissions) call site — /rpc,
+        # /tools, /gateways, /servers, etc. — rejects external-IdP tokens
+        # even when trusted_for_api_auth and SSO_API_TOKEN_AUTH_ENABLED are
+        # both on, because verify_jwt_token_cached() only ever checks the
+        # internal JWT secret. See #6396.
         logger.debug("Attempting JWT token validation")
-        payload = await verify_jwt_token_cached(credentials.credentials, request)
+        payload = await verify_credentials_cached(credentials.credentials, request)
 
         logger.debug("JWT token validated successfully")
 

--- a/tests/live_gateway/sso/test_external_idp_rest_auth_e2e.py
+++ b/tests/live_gateway/sso/test_external_idp_rest_auth_e2e.py
@@ -1,0 +1,341 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/live_gateway/sso/test_external_idp_rest_auth_e2e.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+E2E tests for external-IdP bearer tokens on REST endpoints (issue #6396).
+
+get_current_user() (mcpgateway/auth.py) -- the dependency behind
+get_current_user_with_permissions() and therefore every REST endpoint that
+uses it (/tools, /gateways, /servers, /rpc, etc.) -- only ever verified
+tokens with the internal JWT secret. A bearer token from a provider with
+trusted_for_api_auth=True and a matching SSO_API_TOKEN_AUTH_ENABLED was
+rejected with 401 on all of these endpoints even though the external-IdP
+verification path (verify_credentials_cached -> _maybe_verify_external)
+worked correctly on its own. This suite exercises the fix end to end
+against a real Keycloak-backed gateway: a trusted, correctly-audienced
+token is accepted and correctly team-scoped on GET /tools, while an
+untrusted/misconfigured token is still rejected.
+
+Requirements:
+    - ContextForge running with docker-compose --profile sso, started with
+      SSO_API_TOKEN_AUTH_ENABLED=true in the environment (default: http://localhost:8080)
+    - Keycloak running (default: http://localhost:8180) with the mcp-gateway realm imported
+    - playwright installed: pip install playwright
+
+Usage:
+    SSO_API_TOKEN_AUTH_ENABLED=true docker compose --profile sso up -d
+    pytest tests/live_gateway/sso/test_external_idp_rest_auth_e2e.py -v -s --tb=short
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from contextlib import suppress
+import logging
+import os
+from typing import Any, Generator
+import uuid
+
+# Third-Party
+import pytest
+
+pw = pytest.importorskip("playwright", reason="playwright is not installed – pip install playwright")
+# Third-Party
+from playwright.sync_api import APIRequestContext, Playwright  # noqa: E402
+
+# Local
+from tests.helpers.auth import make_playwright_api_context, make_test_jwt  # noqa: E402
+
+from ..helpers.mcp_test_helpers import BASE_URL, JWT_SECRET, skip_no_gateway  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.e2e, skip_no_gateway]
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+KEYCLOAK_URL = os.getenv("KEYCLOAK_URL", "http://localhost:8180")
+KEYCLOAK_INTERNAL_URL = os.getenv("KEYCLOAK_INTERNAL_URL", "http://keycloak:8080")
+KEYCLOAK_REALM = os.getenv("KEYCLOAK_REALM", "mcp-gateway")
+KEYCLOAK_CLIENT_ID = os.getenv("KEYCLOAK_CLIENT_ID", "mcp-gateway")
+KEYCLOAK_CLIENT_SECRET = os.getenv("KEYCLOAK_CLIENT_SECRET", "keycloak-dev-secret")
+# Matches how the gateway reaches Keycloak for OIDC discovery -- the trusted
+# SSOProvider's `issuer` is derived from SSO_KEYCLOAK_BASE_URL (defaults to
+# the same docker-internal URL), so tokens must be minted against that same
+# issuer for resolve_trusted_provider_by_issuer() to match.
+KEYCLOAK_ISSUER = f"{KEYCLOAK_INTERNAL_URL}/realms/{KEYCLOAK_REALM}"
+KEYCLOAK_TOKEN_URL = f"{KEYCLOAK_URL}/realms/{KEYCLOAK_REALM}/protocol/openid-connect/token"
+KEYCLOAK_TEST_PASSWORD = "changeme"  # pragma: allowlist secret — e2e Keycloak fixture, not a real credential
+# Realm-seeded users (infra/keycloak/realm-export.json): viewer@example.com is a
+# member of the /Viewers group, newuser@example.com belongs to no group. Reusing
+# two distinct real accounts (rather than editing a single token's claims, which
+# would require the realm's signing key) is how a live token-based test represents
+# "group present" vs. "group absent".
+KEYCLOAK_GROUP_MEMBER = os.getenv("KEYCLOAK_VIEWER_EMAIL", "viewer@example.com")
+KEYCLOAK_NO_GROUP_USER = os.getenv("KEYCLOAK_NEWUSER_EMAIL", "newuser@example.com")
+# Short group name as it appears in the access token's `groups` claim (the
+# realm's group-membership mapper is configured with full.path=false).
+KEYCLOAK_VIEWERS_GROUP = "Viewers"
+# Keycloak's built-in "account" client scope adds "account" to every access
+# token's `aud` claim by default, with no custom audience mapper required.
+TRUSTED_PROVIDER_ID = "keycloak"
+TRUSTED_API_AUDIENCE = "account"
+PREFIX = "ext-idp-rest"
+
+
+# ---------------------------------------------------------------------------
+# Skip conditions
+# ---------------------------------------------------------------------------
+def _keycloak_reachable() -> bool:
+    try:
+        # Third-Party
+        import httpx
+
+        resp = httpx.get(f"{KEYCLOAK_URL}/realms/{KEYCLOAK_REALM}/.well-known/openid-configuration", timeout=5)
+        return resp.status_code == 200
+    except Exception as exc:
+        # Standard
+        import warnings
+
+        warnings.warn(f"_keycloak_reachable probe failed: {type(exc).__name__}: {exc}", stacklevel=2)
+        return False
+
+
+def _api_token_auth_enabled() -> bool:
+    """Best-effort check that the operator started the stack with the flag on.
+
+    SSO_API_TOKEN_AUTH_ENABLED is a container-startup env var (see
+    docker-compose.yml), not something a test can flip at runtime. There is
+    no endpoint that reflects it back, so this reads the same env var name
+    from the pytest process's own environment as a documented convention:
+    export it before both `docker compose --profile sso up` and `pytest`.
+    """
+    return os.getenv("SSO_API_TOKEN_AUTH_ENABLED", "false").strip().lower() in ("1", "true", "yes")
+
+
+skip_no_keycloak = pytest.mark.skipif(not _keycloak_reachable(), reason=f"Keycloak not reachable at {KEYCLOAK_URL}")
+skip_no_api_token_auth = pytest.mark.skipif(
+    not _api_token_auth_enabled(),
+    reason="SSO_API_TOKEN_AUTH_ENABLED not set in the test environment — start the sso profile with SSO_API_TOKEN_AUTH_ENABLED=true and export it for pytest too",
+)
+pytestmark.extend([skip_no_keycloak, skip_no_api_token_auth])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _make_cf_jwt(email: str, is_admin: bool = False) -> str:
+    # Shared with the rest of the e2e suite so this token can't drift from
+    # the gateway's configured JWT_SECRET_KEY.
+    return make_test_jwt(email, is_admin=is_admin, secret=JWT_SECRET)
+
+
+def _api_context(playwright: Playwright, token: str) -> APIRequestContext:
+    return make_playwright_api_context(playwright, BASE_URL, token)
+
+
+def _get_keycloak_token(email: str, password: str = KEYCLOAK_TEST_PASSWORD) -> str:
+    """Obtain an access token from Keycloak via Resource Owner Password Credentials grant.
+
+    Requests the token from inside the gateway container so the JWT `iss` claim
+    matches the internal URL (keycloak:8080) the gateway used for OIDC discovery
+    when the trusted SSOProvider row was bootstrapped. Falls back to the host URL
+    if docker exec is unavailable.
+    """
+    # Standard
+    import subprocess
+
+    cmd = [
+        "docker",
+        "compose",
+        "exec",
+        "-T",
+        "gateway",
+        "curl",
+        "-sf",
+        "-X",
+        "POST",
+        f"{KEYCLOAK_INTERNAL_URL}/realms/{KEYCLOAK_REALM}/protocol/openid-connect/token",
+        "-d",
+        f"grant_type=password&client_id={KEYCLOAK_CLIENT_ID}&client_secret={KEYCLOAK_CLIENT_SECRET}" f"&username={email}&password={password}&scope=openid+profile+email",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=15, check=False)
+    if result.returncode == 0 and result.stdout.strip():
+        # Standard
+        import json
+
+        data = json.loads(result.stdout)
+        token = data.get("access_token")
+        if token:
+            return token
+
+    # Fallback: request from host (issuer may differ; only useful for manual debugging)
+    # Third-Party
+    import httpx
+
+    resp = httpx.post(
+        KEYCLOAK_TOKEN_URL,
+        data={
+            "grant_type": "password",
+            "client_id": KEYCLOAK_CLIENT_ID,
+            "client_secret": KEYCLOAK_CLIENT_SECRET,
+            "username": email,
+            "password": password,
+            "scope": "openid profile email",
+        },
+        timeout=10,
+    )
+    assert resp.status_code == 200, f"Keycloak token request failed: {resp.status_code} {resp.text}"
+    return resp.json()["access_token"]
+
+
+def _rest_request(playwright: Playwright, path: str, token: str | None) -> Any:
+    """Issue a GET request against a REST endpoint with an optional bearer token."""
+    headers = {"Accept": "application/json"}
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    ctx = playwright.request.new_context(base_url=BASE_URL, extra_http_headers=headers)
+    try:
+        return ctx.get(path)
+    finally:
+        ctx.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="module")
+def admin_api(playwright: Playwright) -> Generator[APIRequestContext, None, None]:
+    """Admin API context using a CF-issued JWT (internal path, unaffected by this fix)."""
+    token = _make_cf_jwt("admin@example.com", is_admin=True)
+    ctx = _api_context(playwright, token)
+    yield ctx
+    ctx.dispose()
+
+
+@pytest.fixture(scope="module")
+def scoped_team(admin_api: APIRequestContext) -> Generator[dict[str, Any], None, None]:
+    """A dedicated CF team used to prove team-scoped visibility, not just plain 200/401."""
+    uid = uuid.uuid4().hex[:8]
+    name = f"{PREFIX}-team-{uid}"
+    resp = admin_api.post("/teams/", data={"name": name, "description": "External-IdP REST auth E2E team", "visibility": "private"})
+    assert resp.status in (200, 201), f"Failed to create team: {resp.status} {resp.text()}"
+    team = resp.json()
+    team_id = team.get("id") or team.get("team", {}).get("id")
+    logger.info("Created team: %s (id=%s)", name, team_id)
+
+    yield {"id": team_id, "name": name}
+
+    with suppress(Exception):
+        admin_api.delete(f"/teams/{team_id}")
+
+
+@pytest.fixture(scope="module")
+def team_scoped_tool(admin_api: APIRequestContext, scoped_team: dict[str, Any]) -> Generator[dict[str, Any], None, None]:
+    """A tool visible only to members of `scoped_team` -- proves real RBAC scoping, not a static grant."""
+    uid = uuid.uuid4().hex[:8]
+    name = f"{PREFIX}-tool-{uid}"
+    payload = {
+        "tool": {
+            "name": name,
+            "url": "https://example.com/healthz",
+            "description": "External-IdP REST auth E2E marker tool",
+            "integration_type": "REST",
+            "request_type": "GET",
+            "visibility": "team",
+        },
+        "team_id": scoped_team["id"],
+    }
+    resp = admin_api.post("/tools", data=payload)
+    assert resp.status in (200, 201), f"Failed to create team-scoped tool: {resp.status} {resp.text()}"
+    tool = resp.json()
+    logger.info("Created team-scoped tool: %s (id=%s, team=%s)", name, tool["id"], scoped_team["id"])
+
+    yield tool
+
+    with suppress(Exception):
+        admin_api.delete(f"/tools/{tool['id']}")
+
+
+@pytest.fixture(scope="module")
+def trusted_keycloak_provider(admin_api: APIRequestContext, scoped_team: dict[str, Any]) -> Generator[None, None, None]:
+    """Opt the bootstrapped `keycloak` SSOProvider into trusted_for_api_auth for this suite.
+
+    Restores the provider's prior trusted_for_api_auth flag on teardown. Group ->
+    team mapping is dynamic (SSOService._apply_team_mapping runs on every
+    authenticate_or_create_user() call, including via the external-IdP path), so
+    this is also where the /Viewers -> scoped_team mapping is wired up.
+    """
+    original = admin_api.get(f"/auth/sso/admin/providers/{TRUSTED_PROVIDER_ID}")
+    assert original.status == 200, f"keycloak SSOProvider not found — is SSO_KEYCLOAK_ENABLED=true? {original.status} {original.text()}"
+    original_trusted = bool(original.json().get("trusted_for_api_auth"))
+
+    resp = admin_api.put(
+        f"/auth/sso/admin/providers/{TRUSTED_PROVIDER_ID}",
+        data={
+            "trusted_for_api_auth": True,
+            "api_audience": TRUSTED_API_AUDIENCE,
+            "team_mapping": {KEYCLOAK_VIEWERS_GROUP: {"team_id": scoped_team["id"], "role": "member"}},
+        },
+    )
+    assert resp.status == 200, f"Failed to opt keycloak provider into trusted_for_api_auth: {resp.status} {resp.text()}"
+
+    yield
+
+    with suppress(Exception):
+        admin_api.put(f"/auth/sso/admin/providers/{TRUSTED_PROVIDER_ID}", data={"trusted_for_api_auth": original_trusted})
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+class TestExternalIdPRestAuth:
+    """E2E: trusted external-IdP bearer tokens on REST endpoints (#6396)."""
+
+    def test_trusted_group_member_sees_scoped_tool(self, playwright: Playwright, trusted_keycloak_provider: None, team_scoped_tool: dict[str, Any]):
+        """A trusted, correctly-audienced token for a /Viewers member gets 200 with the scoped tool visible.
+
+        Before the fix, get_current_user() never reached external-IdP verification, so
+        this request 401'd unconditionally regardless of trusted_for_api_auth.
+        """
+        token = _get_keycloak_token(KEYCLOAK_GROUP_MEMBER)
+        resp = _rest_request(playwright, "/tools", token)
+        assert resp.status == 200, f"Trusted external-IdP token should be accepted on GET /tools, got {resp.status}: {resp.text()}"
+        tool_ids = {t["id"] for t in resp.json()}
+        assert team_scoped_tool["id"] in tool_ids, "Group member should see the team-scoped tool granted via SSO team_mapping"
+
+    def test_trusted_non_member_sees_zero_matching_tools(self, playwright: Playwright, trusted_keycloak_provider: None, team_scoped_tool: dict[str, Any]):
+        """Same trusted provider, a user in no mapped group: still 200 (authenticated), but the
+        team-scoped tool is absent -- proving team-scoping is real RBAC enforcement, not a
+        blanket grant for any trusted-issuer token.
+        """
+        token = _get_keycloak_token(KEYCLOAK_NO_GROUP_USER)
+        resp = _rest_request(playwright, "/tools", token)
+        assert resp.status == 200, f"Trusted external-IdP token should be accepted on GET /tools, got {resp.status}: {resp.text()}"
+        tool_ids = {t["id"] for t in resp.json()}
+        assert team_scoped_tool["id"] not in tool_ids, "Non-member should not see a tool scoped to a team they were never mapped into"
+
+    def test_wrong_audience_rejected(self, playwright: Playwright, admin_api: APIRequestContext, trusted_keycloak_provider: None):
+        """A validly-signed, trusted-issuer token whose `aud` doesn't match api_audience is rejected."""
+        resp = admin_api.put(
+            f"/auth/sso/admin/providers/{TRUSTED_PROVIDER_ID}",
+            data={"trusted_for_api_auth": True, "api_audience": "not-a-real-audience"},
+        )
+        assert resp.status == 200, f"Failed to set wrong api_audience: {resp.status} {resp.text()}"
+        try:
+            token = _get_keycloak_token(KEYCLOAK_GROUP_MEMBER)
+            resp = _rest_request(playwright, "/tools", token)
+            assert resp.status == 401, f"Token with non-matching audience should be rejected, got {resp.status}"
+        finally:
+            admin_api.put(
+                f"/auth/sso/admin/providers/{TRUSTED_PROVIDER_ID}",
+                data={"trusted_for_api_auth": True, "api_audience": TRUSTED_API_AUDIENCE},
+            )
+
+    def test_no_token_rejected(self, playwright: Playwright, trusted_keycloak_provider: None):
+        """No Authorization header at all is still a plain 401."""
+        resp = _rest_request(playwright, "/tools", None)
+        assert resp.status == 401, f"Unauthenticated request should be rejected, got {resp.status}"

--- a/tests/unit/mcpgateway/test_auth.py
+++ b/tests/unit/mcpgateway/test_auth.py
@@ -131,7 +131,7 @@ class TestGetCurrentUser:
             updated_at=datetime.now(timezone.utc),
         )
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                 with patch("mcpgateway.auth._get_personal_team_sync", return_value="team_123"):
                     user = await get_current_user(credentials=credentials)
@@ -160,7 +160,7 @@ class TestGetCurrentUser:
         monkeypatch.setattr(settings, "auth_cache_enabled", True)
         monkeypatch.setattr(settings, "require_user_in_db", False)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)):
             with patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", AsyncMock(return_value=cached_ctx)):
                 user = await get_current_user(credentials=credentials, request=request)
 
@@ -188,7 +188,7 @@ class TestGetCurrentUser:
         monkeypatch.setattr(settings, "auth_cache_enabled", False)
         monkeypatch.setattr(settings, "auth_cache_batch_queries", True)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)):
             with patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx):
                 user = await get_current_user(credentials=credentials, request=request)
 
@@ -214,7 +214,7 @@ class TestGetCurrentUser:
             updated_at=datetime.now(timezone.utc),
         )
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                 with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
                     user = await get_current_user(credentials=credentials)
@@ -242,7 +242,7 @@ class TestGetCurrentUser:
         monkeypatch.setattr(settings, "auth_cache_enabled", False)
         monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_email_by_id_sync", return_value="resolved@example.com"):
                 with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                     with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
@@ -273,7 +273,7 @@ class TestGetCurrentUser:
         monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)),
             patch("mcpgateway.auth._get_email_by_id_sync", return_value=None) as mock_resolve_id,
             patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user) as mock_resolve_email,
             patch("mcpgateway.auth._get_personal_team_sync", return_value=None),
@@ -297,7 +297,7 @@ class TestGetCurrentUser:
         monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)),
             patch("mcpgateway.auth._get_email_by_id_sync", return_value=None),
             patch("mcpgateway.auth._get_user_by_email_sync") as mock_resolve_email,
             patch("mcpgateway.auth._get_personal_team_sync", return_value=None),
@@ -318,7 +318,7 @@ class TestGetCurrentUser:
         # Mock JWT verification without email/sub
         jwt_payload = {"exp": (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp()}
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with pytest.raises(HTTPException) as exc_info:
                 await get_current_user(credentials=credentials)
 
@@ -332,7 +332,7 @@ class TestGetCurrentUser:
 
         jwt_payload = {"sub": "test@example.com", "jti": "token_id_123", "exp": (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp()}
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._check_token_revoked_sync", return_value=True):
                 with pytest.raises(HTTPException) as exc_info:
                     await get_current_user(credentials=credentials)
@@ -349,7 +349,7 @@ class TestGetCurrentUser:
 
         caplog.set_level(logging.WARNING, logger="mcpgateway.auth")
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._check_token_revoked_sync", side_effect=Exception("Database error")):
                 with patch("mcpgateway.auth._get_user_by_email_sync", return_value=None):
                     with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
@@ -381,7 +381,7 @@ class TestGetCurrentUser:
         """Test that expired JWT token raises 401."""
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="expired_jwt")  # pragma: allowlist secret
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(side_effect=HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token expired"))):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(side_effect=HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token expired"))):
             with pytest.raises(HTTPException) as exc_info:
                 await get_current_user(credentials=credentials)
 
@@ -408,7 +408,7 @@ class TestGetCurrentUser:
         )
 
         # JWT fails, fallback to API token
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(side_effect=Exception("Invalid JWT"))):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(side_effect=Exception("Invalid JWT"))):
             with patch("mcpgateway.auth._lookup_api_token_sync", return_value={"user_email": "api_user@example.com", "jti": "api_token_jti"}):
                 with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                     user = await get_current_user(credentials=credentials)
@@ -440,7 +440,7 @@ class TestGetCurrentUser:
         monkeypatch.setattr(settings, "auth_cache_enabled", True)
         monkeypatch.setattr(settings, "require_user_in_db", False)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", AsyncMock(return_value=cached_ctx)):
                 with patch("mcpgateway.auth._resolve_teams_from_db", return_value=["team-123", "team-456"]) as mock_resolve_db:
                     user = await get_current_user(credentials=credentials, request=request)
@@ -477,7 +477,7 @@ class TestGetCurrentUser:
         monkeypatch.setattr(settings, "auth_cache_enabled", True)
         monkeypatch.setattr(settings, "require_user_in_db", False)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", AsyncMock(return_value=cached_ctx)):
                 with patch("mcpgateway.auth._resolve_teams_from_db", return_value=["db-team-1", "db-team-2"]) as mock_resolve_db:
                     user = await get_current_user(credentials=credentials, request=request)
@@ -514,7 +514,7 @@ class TestGetCurrentUser:
             updated_at=datetime.now(timezone.utc),
         )
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                 with patch("mcpgateway.auth._resolve_teams_from_db", return_value=["team-123"]) as mock_resolve_teams:
                     with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
@@ -547,7 +547,7 @@ class TestGetCurrentUser:
             updated_at=datetime.now(timezone.utc),
         )
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                 with patch("mcpgateway.auth._resolve_teams_from_db", return_value=["db-team-1"]) as mock_resolve_teams:
                     with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
@@ -584,7 +584,7 @@ class TestGetCurrentUser:
             updated_at=datetime.now(timezone.utc),
         )
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                 with patch("mcpgateway.auth._resolve_teams_from_db", return_value=None) as mock_resolve_teams:
                     with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
@@ -620,7 +620,7 @@ class TestGetCurrentUser:
             updated_at=datetime.now(timezone.utc),
         )
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                 with patch("mcpgateway.auth._resolve_teams_from_db") as mock_resolve_teams:
                     with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
@@ -638,7 +638,7 @@ class TestGetCurrentUser:
         api_token_value = "expired_api_token"
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=api_token_value)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(side_effect=Exception("Invalid JWT"))):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(side_effect=Exception("Invalid JWT"))):
             with patch("mcpgateway.auth._lookup_api_token_sync", return_value={"expired": True}):
                 with pytest.raises(HTTPException) as exc_info:
                     await get_current_user(credentials=credentials)
@@ -652,7 +652,7 @@ class TestGetCurrentUser:
         api_token_value = "revoked_api_token"
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=api_token_value)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(side_effect=Exception("Invalid JWT"))):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(side_effect=Exception("Invalid JWT"))):
             with patch("mcpgateway.auth._lookup_api_token_sync", return_value={"revoked": True}):
                 with pytest.raises(HTTPException) as exc_info:
                     await get_current_user(credentials=credentials)
@@ -665,7 +665,7 @@ class TestGetCurrentUser:
         """Test that non-existent API token raises 401."""
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="nonexistent_token")  # pragma: allowlist secret
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(side_effect=Exception("Invalid JWT"))):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(side_effect=Exception("Invalid JWT"))):
             with patch("mcpgateway.auth._lookup_api_token_sync", return_value=None):
                 with pytest.raises(HTTPException) as exc_info:
                     await get_current_user(credentials=credentials)
@@ -678,7 +678,7 @@ class TestGetCurrentUser:
         """Test that database error during API token lookup raises 401."""
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="token_causing_db_error")  # pragma: allowlist secret
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(side_effect=Exception("Invalid JWT"))):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(side_effect=Exception("Invalid JWT"))):
             with patch("mcpgateway.auth._lookup_api_token_sync", side_effect=Exception("Database connection error")):
                 with pytest.raises(HTTPException) as exc_info:
                     await get_current_user(credentials=credentials)
@@ -693,7 +693,7 @@ class TestGetCurrentUser:
 
         jwt_payload = {"sub": "nonexistent@example.com", "exp": (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp()}
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=None):
                 with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
                     with pytest.raises(HTTPException) as exc_info:
@@ -709,7 +709,7 @@ class TestGetCurrentUser:
 
         jwt_payload = {"sub": "admin@example.com", "exp": (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp(), "is_admin": True}
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=None):  # User not in DB
                 with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
                     with patch("mcpgateway.config.settings.platform_admin_email", "admin@example.com"):
@@ -729,7 +729,7 @@ class TestGetCurrentUser:
 
         jwt_payload = {"sub": "admin@example.com", "exp": (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp()}
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=None):  # User not in DB
                 with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
                     with patch("mcpgateway.config.settings.platform_admin_email", "admin@example.com"):
@@ -758,7 +758,7 @@ class TestGetCurrentUser:
             updated_at=datetime.now(timezone.utc),
         )
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                 with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
                     with patch("mcpgateway.config.settings.require_user_in_db", True):
@@ -774,7 +774,7 @@ class TestGetCurrentUser:
 
         jwt_payload = {"sub": "admin@example.com", "exp": (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp()}
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=None):
                 with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
                     with patch("mcpgateway.config.settings.require_user_in_db", True):
@@ -801,7 +801,7 @@ class TestGetCurrentUser:
         mock_auth_cache = MagicMock()
         mock_auth_cache.get_auth_context = AsyncMock(return_value=mock_cached_ctx)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.config.settings.auth_cache_enabled", True):
                 with patch("mcpgateway.cache.auth_cache.auth_cache", mock_auth_cache):
                     with patch("mcpgateway.auth._get_user_by_email_sync", return_value=None):  # User deleted from DB
@@ -822,7 +822,7 @@ class TestGetCurrentUser:
         # Mock the batched query to return no user (user=None means not found)
         mock_batch_result = {"user": None, "is_token_revoked": False, "personal_team_id": None}
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.config.settings.auth_cache_enabled", False):  # Disable cache
                 with patch("mcpgateway.config.settings.auth_cache_batch_queries", True):  # Enable batched queries
                     with patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=mock_batch_result):
@@ -852,7 +852,7 @@ class TestGetCurrentUser:
             updated_at=datetime.now(timezone.utc),
         )
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                 with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
                     with pytest.raises(HTTPException) as exc_info:
@@ -883,7 +883,7 @@ class TestGetCurrentUser:
         monkeypatch.setattr(settings, "auth_cache_enabled", False)
         monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                 with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
                     await get_current_user(credentials=credentials)
@@ -912,7 +912,7 @@ class TestGetCurrentUser:
 
         caplog.set_level(logging.DEBUG)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                 with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
                     await get_current_user(credentials=credentials)
@@ -948,7 +948,7 @@ class TestAuthHooksOptimization:
         mock_pm.invoke_hook = AsyncMock()
 
         with patch("mcpgateway.auth.get_plugin_manager", return_value=mock_pm):
-            with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+            with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
                 with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                     with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
                         user = await get_current_user(credentials=credentials)
@@ -995,7 +995,7 @@ class TestAuthHooksOptimization:
         mock_pm.invoke_hook = AsyncMock(return_value=(mock_plugin_result, None))
 
         with patch("mcpgateway.auth.get_plugin_manager", return_value=mock_pm):
-            with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+            with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
                 with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                     with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
                         user = await get_current_user(credentials=credentials)
@@ -1029,7 +1029,7 @@ class TestAuthHooksOptimization:
 
         # Plugin manager returns None
         with patch("mcpgateway.auth.get_plugin_manager", return_value=None):
-            with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+            with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
                 with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                     with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
                         user = await get_current_user(credentials=credentials)
@@ -1662,7 +1662,7 @@ class TestUpdateApiTokenLastUsed:
         # Disable batch queries to use the standard code path that's already mocked
         monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                 with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
                     with patch("mcpgateway.auth._update_api_token_last_used_sync") as mock_update:
@@ -1711,7 +1711,7 @@ class TestUpdateApiTokenLastUsed:
         monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
 
         # Mock the update function to raise an exception
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                 with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
                     with patch("mcpgateway.auth._check_token_revoked_sync", return_value=False):
@@ -1757,7 +1757,7 @@ class TestUpdateApiTokenLastUsed:
         # Disable batch queries to use the standard code path that's already mocked
         monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                 with patch("mcpgateway.auth._get_personal_team_sync", return_value="team_123"):
                     with patch("mcpgateway.auth._check_token_revoked_sync", return_value=False):
@@ -1798,7 +1798,7 @@ class TestUpdateApiTokenLastUsed:
         # Disable batch queries to use the standard code path that's already mocked
         monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                 with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
                     with patch("mcpgateway.auth._is_api_token_jti_sync", return_value=True):
@@ -1846,7 +1846,7 @@ class TestUpdateApiTokenLastUsed:
         monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
 
         # Mock functions individually
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
                 with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
                     with patch("mcpgateway.auth._check_token_revoked_sync", return_value=False):
@@ -2210,7 +2210,7 @@ class TestSetAuthMethodFromPayload:
         request = SimpleNamespace(state=SimpleNamespace())
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.auth._check_token_revoked_sync", return_value=False),
             patch("mcpgateway.auth._update_api_token_last_used_sync", return_value=None),
             patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
@@ -2242,7 +2242,7 @@ class TestSetAuthMethodFromPayload:
         request = SimpleNamespace(state=SimpleNamespace())
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.auth._check_token_revoked_sync", return_value=False),
             patch("mcpgateway.auth._is_api_token_jti_sync", return_value=True),
             patch("mcpgateway.auth._update_api_token_last_used_sync", return_value=None),
@@ -2275,7 +2275,7 @@ class TestSetAuthMethodFromPayload:
         request = SimpleNamespace(state=SimpleNamespace())
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.auth._is_api_token_jti_sync", return_value=False),
             patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
             patch("mcpgateway.auth._get_personal_team_sync", return_value=None),
@@ -2307,7 +2307,7 @@ class TestSetAuthMethodFromPayload:
         request = SimpleNamespace(state=SimpleNamespace())
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
             patch("mcpgateway.auth._get_personal_team_sync", return_value=None),
         ):
@@ -2373,7 +2373,7 @@ class TestJwtTokenScopeExtraction:
         user_dict = {"email": "user@example.com", "is_admin": False, "is_active": True, "auth_provider": "api_token"}
 
         common = [
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.auth._check_token_revoked_sync", return_value=False),
             patch("mcpgateway.auth._update_api_token_last_used_sync", return_value=None),
             patch("mcpgateway.auth._is_api_token_jti_sync", return_value=True),
@@ -2551,7 +2551,7 @@ class TestDatabaseApiTokenScopeExtraction:
         token_info = {"user_email": "user@example.com", "jti": "db-jti", "resource_scopes": resource_scopes}
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(side_effect=ValueError("not a jwt"))),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(side_effect=ValueError("not a jwt"))),
             patch("mcpgateway.auth._lookup_api_token_sync", return_value=token_info),
             patch("mcpgateway.auth._get_user_by_email_sync", return_value=_scope_test_user()),
             patch("mcpgateway.auth._get_personal_team_sync", return_value=None),
@@ -2663,7 +2663,7 @@ class TestPluginAuthHook:
         with (
             patch("mcpgateway.auth.get_plugin_manager", return_value=mock_pm),
             patch("mcpgateway.auth.get_correlation_id", return_value="req-1"),
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)),
             patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
             patch("mcpgateway.auth._get_personal_team_sync", return_value=None),
         ):
@@ -2726,7 +2726,7 @@ class TestPluginAuthHook:
         with (
             patch("mcpgateway.auth.get_plugin_manager", return_value=mock_pm),
             patch("mcpgateway.auth.get_correlation_id", return_value=None),
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)),
             patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
             patch("mcpgateway.auth._get_personal_team_sync", return_value=None),
         ):
@@ -2766,7 +2766,7 @@ class TestPluginAuthHook:
         with (
             patch("mcpgateway.auth.get_plugin_manager", return_value=mock_pm),
             patch("mcpgateway.auth.get_correlation_id", return_value=None),
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=jwt_payload)),
             patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
             patch("mcpgateway.auth._get_personal_team_sync", return_value=None),
         ):
@@ -2799,7 +2799,7 @@ class TestCachePathBranches:
         cached_ctx = SimpleNamespace(is_token_revoked=True, user=None, personal_team_id=None)
         monkeypatch.setattr(settings, "auth_cache_enabled", True)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)), patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", AsyncMock(return_value=cached_ctx)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)), patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", AsyncMock(return_value=cached_ctx)):
             with pytest.raises(HTTPException) as exc:
                 await get_current_user(credentials=credentials)
             assert exc.value.detail == "Token has been revoked"
@@ -2817,7 +2817,7 @@ class TestCachePathBranches:
         )
         monkeypatch.setattr(settings, "auth_cache_enabled", True)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)), patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", AsyncMock(return_value=cached_ctx)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)), patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", AsyncMock(return_value=cached_ctx)):
             with pytest.raises(HTTPException) as exc:
                 await get_current_user(credentials=credentials)
             assert exc.value.detail == "Account disabled"
@@ -2843,7 +2843,7 @@ class TestCachePathBranches:
         monkeypatch.setattr(settings, "auth_cache_enabled", True)
         monkeypatch.setattr(settings, "require_user_in_db", False)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)), patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", AsyncMock(return_value=cached_ctx)):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)), patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", AsyncMock(return_value=cached_ctx)):
             user = await get_current_user(credentials=credentials, request=request)
 
         assert request.state.token_teams is None  # admin bypass
@@ -2870,7 +2870,7 @@ class TestCachePathBranches:
         monkeypatch.setattr(settings, "require_user_in_db", False)
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", AsyncMock(return_value=cached_ctx)),
             patch("mcpgateway.auth._is_personal_team_sync", return_value=False),
         ):
@@ -2895,7 +2895,7 @@ class TestCachePathBranches:
         mock_user = self._make_user()
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", AsyncMock(return_value=cached_ctx)),
             patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
             patch("mcpgateway.auth._get_personal_team_sync", return_value=None),
@@ -2919,7 +2919,7 @@ class TestCachePathBranches:
         mock_user = self._make_user()
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", AsyncMock(side_effect=RuntimeError("cache down"))),
             patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
             patch("mcpgateway.auth._get_personal_team_sync", return_value=None),
@@ -2954,7 +2954,7 @@ class TestCachePathBranches:
 
         with (
             patch("mcpgateway.auth.get_plugin_manager", return_value=mock_pm),
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", AsyncMock(return_value=cached_ctx)),
             patch("mcpgateway.auth._inject_userinfo_instate") as mock_inject,
         ):
@@ -2977,7 +2977,7 @@ class TestBatchedPathBranches:
 
         auth_ctx = {"user": None, "personal_team_id": None, "is_token_revoked": True}
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)), patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)), patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx):
             with pytest.raises(HTTPException) as exc:
                 await get_current_user(credentials=credentials)
             assert exc.value.detail == "Token has been revoked"
@@ -3003,7 +3003,7 @@ class TestBatchedPathBranches:
         monkeypatch.setattr(settings, "auth_cache_enabled", False)
         monkeypatch.setattr(settings, "auth_cache_batch_queries", True)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)), patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)), patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx):
             user = await get_current_user(credentials=credentials, request=request)
 
         assert request.state.team_id is None
@@ -3030,7 +3030,7 @@ class TestBatchedPathBranches:
         monkeypatch.setattr(settings, "auth_cache_batch_queries", True)
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx),
             patch("mcpgateway.auth._is_personal_team_sync", return_value=False),
         ):
@@ -3061,7 +3061,7 @@ class TestBatchedPathBranches:
         mock_cache.set_auth_context = AsyncMock()
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx),
             patch("mcpgateway.cache.auth_cache.auth_cache", mock_cache),
         ):
@@ -3092,7 +3092,7 @@ class TestBatchedPathBranches:
         mock_cache.set_auth_context = AsyncMock(side_effect=RuntimeError("cache write fail"))
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx),
             patch("mcpgateway.cache.auth_cache.auth_cache", mock_cache),
         ):
@@ -3114,7 +3114,7 @@ class TestBatchedPathBranches:
         monkeypatch.setattr(settings, "auth_cache_enabled", False)
         monkeypatch.setattr(settings, "auth_cache_batch_queries", True)
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)), patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)), patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx):
             with pytest.raises(HTTPException) as exc:
                 await get_current_user(credentials=credentials)  # pragma: allowlist secret
             assert exc.value.detail == "Account disabled"
@@ -3135,7 +3135,7 @@ class TestBatchedPathBranches:
         monkeypatch.setattr(settings, "require_user_in_db", False)
         monkeypatch.setattr(settings, "platform_admin_email", "admin@example.com")
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)), patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)), patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx):
             user = await get_current_user(credentials=credentials)  # pragma: allowlist secret
 
         assert user.email == "admin@example.com"
@@ -3153,7 +3153,7 @@ class TestBatchedPathBranches:
         monkeypatch.setattr(settings, "require_user_in_db", False)
         monkeypatch.setattr(settings, "platform_admin_email", "admin@example.com")
 
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)), patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx):
+        with patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)), patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx):
             with pytest.raises(HTTPException) as exc:
                 await get_current_user(credentials=credentials)  # pragma: allowlist secret
             assert exc.value.detail == "User not found"
@@ -3178,7 +3178,7 @@ class TestBatchedPathBranches:
 
         with (
             patch("mcpgateway.auth.get_plugin_manager", return_value=mock_pm),
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx),
             patch("mcpgateway.auth._inject_userinfo_instate") as mock_inject,
         ):
@@ -3207,7 +3207,7 @@ class TestBatchedPathBranches:
         )
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.auth._get_auth_context_batched_sync", side_effect=RuntimeError("batch fail")),
             patch("mcpgateway.auth._check_token_revoked_sync", return_value=False),
             patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
@@ -3244,7 +3244,7 @@ class TestFallbackPathWithRequest:
         request = SimpleNamespace(state=SimpleNamespace())
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
             patch("mcpgateway.auth._get_personal_team_sync", return_value=None),
             patch("mcpgateway.auth._is_personal_team_sync", return_value=False),
@@ -3282,7 +3282,7 @@ class TestFallbackPathWithRequest:
         monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
             patch("mcpgateway.auth._get_personal_team_sync", return_value=None),
         ):
@@ -3316,7 +3316,7 @@ class TestApiTokenWithRequest:
         request = SimpleNamespace(state=SimpleNamespace())
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(side_effect=Exception("JWT fail"))),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(side_effect=Exception("JWT fail"))),
             patch("mcpgateway.auth._lookup_api_token_sync", return_value={"user_email": "api@example.com", "jti": "api-jti"}),
             patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
         ):
@@ -3565,7 +3565,7 @@ class TestCacheRequireUserInDbFound:
         )
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", AsyncMock(return_value=cached_ctx)),
             patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
         ):
@@ -3603,7 +3603,7 @@ class TestFallbackPathBatchDisabled:
         request = SimpleNamespace(state=SimpleNamespace())
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.auth._check_token_revoked_sync", return_value=False),
             patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
             patch("mcpgateway.auth._get_personal_team_sync", return_value=None),
@@ -4153,7 +4153,7 @@ class TestSessionTokenBranches:
 
         with (
             patch("mcpgateway.auth.get_plugin_manager", return_value=None),
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", AsyncMock(return_value=cached_ctx)),
             patch("mcpgateway.auth._resolve_teams_from_db", mock_resolve),
             patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
@@ -4188,7 +4188,7 @@ class TestSessionTokenBranches:
 
         with (
             patch("mcpgateway.auth.get_plugin_manager", return_value=None),
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx),
         ):
             user = await get_current_user(credentials=credentials)
@@ -4228,7 +4228,7 @@ class TestSessionTokenBranches:
 
         with (
             patch("mcpgateway.auth.get_plugin_manager", return_value=None),
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx),
             patch("mcpgateway.cache.auth_cache.auth_cache", mock_cache),
         ):
@@ -4264,7 +4264,7 @@ class TestSessionTokenBranches:
         monkeypatch.setattr(settings, "require_user_in_db", False)
 
         with (
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", AsyncMock(return_value=cached_ctx)),
         ):
             user = await get_current_user(credentials=credentials, request=request)
@@ -4305,7 +4305,7 @@ class TestSessionTokenBranches:
 
         with (
             patch("mcpgateway.auth.get_plugin_manager", return_value=None),
-            patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+            patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
             patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx),
         ):
             user = await get_current_user(credentials=credentials, request=request)
@@ -4796,7 +4796,7 @@ class TestTenantIdPropagation:
             with (
                 patch("mcpgateway.auth.settings") as mock_settings,
                 patch("mcpgateway.auth.get_plugin_manager", return_value=None),
-                patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+                patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
                 patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", AsyncMock(return_value=cached_ctx)),
             ):
                 mock_settings.auth_cache_enabled = True
@@ -4835,7 +4835,7 @@ class TestTenantIdPropagation:
             with (
                 patch("mcpgateway.auth.settings") as mock_settings,
                 patch("mcpgateway.auth.get_plugin_manager", return_value=None),
-                patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)),
+                patch("mcpgateway.auth.verify_credentials_cached", AsyncMock(return_value=payload)),
                 patch("mcpgateway.auth._get_auth_context_batched_sync", return_value=auth_ctx),
             ):
                 mock_settings.auth_cache_enabled = False


### PR DESCRIPTION
Refs #6396 — REST and `/rpc` surface only.

**This PR does not close #6396.** That issue covers `/rpc`, `/mcp` *and* REST; this
change addresses the first two. The `/mcp` streamable-HTTP mount still rejects
external-IdP bearers (see "Deliberately out of scope" below), so the issue should
stay open until that half is resolved.

## What

`get_current_user()` in `mcpgateway/auth.py` — the dependency behind `get_current_user_with_permissions()`, and therefore behind every `Depends(get_current_user_with_permissions)` endpoint — only ever called `verify_jwt_token_cached()`, the internal-only JWT verifier. A bearer from a provider with `trusted_for_api_auth=True` under `SSO_API_TOKEN_AUTH_ENABLED` was rejected on all of them, even though the external verification path (`verify_credentials_cached` → `_maybe_verify_external` → `verify_external_idp_token`) works correctly when called directly.

This swaps that one call site for `verify_credentials_cached()`, which already implements exactly this fallback — try a trusted external issuer first, fall back to `verify_jwt_token_cached()` otherwise — and is already the verifier behind `require_auth()` / `require_auth_header_first()` elsewhere in the codebase. One import, one call site.

## How this relates to the JWT-trust epic (#5885 / #5884)

This is not a competing mechanism. #5900 adds a trust-mode branch *inside* `get_current_user()` — but today an external bearer never reaches that function, so the branch would sit behind a closed door. This change makes `get_current_user()` the single dispatch point for external bearers, which is the precondition #5900 assumes.

One correction for the epic while I'm here: #5885's description lists the external path as already working. It verifies correctly in-process, but no HTTP request reaches it — which is what #6396 reports and what this fixes.

## What this deliberately does NOT change

Naming these so they aren't mistaken for regressions introduced here. All three are pre-existing behaviour of the `SSO_API_TOKEN_AUTH_ENABLED` path, and all three are things Epic 2 addresses:

1. **No revocation for external bearers.** `build_external_identity()` emits no `jti`, so `get_current_user()`'s revocation check is a no-op for these tokens. This PR widens where that matters — from a handful of endpoints to the whole REST surface. #5900 (keep jti revocation) and #5903 (per-trust-root, fail-closed revocation claim) are the fix.
2. **Identity remains e-mail-keyed.** `build_external_identity()` sets `payload["sub"] = email` and denies with `empty_email` when the claim is absent — the same limitation @alxndr13 flagged for Zitadel in the issue body. #5884 is the fix.
3. **Teams resolve with DB authority.** `token_use="session"` routes through `resolve_session_teams()` after JIT provisioning, rather than from claims. #5903 (claims-derived identity without provisioning) is the fix.

## Deliberately out of scope: the global `/mcp` mount

The `/mcp` streamable-HTTP mount authenticates through its own gate in `streamablehttp_transport.py`, where `_route_idp_issued_token()` hands foreign-issuer tokens to `_try_oauth_access_token()` — the per-virtual-server OAuth feature, which never consults `trusted_for_api_auth`, `api_audience` or `team_mapping`. On the bare `/mcp` mount that returns `NOT_APPLICABLE` and the request 401s.

I have a working change for that, but it overlaps #5896 (the token-dispatch rule artifact) and #5904 (secondary choke points per mode) by design — any fix there is a new dispatch rule, which felt like the epic's call rather than something to settle inside a bug fix. Happy to open it as input to either, or fold it in here if you'd prefer.

## Note for reviewers

Renaming the imported symbol breaks 78 tests in `tests/unit/mcpgateway/test_auth.py` that patch `mcpgateway.auth.verify_jwt_token_cached` by name. The second commit retargets those patch points; `verify_credentials_cached` is a superset wrapper (it falls through to `verify_jwt_token_cached` for internal tokens), so mocked return values and existing assertions are unchanged.

The second commit also passes `SSO_API_TOKEN_AUTH_ENABLED` through to the gateway service in `docker-compose.yml`'s `sso` profile. The flag existed in `config.py` and `.env.example` but was never wired into the container, so the scenario the new test covers was not reachable from the compose stack at all.

## Testing

### Ran
- `tests/unit/mcpgateway/test_auth.py` — **326 passed**, exit 0, on this branch rebased onto `main@89a2dec`.
- `ruff==0.15.20` (the version pinned in the Makefile) over the three changed files: 16 findings, **identical to the 16 that `origin/main`'s own copies of `auth.py` and `test_auth.py` produce**. Zero new findings; the added e2e test file contributes none.
- Checked by hand that the new test file introduces no new credential-shaped strings: its `KEYCLOAK_CLIENT_SECRET` env default and `KEYCLOAK_TEST_PASSWORD` are copied verbatim from the existing sibling `tests/live_gateway/sso/test_oauth_jwks_e2e.py`.

### Not run — flagging rather than claiming
- Full `make test`, `make interrogate`, `make detect-secrets-scan`. The latter two aren't available in my local environment, so I can't report a clean scan for them. CI covers all three.
- The new live-gateway e2e test against a real stack — that needs the Keycloak-backed compose profile running, which I don't have here. It follows the existing `tests/live_gateway/sso/` pattern but has not itself been executed.

### Verified earlier against a deployed gateway
Before this branch existed, the same one-line change was built and run against a deployed gateway configured with a trusted external OIDC provider. A bearer carrying the mapped group claim received team-scoped tools on `GET /v1/tools`; the same token with the group removed received `200` with an empty list (not a `401` — the token is valid, it just isn't a member of anything); wrong audience, untrusted issuer, and no token each received `401`; and a `tools/call` through `/rpc` executed successfully. Offering that as context for why I'm confident in the behaviour, not as a substitute for the e2e test above.

## New test

`tests/live_gateway/sso/test_external_idp_rest_auth_e2e.py`, following the existing Keycloak pattern. Four cases: a trusted, correct-audience token for a mapped-group member gets `200` with the team-scoped tool visible; the same provider with a user in no mapped group gets `200` with the tool *not* visible (so it's real RBAC scoping, not a blanket grant); a wrong-`aud` token gets `401`; no token gets `401`.

---

Both commits are DCO signed-off.

*Disclosure: this fix was developed with AI assistance (Claude). I verified the call graphs against the source, ran the tests reported above, and confirmed the live behaviour myself before opening this.*



---

**Update (2026-08-31):** rebased onto `main@555a9f3` to clear a merge conflict. Two files conflicted — `.secrets.baseline` (generated line numbers) and `tests/unit/mcpgateway/test_auth.py`, where upstream added `_is_personal_team_sync` patches to two `with` blocks. Resolved by taking upstream's version of both and re-applying the patch-target rename, so upstream's new patches and formatting are preserved. `.secrets.baseline` now matches `main` exactly and has dropped out of the diff. `tests/unit/mcpgateway/test_auth.py` passes at **347** (was 326 before upstream's additions), exit 0, zero failures.
