### PR TITLE
chore(ci): remove interrogate args to use pyproject configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -396,7 +396,6 @@ repos:
     rev: 4894019dc8876092bc9b6d56878798c550fad998  #v1.7.0
     hooks:
       - id: interrogate
-        args: []
         files: ^(mcpgateway|plugins)/
         exclude: _pb2(_grpc)?\.py$
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -396,7 +396,7 @@ repos:
     rev: 4894019dc8876092bc9b6d56878798c550fad998  #v1.7.0
     hooks:
       - id: interrogate
-        args: [--fail-under=100]
+        args: []
         files: ^(mcpgateway|plugins)/
         exclude: _pb2(_grpc)?\.py$
 


### PR DESCRIPTION
The args in the pre-commit interrogate configuration override the global interrogate configuration in pyproject.toml, causing the local pre-commit hook to fail.

Removing the args makes interrogate use the configuration from pyproject.toml.

Closes #6529