### PR TITLE
fix: use settings.app_domain for vault OAuth redirect_uri

### DIFF
--- a/mcpgateway/routers/vault_router.py
+++ b/mcpgateway/routers/vault_router.py
@@ -26,12 +26,10 @@ from sqlalchemy.orm import Session
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.db import Gateway, Server, Tool, get_db, server_tool_association
 from mcpgateway.middleware.rbac import get_current_user_with_permissions
-from mcpgateway.config import settings
-from mcpgateway.routers.oauth_router import _build_user_context, _enforce_gateway_access
+from mcpgateway.routers.oauth_router import _build_user_context, _default_redirect_uri, _enforce_gateway_access
 from mcpgateway.services.a2a_server_service import _check_server_access as _check_server_visibility
 from mcpgateway.services.oauth_manager import OAuthManager
 from mcpgateway.services.token_storage_service import TokenStorageService
-from mcpgateway.utils.paths import resolve_root_path
 
 logger = logging.getLogger(__name__)
 
@@ -190,11 +188,7 @@ async def vault_authorize(
 
         # Build authorization URL with user email embedded in state
         # Use the standard /oauth/callback endpoint (it already handles both Database and Vault backends)
-        # Use settings.app_domain (consistent with oauth_router._default_redirect_uri)
-        # so the redirect_uri matches the externally-visible origin registered with the
-        # IdP, even when the request arrives via a reverse-proxy / K8s ingress.
-        root_path = resolve_root_path(request) if request else ""
-        callback_url = f"{str(settings.app_domain).rstrip('/')}{root_path}/oauth/callback"
+        callback_url = _default_redirect_uri(request)
 
         # Add callback URL to oauth_config for this flow
         oauth_config_with_callback = gateway.oauth_config.copy()

--- a/mcpgateway/routers/vault_router.py
+++ b/mcpgateway/routers/vault_router.py
@@ -26,6 +26,7 @@ from sqlalchemy.orm import Session
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.db import Gateway, Server, Tool, get_db, server_tool_association
 from mcpgateway.middleware.rbac import get_current_user_with_permissions
+from mcpgateway.config import settings
 from mcpgateway.routers.oauth_router import _build_user_context, _enforce_gateway_access
 from mcpgateway.services.a2a_server_service import _check_server_access as _check_server_visibility
 from mcpgateway.services.oauth_manager import OAuthManager
@@ -189,9 +190,11 @@ async def vault_authorize(
 
         # Build authorization URL with user email embedded in state
         # Use the standard /oauth/callback endpoint (it already handles both Database and Vault backends)
-        request_origin = f"{request.url.scheme}://{request.url.netloc}"
+        # Use settings.app_domain (consistent with oauth_router._default_redirect_uri)
+        # so the redirect_uri matches the externally-visible origin registered with the
+        # IdP, even when the request arrives via a reverse-proxy / K8s ingress.
         root_path = resolve_root_path(request) if request else ""
-        callback_url = f"{request_origin}{root_path}/oauth/callback"
+        callback_url = f"{str(settings.app_domain).rstrip('/')}{root_path}/oauth/callback"
 
         # Add callback URL to oauth_config for this flow
         oauth_config_with_callback = gateway.oauth_config.copy()

--- a/tests/unit/mcpgateway/routers/test_vault_router.py
+++ b/tests/unit/mcpgateway/routers/test_vault_router.py
@@ -419,3 +419,58 @@ async def test_vault_authorize_generic_exception_returns_500():
     with pytest.raises(HTTPException) as exc_info:
         await vault_authorize(request, "srv-1", None, db, current_user)
     assert exc_info.value.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# redirect_uri derivation: must use settings.app_domain, not request.url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_vault_authorize_redirect_uri_uses_app_domain():
+    """redirect_uri must be derived from settings.app_domain, not request.url.
+
+    Behind a K8s ingress the request origin resolves to an internal pod address;
+    the IdP rejects redirect_uri values that don't match its registered callback.
+    This test mocks request.url to an internal address and settings.app_domain to
+    the public domain, then asserts the redirect_uri reflects app_domain.
+    """
+    db = MagicMock()
+    db.get.return_value = _make_server()
+    gateway = _make_gateway()
+
+    alice = _make_user(email="alice@corp.com", is_admin=False, token_teams=["engineering"])
+
+    # Request arrives on internal pod address
+    request = _make_request()
+    request.url.scheme = "http"
+    request.url.netloc = "internal-pod:4444"
+    request.scope = {"root_path": "/proxy"}
+
+    with patch("mcpgateway.routers.vault_router._resolve_oauth_gateway", return_value=gateway), \
+         patch("mcpgateway.routers.vault_router._enforce_gateway_access", new_callable=AsyncMock, return_value=None), \
+         patch("mcpgateway.routers.vault_router._check_server_visibility", return_value=True), \
+         patch("mcpgateway.routers.vault_router.OAuthManager") as mock_oauth_cls, \
+         patch("mcpgateway.routers.vault_router._default_redirect_uri", return_value="https://public.example.com/proxy/oauth/callback") as mock_redirect:
+        mock_oauth = AsyncMock()
+        mock_oauth.initiate_authorization_code_flow.return_value = {
+            "authorization_url": "https://idp.example.com/authorize?state=xyz"
+        }
+        mock_oauth_cls.return_value = mock_oauth
+
+        await vault_authorize(
+            request=request,
+            server_id="srv-123",
+            gateway_url=None,
+            db=db,
+            current_user=alice,
+        )
+
+        # Verify _default_redirect_uri was called with the request
+        mock_redirect.assert_called_once_with(request)
+
+        # Verify the redirect_uri passed to OAuthManager uses the public domain
+        call_kwargs = mock_oauth.initiate_authorization_code_flow.call_args[1]
+        credentials = call_kwargs["credentials"]
+        assert credentials["redirect_uri"] == "https://public.example.com/proxy/oauth/callback"
+        assert "internal-pod" not in credentials["redirect_uri"]


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Fixes #6555. The `/vault/authorize/{server_id}` endpoint derived the OAuth `redirect_uri` from `request.url`, which behind a K8s ingress resolves to the internal pod address instead of the public domain. This caused IdPs to reject the authorization request with "invalid redirect_uri".

## 🔁 Reproduction Steps

See #6555.

## 🐞 Root Cause

`vault_router.py` constructed the callback URL from `request.url.scheme://request.url.netloc`, which behind a reverse proxy / K8s ingress gives the internal origin (e.g. `http://pod:4444`) rather than the public-facing domain. The standard `/oauth/authorize` endpoint does not have this issue because it uses `settings.app_domain` via `_default_redirect_uri()`.

## 💡 Fix Description

Replace `request.url.scheme://request.url.netloc` with `settings.app_domain` in the vault router, consistent with how `oauth_router._default_redirect_uri()` already constructs the callback URL. One import added, three lines changed.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

Deploy behind a reverse proxy with `APP_DOMAIN` set to the public domain and confirm `/vault/authorize/{server_id}` sends the correct `redirect_uri` to the IdP.

## ✅ Checklist

- [x] Code formatted
- [x] No secrets/credentials committed