### PR TITLE
feat(oauth): discover issuer metadata

### DIFF
--- a/.github/workflows/plugin-integration.yml
+++ b/.github/workflows/plugin-integration.yml
@@ -326,8 +326,11 @@ jobs:
         steps:
             - name: Verify all plugin E2E legs succeeded
               run: |
-                  if [ "${{ needs.plugin-e2e.result }}" != "success" ]; then
+                  if [ "${{ needs.plugin-e2e.result }}" = "success" ]; then
+                    echo "All plugin E2E legs passed."
+                  elif [ "${{ needs.plugin-e2e.result }}" = "skipped" ] && [ "${{ github.event_name }}" = "pull_request" ]; then
+                    echo "Plugin E2E matrix skipped because this PR has no plugin-related changes."
+                  else
                     echo "Plugin E2E matrix result: ${{ needs.plugin-e2e.result }}"
                     exit 1
                   fi
-                  echo "All plugin E2E legs passed."

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -154,6 +154,8 @@ from mcpgateway.schemas import (
     HealthStatusItem,
     JsonPathModifier,
     MetricsResponse,
+    OAuthMetadataDiscoveryRequest,
+    OAuthMetadataDiscoveryResponse,
     PromptCreate,
     PromptExecuteArgs,
     PromptRead,
@@ -179,10 +181,12 @@ from mcpgateway.schemas import (
 )
 from mcpgateway.services.a2a_server_service import A2AServerService
 from mcpgateway.services.a2a_service import A2AAgentError, A2AAgentNameConflictError, A2AAgentNotFoundError, A2AAgentService
+from mcpgateway.services.audit_trail_service import get_audit_trail_service
 from mcpgateway.services.cancellation_service import cancellation_service
 from mcpgateway.services.completion_service import CompletionError, CompletionService
 from mcpgateway.services.content_security import ContentPatternError, ContentSizeError, ContentTypeError, TemplateValidationError
 from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+from mcpgateway.services.dcr_service import DcrError, DcrService
 from mcpgateway.services.email_auth_service import EmailAuthService
 from mcpgateway.services.export_service import ExportError, ExportService
 from mcpgateway.services.gateway_service import (
@@ -7463,6 +7467,75 @@ async def list_gateways(
     if include_pagination:
         return CursorPaginatedGatewaysResponse.model_construct(gateways=data, next_cursor=next_cursor)
     return data
+
+
+_OAUTH_DISCOVERY_ERROR_MESSAGES = {
+    "not_found": "OAuth metadata was not served by this issuer. Enter the endpoint URLs manually.",
+    "invalid_metadata": "OAuth metadata from this issuer was invalid. Enter the endpoint URLs manually.",
+    "blocked": "This issuer URL is blocked by the outbound security policy.",
+    "timeout": "OAuth metadata request timed out. Try again or enter the endpoint URLs manually.",
+}
+
+
+def _safe_oauth_issuer_for_audit(value: str) -> str:
+    """Return an issuer identifier without query, fragment, or credentials for audit logs."""
+    parsed = urlparse(value)
+    if not parsed.scheme or not parsed.hostname:
+        return "invalid-issuer"
+    try:
+        port = f":{parsed.port}" if parsed.port is not None else ""
+    except ValueError:
+        return "invalid-issuer"
+    return f"{parsed.scheme}://{parsed.hostname}{port}{parsed.path}"
+
+
+@gateway_router.post("/discover-metadata", response_model=OAuthMetadataDiscoveryResponse)
+@require_permission("gateways.create")
+async def discover_oauth_metadata(
+    discovery_request: OAuthMetadataDiscoveryRequest,
+    request: Request,
+    user=Depends(get_current_user_with_permissions),
+) -> OAuthMetadataDiscoveryResponse:
+    """Discover OAuth authorization-server metadata for gateway registration.
+
+    The endpoint is deliberately POST so issuer URLs do not appear in access-log
+    query strings. Provider lookup failures return a structured 200 response so
+    callers can keep manual OAuth configuration available.
+    """
+    issuer_for_audit = _safe_oauth_issuer_for_audit(discovery_request.issuer_url)
+    user_email = get_user_email(user)
+    outcome = "success"
+    error_code: Optional[str] = None
+
+    try:
+        metadata = await DcrService().discover_as_metadata(discovery_request.issuer_url)
+        response = OAuthMetadataDiscoveryResponse(
+            discovered=True,
+            authorization_url=metadata.get("authorization_endpoint"),
+            token_url=metadata.get("token_endpoint"),
+            registration_endpoint=metadata.get("registration_endpoint"),
+            scopes_supported=metadata.get("scopes_supported") or [],
+        )
+    except DcrError as exc:
+        outcome = "failure"
+        error_code = exc.code if exc.code in _OAUTH_DISCOVERY_ERROR_MESSAGES else "invalid_metadata"
+        response = OAuthMetadataDiscoveryResponse(
+            discovered=False,
+            error=_OAUTH_DISCOVERY_ERROR_MESSAGES[error_code],
+            error_code=error_code,
+        )
+
+    get_audit_trail_service().log_action(
+        user_id=user_email or "unknown",
+        action="discover_oauth_metadata",
+        resource_type="oauth_issuer",
+        resource_id=None,
+        resource_name=issuer_for_audit,
+        user_email=user_email,
+        client_ip=request.client.host if request.client else None,
+        details={"outcome": outcome, "error_code": error_code},
+    )
+    return response
 
 
 @gateway_router.post("", response_model=GatewayRead)

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -7502,13 +7502,13 @@ async def discover_oauth_metadata(
     query strings. Provider lookup failures return a structured 200 response so
     callers can keep manual OAuth configuration available.
     """
-    issuer_for_audit = _safe_oauth_issuer_for_audit(discovery_request.issuer_url)
+    issuer_for_audit = _safe_oauth_issuer_for_audit(str(discovery_request.issuer_url))
     user_email = get_user_email(user)
     outcome = "success"
     error_code: Optional[str] = None
 
     try:
-        metadata = await DcrService().discover_as_metadata(discovery_request.issuer_url)
+        metadata = await DcrService().discover_public_as_metadata(str(discovery_request.issuer_url))
         response = OAuthMetadataDiscoveryResponse(
             discovered=True,
             authorization_url=metadata.get("authorization_endpoint"),

--- a/mcpgateway/middleware/rate_limit_middleware.py
+++ b/mcpgateway/middleware/rate_limit_middleware.py
@@ -126,6 +126,12 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
                 "limit": settings.rate_limit_high_rpm,
                 "burst": settings.rate_limit_high_burst,
             },
+            "OAUTH_DISCOVERY": {
+                "pattern": r"^/(?:v1/)?gateways/discover-metadata/?$",
+                "methods": {"POST"},
+                "limit": min(10, settings.rate_limit_medium_rpm),
+                "burst": min(10, settings.rate_limit_medium_burst),
+            },
             "MEDIUM": {
                 "pattern": r"^/(mcp|tools|prompts|resources|servers|gateways|llmchat)(/|$)",
                 "limit": settings.rate_limit_medium_rpm,

--- a/mcpgateway/middleware/rate_limit_middleware.py
+++ b/mcpgateway/middleware/rate_limit_middleware.py
@@ -129,8 +129,8 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             "OAUTH_DISCOVERY": {
                 "pattern": r"^/(?:v1/)?gateways/discover-metadata/?$",
                 "methods": {"POST"},
-                "limit": min(10, settings.rate_limit_medium_rpm),
-                "burst": min(10, settings.rate_limit_medium_burst),
+                "limit": 10,
+                "burst": 10,
             },
             "MEDIUM": {
                 "pattern": r"^/(mcp|tools|prompts|resources|servers|gateways|llmchat)(/|$)",

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -135,6 +135,7 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     # They must precede the generic POST sub-resource rule below.
     ("POST", re.compile(r"^/gateways/test(?:$|/)"), Permissions.GATEWAYS_READ),
     ("POST", re.compile(r"^/gateways/test-handshake(?:$|/)"), Permissions.GATEWAYS_READ),
+    ("POST", re.compile(r"^/gateways/discover-metadata/?$"), Permissions.GATEWAYS_CREATE),
     ("GET", re.compile(r"^/gateways(?:$|/)"), Permissions.GATEWAYS_READ),
     ("POST", re.compile(r"^/gateways/?$"), Permissions.GATEWAYS_CREATE),  # Only exact /gateways or /gateways/
     ("POST", re.compile(r"^/gateways/[^/]+/"), Permissions.GATEWAYS_UPDATE),  # POST to sub-resources (state, toggle, refresh)

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -5036,7 +5036,7 @@ class OAuthMetadataDiscoveryRequest(BaseModelWithConfigDict):
 
     model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
 
-    issuer_url: str = Field(..., min_length=1, max_length=2048, description="HTTPS OAuth issuer URL to discover")
+    issuer_url: AnyHttpUrl = Field(..., max_length=2048, description="HTTPS OAuth issuer URL to discover")
 
 
 class OAuthMetadataDiscoveryResponse(BaseModelWithConfigDict):

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -5031,6 +5031,29 @@ class GatewayTestResponse(BaseModelWithConfigDict):
     body: Optional[Union[str, Dict[str, Any]]] = Field(None, description="Response body, can be a string or JSON object")
 
 
+class OAuthMetadataDiscoveryRequest(BaseModelWithConfigDict):
+    """Request OAuth authorization-server metadata for a supplied issuer."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    issuer_url: str = Field(..., min_length=1, max_length=2048, description="HTTPS OAuth issuer URL to discover")
+
+
+class OAuthMetadataDiscoveryResponse(BaseModelWithConfigDict):
+    """Safe OAuth authorization-server metadata for registration-form autofill."""
+
+    discovered: bool = Field(..., description="Whether discovery returned valid issuer metadata")
+    authorization_url: Optional[str] = Field(None, description="Authorization endpoint from issuer metadata")
+    token_url: Optional[str] = Field(None, description="Token endpoint from issuer metadata")
+    registration_endpoint: Optional[str] = Field(None, description="Dynamic Client Registration endpoint when advertised")
+    scopes_supported: List[str] = Field(default_factory=list, description="Scopes advertised by the authorization server")
+    error: Optional[str] = Field(None, description="Safe user-facing discovery failure message")
+    error_code: Optional[Literal["not_found", "invalid_metadata", "blocked", "timeout"]] = Field(
+        None,
+        description="Structured discovery failure code",
+    )
+
+
 class GatewayHandshakeRequest(BaseModelWithConfigDict):
     """Request to run an MCP handshake test against a server URL."""
 

--- a/mcpgateway/services/dcr_service.py
+++ b/mcpgateway/services/dcr_service.py
@@ -12,6 +12,7 @@ This module handles OAuth 2.0 Dynamic Client Registration (DCR) including:
 """
 
 # Standard
+import asyncio
 from datetime import datetime, timezone
 import logging
 from typing import Any, Dict, List
@@ -34,6 +35,11 @@ logger = logging.getLogger(__name__)
 # In-memory cache for AS metadata
 # Format: {issuer: {"metadata": dict, "cached_at": datetime}}
 _metadata_cache: Dict[str, Dict[str, Any]] = {}
+_metadata_locks: Dict[str, asyncio.Lock] = {}
+_metadata_locks_guard = asyncio.Lock()
+
+_DISCOVERY_TIMEOUT_SECONDS = 5.0
+_DISCOVERY_MAX_RESPONSE_BYTES = 256 * 1024
 
 
 class DcrService:
@@ -59,6 +65,104 @@ class DcrService:
         """
         return float(self.settings.oauth_request_timeout)
 
+    @staticmethod
+    def _get_cached_metadata(normalized_issuer: str, cache_ttl: int) -> Dict[str, Any] | None:
+        """Return fresh cached metadata for an issuer when available."""
+        cached_entry = _metadata_cache.get(normalized_issuer)
+        if cached_entry is None:
+            return None
+
+        cache_age = (datetime.now(timezone.utc) - cached_entry["cached_at"]).total_seconds()
+        if cache_age >= cache_ttl:
+            return None
+        return cached_entry["metadata"]
+
+    async def _metadata_lock(self, normalized_issuer: str) -> asyncio.Lock:
+        """Return the process-local singleflight lock for an issuer."""
+        async with _metadata_locks_guard:
+            return _metadata_locks.setdefault(normalized_issuer, asyncio.Lock())
+
+    async def _validate_discovery_issuer(self, issuer: str) -> str:
+        """Validate an issuer URL before it becomes an outbound request target."""
+        try:
+            target = await SecurityValidator.validate_url_for_connection_pinning(issuer, "OAuth issuer URL")
+        except ValueError as exc:
+            raise DcrError("OAuth issuer URL is blocked by outbound security policy", code="blocked") from exc
+
+        normalized_issuer = str(target["validated_url"]).rstrip("/")
+        parsed = urlsplit(normalized_issuer)
+        if parsed.scheme != "https" or not parsed.netloc or parsed.query or parsed.fragment or parsed.username or parsed.password:
+            raise DcrError("OAuth issuer URL must be an HTTPS origin or path without credentials, query, or fragment", code="blocked")
+        return normalized_issuer
+
+    async def _fetch_metadata_document(self, url: str, normalized_issuer: str) -> Dict[str, Any] | None:
+        """Fetch one discovery document within public-registration safety limits."""
+        try:
+            client = await self._get_client()
+            response = await client.get(
+                url,
+                timeout=min(self._get_timeout(), _DISCOVERY_TIMEOUT_SECONDS),
+                follow_redirects=False,
+                headers={"Accept": "application/json"},
+            )
+        except httpx.TimeoutException as exc:
+            raise DcrError("OAuth issuer metadata request timed out", code="timeout") from exc
+        except httpx.HTTPError as exc:
+            raise DcrError("OAuth issuer metadata could not be reached", code="not_found") from exc
+
+        if 300 <= response.status_code < 400:
+            raise DcrError("OAuth issuer metadata redirects are not allowed", code="invalid_metadata")
+        if response.status_code != 200:
+            return None
+
+        content_length = response.headers.get("content-length")
+        if content_length:
+            try:
+                if int(content_length) > _DISCOVERY_MAX_RESPONSE_BYTES:
+                    raise DcrError("OAuth issuer metadata response is too large", code="invalid_metadata")
+            except ValueError:
+                raise DcrError("OAuth issuer metadata response has an invalid content length", code="invalid_metadata") from None
+
+        content = response.content
+        if isinstance(content, bytes) and len(content) > _DISCOVERY_MAX_RESPONSE_BYTES:
+            raise DcrError("OAuth issuer metadata response is too large", code="invalid_metadata")
+
+        try:
+            metadata = response.json()
+        except (ValueError, orjson.JSONDecodeError) as exc:
+            raise DcrError("OAuth issuer metadata is not valid JSON", code="invalid_metadata") from exc
+        if not isinstance(metadata, dict):
+            raise DcrError("OAuth issuer metadata must be a JSON object", code="invalid_metadata")
+
+        metadata_issuer = str(metadata.get("issuer") or "").rstrip("/")
+        if metadata_issuer != normalized_issuer:
+            raise DcrError("OAuth issuer metadata issuer mismatch", code="invalid_metadata")
+        self._validate_metadata_shape(metadata)
+        return metadata
+
+    @staticmethod
+    def _validate_metadata_shape(metadata: Dict[str, Any]) -> None:
+        """Validate metadata fields that are returned to the registration UI."""
+        for field_name in ("authorization_endpoint", "token_endpoint"):
+            value = metadata.get(field_name)
+            if value is None:
+                continue
+            parsed = urlsplit(value) if isinstance(value, str) else None
+            if not parsed or parsed.scheme != "https" or not parsed.netloc or parsed.username or parsed.password:
+                raise DcrError(f"OAuth issuer metadata has invalid {field_name}", code="invalid_metadata")
+
+        registration_endpoint = metadata.get("registration_endpoint")
+        if registration_endpoint is not None:
+            parsed = urlsplit(registration_endpoint) if isinstance(registration_endpoint, str) else None
+            if not parsed or parsed.scheme != "https" or not parsed.netloc or parsed.username or parsed.password:
+                raise DcrError("OAuth issuer metadata has invalid registration_endpoint", code="invalid_metadata")
+
+        scopes_supported = metadata.get("scopes_supported")
+        if scopes_supported is not None and (
+            not isinstance(scopes_supported, list) or not all(isinstance(scope, str) and scope for scope in scopes_supported)
+        ):
+            raise DcrError("OAuth issuer metadata has invalid scopes_supported", code="invalid_metadata")
+
     async def discover_as_metadata(self, issuer: str) -> Dict[str, Any]:
         """Discover AS metadata via RFC 8414.
 
@@ -75,80 +179,48 @@ class DcrService:
         Raises:
             DcrError: If metadata cannot be discovered
         """
-        # Normalize issuer URL by removing trailing slash for consistency.
-        # Per RFC 8414 Section 3.1, any terminating "/" MUST be removed before
-        # inserting "/.well-known/" and the well-known URI suffix.
-        # This also works around MCP Python SDK issue #1919 where Pydantic's
-        # AnyHttpUrl adds trailing slashes to bare hostnames.
-        # See: https://github.com/modelcontextprotocol/python-sdk/issues/1919
-        normalized_issuer = issuer.rstrip("/")
+        # Normalize issuer URL by removing a trailing slash before RFC 8414
+        # well-known-path construction. The validation also prevents this public
+        # discovery capability from becoming an SSRF probing primitive.
+        normalized_issuer = await self._validate_discovery_issuer(issuer)
+        cached = self._get_cached_metadata(normalized_issuer, self.settings.dcr_metadata_cache_ttl)
+        if cached is not None:
+            logger.debug("Using cached AS metadata for %s", normalized_issuer)
+            return cached
 
-        # Check cache first (using normalized issuer as key for consistency)
-        if normalized_issuer in _metadata_cache:
-            cached_entry = _metadata_cache[normalized_issuer]
-            cached_at = cached_entry["cached_at"]
-            cache_age = (datetime.now(timezone.utc) - cached_at).total_seconds()
-
-            if cache_age < self.settings.dcr_metadata_cache_ttl:
-                logger.debug("Using cached AS metadata for %s", normalized_issuer)
-                return cached_entry["metadata"]
-
-        # Try RFC 8414 path first
-        # Per RFC 8414 Section 3.1: "the well-known URI is formed by inserting the
-        # well-known URI string... between the host component and any existing path
-        # component of the issuer's identifier".
-        # See: https://datatracker.ietf.org/doc/html/rfc8414#section-3.1
-        parsed = urlsplit(normalized_issuer)
-        rfc8414_url = f"{parsed.scheme}://{parsed.netloc}/.well-known/oauth-authorization-server"
-        if parsed.path:
-            rfc8414_url += parsed.path
-
+        metadata_lock = await self._metadata_lock(normalized_issuer)
         try:
-            client = await self._get_client()
-            response = await client.get(rfc8414_url, timeout=self._get_timeout(), follow_redirects=False)
-            if 300 <= response.status_code < 400:
-                raise DcrError(f"AS metadata discovery redirect refused for {normalized_issuer} (status: {response.status_code})")
-            if response.status_code == 200:
-                metadata = response.json()
+            async with metadata_lock:
+                cached = self._get_cached_metadata(normalized_issuer, self.settings.dcr_metadata_cache_ttl)
+                if cached is not None:
+                    logger.debug("Using cached AS metadata for %s", normalized_issuer)
+                    return cached
 
-                # Validate issuer matches (normalize metadata issuer for comparison)
-                metadata_issuer = (metadata.get("issuer") or "").rstrip("/")
-                if metadata_issuer != normalized_issuer:
-                    raise DcrError(f"AS metadata issuer mismatch: expected {normalized_issuer}, got {metadata.get('issuer')}")
+                # RFC 8414 inserts the well-known path between authority and any issuer path.
+                parsed = urlsplit(normalized_issuer)
+                rfc8414_url = f"{parsed.scheme}://{parsed.netloc}/.well-known/oauth-authorization-server{parsed.path}"
+                metadata = await self._fetch_metadata_document(rfc8414_url, normalized_issuer)
+                discovery_method = "RFC 8414"
 
-                # Cache the metadata
+                if metadata is None:
+                    metadata = await self._fetch_metadata_document(
+                        f"{normalized_issuer}/.well-known/openid-configuration",
+                        normalized_issuer,
+                    )
+                    discovery_method = "OIDC Discovery"
+
+                if metadata is None:
+                    raise DcrError("OAuth issuer metadata was not found", code="not_found")
+
                 _metadata_cache[normalized_issuer] = {"metadata": metadata, "cached_at": datetime.now(timezone.utc)}
-
-                logger.info("Discovered AS metadata for %s via RFC 8414", normalized_issuer)
+                logger.info("Discovered AS metadata for %s via %s", normalized_issuer, discovery_method)
                 return metadata
-        except httpx.HTTPError as e:
-            logger.debug("RFC 8414 discovery failed for %s: %s, trying OIDC fallback", normalized_issuer, e)
-
-        # Try OIDC discovery fallback
-        oidc_url = f"{normalized_issuer}/.well-known/openid-configuration"
-
-        try:
-            client = await self._get_client()
-            response = await client.get(oidc_url, timeout=self._get_timeout(), follow_redirects=False)
-            if 300 <= response.status_code < 400:
-                raise DcrError(f"AS metadata discovery redirect refused for {normalized_issuer} (status: {response.status_code})")
-            if response.status_code == 200:
-                metadata = response.json()
-
-                # Validate issuer matches (normalize metadata issuer for comparison)
-                metadata_issuer = (metadata.get("issuer") or "").rstrip("/")
-                if metadata_issuer != normalized_issuer:
-                    raise DcrError(f"AS metadata issuer mismatch: expected {normalized_issuer}, got {metadata.get('issuer')}")
-
-                # Cache the metadata
-                _metadata_cache[normalized_issuer] = {"metadata": metadata, "cached_at": datetime.now(timezone.utc)}
-
-                logger.info("Discovered AS metadata for %s via OIDC discovery", normalized_issuer)
-                return metadata
-
-            raise DcrError(f"AS metadata not found for {normalized_issuer} (status: {response.status_code})")
-        except httpx.HTTPError as e:
-            raise DcrError(f"Failed to discover AS metadata for {normalized_issuer}: {e}")
+        finally:
+            # Locks guard only in-flight work. Keeping one for every user-supplied
+            # issuer would let this public endpoint grow process memory forever.
+            async with _metadata_locks_guard:
+                if _metadata_locks.get(normalized_issuer) is metadata_lock and not metadata_lock.locked():
+                    _metadata_locks.pop(normalized_issuer, None)
 
     async def register_client(self, gateway_id: str, gateway_name: str, issuer: str, redirect_uri: str, scopes: List[str], db: Session) -> RegisteredOAuthClient:
         """Register as OAuth client with upstream AS (RFC 7591).
@@ -412,4 +484,9 @@ class DcrService:
 
 
 class DcrError(Exception):
-    """DCR-related errors."""
+    """DCR-related errors with a safe, structured public classification."""
+
+    def __init__(self, message: str, *, code: str = "invalid_metadata") -> None:
+        """Create a DCR error with a safe public error code."""
+        super().__init__(message)
+        self.code = code

--- a/mcpgateway/services/dcr_service.py
+++ b/mcpgateway/services/dcr_service.py
@@ -158,9 +158,7 @@ class DcrService:
                 raise DcrError("OAuth issuer metadata has invalid registration_endpoint", code="invalid_metadata")
 
         scopes_supported = metadata.get("scopes_supported")
-        if scopes_supported is not None and (
-            not isinstance(scopes_supported, list) or not all(isinstance(scope, str) and scope for scope in scopes_supported)
-        ):
+        if scopes_supported is not None and (not isinstance(scopes_supported, list) or not all(isinstance(scope, str) and scope for scope in scopes_supported)):
             raise DcrError("OAuth issuer metadata has invalid scopes_supported", code="invalid_metadata")
 
     async def discover_as_metadata(self, issuer: str) -> Dict[str, Any]:

--- a/mcpgateway/services/dcr_service.py
+++ b/mcpgateway/services/dcr_service.py
@@ -13,9 +13,11 @@ This module handles OAuth 2.0 Dynamic Client Registration (DCR) including:
 
 # Standard
 import asyncio
+from collections import OrderedDict
 from datetime import datetime, timezone
+import ipaddress
 import logging
-from typing import Any, Dict, List
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 from urllib.parse import urlsplit
 
 # Third-Party
@@ -28,18 +30,19 @@ from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import get_settings
 from mcpgateway.db import RegisteredOAuthClient
 from mcpgateway.services.encryption_service import get_encryption_service
-from mcpgateway.services.http_client_service import get_http_client
+from mcpgateway.services.http_client_service import get_http_client, get_http_limits, get_pinned_http_client
 
 logger = logging.getLogger(__name__)
 
 # In-memory cache for AS metadata
 # Format: {issuer: {"metadata": dict, "cached_at": datetime}}
-_metadata_cache: Dict[str, Dict[str, Any]] = {}
+_metadata_cache: OrderedDict[str, Dict[str, Any]] = OrderedDict()
 _metadata_locks: Dict[str, asyncio.Lock] = {}
 _metadata_locks_guard = asyncio.Lock()
 
 _DISCOVERY_TIMEOUT_SECONDS = 5.0
 _DISCOVERY_MAX_RESPONSE_BYTES = 256 * 1024
+_METADATA_CACHE_MAX_ENTRIES = 256
 
 
 class DcrService:
@@ -74,16 +77,30 @@ class DcrService:
 
         cache_age = (datetime.now(timezone.utc) - cached_entry["cached_at"]).total_seconds()
         if cache_age >= cache_ttl:
+            _metadata_cache.pop(normalized_issuer, None)
             return None
+        _metadata_cache.move_to_end(normalized_issuer)
         return cached_entry["metadata"]
+
+    @staticmethod
+    def _cache_metadata(normalized_issuer: str, metadata: Dict[str, Any], cache_ttl: int) -> None:
+        """Store metadata in a bounded LRU cache after removing expired entries."""
+        now = datetime.now(timezone.utc)
+        expired_issuers = [cached_issuer for cached_issuer, cached_entry in _metadata_cache.items() if (now - cached_entry["cached_at"]).total_seconds() >= cache_ttl]
+        for expired_issuer in expired_issuers:
+            _metadata_cache.pop(expired_issuer, None)
+        _metadata_cache[normalized_issuer] = {"metadata": metadata, "cached_at": now}
+        _metadata_cache.move_to_end(normalized_issuer)
+        while len(_metadata_cache) > _METADATA_CACHE_MAX_ENTRIES:
+            _metadata_cache.popitem(last=False)
 
     async def _metadata_lock(self, normalized_issuer: str) -> asyncio.Lock:
         """Return the process-local singleflight lock for an issuer."""
         async with _metadata_locks_guard:
             return _metadata_locks.setdefault(normalized_issuer, asyncio.Lock())
 
-    async def _validate_discovery_issuer(self, issuer: str) -> str:
-        """Validate an issuer URL before it becomes an outbound request target."""
+    async def _validate_public_discovery_issuer(self, issuer: str) -> Dict[str, Optional[str]]:
+        """Validate and pin a user-supplied issuer for public discovery only."""
         try:
             target = await SecurityValidator.validate_url_for_connection_pinning(issuer, "OAuth issuer URL")
         except ValueError as exc:
@@ -93,52 +110,84 @@ class DcrService:
         parsed = urlsplit(normalized_issuer)
         if parsed.scheme != "https" or not parsed.netloc or parsed.query or parsed.fragment or parsed.username or parsed.password:
             raise DcrError("OAuth issuer URL must be an HTTPS origin or path without credentials, query, or fragment", code="blocked")
-        return normalized_issuer
+        if not target.get("hostname") or not target.get("original_authority") or not target.get("resolved_ip"):
+            raise DcrError("OAuth issuer URL is blocked by outbound security policy", code="blocked")
+        resolved_ip = ipaddress.ip_address(str(target["resolved_ip"]))
+        if resolved_ip.is_loopback or resolved_ip.is_link_local:
+            raise DcrError("OAuth issuer URL is blocked by outbound security policy", code="blocked")
+        target["validated_url"] = normalized_issuer
+        return target
 
     async def _fetch_metadata_document(self, url: str, normalized_issuer: str) -> Dict[str, Any] | None:
-        """Fetch one discovery document within public-registration safety limits."""
+        """Fetch one discovery document for existing DCR callers."""
         try:
             client = await self._get_client()
             response = await client.get(
                 url,
-                timeout=min(self._get_timeout(), _DISCOVERY_TIMEOUT_SECONDS),
+                timeout=self._get_timeout(),
                 follow_redirects=False,
-                headers={"Accept": "application/json"},
             )
-        except httpx.TimeoutException as exc:
-            raise DcrError("OAuth issuer metadata request timed out", code="timeout") from exc
-        except httpx.HTTPError as exc:
-            raise DcrError("OAuth issuer metadata could not be reached", code="not_found") from exc
-
-        if 300 <= response.status_code < 400:
-            raise DcrError("OAuth issuer metadata redirects are not allowed", code="invalid_metadata")
-        if response.status_code != 200:
+        except httpx.HTTPError:
             return None
 
-        content_length = response.headers.get("content-length")
-        if content_length:
-            try:
-                if int(content_length) > _DISCOVERY_MAX_RESPONSE_BYTES:
-                    raise DcrError("OAuth issuer metadata response is too large", code="invalid_metadata")
-            except ValueError:
-                raise DcrError("OAuth issuer metadata response has an invalid content length", code="invalid_metadata") from None
-
-        content = response.content
-        if isinstance(content, bytes) and len(content) > _DISCOVERY_MAX_RESPONSE_BYTES:
-            raise DcrError("OAuth issuer metadata response is too large", code="invalid_metadata")
+        if 300 <= response.status_code < 400:
+            raise DcrError(f"AS metadata discovery redirect refused for {normalized_issuer} (status: {response.status_code})")
+        if response.status_code != 200:
+            return None
 
         try:
             metadata = response.json()
         except (ValueError, orjson.JSONDecodeError) as exc:
+            raise DcrError(f"AS metadata response is not valid JSON for {normalized_issuer}") from exc
+        if not isinstance(metadata, dict):
+            raise DcrError(f"AS metadata response is not a JSON object for {normalized_issuer}")
+
+        self._validate_metadata_issuer(metadata, normalized_issuer)
+        return metadata
+
+    async def _fetch_public_metadata_document(self, client: httpx.AsyncClient, url: str, normalized_issuer: str) -> Dict[str, Any] | None:
+        """Stream one public discovery document with strict response-size bounds."""
+        try:
+            async with client.stream("GET", url, headers={"Accept": "application/json"}, follow_redirects=False) as response:
+                if 300 <= response.status_code < 400:
+                    raise DcrError("OAuth issuer metadata redirects are not allowed", code="invalid_metadata")
+                if response.status_code != 200:
+                    return None
+
+                content_length = response.headers.get("content-length")
+                if content_length:
+                    try:
+                        if int(content_length) > _DISCOVERY_MAX_RESPONSE_BYTES:
+                            raise DcrError("OAuth issuer metadata response is too large", code="invalid_metadata")
+                    except ValueError:
+                        raise DcrError("OAuth issuer metadata response has an invalid content length", code="invalid_metadata") from None
+
+                body = bytearray()
+                async for chunk in response.aiter_bytes():
+                    if len(body) + len(chunk) > _DISCOVERY_MAX_RESPONSE_BYTES:
+                        raise DcrError("OAuth issuer metadata response is too large", code="invalid_metadata")
+                    body.extend(chunk)
+        except httpx.TimeoutException as exc:
+            raise DcrError("OAuth issuer metadata request timed out", code="timeout") from exc
+        except httpx.HTTPError:
+            return None
+
+        try:
+            metadata = orjson.loads(body)
+        except orjson.JSONDecodeError as exc:
             raise DcrError("OAuth issuer metadata is not valid JSON", code="invalid_metadata") from exc
         if not isinstance(metadata, dict):
             raise DcrError("OAuth issuer metadata must be a JSON object", code="invalid_metadata")
+        self._validate_metadata_issuer(metadata, normalized_issuer)
+        self._validate_metadata_shape(metadata)
+        return metadata
 
+    @staticmethod
+    def _validate_metadata_issuer(metadata: Dict[str, Any], normalized_issuer: str) -> None:
+        """Require provider metadata to identify the issuer that was requested."""
         metadata_issuer = str(metadata.get("issuer") or "").rstrip("/")
         if metadata_issuer != normalized_issuer:
             raise DcrError("OAuth issuer metadata issuer mismatch", code="invalid_metadata")
-        self._validate_metadata_shape(metadata)
-        return metadata
 
     @staticmethod
     def _validate_metadata_shape(metadata: Dict[str, Any]) -> None:
@@ -161,6 +210,52 @@ class DcrService:
         if scopes_supported is not None and (not isinstance(scopes_supported, list) or not all(isinstance(scope, str) and scope for scope in scopes_supported)):
             raise DcrError("OAuth issuer metadata has invalid scopes_supported", code="invalid_metadata")
 
+    async def _discover_metadata(
+        self,
+        normalized_issuer: str,
+        fetch_document: Callable[[str, str], Awaitable[Dict[str, Any] | None]],
+        validate_cached_metadata: Callable[[Dict[str, Any]], None] | None = None,
+    ) -> Dict[str, Any]:
+        """Discover, singleflight, and cache metadata through caller-selected policy."""
+        cached = self._get_cached_metadata(normalized_issuer, self.settings.dcr_metadata_cache_ttl)
+        if cached is not None:
+            if validate_cached_metadata:
+                validate_cached_metadata(cached)
+            logger.debug("Using cached AS metadata for %s", normalized_issuer)
+            return cached
+
+        metadata_lock = await self._metadata_lock(normalized_issuer)
+        try:
+            async with metadata_lock:
+                cached = self._get_cached_metadata(normalized_issuer, self.settings.dcr_metadata_cache_ttl)
+                if cached is not None:
+                    if validate_cached_metadata:
+                        validate_cached_metadata(cached)
+                    logger.debug("Using cached AS metadata for %s", normalized_issuer)
+                    return cached
+
+                parsed = urlsplit(normalized_issuer)
+                rfc8414_url = f"{parsed.scheme}://{parsed.netloc}/.well-known/oauth-authorization-server{parsed.path}"
+                metadata = await fetch_document(rfc8414_url, normalized_issuer)
+                discovery_method = "RFC 8414"
+
+                if metadata is None:
+                    metadata = await fetch_document(f"{normalized_issuer}/.well-known/openid-configuration", normalized_issuer)
+                    discovery_method = "OIDC Discovery"
+
+                if metadata is None:
+                    raise DcrError("OAuth issuer metadata was not found", code="not_found")
+
+                if validate_cached_metadata:
+                    validate_cached_metadata(metadata)
+                self._cache_metadata(normalized_issuer, metadata, self.settings.dcr_metadata_cache_ttl)
+                logger.info("Discovered AS metadata for %s via %s", normalized_issuer, discovery_method)
+                return metadata
+        finally:
+            async with _metadata_locks_guard:
+                if _metadata_locks.get(normalized_issuer) is metadata_lock and not metadata_lock.locked():
+                    _metadata_locks.pop(normalized_issuer, None)
+
     async def discover_as_metadata(self, issuer: str) -> Dict[str, Any]:
         """Discover AS metadata via RFC 8414.
 
@@ -177,48 +272,29 @@ class DcrService:
         Raises:
             DcrError: If metadata cannot be discovered
         """
-        # Normalize issuer URL by removing a trailing slash before RFC 8414
-        # well-known-path construction. The validation also prevents this public
-        # discovery capability from becoming an SSRF probing primitive.
-        normalized_issuer = await self._validate_discovery_issuer(issuer)
-        cached = self._get_cached_metadata(normalized_issuer, self.settings.dcr_metadata_cache_ttl)
-        if cached is not None:
-            logger.debug("Using cached AS metadata for %s", normalized_issuer)
-            return cached
+        return await self._discover_metadata(issuer.rstrip("/"), self._fetch_metadata_document)
 
-        metadata_lock = await self._metadata_lock(normalized_issuer)
-        try:
-            async with metadata_lock:
-                cached = self._get_cached_metadata(normalized_issuer, self.settings.dcr_metadata_cache_ttl)
-                if cached is not None:
-                    logger.debug("Using cached AS metadata for %s", normalized_issuer)
-                    return cached
-
-                # RFC 8414 inserts the well-known path between authority and any issuer path.
-                parsed = urlsplit(normalized_issuer)
-                rfc8414_url = f"{parsed.scheme}://{parsed.netloc}/.well-known/oauth-authorization-server{parsed.path}"
-                metadata = await self._fetch_metadata_document(rfc8414_url, normalized_issuer)
-                discovery_method = "RFC 8414"
-
-                if metadata is None:
-                    metadata = await self._fetch_metadata_document(
-                        f"{normalized_issuer}/.well-known/openid-configuration",
+    async def discover_public_as_metadata(self, issuer: str) -> Dict[str, Any]:
+        """Discover metadata for a public, user-supplied issuer without SSRF exposure."""
+        target = await self._validate_public_discovery_issuer(issuer)
+        normalized_issuer = str(target["validated_url"])
+        timeout = httpx.Timeout(_DISCOVERY_TIMEOUT_SECONDS)
+        async with get_pinned_http_client(
+            sni_hostname=str(target["hostname"]),
+            pinned_host=str(target["resolved_ip"]),
+            timeout=timeout,
+            verify=not self.settings.skip_ssl_verify,
+            limits=get_http_limits(),
+        ) as client:
+            try:
+                async with asyncio.timeout(_DISCOVERY_TIMEOUT_SECONDS):
+                    return await self._discover_metadata(
                         normalized_issuer,
+                        lambda url, issuer: self._fetch_public_metadata_document(client, url, issuer),
+                        self._validate_metadata_shape,
                     )
-                    discovery_method = "OIDC Discovery"
-
-                if metadata is None:
-                    raise DcrError("OAuth issuer metadata was not found", code="not_found")
-
-                _metadata_cache[normalized_issuer] = {"metadata": metadata, "cached_at": datetime.now(timezone.utc)}
-                logger.info("Discovered AS metadata for %s via %s", normalized_issuer, discovery_method)
-                return metadata
-        finally:
-            # Locks guard only in-flight work. Keeping one for every user-supplied
-            # issuer would let this public endpoint grow process memory forever.
-            async with _metadata_locks_guard:
-                if _metadata_locks.get(normalized_issuer) is metadata_lock and not metadata_lock.locked():
-                    _metadata_locks.pop(normalized_issuer, None)
+            except TimeoutError as exc:
+                raise DcrError("OAuth issuer metadata request timed out", code="timeout") from exc
 
     async def register_client(self, gateway_id: str, gateway_name: str, issuer: str, redirect_uri: str, scopes: List[str], db: Session) -> RegisteredOAuthClient:
         """Register as OAuth client with upstream AS (RFC 7591).

--- a/mcpgateway/services/dcr_service.py
+++ b/mcpgateway/services/dcr_service.py
@@ -150,7 +150,8 @@ class DcrService:
         try:
             async with client.stream("GET", url, headers={"Accept": "application/json"}, follow_redirects=False) as response:
                 if 300 <= response.status_code < 400:
-                    raise DcrError("OAuth issuer metadata redirects are not allowed", code="invalid_metadata")
+                    # Do not follow redirects: try the safe OIDC discovery path instead.
+                    return None
                 if response.status_code != 200:
                     return None
 
@@ -194,11 +195,9 @@ class DcrService:
         """Validate metadata fields that are returned to the registration UI."""
         for field_name in ("authorization_endpoint", "token_endpoint"):
             value = metadata.get(field_name)
-            if value is None:
-                continue
             parsed = urlsplit(value) if isinstance(value, str) else None
             if not parsed or parsed.scheme != "https" or not parsed.netloc or parsed.username or parsed.password:
-                raise DcrError(f"OAuth issuer metadata has invalid {field_name}", code="invalid_metadata")
+                raise DcrError(f"OAuth issuer metadata is missing or has invalid {field_name}", code="invalid_metadata")
 
         registration_endpoint = metadata.get("registration_endpoint")
         if registration_endpoint is not None:
@@ -215,42 +214,45 @@ class DcrService:
         normalized_issuer: str,
         fetch_document: Callable[[str, str], Awaitable[Dict[str, Any] | None]],
         validate_cached_metadata: Callable[[Dict[str, Any]], None] | None = None,
+        *,
+        singleflight: bool = False,
     ) -> Dict[str, Any]:
-        """Discover, singleflight, and cache metadata through caller-selected policy."""
-        cached = self._get_cached_metadata(normalized_issuer, self.settings.dcr_metadata_cache_ttl)
-        if cached is not None:
+        """Discover and cache metadata; optionally singleflight concurrent public requests."""
+
+        async def discover() -> Dict[str, Any]:
+            """Perform one cache-aware discovery attempt."""
+            cached = self._get_cached_metadata(normalized_issuer, self.settings.dcr_metadata_cache_ttl)
+            if cached is not None:
+                if validate_cached_metadata:
+                    validate_cached_metadata(cached)
+                logger.debug("Using cached AS metadata for %s", normalized_issuer)
+                return cached
+
+            parsed = urlsplit(normalized_issuer)
+            rfc8414_url = f"{parsed.scheme}://{parsed.netloc}/.well-known/oauth-authorization-server{parsed.path}"
+            metadata = await fetch_document(rfc8414_url, normalized_issuer)
+            discovery_method = "RFC 8414"
+
+            if metadata is None:
+                metadata = await fetch_document(f"{normalized_issuer}/.well-known/openid-configuration", normalized_issuer)
+                discovery_method = "OIDC Discovery"
+
+            if metadata is None:
+                raise DcrError("OAuth issuer metadata was not found", code="not_found")
+
             if validate_cached_metadata:
-                validate_cached_metadata(cached)
-            logger.debug("Using cached AS metadata for %s", normalized_issuer)
-            return cached
+                validate_cached_metadata(metadata)
+            self._cache_metadata(normalized_issuer, metadata, self.settings.dcr_metadata_cache_ttl)
+            logger.info("Discovered AS metadata for %s via %s", normalized_issuer, discovery_method)
+            return metadata
+
+        if not singleflight:
+            return await discover()
 
         metadata_lock = await self._metadata_lock(normalized_issuer)
         try:
             async with metadata_lock:
-                cached = self._get_cached_metadata(normalized_issuer, self.settings.dcr_metadata_cache_ttl)
-                if cached is not None:
-                    if validate_cached_metadata:
-                        validate_cached_metadata(cached)
-                    logger.debug("Using cached AS metadata for %s", normalized_issuer)
-                    return cached
-
-                parsed = urlsplit(normalized_issuer)
-                rfc8414_url = f"{parsed.scheme}://{parsed.netloc}/.well-known/oauth-authorization-server{parsed.path}"
-                metadata = await fetch_document(rfc8414_url, normalized_issuer)
-                discovery_method = "RFC 8414"
-
-                if metadata is None:
-                    metadata = await fetch_document(f"{normalized_issuer}/.well-known/openid-configuration", normalized_issuer)
-                    discovery_method = "OIDC Discovery"
-
-                if metadata is None:
-                    raise DcrError("OAuth issuer metadata was not found", code="not_found")
-
-                if validate_cached_metadata:
-                    validate_cached_metadata(metadata)
-                self._cache_metadata(normalized_issuer, metadata, self.settings.dcr_metadata_cache_ttl)
-                logger.info("Discovered AS metadata for %s via %s", normalized_issuer, discovery_method)
-                return metadata
+                return await discover()
         finally:
             async with _metadata_locks_guard:
                 if _metadata_locks.get(normalized_issuer) is metadata_lock and not metadata_lock.locked():
@@ -292,6 +294,7 @@ class DcrService:
                         normalized_issuer,
                         lambda url, issuer: self._fetch_public_metadata_document(client, url, issuer),
                         self._validate_metadata_shape,
+                        singleflight=True,
                     )
             except TimeoutError as exc:
                 raise DcrError("OAuth issuer metadata request timed out", code="timeout") from exc

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -119,7 +119,7 @@ from mcpgateway.services.audit_trail_service import get_audit_trail_service
 from mcpgateway.services.base_service import BaseService
 from mcpgateway.services.encryption_service import get_encryption_service, protect_oauth_config_for_storage
 from mcpgateway.services.event_service import EventService
-from mcpgateway.services.http_client_service import get_default_verify, get_http_timeout, get_isolated_http_client
+from mcpgateway.services.http_client_service import SniPinningTransport, get_default_verify, get_http_timeout, get_isolated_http_client
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.mcp_apps import merge_mcp_protocol_meta, optional_extension_metadata, validate_extension_metadata, validate_ui_resource
 from mcpgateway.services.oauth_manager import OAuthManager
@@ -7568,51 +7568,6 @@ _HANDSHAKE_PROTOCOL_COPY = (
 _HANDSHAKE_INVALID_COPY = "The server's response is not valid MCP. The URL may point at a service that does not speak MCP."
 
 
-class _SniPinningTransport(httpx.AsyncHTTPTransport):
-    """Dial a DNS-pinned address while keeping the request's hostname authority and TLS identity.
-
-    The MCP SDK compares the origin it connected to against the origin the
-    server advertises (``mcp.client.sse`` raises on a mismatch), so pinning has
-    to happen below the SDK: requests keep the validated hostname in their URL
-    and ``Host`` header, while every connection goes to the address resolved at
-    validation time and TLS is verified against that hostname.
-    """
-
-    def __init__(self, sni_hostname: str, pinned_host: str, **kwargs: Any) -> None:
-        """Record the validated hostname and the address to dial in its place.
-
-        Args:
-            sni_hostname: Validated hostname whose certificate must match.
-            pinned_host: Address resolved at validation time, dialled instead of re-resolving.
-            **kwargs: Forwarded to ``httpx.AsyncHTTPTransport``.
-        """
-        super().__init__(**kwargs)
-        self._sni_hostname = sni_hostname
-        self._pinned_host = pinned_host
-
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        """Send the request to the pinned address with TLS pinned to the validated hostname.
-
-        Args:
-            request: Outbound request addressed to the validated hostname.
-
-        Returns:
-            httpx.Response: The upstream response.
-
-        Raises:
-            httpx.UnsupportedProtocol: If the request targets any other host.
-        """
-        # Compare the IDNA-encoded form: httpx decodes punycode back to Unicode on `url.host`,
-        # while the validated hostname arrives punycode-encoded from the request schema.
-        if request.url.raw_host.decode("ascii") != self._sni_hostname:
-            raise httpx.UnsupportedProtocol(f"Gateway test refused a request to unvalidated host {request.url.host}", request=request)
-        request.extensions.setdefault("sni_hostname", self._sni_hostname)
-        # httpx derived the Host header from the hostname URL at construction time; rewriting the
-        # URL afterwards keeps that header while sending the bytes to the pinned address.
-        request.url = request.url.copy_with(host=self._pinned_host)
-        return await super().handle_async_request(request)
-
-
 def _gateway_test_visibility_filters(db: Session, user: Any) -> List[Any]:
     """Build Layer-1 visibility conditions for gateway-test queries.
 
@@ -8434,7 +8389,7 @@ async def test_gateway_handshake(
             headers=headers,
             timeout=timeout if timeout else get_http_timeout(),
             auth=auth,
-            transport=_SniPinningTransport(
+            transport=SniPinningTransport(
                 sni_hostname=validated_hostname,
                 pinned_host=target["resolved_ip"],
                 verify=handshake_verify,
@@ -8551,7 +8506,7 @@ async def test_gateway_handshake(
             try:
                 # SECURITY: the SDK keeps the validated hostname (it rejects a server-advertised
                 # endpoint whose origin differs from the one it connected to), while
-                # _SniPinningTransport sends every request to the IP pinned at validation time
+                # SniPinningTransport sends every request to the IP pinned at validation time
                 # with TLS verified against that hostname, closing the same DNS rebinding window
                 # as server/discover, on the follow-up requests too.
                 if gateway and str(gateway.transport).lower() == "sse":

--- a/mcpgateway/services/http_client_service.py
+++ b/mcpgateway/services/http_client_service.py
@@ -55,7 +55,12 @@ logger = logging.getLogger(__name__)
 
 
 class SniPinningTransport(httpx.AsyncHTTPTransport):
-    """Dial a validated address while preserving hostname authority and TLS SNI."""
+    """Dial a DNS-pinned address while keeping request hostname authority and TLS identity.
+
+    Requests retain the validated hostname in their URL and ``Host`` header,
+    while this transport dials the address resolved at validation time. This
+    prevents DNS rebinding without breaking TLS SNI or origin checks in callers.
+    """
 
     def __init__(self, sni_hostname: str, pinned_host: str, **kwargs: Any) -> None:
         """Initialize transport with the validated hostname and resolved address."""
@@ -64,10 +69,14 @@ class SniPinningTransport(httpx.AsyncHTTPTransport):
         self._pinned_host = pinned_host
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        """Send only requests addressed to the validated hostname."""
+        """Send only requests addressed to validated hostname via pinned address."""
+        # Compare the IDNA-encoded form: httpx decodes punycode in ``url.host``
+        # while request validation retains the encoded hostname.
         if request.url.raw_host.decode("ascii") != self._sni_hostname:
             raise httpx.UnsupportedProtocol(f"Refused a request to unvalidated host {request.url.host}", request=request)
         request.extensions.setdefault("sni_hostname", self._sni_hostname)
+        # httpx derives Host from the original URL. Rewrite only dial address so
+        # host authority and TLS identity remain bound to the validated hostname.
         request.url = request.url.copy_with(host=self._pinned_host)
         return await super().handle_async_request(request)
 

--- a/mcpgateway/services/http_client_service.py
+++ b/mcpgateway/services/http_client_service.py
@@ -46,12 +46,45 @@ import asyncio
 from contextlib import asynccontextmanager
 import logging
 import ssl
-from typing import AsyncIterator, Optional
+from typing import Any, AsyncIterator, Optional
 
 # Third-Party
 import httpx
 
 logger = logging.getLogger(__name__)
+
+
+class SniPinningTransport(httpx.AsyncHTTPTransport):
+    """Dial a validated address while preserving hostname authority and TLS SNI."""
+
+    def __init__(self, sni_hostname: str, pinned_host: str, **kwargs: Any) -> None:
+        """Initialize transport with the validated hostname and resolved address."""
+        super().__init__(**kwargs)
+        self._sni_hostname = sni_hostname
+        self._pinned_host = pinned_host
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        """Send only requests addressed to the validated hostname."""
+        if request.url.raw_host.decode("ascii") != self._sni_hostname:
+            raise httpx.UnsupportedProtocol(f"Refused a request to unvalidated host {request.url.host}", request=request)
+        request.extensions.setdefault("sni_hostname", self._sni_hostname)
+        request.url = request.url.copy_with(host=self._pinned_host)
+        return await super().handle_async_request(request)
+
+
+@asynccontextmanager
+async def get_pinned_http_client(
+    *,
+    sni_hostname: str,
+    pinned_host: str,
+    timeout: httpx.Timeout,
+    verify: bool,
+    limits: httpx.Limits,
+) -> AsyncIterator[httpx.AsyncClient]:
+    """Yield a short-lived client that cannot re-resolve its validated target."""
+    transport = SniPinningTransport(sni_hostname=sni_hostname, pinned_host=pinned_host, verify=verify, limits=limits)
+    async with httpx.AsyncClient(transport=transport, timeout=timeout, follow_redirects=False) as client:
+        yield client
 
 
 class SharedHttpClient:

--- a/tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py
@@ -49,6 +49,8 @@ class TestRateLimiterRedisUrl:
         mock_settings.rate_limiting_enabled = True
         mock_settings.rate_limiting_redis_enabled = True
         mock_settings.ratelimiter_redis_url = "redis://localhost:6380/0"
+        mock_settings.rate_limit_medium_rpm = 100
+        mock_settings.rate_limit_medium_burst = 20
 
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client
@@ -67,6 +69,8 @@ class TestRateLimiterRedisUrl:
         mock_settings.rate_limiting_enabled = True
         mock_settings.rate_limiting_redis_enabled = True
         mock_settings.ratelimiter_redis_url = None
+        mock_settings.rate_limit_medium_rpm = 100
+        mock_settings.rate_limit_medium_burst = 20
 
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client
@@ -549,6 +553,7 @@ class TestRateLimitMiddlewareTiers:
             mock_settings.rate_limit_critical_rpm = 10
             mock_settings.rate_limit_high_rpm = 30
             mock_settings.rate_limit_medium_rpm = 100
+            mock_settings.rate_limit_medium_burst = 20
             mock_settings.rate_limit_low_rpm = 500
             mock_settings.rate_limit_lockout_enabled = True
             mock_settings.rate_limit_lockout_threshold = 5
@@ -1163,6 +1168,7 @@ class TestRateLimitMiddlewareTiers:
             mock_settings.rate_limit_critical_rpm = 10
             mock_settings.rate_limit_high_rpm = 30
             mock_settings.rate_limit_medium_rpm = 100
+            mock_settings.rate_limit_medium_burst = 20
             mock_settings.rate_limit_low_rpm = 500
             mock_settings.rate_limit_lockout_enabled = True
             mock_settings.rate_limit_lockout_threshold = 5
@@ -1229,6 +1235,8 @@ class TestRateLimitMiddlewareTiers:
         with patch("mcpgateway.middleware.rate_limit_middleware.settings") as ms:
             ms.rate_limiting_enabled = False
             ms.rate_limiting_redis_enabled = True
+            ms.rate_limit_medium_rpm = 100
+            ms.rate_limit_medium_burst = 20
 
             from mcpgateway.middleware.rate_limit_middleware import RateLimitMiddleware
 

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -259,6 +259,12 @@ class TestTokenScopingMiddleware:
         # A multi-segment tool name must still match (re.match is a prefix match).
         assert middleware._check_permission_restrictions("/tools/preview/gateway-slug/tool-name", "POST", [Permissions.TOOLS_PREVIEW]) is True
 
+    @pytest.mark.parametrize("path", ["/gateways/discover-metadata", "/v1/gateways/discover-metadata"])
+    def test_oauth_metadata_discovery_requires_gateways_create(self, middleware, path):
+        """Scoped gateway-create tokens reach public OAuth metadata discovery."""
+        assert middleware._check_permission_restrictions(path, "POST", [Permissions.GATEWAYS_CREATE]) is True
+        assert middleware._check_permission_restrictions(path, "POST", [Permissions.GATEWAYS_READ]) is False
+
     def test_versioned_virtual_server_restriction_checks_alias_id(self, middleware):
         """Server-scoped tokens must enforce the ID in versioned virtual-server paths."""
         path = "/v1/virtual-servers/server-123/tools"

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -1756,6 +1756,8 @@ class TestTokenScopingMiddleware:
         # Test POST /gateways (exact) requires GATEWAYS_CREATE
         assert middleware._check_permission_restrictions("/gateways", "POST", [Permissions.GATEWAYS_CREATE]) is True
         assert middleware._check_permission_restrictions("/gateways/", "POST", [Permissions.GATEWAYS_CREATE]) is True
+        assert middleware._check_permission_restrictions("/gateways/discover-metadata", "POST", [Permissions.GATEWAYS_CREATE]) is True
+        assert middleware._check_permission_restrictions("/gateways/discover-metadata", "POST", [Permissions.GATEWAYS_UPDATE]) is False
 
         # Test POST to sub-resources requires GATEWAYS_UPDATE (not CREATE)
         assert middleware._check_permission_restrictions("/gateways/gw-123/state", "POST", [Permissions.GATEWAYS_UPDATE]) is True

--- a/tests/unit/mcpgateway/routers/test_mcp_servers_router.py
+++ b/tests/unit/mcpgateway/routers/test_mcp_servers_router.py
@@ -29,6 +29,7 @@ from sqlalchemy.orm import sessionmaker
 from mcpgateway.db import Base, Gateway as DbGateway
 from mcpgateway.routers.mcp_servers_router import _validated_team_id, check_mcp_server_connectivity, check_mcp_server_handshake
 from mcpgateway.schemas import GatewayHandshakeRequest, GatewayHandshakeResponse, GatewayTestRequest, GatewayTestResponse
+from mcpgateway.services.http_client_service import SniPinningTransport
 from mcpgateway.services.gateway_service import (
     _classify_handshake_error,
     _gateway_test_visibility_filters,
@@ -36,7 +37,6 @@ from mcpgateway.services.gateway_service import (
     _HANDSHAKE_INVALID_COPY,
     _HANDSHAKE_PROTOCOL_COPY,
     _HANDSHAKE_TRANSPORT_COPY,
-    _SniPinningTransport,
 )
 
 # Local
@@ -756,10 +756,10 @@ async def test_handshake_discover_fallback_to_initialize(handshake_request, user
     assert result.protocol_version == "2025-11-25"
     assert result.server_name == "legacy-srv"
     assert result.component_counts == {"tools": 2}
-    # The SDK keeps the validated hostname; _SniPinningTransport dials the pinned address.
+    # The SDK keeps the validated hostname; SniPinningTransport dials the pinned address.
     assert mock_streamable.call_args.kwargs["url"] == "http://example.com/mcp"
 
-    with patch("mcpgateway.services.gateway_service._SniPinningTransport", wraps=_SniPinningTransport) as mock_transport:
+    with patch("mcpgateway.services.gateway_service.SniPinningTransport", wraps=SniPinningTransport) as mock_transport:
         factory_client = mock_streamable.call_args.kwargs["httpx_client_factory"]()
         await factory_client.aclose()
 
@@ -1183,7 +1183,7 @@ async def test_handshake_sse_gateway_uses_sse_client(handshake_request, user_ctx
     assert mock_sse.call_args.kwargs["url"] == "http://example.com/mcp"
 
     factory = mock_sse.call_args.kwargs["httpx_client_factory"]
-    with patch("mcpgateway.services.gateway_service._SniPinningTransport", wraps=_SniPinningTransport) as mock_transport:
+    with patch("mcpgateway.services.gateway_service.SniPinningTransport", wraps=SniPinningTransport) as mock_transport:
         factory_client = factory()
         try:
             assert isinstance(factory_client, httpx.AsyncClient)
@@ -1574,7 +1574,7 @@ async def test_handshake_registered_only_allowlist_keeps_public_gateways_probeab
 @pytest.mark.asyncio
 async def test_sni_pinning_transport_dials_pinned_host_with_hostname_identity():
     """The transport rewrites the request onto the pinned address while keeping Host and TLS identity."""
-    transport = _SniPinningTransport(sni_hostname="example.com", pinned_host="8.8.8.8")
+    transport = SniPinningTransport(sni_hostname="example.com", pinned_host="8.8.8.8")
     request = httpx.Request("GET", "http://example.com/mcp")
 
     with patch.object(httpx.AsyncHTTPTransport, "handle_async_request", AsyncMock(return_value=httpx.Response(200))):
@@ -1589,7 +1589,7 @@ async def test_sni_pinning_transport_dials_pinned_host_with_hostname_identity():
 @pytest.mark.asyncio
 async def test_sni_pinning_transport_refuses_unvalidated_host():
     """The transport refuses to send anywhere but the validated hostname."""
-    transport = _SniPinningTransport(sni_hostname="example.com", pinned_host="8.8.8.8")
+    transport = SniPinningTransport(sni_hostname="example.com", pinned_host="8.8.8.8")
     request = httpx.Request("GET", "http://attacker.example.net/mcp")
 
     with pytest.raises(httpx.UnsupportedProtocol):
@@ -1640,7 +1640,7 @@ async def test_handshake_uses_gateway_custom_ca_for_tls(user_ctx, db_session):
     assert result.success is True
     mock_ssl.assert_called_once_with("ca-pem", client_cert="client-pem", client_key="key-pem")
 
-    with patch("mcpgateway.services.gateway_service._SniPinningTransport", wraps=_SniPinningTransport) as mock_transport:
+    with patch("mcpgateway.services.gateway_service.SniPinningTransport", wraps=SniPinningTransport) as mock_transport:
         factory_client = mock_streamable.call_args.kwargs["httpx_client_factory"]()
         await factory_client.aclose()
 
@@ -1653,7 +1653,7 @@ async def test_handshake_uses_gateway_custom_ca_for_tls(user_ctx, db_session):
 @pytest.mark.asyncio
 async def test_sni_pinning_transport_accepts_punycode_host():
     """An internationalized hostname is matched in its IDNA-encoded form, not rejected."""
-    transport = _SniPinningTransport(sni_hostname="xn--nicode-2ya.com", pinned_host="8.8.8.8")
+    transport = SniPinningTransport(sni_hostname="xn--nicode-2ya.com", pinned_host="8.8.8.8")
     request = httpx.Request("GET", "http://xn--nicode-2ya.com/mcp")
 
     with patch.object(httpx.AsyncHTTPTransport, "handle_async_request", AsyncMock(return_value=httpx.Response(200))):

--- a/tests/unit/mcpgateway/services/test_dcr_service.py
+++ b/tests/unit/mcpgateway/services/test_dcr_service.py
@@ -10,6 +10,7 @@ Tests will FAIL until implementation is complete.
 """
 
 # Standard
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
@@ -1261,6 +1262,88 @@ class TestIssuerValidation:
 
                 # Verify the stored issuer is normalized (no trailing slash)
                 assert result.issuer == "https://as-slash.example.com"
+
+
+class TestPublicMetadataDiscoverySafety:
+    """Security and concurrency coverage for public issuer discovery."""
+
+    @pytest.mark.asyncio
+    async def test_discovery_rejects_non_https_issuer(self):
+        """Discovery refuses non-HTTPS issuers after outbound validation."""
+        dcr_service = DcrService()
+
+        with patch(
+            "mcpgateway.services.dcr_service.SecurityValidator.validate_url_for_connection_pinning",
+            new=AsyncMock(return_value={"validated_url": "http://issuer.example.com"}),
+        ):
+            with pytest.raises(DcrError, match="HTTPS") as error:
+                await dcr_service.discover_as_metadata("http://issuer.example.com")
+
+        assert error.value.code == "blocked"
+
+    @pytest.mark.asyncio
+    async def test_discovery_rejects_oversized_metadata_response(self):
+        """Discovery enforces the metadata response-size limit before parsing JSON."""
+        dcr_service = DcrService()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-length": str(256 * 1024 + 1)}
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch.object(dcr_service, "_validate_discovery_issuer", return_value="https://issuer.example.com"),
+            patch.object(dcr_service, "_get_client", return_value=mock_client),
+        ):
+            with pytest.raises(DcrError, match="too large") as error:
+                await dcr_service.discover_as_metadata("https://issuer.example.com")
+
+        assert error.value.code == "invalid_metadata"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_discovery_singleflights_per_issuer(self):
+        """Concurrent cold-cache requests share one issuer metadata fetch."""
+        # First-Party
+        from mcpgateway.services.dcr_service import _metadata_cache, _metadata_locks
+
+        _metadata_cache.clear()
+        _metadata_locks.clear()
+        dcr_service = DcrService()
+        started = asyncio.Event()
+        release = asyncio.Event()
+        metadata = {
+            "issuer": "https://issuer.example.com",
+            "authorization_endpoint": "https://issuer.example.com/authorize",
+            "token_endpoint": "https://issuer.example.com/token",
+        }
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.content = b"{}"
+        mock_response.json = MagicMock(return_value=metadata)
+
+        async def delayed_get(*_args, **_kwargs):
+            started.set()
+            await release.wait()
+            return mock_response
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=delayed_get)
+
+        with (
+            patch.object(dcr_service, "_validate_discovery_issuer", return_value="https://issuer.example.com"),
+            patch.object(dcr_service, "_get_client", return_value=mock_client),
+        ):
+            first = asyncio.create_task(dcr_service.discover_as_metadata("https://issuer.example.com"))
+            await started.wait()
+            second = asyncio.create_task(dcr_service.discover_as_metadata("https://issuer.example.com"))
+            await asyncio.sleep(0)
+            release.set()
+            assert await first == metadata
+            assert await second == metadata
+
+        assert mock_client.get.await_count == 1
 
 
 class TestDcrError:

--- a/tests/unit/mcpgateway/services/test_dcr_service.py
+++ b/tests/unit/mcpgateway/services/test_dcr_service.py
@@ -11,6 +11,7 @@ Tests will FAIL until implementation is complete.
 
 # Standard
 import asyncio
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
@@ -1274,10 +1275,35 @@ class TestPublicMetadataDiscoverySafety:
 
         with patch(
             "mcpgateway.services.dcr_service.SecurityValidator.validate_url_for_connection_pinning",
-            new=AsyncMock(return_value={"validated_url": "http://issuer.example.com"}),
+            new=AsyncMock(
+                return_value={
+                    "validated_url": "http://issuer.example.com",
+                    "hostname": "issuer.example.com",
+                    "original_authority": "issuer.example.com",
+                    "resolved_ip": "203.0.113.10",
+                }
+            ),
         ):
             with pytest.raises(DcrError, match="HTTPS") as error:
-                await dcr_service.discover_as_metadata("http://issuer.example.com")
+                await dcr_service.discover_public_as_metadata("http://issuer.example.com")
+
+        assert error.value.code == "blocked"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "issuer",
+        [
+            "https://127.0.0.1",
+            "https://169.254.10.1",
+            "https://169.254.169.254/latest/meta-data",
+        ],
+    )
+    async def test_public_discovery_rejects_ssrf_addresses(self, issuer):
+        """Public discovery applies real SSRF policy before opening a connection."""
+        dcr_service = DcrService()
+
+        with pytest.raises(DcrError, match="blocked") as error:
+            await dcr_service.discover_public_as_metadata(issuer)
 
         assert error.value.code == "blocked"
 
