### PR TITLE
Release/1.0.9

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,9 +5,9 @@ tag = False
 sign-tags = True
 tag_name = v{new_version} # tag format (only used if you flip tag=True later)
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>BETA|RC)-(?P<build>\d+))?
-serialize = 
-	{major}.{minor}.{patch}-{release}-{build}
-	{major}.{minor}.{patch}
+serialize =
+    {major}.{minor}.{patch}-{release}-{build}
+    {major}.{minor}.{patch}
 
 [bumpversion:file:mcpgateway/__init__.py]
 search = __version__ = "{current_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,13 +1,13 @@
 [bumpversion]
-current_version = 1.0.8
+current_version = 1.0.9
 commit = False
 tag = False
 sign-tags = True
 tag_name = v{new_version} # tag format (only used if you flip tag=True later)
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>BETA|RC)-(?P<build>\d+))?
-serialize =
-    {major}.{minor}.{patch}-{release}-{build}
-    {major}.{minor}.{patch}
+serialize = 
+	{major}.{minor}.{patch}-{release}-{build}
+	{major}.{minor}.{patch}
 
 [bumpversion:file:mcpgateway/__init__.py]
 search = __version__ = "{current_version}"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-31T10:37:33Z",
+  "generated_at": "2026-08-31T14:51:49Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -258,7 +258,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2135,
+        "line_number": 2218,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2223,
+        "line_number": 2306,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2573,
+        "line_number": 2656,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3938,
+        "line_number": 4021,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4029,
+        "line_number": 4112,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4072,
+        "line_number": 4155,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4077,
+        "line_number": 4160,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4082,
+        "line_number": 4165,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Release 1.0.9 consolidates **35 PRs** focused on **inbound mTLS client certifica
 
 #### **Security & Auth**
 
