### PR TITLE
fix(sso): resolve an email claim for generic OIDC providers

### DIFF
--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -1691,6 +1691,58 @@ class SSOService:
         return raw_email_str
 
     @staticmethod
+    def _resolve_email_claim(user_data: Dict[str, Any], metadata: Optional[Dict[str, Any]], provider_id: str) -> Optional[str]:
+        """Resolve the email address for a generic OIDC provider.
+
+        ``authenticate_or_create_user`` keys the local user record on email and
+        refuses any identity without one, but not every OIDC deployment releases
+        an ``email`` claim from ``/userinfo`` even when it advertises the scope.
+        The dedicated Keycloak, Entra and ADFS branches already fall back to other
+        claims; the generic branch did not, so such a provider failed the login
+        with ``user_creation_failed`` after an otherwise successful token
+        exchange.
+
+        Resolution order:
+
+        1. ``provider_metadata["email_claim"]`` when configured -- explicit
+           operator intent, used as-is with no ``@`` check.
+        2. Otherwise the conventional claims, in order: ``email``,
+           ``preferred_username``, ``upn``, ``unique_name``, ``mail``. A fallback
+           value must look like an address (contain ``@``), so a bare username is
+           never silently promoted to an identity key.
+
+        Args:
+            user_data: Raw claims from the provider's userinfo/id_token.
+            metadata: The provider's ``provider_metadata`` mapping, if any.
+            provider_id: Provider id, for logging.
+
+        Returns:
+            The resolved email, or None when no candidate qualifies.
+        """
+        configured = (metadata or {}).get("email_claim")
+        if configured:
+            value = user_data.get(configured)
+            return value if isinstance(value, str) and value else None
+
+        for claim in ("email", "preferred_username", "upn", "unique_name", "mail"):
+            value = user_data.get(claim)
+            if isinstance(value, str) and "@" in value:
+                if claim != "email":
+                    # Say which claim stood in for email: it becomes the identity
+                    # key, so this must be visible rather than inferred later.
+                    logger.info("SSO provider %s: no 'email' claim; using '%s' as the email identity", provider_id, claim)
+                return value
+
+        # Name the claims that WERE present. "no email" alone gives the operator
+        # nothing to act on, and userinfo bodies are not otherwise logged.
+        logger.warning(
+            "SSO provider %s returned no usable email claim. Claims present: %s. Set provider_metadata.email_claim to name the right one.",
+            provider_id,
+            sorted(user_data.keys()),
+        )
+        return None
+
+    @staticmethod
     def _extract_groups_and_roles(user_data: Dict[str, Any], groups_claim: str = "groups") -> list[str]:
         """Extract groups and roles from user data into a unified list.
 
@@ -1919,7 +1971,7 @@ class SSOService:
 
         # Generic OIDC format for all other providers.
         groups = self._extract_groups_and_roles(user_data, groups_claim)
-        return self._build_normalized_user_info(user_data, provider.id, groups)
+        return self._build_normalized_user_info(user_data, provider.id, groups, email=self._resolve_email_claim(user_data, metadata, provider.id))
 
     def _reset_pending_approval(self, pending: PendingUserApproval, incoming_provider: str, user_info: Dict[str, Any]) -> None:
         """Reset a pending approval request to pending state with fresh metadata.

--- a/tests/unit/mcpgateway/services/test_sso_service.py
+++ b/tests/unit/mcpgateway/services/test_sso_service.py
@@ -2552,6 +2552,41 @@ class TestExtractGroupsAndRoles:
         assert result == []
 
 
