### PR TITLE
fix(sso): flatten dict-shaped groups/roles claims in SSO normalization

### DIFF
--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -1691,6 +1691,44 @@ class SSOService:
         return raw_email_str
 
     @staticmethod
+    def _coerce_claim_to_group_names(claim_value: Any) -> list[str]:
+        """Coerce a single groups/roles claim value into a flat list of names.
+
+        Handles the three claim shapes seen across identity providers:
+
+        * ``list`` -- ``["engineering", "finance"]`` (Entra, Okta, generic OIDC).
+        * ``str`` -- ``"engineering"``, a single-valued claim.
+        * ``dict`` -- role names bucketed by scope, e.g. IBM account-iam's
+          ``{"SERVICE": ["ServiceOwner"]}``. Bucket keys are scope identifiers
+          rather than group names, so only the values are collected.
+
+        Non-string entries are dropped, which also excludes ``bool`` (``True`` is
+        an ``int``, never a ``str``).
+
+        Args:
+            claim_value: Raw claim value as it appears in the token or userinfo body.
+
+        Returns:
+            Flat list of group/role names, in claim order.
+        """
+        if isinstance(claim_value, str):
+            return [claim_value]
+
+        if isinstance(claim_value, list):
+            return [entry for entry in claim_value if isinstance(entry, str)]
+
+        if isinstance(claim_value, dict):
+            names: list[str] = []
+            for bucket in claim_value.values():
+                if isinstance(bucket, str):
+                    names.append(bucket)
+                elif isinstance(bucket, list):
+                    names.extend(entry for entry in bucket if isinstance(entry, str))
+            return names
+
+        return []
+
+    @staticmethod
     def _extract_groups_and_roles(user_data: Dict[str, Any], groups_claim: str = "groups") -> list[str]:
         """Extract groups and roles from user data into a unified list.
 
@@ -1699,25 +1737,22 @@ class SSOService:
             groups_claim: Claim key for groups (default: ``"groups"``).
 
         Returns:
-            Combined list of group and role strings.
+            Combined list of group and role names, de-duplicated in first-seen order.
         """
-        groups: list[str] = []
+        names: list[str] = []
+        for claim in (groups_claim, "roles"):
+            if claim in user_data:
+                names.extend(SSOService._coerce_claim_to_group_names(user_data.get(claim)))
 
