### PR TITLE
Replace black formatter docs and lint targets with ruff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ Run from the worktree root, in order. Each must pass (or have a documented waive
 | 5 | `make test-mcp-protocol-e2e test-mcp-rbac` | MCP protocol E2E and RBAC against the live gateway |
 | 6 | `make detect-secrets-scan` | No new secrets in files changed vs `main`; exits non-zero on live/unaudited findings (jq merge preserves out-of-scope audited entries; remediate with `make detect-secrets-audit`) |
 
-Distinct from the per-edit hygiene chain in *Essential Commands → Code Quality* (`make autoflake isort black pre-commit`, then `make ruff bandit interrogate pylint verify`): hygiene runs continuously; this gate runs once before declaring a PR ready.
+Distinct from the per-edit hygiene chain in *Essential Commands → Code Quality* (`make autoflake isort ruff RUFF_MODE=format pre-commit`, then `make ruff bandit interrogate pylint verify`): hygiene runs continuously; this gate runs once before declaring a PR ready.
 
 ### Secret Detection (detect-secrets)
 
@@ -572,4 +572,4 @@ When posting PR reviews, issue comments, or any public-facing text on GitHub, us
 - `make` for build/test automation
 - `uv` for virtual environment management and for `uv tool run` linter invocations
 - Dev-group tools installed in the venv: `pytest`, `mypy`, `bandit`, `pre-commit`, etc. (see `pyproject.toml` `[dependency-groups]`)
-- Formatters and linters (`ruff`, `vulture`, `interrogate`, `radon`, `yamllint`, `tomlcheck`) are pinned in the `Makefile` and invoked on demand via `uv tool run`; always prefer the Makefile targets (`make black`, `make ruff`, etc.) over calling the underlying tools directly
+- Formatters and linters (`ruff`, `vulture`, `interrogate`, `radon`, `yamllint`, `tomlcheck`) are pinned in the `Makefile` and invoked on demand via `uv tool run`; always prefer the Makefile targets (`make ruff RUFF_MODE=format`, `make ruff`, etc.) over calling the underlying tools directly

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ export UV_BIN
 # Targets in this Makefile deliberately split how they use `uv`:
 #
 #   * Execution: invoke tools via `$(VENV_DIR)/bin/<tool>` directly (e.g.
-#     pytest, black, ruff, pylint, python). `uv run` — even with `--active` —
+#     pytest, ruff, pylint, python). `uv run` — even with `--active` —
 #     has historically resolved against an unexpected environment when the
 #     caller has already `source`d the project venv, producing confusing
 #     "works on my machine" failures. Direct invocation removes the ambiguity:
@@ -232,7 +232,7 @@ export UV_BIN
 # If you add a new target: use `$(VENV_DIR)/bin/<tool>` to *run* something and
 # `uv pip ...` to *install* something. Do not reintroduce `uv run`.
 #
-# Exception — tools invoked via `uvx`: `black`, `isort`, `ruff`, `pylint`,
+# Exception — tools invoked via `uvx`: `isort`, `ruff`, `pylint`,
 # `vulture`, `interrogate`, `radon`, `yamllint`, `tomlcheck`, and
 # `detect-secrets` are invoked through `uv tool run <spec>` with pinned
 # versions (see the pins just below). This isolates the tool versions from
@@ -244,7 +244,7 @@ export UV_BIN
 # to PyPI — see DETECT_SECRETS_SPEC below.
 #
 # Sub-exception — pylint needs project context: unlike the pure-AST tools
-# (ruff, black, isort, vulture, interrogate, radon), pylint does deep type
+# (ruff, isort, vulture, interrogate, radon), pylint does deep type
 # inference via astroid and relies on being able to *import* the project
 # modules and their runtime dependencies (pydantic, fastapi, …) to avoid
 # false positives like E1133 (not-an-iterable) and spurious W0246
@@ -263,7 +263,6 @@ export UV_BIN
 # Bump these in lockstep with the lower bounds in pyproject.toml's dev group
 # so editors (which typically use the venv-installed version) and Makefile
 # targets (which use these pins via uvx) stay aligned.
-BLACK_VERSION           ?= 26.3.1
 ISORT_VERSION           ?= 6.1.0
 RUFF_VERSION            ?= 0.15.20
 PYLINT_VERSION          ?= 3.3.9
@@ -3338,11 +3337,10 @@ images:
 # help:   make lint                    - Run all linters on default targets (mcpgateway)
 # help:   make lint TARGET=myfile.py   - Run file-aware linters on specific file
 # help:   make lint myfile.py          - Run file-aware linters on a file (shortcut)
-# help:   make lint-quick myfile.py    - Fast linters only (ruff, black, isort)
+# help:   make lint-quick myfile.py    - Fast linters only (ruff, isort)
 # help:   make lint-fix myfile.py      - Auto-fix formatting issues
 # help:   make lint-changed            - Lint only git-changed files
 # help: lint                 - Run the full linting suite (see targets below)
-# help: black                - Reformat code with black (CHECK=1 for dry-run)
 # help: autoflake            - Remove unused imports / variables with autoflake
 # help: isort                - Organise & sort imports with isort (CHECK=1 for dry-run)
 # help: pylint               - Pylint static analysis
@@ -3409,10 +3407,10 @@ LINTERS := isort pylint mypy bandit pydocstyle pycodestyle \
 		pytype check-manifest markdownlint vulture
 
 # Linters that work well with individual files/directories
-FILE_AWARE_LINTERS := isort black pylint mypy bandit pydocstyle \
+FILE_AWARE_LINTERS := isort pylint mypy bandit pydocstyle \
 	pycodestyle ruff pyright vulture markdownlint
 
-.PHONY: lint $(LINTERS) pyright-pr black black-check isort-check ruff-check ruff-fix ruff-format autoflake lint-py lint-yaml lint-json lint-md lint-strict \
+.PHONY: lint $(LINTERS) pyright-pr black isort-check ruff-check ruff-fix ruff-format autoflake lint-py lint-yaml lint-json lint-md lint-strict \
 	lint-count-errors lint-report lint-changed lint-staged lint-commit \
 	lint-parallel lint-cache-clear lint-stats \
 	lint-complexity lint-watch lint-watch-quick \
@@ -3476,7 +3474,7 @@ lint-all:
 ##  Convenience targets
 ## --------------------------------------------------------------------------- ##
 
-# Quick lint - only fast linters (ruff, black, isort)
+# Quick lint - only fast linters (ruff, isort)
 .PHONY: lint-quick
 lint-quick:
 	@# Handle file arguments
@@ -3486,9 +3484,9 @@ lint-quick:
 	else \
 		actual_target="$(TARGET)"; \
 	fi; \
-	echo "⚡ Quick lint of $$actual_target (ruff + black + isort)..."; \
+	echo "⚡ Quick lint of $$actual_target (ruff + isort)..."; \
 	$(MAKE) --no-print-directory ruff RUFF_MODE=check TARGET="$$actual_target"; \
-	$(MAKE) --no-print-directory black CHECK=1 TARGET="$$actual_target"; \
+	$(MAKE) --no-print-directory ruff RUFF_MODE=format CHECK=1 TARGET="$$actual_target"; \
 	$(MAKE) --no-print-directory isort CHECK=1 TARGET="$$actual_target"
 
 # Fix formatting issues
@@ -3508,7 +3506,7 @@ lint-fix:
 		fi; \
 	done; \
 	echo "🔧 Fixing lint issues in $$actual_target..."; \
-	$(MAKE) --no-print-directory black TARGET="$$actual_target"; \
+	$(MAKE) --no-print-directory ruff RUFF_MODE=format TARGET="$$actual_target"; \
 	$(MAKE) --no-print-directory isort TARGET="$$actual_target"; \
 	$(MAKE) --no-print-directory ruff RUFF_MODE=fix TARGET="$$actual_target"
 
@@ -3763,13 +3761,10 @@ autoflake:                          ## 🧹  Strip unused imports / vars
 
 CHECK ?=
 
-# Deprecated, replaced by Ruff
-black: uv                           ## 🎨  Reformat code with black (CHECK=1 for dry-run)
-	@if [ -n "$(call is_true,$(CHECK))" ]; then \
-		echo "🎨  black --check $(TARGET)..." && $(UV_BIN) tool run black==$(BLACK_VERSION) -l 200 --check --diff $(TARGET); \
-	else \
-		echo "🎨  black $(TARGET)..." && $(UV_BIN) tool run black==$(BLACK_VERSION) -l 200 $(TARGET); \
-	fi
+# Deprecated alias: formatting is handled by ruff (RUFF_MODE=format)
+black:                              ## 🎨  Deprecated alias for ruff format (CHECK=1 for dry-run)
+	$(call deprecated_target,black,make ruff RUFF_MODE=format,1.2.0)
+	@$(MAKE) --no-print-directory ruff RUFF_MODE=format CHECK="$(CHECK)" TARGET="$(TARGET)"
 
 isort: uv                           ## 🔀  Sort imports (CHECK=1 for dry-run)
 	@if [ -n "$(call is_true,$(CHECK))" ]; then \
@@ -3779,12 +3774,7 @@ isort: uv                           ## 🔀  Sort imports (CHECK=1 for dry-run)
 	fi
 
 # --- Deprecated aliases (use CHECK=1 instead) ---
-# deprecated: black-check       - Use "make black CHECK=1" instead (v1.2.0)
 # deprecated: isort-check       - Use "make isort CHECK=1" instead (v1.2.0)
-black-check:
-	$(call deprecated_target,black-check,make black CHECK=1,1.2.0)
-	@$(MAKE) --no-print-directory black CHECK=1 TARGET="$(TARGET)"
-
 isort-check:
 	$(call deprecated_target,isort-check,make isort CHECK=1,1.2.0)
 	@$(MAKE) --no-print-directory isort CHECK=1 TARGET="$(TARGET)"
@@ -3968,7 +3958,12 @@ ruff: uv                            ## ⚡  Ruff linter (RUFF_MODE=check|fix|for
 	case "$(RUFF_MODE)" in \
 		check)  ruff_cmd="check" ;; \
 		fix)    ruff_cmd="check --fix" ;; \