-- **Default token creation to creator's personal team** ([#6354](https://github.com/IBM/mcp-context-forge/pull/6354)) - Token creation now defaults to the creator's personal team ([#5993](https://github.com/IBM/mcp-context-forge/issues/5993)).
+- **Default token creation to creator's personal team** ([#6354](https://github.com/IBM/mcp-context-forge/pull/6354)) - Token creation now defaults to the creator's personal team.
 - **Reject/strip invisible Unicode in stored auth credentials** ([#6350](https://github.com/IBM/mcp-context-forge/pull/6350)) - Gateway rejects or strips invisible Unicode in stored auth credentials.
 - **Enforce component-aware directory confinement on admin log download** ([#6393](https://github.com/IBM/mcp-context-forge/pull/6393)) - Enforced component-aware directory confinement on admin log download.
 - **Harden local A2A egress handling** ([#6399](https://github.com/IBM/mcp-context-forge/pull/6399)) - Hardened local A2A egress handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,13 +87,13 @@ Release 1.0.9 consolidates **41 PRs** focused on **inbound mTLS client certifica
 
 | PR | Description |
 |----|-------------|
-| [#6301](https://github.com/IBM/mcp-context-forge/pull/6301) | chore: remove temporary min-release-age-exclude pins from .npmrc |
-| [#6312](https://github.com/IBM/mcp-context-forge/pull/6312) | chore: bump dependency-review-action from v4.9.0 to v5.0.0 |
-| [#6319](https://github.com/IBM/mcp-context-forge/pull/6319) | chore: .env.example cleanup |
-| [#6325](https://github.com/IBM/mcp-context-forge/pull/6325) | refactor: tool invoke function refactor |
-| [#6306](https://github.com/IBM/mcp-context-forge/pull/6306) | test: add MCP Apps live stack tests to TestRawJsonRpc |
-| [#6398](https://github.com/IBM/mcp-context-forge/pull/6398) | test: fix Playwright gateway OAuth and team flakiness |
-| [#6375](https://github.com/IBM/mcp-context-forge/pull/6375) | chore: routine python/node dependency updates |
+| [#6301](https://github.com/IBM/mcp-context-forge/pull/6301) | remove temporary min-release-age-exclude pins from .npmrc |
+| [#6312](https://github.com/IBM/mcp-context-forge/pull/6312) | bump dependency-review-action from v4.9.0 to v5.0.0 |
+| [#6319](https://github.com/IBM/mcp-context-forge/pull/6319) | .env.example cleanup |
+| [#6325](https://github.com/IBM/mcp-context-forge/pull/6325) | tool invoke function refactor |
+| [#6306](https://github.com/IBM/mcp-context-forge/pull/6306) | add MCP Apps live stack tests to TestRawJsonRpc |
+| [#6398](https://github.com/IBM/mcp-context-forge/pull/6398) | fix Playwright gateway OAuth and team flakiness |
+| [#6375](https://github.com/IBM/mcp-context-forge/pull/6375) | routine python/node dependency updates |
 
 ## [1.0.8] - 2026-08-17 - Plugin Discovery, MCP Apps Bridge, Catalog Registration, and Security Hardening
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,88 @@
 
 - **Catalog registration ownership and visibility** - Catalog registrations now default to private, attribute ownership to the authenticated caller, enforce token/team scope, and preserve ownership during gateway transfer and user deletion ([#6036](https://github.com/IBM/mcp-context-forge/issues/6036)).
 
+## [1.0.9] - 2026-08-31 - mTLS, OAuth Quick Wins, Tool Preview, Catalog Actions, and Security Hardening
+
+### Overview
+
+Release 1.0.9 consolidates **35 PRs** focused on **inbound mTLS client certificate auth**, **MCP server OAuth improvements**, **tool preview and schema publishing**, **catalog gateway actions**, **TLS/SSL enhancements**, and **security hardening**:
+
+- **Security & Auth** - Inbound mTLS (client certificate authentication), MCP server OAuth form quick wins (read-only redirect URI, drop password grant), session refresh and validate endpoints, default token creation to creator's personal team, and invisible Unicode stripping from stored auth credentials.
+- **API & Platform** - MCP handshake test endpoint for Test Connection and virtual servers, new tool preview permission and preview functions, tool schema publishing to dataplane, catalog gateway actions backend support, and gateway-side TLS override for end-to-end HTTPS.
+- **Operations** - Experimental UI added to compose, SSL/TLS exposed for gateway pods, TLS cipher suite exposure, automated catalog icon generation, and load test consolidation.
+- **Documentation** - Dynamic env production risk documentation for translate, live black-box test requirement policy.
+
+### Added
+
+#### **Security & Auth**
+
+- **Inbound mTLS (client certificate authentication)** ([#6352](https://github.com/IBM/mcp-context-forge/pull/6352)) - Added inbound mTLS support for client certificate authentication.
+- **MCP server OAuth form quick wins** ([#6315](https://github.com/IBM/mcp-context-forge/pull/6315)) - Read-only redirect URI and dropped password grant from MCP server OAuth form.
+- **Session refresh and validate endpoints** ([#6235](https://github.com/IBM/mcp-context-forge/pull/6235)) - Added session refresh and validate endpoints.
+
+#### **API & Platform**
+
+- **MCP handshake test endpoint for Test Connection** ([#5934](https://github.com/IBM/mcp-context-forge/pull/5934)) - Added MCP handshake test endpoint for Test Connection.
+- **Tool preview permission** ([#6321](https://github.com/IBM/mcp-context-forge/pull/6321)) - Added new permission for tool preview.
+- **Tool preview functions** ([#6360](https://github.com/IBM/mcp-context-forge/pull/6360)) - Added preview functions to the tools service.
+- **Tool schema publishing to dataplane** ([#6348](https://github.com/IBM/mcp-context-forge/pull/6348)) - Publish tool schemas to the dataplane.
+- **Catalog gateway actions backend** ([#6355](https://github.com/IBM/mcp-context-forge/pull/6355)) - Support catalog gateway actions in backend.
+- **Gateway-side TLS override** ([#6422](https://github.com/IBM/mcp-context-forge/pull/6422)) - Added gateway-side TLS override for end-to-end HTTPS (closes [#6266](https://github.com/IBM/mcp-context-forge/issues/6266)).
+
+#### **Operations & Tooling**
+
+- **Experimental UI in compose** ([#6320](https://github.com/IBM/mcp-context-forge/pull/6320)) - Added experimental UI to docker-compose.
+- **SSL/TLS exposed for gateway pods** ([#6362](https://github.com/IBM/mcp-context-forge/pull/6362)) - SSL/TLS exposed for gateway pods.
+- **TLS cipher suite exposure** ([#6483](https://github.com/IBM/mcp-context-forge/pull/6483)) - Exposed TLS cipher suite configuration.
+- **Automated MCP server catalog icon generation** ([#6397](https://github.com/IBM/mcp-context-forge/pull/6397)) - Automated MCP server catalog icon generation.
+
+### Fixed
+
+#### **Security & Auth**
+
+- **Default token creation to creator's personal team** ([#6354](https://github.com/IBM/mcp-context-forge/pull/6354)) - Token creation now defaults to the creator's personal team ([#5993](https://github.com/IBM/mcp-context-forge/issues/5993)).
+- **Reject/strip invisible Unicode in stored auth credentials** ([#6350](https://github.com/IBM/mcp-context-forge/pull/6350)) - Gateway rejects or strips invisible Unicode in stored auth credentials.
+- **Enforce component-aware directory confinement on admin log download** ([#6393](https://github.com/IBM/mcp-context-forge/pull/6393)) - Enforced component-aware directory confinement on admin log download.
+- **Harden local A2A egress handling** ([#6399](https://github.com/IBM/mcp-context-forge/pull/6399)) - Hardened local A2A egress handling.
+
+#### **Gateway & Platform**
+
+- **Missing migration columns in migrate_enc_secret** ([#6324](https://github.com/IBM/mcp-context-forge/pull/6324)) - Added missing migration columns to migrate_enc_secret.
+- **MCP handshake test endpoint for virtual servers** ([#6405](https://github.com/IBM/mcp-context-forge/pull/6405)) - Added MCP handshake test endpoint for virtual servers.
+- **Gateway/tool/prompt/resource audit rows in activity feed** ([#6351](https://github.com/IBM/mcp-context-forge/pull/6351)) - Render gateway/tool/prompt/resource audit rows correctly in activity feed.
+- **Cache StatefulHTTP JWT admin lookups** ([#6437](https://github.com/IBM/mcp-context-forge/pull/6437)) - Cached StatefulHTTP JWT admin lookups.
+- **Normalize bundled catalog icon bounds** ([#6441](https://github.com/IBM/mcp-context-forge/pull/6441)) - Normalized bundled catalog icon bounds.
+
+#### **Deprecations & Cleanup**
+
+- **Remove deprecated PUT /admin/users endpoint** ([#6304](https://github.com/IBM/mcp-context-forge/pull/6304)) - Removed deprecated PUT /admin/users endpoint and added sunset marker pre-commit hook.
+
+#### **Build & CI**
+
+- **CI venv recreation for broken Python symlink** ([#6302](https://github.com/IBM/mcp-context-forge/pull/6302)) - Recreate CI venv when cached Python symlink is broken.
+- **Raise clippy large-error-threshold for mcp_runtime** ([#6349](https://github.com/IBM/mcp-context-forge/pull/6349)) - Raised clippy large-error-threshold for mcp_runtime.
+- **Bump pinned UBI10 base image tags** ([#6413](https://github.com/IBM/mcp-context-forge/pull/6413)) - Bumped pinned UBI10 base image tags to pick up python3 CVE fix.
+
+### Changed
+
+- **Remove fast_test_server; consolidate load tests** ([#6192](https://github.com/IBM/mcp-context-forge/pull/6192)) - Removed fast_test_server and consolidated load tests.
+
+### Documentation
+
+- **Document dynamic env production risk** ([#6388](https://github.com/IBM/mcp-context-forge/pull/6388)) - Documented dynamic env production risk for translate.
+- **Require live black-box tests where applicable** ([#6326](https://github.com/IBM/mcp-context-forge/pull/6326)) - Required live black-box tests where applicable.
+
+### Chores
+
+| PR | Description |
+|----|-------------|
+| [#6301](https://github.com/IBM/mcp-context-forge/pull/6301) | chore: remove temporary min-release-age-exclude pins from .npmrc |
+| [#6312](https://github.com/IBM/mcp-context-forge/pull/6312) | chore: bump dependency-review-action from v4.9.0 to v5.0.0 |
+| [#6319](https://github.com/IBM/mcp-context-forge/pull/6319) | chore: .env.example cleanup |
+| [#6325](https://github.com/IBM/mcp-context-forge/pull/6325) | refactor: tool invoke function refactor |
+| [#6306](https://github.com/IBM/mcp-context-forge/pull/6306) | test: add MCP Apps live stack tests to TestRawJsonRpc |
+| [#6398](https://github.com/IBM/mcp-context-forge/pull/6398) | test: fix Playwright gateway OAuth and team flakiness |
+
 ## [1.0.8] - 2026-08-17 - Plugin Discovery, MCP Apps Bridge, Catalog Registration, and Security Hardening
 
 ### Overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,10 @@
 
 ### Overview
 
-Release 1.0.9 consolidates **35 PRs** focused on **inbound mTLS client certificate auth**, **MCP server OAuth improvements**, **tool preview and schema publishing**, **catalog gateway actions**, **TLS/SSL enhancements**, and **security hardening**:
+Release 1.0.9 consolidates **41 PRs** focused on **inbound mTLS client certificate auth**, **MCP server OAuth improvements**, **pluggable OAuth token storage**, **tool preview and schema publishing**, **catalog gateway actions**, **TLS/SSL enhancements**, and **security hardening**:
 
-- **Security & Auth** - Inbound mTLS (client certificate authentication), MCP server OAuth form quick wins (read-only redirect URI, drop password grant), session refresh and validate endpoints, default token creation to creator's personal team, and invisible Unicode stripping from stored auth credentials.
-- **API & Platform** - MCP handshake test endpoint for Test Connection and virtual servers, new tool preview permission and preview functions, tool schema publishing to dataplane, catalog gateway actions backend support, and gateway-side TLS override for end-to-end HTTPS.
+- **Security & Auth** - Inbound mTLS (client certificate authentication), pluggable OAuth token storage with HashiCorp Vault backend, MCP server OAuth form quick wins (read-only redirect URI, drop password grant), session refresh and validate endpoints, default token creation to creator's personal team, invisible Unicode stripping from stored auth credentials, and catalog registration scope enforcement.
+- **API & Platform** - MCP handshake test endpoint for Test Connection and virtual servers, new tool preview permission and preview functions, tool schema publishing to dataplane, catalog gateway actions backend support, gateway-side TLS override for end-to-end HTTPS, versioned API aliases, recent activity feed endpoint, and durable observability metrics endpoints.
 - **Operations** - Experimental UI added to compose, SSL/TLS exposed for gateway pods, TLS cipher suite exposure, automated catalog icon generation, and load test consolidation.
 - **Documentation** - Dynamic env production risk documentation for translate, live black-box test requirement policy.
 
@@ -30,6 +30,7 @@ Release 1.0.9 consolidates **35 PRs** focused on **inbound mTLS client certifica
 - **Inbound mTLS (client certificate authentication)** ([#6352](https://github.com/IBM/mcp-context-forge/pull/6352)) - Added inbound mTLS support for client certificate authentication.
 - **MCP server OAuth form quick wins** ([#6315](https://github.com/IBM/mcp-context-forge/pull/6315)) - Read-only redirect URI and dropped password grant from MCP server OAuth form.
 - **Session refresh and validate endpoints** ([#6235](https://github.com/IBM/mcp-context-forge/pull/6235)) - Added session refresh and validate endpoints.
+- **Pluggable OAuth token storage with HashiCorp Vault backend** ([#5599](https://github.com/IBM/mcp-context-forge/pull/5599)) - Pluggable OAuth token storage with HashiCorp Vault backend.
 
 #### **API & Platform**
 
@@ -38,7 +39,10 @@ Release 1.0.9 consolidates **35 PRs** focused on **inbound mTLS client certifica
 - **Tool preview functions** ([#6360](https://github.com/IBM/mcp-context-forge/pull/6360)) - Added preview functions to the tools service.
 - **Tool schema publishing to dataplane** ([#6348](https://github.com/IBM/mcp-context-forge/pull/6348)) - Publish tool schemas to the dataplane.
 - **Catalog gateway actions backend** ([#6355](https://github.com/IBM/mcp-context-forge/pull/6355)) - Support catalog gateway actions in backend.
-- **Gateway-side TLS override** ([#6422](https://github.com/IBM/mcp-context-forge/pull/6422)) - Added gateway-side TLS override for end-to-end HTTPS (closes [#6266](https://github.com/IBM/mcp-context-forge/issues/6266)).
+- **Gateway-side TLS override** ([#6422](https://github.com/IBM/mcp-context-forge/pull/6422)) - Added gateway-side TLS override for end-to-end HTTPS.
+- **Versioned API aliases** ([#6257](https://github.com/IBM/mcp-context-forge/pull/6257)) - Two new paths added as versioned API aliases.
+- **Recent activity feed endpoint** ([#6292](https://github.com/IBM/mcp-context-forge/pull/6292)) - Recent activity feed endpoint (audit + security union).
+- **Durable observability metrics endpoints** ([#6293](https://github.com/IBM/mcp-context-forge/pull/6293)) - Durable observability metrics endpoints for the home dashboard.
 
 #### **Operations & Tooling**
 
@@ -55,6 +59,7 @@ Release 1.0.9 consolidates **35 PRs** focused on **inbound mTLS client certifica
 - **Reject/strip invisible Unicode in stored auth credentials** ([#6350](https://github.com/IBM/mcp-context-forge/pull/6350)) - Gateway rejects or strips invisible Unicode in stored auth credentials.
 - **Enforce component-aware directory confinement on admin log download** ([#6393](https://github.com/IBM/mcp-context-forge/pull/6393)) - Enforced component-aware directory confinement on admin log download.
 - **Harden local A2A egress handling** ([#6399](https://github.com/IBM/mcp-context-forge/pull/6399)) - Hardened local A2A egress handling.
+- **Security hardening: catalog registration scope enforcement** ([#6247](https://github.com/IBM/mcp-context-forge/pull/6247)) - Security hardening for catalog registration scope enforcement.
 
 #### **Gateway & Platform**
 
@@ -93,6 +98,7 @@ Release 1.0.9 consolidates **35 PRs** focused on **inbound mTLS client certifica
 | [#6325](https://github.com/IBM/mcp-context-forge/pull/6325) | refactor: tool invoke function refactor |
 | [#6306](https://github.com/IBM/mcp-context-forge/pull/6306) | test: add MCP Apps live stack tests to TestRawJsonRpc |
 | [#6398](https://github.com/IBM/mcp-context-forge/pull/6398) | test: fix Playwright gateway OAuth and team flakiness |
+| [#6375](https://github.com/IBM/mcp-context-forge/pull/6375) | chore: routine python/node dependency updates |
 
 ## [1.0.8] - 2026-08-17 - Plugin Discovery, MCP Apps Bridge, Catalog Registration, and Security Hardening
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,6 @@
 
 - Rust MCP runtime sidecar, Rust A2A runtime sidecar, and ValidationMiddleware are deprecated as of 2026-06-11 and will sunset on 2026-07-07. Use the Python MCP transport path, the Python A2A invocation path, and endpoint-level Pydantic or protocol-specific validation instead. See [Deprecations](docs/docs/deprecations.md).
 
-## [Unreleased]
-
-### Fixed
-
-- **Catalog registration ownership and visibility** - Catalog registrations now default to private, attribute ownership to the authenticated caller, enforce token/team scope, and preserve ownership during gateway transfer and user deletion ([#6036](https://github.com/IBM/mcp-context-forge/issues/6036)).
 
 ## [1.0.9] - 2026-08-31 - mTLS, OAuth Quick Wins, Tool Preview, Catalog Actions, and Security Hardening
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "contextforge_mcp_runtime"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "async-stream",
  "axum",
@@ -1393,7 +1393,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp_stdio_wrapper"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "actson",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "1.0.8"
+version = "1.0.9"
 edition = "2024"
 rust-version = "1.85"
 authors = ["ContextForge Contributors"]

--- a/Containerfile
+++ b/Containerfile
@@ -373,7 +373,7 @@ LABEL maintainer="Mihai Criveti" \
     org.opencontainers.image.title="mcp/mcpgateway" \
     org.opencontainers.image.description="ContextForge: An enterprise-ready Model Context Protocol Gateway" \
     org.opencontainers.image.licenses="Apache-2.0" \
-    org.opencontainers.image.version="1.0.8"
+    org.opencontainers.image.version="1.0.9"
 
 # ----------------------------------------------------------------------------
 # Install minimal runtime dependencies

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # 🔐 Security Policy
 
-**Current Version: 1.0.8**
+**Current Version: 1.0.9**
 
 
 ### Admin UI is Development-Only

--- a/charts/mcp-stack/Chart.yaml
+++ b/charts/mcp-stack/Chart.yaml
@@ -22,8 +22,8 @@ type: application
 # * appVersion   - upstream application version; shown in UIs but not
 #                  used for upgrade logic.
 # --------------------------------------------------------------------
-version: 1.0.8
-appVersion: "1.0.8"
+version: 1.0.9
+appVersion: "1.0.9"
 
 # Icon shown by registries / dashboards (must be an http(s) URL).
 icon: https://ibm.github.io/mcp-context-forge/images/contextforge-icon_black.svg

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -1062,7 +1062,7 @@ migration:
   # Use same image as mcpgateway
   image:
     repository: ghcr.io/ibm/mcp-context-forge
-    tag: "v1.0.8"                            # Should match mcpContextForge.image.tag
+    tag: "v1.0.9"                            # Should match mcpContextForge.image.tag
     pullPolicy: Always                      # Always pull to ensure latest security patches
 
   # Resource limits for the migration job

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -85,7 +85,7 @@ mcpContextForge:
 
   image:
     repository: ghcr.io/ibm/mcp-context-forge
-    tag: "v1.0.8"                # PRODUCTION: pin a specific immutable tag (e.g. "v1.0.0")
+    tag: "v1.0.9"                # PRODUCTION: pin a specific immutable tag (e.g. "v1.0.0")
     pullPolicy: Always          # Always pull to ensure latest security patches
 
   # Service that fronts the gateway

--- a/crates/mcp_runtime/src/lib.rs
+++ b/crates/mcp_runtime/src/lib.rs
@@ -10375,7 +10375,6 @@ mod unit_tests {
     use reqwest::Url;
     use serde_json::{Value, json};
     use std::collections::HashMap;
-    use std::sync::Once;
     use std::{
         convert::Infallible,
         fs,
@@ -10388,18 +10387,18 @@ mod unit_tests {
     use tracing::warn;
     use uuid::Uuid;
 
-    static TEST_AUTH_SECRET_INIT: Once = Once::new();
-
     fn ensure_test_auth_secret() {
-        TEST_AUTH_SECRET_INIT.call_once(|| {
-            // SAFETY: tests initialize this process-wide env var once before runtime state is built.
+        if std::env::var("AUTH_ENCRYPTION_SECRET")
+            .map(|v| v.trim().is_empty())
+            .unwrap_or(true)
+        {
             unsafe {
                 std::env::set_var(
                     "AUTH_ENCRYPTION_SECRET",
                     "contextforge-rust-runtime-test-secret-1234567890",
                 );
             }
-        });
+        }
     }
 
     fn generate_test_root_cert_pem() -> Option<String> {

--- a/mcpgateway/__init__.py
+++ b/mcpgateway/__init__.py
@@ -9,7 +9,7 @@ ContextForge - A flexible feature-rich FastAPI-based gateway for the Model Conte
 __author__ = "Mihai Criveti"
 __copyright__ = "Copyright 2025"
 __license__ = "Apache 2.0"
-__version__ = "1.0.8"
+__version__ = "1.0.9"
 __description__ = "IBM Consulting Assistants - Extensions API Library"
 __url__ = "https://ibm.github.io/mcp-context-forge/"
 __download_url__ = "https://github.com/IBM/mcp-context-forge"

--- a/plugins/external/cedar/pyproject.toml
+++ b/plugins/external/cedar/pyproject.toml
@@ -45,7 +45,7 @@ authors = [
 dependencies = [
     "cedarpy>=4.8.7",
     "mcp>=1.28.1,<2",
-    "mcp-contextforge-gateway>=1.0.8",
+    "mcp-contextforge-gateway>=1.0.9",
 ]
 
 # URLs

--- a/plugins/external/opa/pyproject.toml
+++ b/plugins/external/opa/pyproject.toml
@@ -45,7 +45,7 @@ authors = [
 dependencies = [
     "httpx>=0.28.1",
     "mcp>=1.28.1,<2",
-    "mcp-contextforge-gateway>=1.0.8",
+    "mcp-contextforge-gateway>=1.0.9",
 ]
 
 # URLs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ cpex-sql-sanitizer = "2026-08-24T23:59:59Z"
 # ----------------------------------------------------------------
 [project]
 name = "mcp-contextforge-gateway"
-version = "1.0.8"
+version = "1.0.9"
 description = "ContextForge AI Gateway — an AI gateway, registry, and proxy for MCP, A2A, and REST/gRPC APIs. Exposes a unified control plane with centralized governance, discovery, and observability. Optimizes agent and tool calling, and supports plugins."
 keywords = ["MCP","API","gateway","proxy","tools",
   "agents","agentic ai","model context protocol","multi-agent","fastapi",
@@ -285,11 +285,11 @@ grpc = [
 
 # Convenience meta-extras
 all = [
-    "mcp-contextforge-gateway[redis]>=1.0.8",
+    "mcp-contextforge-gateway[redis]>=1.0.9",
 ]
 
 dev-all = [
-    "mcp-contextforge-gateway[redis,dev,plugins]>=1.0.8",
+    "mcp-contextforge-gateway[redis,dev,plugins]>=1.0.9",
 ]
 
 # --------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -2539,7 +2539,7 @@ wheels = [
 
 [[package]]
 name = "mcp-contextforge-gateway"
-version = "1.0.8"
+version = "1.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -2769,8 +2769,8 @@ requires-dist = [
     { name = "langsmith", marker = "extra == 'llmchat'", specifier = ">=0.10.10" },
     { name = "mako", specifier = ">=1.4.1" },
     { name = "mcp", specifier = ">=1.28.1,<2" },
-    { name = "mcp-contextforge-gateway", extras = ["redis"], marker = "extra == 'all'", specifier = ">=1.0.8" },
-    { name = "mcp-contextforge-gateway", extras = ["redis", "dev", "plugins"], marker = "extra == 'dev-all'", specifier = ">=1.0.8" },
+    { name = "mcp-contextforge-gateway", extras = ["redis"], marker = "extra == 'all'", specifier = ">=1.0.9" },
+    { name = "mcp-contextforge-gateway", extras = ["redis", "dev", "plugins"], marker = "extra == 'dev-all'", specifier = ">=1.0.9" },
     { name = "memray", marker = "extra == 'profiling'", specifier = ">=1.19.3" },
     { name = "msgpack", specifier = ">=1.2.1" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.44.0" },


### PR DESCRIPTION
## [1.0.9] - 2026-08-31 - mTLS, OAuth Quick Wins, Tool Preview, Catalog Actions, and Security Hardening

### Overview

Release 1.0.9 consolidates **42 PRs** focused on **inbound mTLS client certificate auth**, **MCP server OAuth improvements**, **tool preview and schema publishing**, **catalog gateway actions**, **TLS/SSL enhancements**, and **security hardening**:

- **Security & Auth** - Inbound mTLS (client certificate authentication), MCP server OAuth form quick wins (read-only redirect URI, drop password grant), session refresh and validate endpoints, default token creation to creator's personal team, and invisible Unicode stripping from stored auth credentials.
- **API & Platform** - MCP handshake test endpoint for Test Connection and virtual servers, new tool preview permission and preview functions, tool schema publishing to dataplane, catalog gateway actions backend support, and gateway-side TLS override for end-to-end HTTPS.
- **Operations** - Experimental UI added to compose, SSL/TLS exposed for gateway pods, TLS cipher suite exposure, automated catalog icon generation, and load test consolidation.
- **Documentation** - Dynamic env production risk documentation for translate, live black-box test requirement policy.

### Added

#### **Security & Auth**

- **Inbound mTLS (client certificate authentication)** ([#6352](https://github.com/IBM/mcp-context-forge/pull/6352)) - Added inbound mTLS support for client certificate authentication.
- **MCP server OAuth form quick wins** ([#6315](https://github.com/IBM/mcp-context-forge/pull/6315)) - Read-only redirect URI and dropped password grant from MCP server OAuth form.
- **Session refresh and validate endpoints** ([#6235](https://github.com/IBM/mcp-context-forge/pull/6235)) - Added session refresh and validate endpoints.

#### **API & Platform**

- **MCP handshake test endpoint for Test Connection** ([#5934](https://github.com/IBM/mcp-context-forge/pull/5934)) - Added MCP handshake test endpoint for Test Connection.
- **Tool preview permission** ([#6321](https://github.com/IBM/mcp-context-forge/pull/6321)) - Added new permission for tool preview.
- **Tool preview functions** ([#6360](https://github.com/IBM/mcp-context-forge/pull/6360)) - Added preview functions to the tools service.
- **Tool schema publishing to dataplane** ([#6348](https://github.com/IBM/mcp-context-forge/pull/6348)) - Publish tool schemas to the dataplane.
- **Catalog gateway actions backend** ([#6355](https://github.com/IBM/mcp-context-forge/pull/6355)) - Support catalog gateway actions in backend.
- **Gateway-side TLS override** ([#6422](https://github.com/IBM/mcp-context-forge/pull/6422)) - Added gateway-side TLS override for end-to-end HTTPS (closes [#6266](https://github.com/IBM/mcp-context-forge/issues/6266)).

#### **Operations & Tooling**

- **Experimental UI in compose** ([#6320](https://github.com/IBM/mcp-context-forge/pull/6320)) - Added experimental UI to docker-compose.
- **SSL/TLS exposed for gateway pods** ([#6362](https://github.com/IBM/mcp-context-forge/pull/6362)) - SSL/TLS exposed for gateway pods.
- **TLS cipher suite exposure** ([#6483](https://github.com/IBM/mcp-context-forge/pull/6483)) - Exposed TLS cipher suite configuration.
- **Automated MCP server catalog icon generation** ([#6397](https://github.com/IBM/mcp-context-forge/pull/6397)) - Automated MCP server catalog icon generation.

### Fixed

#### **Security & Auth**

- **Default token creation to creator's personal team** ([#6354](https://github.com/IBM/mcp-context-forge/pull/6354)) - Token creation now defaults to the creator's personal team.
- **Reject/strip invisible Unicode in stored auth credentials** ([#6350](https://github.com/IBM/mcp-context-forge/pull/6350)) - Gateway rejects or strips invisible Unicode in stored auth credentials.
- **Enforce component-aware directory confinement on admin log download** ([#6393](https://github.com/IBM/mcp-context-forge/pull/6393)) - Enforced component-aware directory confinement on admin log download.
- **Harden local A2A egress handling** ([#6399](https://github.com/IBM/mcp-context-forge/pull/6399)) - Hardened local A2A egress handling.

#### **Gateway & Platform**

- **Missing migration columns in migrate_enc_secret** ([#6324](https://github.com/IBM/mcp-context-forge/pull/6324)) - Added missing migration columns to migrate_enc_secret.
- **MCP handshake test endpoint for virtual servers** ([#6405](https://github.com/IBM/mcp-context-forge/pull/6405)) - Added MCP handshake test endpoint for virtual servers.
- **Gateway/tool/prompt/resource audit rows in activity feed** ([#6351](https://github.com/IBM/mcp-context-forge/pull/6351)) - Render gateway/tool/prompt/resource audit rows correctly in activity feed.
- **Cache StatefulHTTP JWT admin lookups** ([#6437](https://github.com/IBM/mcp-context-forge/pull/6437)) - Cached StatefulHTTP JWT admin lookups.
- **Normalize bundled catalog icon bounds** ([#6441](https://github.com/IBM/mcp-context-forge/pull/6441)) - Normalized bundled catalog icon bounds.

#### **Deprecations & Cleanup**

- **Remove deprecated PUT /admin/users endpoint** ([#6304](https://github.com/IBM/mcp-context-forge/pull/6304)) - Removed deprecated PUT /admin/users endpoint and added sunset marker pre-commit hook.

#### **Build & CI**

- **CI venv recreation for broken Python symlink** ([#6302](https://github.com/IBM/mcp-context-forge/pull/6302)) - Recreate CI venv when cached Python symlink is broken.
- **Raise clippy large-error-threshold for mcp_runtime** ([#6349](https://github.com/IBM/mcp-context-forge/pull/6349)) - Raised clippy large-error-threshold for mcp_runtime.
- **Bump pinned UBI10 base image tags** ([#6413](https://github.com/IBM/mcp-context-forge/pull/6413)) - Bumped pinned UBI10 base image tags to pick up python3 CVE fix.

### Changed

- **Remove fast_test_server; consolidate load tests** ([#6192](https://github.com/IBM/mcp-context-forge/pull/6192)) - Removed fast_test_server and consolidated load tests.

### Documentation

- **Document dynamic env production risk** ([#6388](https://github.com/IBM/mcp-context-forge/pull/6388)) - Documented dynamic env production risk for translate.
- **Require live black-box tests where applicable** ([#6326](https://github.com/IBM/mcp-context-forge/pull/6326)) - Required live black-box tests where applicable.

### Chores

| PR | Description |
|----|-------------|
| [#6301](https://github.com/IBM/mcp-context-forge/pull/6301) | chore: remove temporary min-release-age-exclude pins from .npmrc |
| [#6312](https://github.com/IBM/mcp-context-forge/pull/6312) | chore: bump dependency-review-action from v4.9.0 to v5.0.0 |
| [#6319](https://github.com/IBM/mcp-context-forge/pull/6319) | chore: .env.example cleanup |
| [#6325](https://github.com/IBM/mcp-context-forge/pull/6325) | refactor: tool invoke function refactor |
| [#6306](https://github.com/IBM/mcp-context-forge/pull/6306) | test: add MCP Apps live stack tests to TestRawJsonRpc |
| [#6398](https://github.com/IBM/mcp-context-forge/pull/6398) | test: fix Playwright gateway OAuth and team flakiness |