### PR TITLE
fix(resources): skip post-fetch resolution for direct_proxy reads

### DIFF
--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -2357,6 +2357,7 @@ class ResourceService(BaseService):
         resource_db = None
         server_scoped = False
         resource_db_gateway = None  # Only set when eager-loaded via Q2's joinedload
+        direct_proxy_read = False  # True once content is fetched live via direct_proxy
         # CWE-400: Validate meta_data limits before any further processing
         _validate_meta_data(meta_data)
         content = None
@@ -2559,6 +2560,10 @@ class ResourceService(BaseService):
                                         content = TextResourceContents(uri=uri, text="")
 
                                     success = True
+                                    # Content was fetched live from the upstream; it is already the
+                                    # final payload and must not be routed through the post-fetch
+                                    # metadata->content resolution block below (issue #5451).
+                                    direct_proxy_read = True
                                     logger.info(
                                         "[READ RESOURCE] Using direct_proxy mode for gateway %s (from X-Context-Forge-Gateway-Id header). Meta Attached: %s",
                                         SecurityValidator.sanitize_log_message(gateway.id),
@@ -2715,7 +2720,13 @@ class ResourceService(BaseService):
                         )
                         raise ResourceError(f"Resource template '{template_uri}' did not resolve URI '{requested_uri}'")
 