-		format) ruff_cmd="format" ;; \
+		format) \
+			if [ -n "$(call is_true,$(CHECK))" ]; then \
+				ruff_cmd="format --check"; \
+			else \
+				ruff_cmd="format"; \
+			fi ;; \
 		*)      printf 'ERROR: RUFF_MODE must be check, fix, or format (got "%s")\n' '$(RUFF_MODE)'; exit 1 ;; \
 	esac; \
 	select_flag=""; \
@@ -4392,7 +4387,7 @@ lint-parallel:							## 🚀 Run linters in parallel
 		$(UV_BIN) pip install -q pytest-xdist"
 	@# Run fast linters in parallel
 	@$(MAKE) --no-print-directory ruff RUFF_MODE=check TARGET="$(TARGET)" & \
-	$(MAKE) --no-print-directory black CHECK=1 TARGET="$(TARGET)" & \
+	$(MAKE) --no-print-directory ruff RUFF_MODE=format CHECK=1 TARGET="$(TARGET)" & \
 	$(MAKE) --no-print-directory isort CHECK=1 TARGET="$(TARGET)" & \
 	wait
 	@echo "✅ Parallel linting completed!"

--- a/docs/docs/best-practices/mcp-best-practices.md
+++ b/docs/docs/best-practices/mcp-best-practices.md
@@ -44,7 +44,7 @@ Make targets are grouped by functionality. Use `make help` to see them all in yo
 
 | Target               | Description |
 |----------------------|-------------|
