### PR TITLE
fix(mcp): preserve structured-only federated tool results

### DIFF
--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -1929,7 +1929,7 @@ async def call_tool(
                 meta_data=meta_data,
                 require_model_visible=True,
             )
-            if not result or not result.content:
+            if not result or (not result.content and not getattr(result, "structured_content", None)):
                 logger.warning("No content returned by tool: %s", name)
                 return []
 

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -566,6 +566,58 @@ async def test_call_tool_with_structured_content(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_call_tool_preserves_structured_only_result(monkeypatch):
+    """A spec-valid structured-only result must not be discarded as empty."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import call_tool, tool_service
+
+    mock_db = MagicMock()
+    mock_result = MagicMock()
+    mock_result.content = []
+    mock_structured = {"id": "widget-42", "name": "Reproduction Widget", "price": 9.99}
+    mock_result.structured_content = mock_structured
+    mock_result.model_dump = lambda by_alias=True: {"content": [], "structuredContent": mock_structured}
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+    monkeypatch.setattr(tool_service, "invoke_tool", AsyncMock(return_value=mock_result))
+
+    result = await call_tool("widget", {})
+
+    assert isinstance(result, tuple)
+    unstructured, structured = result
+    assert unstructured == []
+    assert structured == mock_structured
+
+
+@pytest.mark.asyncio
+async def test_call_tool_returns_empty_when_neither_representation_exists(monkeypatch):
+    """The early return remains for results with neither content representation."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import call_tool, tool_service
+
+    mock_db = MagicMock()
+    mock_result = MagicMock()
+    mock_result.content = []
+    mock_result.structured_content = None
+    mock_result.model_dump = lambda by_alias=True: {"content": [], "structuredContent": None}
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+    monkeypatch.setattr(tool_service, "invoke_tool", AsyncMock(return_value=mock_result))
+
+    result = await call_tool("empty", {})
+
+    assert result == []
+
+
+@pytest.mark.asyncio
 async def test_call_tool_preserves_is_error_for_egress(monkeypatch):
     """Egress regression guard for ContextForge #4202 — local (non-pooled) branch.
 


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

A successful federated `tools/call` result may carry all data in `structuredContent` while `content` is empty. The streamable-HTTP transport treated that valid shape as empty and returned before its existing structured-content handler.

The guard now returns early only when both representations are absent. Structured-only results reach the existing tuple response path, while genuinely empty results keep returning `[]`.

Closes #5472

## 🔁 Reproduction

1. Federate an upstream tool that declares an `outputSchema`.
2. Have it return `{ "content": [], "structuredContent": { ... } }`.
3. Invoke it through the `/mcp` streamable-HTTP endpoint.
4. Before this change the structured payload is discarded and the SDK reports an output-validation error.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked separately
- [x] Tests are included with the code they validate

## 🏷️ Type of Change

- [x] Bug fix

## 🧪 Verification

The new regression test was run before the source change and failed with `result == []`.

After the fix:

```text
python -m pytest -q tests/unit/mcpgateway/transports/test_streamablehttp_transport.py -k "call_tool_success or with_structured_content or structured_only_result or neither_representation_exists or preserves_is_error_for_egress"
5 passed
```

Ruff 0.15.20 passes for the changed source and the changed test while excluding two unrelated violations already present elsewhere in the 17k-line test module (`E303` at line 9639 and `PLC2801` at line 17055). The source file passes formatting; the test module has two pre-existing formatting differences outside this change.

## ✅ Checklist

- [x] Tests added for structured-only and genuinely empty results
- [x] No secrets or credentials committed
- [x] Commit includes the required DCO sign-off
