### PR TITLE
Changing the dataplane publisher entry to match the new Redis schema 

### DIFF
--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -71,9 +71,6 @@ class BackendConfig(TypedDict):
     tool_schemas: dict[str, dict[str, Any]]
     allowed_resource_uris: list[str]
     allowed_prompt_names: list[str]
-    disable_tool_names_filtering: bool
-    disable_prompt_names_filtering: bool
-    disable_resource_uris_filtering: bool
     mcp_protocol_version: str
 
 
@@ -305,9 +302,6 @@ class DataplanePublisherService:
                         "tool_schemas": backend_items["tool_schemas"],
                         "allowed_resource_uris": allowed_resource_uris,
                         "allowed_prompt_names": allowed_prompt_names,
-                        "disable_tool_names_filtering": False,
-                        "disable_prompt_names_filtering": False,
-                        "disable_resource_uris_filtering": False,
                         "mcp_protocol_version": "2026-07-28",
                     }
 

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -259,7 +259,6 @@ class DataplanePublisherService:
             gateways = user_data["gateways"]
             prompts = user_data["prompts"]
             resources = user_data["resources"]
-            resource_names_by_id = {resource["id"]: resource["name"] for resource in resources}
             resource_uris_by_id = {resource["id"]: resource["uri"] for resource in resources if resource.get("uri")}
 
             prompt_map = {prompt["id"]: prompt["name"] for prompt in prompts}

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -69,9 +69,12 @@ class BackendConfig(TypedDict):
     capabilities: dict[str, Any]
     allowed_tool_names: list[str]
     tool_schemas: dict[str, dict[str, Any]]
-    allowed_resource_names: list[str]
     allowed_resource_uris: list[str]
     allowed_prompt_names: list[str]
+    disable_tool_names_filtering: bool
+    disable_prompt_names_filtering: bool
+    disable_resource_uris_filtering: bool
+    mcp_protocol_version: str
 
 
 class GatewayBaseConfig(TypedDict):
@@ -287,10 +290,9 @@ class DataplanePublisherService:
                     if gateway_config is None:
                         continue
 
-                    allowed_resource_names = [resource_names_by_id[resource_id] for resource_id in backend_items["resources"] if resource_id in resource_names_by_id]
                     allowed_resource_uris = [resource_uris_by_id[resource_id] for resource_id in backend_items["resources"] if resource_id in resource_uris_by_id]
                     allowed_prompt_names = [prompt_map[prompt_id] for prompt_id in backend_items["prompts"] if prompt_id in prompt_map]
-                    if not backend_items["tools"] and not allowed_resource_names and not allowed_prompt_names:
+                    if not backend_items["tools"] and not allowed_resource_uris and not allowed_prompt_names:
                         continue
 
                     backends[gateway_id] = {
@@ -302,9 +304,12 @@ class DataplanePublisherService:
                         "capabilities": gateway_config["capabilities"],
                         "allowed_tool_names": backend_items["tools"],
                         "tool_schemas": backend_items["tool_schemas"],
-                        "allowed_resource_names": allowed_resource_names,
                         "allowed_resource_uris": allowed_resource_uris,
                         "allowed_prompt_names": allowed_prompt_names,
+                        "disable_tool_names_filtering": False,
+                        "disable_prompt_names_filtering": False,
+                        "disable_resource_uris_filtering": False,
+                        "mcp_protocol_version": "2026-07-28",
                     }
 
                 if not backends:

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -308,9 +308,12 @@ async def test_full_payload_generation_with_mock_db():
                 "public_tool": tool1.input_schema,
                 "private_tool": {},
             },
-            "allowed_resource_names": ["Resource 1"],
             "allowed_resource_uris": ["resource://one"],
             "allowed_prompt_names": ["Prompt 1"],
+            "disable_tool_names_filtering": False,
+            "disable_prompt_names_filtering": False,
+            "disable_resource_uris_filtering": False,
+            "mcp_protocol_version": "2026-07-28",
         }
         assert "bad_tool" not in backend["allowed_tool_names"]
         assert "bad_tool" not in backend["tool_schemas"]
@@ -340,6 +343,10 @@ async def test_full_payload_generation_with_mock_db():
             "public_tool": tool1.input_schema,
             "team2_tool": tool3.input_schema,
         }
