### PR TITLE
[FIX]: expose tls cipher suite 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1944,8 +1944,8 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # Allowed TLS cipher suites for Gunicorn HTTPS listener (colon-separated OpenSSL cipher string)
 # SSL_CIPHERS=ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384
 
-# Minimum TLS protocol version constraint for Gunicorn HTTPS listener
-# Options: Numeric ssl version constant (e.g. 5 for TLS 1.3 minimum)
+# Minimum TLS version for the Gunicorn HTTPS listener
+# Options: Numeric ssl version constant or ssl.PROTOCOL_* name (e.g. 5 / PROTOCOL_TLSv1_2 for TLS 1.2 minimum)
 # SSL_VERSION=5
 
 # CORS allowed origins (JSON array of URLs)

--- a/.env.example
+++ b/.env.example
@@ -1942,10 +1942,13 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # SKIP_SSL_VERIFY=false
 
 # Allowed TLS cipher suites for Gunicorn HTTPS listener (colon-separated OpenSSL cipher string)
-# SSL_CIPHERS=ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384
+# Recommended for hardening direct TLS listeners without pinning protocol versions.
+# SSL_CIPHERS=ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305
 
-# Minimum TLS version for the Gunicorn HTTPS listener
-# Options: Numeric ssl version constant or ssl.PROTOCOL_* name (e.g. 5 / PROTOCOL_TLSv1_2 for TLS 1.2 minimum)
+# Specific TLS protocol version selector for the Gunicorn HTTPS listener
+# NOTE: This pins the listener to exactly one protocol version (e.g. 5 / PROTOCOL_TLSv1_2 pins to TLS 1.2 only
+# and disables TLS 1.3). It is not a minimum floor. Leave unset to use system/Python defaults (TLS 1.2+).
+# Options: Numeric ssl version constant or ssl.PROTOCOL_* name (e.g. 5 or PROTOCOL_TLSv1_2)
 # SSL_VERSION=5
 
 # CORS allowed origins (JSON array of URLs)

--- a/.env.example
+++ b/.env.example
@@ -1941,6 +1941,13 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # PRODUCTION: Must be false for security
 # SKIP_SSL_VERIFY=false
 
+# Allowed TLS cipher suites for Gunicorn HTTPS listener (colon-separated OpenSSL cipher string)
+# SSL_CIPHERS=ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384
+
+# Minimum TLS protocol version constraint for Gunicorn HTTPS listener
+# Options: Numeric ssl version constant (e.g. 5 for TLS 1.3 minimum)
+# SSL_VERSION=5
+
 # CORS allowed origins (JSON array of URLs)
 # Controls which domains can make cross-origin requests to the gateway
 # Format: JSON array starting with [ and ending with ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-31T10:07:29Z",
+  "generated_at": "2026-08-31T10:37:33Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1670,7 +1670,7 @@
         "hashed_secret": "4729dd879b70a5a3ae4fa180ccbb4bea7b1d4ce2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 758,
+        "line_number": 764,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-31T09:23:51Z",
+  "generated_at": "2026-08-31T10:07:29Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1670,7 +1670,7 @@
         "hashed_secret": "4729dd879b70a5a3ae4fa180ccbb4bea7b1d4ce2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 731,
+        "line_number": 758,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/deployment/tls-configuration.md
+++ b/docs/docs/deployment/tls-configuration.md
@@ -382,12 +382,26 @@ warning explaining the consequence.
 
 #### Docker Compose
 
+### Exposing TLS Cipher Suite and Protocol Version Constraints
+
+To enforce stronger security on the gateway's direct HTTPS listener (Option 1 architecture), you can optionally restrict the allowed SSL/TLS cipher suites and minimum protocol version using the following environment variables:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `SSL_CIPHERS` | (empty — Python defaults) | Colon-separated list of allowed OpenSSL cipher suites |
+| `SSL_VERSION` | (empty — Gunicorn default) | Numeric constant from Python's `ssl` module defining the protocol version |
+
+#### Recommended Production Configuration
+
+To restrict the gateway to secure modern ciphers and enforce a minimum of TLS 1.2 (or TLS 1.3 depending on Python/OpenSSL platform capabilities), configure these variables in your `.env` or `docker-compose.yml`:
+
 ```yaml
 gateway:
   environment:
     - SSL=true
     - CERT_FILE=/app/certs/cert.pem
     - KEY_FILE=/app/certs/key.pem
+<<<<<<< HEAD
     - CA_CERTS=/app/certs/client/ca-cert.pem
     - CERT_REQS=2
     - LOOPBACK_CLIENT_CERT=/app/certs/client/client-cert.pem
@@ -426,6 +440,14 @@ HTTP loopback. For enforced mTLS in front of the nginx stack, configure `ssl_cli
 
 The credentials from `make certs-client` are for testing. `certs/client/ca-key.pem` is a real CA
 key — use your own PKI in production.
