### PR TITLE
fix(gateway): preserve stored auth when an update omits every auth field

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -3025,11 +3025,21 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                             header_dict[key] = value
                     gateway.auth_value = header_dict  # Store as dict for DB JSON field
                 elif settings.masked_auth_value not in (token, password, header_value):
-                    # Check if values differ from existing ones or if setting for first time
-                    decoded_auth = decode_auth(gateway_update.auth_value) if gateway_update.auth_value else {}
-                    current_auth = getattr(gateway, "auth_value", {}) or {}
-                    if current_auth != decoded_auth:
-                        gateway.auth_value = decoded_auth
+                    # Absent auth is a no-op: a GET → change one field → PUT
+                    # round-trip never saw the real credential (the API masks it
+                    # on read), so omitting every auth field must preserve the
+                    # stored value. Distinguishing absent from empty matches
+                    # the uniqueness-check path a few hundred lines earlier
+                    # (`final_auth_value`) and every other optional field on
+                    # this update. Explicit clear remains possible via
+                    # `auth_type: "none"` / empty string, or an empty
+                    # `auth_headers: []` on the multi-header branch above.
+                    auth_provided = gateway_update.auth_value is not None or any(v is not None for v in (token, password, header_value))
+                    if auth_provided:
+                        decoded_auth = decode_auth(gateway_update.auth_value) if gateway_update.auth_value else {}
+                        current_auth = getattr(gateway, "auth_value", {}) or {}
+                        if current_auth != decoded_auth:
+                            gateway.auth_value = decoded_auth
 
                 # Handle query_param auth updates with service-layer enforcement
                 auth_query_params_decrypted: Optional[Dict[str, str]] = None

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -2167,6 +2167,49 @@ class TestGatewayService:
             test_db.commit.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_update_gateway_omitting_auth_preserves_stored_credential(self, gateway_service, mock_gateway, test_db):
+        """Omitting every auth field must leave the stored credential unchanged (#6446).
+
+        The API masks auth on read, so a GET → change one field → PUT round-trip
+        never saw the real credential and cannot send it back. Treating that
+        omission as an explicit clear wiped auth_value to {} while leaving
+        auth_type intact.
+        """
+        stored_auth = {"X-Api-Key": "a-real-credential"}
+        mock_gateway.auth_type = "authheaders"
+        mock_gateway.auth_value = stored_auth
+        mock_gateway.enabled = True
+        mock_gateway.reachable = True
+
+        test_db.execute = Mock(return_value=_make_execute_result(scalar=mock_gateway))
+        test_db.commit = Mock()
+        test_db.refresh = Mock()
+        test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))))
+
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], [], []))
+        gateway_service._notify_gateway_updated = AsyncMock()
+
+        # Only a non-auth field — every auth field is omitted, matching what a
+        # client that has only ever seen the masked credential must send.
+        gateway_update = GatewayUpdate(passthrough_headers=["X-Tenant-Id", "X-Trace-Id"])
+        assert gateway_update.auth_value is None
+        assert gateway_update.auth_token is None
+        assert gateway_update.auth_password is None
+        assert gateway_update.auth_header_value is None
+        assert gateway_update.auth_headers is None
+
+        mock_gateway_read = MagicMock()
+        mock_gateway_read.masked.return_value = mock_gateway_read
+
+        with patch("mcpgateway.services.gateway_service.GatewayRead.model_validate", return_value=mock_gateway_read):
+            await gateway_service.update_gateway(test_db, 1, gateway_update)
+
+        assert mock_gateway.auth_value is stored_auth
+        assert mock_gateway.auth_type == "authheaders"
+        assert mock_gateway.passthrough_headers == ["X-Tenant-Id", "X-Trace-Id"]
+        test_db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_update_gateway_integrity_error(self, gateway_service, mock_gateway, test_db):
         """Test IntegrityError during gateway update."""
         # Third-Party


### PR DESCRIPTION
Fixes #6446

## Problem

`update_gateway` treated an **absent** auth field as an explicit **clear**. Any PUT that changed some other field and did not carry auth replaced `auth_value` with `{}` while leaving `auth_type` intact.

The uniqueness-check path a few hundred lines earlier already preserved the stored credential when `gateway_update.auth_value is None`; the persist path did not. Because the API masks auth on read, a GET → change one field → PUT round-trip never saw the real credential and cannot send it back — so the obvious client path wiped the credential. Depending on whether the upstream then rejected a credential-less request, this either returned 200 with a silent wipe or 502 with a rolled-back (but failed) legitimate update.

## Fix

Treat auth as provided only when `auth_value` is not None **or** any of `auth_token` / `auth_password` / `auth_header_value` is present. Absent auth is a no-op (preserve), matching `final_auth_value` and every other optional field on this update.

Explicit clear remains possible via the existing sentinels: `auth_type: "none"` / empty string, or an empty `auth_headers: []` on the multi-header branch.

## Tests

- New `test_update_gateway_omitting_auth_preserves_stored_credential`: updates only `passthrough_headers` with every auth field omitted and asserts the stored credential and `auth_type` are unchanged.
- Existing `test_update_gateway_with_masked_auth` (echoing the mask string) still passes.

`pytest tests/unit/mcpgateway/services/test_gateway_service.py` — 376 passed, 1 skipped. `ruff check` on the production file is clean.
