### PR TITLE
fix: isolate async gateway audit sessions

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -3159,7 +3159,6 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         context={
                             "modified_via": modified_via,
                         },
-                        db=db,
                     )
 
                     structured_logger.log(
@@ -4081,7 +4080,6 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         "url": gateway_info["url"],
                         "status": gateway.status,
                     },
-                    db=db,
                 )
 
                 structured_logger.log(

--- a/tests/unit/mcpgateway/services/test_gateway_audit_no_db.py
+++ b/tests/unit/mcpgateway/services/test_gateway_audit_no_db.py
@@ -109,8 +109,10 @@ class TestGatewayAuditNoDb:
                 await gateway_service.register_gateway(db, GatewayCreate(name="g", url="https://example.com", transport="SSE"))
             db.commit.assert_called_once()
 
+    @pytest.mark.parametrize("async_lifecycle", [False, True])
     @pytest.mark.asyncio
-    async def test_update_gateway(self, gateway_service, db, gateway_db):
+    async def test_update_gateway(self, gateway_service, db, gateway_db, monkeypatch, async_lifecycle):
+        monkeypatch.setattr("mcpgateway.services.gateway_service.settings.gateway_async_lifecycle_enabled", async_lifecycle)
         with patch("mcpgateway.services.gateway_service.audit_trail") as mock_audit, patch("mcpgateway.services.gateway_service.structured_logger"):
             mock_audit.log_action = MagicMock(return_value=None)
             db.execute = Mock(return_value=_make_execute_result(scalar=gateway_db))
@@ -135,8 +137,10 @@ class TestGatewayAuditNoDb:
             mock_audit.log_action.assert_called_once()
             _assert_no_db_passed(mock_audit, expected_action="set_gateway_state", resource_type="gateway")
 
+    @pytest.mark.parametrize("async_lifecycle", [False, True])
     @pytest.mark.asyncio
-    async def test_delete_gateway(self, gateway_service, db, gateway_db):
+    async def test_delete_gateway(self, gateway_service, db, gateway_db, monkeypatch, async_lifecycle):
+        monkeypatch.setattr("mcpgateway.services.gateway_service.settings.gateway_async_lifecycle_enabled", async_lifecycle)
         with patch("mcpgateway.services.gateway_service.audit_trail") as mock_audit, patch("mcpgateway.services.gateway_service.structured_logger"):
             mock_audit.log_action = MagicMock(return_value=None)
             db.execute = Mock(return_value=_make_execute_result(scalar=gateway_db, rowcount=1))


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Fixes #6429 by ensuring gateway update and delete audit records use their own audit persistence path when asynchronous lifecycle mode is enabled. This avoids reusing the request-scoped SQLAlchemy session for audit writes.

## 🔁 Reproduction Steps

1. Enable `gateway_async_lifecycle_enabled`.
2. Update or delete a gateway.
3. Observe that `audit_trail.log_action()` receives the request-scoped `db` session.

The parameterized regression tests cover both lifecycle modes and fail on the asynchronous update/delete paths before this change.

## 🐞 Root Cause

The asynchronous branches of `GatewayService.update_gateway()` and `GatewayService.delete_gateway()` still passed `db=db` to `audit_trail.log_action()`, unlike the already-correct synchronous branches.

## 💡 Fix Description

Remove the two stale `db` keyword arguments and extend the existing no-DB audit tests to exercise both `gateway_async_lifecycle_enabled=False` and `True`.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

| Check                                 | Command                                                                    | Status |
|---------------------------------------|----------------------------------------------------------------------------|--------|
| Lint suite                            | `make lint`                                                                | ⚠️ Existing project-wide failures on unchanged `main`; focused Ruff passes |
| Unit tests                            | `make test`                                                                | ✅ 22,974 passed, 871 skipped, 2 xfailed |
| Coverage ≥ 80 %                       | `make coverage`                                                            | Not run; full test suite and focused regression completed |
| Manual regression no longer fails     | `.venv/bin/pytest -q tests/unit/mcpgateway/services/test_gateway_audit_no_db.py` | ✅ 7 passed |

Focused lint:

```text
.venv/bin/ruff check mcpgateway/services/gateway_service.py
All checks passed!
```

`make lint` currently reports existing failures in untouched files (including project-wide Pylint, mypy, Bandit, spelling, ty, Pyright, and Pyrefly diagnostics). No lint finding points to a changed line. The pre-existing full-file `E702`/`F401` findings in `test_gateway_audit_no_db.py` were kept out of this focused fix.

## 📐 MCP Compliance (if relevant)

N/A — this changes internal audit-session handling only and does not affect the MCP wire protocol or clients.

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`) — the aggregate formatter/lint target is not clean on unchanged `main`; focused Ruff and `git diff --check` pass
- [x] No secrets/credentials committed