-        if groups_claim in user_data:
-            groups_value = user_data.get(groups_claim, [])
-            if isinstance(groups_value, list):
-                groups.extend(g for g in groups_value if isinstance(g, str))
-            elif isinstance(groups_value, str):
-                groups.append(groups_value)
-
-        if "roles" in user_data:
-            roles_value = user_data.get("roles", [])
-            if isinstance(roles_value, list):
-                groups.extend(r for r in roles_value if isinstance(r, str))
-            elif isinstance(roles_value, str):
-                groups.append(roles_value)
-
-        return groups
+        # De-duplicate: a provider configured with ``groups_claim: "roles"`` reads the
+        # same claim twice, and a dict-shaped claim can repeat a name across buckets.
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for name in names:
+            if name not in seen:
+                seen.add(name)
+                deduped.append(name)
+        return deduped
 
     @staticmethod
     def _build_normalized_user_info(

--- a/tests/unit/mcpgateway/services/test_sso_service.py
+++ b/tests/unit/mcpgateway/services/test_sso_service.py
@@ -2551,6 +2551,43 @@ class TestExtractGroupsAndRoles:
         result = SSOService._extract_groups_and_roles(user_data)
         assert result == []
 
+    def test_extracts_dict_shaped_roles_claim(self):
+        """IBM account-iam buckets role names by scope: {"SERVICE": ["ServiceOwner"]}."""
+        user_data = {"roles": {"SERVICE": ["ServiceOwner"]}}
+        result = SSOService._extract_groups_and_roles(user_data)
+        assert result == ["ServiceOwner"]
+
+    def test_extracts_dict_shaped_custom_groups_claim(self):
+        user_data = {"roles": {"SERVICE": ["ServiceOwner", "ServiceUser"], "ACCOUNT": ["AccountAdmin"]}}
+        result = SSOService._extract_groups_and_roles(user_data, groups_claim="roles")
+        assert result == ["ServiceOwner", "ServiceUser", "AccountAdmin"]
+
+    def test_dict_claim_accepts_string_buckets(self):
+        user_data = {"groups": {"SERVICE": "ServiceOwner", "ACCOUNT": ["AccountAdmin"]}}
+        result = SSOService._extract_groups_and_roles(user_data)
+        assert result == ["ServiceOwner", "AccountAdmin"]
+
+    def test_dict_claim_filters_non_string_values(self):
+        user_data = {"groups": {"SERVICE": ["valid", 123, None], "OTHER": 7, "NESTED": {"deep": ["x"]}}}
+        result = SSOService._extract_groups_and_roles(user_data)
+        assert result == ["valid"]
+
+    def test_deduplicates_when_groups_claim_is_roles(self):
+        """groups_claim="roles" reads the same claim twice; names must not double."""
+        user_data = {"roles": ["ServiceOwner"]}
+        result = SSOService._extract_groups_and_roles(user_data, groups_claim="roles")
+        assert result == ["ServiceOwner"]
+
+    def test_deduplicates_names_repeated_across_dict_buckets(self):
+        user_data = {"groups": {"A": ["shared", "a-only"], "B": ["shared", "b-only"]}}
+        result = SSOService._extract_groups_and_roles(user_data)
+        assert result == ["shared", "a-only", "b-only"]
+
+    def test_ignores_unsupported_claim_types(self):
+        user_data = {"groups": 42, "roles": None}
+        result = SSOService._extract_groups_and_roles(user_data)
+        assert result == []
+
 
 class TestBuildNormalizedUserInfo:
     """Tests for the extracted _build_normalized_user_info helper."""


### PR DESCRIPTION
Fixes #6425.

## What

`SSOService._extract_groups_and_roles()` accepted only `str`- and `list`-valued groups/roles claims. A provider that buckets role names by scope — a `dict` claim value — produced an empty group list, so every `team_mapping` and `role_mappings` entry for that provider silently no-opped.

IBM account-iam emits exactly that shape:

```json
{"roles": {"SERVICE": ["ServiceOwner"]}}
```

The dedicated `ibm_verify` provider branch routes through the same helper, so this affects a provider path the project already ships.

This adds `_coerce_claim_to_group_names()`, which normalises the three claim shapes seen across IdPs, and reuses it for both the configured groups claim and the hardcoded `roles` claim:

| Shape | Example | Result |
|---|---|---|
| `str` | `"engineering"` | `["engineering"]` |
| `list` | `["engineering", "finance"]` | `["engineering", "finance"]` |
| `dict` | `{"SERVICE": ["ServiceOwner"]}` | `["ServiceOwner"]` |

Non-string entries are dropped, which also excludes `bool` (`True` is an `int`, never a `str`).

## Why this is labelled security, and in which direction

The failure mode **denies access that should have been granted**; it does not grant access that should have been denied. A user with a dict-shaped claim authenticated successfully, provisioned correctly, and landed with zero team memberships and public-only visibility. So the bug is fail-closed — but silently, with no log line at any level indicating the claim was seen and discarded. The operator sees an empty tool catalog, which is indistinguishable from a user who genuinely belongs to nothing.

The corresponding risk *introduced* by this fix is that mappings which previously no-opped now take effect. That is the intent, but it means an operator who configured `team_mapping` against a dict-shaped provider and concluded it "didn't work" may find those mappings live after upgrading. Worth a line in release notes.

## One design decision worth reviewing

**Bucket keys are discarded; only values are collected.** The keys in account-iam's shape are scope identifiers (`SERVICE`, `ACCOUNT`), not group names, so matching on them would be wrong. But the consequence is that a name appearing in *any* bucket satisfies a mapping keyed on that name — `{"SERVICE": ["Admin"]}` and `{"OTHER": ["Admin"]}` are equivalent to the mapper.

If scope-qualified matching is wanted — "`Admin` only when it appears under `SERVICE`" — that is a larger change than this fix, and it seems like it belongs with the namespaced mapping table in #5976 rather than here. Flagging it explicitly so the choice is reviewed rather than inherited.

## Behaviour change beyond the bug

Names are now de-duplicated in first-seen order. This is required because a dict claim can repeat a name across buckets, but it also changes a pre-existing quirk: when `groups_claim` is set to `"roles"`, the function reads the same claim twice — once as the configured groups claim and once as the hardcoded `roles` claim — so every name previously appeared twice in the returned list. Callers that counted entries rather than testing membership would see different numbers.

## Testing

### Ran
- `tests/unit/mcpgateway/services/test_sso_service.py` — **288 passed**, exit 0, on this branch rebased onto `main@3d5b27d`. That includes 7 new tests added here:
  - dict-shaped `roles` claim
  - dict-shaped custom groups claim
  - dict claim with string (not list) buckets
  - non-string values inside buckets filtered out
  - de-duplication when `groups_claim` is `"roles"`
  - de-duplication of a name repeated across buckets
  - unsupported claim types ignored
- `ruff==0.15.20` (the version pinned in the Makefile) over both changed files: 9 findings, **identical to the 9 that `origin/main`'s own copies produce**. Zero new findings.

### Not run — flagging rather than claiming
- Full `make test`, `make interrogate`, `make detect-secrets-scan`. The latter two aren't available in my local environment, so I can't report a clean scan for them. CI covers all three.
- No live SSO login was exercised against this branch specifically. The bug itself was originally found and confirmed against a real deployment with a dict-shaped claim; the fix here is verified at unit level.

## Relationship to Epic 2

#5976 replaces this mapping mechanism with an in-core, issuer-namespaced `external_group_mappings` table. Claim-shape normalisation sits upstream of that — whatever consumes the claim still has to read it correctly — so this fix should remain relevant, and the helper is a natural place for that consumer to call in.

---

Commit is DCO signed-off.

*Disclosure: found and fixed with AI assistance (Claude). I reproduced the bug against a real deployment, confirmed the code path against the source, and ran the tests reported above before opening this.*
