### PR TITLE
fix(dataplane): publish explicit virtual-host routes

### DIFF
--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -58,38 +58,38 @@ def get_publisher_ttl(publisher_interval: int | None = None) -> int:
     return publisher_interval * 2 + 10
 
 
-class BackendConfig(TypedDict):
-    """Backend gateway configuration for dataplane routing."""
-
-    name: str
-    url: str
-    passthrough_headers: list[str]
-    add_headers: dict[str, str]
-    remove_headers: list[str]
-    capabilities: dict[str, Any]
-    allowed_tool_names: list[str]
-    tool_name_aliases: dict[str, str]
-    tool_schemas: dict[str, dict[str, Any]]
-    allowed_resource_names: list[str]
-    allowed_resource_uris: list[str]
-    allowed_prompt_names: list[str]
-
-
 class GatewayBaseConfig(TypedDict):
     """Gateway connection fields shared by every virtual-host backend."""
 
     name: str
     url: str
+    mcp_protocol_version: str
     passthrough_headers: list[str]
     add_headers: dict[str, str]
     remove_headers: list[str]
-    capabilities: dict[str, Any]
+
+
+class BackendConfig(GatewayBaseConfig):
+    """Backend connection configuration with schemas keyed by upstream name."""
+
+    tool_schemas: dict[str, dict[str, Any]]
+
+
+class ServiceRoute(TypedDict):
+    """An exact upstream identifier and the backend that serves it."""
+
+    backend_name: str
+    upstream_name: str
 
 
 class VirtualHostConfig(TypedDict):
     """Virtual host configuration mapping backend IDs to their configs."""
 
     backends: dict[str, BackendConfig]
+    tools: dict[str, ServiceRoute]
+    resources: dict[str, ServiceRoute]
+    resource_templates: dict[str, ServiceRoute]
+    prompts: dict[str, ServiceRoute]
 
 
 class UserConfig(TypedDict):
@@ -106,19 +106,20 @@ class BackendItems(TypedDict):
     prompts: list[str]
 
 
-class PublishedBackendItems(BackendItems):
-    """User-filtered backend items enriched with tool routing metadata."""
-
-    tool_name_aliases: dict[str, str]
-    tool_schemas: dict[str, dict[str, Any]]
-
-
 class ToolMetadata(TypedDict):
     """Tool fields needed to publish dataplane routing configuration."""
 
     exposed_name: str
     upstream_name: str
     input_schema: dict[str, Any]
+
+
+class PublishedBackendItems(TypedDict):
+    """Visible tools and associated resource/prompt IDs for one backend."""
+
+    tools: list[ToolMetadata]
+    resources: list[str]
+    prompts: list[str]
 
 
 BackendItemsByServer = dict[str, dict[str, BackendItems]]
@@ -259,22 +260,19 @@ class DataplanePublisherService:
             gateways = user_data["gateways"]
             prompts = user_data["prompts"]
             resources = user_data["resources"]
-            resource_names_by_id = {resource["id"]: resource["name"] for resource in resources}
-            resource_uris_by_id = {resource["id"]: resource["uri"] for resource in resources if resource.get("uri")}
+            resource_map = {resource["id"]: resource for resource in resources if resource.get("uri")}
+            prompt_map = {prompt["id"]: prompt for prompt in prompts}
 