+class TestResolveEmailClaim:
+    """Tests for generic-OIDC email resolution."""
+
+    def test_prefers_standard_email_claim(self):
+        d = {"email": "a@e.com", "preferred_username": "b@e.com"}
+        assert SSOService._resolve_email_claim(d, {}, "p") == "a@e.com"
+
+    def test_falls_back_to_preferred_username(self):
+        d = {"preferred_username": "user@example.com"}
+        assert SSOService._resolve_email_claim(d, {}, "p") == "user@example.com"
+
+    def test_falls_back_to_upn_then_unique_name_then_mail(self):
+        assert SSOService._resolve_email_claim({"upn": "u@e.com"}, {}, "p") == "u@e.com"
+        assert SSOService._resolve_email_claim({"unique_name": "n@e.com"}, {}, "p") == "n@e.com"
+        assert SSOService._resolve_email_claim({"mail": "m@e.com"}, {}, "p") == "m@e.com"
+
+    def test_does_not_promote_a_bare_username(self):
+        """A fallback must look like an address; it becomes the identity key."""
+        assert SSOService._resolve_email_claim({"preferred_username": "jdoe"}, {}, "p") is None
+
+    def test_configured_email_claim_wins_and_skips_at_check(self):
+        d = {"email": "wrong@e.com", "corpMail": "right@e.com"}
+        assert SSOService._resolve_email_claim(d, {"email_claim": "corpMail"}, "p") == "right@e.com"
+
+    def test_configured_email_claim_missing_returns_none(self):
+        d = {"email": "present@e.com"}
+        assert SSOService._resolve_email_claim(d, {"email_claim": "absent"}, "p") is None
+
+    def test_returns_none_when_nothing_usable(self):
+        assert SSOService._resolve_email_claim({"sub": "abc", "name": "A"}, {}, "p") is None
+
+    def test_handles_missing_metadata(self):
+        assert SSOService._resolve_email_claim({"email": "a@e.com"}, None, "p") == "a@e.com"
+
+
 class TestBuildNormalizedUserInfo:
     """Tests for the extracted _build_normalized_user_info helper."""
 


### PR DESCRIPTION
Fixes #6432.

## What

`authenticate_or_create_user()` keys the local user record on e-mail and refuses any identity without one. The Keycloak, Entra and ADFS branches of `_normalize_user_info()` all fall back to other claims when the provider does not release `email`. The **generic** OIDC branch read `user_data["email"]` directly, with no fallback — so a generic provider that omits the claim completes the entire flow and then fails at provisioning with `user_creation_failed`.

This adds `_resolve_email_claim()`:

1. `provider_metadata["email_claim"]` when the operator has configured it — explicit intent, used as-is.
2. Otherwise `email → preferred_username → upn → unique_name → mail`.

Two properties worth calling out, because the resolved value *becomes* the account identity key:

- **A fallback must contain `@`.** A bare username such as `jdoe` is never promoted into the identity field. The explicitly configured claim skips this check, since that is a deliberate operator decision.
- **Use of a fallback is logged**, and the "nothing usable" warning now reports **which claims were present**. The previous warning reported only absence, and userinfo bodies are logged nowhere else, so an operator had no way to discover what to configure.

## Why this is worth fixing beyond browser login

`_resolve_email_claim()` sits inside `_normalize_user_info()`, which `build_external_identity()` also calls (`mcpgateway/utils/verify_credentials.py:2242`). So this covers the **external-IdP bearer path** as well as interactive SSO.

That makes it the fix for a gap another reporter already documented. From the body of #6396:

> the provisioning step requires an `email` claim in the access token itself (`_normalize_user_info` reads verified claims only). Zitadel omits it by default … IdPs whose access tokens carry no `email` will pass verification and then fail provisioning **even after the wiring fix**.

Different reporter, different IdP (Zitadel there, IBM Verify here), same function.

## Relationship to #6427

Both PRs touch `sso_service.py`, and the two helpers land near each other in the file — but they are independent changes and this PR contains **only** the e-mail helper. Whichever merges second may need a trivial context rebase; there is no logical dependency in either direction, and neither changes the other's behaviour.

## Testing

### Ran
- `tests/unit/mcpgateway/services/test_sso_service.py` — **289 passed**, exit 0, on this branch rebased onto `main@555a9f3`. That includes 8 new tests:
  - standard `email` claim preferred
  - falls back to `preferred_username`
  - falls back through `upn`, `unique_name`, `mail`
  - a bare username is **not** promoted
  - a configured `email_claim` wins and skips the `@` check
  - a configured claim that is absent returns `None`
  - returns `None` when nothing qualifies
  - handles missing `provider_metadata`
- `ruff==0.15.20` (the Makefile-pinned version) over both changed files: 9 findings, **identical to the 9 that `origin/main`'s own copies produce**. Zero new findings.

### Not run — flagging rather than claiming
- Full `make test`, `make interrogate`, `make detect-secrets-scan` — not available in my local environment. CI covers all three.
- No live SSO login against this branch specifically. The failure was originally reproduced against a real deployment with an IdP that does not release `email`; the fix here is verified at unit level.

---

Commit is DCO signed-off.

*Disclosure: found and fixed with AI assistance (Claude). I reproduced the failure against a real deployment, confirmed the shared code path against the source, and ran the tests reported above before opening this.*