-                if isinstance(content, (ResourceContent, ResourceContents, TextContent)):
+                if direct_proxy_read:
+                    # Content already fetched live via direct_proxy; it is the final payload.
+                    # Skip the metadata->content resolution below, which assumes a cached
+                    # record carrying an ``id`` and would raise AttributeError on the id-less
+                    # TextResourceContents / BlobResourceContents models (issue #5451).
+                    pass
+                elif isinstance(content, (ResourceContent, ResourceContents, TextContent)):
                     # Metrics are recorded in read_resource finally block for all resources
                     resource_response = await self.invoke_resource(
                         db,

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -7974,6 +7974,127 @@ class TestReadResourceDirectProxy:
         assert content.blob == "base64encodeddata"
         assert content.uri == "http://example.com/dp-resource"
 
+    def _partial_patches_real_models(self, resource_service):
+        """Patches for direct_proxy tests that exercise the REAL production content
+        models (``TextResourceContents`` / ``BlobResourceContents``) instead of the
+        id-bearing test subclasses used by ``_common_patches``.
+
+        This deliberately does NOT patch the models, so the direct_proxy read path
+        runs against the true classes -- which have no ``id`` field. That is what
+        regression-guards issue #5451: content already fetched live via direct_proxy
+        must not be routed back through the post-fetch ``getattr(content, "id")``
+        resolution block.
+        """
+        # Standard
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _ctx():
+            with (
+                patch.object(resource_service, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+                patch.object(resource_service, "invoke_resource", new_callable=AsyncMock, return_value=None),
+            ):
+                yield
+
+        return _ctx()
+
+    @pytest.mark.asyncio
+    async def test_read_resource_direct_proxy_text_content_real_models(self, resource_service, mock_direct_proxy_resource):
+        """Regression (issue #5451): direct_proxy text read returns the fetched
+        content end-to-end against the real ``TextResourceContents`` model.
+
+        Before the fix the post-fetch block ran ``getattr(content, "id")`` on the
+        id-less production model, raising ``AttributeError`` and yielding empty
+        content to the client.
+        """
+        # Standard
+        from contextlib import asynccontextmanager
+
+        db = self._make_mock_db(mock_direct_proxy_resource)
+
+        first_content = MagicMock()
+        first_content.text = "hello from remote"
+        first_content.mimeType = "text/plain"
+        result_mock = MagicMock()
+        result_mock.contents = [first_content]
+
+        client_session_cm, session_mock = self._make_session_mock(result_mock)
+
+        @asynccontextmanager
+        async def mock_streamable_client(*_args, **_kwargs):
+            yield ("read", "write", None)
+
+        with (
+            patch("mcpgateway.services.resource_service.settings") as mock_settings,
+            patch("mcpgateway.services.resource_service.check_gateway_access", new_callable=AsyncMock, return_value=True),
+            patch("mcpgateway.services.resource_service.build_gateway_auth_headers", return_value={"Authorization": "Bearer remote-token"}),
+            patch("mcpgateway.services.resource_service.streamablehttp_client", mock_streamable_client),
+            patch("mcpgateway.services.resource_service.ClientSession", return_value=client_session_cm),
+            self._partial_patches_real_models(resource_service),
+        ):
+            mock_settings.mcpgateway_direct_proxy_enabled = True
+            mock_settings.mcpgateway_direct_proxy_timeout = 30
+            mock_settings.experimental_validate_io = False
+
+            content = await resource_service.read_resource(
+                db,
+                resource_uri="http://example.com/dp-resource",
+                user="user@example.com",
+                token_teams=["team-1"],
+            )
+            # Content fetched live via direct_proxy must NOT be re-resolved.
+            resource_service.invoke_resource.assert_not_awaited()
+
+        assert isinstance(content, _TextBase)
+        assert content.text == "hello from remote"
+        assert content.uri == "http://example.com/dp-resource"
+
+    @pytest.mark.asyncio
+    async def test_read_resource_direct_proxy_blob_content_real_models(self, resource_service, mock_direct_proxy_resource):
+        """Regression (issue #5451): direct_proxy binary read returns the fetched
+        blob against the real ``BlobResourceContents`` model (also id-less)."""
+        # Standard
+        from contextlib import asynccontextmanager
+
+        db = self._make_mock_db(mock_direct_proxy_resource)
+
+        first_content = MagicMock(spec=[])  # empty spec: only .blob is present
+        first_content.blob = "base64encodeddata"
+        first_content.mimeType = "image/png"
+        result_mock = MagicMock()
+        result_mock.contents = [first_content]
+
+        client_session_cm, session_mock = self._make_session_mock(result_mock)
+
+        @asynccontextmanager
+        async def mock_streamable_client(*_args, **_kwargs):
+            yield ("read", "write", None)
+
+        with (
+            patch("mcpgateway.services.resource_service.settings") as mock_settings,
+            patch("mcpgateway.services.resource_service.check_gateway_access", new_callable=AsyncMock, return_value=True),
+            patch("mcpgateway.services.resource_service.build_gateway_auth_headers", return_value={}),
+            patch("mcpgateway.services.resource_service.streamablehttp_client", mock_streamable_client),
+            patch("mcpgateway.services.resource_service.ClientSession", return_value=client_session_cm),
+            self._partial_patches_real_models(resource_service),
+        ):
+            mock_settings.mcpgateway_direct_proxy_enabled = True
+            mock_settings.mcpgateway_direct_proxy_timeout = 30
+            mock_settings.experimental_validate_io = False
+
+            content = await resource_service.read_resource(
+                db,
+                resource_uri="http://example.com/dp-resource",
+                user="user@example.com",
+                token_teams=["team-1"],
+            )
+            # Content fetched live via direct_proxy must NOT be re-resolved.
+            resource_service.invoke_resource.assert_not_awaited()
+
+        assert isinstance(content, _BlobBase)
+        assert content.blob == "base64encodeddata"
+        assert content.uri == "http://example.com/dp-resource"
+
     @pytest.mark.asyncio
     async def test_read_resource_direct_proxy_unknown_content_type(self, resource_service, mock_direct_proxy_resource):
         """When content has neither text nor blob attribute, returns TextResourceContents with empty text."""


### PR DESCRIPTION
## 🔗 Related Issue

Closes #5451

> **Fresh PR replacing #5463.** That PR was closed on 2026-08-31 during the housekeeping pass on long-open contributions. GitHub refused to re-open it after the rebase (a force-push makes a closed PR non-reopenable), so this is the "or open a fresh one" path @jonpspri suggested. The change itself is unchanged — only rebased.

## 📝 Summary

In `direct_proxy` gateway mode, `ResourceService.read_resource` fetches the
resource live from the upstream and builds the final `TextResourceContents` /
`BlobResourceContents`. Execution then falls through into the shared post-fetch
**RESOLVE CONTENT** block, whose first branch runs `getattr(content, "id")`
unconditionally. Those MCP-compliant models (`mcpgateway/common/models.py`) have
no `id` field, so **every** direct_proxy text or blob read raises
`AttributeError: 'TextResourceContents' object has no attribute 'id'`. The
transport layer catches the exception and returns empty content, so the client
silently receives `text=""` instead of the fetched payload.

### Root cause
The direct_proxy branch never marked its content as already-resolved — the
`# Skip the rest of the DB lookup logic` comment does not actually skip anything.

### Fix
Track whether content came from the direct_proxy branch (`direct_proxy_read`) and
skip the metadata→content resolution for it. The gateway access check, the
resource access check, and the post-fetch plugin hooks all still run — only the
id-based `invoke_resource` re-resolution is bypassed, since the payload is final.

### Tests (before → after)
The existing happy-path direct_proxy tests masked the bug by monkey-patching
id-bearing subclasses over the real models, so production classes never took the
failing path. This PR adds two regression tests exercising the **real**
`TextResourceContents` / `BlobResourceContents`:

- Without the fix: both raise `AttributeError` at the `getattr(content, "id")` call.
- With the fix: text read returns the live text, `image/png` blob read returns its
  blob, and `invoke_resource` is asserted **not** re-awaited.

## 🔄 Rebase notes (2026-08-31)

Rebased onto current `main` (`ffcc0822`). **One conflict, resolved by keeping both
sides:** `main` grew the `_set_gateway_content` helper immediately above the
`if isinstance(content, ...)` branch. The helper is untouched — the
`direct_proxy_read` guard simply sits in front of it as
`if direct_proxy_read: ... elif isinstance(...)`.

Re-verified against today's `main`, since a lot landed in the six weeks the PR sat:

- **The bug is still present.** The RESOLVE CONTENT block still calls
  `getattr(content, "id")` unconditionally, and the MCP-compliant models still have
  no `id`.
- **The regression proof still holds.** With the production hunk reverted to `main`,
  both new tests fail with
  `AttributeError: 'TextResourceContents' object has no attribute 'id'`; with the
  hunk applied, both pass.
- `pytest tests/unit/mcpgateway/services/test_resource_service.py` — 309 passed.
- `ruff check`, `ruff format --check` and `black --check` clean on both touched files.

Also: #5451 is no longer labeled `triage` (it is `bug` / `COULD` now), which was the
concern I flagged in my comment on the original PR.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## 🏷️ Type of Change

- [x] Bug fix