-            prompt_map = {prompt["id"]: prompt["name"] for prompt in prompts}
-
-            # The dataplane proxies streamable-HTTP upstreams only. Exclude
-            # every other transport before building its transport-agnostic
-            # backend config.
+            # Use the configured MCP version as the client's preferred version;
+            # the dataplane negotiates with each upstream when connecting.
             gateway_base: dict[str, GatewayBaseConfig] = {
                 gateway["id"]: {
                     "name": gateway["name"],
                     "url": gateway["url"],
+                    "mcp_protocol_version": settings.protocol_version,
                     "passthrough_headers": gateway["passthrough_headers"] or [],
                     "add_headers": gateway.get("add_headers") or {},
                     "remove_headers": gateway.get("remove_headers") or [],
-                    "capabilities": gateway.get("capabilities") or {},
                 }
                 for gateway in gateways
                 if (gateway["transport"] or "").upper() == "STREAMABLEHTTP"
@@ -284,45 +282,62 @@ class DataplanePublisherService:
 
             for server in servers:
                 backends: dict[str, BackendConfig] = {}
+                tool_routes: list[tuple[str, ServiceRoute]] = []
+                resource_routes: list[tuple[str, ServiceRoute]] = []
+                prompt_routes: list[tuple[str, ServiceRoute]] = []
 
                 for gateway_id, backend_items in server["backend_items"].items():
                     gateway_config = gateway_base.get(gateway_id)
                     if gateway_config is None:
                         continue
 
-                    allowed_resource_names = [resource_names_by_id[resource_id] for resource_id in backend_items["resources"] if resource_id in resource_names_by_id]
-                    allowed_resource_uris = [resource_uris_by_id[resource_id] for resource_id in backend_items["resources"] if resource_id in resource_uris_by_id]
-                    allowed_prompt_names = [prompt_map[prompt_id] for prompt_id in backend_items["prompts"] if prompt_id in prompt_map]
-                    if not backend_items["tools"] and not allowed_resource_names and not allowed_prompt_names:
+                    visible_resources = [resource_map[resource_id] for resource_id in backend_items["resources"] if resource_id in resource_map]
+                    visible_prompts = [prompt_map[prompt_id] for prompt_id in backend_items["prompts"] if prompt_id in prompt_map]
+                    if not backend_items["tools"] and not visible_resources and not visible_prompts:
                         continue
 
                     backends[gateway_id] = {
-                        "name": gateway_config["name"],
-                        "url": gateway_config["url"],
-                        "passthrough_headers": gateway_config["passthrough_headers"],
-                        "add_headers": gateway_config["add_headers"],
-                        "remove_headers": gateway_config["remove_headers"],
-                        "capabilities": gateway_config["capabilities"],
-                        "allowed_tool_names": backend_items["tools"],
-                        "tool_name_aliases": backend_items.get("tool_name_aliases", {}),
-                        "tool_schemas": backend_items["tool_schemas"],
-                        "allowed_resource_names": allowed_resource_names,
-                        "allowed_resource_uris": allowed_resource_uris,
-                        "allowed_prompt_names": allowed_prompt_names,
+                        **gateway_config,
+                        "tool_schemas": {tool["upstream_name"]: tool["input_schema"] for tool in backend_items["tools"]},
                     }
+                    tool_routes.extend((tool["exposed_name"], {"backend_name": gateway_id, "upstream_name": tool["upstream_name"]}) for tool in backend_items["tools"])
+                    resource_routes.extend((resource["uri"], {"backend_name": gateway_id, "upstream_name": resource["uri"]}) for resource in visible_resources)
+                    prompt_routes.extend((prompt["name"], {"backend_name": gateway_id, "upstream_name": prompt["original_name"]}) for prompt in visible_prompts)
 
                 if not backends:
-                    # No publishable backends: leave the virtual host out so
-                    # the dataplane returns 404 for it and deployments can
-                    # route the request back to the control plane, instead of
-                    # serving an empty tool list that looks like success.
                     continue
 
-                virtual_hosts[server["id"]] = {"backends": backends}
+                tools = self._build_routes(tool_routes, server["id"], "tool")
+                resources_by_uri = self._build_routes(resource_routes, server["id"], "resource")
+                prompts_by_name = self._build_routes(prompt_routes, server["id"], "prompt")
+                if tools is None or resources_by_uri is None or prompts_by_name is None:
+                    # Preserve control-plane naming/visibility-priority resolution.
+                    # Omitting the host makes the dataplane return 404 so callers
+                    # can fall back to the control plane instead of misrouting.
+                    continue
+
+                virtual_hosts[server["id"]] = {
+                    "backends": backends,
+                    "tools": tools,
+                    "resources": resources_by_uri,
+                    "resource_templates": {},
+                    "prompts": prompts_by_name,
+                }
 
             result[subject_key] = {"virtual_hosts": virtual_hosts}
 
         return result
+
+    @staticmethod
+    def _build_routes(candidates: list[tuple[str, ServiceRoute]], server_id: str, kind: str) -> dict[str, ServiceRoute] | None:
+        """Build a route map, rejecting names that resolve to different targets."""
+        routes: dict[str, ServiceRoute] = {}
+        for name, route in candidates:
+            if name in routes and routes[name] != route:
+                logger.warning("Excluding server %s from the dataplane snapshot because %s route %s is ambiguous", server_id, kind, name)
+                return None
+            routes[name] = route
+        return routes
 
     async def get_data_from_db(self) -> dict[str, Any] | None:
         """Fetch active users and dataplane data with bulk minimal-column queries."""
@@ -356,13 +371,14 @@ class DataplanePublisherService:
                         DbGateway.passthrough_headers,
                         DbGateway.add_headers,
                         DbGateway.remove_headers,
-                        DbGateway.capabilities,
                         DbGateway.owner_email,
                         DbGateway.team_id,
                         DbGateway.visibility,
                     ).where(DbGateway.enabled.is_(True))
                 ).all()
-                prompt_rows = db.execute(select(DbPrompt.id, DbPrompt.name, DbPrompt.owner_email, DbPrompt.team_id, DbPrompt.visibility).where(DbPrompt.enabled.is_(True))).all()
+                prompt_rows = db.execute(
+                    select(DbPrompt.id, DbPrompt.name, DbPrompt.original_name, DbPrompt.owner_email, DbPrompt.team_id, DbPrompt.visibility).where(DbPrompt.enabled.is_(True))
+                ).all()
                 resource_rows = db.execute(
                     select(DbResource.id, DbResource.name, DbResource.uri, DbResource.owner_email, DbResource.team_id, DbResource.visibility).where(
                         DbResource.enabled.is_(True),
@@ -437,12 +453,13 @@ class DataplanePublisherService:
                     "passthrough_headers": gateway.passthrough_headers,
                     "add_headers": gateway.add_headers or {},
                     "remove_headers": gateway.remove_headers or [],
-                    "capabilities": gateway.capabilities or {},
                 }
                 for gateway in gateway_rows
                 if self._filter_for_user(gateway, user_email, team_ids, is_admin=is_admin)
             ],
-            "prompts": [{"id": prompt.id, "name": prompt.name} for prompt in prompt_rows if self._filter_for_user(prompt, user_email, team_ids, is_admin=is_admin)],
+            "prompts": [
+                {"id": prompt.id, "name": prompt.name, "original_name": prompt.original_name} for prompt in prompt_rows if self._filter_for_user(prompt, user_email, team_ids, is_admin=is_admin)
+            ],
             "resources": [{"id": resource.id, "name": resource.name, "uri": resource.uri} for resource in resource_rows if self._filter_for_user(resource, user_email, team_ids, is_admin=is_admin)],
         }
 
@@ -460,12 +477,10 @@ class DataplanePublisherService:
 
     @staticmethod
     def _filter_backend_items_for_user(backend_items_by_gateway: dict[str, BackendItems], tool_by_id: dict[str, ToolMetadata]) -> dict[str, PublishedBackendItems]:
-        """Filter backend tool IDs and publish client-to-upstream name mappings."""
+        """Filter backend tool IDs without collapsing tools with identical exposed names."""
         return {
             gateway_id: {
-                "tools": [tool_by_id[tool_id]["upstream_name"] for tool_id in backend_items["tools"] if tool_id in tool_by_id],
-                "tool_name_aliases": {tool_by_id[tool_id]["exposed_name"]: tool_by_id[tool_id]["upstream_name"] for tool_id in backend_items["tools"] if tool_id in tool_by_id},
-                "tool_schemas": {tool_by_id[tool_id]["upstream_name"]: tool_by_id[tool_id]["input_schema"] for tool_id in backend_items["tools"] if tool_id in tool_by_id},
+                "tools": [tool_by_id[tool_id] for tool_id in backend_items["tools"] if tool_id in tool_by_id],
                 "resources": list(backend_items["resources"]),
                 "prompts": list(backend_items["prompts"]),
             }

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -68,6 +68,7 @@ class BackendConfig(TypedDict):
     remove_headers: list[str]
     capabilities: dict[str, Any]
     allowed_tool_names: list[str]
+    tool_name_aliases: dict[str, str]
     tool_schemas: dict[str, dict[str, Any]]
     allowed_resource_names: list[str]
     allowed_resource_uris: list[str]
@@ -106,15 +107,17 @@ class BackendItems(TypedDict):
 
 
 class PublishedBackendItems(BackendItems):
-    """User-filtered backend items enriched with tool input schemas."""
+    """User-filtered backend items enriched with tool routing metadata."""
 
+    tool_name_aliases: dict[str, str]
     tool_schemas: dict[str, dict[str, Any]]
 
 
 class ToolMetadata(TypedDict):
     """Tool fields needed to publish dataplane routing configuration."""
 
-    name: str
+    exposed_name: str
+    upstream_name: str
     input_schema: dict[str, Any]
 
 
@@ -301,6 +304,7 @@ class DataplanePublisherService:
                         "remove_headers": gateway_config["remove_headers"],
                         "capabilities": gateway_config["capabilities"],
                         "allowed_tool_names": backend_items["tools"],
+                        "tool_name_aliases": backend_items.get("tool_name_aliases", {}),
                         "tool_schemas": backend_items["tool_schemas"],
                         "allowed_resource_names": allowed_resource_names,
                         "allowed_resource_uris": allowed_resource_uris,
@@ -365,7 +369,9 @@ class DataplanePublisherService:
                         DbResource.uri_template.is_(None),
                     )
                 ).all()
