### PR TITLE
fix(mcp): cache StatefulHTTP JWT admin lookups

### DIFF
--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -63,12 +63,13 @@ wrapper or whether the helper genuinely deserves promotion to the public API.
 
 # Standard
 import asyncio
+from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
 import hashlib
 import logging
 import threading
 import time
-from typing import Any, Dict, Generator, List, Never, Optional
+from typing import Any, Callable, Dict, Generator, List, Never, Optional
 from urllib.parse import urlparse
 import uuid
 
@@ -114,6 +115,7 @@ __all__ = [
     "validate_token_user",
     "get_user_team_roles",
     "normalize_token_teams",
+    "validate_token_team_membership",
     "resolve_session_teams",
     "derive_token_team_id",
 ]
@@ -269,6 +271,65 @@ def _get_user_team_ids_sync(email: str) -> List[str]:
             .order_by(EmailTeamMember.id)  # Stable ordering: teams[0] used as Vault path key
         )
         return [row[0] for row in result.all()]
+
+
+def validate_token_team_membership(
+    user_email: str,
+    team_ids: List[str],
+    db: Optional[Session] = None,
+    *,
+    on_cache_event: Optional[Callable[[str], None]] = None,
+) -> bool:
+    """Return whether a token's claimed teams are active memberships.
+
+    The cache is checked before querying the database. A caller-provided
+    session remains caller-owned; otherwise this helper opens and closes one.
+
+    Args:
+        user_email: Email encoded in the verified token.
+        team_ids: Team IDs claimed by the token.
+        db: Optional caller-owned SQLAlchemy session.
+        on_cache_event: Optional callback receiving ``hit``, ``miss``, or
+            ``reject`` for cache instrumentation.
+
+    Returns:
+        ``True`` when the user belongs to every claimed team.
+    """
+    if not team_ids:
+        return True
+
+    # First-Party
+    from mcpgateway.cache.auth_cache import get_auth_cache  # pylint: disable=import-outside-toplevel
+    from mcpgateway.db import EmailTeamMember  # pylint: disable=import-outside-toplevel
+
+    auth_cache = get_auth_cache()
+    cached_result = auth_cache.get_team_membership_valid_sync(user_email, team_ids)
+    if cached_result is not None:
+        if on_cache_event:
+            on_cache_event("reject" if not cached_result else "hit")
+        return cached_result
+
+    if on_cache_event:
+        on_cache_event("miss")
+
+    owns_session = db is None
+    with SessionLocal() if owns_session else nullcontext(db) as session:
+        memberships = (
+            session.execute(
+                select(EmailTeamMember.team_id).where(
+                    EmailTeamMember.team_id.in_(team_ids),
+                    EmailTeamMember.user_email == user_email,
+                    EmailTeamMember.is_active.is_(True),
+                )
+            )
+            .scalars()
+            .all()
+        )
+        valid = not (set(team_ids) - set(memberships))
+        auth_cache.set_team_membership_valid_sync(user_email, team_ids, valid)
+        if owns_session:
+            session.commit()
+        return valid
 
 
 def _get_team_name_by_id_sync(team_id: Optional[str]) -> Optional[str]:

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -325,7 +325,7 @@ def validate_token_team_membership(
             .scalars()
             .all()
         )
-        valid = not (set(team_ids) - set(memberships))
+        valid = not set(team_ids).difference(memberships)
         auth_cache.set_team_membership_valid_sync(user_email, team_ids, valid)
         if owns_session:
             session.commit()

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -883,22 +883,7 @@ class TokenScopingMiddleware:
 
         # Extract team IDs from token (handles both dict and string formats)
         team_ids = [team["id"] if isinstance(team, dict) else team for team in teams]
-        # Keep session ownership in this middleware; the shared helper owns only
-        # membership cache/query policy.
-        owns_session = db is None
-        if owns_session:
-            # First-Party
-            from mcpgateway.db import get_db  # pylint: disable=import-outside-toplevel
-
-            db = next(get_db())
-        try:
-            valid = validate_token_team_membership(user_email, team_ids, db=db)
-        finally:
-            if owns_session:
-                try:
-                    db.commit()
-                finally:
-                    db.close()
+        valid = validate_token_team_membership(user_email, team_ids, db=db)
         if not valid:
             logger.warning(f"Token invalid: User {SecurityValidator.sanitize_log_message(user_email)} no longer member of teams")
         return valid

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -23,7 +23,7 @@ from fastapi import HTTPException, Request, status
 from sqlalchemy import and_, func, select
 
 # First-Party
-from mcpgateway.auth import normalize_token_teams, resolve_session_teams
+from mcpgateway.auth import normalize_token_teams, resolve_session_teams, validate_token_team_membership
 from mcpgateway.auth_context import get_jwt_user_email_from_payload, resolve_jwt_user_email_from_payload
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
@@ -883,61 +883,25 @@ class TokenScopingMiddleware:
 
         # Extract team IDs from token (handles both dict and string formats)
         team_ids = [team["id"] if isinstance(team, dict) else team for team in teams]
-
-        # First-Party
-        from mcpgateway.cache.auth_cache import get_auth_cache  # pylint: disable=import-outside-toplevel
-
-        # Check cache first (synchronous in-memory lookup)
-        auth_cache = get_auth_cache()
-        cached_result = auth_cache.get_team_membership_valid_sync(user_email, team_ids)
-        if cached_result is not None:
-            if not cached_result:
-                logger.warning(f"Token invalid (cached): User {SecurityValidator.sanitize_log_message(user_email)} no longer member of teams")
-            return cached_result
-
-        # Cache miss - query database
-        # First-Party
-        from mcpgateway.db import EmailTeamMember, get_db  # pylint: disable=import-outside-toplevel
-
-        # Track if we own the session (and thus must clean it up)
+        # Keep session ownership in this middleware; the shared helper owns only
+        # membership cache/query policy.
         owns_session = db is None
         if owns_session:
+            # First-Party
+            from mcpgateway.db import get_db  # pylint: disable=import-outside-toplevel
+
             db = next(get_db())
-
         try:
-            # Single query for all teams (fixes N+1 pattern)
-            memberships = (
-                db.execute(
-                    select(EmailTeamMember.team_id).where(
-                        EmailTeamMember.team_id.in_(team_ids),
-                        EmailTeamMember.user_email == user_email,
-                        EmailTeamMember.is_active.is_(True),
-                    )
-                )
-                .scalars()
-                .all()
-            )
-
-            # Check if user is member of ALL teams in token
-            valid_team_ids = set(memberships)
-            missing_teams = set(team_ids) - valid_team_ids
-
-            if missing_teams:
-                logger.warning(f"Token invalid: User {SecurityValidator.sanitize_log_message(user_email)} no longer member of teams: {SecurityValidator.sanitize_log_message(str(missing_teams))}")
-                # Cache negative result
-                auth_cache.set_team_membership_valid_sync(user_email, team_ids, False)
-                return False
-
-            # Cache positive result
-            auth_cache.set_team_membership_valid_sync(user_email, team_ids, True)
-            return True
+            valid = validate_token_team_membership(user_email, team_ids, db=db)
         finally:
