### PR TITLE
fix: wire include_metrics through GET /tools/{tool_id}

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -5960,6 +5960,7 @@ async def get_tool(
     request: Request,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
+    include_metrics: bool = False,
     apijsonpath: Optional[str] = Query(None, max_length=1000, description="Optional JSONPath modifier as JSON string"),
 ) -> ToolResponse:
     """
@@ -5970,6 +5971,7 @@ async def get_tool(
         request: The incoming HTTP request.
         db:     Active SQLAlchemy session (dependency).
         user:   Authenticated username (dependency).
+        include_metrics: Whether to include aggregated metrics in the response.
         apijsonpath: Optional JSON-Path modifier supplied as URL-encoded query parameter.
                      Example: ?apijsonpath=%7B%22jsonpath%22%3A%22%24.name%22%7D
                      (decoded: {"jsonpath":"$.name","mapping":null})
@@ -5997,6 +5999,7 @@ async def get_tool(
             requesting_user_is_admin=_req_is_admin,
             requesting_user_team_roles=_req_team_roles,
             token_teams=auth_token_teams,
+            include_metrics=include_metrics,
         )
         _enforce_scoped_resource_access(request, db, user, f"/tools/{tool_id}")
 

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -3418,6 +3418,7 @@ class ToolService(BaseService):
         requesting_user_is_admin: bool = False,
         requesting_user_team_roles: Optional[Dict[str, str]] = None,
         token_teams: Optional[List[str]] = None,
+        include_metrics: bool = False,
     ) -> ToolRead:
         """
         Retrieve a tool by its ID with access control.
@@ -3434,6 +3435,8 @@ class ToolService(BaseService):
                 ``[]`` means public-only scope. ``[...]`` means team-scoped.
                 This is kept separate from ``requesting_user_team_roles`` to avoid the Layer 1
                 visibility check silently widening a scoped token to full DB team membership.
+            include_metrics (bool): Whether to include aggregated metrics in the result.
+                Defaults to False, preserving the historical behavior of the detail view.
 
         Returns:
             ToolRead: The tool object.
@@ -3487,6 +3490,7 @@ class ToolService(BaseService):
 
         tool_read = self.convert_tool_to_read(
             tool,
+            include_metrics=include_metrics,
             requesting_user_email=requesting_user_email,
             requesting_user_is_admin=requesting_user_is_admin,
             requesting_user_team_roles=requesting_user_team_roles,

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -686,6 +686,32 @@ class TestToolService:
             assert h["value"] == settings.masked_auth_value
 
     @pytest.mark.asyncio
+    async def test_get_tool_omits_metrics_by_default(self, tool_service, mock_tool):
+        """The detail view keeps metrics null unless explicitly requested (#6453)."""
+        db = MagicMock()
+        db.get.return_value = mock_tool
+        tool_service._check_tool_access = AsyncMock(return_value=True)
+
+        tool_read = await tool_service.get_tool(db, mock_tool.id)
+
+        assert tool_read.metrics is None
+        assert tool_read.execution_count is None
+
+    @pytest.mark.asyncio
+    async def test_get_tool_include_metrics_returns_summary(self, tool_service, mock_tool):
+        """include_metrics=True surfaces the aggregated metrics block (#6453)."""
+        mock_tool.metrics_summary = {**mock_tool.metrics_summary, "total_executions": 7}
+        db = MagicMock()
+        db.get.return_value = mock_tool
+        tool_service._check_tool_access = AsyncMock(return_value=True)
+
+        tool_read = await tool_service.get_tool(db, mock_tool.id, include_metrics=True)
+
+        assert tool_read.metrics is not None
+        assert tool_read.metrics.total_executions == 7
+        assert tool_read.execution_count == 7
+
+    @pytest.mark.asyncio
     async def test_convert_tool_to_read_authheaders_empty(self, tool_service, mock_tool):
         """Check auth for authheaders auth with empty value (regression test for StopIteration)"""
 
@@ -1624,7 +1650,13 @@ class TestToolService:
 
         # Verify result
         assert result == tool_read
-        tool_service.convert_tool_to_read.assert_called_once_with(mock_tool, requesting_user_email=None, requesting_user_is_admin=False, requesting_user_team_roles=None)
+        tool_service.convert_tool_to_read.assert_called_once_with(
+            mock_tool,
+            include_metrics=False,
+            requesting_user_email=None,
+            requesting_user_is_admin=False,
+            requesting_user_team_roles=None,
+        )
 
     @pytest.mark.asyncio
     async def test_get_tool_not_found(self, tool_service, test_db):


### PR DESCRIPTION
Closes #6453.

## Summary

`GET /tools/{tool_id}` hardcoded `metrics` and `execution_count` to null: the route never accepted `include_metrics`, and `ToolService.get_tool()` called `convert_tool_to_read()` with the `False` default — while the list endpoint (`GET /tools`) wired the flag correctly.

## Changes

- `mcpgateway/main.py` — the detail route accepts `include_metrics: bool = False` (matching the list endpoints) and forwards it
- `mcpgateway/services/tool_service.py` — `get_tool()` gains an `include_metrics` parameter and passes it through to `convert_tool_to_read()`
- Unit tests: the default-off behavior is pinned, `include_metrics=True` now returns the aggregated summary, and the existing `test_get_tool` call assertion is updated

The default stays `False`, so responses are unchanged unless the caller opts in.