+        assert user2_backend["disable_tool_names_filtering"] is False
+        assert user2_backend["disable_prompt_names_filtering"] is False
+        assert user2_backend["disable_resource_uris_filtering"] is False
+        assert user2_backend["mcp_protocol_version"] == "2026-07-28"
 
         # Verify active users with no team membership still get public-only config.
         user3_config = payload[USER3_ID]
@@ -348,6 +355,10 @@ async def test_full_payload_generation_with_mock_db():
         user3_backend = user3_config["virtual_hosts"]["s1"]["backends"]["g1"]
         assert user3_backend["allowed_tool_names"] == ["public_tool"]
         assert user3_backend["tool_schemas"] == {"public_tool": tool1.input_schema}
+        assert user3_backend["disable_tool_names_filtering"] is False
+        assert user3_backend["disable_prompt_names_filtering"] is False
+        assert user3_backend["disable_resource_uris_filtering"] is False
+        assert user3_backend["mcp_protocol_version"] == "2026-07-28"
 
 
 def test_build_user_data_excludes_non_object_tool_schema(caplog):
@@ -530,6 +541,10 @@ def test_create_payload_normalizes_null_passthrough_headers():
     assert backend["add_headers"] == {}
     assert backend["remove_headers"] == []
     assert backend["capabilities"] == {}
+    assert backend["disable_tool_names_filtering"] is False
+    assert backend["disable_prompt_names_filtering"] is False
+    assert backend["disable_resource_uris_filtering"] is False
+    assert backend["mcp_protocol_version"] == "2026-07-28"
 
 
 def test_create_payload_handles_missing_references():

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -310,9 +310,6 @@ async def test_full_payload_generation_with_mock_db():
             },
             "allowed_resource_uris": ["resource://one"],
             "allowed_prompt_names": ["Prompt 1"],
-            "disable_tool_names_filtering": False,
-            "disable_prompt_names_filtering": False,
-            "disable_resource_uris_filtering": False,
             "mcp_protocol_version": "2026-07-28",
         }
         assert "bad_tool" not in backend["allowed_tool_names"]
@@ -343,9 +340,6 @@ async def test_full_payload_generation_with_mock_db():
             "public_tool": tool1.input_schema,
             "team2_tool": tool3.input_schema,
         }
-        assert user2_backend["disable_tool_names_filtering"] is False
-        assert user2_backend["disable_prompt_names_filtering"] is False
-        assert user2_backend["disable_resource_uris_filtering"] is False
         assert user2_backend["mcp_protocol_version"] == "2026-07-28"
 
         # Verify active users with no team membership still get public-only config.
@@ -355,9 +349,6 @@ async def test_full_payload_generation_with_mock_db():
         user3_backend = user3_config["virtual_hosts"]["s1"]["backends"]["g1"]
         assert user3_backend["allowed_tool_names"] == ["public_tool"]
         assert user3_backend["tool_schemas"] == {"public_tool": tool1.input_schema}
-        assert user3_backend["disable_tool_names_filtering"] is False
-        assert user3_backend["disable_prompt_names_filtering"] is False
-        assert user3_backend["disable_resource_uris_filtering"] is False
         assert user3_backend["mcp_protocol_version"] == "2026-07-28"
 
 
@@ -541,9 +532,6 @@ def test_create_payload_normalizes_null_passthrough_headers():
     assert backend["add_headers"] == {}
     assert backend["remove_headers"] == []
     assert backend["capabilities"] == {}
-    assert backend["disable_tool_names_filtering"] is False
-    assert backend["disable_prompt_names_filtering"] is False
-    assert backend["disable_resource_uris_filtering"] is False
     assert backend["mcp_protocol_version"] == "2026-07-28"
 
 


### PR DESCRIPTION
Changes to the control plane to match changes to the external dataplane https://github.com/contextforge-org/contextforge-data-plane/pull/118

- Remove allowed_resource_names field from BackendConfig TypedDict
- Remove computation and usage of allowed_resource_names
- Update empty backend check to use allowed_resource_uris instead
- Add disable_tool_names_filtering field (default: False)
- Add disable_prompt_names_filtering field (default: False)
- Add disable_resource_uris_filtering field (default: False)
- Add mcp_protocol_version field (default: '2026-07-28')
- Update all test assertions to verify new fields