@@ -1285,21 +1311,137 @@ class TestPublicMetadataDiscoverySafety:
     async def test_discovery_rejects_oversized_metadata_response(self):
         """Discovery enforces the metadata response-size limit before parsing JSON."""
         dcr_service = DcrService()
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.headers = {"content-length": str(256 * 1024 + 1)}
+        mock_response = MagicMock(status_code=200, headers={})
 
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
+        async def oversized_chunks():
+            yield b"x" * (256 * 1024 + 1)
+
+        mock_response.aiter_bytes.return_value = oversized_chunks()
+
+        class StreamContext:
+            """Minimal async stream context for a bounded-body test."""
+
+            async def __aenter__(self):
+                return mock_response
+
+            async def __aexit__(self, *_args):
+                return False
+
+        mock_client = MagicMock()
+        mock_client.stream.return_value = StreamContext()
+
+        @asynccontextmanager
+        async def pinned_client(**_kwargs):
+            yield mock_client
 
         with (
-            patch.object(dcr_service, "_validate_discovery_issuer", return_value="https://issuer.example.com"),
-            patch.object(dcr_service, "_get_client", return_value=mock_client),
+            patch(
+                "mcpgateway.services.dcr_service.SecurityValidator.validate_url_for_connection_pinning",
+                new=AsyncMock(
+                    return_value={
+                        "validated_url": "https://issuer.example.com",
+                        "hostname": "issuer.example.com",
+                        "original_authority": "issuer.example.com",
+                        "resolved_ip": "203.0.113.10",
+                    }
+                ),
+            ),
+            patch("mcpgateway.services.dcr_service.get_pinned_http_client", pinned_client),
         ):
             with pytest.raises(DcrError, match="too large") as error:
-                await dcr_service.discover_as_metadata("https://issuer.example.com")
+                await dcr_service.discover_public_as_metadata("https://issuer.example.com")
 
         assert error.value.code == "invalid_metadata"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "body",
+        [
+            b"{not-json}",
+            b'{"issuer":"https://other.example.com"}',
+        ],
+    )
+    async def test_public_discovery_rejects_invalid_metadata(self, body):
+        """Public discovery rejects malformed JSON and mismatched issuers."""
+        dcr_service = DcrService()
+        response = MagicMock(status_code=200, headers={})
+
+        async def response_bytes():
+            yield body
+
+        response.aiter_bytes.return_value = response_bytes()
+
+        class StreamContext:
+            """Minimal async stream context for metadata validation tests."""
+
+            async def __aenter__(self):
+                return response
+
+            async def __aexit__(self, *_args):
+                return False
+
+        client = MagicMock()
+        client.stream.return_value = StreamContext()
+
+        @asynccontextmanager
+        async def pinned_client(**_kwargs):
+            yield client
+
+        target = {
+            "validated_url": "https://issuer.example.com",
+            "hostname": "issuer.example.com",
+            "original_authority": "issuer.example.com",
+            "resolved_ip": "203.0.113.10",
+        }
+        with (
+            patch("mcpgateway.services.dcr_service.SecurityValidator.validate_url_for_connection_pinning", new=AsyncMock(return_value=target)),
+            patch("mcpgateway.services.dcr_service.get_pinned_http_client", pinned_client),
+            pytest.raises(DcrError) as error,
+        ):
+            await dcr_service.discover_public_as_metadata("https://issuer.example.com")
+
+        assert error.value.code == "invalid_metadata"
+
+    @pytest.mark.asyncio
+    async def test_public_discovery_enforces_total_timeout(self):
+        """Both metadata paths share one five-second public-discovery budget."""
+        dcr_service = DcrService()
+        target = {
+            "validated_url": "https://timeout.example.com",
+            "hostname": "timeout.example.com",
+            "original_authority": "timeout.example.com",
+            "resolved_ip": "203.0.113.10",
+        }
+
+        @asynccontextmanager
+        async def pinned_client(**_kwargs):
+            yield MagicMock()
+
+        async def never_returns(*_args):
+            await asyncio.Event().wait()
+
+        with (
+            patch("mcpgateway.services.dcr_service._DISCOVERY_TIMEOUT_SECONDS", 0.01),
+            patch("mcpgateway.services.dcr_service.SecurityValidator.validate_url_for_connection_pinning", new=AsyncMock(return_value=target)),
+            patch("mcpgateway.services.dcr_service.get_pinned_http_client", pinned_client),
+            patch.object(dcr_service, "_fetch_public_metadata_document", side_effect=never_returns),
+            pytest.raises(DcrError, match="timed out") as error,
+        ):
+            await dcr_service.discover_public_as_metadata("https://timeout.example.com")
+
+        assert error.value.code == "timeout"
+
+    def test_metadata_cache_evicts_least_recently_used_issuer(self):
+        """Arbitrary public issuer input cannot grow metadata cache without bound."""
+        # First-Party
+        from mcpgateway.services.dcr_service import _METADATA_CACHE_MAX_ENTRIES, _metadata_cache
+
+        _metadata_cache.clear()
+        for index in range(_METADATA_CACHE_MAX_ENTRIES + 1):
+            DcrService._cache_metadata(f"https://issuer-{index}.example.com", {"issuer": str(index)}, cache_ttl=60)
+
+        assert len(_metadata_cache) == _METADATA_CACHE_MAX_ENTRIES
+        assert "https://issuer-0.example.com" not in _metadata_cache
 
     @pytest.mark.asyncio
     async def test_concurrent_discovery_singleflights_per_issuer(self):