+
+    # Recommended secure cipher suites (restricts to high-strength modern ciphers)
+    - SSL_CIPHERS=ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305
+    # Enforce minimum protocol version (5 maps to ssl.PROTOCOL_TLSv1_2 / TLS 1.2 minimum)
+    - SSL_VERSION=5
+```
+
+These variables are directly forwarded to Gunicorn's `--ciphers` and `--ssl-version` command-line flags.
 
 ### Mount Certificates
 

--- a/docs/docs/deployment/tls-configuration.md
+++ b/docs/docs/deployment/tls-configuration.md
@@ -382,26 +382,12 @@ warning explaining the consequence.
 
 #### Docker Compose
 
-### Exposing TLS Cipher Suite and Protocol Version Constraints
-
-To enforce stronger security on the gateway's direct HTTPS listener (Option 1 architecture), you can optionally restrict the allowed SSL/TLS cipher suites and minimum protocol version using the following environment variables:
-
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `SSL_CIPHERS` | (empty — Python defaults) | Colon-separated list of allowed OpenSSL cipher suites |
-| `SSL_VERSION` | (empty — library default) | Minimum TLS version selector (`5` or `ssl.PROTOCOL_TLSv1_2` → TLS 1.2 minimum) |
-
-#### Recommended Production Configuration
-
-To restrict the gateway to secure modern ciphers and enforce a minimum TLS version, configure these variables in your `.env` or `docker-compose.yml`:
-
 ```yaml
 gateway:
   environment:
     - SSL=true
     - CERT_FILE=/app/certs/cert.pem
     - KEY_FILE=/app/certs/key.pem
-<<<<<<< HEAD
     - CA_CERTS=/app/certs/client/ca-cert.pem
     - CERT_REQS=2
     - LOOPBACK_CLIENT_CERT=/app/certs/client/client-cert.pem
@@ -441,6 +427,25 @@ HTTP loopback. For enforced mTLS in front of the nginx stack, configure `ssl_cli
 The credentials from `make certs-client` are for testing. `certs/client/ca-key.pem` is a real CA
 key — use your own PKI in production.
 
+### Exposing TLS Cipher Suite and Protocol Version Constraints
+
+To enforce stronger security on the gateway's direct HTTPS listener (Option 1 architecture), you can optionally restrict the allowed SSL/TLS cipher suites and minimum protocol version using the following environment variables:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `SSL_CIPHERS` | (empty — Python defaults) | Colon-separated list of allowed OpenSSL cipher suites |
+| `SSL_VERSION` | (empty — library default) | Minimum TLS version selector (`5` or `ssl.PROTOCOL_TLSv1_2` → TLS 1.2 minimum) |
+
+#### Recommended Production Configuration
+
+To restrict the gateway to secure modern ciphers and enforce a minimum TLS version, configure these variables in your `.env` or `docker-compose.yml`:
+
+```yaml
+gateway:
+  environment:
+    - SSL=true
+    - CERT_FILE=/app/certs/cert.pem
+    - KEY_FILE=/app/certs/key.pem
     # Recommended secure cipher suites (restricts to high-strength modern ciphers)
     - SSL_CIPHERS=ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305
     # Enforce a TLS 1.2 minimum (same as ssl.PROTOCOL_TLSv1_2)

--- a/docs/docs/deployment/tls-configuration.md
+++ b/docs/docs/deployment/tls-configuration.md
@@ -447,7 +447,7 @@ key — use your own PKI in production.
     - SSL_VERSION=5
 ```
 
-`SSL_CIPHERS` is forwarded to Gunicorn's `--ciphers` flag. `SSL_VERSION` is also forwarded to `--ssl-version`, but Gunicorn 26 deprecates and ignores that setting, so [`ssl_context()`](mcp-context-forge/gunicorn.config.py:77) applies the effective minimum TLS version on the final `SSLContext`.
+`SSL_CIPHERS` is forwarded to Gunicorn's `--ciphers` flag. `SSL_VERSION` is forwarded to Gunicorn's `--ssl-version` flag, and normalized in [`gunicorn.config.py`](mcp-context-forge/gunicorn.config.py) so Uvicorn creates the corresponding `ssl.SSLContext`.
 
 ### Mount Certificates
 

--- a/docs/docs/deployment/tls-configuration.md
+++ b/docs/docs/deployment/tls-configuration.md
@@ -389,11 +389,11 @@ To enforce stronger security on the gateway's direct HTTPS listener (Option 1 ar
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `SSL_CIPHERS` | (empty — Python defaults) | Colon-separated list of allowed OpenSSL cipher suites |
-| `SSL_VERSION` | (empty — Gunicorn default) | Numeric constant from Python's `ssl` module defining the protocol version |
+| `SSL_VERSION` | (empty — library default) | Minimum TLS version selector (`5` or `ssl.PROTOCOL_TLSv1_2` → TLS 1.2 minimum) |
 
 #### Recommended Production Configuration
 
-To restrict the gateway to secure modern ciphers and enforce a minimum of TLS 1.2 (or TLS 1.3 depending on Python/OpenSSL platform capabilities), configure these variables in your `.env` or `docker-compose.yml`:
+To restrict the gateway to secure modern ciphers and enforce a minimum TLS version, configure these variables in your `.env` or `docker-compose.yml`:
 
 ```yaml
 gateway:
@@ -443,11 +443,11 @@ key — use your own PKI in production.
 
     # Recommended secure cipher suites (restricts to high-strength modern ciphers)
     - SSL_CIPHERS=ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305
-    # Enforce minimum protocol version (5 maps to ssl.PROTOCOL_TLSv1_2 / TLS 1.2 minimum)
+    # Enforce a TLS 1.2 minimum (same as ssl.PROTOCOL_TLSv1_2)
     - SSL_VERSION=5
 ```
 
-These variables are directly forwarded to Gunicorn's `--ciphers` and `--ssl-version` command-line flags.
+`SSL_CIPHERS` is forwarded to Gunicorn's `--ciphers` flag. `SSL_VERSION` is also forwarded to `--ssl-version`, but Gunicorn 26 deprecates and ignores that setting, so [`ssl_context()`](mcp-context-forge/gunicorn.config.py:77) applies the effective minimum TLS version on the final `SSLContext`.
 
 ### Mount Certificates
 

--- a/docs/docs/deployment/tls-configuration.md
+++ b/docs/docs/deployment/tls-configuration.md
@@ -429,16 +429,16 @@ key — use your own PKI in production.
 
 ### Exposing TLS Cipher Suite and Protocol Version Constraints
 
-To enforce stronger security on the gateway's direct HTTPS listener (Option 1 architecture), you can optionally restrict the allowed SSL/TLS cipher suites and minimum protocol version using the following environment variables:
+To enforce stronger security on the gateway's direct HTTPS listener (Option 1 architecture), you can optionally restrict the allowed SSL/TLS cipher suites and protocol version using the following environment variables:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `SSL_CIPHERS` | (empty — Python defaults) | Colon-separated list of allowed OpenSSL cipher suites |
-| `SSL_VERSION` | (empty — library default) | Minimum TLS version selector (`5` or `ssl.PROTOCOL_TLSv1_2` → TLS 1.2 minimum) |
+| `SSL_VERSION` | (empty — library default) | Specific TLS protocol version selector (`5` or `ssl.PROTOCOL_TLSv1_2`) |
 
 #### Recommended Production Configuration
 
-To restrict the gateway to secure modern ciphers and enforce a minimum TLS version, configure these variables in your `.env` or `docker-compose.yml`:
+To restrict the direct HTTPS gateway listener to secure modern ciphers without pinning protocol versions, configure `SSL_CIPHERS` in your `.env` or `docker-compose.yml`:
 
 ```yaml
 gateway:
@@ -448,11 +448,17 @@ gateway:
     - KEY_FILE=/app/certs/key.pem
     # Recommended secure cipher suites (restricts to high-strength modern ciphers)
     - SSL_CIPHERS=ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305
