### PR TITLE
fix(observability): register ObservabilityMiddleware inside auth so user_email is captured

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3430,24 +3430,14 @@ if settings.correlation_id_enabled:
     logger.info(f"✅ Correlation ID tracking enabled (header: {settings.correlation_id_header})")
 
 
-register_auth_context_middleware(app)
-
-# Add token usage logging middleware
-# This tracks API token usage for analytics and security monitoring
-# Note: Runs after AuthContextMiddleware so request.state.auth_method is available
-if settings.token_usage_logging_enabled:
-    # First-Party
-    from mcpgateway.middleware.token_usage_middleware import TokenUsageMiddleware  # noqa: E402
-
-    app.add_middleware(TokenUsageMiddleware)
-    logger.info("📊 Token usage logging middleware enabled - tracking API token usage")
-else:
-    logger.info("📊 Token usage logging middleware disabled")
-
 # Add observability middleware if enabled
-# Note: Middleware runs in REVERSE order (last added runs first)
-# If AuthContextMiddleware is already registered, ObservabilityMiddleware wraps it
-# Execution order will be: AuthContext -> Observability -> Request Handler
+# Note: Starlette's add_middleware() inserts at position 0, so the LAST
+# middleware registered is OUTERMOST and executes FIRST. Registering
+# ObservabilityMiddleware BEFORE AuthContextMiddleware places it inside auth,
+# so start_trace() reads the identity AuthContextMiddleware has already set
+# (request.state.user / request.state.user_email). The previous order ran
+# observability before auth, leaving observability_traces.user_email NULL on
+# every row (#6473).
 # Wire observability adapter into the plugin manager when observability is enabled
 # _service is a module-level global read later in lifespan(); it must always be bound
 # (even when this branch doesn't run at import time) so tests that flip
@@ -3465,6 +3455,20 @@ if settings.observability_enabled:
     logger.info("🔍 Observability middleware enabled - tracing include-listed requests")
 else:
     logger.info("🔍 Observability middleware disabled")
+
+register_auth_context_middleware(app)
+
+# Add token usage logging middleware
+# This tracks API token usage for analytics and security monitoring
+# Note: Runs after AuthContextMiddleware so request.state.auth_method is available
+if settings.token_usage_logging_enabled:
+    # First-Party
+    from mcpgateway.middleware.token_usage_middleware import TokenUsageMiddleware  # noqa: E402
+
+    app.add_middleware(TokenUsageMiddleware)
+    logger.info("📊 Token usage logging middleware enabled - tracking API token usage")
+else:
+    logger.info("📊 Token usage logging middleware disabled")
 
 if otel_tracing_enabled():
     app.add_middleware(OpenTelemetryRequestMiddleware)

--- a/mcpgateway/middleware/observability_middleware.py
+++ b/mcpgateway/middleware/observability_middleware.py
@@ -134,9 +134,12 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
         ip_address = request.client.host if request.client else None
         user_agent = sanitize_header_for_storage(request.headers.get("user-agent"), max_length=500)
 
-        # Try to extract user from request state (set by auth middleware)
+        # Identity set by auth middleware. Prefer the full user object; the
+        # JWT and API-token paths only leave `request.state.user_email` behind.
         if hasattr(request.state, "user") and hasattr(request.state.user, "email"):
             user_email = request.state.user.email
+        elif hasattr(request.state, "user_email"):
+            user_email = request.state.user_email
 
         # Extract W3C Trace Context from headers (for distributed tracing)
         external_trace_id = None