@@ -1331,10 +1473,7 @@ class TestPublicMetadataDiscoverySafety:
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(side_effect=delayed_get)
 
-        with (
-            patch.object(dcr_service, "_validate_discovery_issuer", return_value="https://issuer.example.com"),
-            patch.object(dcr_service, "_get_client", return_value=mock_client),
-        ):
+        with patch.object(dcr_service, "_get_client", return_value=mock_client):
             first = asyncio.create_task(dcr_service.discover_as_metadata("https://issuer.example.com"))
             await started.wait()
             second = asyncio.create_task(dcr_service.discover_as_metadata("https://issuer.example.com"))
@@ -1344,6 +1483,25 @@ class TestPublicMetadataDiscoverySafety:
             assert await second == metadata
 
         assert mock_client.get.await_count == 1
+
+
+class TestExistingDiscoveryCompatibility:
+    """Regression coverage for DCR callers outside the public endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_existing_discovery_keeps_http_issuer_compatibility(self):
+        """OAuth login and gateway registration retain pre-endpoint HTTP behavior."""
+        dcr_service = DcrService()
+        metadata = {"issuer": "http://issuer.example.com"}
+        response = MagicMock(status_code=200)
+        response.json.return_value = metadata
+        client = AsyncMock()
+        client.get.return_value = response
+
+        with patch.object(dcr_service, "_get_client", return_value=client):
+            result = await dcr_service.discover_as_metadata("http://issuer.example.com")
+
+        assert result == metadata
 
 
 class TestDcrError:

--- a/tests/unit/mcpgateway/services/test_dcr_service.py
+++ b/tests/unit/mcpgateway/services/test_dcr_service.py
@@ -1405,6 +1405,56 @@ class TestPublicMetadataDiscoverySafety:
         assert error.value.code == "invalid_metadata"
 
     @pytest.mark.asyncio
+    async def test_public_discovery_falls_back_after_rfc8414_redirect(self):
+        """A refused RFC 8414 redirect still permits safe OIDC discovery."""
+        dcr_service = DcrService()
+        redirect_response = MagicMock(status_code=302, headers={})
+        metadata_response = MagicMock(status_code=200, headers={})
+        metadata = {
+            "issuer": "https://issuer.example.com",
+            "authorization_endpoint": "https://issuer.example.com/authorize",
+            "token_endpoint": "https://issuer.example.com/token",
+        }
+
+        async def metadata_bytes():
+            yield b'{"issuer":"https://issuer.example.com","authorization_endpoint":"https://issuer.example.com/authorize","token_endpoint":"https://issuer.example.com/token"}'
+
+        metadata_response.aiter_bytes.return_value = metadata_bytes()
+
+        class StreamContext:
+            """Minimal async stream context for a discovery response."""
+
+            def __init__(self, response):
+                self.response = response
+
+            async def __aenter__(self):
+                return self.response
+
+            async def __aexit__(self, *_args):
+                return False
+
+        client = MagicMock()
+        client.stream.side_effect = [StreamContext(redirect_response), StreamContext(metadata_response)]
+
+        @asynccontextmanager
+        async def pinned_client(**_kwargs):
+            yield client
+
+        target = {
+            "validated_url": "https://issuer.example.com",
+            "hostname": "issuer.example.com",
+            "original_authority": "issuer.example.com",
+            "resolved_ip": "203.0.113.10",
+        }
+        with (
+            patch("mcpgateway.services.dcr_service.SecurityValidator.validate_url_for_connection_pinning", new=AsyncMock(return_value=target)),
+            patch("mcpgateway.services.dcr_service.get_pinned_http_client", pinned_client),
+        ):
+            assert await dcr_service.discover_public_as_metadata("https://issuer.example.com") == metadata
+
+        assert client.stream.call_count == 2
+
+    @pytest.mark.asyncio
     async def test_public_discovery_enforces_total_timeout(self):
         """Both metadata paths share one five-second public-discovery budget."""
         dcr_service = DcrService()
@@ -1446,8 +1496,8 @@ class TestPublicMetadataDiscoverySafety:
         assert "https://issuer-0.example.com" not in _metadata_cache
 
     @pytest.mark.asyncio
-    async def test_concurrent_discovery_singleflights_per_issuer(self):
-        """Concurrent cold-cache requests share one issuer metadata fetch."""
+    async def test_public_discovery_singleflights_per_issuer(self):
+        """Concurrent cold-cache public requests share one issuer metadata fetch."""
         # First-Party
         from mcpgateway.services.dcr_service import _metadata_cache, _metadata_locks
 
@@ -1461,30 +1511,69 @@ class TestPublicMetadataDiscoverySafety:
             "authorization_endpoint": "https://issuer.example.com/authorize",
             "token_endpoint": "https://issuer.example.com/token",
         }
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.headers = {}
-        mock_response.content = b"{}"
-        mock_response.json = MagicMock(return_value=metadata)
+        target = {
+            "validated_url": "https://issuer.example.com",
+            "hostname": "issuer.example.com",
+            "original_authority": "issuer.example.com",
+            "resolved_ip": "203.0.113.10",
+        }
 
-        async def delayed_get(*_args, **_kwargs):
+        @asynccontextmanager
+        async def pinned_client(**_kwargs):
+            yield MagicMock()
+
+        async def delayed_fetch(*_args, **_kwargs):
             started.set()
             await release.wait()
-            return mock_response
+            return metadata
 
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(side_effect=delayed_get)
-
-        with patch.object(dcr_service, "_get_client", return_value=mock_client):
-            first = asyncio.create_task(dcr_service.discover_as_metadata("https://issuer.example.com"))
+        with (
+            patch("mcpgateway.services.dcr_service.SecurityValidator.validate_url_for_connection_pinning", new=AsyncMock(return_value=target)),
+            patch("mcpgateway.services.dcr_service.get_pinned_http_client", pinned_client),
+            patch.object(dcr_service, "_fetch_public_metadata_document", new=AsyncMock(side_effect=delayed_fetch)) as fetch,
+        ):
+            first = asyncio.create_task(dcr_service.discover_public_as_metadata("https://issuer.example.com"))
             await started.wait()
-            second = asyncio.create_task(dcr_service.discover_as_metadata("https://issuer.example.com"))
+            second = asyncio.create_task(dcr_service.discover_public_as_metadata("https://issuer.example.com"))
             await asyncio.sleep(0)
             release.set()
             assert await first == metadata
             assert await second == metadata
 
-        assert mock_client.get.await_count == 1
+        assert fetch.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_legacy_discovery_does_not_serialize_concurrent_failures(self):
+        """Existing discovery callers do not queue behind an unreachable issuer."""
+        # First-Party
+        from mcpgateway.services.dcr_service import _metadata_cache, _metadata_locks
+
+        _metadata_cache.clear()
+        _metadata_locks.clear()
+        dcr_service = DcrService()
+        both_started = asyncio.Event()
+        release = asyncio.Event()
+        fetch_count = 0
+
+        async def unreachable(*_args, **_kwargs):
+            nonlocal fetch_count
+            fetch_count += 1
+            if fetch_count == 2:
+                both_started.set()
+            await release.wait()
+            return None
+
+        with patch.object(dcr_service, "_fetch_metadata_document", new=AsyncMock(side_effect=unreachable)) as fetch:
+            first = asyncio.create_task(dcr_service.discover_as_metadata("https://issuer.example.com"))
+            second = asyncio.create_task(dcr_service.discover_as_metadata("https://issuer.example.com"))
+            await asyncio.wait_for(both_started.wait(), timeout=0.1)
+            release.set()
+            with pytest.raises(DcrError, match="not found"):
+                await first
+            with pytest.raises(DcrError, match="not found"):
+                await second
+
+        assert fetch.await_count == 4
 
 
 class TestPublicMetadataDiscoveryCoverage:
@@ -1594,7 +1683,6 @@ class TestPublicMetadataDiscoveryCoverage:
         service = DcrService()
         issuer = "https://issuer.example.com"
         unsafe_responses = (
-            (self._stream_response(status_code=302), "redirects"),
             (self._stream_response(headers={"content-length": "not-a-number"}), "invalid content length"),
             (self._stream_response(headers={"content-length": str(256 * 1024 + 1)}), "too large"),
             (self._stream_response(chunks=[b"x" * (256 * 1024 + 1)]), "too large"),
@@ -1610,6 +1698,22 @@ class TestPublicMetadataDiscoveryCoverage:
         for response, message in unsafe_responses:
             with pytest.raises(DcrError, match=message):
                 await service._fetch_public_metadata_document(self._stream_client(response), "https://issuer.example.com/metadata", issuer)
+
+    @pytest.mark.asyncio
+    async def test_public_stream_fetch_requires_both_endpoints_and_rejects_redirects(self):
+        """Public metadata cannot claim success without endpoints or by redirecting."""
+        service = DcrService()
+        issuer = "https://issuer.example.com"
+        assert await service._fetch_public_metadata_document(self._stream_client(self._stream_response(status_code=302)), "https://issuer.example.com/metadata", issuer) is None
+
+        with pytest.raises(DcrError, match="missing or has invalid authorization_endpoint") as error:
+            await service._fetch_public_metadata_document(
+                self._stream_client(self._stream_response(chunks=[b'{"issuer":"https://issuer.example.com"}'])),
+                "https://issuer.example.com/metadata",
+                issuer,
+            )
+
+        assert error.value.code == "invalid_metadata"
 
     @pytest.mark.asyncio
     async def test_public_stream_fetch_classifies_transport_failures(self):
@@ -1629,7 +1733,7 @@ class TestPublicMetadataDiscoveryCoverage:
         from mcpgateway.services.dcr_service import _metadata_cache
 
         issuer = "https://issuer.example.com"
-        metadata = {"issuer": issuer, "authorization_endpoint": "https://issuer.example.com/authorize"}
+        metadata = {"issuer": issuer, "authorization_endpoint": "https://issuer.example.com/authorize", "token_endpoint": "https://issuer.example.com/token"}
         _metadata_cache.clear()
         try:
             DcrService._cache_metadata(issuer, metadata, 60)

--- a/tests/unit/mcpgateway/services/test_dcr_service.py
+++ b/tests/unit/mcpgateway/services/test_dcr_service.py
@@ -12,9 +12,11 @@ Tests will FAIL until implementation is complete.
 # Standard
 import asyncio
 from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
+import httpx
 import pytest
 
 # First-Party
@@ -1483,6 +1485,162 @@ class TestPublicMetadataDiscoverySafety:
             assert await second == metadata
 
         assert mock_client.get.await_count == 1
+
+
+class TestPublicMetadataDiscoveryCoverage:
+    """Cover public-discovery failure handling and cache boundaries."""
+
+    @staticmethod
+    def _stream_client(response=None, error=None):
+        """Return a client mock implementing httpx's async streaming protocol."""
+
+        class StreamContext:
+            """Minimal async context wrapper for a streamed response."""
+
+            async def __aenter__(self):
+                return response
+
+            async def __aexit__(self, *_args):
+                return False
+
+        client = MagicMock()
+        client.stream.side_effect = error if error else lambda *_args, **_kwargs: StreamContext()
+        return client
+
+    @staticmethod
+    def _stream_response(status_code=200, headers=None, chunks=()):
+        """Build a deterministic streamed metadata response."""
+        response = MagicMock(status_code=status_code, headers=headers or {})
+
+        async def aiter_bytes():
+            for chunk in chunks:
+                yield chunk
+
+        response.aiter_bytes.return_value = aiter_bytes()
+        return response
+
+    @pytest.mark.asyncio
+    async def test_public_issuer_validation_fails_closed(self):
+        """Validation blocks resolver errors, incomplete pinning data, and local targets."""
+        service = DcrService()
+        with patch(
+            "mcpgateway.services.dcr_service.SecurityValidator.validate_url_for_connection_pinning",
+            new=AsyncMock(side_effect=ValueError("private address")),
+        ):
+            with pytest.raises(DcrError, match="blocked"):
+                await service._validate_public_discovery_issuer("https://issuer.example.com")
+
+        for target in (
+            {"validated_url": "https://issuer.example.com", "hostname": "issuer.example.com"},
+            {
+                "validated_url": "https://issuer.example.com",
+                "hostname": "issuer.example.com",
+                "original_authority": "issuer.example.com",
+                "resolved_ip": "127.0.0.1",
+            },
+        ):
+            with patch(
+                "mcpgateway.services.dcr_service.SecurityValidator.validate_url_for_connection_pinning",
+                new=AsyncMock(return_value=target),
+            ):
+                with pytest.raises(DcrError, match="blocked"):
+                    await service._validate_public_discovery_issuer("https://issuer.example.com")
+
+    def test_cache_removes_expired_entries_before_storing_new_metadata(self):
+        """Expired issuer metadata is removed and cannot grow cache indefinitely."""
+        # First-Party
+        from mcpgateway.services.dcr_service import _metadata_cache
+
+        _metadata_cache.clear()
+        try:
+            _metadata_cache["https://expired.example.com"] = {
+                "metadata": {"issuer": "https://expired.example.com"},
+                "cached_at": datetime.now(timezone.utc) - timedelta(seconds=61),
+            }
+            assert DcrService._get_cached_metadata("https://expired.example.com", 60) is None
+
+            _metadata_cache["https://expired-again.example.com"] = {
+                "metadata": {"issuer": "https://expired-again.example.com"},
+                "cached_at": datetime.now(timezone.utc) - timedelta(seconds=61),
+            }
+            DcrService._cache_metadata("https://fresh.example.com", {"issuer": "https://fresh.example.com"}, 60)
+            assert list(_metadata_cache) == ["https://fresh.example.com"]
+        finally:
+            _metadata_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_generic_fetch_handles_transport_and_invalid_responses(self):
+        """Legacy callers retain safe transport, redirect, and JSON failure handling."""
+        service = DcrService()
+        client = MagicMock()
+        client.get = AsyncMock(side_effect=httpx.ConnectError("unreachable"))
+        with patch.object(service, "_get_client", return_value=client):
+            assert await service._fetch_metadata_document("https://issuer.example.com/metadata", "https://issuer.example.com") is None
+
+        redirect = MagicMock(status_code=302)
+        invalid_json = MagicMock(status_code=200)
+        invalid_json.json.side_effect = ValueError("bad json")
+        non_object = MagicMock(status_code=200)
+        non_object.json.return_value = []
+        for response, message in ((redirect, "redirect"), (invalid_json, "valid JSON"), (non_object, "JSON object")):
+            client.get = AsyncMock(return_value=response)
+            with patch.object(service, "_get_client", return_value=client):
+                with pytest.raises(DcrError, match=message):
+                    await service._fetch_metadata_document("https://issuer.example.com/metadata", "https://issuer.example.com")
+
+    @pytest.mark.asyncio
+    async def test_public_stream_fetch_rejects_unsafe_responses(self):
+        """Public discovery rejects redirects, unbounded bodies, invalid JSON, and unsafe fields."""
+        service = DcrService()
+        issuer = "https://issuer.example.com"
+        unsafe_responses = (
+            (self._stream_response(status_code=302), "redirects"),
+            (self._stream_response(headers={"content-length": "not-a-number"}), "invalid content length"),
+            (self._stream_response(headers={"content-length": str(256 * 1024 + 1)}), "too large"),
+            (self._stream_response(chunks=[b"x" * (256 * 1024 + 1)]), "too large"),
+            (self._stream_response(chunks=[b"not-json"]), "valid JSON"),
+            (self._stream_response(chunks=[b"[]"]), "JSON object"),
+            (
+                self._stream_response(
+                    chunks=[b'{"issuer":"https://issuer.example.com","authorization_endpoint":"http://issuer.example.com/authorize"}']
+                ),
+                "invalid authorization_endpoint",
+            ),
+        )
+        for response, message in unsafe_responses:
+            with pytest.raises(DcrError, match=message):
+                await service._fetch_public_metadata_document(self._stream_client(response), "https://issuer.example.com/metadata", issuer)
+
+    @pytest.mark.asyncio
+    async def test_public_stream_fetch_classifies_transport_failures(self):
+        """Timeouts and non-timeout HTTP failures have safe structured outcomes."""
+        service = DcrService()
+        with pytest.raises(DcrError, match="timed out") as timeout_error:
+            await service._fetch_public_metadata_document(self._stream_client(error=httpx.TimeoutException("slow")), "https://issuer.example.com/metadata", "https://issuer.example.com")
+        assert timeout_error.value.code == "timeout"
+        assert await service._fetch_public_metadata_document(
+            self._stream_client(error=httpx.ConnectError("refused")), "https://issuer.example.com/metadata", "https://issuer.example.com"
+        ) is None
+
+    @pytest.mark.asyncio
+    async def test_cached_metadata_is_revalidated_for_public_discovery(self):
+        """Cached public metadata still passes output-shape validation before return."""
+        # First-Party
+        from mcpgateway.services.dcr_service import _metadata_cache
+
+        issuer = "https://issuer.example.com"
+        metadata = {"issuer": issuer, "authorization_endpoint": "https://issuer.example.com/authorize"}
+        _metadata_cache.clear()
+        try:
+            DcrService._cache_metadata(issuer, metadata, 60)
+            validator = MagicMock()
+            fetch = AsyncMock()
+            result = await DcrService()._discover_metadata(issuer, fetch, validator)
+            assert result == metadata
+            validator.assert_called_once_with(metadata)
+            fetch.assert_not_awaited()
+        finally:
+            _metadata_cache.clear()
 
 
 class TestExistingDiscoveryCompatibility:

--- a/tests/unit/mcpgateway/services/test_http_client_service.py
+++ b/tests/unit/mcpgateway/services/test_http_client_service.py
@@ -16,6 +16,7 @@ import httpx
 import pytest
 
 from mcpgateway.services.http_client_service import (
+    SniPinningTransport,
     SharedHttpClient,
     get_admin_timeout,
     get_default_verify,
@@ -23,6 +24,7 @@ from mcpgateway.services.http_client_service import (
     get_http_limits,
     get_http_timeout,
     get_isolated_http_client,
+    get_pinned_http_client,
 )
 
 
@@ -44,6 +46,48 @@ def test_constructor():
     assert c._client is None
     assert c._initialized is False
     assert c._limits is None
+
+
+@pytest.mark.asyncio
+async def test_sni_pinning_transport_refuses_unvalidated_host():
+    """Pinned transport never follows a request to another hostname."""
+    transport = SniPinningTransport("issuer.example.com", "203.0.113.10")
+    request = httpx.Request("GET", "https://other.example.com/metadata")
+
+    with pytest.raises(httpx.UnsupportedProtocol, match="unvalidated host"):
+        await transport.handle_async_request(request)
+
+    await transport.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sni_pinning_transport_uses_validated_address_and_sni():
+    """Pinned transport preserves SNI while dialing only validated resolved address."""
+    response = httpx.Response(200)
+    transport = SniPinningTransport("issuer.example.com", "203.0.113.10")
+    request = httpx.Request("GET", "https://issuer.example.com/metadata")
+
+    with patch.object(httpx.AsyncHTTPTransport, "handle_async_request", new=AsyncMock(return_value=response)) as send:
+        assert await transport.handle_async_request(request) is response
+
+    assert request.url.host == "203.0.113.10"
+    assert request.extensions["sni_hostname"] == "issuer.example.com"
+    send.assert_awaited_once_with(request)
+    await transport.aclose()
+
+
+@pytest.mark.asyncio
+async def test_get_pinned_http_client_yields_short_lived_client():
+    """Pinned client uses dedicated transport with redirects disabled."""
+    async with get_pinned_http_client(
+        sni_hostname="issuer.example.com",
+        pinned_host="203.0.113.10",
+        timeout=httpx.Timeout(5),
+        verify=True,
+        limits=httpx.Limits(max_connections=2),
+    ) as client:
+        assert isinstance(client, httpx.AsyncClient)
+        assert client.follow_redirects is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_oauth_metadata_discovery.py
+++ b/tests/unit/mcpgateway/test_oauth_metadata_discovery.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""API tests for secure OAuth issuer metadata discovery."""
+
+# Standard
+from unittest.mock import AsyncMock, MagicMock
+
+# Third-Party
+from fastapi.testclient import TestClient
+import pytest
+
+# First-Party
+from mcpgateway.main import app
+from mcpgateway.middleware.rbac import get_current_user_with_permissions
+from mcpgateway.services.dcr_service import DcrError, DcrService
+
+
+@pytest.fixture
+def allow_gateway_create(monkeypatch):
+    """Allow the route's gateway-create permission check."""
+    permission_service = MagicMock()
+    permission_service.check_permission = AsyncMock(return_value=True)
+    monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", lambda _db: permission_service)
+    monkeypatch.setattr("mcpgateway.plugins.get_plugin_manager", AsyncMock(return_value=None))
+    app.dependency_overrides[get_current_user_with_permissions] = lambda: {"email": "operator@example.com"}
+    yield
+    app.dependency_overrides.pop(get_current_user_with_permissions, None)
+
+
+def test_discover_metadata_returns_form_safe_values(monkeypatch, allow_gateway_create):
+    """Successful discovery exposes only metadata needed for form autofill."""
+    discover = AsyncMock(
+        return_value={
+            "issuer": "https://issuer.example.com",
+            "authorization_endpoint": "https://issuer.example.com/authorize",
+            "token_endpoint": "https://issuer.example.com/token",
+            "registration_endpoint": "https://issuer.example.com/register",
+            "scopes_supported": ["openid", "profile"],
+        }
+    )
+    audit = MagicMock()
+    monkeypatch.setattr(DcrService, "discover_as_metadata", discover)
+    monkeypatch.setattr("mcpgateway.main.get_audit_trail_service", lambda: audit)
+
+    response = TestClient(app).post("/v1/gateways/discover-metadata", json={"issuer_url": "https://issuer.example.com"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "discovered": True,
+        "authorizationUrl": "https://issuer.example.com/authorize",
+        "tokenUrl": "https://issuer.example.com/token",
+        "registrationEndpoint": "https://issuer.example.com/register",
+        "scopesSupported": ["openid", "profile"],
+        "error": None,
+        "errorCode": None,
+    }
+    discover.assert_awaited_once_with("https://issuer.example.com")
+    assert audit.log_action.call_args.kwargs["details"] == {"outcome": "success", "error_code": None}
+
+
+def test_discover_metadata_returns_safe_nonblocking_failure(monkeypatch, allow_gateway_create):
+    """Blocked issuer errors do not expose raw outbound-validation details."""
+    audit = MagicMock()
+    monkeypatch.setattr(DcrService, "discover_as_metadata", AsyncMock(side_effect=DcrError("loopback host", code="blocked")))
+    monkeypatch.setattr("mcpgateway.main.get_audit_trail_service", lambda: audit)
+
+    response = TestClient(app).post("/v1/gateways/discover-metadata", json={"issuer_url": "https://localhost.example.com"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "discovered": False,
+        "authorizationUrl": None,
+        "tokenUrl": None,
+        "registrationEndpoint": None,
+        "scopesSupported": [],
+        "error": "This issuer URL is blocked by the outbound security policy.",
+        "errorCode": "blocked",
+    }
+    assert audit.log_action.call_args.kwargs["details"] == {"outcome": "failure", "error_code": "blocked"}
+
+
+def test_discover_metadata_requires_gateway_create_permission(monkeypatch):
+    """Caller lacking gateway creation permission cannot use the discovery oracle."""
+    permission_service = MagicMock()
+    permission_service.check_permission = AsyncMock(return_value=False)
+    monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", lambda _db: permission_service)
+    monkeypatch.setattr("mcpgateway.plugins.get_plugin_manager", AsyncMock(return_value=None))
+    app.dependency_overrides[get_current_user_with_permissions] = lambda: {"email": "viewer@example.com"}
+    try:
+        response = TestClient(app).post("/v1/gateways/discover-metadata", json={"issuer_url": "https://issuer.example.com"})
+    finally:
+        app.dependency_overrides.pop(get_current_user_with_permissions, None)
+
+    assert response.status_code == 403

--- a/tests/unit/mcpgateway/test_oauth_metadata_discovery.py
+++ b/tests/unit/mcpgateway/test_oauth_metadata_discovery.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-"""API tests for secure OAuth issuer metadata discovery."""
+"""Location: ./tests/unit/mcpgateway/test_oauth_metadata_discovery.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+API tests for secure OAuth issuer metadata discovery.
+"""
 
 # Standard
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/unit/mcpgateway/test_oauth_metadata_discovery.py
+++ b/tests/unit/mcpgateway/test_oauth_metadata_discovery.py
@@ -14,7 +14,7 @@ from fastapi.testclient import TestClient
 import pytest
 
 # First-Party
-from mcpgateway.main import app
+from mcpgateway.main import _safe_oauth_issuer_for_audit, app
 from mcpgateway.middleware.rbac import get_current_user_with_permissions
 from mcpgateway.services.dcr_service import DcrError, DcrService
 
@@ -103,6 +103,12 @@ def test_discover_metadata_rejects_malformed_issuer_url(allow_gateway_create):
     response = TestClient(app).post("/v1/gateways/discover-metadata", json={"issuer_url": "not-a-url"})
 
     assert response.status_code == 422
+
+
+@pytest.mark.parametrize("issuer", ["not-a-url", "https://issuer.example.com:invalid"])
+def test_safe_oauth_issuer_for_audit_rejects_malformed_issuer(issuer):
+    """Audit sanitization never raises or retains malformed issuer input."""
+    assert _safe_oauth_issuer_for_audit(issuer) == "invalid-issuer"
 
 
 def test_discover_metadata_requires_authentication():

--- a/tests/unit/mcpgateway/test_oauth_metadata_discovery.py
+++ b/tests/unit/mcpgateway/test_oauth_metadata_discovery.py
@@ -43,7 +43,7 @@ def test_discover_metadata_returns_form_safe_values(monkeypatch, allow_gateway_c
         }
     )
     audit = MagicMock()
-    monkeypatch.setattr(DcrService, "discover_as_metadata", discover)
+    monkeypatch.setattr(DcrService, "discover_public_as_metadata", discover)
     monkeypatch.setattr("mcpgateway.main.get_audit_trail_service", lambda: audit)
 
     response = TestClient(app).post("/v1/gateways/discover-metadata", json={"issuer_url": "https://issuer.example.com"})
@@ -58,14 +58,14 @@ def test_discover_metadata_returns_form_safe_values(monkeypatch, allow_gateway_c
         "error": None,
         "errorCode": None,
     }
-    discover.assert_awaited_once_with("https://issuer.example.com")
+    discover.assert_awaited_once_with("https://issuer.example.com/")
     assert audit.log_action.call_args.kwargs["details"] == {"outcome": "success", "error_code": None}
 
 
 def test_discover_metadata_returns_safe_nonblocking_failure(monkeypatch, allow_gateway_create):
     """Blocked issuer errors do not expose raw outbound-validation details."""
     audit = MagicMock()
-    monkeypatch.setattr(DcrService, "discover_as_metadata", AsyncMock(side_effect=DcrError("loopback host", code="blocked")))
+    monkeypatch.setattr(DcrService, "discover_public_as_metadata", AsyncMock(side_effect=DcrError("loopback host", code="blocked")))
     monkeypatch.setattr("mcpgateway.main.get_audit_trail_service", lambda: audit)
 
     response = TestClient(app).post("/v1/gateways/discover-metadata", json={"issuer_url": "https://localhost.example.com"})
@@ -96,3 +96,17 @@ def test_discover_metadata_requires_gateway_create_permission(monkeypatch):
         app.dependency_overrides.pop(get_current_user_with_permissions, None)
 
     assert response.status_code == 403
+
+
+def test_discover_metadata_rejects_malformed_issuer_url(allow_gateway_create):
+    """Malformed issuer input is rejected before public discovery runs."""
+    response = TestClient(app).post("/v1/gateways/discover-metadata", json={"issuer_url": "not-a-url"})
+
+    assert response.status_code == 422
+
+
+def test_discover_metadata_requires_authentication():
+    """Unauthenticated callers cannot probe issuer metadata."""
+    response = TestClient(app).post("/v1/gateways/discover-metadata", json={"issuer_url": "https://issuer.example.com"})
+
+    assert response.status_code == 401


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #5717

---

## 📝 Summary

Adds secure OAuth issuer metadata discovery for gateway setup. Client sends issuer URL; gateway discovers provider metadata before user must manually enter authorization/token endpoints.

### What changed / achieved

- Adds `POST /v1/gateways/discover-metadata`, protected by `gateways.create`.
- Tries RFC 8414 authorization-server metadata first, then OpenID Connect discovery fallback.
- Returns authorization endpoint, token endpoint, registration endpoint, and provider-supported scopes in typed response.
- Returns safe `not_found`, `invalid_metadata`, `blocked`, or `timeout` result. No upstream error body leaks to client.
- Caches successful issuer metadata; singleflight shares concurrent lookup for same issuer.
- Protects outbound lookup: HTTPS issuer/endpoint validation, outbound security-policy check, redirects refused, 5-second timeout, 256 KiB response limit, issuer-match validation.
- Adds audit event with sanitized issuer; discovery route gets 10 RPM limit.
- Adds unit coverage for route, permission denial, safe failures, metadata size cap, HTTPS validation, and singleflight.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Focused unit tests | `pytest tests/unit/mcpgateway/services/test_dcr_service.py tests/unit/mcpgateway/test_oauth_metadata_discovery.py -q` | Pass (48) |
| Ruff | `make ruff` | Pass |
| Full lint suite | `make lint` | Not run |
| Full unit suite | `make test` | Not run |
| Coverage >= 80% | `make coverage` | Not run |

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (not applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

Frontend issuer-field integration intentionally deferred. This PR provides backend discovery API for later catalog/OAuth setup flow (#5967).