-    # Enforce a TLS 1.2 minimum (same as ssl.PROTOCOL_TLSv1_2)
-    - SSL_VERSION=5
 ```
 
-`SSL_CIPHERS` is forwarded to Gunicorn's `--ciphers` flag. `SSL_VERSION` is forwarded to Gunicorn's `--ssl-version` flag, and normalized in [`gunicorn.config.py`](mcp-context-forge/gunicorn.config.py) so Uvicorn creates the corresponding `ssl.SSLContext`.
+`SSL_CIPHERS` is forwarded to Gunicorn's `--ciphers` flag. When set, `SSL_VERSION` is forwarded to Gunicorn's `--ssl-version` flag and normalized in `gunicorn.config.py` so Uvicorn creates the corresponding `ssl.SSLContext`.
+
+!!! warning "Protocol version pinning vs version floors"
+    `SSL_VERSION` sets an exact, version-specific protocol selector in Python's SSL layer (e.g., `SSL_VERSION=5` / `PROTOCOL_TLSv1_2` pins the listener to **TLS 1.2 only** and disables TLS 1.3). It is **not** a minimum floor.
+
+    Leave `SSL_VERSION` unset to retain default auto-negotiation (TLS 1.2 and TLS 1.3). Python's standard library does not provide a protocol selector constant for TLS 1.3 only. If you require strict TLS version floor enforcement (such as enforcing TLS 1.3 minimum or TLS 1.3 only), terminate TLS at the nginx layer (Option 2) using `ssl_protocols TLSv1.3;`.
+
+!!! note "Gunicorn deprecation notice"
+    When `SSL_VERSION` is provided, Gunicorn's CLI argument validator emits `Warning: option 'ssl_version' is deprecated and it is ignored. Use ssl_context instead.` to stderr. In our stack, `UvicornWorker` forwards the configured setting to Uvicorn's SSL context loader, so the option is actively applied.
 
 ### Mount Certificates
 

--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -94,6 +94,23 @@ def on_starting(server):
     ssl_enabled = os.environ.get("SSL", "false").lower() == "true"
     ssl_key_password = os.environ.get("SSL_KEY_PASSWORD")
 
+    # If ssl_version is passed as a string (e.g. from run-gunicorn.sh CLI),
+    # convert it to the integer/constant that uvicorn/ssl expects
+    if ssl_enabled and hasattr(server, "cfg"):
+        try:
+            ssl_version = server.cfg.ssl_version
+            if isinstance(ssl_version, str):
+                import ssl as ssl_module
+                if ssl_version.isdigit():
+                    server.cfg.set("ssl_version", int(ssl_version))
+                    server.log.info(f"Converted SSL version string to integer: {ssl_version}")
+                elif hasattr(ssl_module, ssl_version):
+                    resolved_val = getattr(ssl_module, ssl_version)
+                    server.cfg.set("ssl_version", resolved_val)
+                    server.log.info(f"Resolved SSL version constant name to: {resolved_val}")
+        except Exception as e:
+            server.log.warning(f"Failed to normalize Gunicorn ssl_version setting: {e}")
+
     if ssl_enabled and ssl_key_password:
         try:
             from mcpgateway.utils.ssl_key_manager import prepare_ssl_key

--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -85,38 +85,6 @@ _prepared_key_file = None
 # server hooks
 
 
-def ssl_context(conf, default_ssl_context_factory):
-    """Customize Gunicorn's SSLContext for the direct Gunicorn TLS path."""
-    context = default_ssl_context_factory()
-    ssl_version = os.environ.get("SSL_VERSION", "").strip()
-    if ssl_version:
-        try:
-            if ssl_version.isdigit():
-                protocol = int(ssl_version)
-            else:
-                protocol = getattr(ssl, ssl_version)
-            minimum_versions = {
-                ssl.PROTOCOL_TLSv1: ssl.TLSVersion.TLSv1,
-                ssl.PROTOCOL_TLSv1_1: ssl.TLSVersion.TLSv1_1,
-                ssl.PROTOCOL_TLSv1_2: ssl.TLSVersion.TLSv1_2,
-            }
-            minimum_version = minimum_versions.get(protocol)
-            if minimum_version is not None:
-                context.minimum_version = minimum_version
-        except AttributeError as exc:
-            raise RuntimeError(f"Invalid SSL_VERSION value: {ssl_version}") from exc
-    return context
-
-
-class ContextForgeUvicornWorker(UvicornWorker):
-    """Uvicorn worker that applies TLS restrictions on Uvicorn's SSLContext."""
-
-    CONFIG_KWARGS = {
-        **UvicornWorker.CONFIG_KWARGS,
-        "ssl_context_factory": staticmethod(ssl_context),
-    }
-
-
 def on_starting(server):
     """Called just before the master process is initialized.
 
@@ -129,6 +97,19 @@ def on_starting(server):
     # and a passphrase is provided
     ssl_enabled = os.environ.get("SSL", "false").lower() == "true"
     ssl_key_password = os.environ.get("SSL_KEY_PASSWORD")
+
+    # If ssl_version is passed as a string from CLI, normalize to integer for Uvicorn
+    if ssl_enabled and hasattr(server, "cfg"):
+        try:
+            ssl_ver = server.cfg.ssl_version
+            if isinstance(ssl_ver, str):
+                import ssl as _ssl
+                if ssl_ver.isdigit():
+                    server.cfg.set("ssl_version", int(ssl_ver))
+                elif hasattr(_ssl, ssl_ver):
+                    server.cfg.set("ssl_version", getattr(_ssl, ssl_ver))
+        except Exception as e:
+            server.log.warning(f"Failed to normalize Gunicorn ssl_version setting: {e}")
 
     if ssl_enabled and ssl_key_password:
         try:

--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -17,7 +17,6 @@ Reference: https://stackoverflow.com/questions/10855197/frequent-worker-timeout
 # Standard
 import os
 import platform
-import ssl
 
 # macOS fork safety fix: Must be set before any workers fork
 # On macOS, Objective-C is not fork-safe. When gunicorn forks workers after
@@ -28,9 +27,6 @@ if platform.system() == "Darwin":
 # First-Party
 # Import Pydantic Settings singleton
 from mcpgateway.config import settings
-
-# Third-Party
-from uvicorn.workers import UvicornWorker
 
 # import multiprocessing
 
@@ -106,10 +102,10 @@ def on_starting(server):
                 import ssl as _ssl
                 if ssl_ver.isdigit():
                     server.cfg.set("ssl_version", int(ssl_ver))
-                elif hasattr(_ssl, ssl_ver):
+                elif ssl_ver.startswith("PROTOCOL_") and hasattr(_ssl, ssl_ver):
                     server.cfg.set("ssl_version", getattr(_ssl, ssl_ver))
         except Exception as e:
-            server.log.warning(f"Failed to normalize Gunicorn ssl_version setting: {e}")
+            server.log.warning("Failed to normalize Gunicorn ssl_version setting: %s", e)
 
     if ssl_enabled and ssl_key_password:
         try:

--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -104,6 +104,8 @@ def on_starting(server):
                     server.cfg.set("ssl_version", int(ssl_ver))
                 elif ssl_ver.startswith("PROTOCOL_") and hasattr(_ssl, ssl_ver):
                     server.cfg.set("ssl_version", getattr(_ssl, ssl_ver))
+                else:
+                    server.log.warning("Unrecognized SSL_VERSION value %r; leaving unchanged (boot may fail downstream)", ssl_ver)
         except Exception as e:
             server.log.warning("Failed to normalize Gunicorn ssl_version setting: %s", e)
 

--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -17,6 +17,7 @@ Reference: https://stackoverflow.com/questions/10855197/frequent-worker-timeout
 # Standard
 import os
 import platform
+import ssl
 
 # macOS fork safety fix: Must be set before any workers fork
 # On macOS, Objective-C is not fork-safe. When gunicorn forks workers after
@@ -27,6 +28,9 @@ if platform.system() == "Darwin":
 # First-Party
 # Import Pydantic Settings singleton
 from mcpgateway.config import settings
+
+# Third-Party
+from uvicorn.workers import UvicornWorker
 
 # import multiprocessing
 
@@ -81,6 +85,38 @@ _prepared_key_file = None
 # server hooks
 
 
+def ssl_context(conf, default_ssl_context_factory):
+    """Customize Gunicorn's SSLContext for the direct Gunicorn TLS path."""
+    context = default_ssl_context_factory()
+    ssl_version = os.environ.get("SSL_VERSION", "").strip()
+    if ssl_version:
+        try:
+            if ssl_version.isdigit():
+                protocol = int(ssl_version)
+            else:
+                protocol = getattr(ssl, ssl_version)
+            minimum_versions = {
+                ssl.PROTOCOL_TLSv1: ssl.TLSVersion.TLSv1,
+                ssl.PROTOCOL_TLSv1_1: ssl.TLSVersion.TLSv1_1,
+                ssl.PROTOCOL_TLSv1_2: ssl.TLSVersion.TLSv1_2,
+            }
+            minimum_version = minimum_versions.get(protocol)
+            if minimum_version is not None:
+                context.minimum_version = minimum_version
+        except AttributeError as exc:
+            raise RuntimeError(f"Invalid SSL_VERSION value: {ssl_version}") from exc
+    return context
+
+
+class ContextForgeUvicornWorker(UvicornWorker):
+    """Uvicorn worker that applies TLS restrictions on Uvicorn's SSLContext."""
+
+    CONFIG_KWARGS = {
+        **UvicornWorker.CONFIG_KWARGS,
+        "ssl_context_factory": staticmethod(ssl_context),
+    }
+
+
 def on_starting(server):
     """Called just before the master process is initialized.
 
@@ -93,23 +129,6 @@ def on_starting(server):
     # and a passphrase is provided
     ssl_enabled = os.environ.get("SSL", "false").lower() == "true"
     ssl_key_password = os.environ.get("SSL_KEY_PASSWORD")
-
-    # If ssl_version is passed as a string (e.g. from run-gunicorn.sh CLI),
-    # convert it to the integer/constant that uvicorn/ssl expects
-    if ssl_enabled and hasattr(server, "cfg"):
-        try:
-            ssl_version = server.cfg.ssl_version
-            if isinstance(ssl_version, str):
-                import ssl as ssl_module
-                if ssl_version.isdigit():
-                    server.cfg.set("ssl_version", int(ssl_version))
-                    server.log.info(f"Converted SSL version string to integer: {ssl_version}")
-                elif hasattr(ssl_module, ssl_version):
-                    resolved_val = getattr(ssl_module, ssl_version)
-                    server.cfg.set("ssl_version", resolved_val)
-                    server.log.info(f"Resolved SSL version constant name to: {resolved_val}")
-        except Exception as e:
-            server.log.warning(f"Failed to normalize Gunicorn ssl_version setting: {e}")
 
     if ssl_enabled and ssl_key_password:
         try:

--- a/run-gunicorn.sh
+++ b/run-gunicorn.sh
@@ -298,7 +298,7 @@ KEY_FILE=${KEY_FILE:-certs/key.pem}     # Path to SSL private key file
 KEY_FILE_PASSWORD=${KEY_FILE_PASSWORD:-}  # Optional passphrase for encrypted key
 CERT_PASSPHRASE=${CERT_PASSPHRASE:-}      # Alternative name for passphrase
 SSL_CIPHERS=${SSL_CIPHERS:-}              # Colon-separated OpenSSL cipher string (empty = default)
-SSL_VERSION=${SSL_VERSION:-}              # Numeric SSL version constant (empty = Gunicorn default)
+SSL_VERSION=${SSL_VERSION:-}              # Minimum TLS protocol version constant/name (empty = library default)
 
 # Use CERT_PASSPHRASE if KEY_FILE_PASSWORD is not set (for compatibility)
 if [[ -z "${KEY_FILE_PASSWORD}" && -n "${CERT_PASSPHRASE}" ]]; then
@@ -469,7 +469,7 @@ echo "────────────────────────�
 cmd=(
     gunicorn
     -c gunicorn.config.py
-    --worker-class uvicorn.workers.UvicornWorker
+    --worker-class gunicorn.config.py:ContextForgeUvicornWorker
     --workers              "${GUNICORN_WORKERS}"
     --timeout              "${GUNICORN_TIMEOUT}"
     --max-requests         "${GUNICORN_MAX_REQUESTS}"

--- a/run-gunicorn.sh
+++ b/run-gunicorn.sh
@@ -297,6 +297,8 @@ CERT_FILE=${CERT_FILE:-certs/cert.pem}  # Path to SSL certificate file
 KEY_FILE=${KEY_FILE:-certs/key.pem}     # Path to SSL private key file
 KEY_FILE_PASSWORD=${KEY_FILE_PASSWORD:-}  # Optional passphrase for encrypted key
 CERT_PASSPHRASE=${CERT_PASSPHRASE:-}      # Alternative name for passphrase
+SSL_CIPHERS=${SSL_CIPHERS:-}              # Colon-separated OpenSSL cipher string (empty = default)
+SSL_VERSION=${SSL_VERSION:-}              # Numeric SSL version constant (empty = Gunicorn default)
 
 # Use CERT_PASSPHRASE if KEY_FILE_PASSWORD is not set (for compatibility)
 if [[ -z "${KEY_FILE_PASSWORD}" && -n "${CERT_PASSPHRASE}" ]]; then
@@ -427,6 +429,16 @@ if [[ "${SSL}" == "true" ]]; then
     else
         echo "   Passphrase: (none)"
     fi
+    if [[ -n "${SSL_CIPHERS}" ]]; then
+        echo "   Ciphers: ${SSL_CIPHERS}"
+    else
+        echo "   Ciphers: (default)"
+    fi
+    if [[ -n "${SSL_VERSION}" ]]; then
+        echo "   SSL/TLS Version: ${SSL_VERSION}"
+    else
+        echo "   SSL/TLS Version: (default)"
+    fi
 else
     echo "🔓  Running without TLS (HTTP only)"
 fi
@@ -508,8 +520,15 @@ fi
 if [[ "${SSL}" == "true" ]]; then
     cmd+=( --certfile "${CERT_FILE}" --keyfile "${KEY_FILE}" )
     # If passphrase is set, it will be available to Python via SSL_KEY_PASSWORD env var
+
     if [[ -n "${CA_CERTS}" ]]; then
         cmd+=( --ca-certs "${CA_CERTS}" --cert-reqs "${CERT_REQS}" )
+    fi
+    if [[ -n "${SSL_CIPHERS}" ]]; then
+        cmd+=( --ciphers "${SSL_CIPHERS}" )
+    fi
+    if [[ -n "${SSL_VERSION}" ]]; then
+        cmd+=( --ssl-version "${SSL_VERSION}" )
     fi
 fi
 

--- a/run-gunicorn.sh
+++ b/run-gunicorn.sh
@@ -469,7 +469,7 @@ echo "────────────────────────�
 cmd=(
     gunicorn
     -c gunicorn.config.py
-    --worker-class gunicorn.config.py:ContextForgeUvicornWorker
+    --worker-class uvicorn.workers.UvicornWorker
     --workers              "${GUNICORN_WORKERS}"
     --timeout              "${GUNICORN_TIMEOUT}"
     --max-requests         "${GUNICORN_MAX_REQUESTS}"

--- a/tests/bash/run_gunicorn_mtls.bats
+++ b/tests/bash/run_gunicorn_mtls.bats
@@ -201,3 +201,28 @@ tls_args() {
     [ "$status" -eq 1 ]
     [[ "$output" == *"Loopback client credential not found"* ]]
 }
+
+# --- TLS Cipher Suites and Protocol Version ----------------------------------
+
+@test "SSL_CIPHERS passes --ciphers flag to gunicorn when SSL=true" {
+    run_launcher SSL=true CERT_FILE="${TMP_DIR}/cert.pem" KEY_FILE="${TMP_DIR}/key.pem" \
+        SSL_CIPHERS="ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--ciphers ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256"* ]]
+}
+
+@test "SSL_VERSION passes --ssl-version flag to gunicorn when SSL=true" {
+    run_launcher SSL=true CERT_FILE="${TMP_DIR}/cert.pem" KEY_FILE="${TMP_DIR}/key.pem" \
+        SSL_VERSION="5"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--ssl-version 5"* ]]
+}
+
+@test "SSL_CIPHERS and SSL_VERSION are ignored when SSL=false" {
+    run_launcher SSL=false \
+        SSL_CIPHERS="ECDHE-RSA-AES256-GCM-SHA384" \
+        SSL_VERSION="5"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"--ciphers"* ]]
+    [[ "$output" != *"--ssl-version"* ]]
+}

--- a/tests/unit/test_gunicorn_config.py
+++ b/tests/unit/test_gunicorn_config.py
@@ -291,8 +291,8 @@ class TestOnStartingHook:
         cfg_module.on_starting(mock_server)
         mock_cfg.set.assert_called_once_with("ssl_version", ssl.PROTOCOL_TLSv1_2)
 
-    def test_on_starting_unrecognized_ssl_version_does_not_crash(self, monkeypatch):
-        """Test that unrecognized string ssl_version does not set and does not crash."""
+    def test_on_starting_unrecognized_ssl_version_logs_warning_and_does_not_crash(self, monkeypatch):
+        """Test that unrecognized string ssl_version logs a warning, does not set, and does not crash."""
         monkeypatch.setenv("SSL", "true")
         cfg_module = _load_gunicorn_config()
 
@@ -303,6 +303,9 @@ class TestOnStartingHook:
 
         cfg_module.on_starting(mock_server)
         mock_cfg.set.assert_not_called()
+        assert mock_server.log.warning.called
+        warning_call_args = mock_server.log.warning.call_args
+        assert "Unrecognized SSL_VERSION value" in str(warning_call_args)
 
     def test_on_starting_exception_in_normalization_logs_warning(self, monkeypatch):
         """Test that exceptions during normalization log a warning and don't crash."""

--- a/tests/unit/test_gunicorn_config.py
+++ b/tests/unit/test_gunicorn_config.py
@@ -259,3 +259,76 @@ def test_post_fork_logs_warning_when_rebind_fails(fake_worker, monkeypatch):
     fmt = call_args.args[0] if call_args.args else ""
     assert "WORKER_ID" in fmt
     assert "broadcast" in fmt, "warning should describe the consequence (per-container broadcast) so operators can act on it"
+
+
+class TestOnStartingHook:
+    """Test the on_starting() hook in gunicorn.config.py."""
+
+    def test_on_starting_normalizes_digit_ssl_version(self, monkeypatch):
+        """Test that string digit ssl_version (e.g. '5') is converted to int."""
+        monkeypatch.setenv("SSL", "true")
+        cfg_module = _load_gunicorn_config()
+
+        mock_server = _make_fake_server()
+        mock_cfg = MagicMock()
+        mock_cfg.ssl_version = "5"
+        mock_server.cfg = mock_cfg
+
+        cfg_module.on_starting(mock_server)
+        mock_cfg.set.assert_called_once_with("ssl_version", 5)
+
+    def test_on_starting_normalizes_protocol_constant_name(self, monkeypatch):
+        """Test that PROTOCOL_* name is resolved to ssl constant."""
+        import ssl
+        monkeypatch.setenv("SSL", "true")
+        cfg_module = _load_gunicorn_config()
+
+        mock_server = _make_fake_server()
+        mock_cfg = MagicMock()
+        mock_cfg.ssl_version = "PROTOCOL_TLSv1_2"
+        mock_server.cfg = mock_cfg
+
+        cfg_module.on_starting(mock_server)
+        mock_cfg.set.assert_called_once_with("ssl_version", ssl.PROTOCOL_TLSv1_2)
+
+    def test_on_starting_unrecognized_ssl_version_does_not_crash(self, monkeypatch):
+        """Test that unrecognized string ssl_version does not set and does not crash."""
+        monkeypatch.setenv("SSL", "true")
+        cfg_module = _load_gunicorn_config()
+
+        mock_server = _make_fake_server()
+        mock_cfg = MagicMock()
+        mock_cfg.ssl_version = "NOT_A_VALID_SSL_VERSION"
+        mock_server.cfg = mock_cfg
+
+        cfg_module.on_starting(mock_server)
+        mock_cfg.set.assert_not_called()
+
+    def test_on_starting_exception_in_normalization_logs_warning(self, monkeypatch):
+        """Test that exceptions during normalization log a warning and don't crash."""
+        monkeypatch.setenv("SSL", "true")
+        cfg_module = _load_gunicorn_config()
+
+        mock_server = _make_fake_server()
+        mock_cfg = MagicMock()
+        mock_cfg.ssl_version = "5"
+        mock_cfg.set.side_effect = RuntimeError("failed to set")
+        mock_server.cfg = mock_cfg
+
+        cfg_module.on_starting(mock_server)
+        assert mock_server.log.warning.called
+        warning_msg = str(mock_server.log.warning.call_args)
+        assert "Failed to normalize Gunicorn ssl_version setting" in warning_msg
+
+    def test_on_starting_ssl_disabled_skips_normalization(self, monkeypatch):
+        """Test that when SSL is false/unset, normalization is skipped."""
+        monkeypatch.setenv("SSL", "false")
+        cfg_module = _load_gunicorn_config()
+
+        mock_server = _make_fake_server()
+        mock_cfg = MagicMock()
+        mock_cfg.ssl_version = "5"
+        mock_server.cfg = mock_cfg
+
+        cfg_module.on_starting(mock_server)
+        mock_cfg.set.assert_not_called()


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes https://github.com/IBM/mcp-context-forge/issues/6267

---

## 📝 Summary

Exposes TLS cipher suite (`SSL_CIPHERS`) and protocol version (`SSL_VERSION`) configuration options as opt-in environment variables for Gunicorn's HTTPS listener (`run-gunicorn.sh`).

### Why
Operators terminating TLS directly at the gateway (Option 1 topology) previously had no mechanism to enforce custom cipher allowlists or restrict TLS versions (such as TLS 1.2 minimum) via environment configuration. While downstream components (`UvicornWorker` → `uvicorn.config.Config` → `ssl.SSLContext`) already support these options, `run-gunicorn.sh` lacked support to pass them.

### Key Changes
1. **`run-gunicorn.sh`**:
   - Added `SSL_CIPHERS` and `SSL_VERSION` environment variable parsing.
   - Forwards `--ciphers "${SSL_CIPHERS}"` and `--ssl-version "${SSL_VERSION}"` to Gunicorn when set.
   - Logs active TLS cipher and version configurations at server startup.
2. **`gunicorn.config.py`**:
   - Added string-to-int normalization for `ssl_version` inside the `on_starting()` server hook. When passed via CLI from bash, string inputs like `"5"` or `"PROTOCOL_TLSv1_2"` are cast to integer constants, preventing `TypeError: 'str' object cannot be interpreted as an integer` when Uvicorn initializes its `SSLContext`.
3. **Configuration & Documentation**:
   - Added commented configuration entries to `.env.example`.
   - Documented variable mappings and recommended production configurations in `docs/docs/deployment/tls-configuration.md`.
 4. **Tests**:
   - Added unit tests in `tests/unit/test_gunicorn_config.py` verifying `on_starting()` normalization of digit strings (`"5"`), `PROTOCOL_*` constants, error handling, and SSL toggle state.
   - Added BATS tests in `tests/bash/run_gunicorn_mtls.bats` asserting that `SSL_CIPHERS` and `SSL_VERSION` forward `--ciphers` and `--ssl-version` to Gunicorn when `SSL=true` and are ignored when `SSL=false`.
   
---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

### 1. Verification of Type Normalization & Server Boot
Started the server with strict cipher allowlist and TLS version constraints:
```bash
SSL=true SSL_CIPHERS="ECDHE-RSA-AES256-GCM-SHA384" SSL_VERSION=5 make serve-ssl
```

Verified that Gunicorn parses the CLI arguments cleanly and workers boot without TypeError.

2. Live TLS Handshake Verification (openssl s_client)
Allowed Cipher Test (matching ECDHE-RSA-AES256-GCM-SHA384):

openssl s_client -connect localhost:4444 -cipher ECDHE-RSA-AES256-GCM-SHA384 -tls1_2 -brief

Result: CONNECTION ESTABLISHED, Protocol version: TLSv1.2, Ciphersuite: ECDHE-RSA-AES256-GCM-SHA384.

Blocked Cipher Test (non-matching ECDHE-RSA-AES128-GCM-SHA256):

openssl s_client -connect localhost:4444 -cipher ECDHE-RSA-AES128-GCM-SHA256 -tls1_2 -brief

Result: Handshake rejected (SSL routines:SSL_shutdown:shutdown while in init / unexpected EOF), confirming cipher enforcement is active.

### 3. Automated Test Suites
- Unit tests: `uv run pytest tests/unit/test_gunicorn_config.py` (12 passed)
- Bash CLI forwarding tests: `bats tests/bash/run_gunicorn_mtls.bats` (19 passed)
- Linting: `uv run ruff check --select F401 gunicorn.config.py` (clean, no unused imports)

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---


## 📓 Notes (optional)

All changes are additive and opt-in. When neither variable is set, behavior is identical to default Gunicorn and Python ssl module defaults.