### PR TITLE
fix(prompts): fetch gateway-backed prompt content in server listing

### DIFF
--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -14,6 +14,7 @@ It handles:
 """
 
 # Standard
+import asyncio
 import binascii
 from datetime import datetime, timezone
 from functools import lru_cache
@@ -1746,13 +1747,34 @@ class PromptService(BaseService):
             db.commit()  # Release transaction to avoid idle-in-transaction
 
             result = []
+            reads_by_prompt = {}
             for t in prompts:
                 try:
                     t.team = team_map.get(str(t.team_id)) if t.team_id else None
-                    result.append(self.convert_prompt_to_read(t, include_metrics=include_metrics))
+                    read = self.convert_prompt_to_read(t, include_metrics=include_metrics)
+                    reads_by_prompt[id(t)] = read
+                    result.append(read)
                 except (ValidationError, ValueError, KeyError, TypeError, binascii.Error) as e:
                     logger.exception("Failed to convert prompt %s (%s): %s", getattr(t, "id", "unknown"), getattr(t, "name", "unknown"), e)
                     # Continue with remaining prompts instead of failing completely
+
+            # Gateway-backed prompts are synced into the catalog as metadata only
+            # (template=""), so their content must be fetched live from the
+            # upstream, same as the single-prompt GET endpoint already does via
+            # _should_fetch_gateway_prompt() / _fetch_gateway_prompt_result()
+            # (issue #6440). Fetched concurrently; a per-prompt failure is logged
+            # and leaves that prompt's template as-is rather than failing the list.
+            gateway_backed = [t for t in prompts if id(t) in reads_by_prompt and self._should_fetch_gateway_prompt(t)]
+            if gateway_backed:
+                fetches = await asyncio.gather(*(self._fetch_gateway_prompt_result(t, None, meta_data=None) for t in gateway_backed), return_exceptions=True)
+                for t, fetched in zip(gateway_backed, fetches):
+                    if isinstance(fetched, BaseException):
+                        logger.warning("Failed to fetch live content for gateway-backed prompt %s: %s", getattr(t, "name", "unknown"), fetched)
+                        continue
+                    text = next((m.content.text for m in fetched.messages if isinstance(m.content, TextContent)), None)
+                    if text is not None:
+                        reads_by_prompt[id(t)].template = text
+
             return result
 
     async def _record_prompt_metric(self, db: Session, prompt: DbPrompt, start_time: float, success: bool, error_message: Optional[str]) -> None:

--- a/tests/unit/mcpgateway/services/test_prompt_service.py
+++ b/tests/unit/mcpgateway/services/test_prompt_service.py
@@ -2936,6 +2936,89 @@ class TestListServerPrompts:
         assert mock_prompt.team == "Engineering"
 
     @pytest.mark.asyncio
+    async def test_gateway_backed_prompt_template_fetched_live(self, prompt_service):
+        """Gateway-backed prompts with an empty local template must have their
+        content fetched live from the upstream gateway, mirroring the
+        ``_should_fetch_gateway_prompt`` / ``_fetch_gateway_prompt_result`` behaviour
+        already used by ``get_prompt()`` for the single-prompt endpoint
+        (issue #6440). A custom (non-gateway) prompt's local template must be
+        left untouched.
+        """
+        db = MagicMock()
+
+        gateway_prompt = MagicMock()
+        gateway_prompt.team_id = None
+        gateway_prompt.gateway_id = "gw-1"
+        gateway_prompt.template = ""
+
+        local_prompt = MagicMock()
+        local_prompt.team_id = None
+        local_prompt.gateway_id = None
+        local_prompt.template = "Local template text"
+
+        prompt_result = MagicMock()
+        prompt_result.scalars.return_value.all.return_value = [gateway_prompt, local_prompt]
+        db.execute = MagicMock(return_value=prompt_result)
+        db.commit = MagicMock()
+
+        remote_result = PromptResult(
+            messages=[Message(role=Role.USER, content=TextContent(type="text", text="Live upstream content"))],
+            description="Overview of all GitHub tools",
+        )
+        prompt_service._fetch_gateway_prompt_result = AsyncMock(return_value=remote_result)
+
+        read_by_prompt = {}
+
+        def _fake_convert(prompt, include_metrics=False):
+            read = MagicMock()
+            read.template = prompt.template
+            read_by_prompt[id(prompt)] = read
+            return read
+
+        prompt_service.convert_prompt_to_read = MagicMock(side_effect=_fake_convert)
+
+        await prompt_service.list_server_prompts(db, "server-1")
+
+        prompt_service._fetch_gateway_prompt_result.assert_awaited_once_with(gateway_prompt, None, meta_data=None)
+        assert read_by_prompt[id(gateway_prompt)].template == "Live upstream content"
+        # Local (non-gateway) prompt's template must be untouched.
+        assert read_by_prompt[id(local_prompt)].template == "Local template text"
+
+    @pytest.mark.asyncio
+    async def test_gateway_backed_prompt_fetch_failure_leaves_template_empty(self, prompt_service):
+        """A failed upstream fetch for one gateway-backed prompt must not break the
+        listing, and must leave that prompt's template as the empty string it
+        already was (graceful degradation, not a 500)."""
+        db = MagicMock()
+
+        gateway_prompt = MagicMock()
+        gateway_prompt.team_id = None
+        gateway_prompt.gateway_id = "gw-1"
+        gateway_prompt.template = ""
+
+        prompt_result = MagicMock()
+        prompt_result.scalars.return_value.all.return_value = [gateway_prompt]
+        db.execute = MagicMock(return_value=prompt_result)
+        db.commit = MagicMock()
+
+        prompt_service._fetch_gateway_prompt_result = AsyncMock(side_effect=PromptError("upstream unreachable"))
+
+        read_by_prompt = {}
+
+        def _fake_convert(prompt, include_metrics=False):
+            read = MagicMock()
+            read.template = prompt.template
+            read_by_prompt[id(prompt)] = read
+            return read
+
+        prompt_service.convert_prompt_to_read = MagicMock(side_effect=_fake_convert)
+
+        result = await prompt_service.list_server_prompts(db, "server-1")
+
+        assert len(result) == 1
+        assert read_by_prompt[id(gateway_prompt)].template == ""
+
+    @pytest.mark.asyncio
     async def test_with_token_teams_public_only(self, prompt_service):
         """token_teams=[] restricts to public-only prompts."""
         db = MagicMock()


### PR DESCRIPTION
## 🔗 Related Issue

Closes #6440

## 📝 Summary

`GET /v1/servers/{server_id}/prompts` returned `"template": ""` for every
auto-discovered (gateway-backed) prompt. Custom prompts returned their
content correctly; getting a gateway-backed prompt's actual content required
a separate `GET /v1/prompts/{id}` call per prompt.

### Root cause
Gateway-backed prompts are synced into the catalog as **metadata only** — the
MCP `prompts/list` protocol call doesn't return content, so `template` is
stored as `""` at sync time. The single-prompt endpoint (`GET /v1/prompts/{id}`
→ `get_prompt()`) already detects this via `_should_fetch_gateway_prompt()` and
fetches the content live from upstream via `_fetch_gateway_prompt_result()`.
`list_server_prompts()` in `prompt_service.py` never applied that same check,
so it always returned the empty stored value.

### Fix
After the listing query, identify gateway-backed prompts with
`_should_fetch_gateway_prompt()` (existing helper, unchanged) and fetch their
live content concurrently via `asyncio.gather(...)`, applying the fetched text
onto the already-built `PromptRead` objects. A per-prompt fetch failure is
caught, logged, and leaves that prompt's `template` as the empty string it
already was — one unreachable gateway doesn't fail the whole listing.

### Tests (before → after)
- `test_gateway_backed_prompt_template_fetched_live`: a gateway-backed prompt
  (empty template) and a local custom prompt (populated template) in the same
  listing — asserts the gateway-backed one gets its live content, the local one
  is untouched. Without the fix, `_fetch_gateway_prompt_result` is never
  called (`Awaited 0 times`) and the read stays empty; with the fix, both
  assertions hold. Verified RED→GREEN via `git stash`.
- `test_gateway_backed_prompt_fetch_failure_leaves_template_empty`: an
  unreachable gateway raises `PromptError` — the listing still returns the
  prompt, with `template` left as `""` (graceful degradation, no 500).

`pytest tests/unit/mcpgateway/services/test_prompt_service.py` — full file
green (all tests, not just the two new ones).

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## 🏷️ Type of Change

- [x] Bug fix