-| `make lint`          | Run the full lint suite (`make ruff`, `make black`, `make isort`, `make pylint`, etc.). |
+| `make lint`          | Run the full lint suite (`make ruff`, `make isort`, `make pylint`, etc.). |
 
 #### 🐳 CONTAINER BUILD & RUN
 

--- a/docs/docs/faq/index.md
+++ b/docs/docs/faq/index.md
@@ -408,7 +408,7 @@
 
 ???+ tip "🧑🎓 What code style and CI tools are used?"
 
-    - Pre-commit: `ruff`, `black`, `mypy`, `isort`
+    - Pre-commit: `ruff`, `mypy`, `isort`
     - Run `make lint` before PRs
 
 ???+ tip "💬 Where can I chat or ask questions?"

--- a/llms/mcp-server-python.md
+++ b/llms/mcp-server-python.md
@@ -111,7 +111,6 @@ dev = [
   "pytest>=7.0.0",
   "pytest-asyncio>=0.21.0",
   "pytest-cov>=4.0.0",
-  "black>=23.0.0",
   "mypy>=1.5.0",
   "ruff>=0.0.290",
 ]
@@ -125,10 +124,6 @@ packages = ["src/awesome_server"]
 
 [project.scripts]
 awesome-server = "awesome_server.server_fastmcp:main"
-
-[tool.black]
-line-length = 100
-target-version = ["py311"]
 
 [tool.mypy]
 python_version = "3.11"