-                tool_rows = db.execute(select(DbTool.id, DbTool.original_name, DbTool.input_schema, DbTool.owner_email, DbTool.team_id, DbTool.visibility).where(DbTool.enabled.is_(True))).all()
+                tool_rows = db.execute(
+                    select(DbTool.id, DbTool.__table__.c.name, DbTool.original_name, DbTool.input_schema, DbTool.owner_email, DbTool.team_id, DbTool.visibility).where(DbTool.enabled.is_(True))
+                ).all()
                 backend_items_by_server = self._get_backend_items_by_server(db)
 
                 return {
@@ -408,7 +414,8 @@ class DataplanePublisherService:
                 logger.warning("Excluding tool %s from the dataplane snapshot because its input schema is not an object", tool.id)
                 continue
             tool_by_id[tool.id] = {
-                "name": tool.original_name,
+                "exposed_name": tool.name,
+                "upstream_name": tool.original_name,
                 "input_schema": tool.input_schema,
             }
 
@@ -453,11 +460,12 @@ class DataplanePublisherService:
 
     @staticmethod
     def _filter_backend_items_for_user(backend_items_by_gateway: dict[str, BackendItems], tool_by_id: dict[str, ToolMetadata]) -> dict[str, PublishedBackendItems]:
-        """Filter backend tool IDs for one user and publish visible names with schemas."""
+        """Filter backend tool IDs and publish client-to-upstream name mappings."""
         return {
             gateway_id: {
-                "tools": [tool_by_id[tool_id]["name"] for tool_id in backend_items["tools"] if tool_id in tool_by_id],
-                "tool_schemas": {tool_by_id[tool_id]["name"]: tool_by_id[tool_id]["input_schema"] for tool_id in backend_items["tools"] if tool_id in tool_by_id},
+                "tools": [tool_by_id[tool_id]["upstream_name"] for tool_id in backend_items["tools"] if tool_id in tool_by_id],
+                "tool_name_aliases": {tool_by_id[tool_id]["exposed_name"]: tool_by_id[tool_id]["upstream_name"] for tool_id in backend_items["tools"] if tool_id in tool_by_id},
+                "tool_schemas": {tool_by_id[tool_id]["upstream_name"]: tool_by_id[tool_id]["input_schema"] for tool_id in backend_items["tools"] if tool_id in tool_by_id},
                 "resources": list(backend_items["resources"]),
                 "prompts": list(backend_items["prompts"]),
             }

--- a/tests/live_gateway/mcp/test_dataplane_publisher_e2e.py
+++ b/tests/live_gateway/mcp/test_dataplane_publisher_e2e.py
@@ -1,0 +1,243 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/live_gateway/mcp/test_dataplane_publisher_e2e.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Black-box publisher contract test: control-plane API -> Redis -> Rust data plane.
+
+Run against dedicated local services with DATAPLANE_TEST_CONTROL_URL,
+DATAPLANE_TEST_URL, DATAPLANE_TEST_REDIS_URL, DATAPLANE_TEST_JWT_SECRET and
+DATAPLANE_TEST_SIGNING_KEY set (path to a test RSA private key).
+The control plane must enable DATAPLANE_PUBLISHER with a short publish interval;
+the data plane must use the same Redis, trust the test key through JWKS, permit plaintext upstreams,
+and disable its config cache. Both services must reach this test's localhost.
+For a direct data-plane listener, DATAPLANE_TEST_URL includes /contextforge-rs.
+The test starts its own SDK upstreams and removes all API objects it creates.
+"""
+
+# Standard
+import json
+import multiprocessing
+import os
+from pathlib import Path
+import socket
+import time
+from contextlib import ExitStack
+from typing import Any
+from uuid import uuid4
+
+# Third-Party
+import httpx
+import msgpack
+import pytest
+import uvicorn
+from mcp.server.fastmcp import FastMCP
+from redis import Redis
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+# First-Party
+from tests.helpers.auth import make_test_jwt
+
+_REQUIRED_ENV = ("DATAPLANE_TEST_CONTROL_URL", "DATAPLANE_TEST_URL", "DATAPLANE_TEST_REDIS_URL", "DATAPLANE_TEST_JWT_SECRET", "DATAPLANE_TEST_SIGNING_KEY")
+pytestmark = [pytest.mark.e2e, pytest.mark.skipif(not all(os.getenv(key) for key in _REQUIRED_ENV), reason="Requires dedicated control-plane, Redis and data-plane services")]
+
+
+def _serve_upstream(port: int, marker: str) -> None:
+    """Expose exact SDK names that fail if the router reconstructs or slugifies them."""
+    server = FastMCP("Publisher contract", host="127.0.0.1", port=port, stateless_http=True, json_response=True)
+
+    @server.tool(name="Admin.Tools_List")
+    def list_admin_tools() -> str:
+        """Return the upstream identity and exact tool name."""
+        return f"{marker}:Admin.Tools_List"
+
+    @server.prompt(name="Prompt.Original")
+    def original_prompt() -> str:
+        """Return the upstream identity and exact prompt name."""
+        return f"{marker}:Prompt.Original"
+
+    @server.resource("resource://exact/path")
+    def original_resource() -> str:
+        """Return the upstream identity for an exact resource URI."""
+        return f"{marker}:resource://exact/path"
+
+    app = server.streamable_http_app()
+
+    async def unsupported_discovery(request, call_next):
+        """Return method-not-found for discovery so modern clients negotiate legacy MCP."""
+        # The pinned SDK predates server/discover and incorrectly responds with
+        # invalid-params. A method-not-found response permits the consumer's
+        # existing Auto lifecycle to negotiate the SDK's supported version.
+        if request.method == "POST":
+            payload = await request.json()
+            if payload.get("method") == "server/discover":
+                return JSONResponse({"jsonrpc": "2.0", "id": payload["id"], "error": {"code": -32601, "message": "Method not found"}})
+        return await call_next(request)
+
+    app.add_middleware(BaseHTTPMiddleware, dispatch=unsupported_discovery)
+    uvicorn.run(app, host="127.0.0.1", port=port, log_level="warning")
+
+
+@pytest.fixture
+def upstream_urls():
+    """Start two independent SDK servers, terminating only these test processes."""
+    processes = []
+    urls = []
+    try:
+        for marker in ("one", "two"):
+            with socket.socket() as listener:
+                listener.bind(("127.0.0.1", 0))
+                port = listener.getsockname()[1]
+            process = multiprocessing.get_context("spawn").Process(target=_serve_upstream, args=(port, marker))
+            process.start()
+            processes.append(process)
+            deadline = time.monotonic() + 20
+            while time.monotonic() < deadline:
+                assert process.is_alive(), "SDK upstream exited before startup"
+                try:
+                    with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                        break
+                except OSError:
+                    time.sleep(0.1)
+            else:
+                pytest.fail("SDK upstream did not start")
+            urls.append(f"http://127.0.0.1:{port}/mcp")
+        yield urls
+    finally:
+        for process in processes:
+            process.terminate()
+            process.join(timeout=10)
+            if process.is_alive():
+                process.kill()
+                process.join(timeout=5)
+
+
+def _api(client: httpx.Client, method: str, path: str, **kwargs: Any) -> Any:
+    """Issue a control-plane request and retain the response body on failure."""
+    response = client.request(method, path, **kwargs)
+    assert response.is_success, f"{method} {path}: {response.status_code} {response.text}"
+    return response.json()
+
+
+def _rpc(client: httpx.Client, server_id: str, method: str, params: dict[str, Any]) -> httpx.Response:
+    """Send a modern stateless MCP request with matching parameter headers."""
+    headers = {"Mcp-Protocol-Version": "2026-07-28", "Mcp-Method": method, "Mcp-Name": str(params.get("name", params.get("uri", "")))}
+    return client.post(
+        f"/servers/{server_id}/mcp",
+        headers=headers,
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method,
+            "params": {
+                **params,
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                    "io.modelcontextprotocol/clientInfo": {"name": "publisher-contract", "version": "1"},
+                    "io.modelcontextprotocol/clientCapabilities": {},
+                },
+            },
+        },
+    )
+
+
+def _result(response: httpx.Response) -> dict[str, Any]:
+    """Read the JSON-RPC result from either JSON or an SSE response."""
+    assert response.is_success, response.text
+    if response.headers.get("content-type", "").startswith("text/event-stream"):
+        messages = [json.loads(line[5:].strip()) for line in response.text.splitlines() if line.startswith("data:")]
+        payload = next(message for message in messages if message.get("id") == 1)
+    else:
+        payload = response.json()
+    assert "error" not in payload, payload
+    result = payload["result"]
+    assert isinstance(result, dict), result
+    return result
+
+
+def test_published_routes_execute_exact_names_and_reject_collisions(upstream_urls):
+    """Exercise real discovery, publication, consumer decoding, routing and collision fallback."""
+    secret = os.environ["DATAPLANE_TEST_JWT_SECRET"]
+    email = os.getenv("DATAPLANE_TEST_ADMIN_EMAIL", "admin@example.com")
+    admin_token = make_test_jwt(email, is_admin=True, teams=None, secret=secret)
+    suffix = uuid4().hex[:12]
+    with ExitStack() as cleanup:
+        control = cleanup.enter_context(httpx.Client(base_url=os.environ["DATAPLANE_TEST_CONTROL_URL"], headers={"Authorization": f"Bearer {admin_token}"}, timeout=30, follow_redirects=True))
+        redis = Redis.from_url(os.environ["DATAPLANE_TEST_REDIS_URL"])
+        cleanup.callback(redis.close)
+        gateways = []
+        for index, url in enumerate(upstream_urls):
+            team = _api(control, "POST", "/teams/", json={"name": f"publisher-{suffix}-{index}"})
+            cleanup.callback(control.delete, f"/teams/{team['id']}")
+            gateway = _api(control, "POST", "/gateways", json={"name": f"shared-{suffix}", "url": url, "transport": "STREAMABLEHTTP", "team_id": team["id"], "visibility": "team"})
+            gateways.append(gateway["id"])
+            cleanup.callback(control.delete, f"/gateways/{gateway['id']}")
+
+        tools = _api(control, "GET", "/tools")
+        tools_by_gateway = {gateway: [tool for tool in tools if tool.get("gatewayId") == gateway] for gateway in gateways}
+        assert all(len(items) == 1 for items in tools_by_gateway.values()), tools_by_gateway
+        resources = [item for item in _api(control, "GET", "/resources") if item.get("gatewayId") == gateways[0]]
+        prompts = [item for item in _api(control, "GET", "/prompts") if item.get("gatewayId") == gateways[0]]
+        assert len(resources) == len(prompts) == 1
+        first_tool = tools_by_gateway[gateways[0]][0]
+        server = _api(
+            control,
+            "POST",
+            "/servers",
+            json={"server": {"name": f"publisher-{suffix}", "associated_tools": [first_tool["id"]], "associated_resources": [resources[0]["id"]], "associated_prompts": [prompts[0]["id"]]}},
+        )
+        server_id = server["id"]
+        cleanup.callback(control.delete, f"/servers/{server_id}")
+
+        # Read the actual publisher output; do not manufacture a consumer config.
+        deadline = time.monotonic() + 30
+        subject = None
+        while time.monotonic() < deadline and subject is None:
+            for key in redis.scan_iter():
+                try:
+                    decoded_key = msgpack.unpackb(key, raw=False)
+                except (ValueError, msgpack.ExtraData):
+                    continue
+                if not isinstance(decoded_key, list) or len(decoded_key) != 2 or decoded_key[0] != "UserConfig":
+                    continue
+                value = redis.get(key)
+                if value and server_id in msgpack.unpackb(value, raw=False)["virtual_hosts"]:
+                    subject = decoded_key[1]
+                    break
+            if subject is None:
+                time.sleep(0.2)
+        assert subject is not None, "Publisher did not publish the server"
+        token = make_test_jwt(
+            email, is_admin=True, teams=None, secret=Path(os.environ["DATAPLANE_TEST_SIGNING_KEY"]).read_text(), algorithm="RS256", extra_payload={"sub": subject, "tenant_id": "publisher-contract"}
+        )
+        data_plane = cleanup.enter_context(
+            httpx.Client(base_url=os.environ["DATAPLANE_TEST_URL"], headers={"Authorization": f"Bearer {token}", "Accept": "application/json, text/event-stream"}, timeout=20)
+        )
+
+        tool_result = _result(_rpc(data_plane, server_id, "tools/call", {"name": first_tool["name"], "arguments": {}}))
+        assert tool_result.get("isError") is not True, tool_result
+        assert tool_result["content"][0]["text"] == "one:Admin.Tools_List"
+        prompt_result = _result(_rpc(data_plane, server_id, "prompts/get", {"name": prompts[0]["name"], "arguments": {}}))
+        assert prompt_result["messages"][0]["content"]["text"] == "one:Prompt.Original"
+        resource_result = _result(_rpc(data_plane, server_id, "resources/read", {"uri": resources[0]["uri"]}))
+        assert resource_result["contents"][0]["text"] == "one:resource://exact/path"
+
+        # An unassociated upstream tool name is not accepted as a route.
+        unknown = _rpc(data_plane, server_id, "tools/call", {"name": "Admin.Tools_List", "arguments": {}})
+        assert unknown.status_code in (200, 400) and unknown.json().get("error", {}).get("code") == -32602, unknown.text
+        anonymous = cleanup.enter_context(httpx.Client(base_url=os.environ["DATAPLANE_TEST_URL"], timeout=10))
+        unauthorized = _rpc(anonymous, server_id, "tools/call", {"name": first_tool["name"], "arguments": {}})
+        assert unauthorized.status_code == 401
+
+        second_tool = tools_by_gateway[gateways[1]][0]
+        assert first_tool["name"] == second_tool["name"]
+        _api(control, "PUT", f"/servers/{server_id}", json={"associated_tools": [first_tool["id"], second_tool["id"]]})
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            response = _rpc(data_plane, server_id, "tools/call", {"name": first_tool["name"], "arguments": {}})
+            if response.status_code == 404:
+                break
+            time.sleep(0.2)
+        assert response.status_code == 404, "Ambiguous virtual host remained published"
+        assert _api(control, "GET", f"/servers/{server_id}")["id"] == server_id

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -194,7 +194,8 @@ async def test_full_payload_generation_with_mock_db():
 
     prompt1 = Mock()
     prompt1.id = "p1"
-    prompt1.name = "Prompt 1"
+    prompt1.name = "gw1-prompt"
+    prompt1.original_name = "Prompt.Original"
     prompt1.owner_email = "user1@example.com"
     prompt1.team_id = "team1"
     prompt1.visibility = "public"
@@ -302,22 +303,20 @@ async def test_full_payload_generation_with_mock_db():
             "passthrough_headers": ["Authorization"],
             "add_headers": {"X-Tenant": "acme"},
             "remove_headers": ["Cookie"],
-            "capabilities": {"resources": {"subscribe": True}},
-            "allowed_tool_names": ["admin.tools.list", "private_tool"],
-            "tool_name_aliases": {
-                "gw1-admin-tools-list": "admin.tools.list",
-                "gw1-private_tool": "private_tool",
-            },
+            "mcp_protocol_version": "2025-11-25",
             "tool_schemas": {
                 "admin.tools.list": tool1.input_schema,
                 "private_tool": {},
             },
-            "allowed_resource_names": ["Resource 1"],
-            "allowed_resource_uris": ["resource://one"],
-            "allowed_prompt_names": ["Prompt 1"],
         }
-        assert "bad_tool" not in backend["allowed_tool_names"]
-        assert "gw1-bad_tool" not in backend["tool_name_aliases"]
+        assert server1["tools"] == {
+            "gw1-admin-tools-list": {"backend_name": "g1", "upstream_name": "admin.tools.list"},
+            "gw1-private_tool": {"backend_name": "g1", "upstream_name": "private_tool"},
+        }
+        assert server1["resources"] == {"resource://one": {"backend_name": "g1", "upstream_name": "resource://one"}}
+        assert server1["prompts"] == {"gw1-prompt": {"backend_name": "g1", "upstream_name": "Prompt.Original"}}
+        assert server1["resource_templates"] == {}
+        assert "gw1-bad_tool" not in server1["tools"]
         assert "bad_tool" not in backend["tool_schemas"]
 
         # Verify the gateway SELECT projection actually includes the new columns
@@ -342,10 +341,9 @@ async def test_full_payload_generation_with_mock_db():
         # is omitted from the payload (no publishable backends).
         assert "s2" not in user2_config["virtual_hosts"]
         user2_backend = user2_config["virtual_hosts"]["s1"]["backends"]["g1"]
-        assert user2_backend["allowed_tool_names"] == ["admin.tools.list", "team2_tool"]
-        assert user2_backend["tool_name_aliases"] == {
-            "gw1-admin-tools-list": "admin.tools.list",
-            "gw1-team2_tool": "team2_tool",
+        assert user2_config["virtual_hosts"]["s1"]["tools"] == {
+            "gw1-admin-tools-list": {"backend_name": "g1", "upstream_name": "admin.tools.list"},
+            "gw1-team2_tool": {"backend_name": "g1", "upstream_name": "team2_tool"},
         }
         assert user2_backend["tool_schemas"] == {
             "admin.tools.list": tool1.input_schema,
@@ -357,8 +355,7 @@ async def test_full_payload_generation_with_mock_db():
         assert "s1" in user3_config["virtual_hosts"]
         assert "s2" not in user3_config["virtual_hosts"]
         user3_backend = user3_config["virtual_hosts"]["s1"]["backends"]["g1"]
-        assert user3_backend["allowed_tool_names"] == ["admin.tools.list"]
-        assert user3_backend["tool_name_aliases"] == {"gw1-admin-tools-list": "admin.tools.list"}
+        assert user3_config["virtual_hosts"]["s1"]["tools"] == {"gw1-admin-tools-list": {"backend_name": "g1", "upstream_name": "admin.tools.list"}}
         assert user3_backend["tool_schemas"] == {"admin.tools.list": tool1.input_schema}
 
 
@@ -386,9 +383,7 @@ def test_build_user_data_excludes_non_object_tool_schema(caplog):
     result = DataplanePublisherService()._build_user_data("user@example.com", set(), False, [server], [], [], [], [bad_tool, good_tool], backend_items_by_server)
 
     backend_items = result["servers"][0]["backend_items"]["gateway"]
-    assert backend_items["tools"] == ["good"]
-    assert backend_items["tool_name_aliases"] == {"gateway-good": "good"}
-    assert backend_items["tool_schemas"] == {"good": {"type": "object"}}
+    assert backend_items["tools"] == [{"exposed_name": "gateway-good", "upstream_name": "good", "input_schema": {"type": "object"}}]
     assert "Excluding tool bad-tool" in caplog.text
 
 
@@ -467,7 +462,7 @@ def test_create_payload_filters_empty_backends():
                 {
                     "id": "server1",
                     "backend_items": {
-                        "gateway1": {"tools": [], "tool_schemas": {}, "resources": [], "prompts": []},
+                        "gateway1": {"tools": [], "resources": [], "prompts": []},
                     },
                 }
             ],
@@ -497,8 +492,7 @@ def test_create_payload_excludes_non_streamable_gateways(transport: str):
                     "id": "server1",
                     "backend_items": {
                         "gateway_non_streamable": {
-                            "tools": ["tool1"],
-                            "tool_schemas": {},
+                            "tools": [{"exposed_name": "gateway-tool1", "upstream_name": "tool1", "input_schema": {}}],
                             "resources": [],
                             "prompts": [],
                         },
@@ -528,7 +522,7 @@ def test_create_payload_normalizes_null_passthrough_headers():
                 {
                     "id": "server1",
                     "backend_items": {
-                        "gateway1": {"tools": ["tool1"], "tool_schemas": {}, "resources": [], "prompts": []},
+                        "gateway1": {"tools": [{"exposed_name": "gateway-tool1", "upstream_name": "tool1", "input_schema": {}}], "resources": [], "prompts": []},
                     },
                 }
             ],
@@ -544,7 +538,7 @@ def test_create_payload_normalizes_null_passthrough_headers():
     assert backend["passthrough_headers"] == []
     assert backend["add_headers"] == {}
     assert backend["remove_headers"] == []
-    assert backend["capabilities"] == {}
+    assert backend["mcp_protocol_version"] == "2025-11-25"
 
 
 def test_create_payload_handles_missing_references():
@@ -559,8 +553,7 @@ def test_create_payload_handles_missing_references():
                     "id": "server1",
                     "backend_items": {
                         "missing_gateway": {
-                            "tools": ["tool1"],
-                            "tool_schemas": {},
+                            "tools": [{"exposed_name": "gateway-tool1", "upstream_name": "tool1", "input_schema": {}}],
                             "resources": ["missing_res"],
                             "prompts": ["missing_prompt"],
                         },
@@ -579,6 +572,90 @@ def test_create_payload_handles_missing_references():
     # With its only gateway missing, the server has no publishable backends
     # and is omitted from the payload.
     assert "server1" not in result[USER1_ID]["virtual_hosts"]
+
+
+@pytest.mark.parametrize("kind", ["tools", "resources", "prompts"])
+@pytest.mark.parametrize("same_backend", [False, True])
+def test_create_payload_omits_ambiguous_virtual_host(kind, same_backend, caplog):
+    """Duplicate visible names never overwrite routes, even within one backend."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    backend_items = {"g1": {"tools": [], "resources": [], "prompts": []}, "g2": {"tools": [], "resources": [], "prompts": []}}
+    gateways = [{"id": gateway_id, "name": "Shared", "url": "http://localhost:9000/mcp", "transport": "STREAMABLEHTTP", "passthrough_headers": []} for gateway_id in backend_items]
+    resources = []
+    prompts = []
+    for index, gateway_id in enumerate(["g1", "g1" if same_backend else "g2"]):
+        if kind == "tools":
+            backend_items[gateway_id][kind].append({"exposed_name": "shared-tool", "upstream_name": f"Tool.{index}", "input_schema": {}})
+        elif kind == "resources":
+            # Identical backend/URI pairs describe the same route, so they
+            # are harmless duplicates; different backends are ambiguous.
+            backend_items[gateway_id][kind].append(str(index))
+            resources.append({"id": str(index), "name": f"Resource {index}", "uri": "resource://same"})
+        else:
+            backend_items[gateway_id][kind].append(str(index))
+            prompts.append({"id": str(index), "name": "shared-prompt", "original_name": f"Prompt.{index}"})
+
+    data = {USER1_ID: {"servers": [{"id": "server", "backend_items": backend_items}], "gateways": gateways, "resources": resources, "prompts": prompts}}
+    result = DataplanePublisherService().create_payload(data)
+
+    if same_backend and kind == "resources":
+        assert result[USER1_ID]["virtual_hosts"]["server"]["resources"] == {"resource://same": {"backend_name": "g1", "upstream_name": "resource://same"}}
+    else:
+        assert result[USER1_ID]["virtual_hosts"] == {}
+        assert "is ambiguous" in caplog.text
+
+
+@pytest.mark.parametrize("hidden_reason", ["private", "wrong_team", "unsupported", "unassociated"])
+def test_only_visible_publishable_tools_participate_in_collisions(hidden_reason):
+    """An invisible or unsupported duplicate cannot suppress a valid route."""
+    from types import SimpleNamespace
+
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    service = DataplanePublisherService()
+    tools = [
+        SimpleNamespace(id="t1", name="shared-tool", original_name="Tool.One", input_schema={}, visibility="public"),
+        SimpleNamespace(id="t2", name="shared-tool", original_name="Tool.Two", input_schema={}, visibility="public", team_id="other-team", owner_email="other@example.com"),
+    ]
+    if hidden_reason == "private":
+        tools[1].visibility = "private"
+    elif hidden_reason == "wrong_team":
+        tools[1].visibility = "team"
+    gateways = [
+        SimpleNamespace(id=gateway_id, name="Shared", url="http://localhost:9000/mcp", transport="STREAMABLEHTTP", passthrough_headers=[], add_headers={}, remove_headers={}, visibility="public")
+        for gateway_id in ["g1", "g2"]
+    ]
+    if hidden_reason == "unsupported":
+        gateways[1].transport = "SSE"
+    associations = {"server": {"g1": {"tools": ["t1"], "resources": [], "prompts": []}, "g2": {"tools": [] if hidden_reason == "unassociated" else ["t2"], "resources": [], "prompts": []}}}
+    data = service._build_user_data("user@example.com", set(), False, [SimpleNamespace(id="server", visibility="public")], gateways, [], [], tools, associations)
+
+    result = service.create_payload({USER1_ID: data})
+
+    assert result[USER1_ID]["virtual_hosts"]["server"]["tools"] == {"shared-tool": {"backend_name": "g1", "upstream_name": "Tool.One"}}
+    assert set(result[USER1_ID]["virtual_hosts"]["server"]["backends"]) == {"g1"}
+
+
+@pytest.mark.parametrize("kind", ["resources", "prompts"])
+def test_create_payload_keeps_backends_without_tools(kind):
+    """Resource-only and prompt-only backends remain routable in the new contract."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    data = {
+        USER1_ID: {
+            "servers": [{"id": "server", "backend_items": {"gateway": {"tools": [], "resources": ["r"] if kind == "resources" else [], "prompts": ["p"] if kind == "prompts" else []}}}],
+            "gateways": [{"id": "gateway", "name": "Gateway", "url": "http://localhost:9000/mcp", "transport": "STREAMABLEHTTP", "passthrough_headers": []}],
+            "resources": [{"id": "r", "name": "Display name", "uri": "resource://one"}],
+            "prompts": [{"id": "p", "name": "gateway-prompt", "original_name": "Prompt.Original"}],
+        }
+    }
+    result = DataplanePublisherService().create_payload(data)[USER1_ID]["virtual_hosts"]["server"]
+    assert result["tools"] == {}
+    assert result["backends"]["gateway"]["tool_schemas"] == {}
+    expected_name = "resource://one" if kind == "resources" else "gateway-prompt"
+    expected_upstream = "resource://one" if kind == "resources" else "Prompt.Original"
+    assert result[kind] == {expected_name: {"backend_name": "gateway", "upstream_name": expected_upstream}}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -211,8 +211,8 @@ async def test_full_payload_generation_with_mock_db():
 
     tool1 = Mock()
     tool1.id = "t1"
-    tool1.name = "gw1-public_tool"
-    tool1.original_name = "public_tool"
+    tool1.name = "gw1-admin-tools-list"
+    tool1.original_name = "admin.tools.list"
     tool1.input_schema = {
         "type": "object",
         "properties": {"region": {"type": "string", "x-mcp-header": "Region"}},
@@ -303,9 +303,13 @@ async def test_full_payload_generation_with_mock_db():
             "add_headers": {"X-Tenant": "acme"},
             "remove_headers": ["Cookie"],
             "capabilities": {"resources": {"subscribe": True}},
-            "allowed_tool_names": ["public_tool", "private_tool"],
+            "allowed_tool_names": ["admin.tools.list", "private_tool"],
+            "tool_name_aliases": {
+                "gw1-admin-tools-list": "admin.tools.list",
+                "gw1-private_tool": "private_tool",
+            },
             "tool_schemas": {
-                "public_tool": tool1.input_schema,
+                "admin.tools.list": tool1.input_schema,
                 "private_tool": {},
             },
             "allowed_resource_names": ["Resource 1"],
@@ -313,6 +317,7 @@ async def test_full_payload_generation_with_mock_db():
             "allowed_prompt_names": ["Prompt 1"],
         }
         assert "bad_tool" not in backend["allowed_tool_names"]
+        assert "gw1-bad_tool" not in backend["tool_name_aliases"]
         assert "bad_tool" not in backend["tool_schemas"]
 
         # Verify the gateway SELECT projection actually includes the new columns
@@ -326,6 +331,8 @@ async def test_full_payload_generation_with_mock_db():
         tool_execute_call = mock_db.execute.call_args_list[6]
         tool_stmt = tool_execute_call[0][0]
         selected_tool_keys = {col.key for col in tool_stmt.selected_columns}
+        assert "name" in selected_tool_keys, "Tool SELECT must include the client-visible name"
+        assert "original_name" in selected_tool_keys, "Tool SELECT must include the upstream name"
         assert "input_schema" in selected_tool_keys, "Tool SELECT must include input_schema"
 
         # Verify user2 sees public server but not private server from user1
@@ -335,9 +342,13 @@ async def test_full_payload_generation_with_mock_db():
         # is omitted from the payload (no publishable backends).
         assert "s2" not in user2_config["virtual_hosts"]
         user2_backend = user2_config["virtual_hosts"]["s1"]["backends"]["g1"]
-        assert user2_backend["allowed_tool_names"] == ["public_tool", "team2_tool"]
+        assert user2_backend["allowed_tool_names"] == ["admin.tools.list", "team2_tool"]
+        assert user2_backend["tool_name_aliases"] == {
+            "gw1-admin-tools-list": "admin.tools.list",
+            "gw1-team2_tool": "team2_tool",
+        }
         assert user2_backend["tool_schemas"] == {
-            "public_tool": tool1.input_schema,
+            "admin.tools.list": tool1.input_schema,
             "team2_tool": tool3.input_schema,
         }
 
@@ -346,8 +357,9 @@ async def test_full_payload_generation_with_mock_db():
         assert "s1" in user3_config["virtual_hosts"]
         assert "s2" not in user3_config["virtual_hosts"]
         user3_backend = user3_config["virtual_hosts"]["s1"]["backends"]["g1"]
-        assert user3_backend["allowed_tool_names"] == ["public_tool"]
-        assert user3_backend["tool_schemas"] == {"public_tool": tool1.input_schema}
+        assert user3_backend["allowed_tool_names"] == ["admin.tools.list"]
+        assert user3_backend["tool_name_aliases"] == {"gw1-admin-tools-list": "admin.tools.list"}
+        assert user3_backend["tool_schemas"] == {"admin.tools.list": tool1.input_schema}
 
 
 def test_build_user_data_excludes_non_object_tool_schema(caplog):
@@ -357,7 +369,9 @@ def test_build_user_data_excludes_non_object_tool_schema(caplog):
     from mcpgateway.services.dataplane_publisher import BackendItemsByServer, DataplanePublisherService
 
     bad_tool = Mock(id="bad-tool", original_name="bad", input_schema=None, visibility="public")
+    bad_tool.name = "gateway-bad"
     good_tool = Mock(id="good-tool", original_name="good", input_schema={"type": "object"}, visibility="public")
+    good_tool.name = "gateway-good"
     server = Mock(id="server", visibility="public")
     backend_items_by_server: BackendItemsByServer = {
         "server": {
@@ -373,6 +387,7 @@ def test_build_user_data_excludes_non_object_tool_schema(caplog):
 
     backend_items = result["servers"][0]["backend_items"]["gateway"]
     assert backend_items["tools"] == ["good"]
+    assert backend_items["tool_name_aliases"] == {"gateway-good": "good"}
     assert backend_items["tool_schemas"] == {"good": {"type": "object"}}
     assert "Excluding tool bad-tool" in caplog.text
 


### PR DESCRIPTION
## Summary

Publish explicit virtual-host routes using the data-plane contract introduced in contextforge-org/contextforge-data-plane#124. Each client-visible tool or prompt name maps to its backend and exact upstream name; resources map by URI. For example, an SDK tool registered as `Admin.Tools_List` reaches the upstream unchanged.

Include the required MCP protocol version and preserve per-user visibility filtering and upstream tool schemas. Detect duplicate visible routes across supported backends and omit ambiguous virtual hosts, allowing the existing control-plane fallback on data-plane 404 responses. Existing client-facing names remain unchanged.

## Compatibility

This targets the current data-plane consumer and replaces obsolete backend allowlists and `tool_name_aliases`. Older data-plane consumers must be upgraded. Resource templates remain outside this publisher's supported scope.

## Verification

- 38 publisher unit tests passed, with 100% publisher statement coverage.
- Live control-plane API → publisher → Redis → current Rust consumer → SDK upstream test passed, including exact tool/prompt/resource forwarding, unknown-route and unauthenticated denial, and collision fallback.
- Focused lint, type checks, pre-commit secret checks, and package verification passed. Broader mypy encounters existing imported-module errors and missing MessagePack stubs.
- Full repository test, coverage, and protocol/RBAC gates were not run. Existing local stacks were preserved; the live test used isolated services.
