### PR TITLE
Docs: optional TOA verify before MCP register

### DIFF
--- a/docs/docs/howto/index.md
+++ b/docs/docs/howto/index.md
@@ -9,6 +9,7 @@ How-to guides are task-oriented walkthroughs that help you accomplish specific o
 - [Configure RBAC for Tool Authorization](rbac-tool-authorization.md) -- Configure RBAC roles and token scoping to control who can list and execute tools on a virtual server.
 - [Deploy ContextForge on IBM Cloud with Code Engine](ibm-cloud-code-engine.md) -- Provision Code Engine, Databases for PostgreSQL, and Databases for Redis for a production-ready deployment.
 - [Configure ContextForge Plugins on Code Engine](code-engine-plugin-configmap.md) -- Manage plugin configuration via a Code Engine ConfigMap without rebuilding the container image.
+- [Optional TOA verify before register / promote](toa-optional-register-gate.md) -- Offline delivery-evidence check before registering or promoting an MCP server.
 
 ---
 

--- a/docs/docs/howto/toa-after-register.yml
+++ b/docs/docs/howto/toa-after-register.yml
@@ -1,0 +1,20 @@
+# Example only. Copy into your org workflow as needed.
+name: Optional TOA before MCP register
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "mcp-catalog.yml"
+      - "toa.json"
+
+jobs:
+  toa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass

--- a/docs/docs/howto/toa-after-register.yml
+++ b/docs/docs/howto/toa-after-register.yml
@@ -16,5 +16,5 @@ jobs:
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@99e2690fec24a5290d9542e58383a8bf753e8b74#subdirectory=python"
           toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d

--- a/docs/docs/howto/toa-after-register.yml
+++ b/docs/docs/howto/toa-after-register.yml
@@ -16,5 +16,5 @@ jobs:
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
-          toa-verify toa.json --require-layer functional=pass
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d

--- a/docs/docs/howto/toa-optional-register-gate.md
+++ b/docs/docs/howto/toa-optional-register-gate.md
@@ -32,8 +32,8 @@ No AgentStatus account is required to verify.
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
-          toa-verify toa.json --require-layer functional=pass
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 
 Pin the emitter public key with the flags documented in the toa repo when you
@@ -62,8 +62,8 @@ jobs:
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
-          toa-verify toa.json --require-layer functional=pass
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 
 ## Out of scope

--- a/docs/docs/howto/toa-optional-register-gate.md
+++ b/docs/docs/howto/toa-optional-register-gate.md
@@ -32,7 +32,7 @@ No AgentStatus account is required to verify.
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@99e2690fec24a5290d9542e58383a8bf753e8b74#subdirectory=python"
           toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 
@@ -62,7 +62,7 @@ jobs:
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@99e2690fec24a5290d9542e58383a8bf753e8b74#subdirectory=python"
           toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 

--- a/docs/docs/howto/toa-optional-register-gate.md
+++ b/docs/docs/howto/toa-optional-register-gate.md
@@ -1,0 +1,80 @@
+# Optional TOA verify before register / promote
+
+How to add an optional offline Tool Outcome Attestation (`toa/0.1`) check before
+registering or promoting an MCP server in ContextForge.
+
+## Context
+
+ContextForge already registers MCP servers, runs health checks, and applies
+governance. That answers reachability and catalog state. It does not prove that
+a tool recently delivered a real result under an outside probe.
+
+[TOA](https://github.com/Carmel-Labs-Inc/toa) is an Apache-2.0 signed JSON
+evidence format for MCP tool delivery (reach, invoke, functional, shape, and
+related layers). It is not a wire protocol. It is not meant to run on every live
+`tools/call`.
+
+## When to use this
+
+Optional, off by default. Use it in CI or change control before:
+
+- Registering a new MCP server via Admin UI / API
+- Promoting a catalog entry into production
+- Enabling a virtual server that exposes new tools
+
+Any party can emit if they sign the schema. AgentStatus is one optional emitter.
+No AgentStatus account is required to verify.
+
+## Example GitHub Actions step
+
+```yaml
+      # After your existing register / health / policy checks.
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass
+```
+
+Pin the emitter public key with the flags documented in the toa repo when you
+need a specific signer.
+
+## Full copy-paste workflow
+
+```yaml
+# .github/workflows/contextforge-toa.yml
+name: Optional TOA before MCP register
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "mcp-catalog.yml"
+      - "toa.json"
+
+jobs:
+  toa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Your catalog lint / register dry-run steps go here.
+
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass
+```
+
+## Out of scope
+
+- Replacing ContextForge health checks, RBAC, or plugins
+- Signing every production `tools/call`
+- Requiring a vendor account to verify
+
+## See also
+
+- [MCP Server Catalog](../manage/catalog.md)
+- [RBAC for Tool Authorization](rbac-tool-authorization.md)
+
+Raw workflow file: [toa-after-register.yml](toa-after-register.yml).

--- a/docs/docs/manage/catalog.md
+++ b/docs/docs/manage/catalog.md
@@ -600,6 +600,18 @@ The catalog now supports:
 
 ---
 
+## Optional: Tool Outcome Attestation (TOA) before register
+
+Catalog registration and health checks cover discovery and reachability.
+[TOA](https://github.com/Carmel-Labs-Inc/toa) (`toa/0.1`) is adjacent delivery
+evidence you can verify offline before promoting a catalog server into
+production. Optional and off by default. No AgentStatus account is required to
+verify.
+
+See [Optional TOA verify before register / promote](../howto/toa-optional-register-gate.md).
+
+---
+
 ## See Also
 
 - [Configuration Reference](./index.md) - Complete configuration guide


### PR DESCRIPTION
# Documentation PR

## Related Issue / Epic

Related discussion (closed): https://github.com/IBM/mcp-context-forge/issues/6476

Does not use `Closes` because that issue was filed under the wrong author account and closed. This PR stands alone as docs-only.

## Summary

Adds an optional howto for offline `toa-verify` before registering or promoting an MCP server in ContextForge, plus a short pointer from the catalog docs.

- `docs/docs/howto/toa-optional-register-gate.md`
- `docs/docs/howto/toa-after-register.yml`
- howto index + `manage/catalog.md` pointer

TOA (`toa/0.1`) is adjacent delivery evidence. It does not replace health checks, RBAC, or plugins. No AgentStatus account is required to verify.

## Reviewability

- [x] This PR has one clear purpose
- [x] Unrelated docs fixes are not included
- [x] AI-assisted; changes are docs-only and explained above

## Type of Change

- [x] New page or major rewrite (new howto + catalog pointer)

## Verification

Docs-only; no runtime code changes.

- Inspected rendered markdown locally in the branch
- Example YAML is gated on `hashFiles('toa.json')` and marked optional
- Commit includes DCO `Signed-off-by: AgentStatus <dev@agentstatus.dev>`

Did not run `make markdownlint spellcheck` in this environment; happy to fix any linter findings from CI.


Made with [Cursor](https://cursor.com)