@@ -178,8 +173,8 @@ install: ## Install in editable mode
 dev-install: ## Install with dev extras
     $(PYTHON) -m pip install -e ".[dev]"
 
-format: ## Format (black + ruff --fix)
-    black . && ruff check --fix .
+format: ## Format (ruff format + ruff --fix)
+    ruff format . && ruff check --fix .
 
 lint: ## Lint (ruff, mypy)
     ruff check . && mypy src/awesome_server

--- a/llms/mcpgateway.md
+++ b/llms/mcpgateway.md
@@ -77,7 +77,7 @@ ContextForge: Full Project Overview
   - HTML coverage only: `make htmlcov`
 - Selective pytest: `pytest -k "fragment"`, `pytest -m "not slow"`
 - Lint & static analysis:
-  - Format & hooks: `make autoflake isort black pre-commit`
+  - Format & hooks: `make autoflake isort ruff RUFF_MODE=format pre-commit`
   - Static: `make pylint ruff`, full lint: `make lint`
   - Security/docs QA (as configured): `make bandit interrogate verify check-manifest`
 - PR readiness (recommended):

--- a/llms/mkdocs.md
+++ b/llms/mkdocs.md
@@ -51,7 +51,7 @@ Notes
 
 **Quality & Linting**
 - Prefer keeping docs consistent with the project's quality workflow:
-  - `make autoflake isort black pre-commit` (root) to format Python, sort imports, and run hooks.
+  - `make autoflake isort ruff RUFF_MODE=format pre-commit` (root) to format Python, sort imports, and run hooks.
   - Additional docs authoring guidance: `docs/docs/development/documentation.md`.
 
 **Common Tips**

--- a/llms/plugins-llms.md
+++ b/llms/plugins-llms.md
@@ -303,7 +303,7 @@ async function toolPreInvoke({ payload, context }: any) {
 
 **Testing Plugins**
 - Code quality & pre-commit (see AGENTS.md for details):
-  - `make autoflake isort black pre-commit` formats, orders imports, applies autoflake, and runs pre-commit hooks.
+  - `make autoflake isort ruff RUFF_MODE=format pre-commit` formats, orders imports, applies autoflake, and runs pre-commit hooks.
   - `make pylint ruff` runs static analysis; fix findings before committing.
   - `make doctest test` executes doctests then pytest; mirrors CI expectations locally.
 

--- a/llms/testing.md
+++ b/llms/testing.md
@@ -38,7 +38,7 @@ Testing: Quick Guide for LLMs
 - HTML report only: `make htmlcov` (auto-runs coverage if `.coverage` missing).
 
 **Code Quality & Security**
-- Formatting & hooks: `make autoflake isort black pre-commit`
+- Formatting & hooks: `make autoflake isort ruff RUFF_MODE=format pre-commit`
 - Static analysis: `make pylint ruff`
 - Full lint suite (includes web linters after one-time setup): `make lint` and `make lint-web` (install web linters once if needed)
 - Additional checks (varies by repo config): `make bandit interrogate verify check-manifest`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -351,7 +351,7 @@ mcpgateway = [
 ]
 
 # --------------------------------------------------------------------
-#  🛠  Tool configurations (black, mypy, etc.)
+#  🛠  Tool configurations (ruff, mypy, etc.)
 # --------------------------------------------------------------------
 [tool.pytype]
 # Directory-specific options:


### PR DESCRIPTION
## Summary
Fixes #5248

The project already formats with ruff. This updates the Makefile lint targets and related docs so they call ruff format instead of black.

Changes:
* Makefile lint quick, lint fix, and lint parallel now use ruff RUFF_MODE=format
* black target is a deprecated alias that calls ruff format
* RUFF_MODE=format respects CHECK=1 via format check mode
* Removed black check target and BLACK_VERSION pin
* Agent guides and FAQ or best practices docs no longer tell people to run black

SVG logo names, CSS fontcolor black, blacklist or whitelist wording, black box tests, and isort profile = "black" are unchanged.

## DCO
Signed off by Hashim1999164 under the Developer Certificate of Origin.

## Test plan
* [ ] Confirm make help no longer lists a real black formatter target
* [ ] Confirm make black prints the deprecation warning and routes to ruff format
* [ ] Confirm make lint quick uses ruff format check
* [ ] Spot check AGENTS.md and llms docs for ruff RUFF_MODE=format