### PR TITLE
fix(ui): mark OAuth endpoint fields optional

### DIFF
--- a/client/src/components/mcp-servers/OAuth2Auth.test.tsx
+++ b/client/src/components/mcp-servers/OAuth2Auth.test.tsx
@@ -51,6 +51,13 @@ describe("OAuth2Auth", () => {
     expect(screen.queryByLabelText(/Password/i)).not.toBeInTheDocument();
   });
 
+  it("should mark issuer and token URLs as optional", () => {
+    render(<OAuth2Auth {...defaultProps} />);
+
+    expect(screen.getByLabelText("Issuer URL")).toBeInTheDocument();
+    expect(screen.getByLabelText("Token URL")).toBeInTheDocument();
+  });
+
   it("should render authorization_code fields", () => {
     render(<OAuth2Auth {...defaultProps} grantType="authorization_code" />);
 

--- a/client/src/components/mcp-servers/OAuth2Auth.tsx
+++ b/client/src/components/mcp-servers/OAuth2Auth.tsx
@@ -96,8 +96,7 @@ export function OAuth2Auth({
           htmlFor="oauth-issuer-url"
           className="inline-flex items-center gap-0.5 text-sm font-medium text-neutral-900 dark:text-neutral-100"
         >
-          Issuer URL<span className="text-red-500">*</span>
-          <span className="sr-only">(required)</span>
+          Issuer URL
         </label>
         <Input
           id="oauth-issuer-url"
@@ -235,8 +234,7 @@ export function OAuth2Auth({
           htmlFor="oauth-token-url"
           className="inline-flex items-center gap-0.5 text-sm font-medium text-neutral-900 dark:text-neutral-100"
         >
-          Token URL<span className="text-red-500">*</span>
-          <span className="sr-only">(required)</span>
+          Token URL
         </label>
         <Input
           id="oauth-token-url"


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - Not run; the changed UI files pass targeted ESLint.
2. `make test`            - Not run; the focused OAuth2Auth Vitest suite passes.
3. `make coverage`        - Not run for this label-only UI change.
4. `make docker docker-run-ssl` or `make podman podman-run-ssl` - N/A; no runtime or container changes.
5. Update relevant documentation. - N/A; behavior now matches the existing form schema and backend behavior.
6. Tested with sqlite and postgres + redis. - N/A; no persistence changes.
7. Manual regression no longer fails. Ensure the UI and /version work correctly. - Covered by the focused UI regression test; `/version` is unaffected.

---

## 📌 Summary

Remove the required indicators from the optional OAuth Issuer URL and Token URL fields so the UI matches the form schema and backend endpoint-discovery behavior.

Closes #6467.

## 🔁 Reproduction Steps

Before this change, open the MCP server form, select OAuth 2.0 authentication, and observe that both Issuer URL and Token URL are announced and displayed as required. The exact-label regression test now verifies that neither field carries required text.

## 🐞 Root Cause

`OAuth2Auth.tsx` rendered a red asterisk and screen-reader-only `(required)` text for both labels even though `oauthConfigSchema` declares both values optional.

## 💡 Fix Description

Remove the visual and accessible required markers from both labels, and add a component test that queries each field by its exact optional accessible name.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage` (it is currently labeled `triage`)
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

| Check                                 | Command                                                                                                      | Status                         |
|---------------------------------------|--------------------------------------------------------------------------------------------------------------|--------------------------------|
| Lint suite                            | `npx eslint src/components/mcp-servers/OAuth2Auth.tsx src/components/mcp-servers/OAuth2Auth.test.tsx`       | Passed (targeted UI lint)      |
| Unit tests                            | `npm run test:run -- src/components/mcp-servers/OAuth2Auth.test.tsx`                                        | Passed (9 tests)               |
| Coverage ≥ 80 %                       | Not run                                                                                                      | N/A for label-only UI change   |
| Manual regression no longer fails     | Exact accessible-label assertions in `OAuth2Auth.test.tsx`                                                   | Passed                         |
| Formatting                            | `npx prettier --check src/components/mcp-servers/OAuth2Auth.tsx src/components/mcp-servers/OAuth2Auth.test.tsx` | Passed                      |

## 📐 MCP Compliance (if relevant)

- [ ] Matches current MCP spec (N/A; presentation-only change)
- [ ] No breaking change to MCP clients (N/A; no protocol or client API change)

## ✅ Checklist

- [x] Code formatted (`npx prettier --check` on both changed files)
- [x] No secrets/credentials committed
