### PR TITLE
fix(plugins): preserve virtual server context for tool calls

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -185,16 +185,20 @@ def _apply_tool_payload_to_global_context(
     tool_gateway_id: Optional[str],
     app_user_email: Optional[str],
     payload_tenant_id: Optional[str],
+    server_id: Optional[str] = None,
 ) -> None:
-    """Enrich an existing GlobalContext with tool-payload-derived values without overwriting.
+    """Enrich an existing GlobalContext with invocation-derived values.
 
     Populates server_id, user, and tenant_id on a GlobalContext that was
     supplied by the plugin manager / middleware — filling gaps the upstream
-    propagation did not cover while never overwriting a value that was
-    already set there. Shared by the two tool-invocation call sites so they
-    stay in lockstep.
+    propagation did not cover while preserving existing values. An explicit
+    virtual-server ID takes precedence over an existing server ID; otherwise,
+    the gateway ID is only used as a fallback. Shared by the two
+    tool-invocation call sites so they stay in lockstep.
     """
-    if tool_gateway_id and isinstance(tool_gateway_id, str):
+    if server_id and isinstance(server_id, str):
+        global_context.server_id = server_id
+    elif not global_context.server_id and tool_gateway_id and isinstance(tool_gateway_id, str):
         global_context.server_id = tool_gateway_id
     if not global_context.user and app_user_email and isinstance(app_user_email, str):
         global_context.user = app_user_email
@@ -4691,10 +4695,10 @@ class ToolService(BaseService):
 
         if plugin_global_context:
             hook_global_context = plugin_global_context
-            _apply_tool_payload_to_global_context(hook_global_context, tool_gateway_id, app_user_email, hook_tenant_id)
+            _apply_tool_payload_to_global_context(hook_global_context, tool_gateway_id, app_user_email, hook_tenant_id, server_id=server_id)
         else:
             request_id = get_correlation_id() or uuid.uuid4().hex
-            context_server_id = tool_gateway_id if tool_gateway_id and isinstance(tool_gateway_id, str) else server_id
+            context_server_id = server_id if server_id and isinstance(server_id, str) else tool_gateway_id if tool_gateway_id and isinstance(tool_gateway_id, str) else None
             content_type = request_headers.get("content-type") if request_headers else None
             hook_global_context = GlobalContext(request_id=request_id, server_id=context_server_id, tenant_id=hook_tenant_id, user=app_user_email, content_type=content_type)
 
@@ -5500,12 +5504,12 @@ class ToolService(BaseService):
 
         if plugin_global_context:
             global_context = plugin_global_context
-            _apply_tool_payload_to_global_context(global_context, tool_gateway_id, app_user_email, payload_tenant_id)
+            _apply_tool_payload_to_global_context(global_context, tool_gateway_id, app_user_email, payload_tenant_id, server_id=server_id)
         else:
             # Create new context (fallback when middleware didn't run)
             # Use correlation ID from context if available, otherwise generate new one
             request_id = get_correlation_id() or uuid.uuid4().hex
-            context_server_id = tool_gateway_id if tool_gateway_id and isinstance(tool_gateway_id, str) else "unknown"
+            context_server_id = server_id if server_id and isinstance(server_id, str) else tool_gateway_id if tool_gateway_id and isinstance(tool_gateway_id, str) else "unknown"
             content_type = request_headers.get("content-type") if request_headers else None
             global_context = GlobalContext(request_id=request_id, server_id=context_server_id, tenant_id=payload_tenant_id, user=app_user_email, content_type=content_type)
 

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -7604,7 +7604,7 @@ class TestInvokeToolGatewayQueryParams:
 class TestInvokeToolPluginContext:
     @pytest.mark.asyncio
     async def test_global_context_updated_with_server_id_and_email(self, tool_service):
-        """Plugin global context is updated with gateway_id and user email."""
+        """A missing context server ID falls back to the tool gateway ID and user email."""
         # Third-Party
         from cpex.framework.models import GlobalContext
 
@@ -7619,7 +7619,7 @@ class TestInvokeToolPluginContext:
         async def fake_get(*a, **kw):
             return mock_response
 
-        gc = GlobalContext(request_id="req-1", server_id="old-server", tenant_id=None, user=None)
+        gc = GlobalContext(request_id="req-1", server_id=None, tenant_id=None, user=None)
 
         mock_metrics_buffer = MagicMock()
         mock_metrics_buffer.record_tool_metric = MagicMock()
@@ -7650,6 +7650,55 @@ class TestInvokeToolPluginContext:
             )
         assert gc.server_id == "gw-42"
         assert gc.user == "user@test.com"
+
+    @pytest.mark.asyncio
+    async def test_fresh_global_context_uses_virtual_server_id(self, tool_service):
+        """A fresh invoke context keeps the explicit virtual-server scope over its gateway."""
+        # Third-Party
+        from cpex.framework.models import GlobalContext
+
+        tp = _make_tool_payload(integration_type="REST", request_type="GET", gateway_id="gw-42")
+        db = MagicMock()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json = MagicMock(return_value={"ok": True})
+        mock_response.raise_for_status = MagicMock()
+
+        async def fake_get(*_args, **_kwargs):
+            return mock_response
+
+        plugin_manager = MagicMock()
+        plugin_manager.has_hooks_for = MagicMock(return_value=True)
+        plugin_manager.invoke_hook = AsyncMock(return_value=(SimpleNamespace(modified_payload=None, retry_delay_ms=0, metadata=None, executions=[]), {}))
+
+        mock_metrics_buffer = MagicMock()
+        mock_metrics_buffer.record_tool_metric = MagicMock()
+
+        with (
+            _setup_cache_for_invoke(tp),
+            patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=plugin_manager)),
+            patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
+            patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
+            patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={}),
+        ):
+            mock_gcc.get_passthrough_headers = MagicMock(return_value=[])
+            mock_trace.get = MagicMock(return_value=None)
+            mock_span_ctx.return_value.__enter__ = MagicMock(return_value=MagicMock())
+            mock_span_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+            tool_service._http_client = AsyncMock()
+            tool_service._http_client.get = fake_get
+
+            await tool_service.invoke_tool(db, "test_tool", {}, server_id="virtual-server")
+
+        contexts = [call.kwargs["global_context"] for call in plugin_manager.invoke_hook.call_args_list if "global_context" in call.kwargs]
+        assert contexts
+        assert all(isinstance(context, GlobalContext) for context in contexts)
+        assert all(context.server_id == "virtual-server" for context in contexts)
 
     @pytest.mark.asyncio
     async def test_global_context_not_updated_when_gateway_id_missing_and_user_already_set(self, tool_service):

--- a/tests/unit/mcpgateway/services/test_tool_service_tenant_id.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_tenant_id.py
@@ -30,7 +30,7 @@ def test_build_rust_tool_hook_global_context_propagates_team_id_as_tenant_id():
         request_headers=None,
     )
 
-    assert ctx.tenant_id == "team_a", "fallback-path GlobalContext must carry tool_payload['team_id'] as tenant_id — " f"got tenant_id={ctx.tenant_id!r}"
+    assert ctx.tenant_id == "team_a", f"fallback-path GlobalContext must carry tool_payload['team_id'] as tenant_id — got tenant_id={ctx.tenant_id!r}"
 
 
 def test_build_rust_tool_hook_global_context_tenant_id_none_when_team_id_absent():
@@ -47,7 +47,7 @@ def test_build_rust_tool_hook_global_context_tenant_id_none_when_team_id_absent(
         request_headers=None,
     )
 
-    assert ctx.tenant_id is None, "tenant_id must remain None when tool_payload has no team_id, " f"got tenant_id={ctx.tenant_id!r}"
+    assert ctx.tenant_id is None, f"tenant_id must remain None when tool_payload has no team_id, got tenant_id={ctx.tenant_id!r}"
 
 
 def test_build_rust_tool_hook_global_context_non_string_team_id_is_ignored():
@@ -64,7 +64,7 @@ def test_build_rust_tool_hook_global_context_non_string_team_id_is_ignored():
         request_headers=None,
     )
 
-    assert ctx.tenant_id is None, "Non-string team_id must not be accepted as tenant_id; " f"got tenant_id={ctx.tenant_id!r}"
+    assert ctx.tenant_id is None, f"Non-string team_id must not be accepted as tenant_id; got tenant_id={ctx.tenant_id!r}"
 
 
 def test_build_rust_tool_hook_global_context_fills_missing_existing_tenant_id():
@@ -83,7 +83,7 @@ def test_build_rust_tool_hook_global_context_fills_missing_existing_tenant_id():
     )
 
     assert ctx is existing_context
-    assert ctx.tenant_id == "team_a", "existing GlobalContext with tenant_id=None must be filled from " f"tool_payload['team_id']; got tenant_id={ctx.tenant_id!r}"
+    assert ctx.tenant_id == "team_a", f"existing GlobalContext with tenant_id=None must be filled from tool_payload['team_id']; got tenant_id={ctx.tenant_id!r}"
 
 
 def test_build_rust_tool_hook_global_context_preserves_existing_tenant_id():
@@ -108,5 +108,60 @@ def test_build_rust_tool_hook_global_context_preserves_existing_tenant_id():
 
     assert ctx is existing_context
     assert ctx.tenant_id == "team_middleware", (
-        "existing GlobalContext with tenant_id already set must NOT be overwritten by " f"tool_payload['team_id']; expected 'team_middleware', got tenant_id={ctx.tenant_id!r}"
+        f"existing GlobalContext with tenant_id already set must NOT be overwritten by tool_payload['team_id']; expected 'team_middleware', got tenant_id={ctx.tenant_id!r}"
     )
+
+
+def test_build_rust_tool_hook_global_context_uses_virtual_server_id():
+    """An explicit virtual-server ID must win over gateway and existing context IDs."""
+    service = ToolService()
+    existing_context = GlobalContext(request_id="request-1", server_id="middleware-server")
+
+    ctx = service._build_rust_tool_hook_global_context(
+        app_user_email="alice@example.com",
+        server_id="virtual-server",
+        tool_gateway_id="gateway-server",
+        plugin_global_context=existing_context,
+        tool_payload={"name": "search"},
+        gateway_payload=None,
+        request_headers=None,
+    )
+
+    assert ctx is existing_context
+    assert ctx.server_id == "virtual-server"
+
+
+def test_build_rust_tool_hook_global_context_preserves_existing_server_id_without_virtual_server():
+    """Without a virtual-server scope, an existing server ID is not replaced by the gateway ID."""
+    service = ToolService()
+    existing_context = GlobalContext(request_id="request-1", server_id="middleware-server")
+
+    ctx = service._build_rust_tool_hook_global_context(
+        app_user_email=None,
+        server_id=None,
+        tool_gateway_id="gateway-server",
+        plugin_global_context=existing_context,
+        tool_payload=None,
+        gateway_payload=None,
+        request_headers=None,
+    )
+
+    assert ctx is existing_context
+    assert ctx.server_id == "middleware-server"
+
+
+def test_build_rust_tool_hook_global_context_falls_back_to_gateway_server_id():
+    """A fresh context uses the gateway ID when no virtual-server ID is provided."""
+    service = ToolService()
+
+    ctx = service._build_rust_tool_hook_global_context(
+        app_user_email=None,
+        server_id=None,
+        tool_gateway_id="gateway-server",
+        plugin_global_context=None,
+        tool_payload=None,
+        gateway_payload=None,
+        request_headers=None,
+    )
+
+    assert ctx.server_id == "gateway-server"


### PR DESCRIPTION
## Summary

Fixes #6233.

Tool plugin `GlobalContext.server_id` was not reliable for virtual-server calls. The normal invocation fallback discarded the explicit virtual-server ID, while the existing-context path could overwrite it with the tool's gateway ID. That made `PluginCondition.server_ids` and custom server-scoped plugin logic silently miss every call routed through a virtual server.

This patch:

- preserves the explicit virtual-server `server_id` through both tool-context construction paths;
- keeps an existing middleware context ID when no virtual-server scope is present;
- uses the tool gateway ID only as the fallback when no virtual-server ID exists.

## Testing

- `uv run --frozen pytest -q tests/unit/mcpgateway/services/test_tool_service_tenant_id.py tests/unit/mcpgateway/services/test_tool_service_coverage.py` - 383 passed, 1 skipped (intentional pre-existing coverage marker)
- `uv run --frozen ruff check mcpgateway/services/tool_service.py tests/unit/mcpgateway/services/test_tool_service_tenant_id.py tests/unit/mcpgateway/services/test_tool_service_coverage.py` - passed
- `uv run --frozen ruff format --check mcpgateway/services/tool_service.py tests/unit/mcpgateway/services/test_tool_service_tenant_id.py tests/unit/mcpgateway/services/test_tool_service_coverage.py` - passed
- `git diff --check` - passed

The full `make test` target was also started locally but did not complete within the available run window; no full-suite result is claimed here.