--- a/tests/unit/mcpgateway/middleware/test_observability_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_observability_middleware.py
@@ -7,7 +7,7 @@ Unit tests for observability middleware.
 """
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 from starlette.requests import Request
 from starlette.responses import Response
 from mcpgateway.middleware.observability_middleware import ObservabilityMiddleware
@@ -53,6 +53,46 @@ async def test_dispatch_health_check_skipped(mock_request, mock_call_next):
     mock_request.url.path = "/health"
     response = await middleware.dispatch(mock_request, mock_call_next)
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_dispatch_reads_user_email_from_user_object(mock_request, mock_call_next):
+    """start_trace() receives the email from request.state.user.email (#6473)."""
+    from types import SimpleNamespace
+
+    middleware = ObservabilityMiddleware(app=None, enabled=True)
+    mock_request.state = SimpleNamespace(user=SimpleNamespace(email="user@example.com"))
+    with (
+        patch.object(middleware.service, "start_trace", return_value="trace123") as mock_start_trace,
+        patch.object(middleware.service, "start_span", return_value="span123"),
+        patch.object(middleware.service, "end_span"),
+        patch.object(middleware.service, "end_trace"),
+        patch("mcpgateway.middleware.observability_middleware.attach_trace_to_session"),
+        patch("mcpgateway.middleware.observability_middleware.parse_traceparent", return_value=None),
+        patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False),
+    ):
+        await middleware.dispatch(mock_request, mock_call_next)
+    assert mock_start_trace.call_args.kwargs["user_email"] == "user@example.com"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_falls_back_to_request_state_user_email(mock_request, mock_call_next):
+    """The JWT and API-token paths only set request.state.user_email (#6473)."""
+    from types import SimpleNamespace
+
+    middleware = ObservabilityMiddleware(app=None, enabled=True)
+    mock_request.state = SimpleNamespace(user_email="token-user@example.com")
+    with (
+        patch.object(middleware.service, "start_trace", return_value="trace123") as mock_start_trace,
+        patch.object(middleware.service, "start_span", return_value="span123"),
+        patch.object(middleware.service, "end_span"),
+        patch.object(middleware.service, "end_trace"),
+        patch("mcpgateway.middleware.observability_middleware.attach_trace_to_session"),
+        patch("mcpgateway.middleware.observability_middleware.parse_traceparent", return_value=None),
+        patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False),
+    ):
+        await middleware.dispatch(mock_request, mock_call_next)
+    assert mock_start_trace.call_args.kwargs["user_email"] == "token-user@example.com"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_main_observability_order.py
+++ b/tests/unit/mcpgateway/test_main_observability_order.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_main_observability_order.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Tests for the observability middleware registration order in main.py.
+
+Issue #6473: observability_traces.user_email was NULL on every row because
+ObservabilityMiddleware was registered after AuthContextMiddleware. Starlette's
+add_middleware() inserts at position 0, so the later-registered middleware is
+outermost and executes FIRST — observability ran before auth and start_trace()
+read request.state.user before any authentication had set it.
+"""
+
+import importlib
+from unittest.mock import patch
+
+
+def test_observability_middleware_registered_inside_auth_context():
+    """AuthContextMiddleware must execute before ObservabilityMiddleware.
+
+    user_middleware[0] is the outermost, first-running middleware (reverse
+    registration order), so AuthContextMiddleware must sit closer to the front
+    of the list than ObservabilityMiddleware: start_trace() reads the identity
+    AuthContextMiddleware has already set on request.state.
+    """
+    with (
+        patch("mcpgateway.main.settings.observability_enabled", True),
+        patch("mcpgateway.main.settings.security_logging_enabled", True),
+    ):
+        main = importlib.reload(importlib.import_module("mcpgateway.main"))
+
+    middleware_classes = [mw.cls.__name__ for mw in main.app.user_middleware]
+    assert "AuthContextMiddleware" in middleware_classes
+    assert "ObservabilityMiddleware" in middleware_classes
+    assert middleware_classes.index("AuthContextMiddleware") < middleware_classes.index("ObservabilityMiddleware")


### PR DESCRIPTION
Fixes #6473

## Problem

`observability_traces.user_email` was NULL on 100% of rows regardless of auth mode. `ObservabilityMiddleware` was registered **after** `AuthContextMiddleware` in `main.py`, and Starlette's `add_middleware()` inserts at position 0 — the later-registered middleware is outermost and executes **first**. So `start_trace()` ran before any authentication had set `request.state.user`, and `end_trace()` has no backfill. The comment in `main.py` claimed the opposite execution order, which is what let this slip through.

## Fix

- Register `ObservabilityMiddleware` before `AuthContextMiddleware` so it ends up **inside** auth: `AuthContextMiddleware` executes first and populates `request.state.user` / `request.state.user_email`, then `start_trace()` can read the identity. The ordering comment now describes the real `add_middleware` semantics (last registered = outermost = first) so the order doesn't silently regress.
- In `observability_middleware.py`, read the identity defensively: prefer `request.state.user.email`, falling back to `request.state.user_email`, which is what the JWT and API-token paths set.
- Dropped an unused `AsyncMock` import in the touched test file.

## Tests

- New `test_main_observability_order.py`: pins on the assembled app that `AuthContextMiddleware` sits closer to the front of `user_middleware` than `ObservabilityMiddleware` (i.e. executes first).
- Two dispatch tests in `test_observability_middleware.py`: `request.state.user.email` and the `request.state.user_email` fallback both reach `start_trace(user_email=...)`.

`pytest tests/unit/mcpgateway/middleware/test_observability_middleware.py tests/unit/mcpgateway/test_main_observability_order.py` — 17 passed; related `test_main*.py` / observability-migration suites (444 tests) pass; `ruff check` / `ruff format` clean.