-            # Only commit/close if we created the session
             if owns_session:
                 try:
-                    db.commit()  # Commit read-only transaction to avoid implicit rollback
+                    db.commit()
                 finally:
                     db.close()
+        if not valid:
+            logger.warning(f"Token invalid: User {SecurityValidator.sanitize_log_message(user_email)} no longer member of teams")
+        return valid
 
     def _is_targeted_missing_resource_delete(self, request_path: str, method: str) -> bool:
         """Return whether request is an exact server or gateway DELETE path."""

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2334,6 +2334,32 @@ async def _normalize_jwt_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 if user_record is None and settings.require_user_in_db and email != platform_admin_email:
                     raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="User not found in database")
                 db_user_is_admin = bool(user_record and getattr(user_record, "is_admin", False))
+                # Warm the auth cache so subsequent requests on this stateful
+                # session avoid the DB round-trip (mirrors primary path at 5328+).
+                if auth_cache is not None:
+                    try:
+                        # First-Party
+                        from mcpgateway.cache.auth_cache import CachedAuthContext  # pylint: disable=import-outside-toplevel
+
+                        await auth_cache.set_auth_context(
+                            email,
+                            jti,
+                            CachedAuthContext(
+                                user=(
+                                    {
+                                        "email": getattr(user_record, "email", email),
+                                        "is_admin": bool(getattr(user_record, "is_admin", False)),
+                                        "is_active": bool(getattr(user_record, "is_active", True)),
+                                    }
+                                    if user_record is not None
+                                    else None
+                                ),
+                                personal_team_id=None,
+                                is_token_revoked=False,
+                            ),
+                        )
+                    except Exception as cache_set_error:
+                        logger.debug("Failed to cache stateful-session auth context for %s: %s", email, cache_set_error)
     if email == platform_admin_email:
         db_user_is_admin = True
 

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2348,8 +2348,15 @@ async def _normalize_jwt_payload(payload: dict[str, Any]) -> dict[str, Any]:
                                 user=(
                                     {
                                         "email": getattr(user_record, "email", email),
+                                        "password_hash": getattr(user_record, "password_hash", ""),
+                                        "full_name": getattr(user_record, "full_name", None),
                                         "is_admin": bool(getattr(user_record, "is_admin", False)),
                                         "is_active": bool(getattr(user_record, "is_active", True)),
+                                        "auth_provider": getattr(user_record, "auth_provider", "local"),
+                                        "password_change_required": bool(getattr(user_record, "password_change_required", False)),
+                                        "email_verified_at": getattr(user_record, "email_verified_at", None),
+                                        "created_at": getattr(user_record, "created_at", None),
+                                        "updated_at": getattr(user_record, "updated_at", None),
                                     }
                                     if user_record is not None
                                     else None

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2189,6 +2189,8 @@ async def _get_request_context_or_default() -> Tuple[str, dict[str, Any], dict[s
                 user_ctx = await _normalize_jwt_payload(raw_payload)
             else:
                 user_ctx = {}
+        except HTTPException:
+            raise
         except Exception as e:
             logger.warning("Failed to recover user context in stateful session: %s", e)
             user_ctx = {}
@@ -2198,6 +2200,8 @@ async def _get_request_context_or_default() -> Tuple[str, dict[str, Any], dict[s
     except LookupError:
         # Not in a request context
         return s_id, request_headers_var.get(), user_context_var.get()
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Error recovering context in stateful session: %s", e)
         return s_id, request_headers_var.get(), user_context_var.get()
@@ -2261,6 +2265,15 @@ async def _normalize_jwt_payload(payload: dict[str, Any]) -> dict[str, Any]:
                         raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Account disabled")
                     if cached_user is None and settings.require_user_in_db and email != platform_admin_email:
                         raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="User not found in database")
+                    if cached_user and settings.require_user_in_db:
+                        # Match the primary auth path: a cached user is not proof
+                        # that the database record still exists in strict mode.
+                        # First-Party
+                        from mcpgateway.auth import _get_user_by_email_sync  # pylint: disable=import-outside-toplevel
+
+                        db_user = await asyncio.to_thread(_get_user_by_email_sync, email)
+                        if db_user is None:
+                            raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="User not found in database")
                     db_user_is_admin = bool(cached_user and cached_user.get("is_admin", False))
                     auth_context_resolved = True
                 elif settings.auth_cache_batch_queries:
@@ -2343,31 +2356,10 @@ async def _normalize_jwt_payload(payload: dict[str, Any]) -> dict[str, Any]:
     # SECURITY: API/legacy team claims must still match current active memberships.
     if token_use != "session" and final_teams and email:
         # First-Party
-        from mcpgateway.cache.auth_cache import get_auth_cache  # pylint: disable=import-outside-toplevel
-        from mcpgateway.db import EmailTeamMember  # pylint: disable=import-outside-toplevel
+        from mcpgateway.auth import validate_token_team_membership  # pylint: disable=import-outside-toplevel
 
-        if auth_cache is None:
-            auth_cache = get_auth_cache()
-        cached_membership = auth_cache.get_team_membership_valid_sync(email, final_teams)
-        if cached_membership is False:
+        if not validate_token_team_membership(email, final_teams):
             raise HTTPException(status_code=HTTP_403_FORBIDDEN, detail="Token invalid: User is no longer a member of the associated team")
-        if cached_membership is None:
-            with SessionLocal() as db:
-                memberships = (
-                    db.execute(
-                        select(EmailTeamMember.team_id).where(
-                            EmailTeamMember.team_id.in_(final_teams),
-                            EmailTeamMember.user_email == email,
-                            EmailTeamMember.is_active.is_(True),
-                        )
-                    )
-                    .scalars()
-                    .all()
-                )
-            if set(final_teams) - set(memberships):
-                auth_cache.set_team_membership_valid_sync(email, final_teams, False)
-                raise HTTPException(status_code=HTTP_403_FORBIDDEN, detail="Token invalid: User is no longer a member of the associated team")
-            auth_cache.set_team_membership_valid_sync(email, final_teams, True)
 
     user_ctx: dict[str, Any] = {
         "email": email,
@@ -5397,48 +5389,17 @@ class _StreamableHttpAuthHandler:
             # are skipped: resolve_session_teams() already resolved teams from
             # DB/cache, so a second membership query would be redundant.
             if token_use != "session" and final_teams and len(final_teams) > 0 and user_email:  # nosec B105
-                # Import lazily to avoid circular imports
                 # First-Party
-                from mcpgateway.cache.auth_cache import get_auth_cache  # pylint: disable=import-outside-toplevel
-                from mcpgateway.db import EmailTeamMember  # pylint: disable=import-outside-toplevel
+                from mcpgateway.auth import validate_token_team_membership  # pylint: disable=import-outside-toplevel
 
-                auth_cache = get_auth_cache()
-
-                # Check cache first (60s TTL)
-                cached_result = auth_cache.get_team_membership_valid_sync(user_email, final_teams)
-                if cached_result is False:
-                    _record_mcp_auth_cache_event("team_membership_cache_reject")
-                    logger.warning("MCP auth rejected: User %s no longer member of teams (cached)", user_email)
+                valid_membership = validate_token_team_membership(
+                    user_email,
+                    final_teams,
+                    on_cache_event=lambda outcome: _record_mcp_auth_cache_event(f"team_membership_cache_{outcome}"),
+                )
+                if not valid_membership:
+                    logger.warning("MCP auth rejected: User %s no longer member of teams", user_email)
                     return await self._send_error(detail="Token invalid: User is no longer a member of the associated team", status_code=HTTP_403_FORBIDDEN)
-
-                if cached_result is None:
-                    _record_mcp_auth_cache_event("team_membership_cache_miss")
-                    # Cache miss - query database
-                    with SessionLocal() as db:
-                        memberships = (
-                            db.execute(
-                                select(EmailTeamMember.team_id).where(
-                                    EmailTeamMember.team_id.in_(final_teams),
-                                    EmailTeamMember.user_email == user_email,
-                                    EmailTeamMember.is_active.is_(True),
-                                )
-                            )
-                            .scalars()
-                            .all()
-                        )
-
-                        valid_team_ids = set(memberships)
-                        missing_teams = set(final_teams) - valid_team_ids
-
-                        if missing_teams:
-                            logger.warning("MCP auth rejected: User %s no longer member of teams: %s", user_email, missing_teams)
-                            auth_cache.set_team_membership_valid_sync(user_email, final_teams, False)
-                            return await self._send_error(detail="Token invalid: User is no longer a member of the associated team", status_code=HTTP_403_FORBIDDEN)
-
-                        # Cache positive result
-                        auth_cache.set_team_membership_valid_sync(user_email, final_teams, True)
-                else:
-                    _record_mcp_auth_cache_event("team_membership_cache_hit")
 
             auth_user_ctx: dict[str, Any] = {
                 "email": user_email,

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2242,11 +2242,54 @@ async def _normalize_jwt_payload(payload: dict[str, Any]) -> dict[str, Any]:
     # stateful-session path, matching the primary _auth_jwt path behavior (issue #4070).
     db_user_is_admin = False
     if email:
-        # First-Party
-        from mcpgateway.utils.admin_check import is_user_admin  # pylint: disable=import-outside-toplevel
+        jti = payload.get("jti")
+        auth_cache = None
+        auth_context_resolved = False
+        platform_admin_email = getattr(settings, "platform_admin_email", "")
 
-        with SessionLocal() as db:
-            db_user_is_admin = is_user_admin(db, email)
+        if email == platform_admin_email:
+            db_user_is_admin = True
+            auth_context_resolved = True
+        elif settings.auth_cache_enabled:
+            try:
+                # First-Party
+                from mcpgateway.cache.auth_cache import CachedAuthContext, get_auth_cache  # pylint: disable=import-outside-toplevel
+
+                auth_cache = get_auth_cache()
+                cached_ctx = await auth_cache.get_auth_context(email, jti)
+                if cached_ctx is not None:
+                    cached_user = cached_ctx.user
+                    db_user_is_admin = bool(cached_user and cached_user.get("is_admin", False))
+                    auth_context_resolved = True
+                elif settings.auth_cache_batch_queries:
+                    # First-Party
+                    from mcpgateway.auth import _get_auth_context_batched_sync  # pylint: disable=import-outside-toplevel
+
+                    batched_ctx = await asyncio.to_thread(_get_auth_context_batched_sync, email, jti)
+                    batched_user = batched_ctx.get("user")
+                    db_user_is_admin = bool(batched_user and batched_user.get("is_admin", False))
+                    auth_context_resolved = True
+                    try:
+                        await auth_cache.set_auth_context(
+                            email,
+                            jti,
+                            CachedAuthContext(
+                                user=batched_user,
+                                personal_team_id=batched_ctx.get("personal_team_id"),
+                                is_token_revoked=bool(batched_ctx.get("is_token_revoked", False)),
+                            ),
+                        )
+                    except Exception as cache_set_error:
+                        logger.debug("Failed to cache stateful-session auth context for %s: %s", email, cache_set_error)
+            except Exception as cache_error:
+                logger.debug("Stateful-session auth cache lookup failed for %s: %s", email, cache_error)
+
+        if not auth_context_resolved:
+            # First-Party
+            from mcpgateway.utils.admin_check import is_user_admin  # pylint: disable=import-outside-toplevel
+
+            with SessionLocal() as db:
+                db_user_is_admin = is_user_admin(db, email)
 
     effective_is_admin = db_user_is_admin or jwt_is_admin
 

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2241,16 +2241,12 @@ async def _normalize_jwt_payload(payload: dict[str, Any]) -> dict[str, Any]:
     # This ensures SSO-provisioned platform_admins get admin bypass on the fallback
     # stateful-session path, matching the primary _auth_jwt path behavior (issue #4070).
     db_user_is_admin = False
+    auth_cache = None
+    auth_context_resolved = False
+    platform_admin_email = getattr(settings, "platform_admin_email", "")
     if email:
         jti = payload.get("jti")
-        auth_cache = None
-        auth_context_resolved = False
-        platform_admin_email = getattr(settings, "platform_admin_email", "")
-
-        if email == platform_admin_email:
-            db_user_is_admin = True
-            auth_context_resolved = True
-        elif settings.auth_cache_enabled:
+        if settings.auth_cache_enabled:
             try:
                 # First-Party
                 from mcpgateway.cache.auth_cache import CachedAuthContext, get_auth_cache  # pylint: disable=import-outside-toplevel
@@ -2258,7 +2254,13 @@ async def _normalize_jwt_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 auth_cache = get_auth_cache()
                 cached_ctx = await auth_cache.get_auth_context(email, jti)
                 if cached_ctx is not None:
+                    if cached_ctx.is_token_revoked:
+                        raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Token has been revoked")
                     cached_user = cached_ctx.user
+                    if cached_user and not cached_user.get("is_active", True):
+                        raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Account disabled")
+                    if cached_user is None and settings.require_user_in_db and email != platform_admin_email:
+                        raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="User not found in database")
                     db_user_is_admin = bool(cached_user and cached_user.get("is_admin", False))
                     auth_context_resolved = True
                 elif settings.auth_cache_batch_queries:
@@ -2266,7 +2268,13 @@ async def _normalize_jwt_payload(payload: dict[str, Any]) -> dict[str, Any]:
                     from mcpgateway.auth import _get_auth_context_batched_sync  # pylint: disable=import-outside-toplevel
 
                     batched_ctx = await asyncio.to_thread(_get_auth_context_batched_sync, email, jti)
+                    if batched_ctx.get("is_token_revoked", False):
+                        raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Token has been revoked")
                     batched_user = batched_ctx.get("user")
+                    if batched_user and not batched_user.get("is_active", True):
+                        raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Account disabled")
+                    if batched_user is None and settings.require_user_in_db and email != platform_admin_email:
+                        raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="User not found in database")
                     db_user_is_admin = bool(batched_user and batched_user.get("is_admin", False))
                     auth_context_resolved = True
                     try:
@@ -2281,15 +2289,40 @@ async def _normalize_jwt_payload(payload: dict[str, Any]) -> dict[str, Any]:
                         )
                     except Exception as cache_set_error:
                         logger.debug("Failed to cache stateful-session auth context for %s: %s", email, cache_set_error)
+            except HTTPException:
+                raise
             except Exception as cache_error:
                 logger.debug("Stateful-session auth cache lookup failed for %s: %s", email, cache_error)
 
         if not auth_context_resolved:
             # First-Party
-            from mcpgateway.utils.admin_check import is_user_admin  # pylint: disable=import-outside-toplevel
+            from mcpgateway.auth import _check_token_revoked_sync, _get_user_by_email_sync  # pylint: disable=import-outside-toplevel
 
-            with SessionLocal() as db:
-                db_user_is_admin = is_user_admin(db, email)
+            if jti and await asyncio.to_thread(_check_token_revoked_sync, jti):
+                raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Token has been revoked")
+
+            try:
+                user_record = await asyncio.to_thread(_get_user_by_email_sync, email)
+            except Exception as user_lookup_error:
+                # Preserve the primary auth path's fail-open behavior when the
+                # user status lookup is unavailable; JWT signature validation
+                # has already succeeded.  Keep the legacy admin helper as a
+                # compatibility fallback for deployments that provide it.
+                logger.warning("Stateful-session user lookup failed for %s: %s", email, user_lookup_error)
+                # First-Party
+                from mcpgateway.utils.admin_check import is_user_admin  # pylint: disable=import-outside-toplevel
+
+                with SessionLocal() as db:
+                    db_user_is_admin = is_user_admin(db, email)
+                user_record = None
+            else:
+                if user_record and not getattr(user_record, "is_active", True):
+                    raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Account disabled")
+                if user_record is None and settings.require_user_in_db and email != platform_admin_email:
+                    raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="User not found in database")
+                db_user_is_admin = bool(user_record and getattr(user_record, "is_admin", False))
+    if email == platform_admin_email:
+        db_user_is_admin = True
 
     effective_is_admin = db_user_is_admin or jwt_is_admin
 
@@ -2306,6 +2339,35 @@ async def _normalize_jwt_payload(payload: dict[str, Any]) -> dict[str, Any]:
         from mcpgateway.auth import normalize_token_teams  # pylint: disable=import-outside-toplevel
 
         final_teams = normalize_token_teams(payload)
+
+    # SECURITY: API/legacy team claims must still match current active memberships.
+    if token_use != "session" and final_teams and email:
+        # First-Party
+        from mcpgateway.cache.auth_cache import get_auth_cache  # pylint: disable=import-outside-toplevel
+        from mcpgateway.db import EmailTeamMember  # pylint: disable=import-outside-toplevel
+
+        if auth_cache is None:
+            auth_cache = get_auth_cache()
+        cached_membership = auth_cache.get_team_membership_valid_sync(email, final_teams)
+        if cached_membership is False:
+            raise HTTPException(status_code=HTTP_403_FORBIDDEN, detail="Token invalid: User is no longer a member of the associated team")
+        if cached_membership is None:
+            with SessionLocal() as db:
+                memberships = (
+                    db.execute(
+                        select(EmailTeamMember.team_id).where(
+                            EmailTeamMember.team_id.in_(final_teams),
+                            EmailTeamMember.user_email == email,
+                            EmailTeamMember.is_active.is_(True),
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+            if set(final_teams) - set(memberships):
+                auth_cache.set_team_membership_valid_sync(email, final_teams, False)
+                raise HTTPException(status_code=HTTP_403_FORBIDDEN, detail="Token invalid: User is no longer a member of the associated team")
+            auth_cache.set_team_membership_valid_sync(email, final_teams, True)
 
     user_ctx: dict[str, Any] = {
         "email": email,

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -1405,29 +1405,27 @@ class TestTokenScopingMiddleware:
 
         # Valid membership case
         db = MagicMock()
+        db.__enter__ = MagicMock(return_value=db)
+        db.__exit__ = MagicMock(return_value=False)
         result_proxy = MagicMock()
         result_proxy.scalars.return_value.all.return_value = ["team-1", "team-2"]
         db.execute.return_value = result_proxy
 
-        def _get_db():
-            yield db
-
-        monkeypatch.setattr("mcpgateway.db.get_db", _get_db)
+        # validate_token_team_membership uses SessionLocal() as a context manager
+        monkeypatch.setattr("mcpgateway.auth.SessionLocal", lambda: db)
         assert middleware._check_team_membership(payload) is True
         cache.set_team_membership_valid_sync.assert_called_with("user@example.com", ["team-1", "team-2"], True)
         db.commit.assert_called_once()
-        db.close.assert_called_once()
 
         # Missing team case
         db = MagicMock()
+        db.__enter__ = MagicMock(return_value=db)
+        db.__exit__ = MagicMock(return_value=False)
         result_proxy = MagicMock()
         result_proxy.scalars.return_value.all.return_value = ["team-1"]
         db.execute.return_value = result_proxy
 
-        def _get_db_missing():
-            yield db
-
-        monkeypatch.setattr("mcpgateway.db.get_db", _get_db_missing)
+        monkeypatch.setattr("mcpgateway.auth.SessionLocal", lambda: db)
         assert middleware._check_team_membership(payload) is False
         cache.set_team_membership_valid_sync.assert_called_with("user@example.com", ["team-1", "team-2"], False)
 

--- a/tests/unit/mcpgateway/test_auth.py
+++ b/tests/unit/mcpgateway/test_auth.py
@@ -7178,3 +7178,60 @@ class TestAuthJwtRoutingReturn:
             result = await handler._auth_jwt(token="unused")
 
         assert result is False
+
+
+class TestUserFromCachedDictFullShape:
+    """Regression: cache entries must preserve all security-sensitive fields.
+
+    A partial user dict (missing auth_provider, password_change_required, etc.)
+    silently gets wrong defaults from _user_from_cached_dict, masking SSO
+    identities and bypassing forced password changes.
+    """
+
+    def test_full_dict_round_trips_all_fields(self):
+        """A full 10-field cache dict produces an EmailUser with every field intact."""
+        # First-Party
+        from mcpgateway.auth import _user_from_cached_dict  # pylint: disable=import-outside-toplevel
+
+        now = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        user_dict = {
+            "email": "sso@corp.com",
+            "password_hash": "hashed",
+            "full_name": "SSO User",
+            "is_admin": False,
+            "is_active": True,
+            "auth_provider": "okta",
+            "password_change_required": True,
+            "email_verified_at": now,
+            "created_at": now,
+            "updated_at": now,
+        }
+
+        user = _user_from_cached_dict(user_dict)
+
+        assert user.auth_provider == "okta", "auth_provider must not default to 'local'"
+        assert user.password_change_required is True, "password_change_required must not default to False"
+        assert user.password_hash == "hashed"
+        assert user.full_name == "SSO User"
+        assert user.email_verified_at == now
+        assert user.created_at == now
+        assert user.updated_at == now
+
+    def test_partial_dict_exposes_wrong_defaults(self):
+        """A 3-field dict (the old bug shape) would produce wrong defaults.
+
+        This test documents the _user_from_cached_dict contract: callers MUST
+        supply all fields.  The fallback defaults exist only for forward
+        compatibility when new fields are added, not to silently paper over
+        missing security-sensitive data.
+        """
+        # First-Party
+        from mcpgateway.auth import _user_from_cached_dict  # pylint: disable=import-outside-toplevel
+
+        partial_dict = {"email": "sso@corp.com", "is_admin": False, "is_active": True}
+        user = _user_from_cached_dict(partial_dict)
+
+        # These are the WRONG values a partial dict produces — documenting the
+        # contract that writers must not rely on these defaults for existing fields.
+        assert user.auth_provider == "local", "default masks real provider"
+        assert user.password_change_required is False, "default skips forced change"

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -18222,3 +18222,158 @@ async def test_normalize_jwt_payload_rejects_stale_api_token_membership(monkeypa
 
     with pytest.raises(HTTPException, match="no longer a member"):
         await tr._normalize_jwt_payload({"sub": "stale@example.com", "jti": "stale-jti", "token_use": "api", "teams": ["team-stale"]})
+
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_rejects_batched_inactive_user(monkeypatch):
+    """Batched inactive users must not become authenticated fallback contexts."""
+    auth_cache = MagicMock()
+    auth_cache.get_auth_context = AsyncMock(return_value=None)
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(tr.settings, "auth_cache_batch_queries", True)
+    monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="batched-disabled@example.com"))
+    monkeypatch.setattr(
+        "mcpgateway.auth._get_auth_context_batched_sync",
+        MagicMock(
+            return_value={
+                "user": {"email": "batched-disabled@example.com", "is_admin": False, "is_active": False},
+                "is_token_revoked": False,
+                "team_ids": [],
+            }
+        ),
+    )
+
+    with pytest.raises(HTTPException, match="Account disabled"):
+        await tr._normalize_jwt_payload({"sub": "batched-disabled@example.com", "jti": "batched-disabled-jti", "token_use": "session"})
+
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_rejects_batched_missing_user_when_required(monkeypatch):
+    """Strict user-in-DB mode must reject a missing batched user."""
+    auth_cache = MagicMock()
+    auth_cache.get_auth_context = AsyncMock(return_value=None)
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(tr.settings, "auth_cache_batch_queries", True)
+    monkeypatch.setattr(tr.settings, "require_user_in_db", True)
+    monkeypatch.setattr(tr.settings, "platform_admin_email", "admin@example.com")
+    monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="batched-missing@example.com"))
+    monkeypatch.setattr(
+        "mcpgateway.auth._get_auth_context_batched_sync",
+        MagicMock(return_value={"user": None, "is_token_revoked": False, "team_ids": []}),
+    )
+
+    with pytest.raises(HTTPException, match="User not found in database"):
+        await tr._normalize_jwt_payload({"sub": "batched-missing@example.com", "jti": "batched-missing-jti", "token_use": "session"})
+
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_continues_when_batch_cache_write_fails(monkeypatch):
+    """A cache-write failure must not reject an otherwise valid JWT."""
+    auth_cache = MagicMock()
+    auth_cache.get_auth_context = AsyncMock(return_value=None)
+    auth_cache.set_auth_context = AsyncMock(side_effect=RuntimeError("cache unavailable"))
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(tr.settings, "auth_cache_batch_queries", True)
+    monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="cache-write@example.com"))
+    monkeypatch.setattr(
+        "mcpgateway.auth._get_auth_context_batched_sync",
+        MagicMock(
+            return_value={
+                "user": {"email": "cache-write@example.com", "is_admin": False, "is_active": True},
+                "is_token_revoked": False,
+                "team_ids": [],
+            }
+        ),
+    )
+
+    result = await tr._normalize_jwt_payload({"sub": "cache-write@example.com", "jti": "cache-write-jti", "token_use": "api", "teams": []})
+
+    assert result["email"] == "cache-write@example.com"
+    assert result["is_authenticated"] is True
+
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_rejects_direct_revoked_token(monkeypatch):
+    """Direct fallback lookup must reject revoked tokens."""
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", False)
+    monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="direct-revoked@example.com"))
+    monkeypatch.setattr("mcpgateway.auth._check_token_revoked_sync", MagicMock(return_value=True))
+
+    with pytest.raises(HTTPException, match="Token has been revoked"):
+        await tr._normalize_jwt_payload({"sub": "direct-revoked@example.com", "jti": "direct-revoked-jti", "token_use": "session"})
+
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_rejects_direct_inactive_user(monkeypatch):
+    """Direct fallback lookup must reject inactive users."""
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", False)
+    monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="direct-disabled@example.com"))
+    monkeypatch.setattr("mcpgateway.auth._check_token_revoked_sync", MagicMock(return_value=False))
+    monkeypatch.setattr("mcpgateway.auth._get_user_by_email_sync", MagicMock(return_value=SimpleNamespace(is_active=False, is_admin=False)))
+
+    with pytest.raises(HTTPException, match="Account disabled"):
+        await tr._normalize_jwt_payload({"sub": "direct-disabled@example.com", "jti": "direct-disabled-jti", "token_use": "session"})
+
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_rejects_direct_missing_user_when_required(monkeypatch):
+    """Strict user-in-DB mode must reject a missing direct user."""
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", False)
+    monkeypatch.setattr(tr.settings, "require_user_in_db", True)
+    monkeypatch.setattr(tr.settings, "platform_admin_email", "admin@example.com")
+    monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="direct-missing@example.com"))
+    monkeypatch.setattr("mcpgateway.auth._check_token_revoked_sync", MagicMock(return_value=False))
+    monkeypatch.setattr("mcpgateway.auth._get_user_by_email_sync", MagicMock(return_value=None))
+
+    with pytest.raises(HTTPException, match="User not found in database"):
+        await tr._normalize_jwt_payload({"sub": "direct-missing@example.com", "jti": "direct-missing-jti", "token_use": "session"})
+
+
+def _mock_membership_session(monkeypatch, memberships):
+    """Patch the direct fallback session with deterministic team rows."""
+    db = MagicMock()
+    db.execute.return_value.scalars.return_value.all.return_value = memberships
+    session = MagicMock()
+    session.__enter__.return_value = db
+    monkeypatch.setattr(tr, "SessionLocal", MagicMock(return_value=session))
+
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_validates_membership_on_cache_miss(monkeypatch):
+    """API team claims must be confirmed by the database on cache miss."""
+    auth_cache = MagicMock()
+    auth_cache.get_team_membership_valid_sync.return_value = None
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", False)
+    monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="member@example.com"))
+    monkeypatch.setattr("mcpgateway.auth._check_token_revoked_sync", MagicMock(return_value=False))
+    monkeypatch.setattr("mcpgateway.auth._get_user_by_email_sync", MagicMock(return_value=SimpleNamespace(is_active=True, is_admin=False)))
+    monkeypatch.setattr("mcpgateway.auth.normalize_token_teams", lambda _payload: ["team-a"])
+    _mock_membership_session(monkeypatch, ["team-a"])
+
+    result = await tr._normalize_jwt_payload({"sub": "member@example.com", "jti": "member-jti", "token_use": "api", "teams": ["team-a"]})
+
+    assert result["teams"] == ["team-a"]
+    auth_cache.set_team_membership_valid_sync.assert_called_once_with("member@example.com", ["team-a"], True)
+
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_rejects_missing_membership_on_cache_miss(monkeypatch):
+    """API team claims must be rejected when the database membership is absent."""
+    auth_cache = MagicMock()
+    auth_cache.get_team_membership_valid_sync.return_value = None
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", False)
+    monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="former-member@example.com"))
+    monkeypatch.setattr("mcpgateway.auth._check_token_revoked_sync", MagicMock(return_value=False))
+    monkeypatch.setattr("mcpgateway.auth._get_user_by_email_sync", MagicMock(return_value=SimpleNamespace(is_active=True, is_admin=False)))
+    monkeypatch.setattr("mcpgateway.auth.normalize_token_teams", lambda _payload: ["team-removed"])
+    _mock_membership_session(monkeypatch, [])
+
+    with pytest.raises(HTTPException, match="no longer a member"):
+        await tr._normalize_jwt_payload({"sub": "former-member@example.com", "jti": "former-member-jti", "token_use": "api", "teams": ["team-removed"]})
+
+    auth_cache.set_team_membership_valid_sync.assert_called_once_with("former-member@example.com", ["team-removed"], False)

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -3084,7 +3084,7 @@ async def test_streamable_http_auth_validates_team_membership_on_cache_miss(monk
 
     with (
         patch("mcpgateway.cache.auth_cache.get_auth_cache", return_value=mock_auth_cache),
-        patch("mcpgateway.transports.streamablehttp_transport.SessionLocal", mock_session_local),
+        patch("mcpgateway.auth.SessionLocal", mock_session_local),
     ):
         result = await streamable_http_auth(scope, None, send)
 
@@ -5419,7 +5419,7 @@ async def test_streamable_http_auth_caches_positive_team_membership(monkeypatch)
 
     with (
         patch("mcpgateway.cache.auth_cache.get_auth_cache", return_value=mock_auth_cache),
-        patch("mcpgateway.transports.streamablehttp_transport.SessionLocal", mock_session_local),
+        patch("mcpgateway.auth.SessionLocal", mock_session_local),
     ):
         result = await streamable_http_auth(scope, None, send)
 
@@ -5472,7 +5472,7 @@ async def test_streamable_http_auth_db_context_manager(monkeypatch):
 
     with (
         patch("mcpgateway.cache.auth_cache.get_auth_cache", return_value=mock_auth_cache),
-        patch("mcpgateway.transports.streamablehttp_transport.SessionLocal", mock_session_local),
+        patch("mcpgateway.auth.SessionLocal", mock_session_local),
     ):
         result = await streamable_http_auth(scope, None, send)
 
@@ -13297,6 +13297,7 @@ async def test_normalize_jwt_payload_uses_cached_admin_status(monkeypatch):
     )
     monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
     monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(tr.settings, "require_user_in_db", False)
     session_factory = MagicMock()
     monkeypatch.setattr(tr, "SessionLocal", session_factory)
     monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="cached@example.com"))
