### PR TITLE
Pass include metrics through tool detail reads

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -5901,6 +5901,7 @@ async def get_tool(
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
     apijsonpath: Optional[str] = Query(None, max_length=1000, description="Optional JSONPath modifier as JSON string"),
+    include_metrics: bool = False,
 ) -> ToolResponse:
     """
     Retrieve a tool by ID, optionally applying a JSONPath post-filter.
@@ -5914,6 +5915,7 @@ async def get_tool(
                      Example: ?apijsonpath=%7B%22jsonpath%22%3A%22%24.name%22%7D
                      (decoded: {"jsonpath":"$.name","mapping":null})
                      Use to filter or transform the response via JSONPath expressions.
+        include_metrics: Whether to include aggregated metrics in the response.
 
     Returns:
         The raw ``ToolRead`` model **or** a JSON-transformed ``dict`` if
@@ -5937,6 +5939,7 @@ async def get_tool(
             requesting_user_is_admin=_req_is_admin,
             requesting_user_team_roles=_req_team_roles,
             token_teams=auth_token_teams,
+            include_metrics=include_metrics,
         )
         _enforce_scoped_resource_access(request, db, user, f"/tools/{tool_id}")
 

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -3327,6 +3327,7 @@ class ToolService(BaseService):
         requesting_user_is_admin: bool = False,
         requesting_user_team_roles: Optional[Dict[str, str]] = None,
         token_teams: Optional[List[str]] = None,
+        include_metrics: bool = False,
     ) -> ToolRead:
         """
         Retrieve a tool by its ID with access control.
@@ -3343,6 +3344,7 @@ class ToolService(BaseService):
                 ``[]`` means public-only scope. ``[...]`` means team-scoped.
                 This is kept separate from ``requesting_user_team_roles`` to avoid the Layer 1
                 visibility check silently widening a scoped token to full DB team membership.
+            include_metrics (bool): If True, include aggregated metrics. Defaults to False.
 
         Returns:
             ToolRead: The tool object.
@@ -3396,6 +3398,7 @@ class ToolService(BaseService):
 
         tool_read = self.convert_tool_to_read(
             tool,
+            include_metrics=include_metrics,
             requesting_user_email=requesting_user_email,
             requesting_user_is_admin=requesting_user_is_admin,
             requesting_user_team_roles=requesting_user_team_roles,

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -1624,7 +1624,21 @@ class TestToolService:
 
         # Verify result
         assert result == tool_read
-        tool_service.convert_tool_to_read.assert_called_once_with(mock_tool, requesting_user_email=None, requesting_user_is_admin=False, requesting_user_team_roles=None)
+        tool_service.convert_tool_to_read.assert_called_once_with(
+            mock_tool, include_metrics=False, requesting_user_email=None, requesting_user_is_admin=False, requesting_user_team_roles=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_tool_forwards_include_metrics(self, tool_service, mock_tool, test_db):
+        """get_tool should pass include_metrics through to convert_tool_to_read."""
+        test_db.get = Mock(return_value=mock_tool)
+        tool_service.convert_tool_to_read = Mock(return_value=Mock())
+
+        await tool_service.get_tool(test_db, 1, include_metrics=True)
+
+        tool_service.convert_tool_to_read.assert_called_once_with(
+            mock_tool, include_metrics=True, requesting_user_email=None, requesting_user_is_admin=False, requesting_user_team_roles=None
+        )
 
     @pytest.mark.asyncio
     async def test_get_tool_not_found(self, tool_service, test_db):


### PR DESCRIPTION
## Summary
* GET /tools/{tool_id} always returned metrics as null because get_tool never forwarded include_metrics into convert_tool_to_read
* The detail route now accepts include_metrics like the server tools list, and the service passes it through

Fixes : #6453

## Test plan
* tests/unit/mcpgateway/services/test_tool_service.py::TestToolService::test_get_tool
* tests/unit/mcpgateway/services/test_tool_service.py::TestToolService::test_get_tool_forwards_include_metrics