### PR TITLE
fix(resources): fetch federated resource live when cached content is NULL

### DIFF
--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -2572,7 +2572,24 @@ class ResourceService(BaseService):
 
                     elif resource_db:
                         # Normal cache mode - resource found in DB
-                        content = resource_db.content
+                        try:
+                            content = resource_db.content
+                        except ValueError:
+                            # Federated resource with no cached content (e.g. NULL text/binary
+                            # from the migration / re-discovery path). Build a metadata-only
+                            # ResourceContent so the RESOLVE CONTENT block below fetches it live
+                            # from the gateway, instead of the ValueError bubbling up and the
+                            # client receiving empty content (issue #5450). Local (non-federated)
+                            # resources have nothing to fetch, so the original error is preserved.
+                            if resource_db.gateway is None:
+                                raise
+                            content = ResourceContent(
+                                type="resource",
+                                id=str(resource_db.id),
+                                uri=resource_db.uri,
+                                mime_type=getattr(resource_db, "mime_type", None),
+                                text="",
+                            )
                     else:
                         # Check the inactivity first using the same server scope that
                         # governed the active lookup. Without this, duplicate URIs

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -888,6 +888,100 @@ class TestResourceReading:
         finally:
             current_trace_id.reset(token)
 
+    @pytest.mark.asyncio
+    async def test_read_resource_cache_mode_null_content_federated_fetches_live(self):
+        """Regression (issue #5450): a federated resource whose cached content is NULL
+        must be fetched live from the gateway, not returned as empty content.
+
+        Before the fix ``resource_db.content`` raised ``ValueError('Resource has no
+        content')`` before the RESOLVE CONTENT block, the transport swallowed it, and the
+        client received empty content instead of the upstream payload.
+        """
+        # First-Party
+        from mcpgateway.services.resource_service import ResourceService
+
+        class _NullContentResource:
+            id = "res-null-1"
+            uri = "wiki://schema"
+            name = "wiki"
+            enabled = True
+            visibility = "public"
+            team_id = None
+            owner_email = None
+            tags = []
+            team = None
+            mime_type = "text/markdown"
+
+            def __init__(self, gateway):
+                self.gateway = gateway
+
+            @property
+            def content(self):
+                raise ValueError("Resource has no content")
+
+        gateway = MagicMock()
+        gateway.gateway_mode = "cache"  # normal cache mode (NOT direct_proxy)
+        resource_db = _NullContentResource(gateway)
+
+        db = MagicMock()
+        scalar = MagicMock()
+        scalar.scalar_one_or_none.return_value = resource_db
+        db.execute.return_value = scalar
+        db.get.return_value = None
+
+        svc = ResourceService()
+        with (
+            patch.object(svc, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch.object(svc, "invoke_resource", new_callable=AsyncMock, return_value="live wiki body"),
+        ):
+            result = await svc.read_resource(db, resource_uri="wiki://schema", user="u@example.com", token_teams=["team-1"])
+            # The empty local content must trigger a live fetch through the gateway.
+            svc.invoke_resource.assert_awaited()
+
+        assert result is not None
+        assert getattr(result, "text", None) == "live wiki body"
+
+    @pytest.mark.asyncio
+    async def test_read_resource_cache_mode_null_content_no_gateway_preserved(self):
+        """A NULL-content resource with NO gateway is not federated and cannot be fetched
+        live, so the existing 'no content' error is preserved and no live fetch is attempted
+        (the #5450 fix is scoped to federated resources)."""
+        # First-Party
+        from mcpgateway.services.resource_service import ResourceService
+
+        class _NullContentResource:
+            id = "res-null-2"
+            uri = "local://empty"
+            name = "empty"
+            enabled = True
+            visibility = "public"
+            team_id = None
+            owner_email = None
+            tags = []
+            team = None
+            mime_type = "text/plain"
+            gateway = None
+
+            @property
+            def content(self):
+                raise ValueError("Resource has no content")
+
+        resource_db = _NullContentResource()
+        db = MagicMock()
+        scalar = MagicMock()
+        scalar.scalar_one_or_none.return_value = resource_db
+        db.execute.return_value = scalar
+        db.get.return_value = None
+
+        svc = ResourceService()
+        with (
+            patch.object(svc, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch.object(svc, "invoke_resource", new_callable=AsyncMock, return_value="should-not-be-used"),
+        ):
+            with pytest.raises(ValueError, match="no content"):
+                await svc.read_resource(db, resource_uri="local://empty", user="u@example.com", token_teams=["team-1"])
+            svc.invoke_resource.assert_not_awaited()
+
 
 # --------------------------------------------------------------------------- #
 # Resource management tests                                                   #


### PR DESCRIPTION
## 🔗 Related Issue

Refs #5450 (scoped to the NULL-content case — see **Scope** below; not an auto-close).

> **Fresh PR replacing #5467.** That PR was closed on 2026-08-31 during the housekeeping pass on long-open contributions. GitHub refused to re-open it after the rebase (a force-push makes a closed PR non-reopenable), so this is the "or open a fresh one" path @jonpspri suggested. The change itself is unchanged — only rebased.
>
> On the "open an issue describing the problem" step: #5450 already exists and is still open, so I did not file a duplicate. Happy to open a fresh one if you'd rather.

## 📝 Summary

In `cache` gateway mode, `ResourceService.read_resource` reads
`content = resource_db.content` for a federated resource. When both
`text_content` and `binary_content` are `NULL` (e.g. resources created via the
migration / re-discovery path, `createdVia: rediscovery`), the `Resource.content`
property raises `ValueError("Resource has no content")` **before** the RESOLVE
CONTENT block. The transport layer catches the exception and returns empty
content, so the client silently receives an empty read instead of the upstream's
real content.

### Fix
Catch that `ValueError` in the cache-mode branch and, when the resource is
federated (has a gateway), build a metadata-only `ResourceContent` so the
**existing** RESOLVE CONTENT block fetches it live from the gateway — the same
path already used for resources whose cached content is an empty string. A
non-federated resource has nothing to fetch, so the original error is preserved
(re-raised).

### Tests (before → after)
- `..._null_content_federated_fetches_live`: NULL content + gateway → without the
  fix, `ValueError` propagates and the read is empty; with the fix, the content is
  fetched live via `invoke_resource`.
- `..._null_content_no_gateway_preserved`: NULL content + no gateway → the
  "no content" error is preserved and no live fetch is attempted.

## 🔄 Rebase notes (2026-08-31)

Rebased onto current `main` (`ffcc0822`) — clean rebase, no conflicts. Re-verified
against today's `main`:

- **Still reproducible.** Cache mode still does a bare `content = resource_db.content`,
  so a federated row with NULL cached content still raises
  `ValueError: Resource has no content` instead of proxying upstream.
- **Regression proof still holds.** With the production hunk reverted to `main`,
  `..._null_content_federated_fetches_live` fails with that `ValueError`; with the
  hunk applied, both new tests pass.
- `pytest tests/unit/mcpgateway/services/test_resource_service.py` — 309 passed.
- `ruff check`, `ruff format --check` and `black --check` clean on both touched files.

Coordination note (unchanged): this and the direct_proxy fix for #5451 both touch
`read_resource` in `resource_service.py`, but they fix different bugs on different
code paths and their hunks do not overlap, so they merge cleanly in either order and
neither depends on the other. Kept separate deliberately, per the one-concern rule.

Also: #5450 is no longer labeled `triage` (it is `bug` / `COULD` now), which was the
concern I flagged in my comment on the original PR.

## 🔎 Scope / follow-up (binary resources)

The issue also notes that **binary** federated resources read empty for a
separate reason: `invoke_resource`'s SSE/StreamableHTTP helpers extract the live
payload with `getattr(contents[0], "text")` unconditionally, so a
`BlobResourceContents` (e.g. `image/png`) yields `None`. Fixing that cleanly
requires `invoke_resource` to signal **which** field (text vs blob) the upstream
returned — both are strings, so they can't be disambiguated after the fact — i.e.
a small change to its return contract, plus routing in the RESOLVE block. That is
a deliberate design decision I left out of this PR to keep it focused and
low-risk. Happy to follow up with that in a separate PR if you'd like — just let
me know your preference on the `invoke_resource` return shape.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## 🏷️ Type of Change

- [x] Bug fix
