### PR TITLE
feat(health): SSE health checks gain an MCP initialize round-trip (capability probe)

### DIFF
--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -2839,6 +2839,13 @@ class Settings(BaseSettings):
     health_check_interval: int = 60
     # Timeout in seconds for each health check request
     health_check_timeout: int = 30
+    # When true, SSE health checks also perform an MCP initialize round-trip
+    # (capability check) instead of trusting the HTTP 200 from the SSE endpoint.
+    # Rationale: an SSE front-end (e.g. an mcp-proxy) can answer GET /sse with
+    # 200 while the stdio child behind it is wedged — transport-alive but
+    # capability-dead. The initialize round-trip is the cheapest probe that
+    # crosses all three hops. StreamableHTTP checks already initialize.
+    health_check_capability_probe: bool = True
     # Per-check timeout (seconds) to bound total time of one gateway health check
     # Env: GATEWAY_HEALTH_CHECK_TIMEOUT
     gateway_health_check_timeout: float = 30.0

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -4937,6 +4937,21 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                             response.raise_for_status()
                             if span:
                                 set_span_attribute(span, "http.status_code", response.status_code)
+                        # Capability probe: a 200 from the SSE endpoint only proves the
+                        # HTTP front-end is alive. When the gateway is an SSE-to-stdio
+                        # bridge (mcp-proxy et al.), the child process can be wedged while
+                        # the SSE layer keeps answering — transport-alive, capability-dead,
+                        # and every downstream tool call then hangs. An initialize
+                        # round-trip crosses all three hops and is the cheapest probe
+                        # that can fail for that reason. Disable via
+                        # HEALTH_CHECK_CAPABILITY_PROBE=false for pure-HTTP SSE servers
+                        # that do not speak MCP initialize (rare).
+                        if settings.health_check_capability_probe:
+                            async with sse_client(url=gateway_url, headers=headers) as (read_stream, write_stream):
+                                async with ClientSession(read_stream, write_stream) as session:
+                                    await asyncio.wait_for(session.initialize(), timeout=settings.health_check_timeout)
+                            if span:
+                                set_span_attribute(span, "health.mode", "capability")
                     elif (gateway_transport).lower() == "streamablehttp":
                         # Health checks are system operations with no downstream MCP session,
                         # so they don't go through the UpstreamSessionRegistry (which requires


### PR DESCRIPTION
## Problem

The gateway health check for SSE transport does `GET /sse` + `raise_for_status()`. A **200 proves only that the SSE front-end answers** — it says nothing about the MCP capability behind it.

When the gateway URL fronts an SSE-to-stdio bridge (`mcp-proxy` and friends), the stdio child can be wedged while the SSE layer keeps answering 200 forever. We observed exactly this in production:

- `gateways.reachable` stayed 1 and `last_seen` advanced every 60-second interval
- the stdio child answered a direct stdio handshake instantly (11 tools) — the process was alive and healthy; only the proxy↔child pipe conversation was lost
- every real tool call through the gateway hung until client timeout
- tools harvested earlier remained advertised to clients

Three consecutive health checks passed on HTTP 200 alone while capability was fully dead. Process-level supervision cannot catch this class either (all processes alive).

## Change

The SSE branch of `_check_single_gateway_health` now performs an MCP `initialize` round-trip **after** the cheap GET succeeds — bringing SSE to parity with the streamablehttp branch, which already does an initialize in this exact spot.

- Connection-level failures keep their existing semantics (including the 401/403-as-reachable path for `authorization_code` flows, which returns before this code runs).
- New setting `health_check_capability_probe` (env `HEALTH_CHECK_CAPABILITY_PROBE`, default `true`) disables the round-trip for operators fronting a pure-HTTP SSE server that does not speak MCP initialize.
- A span attribute `health.mode=capability` records which mode ran.

## Notes

- The initialize uses `settings.health_check_timeout` via `asyncio.wait_for`, bounded like the rest of the check.
- No DB/schema changes; `reachable` semantics become *capability*-alive instead of *transport*-alive, which is what consumers of the admin UI assume it already means.