@@ -13357,6 +13358,7 @@ async def test_normalize_jwt_payload_warms_cache_after_batched_miss(monkeypatch)
     monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
     monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
     monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="batched@example.com"))
+    monkeypatch.setattr(tr.settings, "require_user_in_db", False)
     batch_lookup = MagicMock(
         return_value={
             "user": {"email": "batched@example.com", "is_admin": True, "is_active": True},
@@ -18217,6 +18219,7 @@ async def test_normalize_jwt_payload_rejects_stale_api_token_membership(monkeypa
     auth_cache.get_team_membership_valid_sync.return_value = False
     monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
     monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(tr.settings, "require_user_in_db", False)
     monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="stale@example.com"))
     monkeypatch.setattr("mcpgateway.auth.normalize_token_teams", lambda _payload: ["team-stale"])
 
@@ -18333,12 +18336,18 @@ async def test_normalize_jwt_payload_rejects_direct_missing_user_when_required(m
 
 
 def _mock_membership_session(monkeypatch, memberships):
-    """Patch the direct fallback session with deterministic team rows."""
+    """Patch membership sessions with deterministic team rows."""
     db = MagicMock()
     db.execute.return_value.scalars.return_value.all.return_value = memberships
     session = MagicMock()
     session.__enter__.return_value = db
-    monkeypatch.setattr(tr, "SessionLocal", MagicMock(return_value=session))
+    session.__exit__.return_value = False
+
+    def _get_db():
+        yield db
+
+    monkeypatch.setattr("mcpgateway.auth.SessionLocal", MagicMock(return_value=session))
+    monkeypatch.setattr("mcpgateway.db.get_db", _get_db)
 
 
 @pytest.mark.asyncio
@@ -18377,3 +18386,69 @@ async def test_normalize_jwt_payload_rejects_missing_membership_on_cache_miss(mo
         await tr._normalize_jwt_payload({"sub": "former-member@example.com", "jti": "former-member-jti", "token_use": "api", "teams": ["team-removed"]})
 
     auth_cache.set_team_membership_valid_sync.assert_called_once_with("former-member@example.com", ["team-removed"], False)
+
+@pytest.mark.asyncio
+async def test_get_request_context_propagates_normalization_http_exception(monkeypatch):
+    """Authentication failures from fallback normalization must reach the caller."""
+    from unittest.mock import PropertyMock
+
+    token = tr.server_id_var.set("default_server_id")
+    mock_request = MagicMock()
+    mock_request.url.path = "/mcp"
+    mock_request.headers = {"authorization": "Bearer token"}
+    mock_request.cookies = {}
+    mock_ctx = MagicMock()
+    mock_ctx.request = mock_request
+
+    monkeypatch.setattr(tr, "require_auth_header_first", AsyncMock(return_value={"sub": "revoked@example.com"}))
+    monkeypatch.setattr(
+        tr,
+        "_normalize_jwt_payload",
+        AsyncMock(side_effect=HTTPException(status_code=tr.HTTP_401_UNAUTHORIZED, detail="Token has been revoked")),
+    )
+
+    try:
+        with patch.object(type(tr.mcp_app), "request_context", new_callable=PropertyMock, return_value=mock_ctx):
+            with pytest.raises(HTTPException, match="Token has been revoked"):
+                await tr._get_request_context_or_default()
+    finally:
+        tr.server_id_var.reset(token)
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_rechecks_cached_user_in_strict_mode(monkeypatch):
+    """Strict user-in-DB mode must reject a deleted user still present in cache."""
+    from mcpgateway.cache.auth_cache import CachedAuthContext
+
+    auth_cache = MagicMock()
+    auth_cache.get_auth_context = AsyncMock(
+        return_value=CachedAuthContext(
+            user={"email": "deleted@example.com", "is_admin": False, "is_active": True},
+            is_token_revoked=False,
+        )
+    )
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(tr.settings, "auth_cache_batch_queries", False)
+    monkeypatch.setattr(tr.settings, "require_user_in_db", True)
+    monkeypatch.setattr(tr.settings, "platform_admin_email", "admin@example.com")
+    monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="deleted@example.com"))
+    monkeypatch.setattr("mcpgateway.auth.resolve_session_teams", AsyncMock(return_value=[]))
+    db_lookup = MagicMock(return_value=None)
+    monkeypatch.setattr("mcpgateway.auth._get_user_by_email_sync", db_lookup)
+
+    with pytest.raises(HTTPException, match="User not found in database"):
+        await tr._normalize_jwt_payload({"sub": "deleted@example.com", "jti": "deleted-jti", "token_use": "session"})
+
+    db_lookup.assert_called_once_with("deleted@example.com")
+
+def test_validate_token_team_membership_checks_cache_and_database(monkeypatch):
+    """The shared membership helper validates all claimed teams and caches the result."""
+    from mcpgateway.auth import validate_token_team_membership
+
+    auth_cache = MagicMock()
+    auth_cache.get_team_membership_valid_sync.return_value = None
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    _mock_membership_session(monkeypatch, ["team-a"])
+
+    assert validate_token_team_membership("member@example.com", ["team-a"]) is True
+    auth_cache.set_team_membership_valid_sync.assert_called_once_with("member@example.com", ["team-a"], True)

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -12937,6 +12937,10 @@ async def test_get_request_context_fast_path_no_session_id_falls_through(monkeyp
 
     mock_auth = AsyncMock(return_value={"email": "fallback@test.com", "teams": ["t2"], "is_authenticated": True})
     monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.require_auth_header_first", mock_auth)
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._normalize_jwt_payload",
+        AsyncMock(return_value={"email": "fallback@test.com", "teams": ["t2"], "is_authenticated": True}),
+    )
 
     try:
         with patch.object(type(mcp_app), "request_context", new_callable=PropertyMock, return_value=mock_ctx):
@@ -13192,6 +13196,12 @@ async def test_normalize_jwt_payload_api_token(monkeypatch):
     """API token (no token_use or token_use != 'session') uses normalize_token_teams."""
     # First-Party
     from mcpgateway.transports.streamablehttp_transport import _normalize_jwt_payload
+    auth_cache = MagicMock()
+    auth_cache.get_auth_context = AsyncMock(return_value=None)
+    auth_cache.get_team_membership_valid_sync.return_value = True
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(tr.settings, "auth_cache_batch_queries", False)
 
     monkeypatch.setattr("mcpgateway.auth.normalize_token_teams", lambda payload: ["team-a"])
 
@@ -15716,6 +15726,12 @@ async def test_normalize_jwt_payload_with_scoped_permissions(monkeypatch):
     """API token with scopes.permissions should include scoped_permissions in context."""
     # First-Party
     from mcpgateway.transports.streamablehttp_transport import _normalize_jwt_payload
+    auth_cache = MagicMock()
+    auth_cache.get_auth_context = AsyncMock(return_value=None)
+    auth_cache.get_team_membership_valid_sync.return_value = True
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(tr.settings, "auth_cache_batch_queries", False)
 
     monkeypatch.setattr("mcpgateway.auth.normalize_token_teams", lambda payload: ["team-a"])
 
@@ -18100,3 +18116,109 @@ async def test_list_tools_sso_admin_gets_admin_bypass_at_service_layer(monkeypat
     await list_tools()
 
     assert called["args"] == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_rejects_cached_revoked_token(monkeypatch):
+    """Cached revoked tokens must not become authenticated fallback contexts."""
+    from mcpgateway.cache.auth_cache import CachedAuthContext
+
+    auth_cache = MagicMock()
+    auth_cache.get_auth_context = AsyncMock(
+        return_value=CachedAuthContext(
+            user={"email": "revoked@example.com", "is_admin": False, "is_active": True},
+            is_token_revoked=True,
+        )
+    )
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(tr.settings, "auth_cache_batch_queries", False)
+    monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="revoked@example.com"))
+
+    with pytest.raises(HTTPException, match="Token has been revoked"):
+        await tr._normalize_jwt_payload({"sub": "revoked@example.com", "jti": "revoked-jti", "token_use": "session"})
+
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_rejects_cached_inactive_user(monkeypatch):
+    """Cached inactive users must not become authenticated fallback contexts."""
+    from mcpgateway.cache.auth_cache import CachedAuthContext
+
+    auth_cache = MagicMock()
+    auth_cache.get_auth_context = AsyncMock(
+        return_value=CachedAuthContext(
+            user={"email": "disabled@example.com", "is_admin": False, "is_active": False},
+            is_token_revoked=False,
+        )
+    )
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(tr.settings, "auth_cache_batch_queries", False)
+    monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="disabled@example.com"))
+
+    with pytest.raises(HTTPException, match="Account disabled"):
+        await tr._normalize_jwt_payload({"sub": "disabled@example.com", "jti": "disabled-jti", "token_use": "session"})
+
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_rejects_cached_missing_user_when_required(monkeypatch):
+    """Strict user-in-DB mode must reject a cache hit without a user record."""
+    from mcpgateway.cache.auth_cache import CachedAuthContext
+
+    auth_cache = MagicMock()
+    auth_cache.get_auth_context = AsyncMock(return_value=CachedAuthContext(user=None, is_token_revoked=False))
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(tr.settings, "auth_cache_batch_queries", False)
+    monkeypatch.setattr(tr.settings, "require_user_in_db", True)
+    monkeypatch.setattr(tr.settings, "platform_admin_email", "admin@example.com")
+    monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="missing@example.com"))
+
+    with pytest.raises(HTTPException, match="User not found in database"):
+        await tr._normalize_jwt_payload({"sub": "missing@example.com", "jti": "missing-jti", "token_use": "session"})
+
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_rejects_batched_revoked_token(monkeypatch):
+    """Batched revoked tokens must not become authenticated fallback contexts."""
+    auth_cache = MagicMock()
+    auth_cache.get_auth_context = AsyncMock(return_value=None)
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(tr.settings, "auth_cache_batch_queries", True)
+    monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="batched-revoked@example.com"))
+    monkeypatch.setattr(
+        "mcpgateway.auth._get_auth_context_batched_sync",
+        MagicMock(
+            return_value={
+                "user": {"email": "batched-revoked@example.com", "is_admin": False, "is_active": True},
+                "is_token_revoked": True,
+                "team_ids": [],
+            }
+        ),
+    )
+
+    with pytest.raises(HTTPException, match="Token has been revoked"):
+        await tr._normalize_jwt_payload({"sub": "batched-revoked@example.com", "jti": "batched-jti", "token_use": "session"})
+
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_rejects_stale_api_token_membership(monkeypatch):
+    """API and legacy team claims must be validated against current membership."""
+    from mcpgateway.cache.auth_cache import CachedAuthContext
+
+    auth_cache = MagicMock()
+    auth_cache.get_auth_context = AsyncMock(
+        return_value=CachedAuthContext(
+            user={"email": "stale@example.com", "is_admin": False, "is_active": True},
+            is_token_revoked=False,
+        )
+    )
+    auth_cache.get_team_membership_valid_sync.return_value = False
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="stale@example.com"))
+    monkeypatch.setattr("mcpgateway.auth.normalize_token_teams", lambda _payload: ["team-stale"])
+
+    with pytest.raises(HTTPException, match="no longer a member"):
+        await tr._normalize_jwt_payload({"sub": "stale@example.com", "jti": "stale-jti", "token_use": "api", "teams": ["team-stale"]})

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -13277,6 +13277,98 @@ async def test_normalize_jwt_payload_session_admin_no_email_no_bypass():
     assert result["is_admin"] is True
 
 
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_uses_cached_admin_status(monkeypatch):
+    from mcpgateway.cache.auth_cache import CachedAuthContext
+
+    auth_cache = MagicMock()
+    auth_cache.get_auth_context = AsyncMock(
+        return_value=CachedAuthContext(user={"email": "cached@example.com", "is_admin": True})
+    )
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    session_factory = MagicMock()
+    monkeypatch.setattr(tr, "SessionLocal", session_factory)
+    monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="cached@example.com"))
+
+    with patch("mcpgateway.auth.resolve_session_teams", new_callable=AsyncMock, return_value=None):
+        result = await tr._normalize_jwt_payload({"sub": "cached@example.com", "token_use": "session", "jti": "jti-1"})
+
+    assert result["is_admin"] is True
+    session_factory.assert_not_called()
+    auth_cache.get_auth_context.assert_awaited_once_with("cached@example.com", "jti-1")
+
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_preserves_platform_admin_fast_path(monkeypatch):
+    auth_cache = MagicMock()
+    auth_cache.get_auth_context = AsyncMock(return_value=None)
+    auth_cache.set_auth_context = AsyncMock()
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(tr.settings, "auth_cache_batch_queries", True)
+    monkeypatch.setattr(tr.settings, "platform_admin_email", "platform@example.com")
+    monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="platform@example.com"))
+    monkeypatch.setattr(
+        "mcpgateway.auth._get_auth_context_batched_sync",
+        MagicMock(
+            return_value={
+                "user": None,
+                "personal_team_id": None,
+                "is_token_revoked": False,
+            }
+        ),
+    )
+    session_factory = MagicMock()
+    monkeypatch.setattr(tr, "SessionLocal", session_factory)
+
+    with patch("mcpgateway.auth.resolve_session_teams", new_callable=AsyncMock, return_value=None):
+        result = await tr._normalize_jwt_payload({"sub": "platform@example.com", "token_use": "session", "jti": "jti-3"})
+
+    assert result["is_admin"] is True
+    session_factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_warms_cache_after_batched_miss(monkeypatch):
+    from mcpgateway.cache.auth_cache import CachedAuthContext
+
+    cached = {}
+    auth_cache = MagicMock()
+
+    async def get_auth_context(email, jti):
+        return cached.get((email, jti))
+
+    async def set_auth_context(email, jti, context):
+        cached[(email, jti)] = context
+
+    auth_cache.get_auth_context = AsyncMock(side_effect=get_auth_context)
+    auth_cache.set_auth_context = AsyncMock(side_effect=set_auth_context)
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(tr, "_resolve_jwt_user_email_for_streamable", AsyncMock(return_value="batched@example.com"))
+    batch_lookup = MagicMock(
+        return_value={
+            "user": {"email": "batched@example.com", "is_admin": True, "is_active": True},
+            "personal_team_id": None,
+            "is_token_revoked": False,
+            "team_ids": [],
+            "team_names": {},
+        }
+    )
+    monkeypatch.setattr("mcpgateway.auth._get_auth_context_batched_sync", batch_lookup)
+
+    with patch("mcpgateway.auth.resolve_session_teams", new_callable=AsyncMock, return_value=None):
+        first = await tr._normalize_jwt_payload({"sub": "batched@example.com", "token_use": "session", "jti": "jti-2"})
+        second = await tr._normalize_jwt_payload({"sub": "batched@example.com", "token_use": "session", "jti": "jti-2"})
+
+    assert first["is_admin"] is True
+    assert second["is_admin"] is True
+    batch_lookup.assert_called_once_with("batched@example.com", "jti-2")
+    auth_cache.set_auth_context.assert_awaited_once()
+    assert isinstance(cached[("batched@example.com", "jti-2")], CachedAuthContext)
+
+
 # ---------------------------------------------------------------------------
 # _resolve_jwt_user_email_for_streamable tests (issue #5215)
 #


### PR DESCRIPTION
Fixes #4988

## Problem

The StreamableHTTP stateful-session fallback called `_normalize_jwt_payload()` for requests without propagated context. Each call opened a new `SessionLocal()` for `is_user_admin()`, defeating the session-scoped memoization and adding a synchronous database lookup to the request path.

## Fix

- Check the existing `AuthCache` before opening a database session.
- Warm the cache on misses through the existing batched auth-context lookup.
- Preserve the platform-admin fast path and direct DB fallback when caching is unavailable.
- Enforce token revocation, active-user, strict user-in-DB, and API/legacy team-membership checks in the fallback.
- Keep JWT team normalization and session-token policy unchanged.