### PR TITLE
fix: security hardening for auth-gated default password validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,21 +27,20 @@
 # Docker Compose / CI (non-interactive):
 #   python3 -m mcpgateway.scripts.init_secrets --patch-env .env
 #   # or: python3 -m mcpgateway.scripts.init_secrets --force && \
-#   #     grep -E '^(JWT_SECRET_KEY|AUTH_ENCRYPTION_SECRET|BASIC_AUTH_PASSWORD)=' .env.secrets >> .env
+#   #     grep -E '^(JWT_SECRET_KEY|AUTH_ENCRYPTION_SECRET|BASIC_AUTH_PASSWORD|PLATFORM_ADMIN_PASSWORD|DEFAULT_USER_PASSWORD)=' .env.secrets >> .env
 #
 # What each path writes:
 #   make init-secrets / --stdout / --force (writes .env.secrets):
 #     - JWT_SECRET_KEY          (REQUIRED — all environments)
 #     - AUTH_ENCRYPTION_SECRET  (REQUIRED — all environments)
-#     - BASIC_AUTH_PASSWORD     (for UI/API Basic Auth)
+#     - BASIC_AUTH_PASSWORD     (for API/docs Basic Auth when enabled)
 #     - PLATFORM_ADMIN_PASSWORD (for bootstrap admin account)
+#     - DEFAULT_USER_PASSWORD   (for email-auth user password handling)
 #
 #   make setup / make init-secrets-patch-env / --patch-env (in-place patch):
-#     - JWT_SECRET_KEY          (patched when placeholder or weak)
-#     - AUTH_ENCRYPTION_SECRET  (patched when placeholder or weak)
-#     - BASIC_AUTH_PASSWORD     (patched when "changeme" or placeholder; 18 bytes → 24 chars)
-#     NOTE: PLATFORM_ADMIN_PASSWORD is NOT patched by this path — set it manually
-#           or via helm/k8s secrets before production deployment.
+#     - JWT_SECRET_KEY, AUTH_ENCRYPTION_SECRET
+#     - BASIC_AUTH_PASSWORD, PLATFORM_ADMIN_PASSWORD, DEFAULT_USER_PASSWORD
+#       (each patched when empty, placeholder, or known-weak)
 #
 # =============================================================================
 
@@ -68,9 +67,9 @@ ENVIRONMENT=development
 # Admin UI HTTP Basic Auth credentials
 # =============================================================================
 # BASIC_AUTH_PASSWORD is patched to a strong value by make setup / make init-secrets-patch-env.
-# PLATFORM_ADMIN_PASSWORD must be set manually — it is not patched by the automated path.
+# PLATFORM_ADMIN_PASSWORD and DEFAULT_USER_PASSWORD are also patched by init-secrets-patch-env.
 BASIC_AUTH_USER=admin
-BASIC_AUTH_PASSWORD=changeme  # pragma: allowlist secret
+BASIC_AUTH_PASSWORD=__REPLACE_ME__run_init-secrets_before_starting
 
 # -----------------------------------------------------------------------------
 # CSRF Protection Configuration
@@ -121,8 +120,8 @@ CSRF_TRUSTED_ORIGINS=["http://localhost:4444","http://localhost:8080"]
 # Bootstrap admin credentials (email auth)
 # PRODUCTION: Change these values
 PLATFORM_ADMIN_EMAIL=admin@example.com
-#PLATFORM_ADMIN_PASSWORD="< replace me >"
-DEFAULT_USER_PASSWORD=UserP@ssw0rd!2026Secure
+PLATFORM_ADMIN_PASSWORD=__REPLACE_ME__run_init-secrets_before_starting
+DEFAULT_USER_PASSWORD=__REPLACE_ME__run_init-secrets_before_starting
 # Set to false in development to enable the platform admin bootstrap path.
 # Production default is true (requires admin user seeded in the database).
 # Uncomment in development if you rely on the platform-admin email match
@@ -1045,11 +1044,11 @@ MCPGATEWAY_SKIP_MIGRATIONS=false
 # Authentication
 # =============================================================================
 
-# Admin UI HTTP Basic Auth credentials
-# Used for: Admin UI login, /docs endpoint (if DOCS_ALLOW_BASIC_AUTH=true)
+# HTTP Basic Auth credentials
+# Used for API or /docs authentication only when the corresponding feature is enabled.
 # PRODUCTION: Change these to strong, unique values!
 # BASIC_AUTH_USER=admin
-# BASIC_AUTH_PASSWORD=changeme
+# BASIC_AUTH_PASSWORD=__REPLACE_ME__run_init-secrets_before_starting
 
 # Global authentication requirement
 # Options: true (default), false
@@ -1269,11 +1268,11 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # Platform admin user (bootstrap from environment)
 # PRODUCTION: Change these to your actual admin credentials!
 # PLATFORM_ADMIN_EMAIL=admin@example.com
-# PLATFORM_ADMIN_PASSWORD=changeme
+# PLATFORM_ADMIN_PASSWORD=__REPLACE_ME__run_init-secrets_before_starting
 # PLATFORM_ADMIN_FULL_NAME=Platform Administrator
 
 # Default password for newly created users (bootstrap only)
-# DEFAULT_USER_PASSWORD=changeme
+# DEFAULT_USER_PASSWORD=__REPLACE_ME__run_init-secrets_before_starting
 
 # Argon2id Password Hashing Configuration
 # Time cost (iterations) - higher = more secure but slower

--- a/.github/workflows/compose-prod-smoke.yml
+++ b/.github/workflows/compose-prod-smoke.yml
@@ -80,8 +80,16 @@ jobs:
           # alphabet has no '|' or '&', so it is safe with the sed delimiter.
           jwt_secret="$(openssl rand -base64 32)"  # pragma: allowlist secret
           enc_secret="$(openssl rand -base64 32)"  # pragma: allowlist secret
+          admin_password="$(openssl rand -base64 24)"  # pragma: allowlist secret
+          user_password="$(openssl rand -base64 24)"  # pragma: allowlist secret
           sed -i "s|^JWT_SECRET_KEY=.*|JWT_SECRET_KEY=${jwt_secret}|" .env
           sed -i "s|^AUTH_ENCRYPTION_SECRET=.*|AUTH_ENCRYPTION_SECRET=${enc_secret}|" .env
+          # EMAIL_AUTH_ENABLED=true on the gateway service (docker-compose.yml)
+          # feature-gates platform_admin_password/default_user_password checks
+          # in Settings.validate_security_combinations() — the .env.example
+          # placeholders must be patched too or the gateway refuses to boot.
+          sed -i "s|^PLATFORM_ADMIN_PASSWORD=.*|PLATFORM_ADMIN_PASSWORD=${admin_password}|" .env
+          sed -i "s|^DEFAULT_USER_PASSWORD=.*|DEFAULT_USER_PASSWORD=${user_password}|" .env
 
       # ── Default compose stack ──────────────────────────────────
       # Start the stack, wait up to 3 min for nginx to proxy

--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -50,6 +50,12 @@ jobs:
       # Override .env.example placeholders — env vars take precedence over .env in pydantic-settings
       JWT_SECRET_KEY: "ci-playwright-smoke-jwt-secret-not-for-production-use"  # pragma: allowlist secret
       AUTH_ENCRYPTION_SECRET: "ci-playwright-smoke-auth-enc-secret-not-for-production"  # pragma: allowlist secret
+      # email_auth_enabled defaults true, so Settings() fails closed on the
+      # .env.example placeholder for these unless overridden. Value matches
+      # tests/playwright/conftest.py's ADMIN_PASSWORD default so the UI login
+      # tests authenticate without extra configuration.
+      PLATFORM_ADMIN_PASSWORD: "5S1Nd8z$Ivb6N%Lsj^okvVF6"  # pragma: allowlist secret
+      DEFAULT_USER_PASSWORD: "ci-playwright-smoke-default-user-password-not-for-production"  # pragma: allowlist secret
 
     steps:
       - name: ⬇️ Checkout source

--- a/.github/workflows/plugin-integration.yml
+++ b/.github/workflows/plugin-integration.yml
@@ -255,6 +255,12 @@ jobs:
                   SSRF_PROTECTION_ENABLED: false
                   JWT_SECRET_KEY: ${{ env.DYNAMIC_JWT_SECRET }}
                   AUTH_ENCRYPTION_SECRET: ${{ env.DYNAMIC_ENC_SECRET }}
+                  # email_auth_enabled defaults true, which feature-gates
+                  # platform_admin_password/default_user_password checks in
+                  # Settings.validate_security_combinations(); unset, they
+                  # fall back to the "changeme" default and boot fails closed.
+                  PLATFORM_ADMIN_PASSWORD: "ci-test-admin-P@ssw0rd-DO-NOT-USE-IN-PRODUCTION"  # pragma: allowlist secret
+                  DEFAULT_USER_PASSWORD: "ci-test-user-P@ssw0rd-DO-NOT-USE-IN-PRODUCTION"  # pragma: allowlist secret
                   ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP: false
                   PASSWORD_CHANGE_ENFORCEMENT_ENABLED: false
                   LOG_LEVEL: INFO

--- a/.github/workflows/pytest-rust.yml
+++ b/.github/workflows/pytest-rust.yml
@@ -53,6 +53,11 @@ jobs:
       REQUIRE_RUST: "1"
       JWT_SECRET_KEY: "ci-rust-jwt-secret-DO-NOT-USE-IN-PRODUCTION-this-is-only-for-ci-pytest"  # pragma: allowlist secret
       AUTH_ENCRYPTION_SECRET: ci-rust-auth-encryption-secret-1234567890 # pragma: allowlist secret
+      # PLATFORM_ADMIN_PASSWORD/DEFAULT_USER_PASSWORD are feature-gated on EMAIL_AUTH_ENABLED
+      # (default true) — required because --doctest-modules mcpgateway/ imports mcpgateway.config
+      # outside of tests/conftest.py, which normally supplies these.
+      PLATFORM_ADMIN_PASSWORD: "ci-rust-admin-P@ssw0rd-DO-NOT-USE-IN-PRODUCTION"  # pragma: allowlist secret
+      DEFAULT_USER_PASSWORD: "ci-rust-user-P@ssw0rd-DO-NOT-USE-IN-PRODUCTION"  # pragma: allowlist secret
       REDIS_URL: redis://127.0.0.1:6379/0
       MCP_RUST_REDIS_URL: redis://127.0.0.1:6379/0
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -76,10 +76,15 @@ jobs:
       PYTHONUNBUFFERED: "1"
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
       # Strong test-only secrets so Settings() validates in all environments.
-      # config.py now rejects placeholder/weak secrets unconditionally (GHSA-8pcq-mx48-hjvj).
+      # config.py now rejects placeholder/weak secrets unconditionally (GHSA-8pcq-mx48-hjvj)
+      # and feature-gates PLATFORM_ADMIN_PASSWORD/DEFAULT_USER_PASSWORD on EMAIL_AUTH_ENABLED
+      # (default true) — required here because --doctest-modules mcpgateway/ imports
+      # mcpgateway.config outside of tests/conftest.py, which normally supplies these.
       # These values are CI-only and are never used outside the test suite.
       JWT_SECRET_KEY: "ci-test-jwt-secret-DO-NOT-USE-IN-PRODUCTION-this-is-only-for-ci-pytest"  # pragma: allowlist secret
       AUTH_ENCRYPTION_SECRET: "ci-test-enc-secret-DO-NOT-USE-IN-PRODUCTION-this-is-only-for-ci-pytest"  # pragma: allowlist secret
+      PLATFORM_ADMIN_PASSWORD: "ci-test-admin-P@ssw0rd-DO-NOT-USE-IN-PRODUCTION"  # pragma: allowlist secret
+      DEFAULT_USER_PASSWORD: "ci-test-user-P@ssw0rd-DO-NOT-USE-IN-PRODUCTION"  # pragma: allowlist secret
 
     steps:
       # -----------------------------------------------------------

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-03T15:18:51Z",
+  "generated_at": "2026-09-03T15:49:29Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -234,7 +234,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2218,
+        "line_number": 2228,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -242,7 +242,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2306,
+        "line_number": 2316,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -250,7 +250,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2656,
+        "line_number": 2666,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -258,7 +258,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4021,
+        "line_number": 4031,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4112,
+        "line_number": 4122,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4155,
+        "line_number": 4165,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4160,
+        "line_number": 4170,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4165,
+        "line_number": 4175,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -675,18 +675,26 @@
     ],
     "docker-compose-embedded.yml": [
       {
-        "hashed_secret": "119ffab9fda36e29816a09097c441eb8bcd8b684",
+        "hashed_secret": "afba9d98073dfb79fba7b21516c4d4d676c72935",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 89,
+        "line_number": 165,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "afba9d98073dfb79fba7b21516c4d4d676c72935",
+        "hashed_secret": "db521f60ff25f37ce29401ad93cb12cf4dc9f814",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 164,
+        "line_number": 168,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b7aa580d298f50cfece35543607ccd68177c6413",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 169,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -806,7 +814,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1244,
+        "line_number": 1247,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -814,7 +822,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1279,
+        "line_number": 1282,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -822,7 +830,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1852,
+        "line_number": 1863,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -830,7 +838,23 @@
         "hashed_secret": "afba9d98073dfb79fba7b21516c4d4d676c72935",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2282,
+        "line_number": 2306,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "db521f60ff25f37ce29401ad93cb12cf4dc9f814",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2309,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b7aa580d298f50cfece35543607ccd68177c6413",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2310,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -838,7 +862,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2382,
+        "line_number": 2410,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -846,7 +870,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2382,
+        "line_number": 2410,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -854,7 +878,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2395,
+        "line_number": 2423,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -862,7 +886,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2545,
+        "line_number": 2573,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -870,7 +894,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2566,
+        "line_number": 2594,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -878,7 +902,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2574,
+        "line_number": 2602,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -886,7 +910,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2579,
+        "line_number": 2607,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1916,7 +1940,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 177,
+        "line_number": 188,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1924,7 +1948,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 482,
+        "line_number": 493,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1932,7 +1956,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 925,
+        "line_number": 936,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1940,7 +1964,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1432,
+        "line_number": 1445,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -1948,7 +1972,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1436,
+        "line_number": 1449,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2881,6 +2905,24 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 752,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "docs/docs/operations/default-password-fail-closed-migration.md": [
+      {
+        "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7ea292dbb9281fae2508df215f5a0f9dc4fbf404",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 75,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4751,6 +4793,32 @@
         "verified_result": null
       }
     ],
+    "tests/test_config_security.py": [
+      {
+        "hashed_secret": "41619c1a2210623e4e54b9688037634c72bd9b91",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 114,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5c6dc03d3bd675de03154ec5b7eebaa496b7bed2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 115,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a3477e075d171e91f671eef7fdd3287d2451fb1f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 116,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "tests/unit/mcpgateway/scripts/test_migrate_enc_secret.py": [
       {
         "hashed_secret": "cd60be54aa0dff795929c4bbeda21e12e308dffa",
@@ -4804,7 +4872,7 @@
         "hashed_secret": "a24a9eab46fcd2eb51c24d7e647a1e398c2c4b26",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2276,
+        "line_number": 2285,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-03T15:49:29Z",
+  "generated_at": "2026-09-04T09:25:46Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1964,12 +1964,20 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
+        "line_number": 1413,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
+        "is_secret": false,
+        "is_verified": false,
         "line_number": 1445,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
       {
-        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
+        "hashed_secret": "424ca52f87120d5dd4475b0b4aaed10adc379fb9",
         "is_secret": false,
         "is_verified": false,
         "line_number": 1449,
@@ -2965,7 +2973,7 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
+        "hashed_secret": "2c92c42456663ddd63c1ad1a4a8f0c71a435919e",
         "is_secret": false,
         "is_verified": false,
         "line_number": 161,

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-03T09:00:59Z",
+  "generated_at": "2026-09-03T15:18:51Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -89,42 +89,18 @@
     ],
     ".env.example": [
       {
-        "hashed_secret": "15ab6d87c10ed359ba98e6a578764fa53954fdfc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 54,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "548a5cde15c93a9e50e12e4cba776b85f6befc83",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 124,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8e9a8667ded25c805ce3dc920a5f2343bd2d198f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 125,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 804,
+        "line_number": 803,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
       {
-        "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
+        "hashed_secret": "15ab6d87c10ed359ba98e6a578764fa53954fdfc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1049,
+        "line_number": 1275,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +108,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1382,
+        "line_number": 1381,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +116,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1417,
+        "line_number": 1416,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +124,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1570,
+        "line_number": 1569,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +132,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1575,
+        "line_number": 1574,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +140,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1580,
+        "line_number": 1579,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +148,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1586,
+        "line_number": 1585,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +156,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1598,
+        "line_number": 1597,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +164,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1616,
+        "line_number": 1615,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +172,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1677,
+        "line_number": 1676,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -334,7 +310,7 @@
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 632,
+        "line_number": 633,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -342,7 +318,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1084,
+        "line_number": 1085,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +326,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1086,
+        "line_number": 1087,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +334,7 @@
         "hashed_secret": "db69d9215c29ae2f2e4ead587890a9f8455059dd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1160,
+        "line_number": 1161,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +342,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1739,
+        "line_number": 1740,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +350,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1958,
+        "line_number": 1959,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +358,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6141,
+        "line_number": 6142,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +366,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6638,
+        "line_number": 6639,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +374,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6650,
+        "line_number": 6651,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +382,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6722,
+        "line_number": 6723,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +390,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7138,
+        "line_number": 7139,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +398,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7828,
+        "line_number": 7829,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4762,7 +4738,7 @@
         "hashed_secret": "61ae516fe556ac031cfa24a280de3822d9c4cdb9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 444,
+        "line_number": 464,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4770,7 +4746,7 @@
         "hashed_secret": "c9ea447161081f3688e5360597ab2ae22ec43be6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 448,
+        "line_number": 468,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - Rust MCP runtime sidecar, Rust A2A runtime sidecar, and ValidationMiddleware are deprecated as of 2026-06-11 and will sunset on 2026-07-07. Use the Python MCP transport path, the Python A2A invocation path, and endpoint-level Pydantic or protocol-specific validation instead. See [Deprecations](docs/docs/deprecations.md).
 
 
+## [Unreleased]
+
+### Breaking Changes
+
+- **Enabled authentication rejects default passwords** - When Basic Auth or email authentication is enabled, empty, placeholder, and known-weak password values now fail startup. Set `BASIC_AUTH_PASSWORD` for `API_ALLOW_BASIC_AUTH=true` or `DOCS_ALLOW_BASIC_AUTH=true`; set `PLATFORM_ADMIN_PASSWORD` and `DEFAULT_USER_PASSWORD` for `EMAIL_AUTH_ENABLED=true`. Existing deployments must run `make init-secrets-patch-env` or update their deployment Secret before restarting. See the [migration guide](docs/docs/operations/default-password-fail-closed-migration.md).
+
 ## [1.0.9] - 2026-08-31 - mTLS, OAuth Quick Wins, Tool Preview, Catalog Actions, and Security Hardening
 
 ### Overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ Release 1.0.9 consolidates **41 PRs** focused on **inbound mTLS client certifica
 - **TLS cipher suite exposure** ([#6483](https://github.com/IBM/mcp-context-forge/pull/6483)) - Exposed TLS cipher suite configuration.
 - **Automated MCP server catalog icon generation** ([#6397](https://github.com/IBM/mcp-context-forge/pull/6397)) - Automated MCP server catalog icon generation.
 
+### Breaking Changes
+
+- **Enabled authentication rejects default passwords** - When Basic Auth or email authentication is enabled, empty, placeholder, and known-weak password values now fail startup. Set `BASIC_AUTH_PASSWORD` for `API_ALLOW_BASIC_AUTH=true` or `DOCS_ALLOW_BASIC_AUTH=true`; set `PLATFORM_ADMIN_PASSWORD` and `DEFAULT_USER_PASSWORD` for `EMAIL_AUTH_ENABLED=true`. Existing deployments must run `make init-secrets-patch-env` or update their deployment Secret before restarting. See the [migration guide](docs/docs/operations/default-password-fail-closed-migration.md).
+
 ### Fixed
 
 #### **Security & Auth**

--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,8 @@ install-dev: venv
 	@echo "🔑  Next step — choose one:"
 	@echo "    make setup           # recommended: auto-creates .env and patches secrets in-place"
 	@echo "    make init-secrets    # writes secrets to .env.secrets so you can review before copying"
-	@echo "    The gateway will not start until JWT_SECRET_KEY and AUTH_ENCRYPTION_SECRET are set."
+	@echo "    The gateway will not start until secrets and passwords are configured."
+	@echo "    Run 'make setup' to auto-generate all required values."
 
 # help: build-ui              - Build Admin UI CSS and JS bundles (requires npm; set SKIP_UI_BUILD=1 to bypass)
 .PHONY: build-ui

--- a/charts/mcp-stack/README.md
+++ b/charts/mcp-stack/README.md
@@ -760,9 +760,9 @@ For detailed guidance on resource limits and process management, see `docs/docs/
 | mcpContextForge.secret.EMAIL_AUTH_ENABLED | string | `"true"` |  |
 | mcpContextForge.secret.PROTECT_ALL_ADMINS | string | `"true"` |  |
 | mcpContextForge.secret.PLATFORM_ADMIN_EMAIL | string | `"admin@example.com"` |  |
-| mcpContextForge.secret.PLATFORM_ADMIN_PASSWORD | string | `"changeme"` |  |
+| mcpContextForge.secret.PLATFORM_ADMIN_PASSWORD | string | `""` |  |
 | mcpContextForge.secret.PLATFORM_ADMIN_FULL_NAME | string | `"Platform Administrator"` |  |
-| mcpContextForge.secret.DEFAULT_USER_PASSWORD | string | `"changeme"` |  |
+| mcpContextForge.secret.DEFAULT_USER_PASSWORD | string | `""` |  |
 | mcpContextForge.secret.ARGON2ID_TIME_COST | string | `"3"` |  |
 | mcpContextForge.secret.ARGON2ID_MEMORY_COST | string | `"65536"` |  |
 | mcpContextForge.secret.ARGON2ID_PARALLELISM | string | `"1"` |  |

--- a/charts/mcp-stack/README.md
+++ b/charts/mcp-stack/README.md
@@ -744,7 +744,7 @@ For detailed guidance on resource limits and process management, see `docs/docs/
 | mcpContextForge.config.LOG_SEARCH_MAX_RESULTS | string | `"1000"` |  |
 | mcpContextForge.config.MASKED_AUTH_VALUE | string | `"*****"` |  |
 | mcpContextForge.secret.BASIC_AUTH_USER | string | `"admin"` |  |
-| mcpContextForge.secret.BASIC_AUTH_PASSWORD | string | `"changeme"` |  |
+| mcpContextForge.secret.BASIC_AUTH_PASSWORD | string | `""` |  |
 | mcpContextForge.secret.API_ALLOW_BASIC_AUTH | string | `"false"` |  |
 | mcpContextForge.secret.AUTH_REQUIRED | string | `"true"` |  |
 | mcpContextForge.secret.MCP_REQUIRE_AUTH | string | `"false"` |  |

--- a/charts/mcp-stack/profiles/ocp/values-pgo.yaml
+++ b/charts/mcp-stack/profiles/ocp/values-pgo.yaml
@@ -282,7 +282,7 @@ mcpContextForge:
     JWT_SECRET_KEY: ""  # must be set to a strong value before deploy (run make init-secrets-patch-env)
     AUTH_ENCRYPTION_SECRET: ""  # must be set to a strong value before deploy (run make init-secrets-patch-env)
     BASIC_AUTH_PASSWORD: "changeme"  # CHANGE THIS before deploy  # pragma: allowlist secret
-    PLATFORM_ADMIN_PASSWORD: "changeme"  # CHANGE THIS before deploy  # pragma: allowlist secret
+    PLATFORM_ADMIN_PASSWORD: ""  # must be set to a strong value before deploy (run make init-secrets-patch-env)
     REQUIRE_STRONG_SECRETS: "true"         # gateway refuses to start with weak/default secrets
 
 # --- Migration ---

--- a/charts/mcp-stack/values-minikube.yaml
+++ b/charts/mcp-stack/values-minikube.yaml
@@ -51,7 +51,7 @@ mcpContextForge:
     AUTH_REQUIRED: "true"
     MCP_REQUIRE_AUTH: "true"
     PLATFORM_ADMIN_EMAIL: admin@example.com
-    PLATFORM_ADMIN_PASSWORD: changeme  # CHANGE THIS before deploy  # pragma: allowlist secret
+    PLATFORM_ADMIN_PASSWORD: ""  # must be set to a strong value before deploy (run make init-secrets-patch-env)
     # Relax password policy for local dev bootstrap
     PASSWORD_REQUIRE_UPPERCASE: "false"
     PASSWORD_REQUIRE_LOWERCASE: "false"

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -843,7 +843,7 @@ mcpContextForge:
   secret:
     # ─ Admin & auth ─
     BASIC_AUTH_USER: admin                 # username for basic-auth (when enabled)
-    BASIC_AUTH_PASSWORD: changeme          # password for basic-auth (CHANGE IN PROD!)
+    BASIC_AUTH_PASSWORD: ""                # REQUIRED when API_ALLOW_BASIC_AUTH or DOCS_ALLOW_BASIC_AUTH is true — generate with: make init-secrets
     API_ALLOW_BASIC_AUTH: "false"          # SECURITY: disabled by default - use JWT instead
     AUTH_REQUIRED: "true"                  # enforce authentication globally (true/false)
     MCP_REQUIRE_AUTH: "true"               # require auth for /mcp endpoints (recommended secure default)

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -865,9 +865,9 @@ mcpContextForge:
     EMAIL_AUTH_ENABLED: "true"             # enable email-based authentication system
     PROTECT_ALL_ADMINS: "true"             # allow active admin accounts to bypass login lockout
     PLATFORM_ADMIN_EMAIL: admin@example.com # email for bootstrap platform admin user
-    PLATFORM_ADMIN_PASSWORD: changeme     # password for bootstrap platform admin user
+    PLATFORM_ADMIN_PASSWORD: ""           # REQUIRED — set a strong value; generate with: make init-secrets
     PLATFORM_ADMIN_FULL_NAME: Platform Administrator # full name for bootstrap platform admin
-    DEFAULT_USER_PASSWORD: changeme       # default password for new users (bootstrap)
+    DEFAULT_USER_PASSWORD: ""             # REQUIRED — set a strong value; generate with: make init-secrets
 
     # ─ Password Hashing & Security ─
     ARGON2ID_TIME_COST: "3"                # Argon2id time cost (iterations)

--- a/docker-compose-embedded.yml
+++ b/docker-compose-embedded.yml
@@ -163,6 +163,10 @@ services:
     environment:
       - "JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
       - "AUTH_ENCRYPTION_SECRET=${AUTH_ENCRYPTION_SECRET:?AUTH_ENCRYPTION_SECRET is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
+      # create_jwt_token instantiates Settings(), which fails closed on the default "changeme"
+      # platform_admin_password/default_user_password once email_auth_enabled (default true).
+      - "PLATFORM_ADMIN_PASSWORD=${PLATFORM_ADMIN_PASSWORD:?PLATFORM_ADMIN_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
+      - "DEFAULT_USER_PASSWORD=${DEFAULT_USER_PASSWORD:?DEFAULT_USER_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
       - BENCHMARK_SERVER_COUNT=${BENCHMARK_SERVER_COUNT:-10}
       - BENCHMARK_START_PORT=${BENCHMARK_START_PORT:-9000}
     command:

--- a/docker-compose-embedded.yml
+++ b/docker-compose-embedded.yml
@@ -86,7 +86,8 @@ services:
       - "JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
       - "AUTH_ENCRYPTION_SECRET=${AUTH_ENCRYPTION_SECRET:?AUTH_ENCRYPTION_SECRET is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
       - PLATFORM_ADMIN_EMAIL=admin@example.com
-      - PLATFORM_ADMIN_PASSWORD=Changeme123!
+      - "PLATFORM_ADMIN_PASSWORD=${PLATFORM_ADMIN_PASSWORD:?PLATFORM_ADMIN_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
+      - "DEFAULT_USER_PASSWORD=${DEFAULT_USER_PASSWORD:?DEFAULT_USER_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
       - PLATFORM_ADMIN_FULL_NAME=Platform Administrator
       - TOKEN_EXPIRY=1440
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1338,6 +1338,10 @@ services:
     environment:
       - "JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY is not set. Run: make setup (first time) or make init-secrets-patch-env (if .env exists)}"
       - "AUTH_ENCRYPTION_SECRET=${AUTH_ENCRYPTION_SECRET:?AUTH_ENCRYPTION_SECRET is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
+      # create_jwt_token instantiates Settings(), which fails closed on the default "changeme"
+      # platform_admin_password/default_user_password once email_auth_enabled (default true).
+      - "PLATFORM_ADMIN_PASSWORD=${PLATFORM_ADMIN_PASSWORD:?PLATFORM_ADMIN_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
+      - "DEFAULT_USER_PASSWORD=${DEFAULT_USER_PASSWORD:?DEFAULT_USER_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
@@ -1923,6 +1927,11 @@ services:
         condition: service_healthy
     environment:
       - "JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY is not set. Run: make setup (first time) or make init-secrets-patch-env (if .env exists)}"
+      - "AUTH_ENCRYPTION_SECRET=${AUTH_ENCRYPTION_SECRET:?AUTH_ENCRYPTION_SECRET is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
+      # create_jwt_token instantiates Settings(), which fails closed on the default "changeme"
+      # platform_admin_password/default_user_password once email_auth_enabled (default true).
+      - "PLATFORM_ADMIN_PASSWORD=${PLATFORM_ADMIN_PASSWORD:?PLATFORM_ADMIN_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
+      - "DEFAULT_USER_PASSWORD=${DEFAULT_USER_PASSWORD:?DEFAULT_USER_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
     restart: "no"
     entrypoint: ["/bin/sh", "-c"]
     command:
@@ -2044,6 +2053,10 @@ services:
     environment:
       - "JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY is not set. Run: make setup (first time) or make init-secrets-patch-env (if .env exists)}"
       - "AUTH_ENCRYPTION_SECRET=${AUTH_ENCRYPTION_SECRET:?AUTH_ENCRYPTION_SECRET is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
+      # create_jwt_token instantiates Settings(), which fails closed on the default "changeme"
+      # platform_admin_password/default_user_password once email_auth_enabled (default true).
+      - "PLATFORM_ADMIN_PASSWORD=${PLATFORM_ADMIN_PASSWORD:?PLATFORM_ADMIN_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
+      - "DEFAULT_USER_PASSWORD=${DEFAULT_USER_PASSWORD:?DEFAULT_USER_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
     restart: "no"
     entrypoint: ["/bin/sh", "-c"]
     command:
@@ -2116,6 +2129,10 @@ services:
     environment:
       - "JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY is not set. Run: make setup (first time) or make init-secrets-patch-env (if .env exists)}"
       - "AUTH_ENCRYPTION_SECRET=${AUTH_ENCRYPTION_SECRET:?AUTH_ENCRYPTION_SECRET is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
+      # create_jwt_token instantiates Settings(), which fails closed on the default "changeme"
+      # platform_admin_password/default_user_password once email_auth_enabled (default true).
+      - "PLATFORM_ADMIN_PASSWORD=${PLATFORM_ADMIN_PASSWORD:?PLATFORM_ADMIN_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
+      - "DEFAULT_USER_PASSWORD=${DEFAULT_USER_PASSWORD:?DEFAULT_USER_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
@@ -2287,6 +2304,10 @@ services:
     environment:
       - "JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY is not set. Run: make setup (first time) or make init-secrets-patch-env (if .env exists)}"
       - "AUTH_ENCRYPTION_SECRET=${AUTH_ENCRYPTION_SECRET:?AUTH_ENCRYPTION_SECRET is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
+      # create_jwt_token instantiates Settings(), which fails closed on the default "changeme"
+      # platform_admin_password/default_user_password once email_auth_enabled (default true).
+      - "PLATFORM_ADMIN_PASSWORD=${PLATFORM_ADMIN_PASSWORD:?PLATFORM_ADMIN_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
+      - "DEFAULT_USER_PASSWORD=${DEFAULT_USER_PASSWORD:?DEFAULT_USER_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
       - BENCHMARK_SERVER_COUNT=${BENCHMARK_SERVER_COUNT:-10}
       - BENCHMARK_START_PORT=${BENCHMARK_START_PORT:-9000}
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1588,6 +1588,10 @@ services:
     environment:
       - "JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY is not set. Run: make setup (first time) or make init-secrets-patch-env (if .env exists)}"
       - "AUTH_ENCRYPTION_SECRET=${AUTH_ENCRYPTION_SECRET:?AUTH_ENCRYPTION_SECRET is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
+      # create_jwt_token instantiates Settings(), which fails closed on the default "changeme"
+      # platform_admin_password/default_user_password once email_auth_enabled (default true).
+      - "PLATFORM_ADMIN_PASSWORD=${PLATFORM_ADMIN_PASSWORD:?PLATFORM_ADMIN_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
+      - "DEFAULT_USER_PASSWORD=${DEFAULT_USER_PASSWORD:?DEFAULT_USER_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
       - "GATEWAY_URL=${GATEWAY_URL:-http://gateway:4444}"
 
     # This is a one-shot container that exits after registration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -349,12 +349,12 @@ services:
       # - BASIC_AUTH_PASSWORD=${BASIC_AUTH_PASSWORD:-changeme}
       # Auth encryption secret + default user password
       - "AUTH_ENCRYPTION_SECRET=${AUTH_ENCRYPTION_SECRET:?AUTH_ENCRYPTION_SECRET is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
-      - DEFAULT_USER_PASSWORD=${DEFAULT_USER_PASSWORD:-changeme}
+      - "DEFAULT_USER_PASSWORD=${DEFAULT_USER_PASSWORD:?DEFAULT_USER_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
       # Admin UI uses email/password authentication
       - EMAIL_AUTH_ENABLED=true
       - PROTECT_ALL_ADMINS=${PROTECT_ALL_ADMINS:-true}
       - PLATFORM_ADMIN_EMAIL=${PLATFORM_ADMIN_EMAIL:-admin@example.com}
-      - PLATFORM_ADMIN_PASSWORD=${PLATFORM_ADMIN_PASSWORD:-changeme}
+      - "PLATFORM_ADMIN_PASSWORD=${PLATFORM_ADMIN_PASSWORD:?PLATFORM_ADMIN_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
       # Compose default off so /admin/* REST works without bootstrap redirect; override for production.
       - PASSWORD_CHANGE_ENFORCEMENT_ENABLED=${PASSWORD_CHANGE_ENFORCEMENT_ENABLED:-true}
       - ACCOUNT_LOCKOUT_NOTIFICATION_ENABLED=${ACCOUNT_LOCKOUT_NOTIFICATION_ENABLED:-true}
@@ -1076,10 +1076,13 @@ services:
     environment:
       - DATABASE_URL=postgresql+psycopg://postgres:${POSTGRES_PASSWORD:-mysecretpassword}@postgres:5432/mcp
       - "JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY is not set. Run: make setup (first time) or make init-secrets-patch-env (if .env exists)}"
+      # Basic auth is DISABLED by default for security (API_ALLOW_BASIC_AUTH unset here)
+      # Only set these if you explicitly enable Basic auth for this container
       - BASIC_AUTH_USER=${BASIC_AUTH_USER:-admin}
-      - BASIC_AUTH_PASSWORD=${BASIC_AUTH_PASSWORD:-changeme}
+      # - BASIC_AUTH_PASSWORD=${BASIC_AUTH_PASSWORD:-changeme}
       - PLATFORM_ADMIN_EMAIL=${PLATFORM_ADMIN_EMAIL:-admin@example.com}
-      - PLATFORM_ADMIN_PASSWORD=${PLATFORM_ADMIN_PASSWORD:-changeme}
+      - "PLATFORM_ADMIN_PASSWORD=${PLATFORM_ADMIN_PASSWORD:?PLATFORM_ADMIN_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
+      - "DEFAULT_USER_PASSWORD=${DEFAULT_USER_PASSWORD:?DEFAULT_USER_PASSWORD is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
       - AUTH_REQUIRED=${AUTH_REQUIRED:-true}
       - "AUTH_ENCRYPTION_SECRET=${AUTH_ENCRYPTION_SECRET:?AUTH_ENCRYPTION_SECRET is not set. Run: make setup (if .env does not exist) or make init-secrets-patch-env (if .env exists)}"
       - LOG_LEVEL=${LOG_LEVEL:-INFO}

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -6,22 +6,33 @@ This guide provides comprehensive configuration options for ContextForge, includ
 
 ## 🔐 Required: Change Before Use
 
-These variables have insecure defaults and **must be changed** before production deployment:
+These variables have insecure built-in placeholders. Set each credential before enabling its consuming authentication feature; the gateway rejects empty, placeholder, and known-weak password values at startup.
 
 | Variable | Description | Default | Action Required |
 |----------|-------------|---------|-----------------|
 | `JWT_SECRET_KEY` | Secret key for signing JWT tokens | *(must be set — no default)* | Generate with `make init-secrets-patch-env` or `openssl rand -hex 32` |
 | `AUTH_ENCRYPTION_SECRET` | Passphrase for encrypting stored credentials | *(must be set — no default)* | Generate with `make init-secrets-patch-env` or `openssl rand -hex 32` |
 | `BASIC_AUTH_USER` | Username for HTTP Basic auth | `admin` | Change for production |
-| `BASIC_AUTH_PASSWORD` | Password for HTTP Basic auth | `changeme` | Set a strong password |
+| `BASIC_AUTH_PASSWORD` | Password for HTTP Basic auth | `changeme` (rejected when Basic Auth is enabled) | Set a strong password |
 | `PLATFORM_ADMIN_EMAIL` | Email for bootstrap admin user | `admin@example.com` | Use real admin email |
-| `PLATFORM_ADMIN_PASSWORD` | Password for bootstrap admin user | `changeme` | Set a strong password |
-| `DEFAULT_USER_PASSWORD` | Default password for new users | `changeme` | Set a strong password |
+| `PLATFORM_ADMIN_PASSWORD` | Password for bootstrap admin user | `changeme` (rejected when email auth is enabled) | Set a strong password |
+| `DEFAULT_USER_PASSWORD` | Default password for new users | `changeme` (rejected when email auth is enabled) | Set a strong password |
 
-Copy [.env.example](https://github.com/IBM/mcp-context-forge/blob/main/.env.example) to `.env` and update these values.
+Copy [.env.example](https://github.com/IBM/mcp-context-forge/blob/main/.env.example) to `.env`, then run `make setup` or `make init-secrets-patch-env`.
 
 !!! warning "Startup Validation"
-    If any required `.env` variable is missing or invalid, the gateway will fail fast at startup with a validation error via Pydantic.
+    If an enabled authentication feature has a missing, placeholder, or known-weak password, the gateway fails fast at startup with a Pydantic validation error.
+
+### Migrating Existing Deployments
+
+Before upgrading, set strong values for every enabled authentication path:
+
+1. Run `make init-secrets-patch-env` against the existing `.env`, or set the values manually.
+2. Set `BASIC_AUTH_PASSWORD` when `API_ALLOW_BASIC_AUTH=true` or `DOCS_ALLOW_BASIC_AUTH=true`.
+3. Set `PLATFORM_ADMIN_PASSWORD` and `DEFAULT_USER_PASSWORD` when `EMAIL_AUTH_ENABLED=true`.
+4. For Helm or Kubernetes, update the corresponding Secret values before restarting the gateway.
+
+Deployments that previously relied on `changeme`, an empty value, or a `__REPLACE_ME__` placeholder will not start until the affected credential is replaced. See the [full migration guide](../operations/default-password-fail-closed-migration.md) for verification steps and rollback notes.
 
 ### 🔒 Security Defaults (Secure by Default)
 
@@ -137,7 +148,7 @@ appropriate secure-cookie, SameSite, credential, and CSRF configuration.
 | Setting                     | Description                                                                  | Default             | Options     |
 |-----------------------------|------------------------------------------------------------------------------|---------------------|-------------|
 | `BASIC_AUTH_USER`           | Username for HTTP Basic authentication (when enabled)                        | `admin`             | string      |
-| `BASIC_AUTH_PASSWORD`       | Password for HTTP Basic authentication (when enabled)                        | `changeme`          | string      |
+| `BASIC_AUTH_PASSWORD`       | Password for HTTP Basic authentication (when enabled)                        | `changeme` (rejected when enabled) | string      |
 | `API_ALLOW_BASIC_AUTH`      | Enable Basic auth for API endpoints (disabled by default for security)       | `false`             | bool        |
 | `DOCS_ALLOW_BASIC_AUTH`     | Enable Basic auth for docs endpoints (disabled by default)                   | `false`             | bool        |
 | `PLATFORM_ADMIN_EMAIL`      | Email for bootstrap platform admin user (auto-created with admin privileges). Also used as the default identity for OAuth health-check token lookups on `authorization_code` gateways — if this user has not completed consent for a gateway, health checks proceed unauthenticated (expected behaviour). | `admin@example.com` | string      |
@@ -408,9 +419,9 @@ curl -X POST -H "Authorization: Bearer $TOKEN" \
 | ------------------------------ | ------------------------------------------------ | --------------------- | ------- |
 | `EMAIL_AUTH_ENABLED`          | Enable email-based authentication system         | `true`                | bool    |
 | `PLATFORM_ADMIN_EMAIL`        | Email for bootstrap platform admin user          | `admin@example.com`   | string  |
-| `PLATFORM_ADMIN_PASSWORD`     | Password for bootstrap platform admin user       | `changeme`            | string  |
+| `PLATFORM_ADMIN_PASSWORD`     | Password for bootstrap platform admin user       | `changeme` (rejected when email auth is enabled) | string  |
 | `PLATFORM_ADMIN_FULL_NAME`    | Full name for bootstrap platform admin user      | `Platform Administrator` | string |
-| `DEFAULT_USER_PASSWORD`       | Default password for newly created users         | `changeme`            | string  |
+| `DEFAULT_USER_PASSWORD`       | Default password for newly created users         | `changeme` (rejected when email auth is enabled) | string  |
 | `ARGON2ID_TIME_COST`          | Argon2id time cost (iterations)                  | `3`                   | int > 0 |
 | `ARGON2ID_MEMORY_COST`        | Argon2id memory cost in KiB                      | `65536`               | int > 0 |
 | `ARGON2ID_PARALLELISM`        | Argon2id parallelism (threads)                   | `1`                   | int > 0 |
@@ -1361,9 +1372,11 @@ HOST=0.0.0.0
 PORT=4444
 DATABASE_URL=postgresql+psycopg://postgres:changeme@postgres:5432/mcp
 REDIS_URL=redis://redis:6379/0
-JWT_SECRET_KEY=my-secret-key
-BASIC_AUTH_USER=admin
-BASIC_AUTH_PASSWORD=changeme
+JWT_SECRET_KEY=$(openssl rand -hex 32)
+AUTH_ENCRYPTION_SECRET=$(openssl rand -hex 32)
+BASIC_AUTH_PASSWORD=$(openssl rand -base64 24 | tr -d '\n')
+PLATFORM_ADMIN_PASSWORD=$(openssl rand -base64 24 | tr -d '\n')
+DEFAULT_USER_PASSWORD=$(openssl rand -base64 24 | tr -d '\n')
 MCPGATEWAY_UI_ENABLED=true
 MCPGATEWAY_ADMIN_API_ENABLED=true
 # Embedded UI mode (hides logout + team selector by default)

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -1399,7 +1399,7 @@ services:
     environment:
       - DATABASE_URL=postgresql+psycopg://postgres:changeme@postgres:5432/mcp
       - REDIS_URL=redis://redis:6379/0
-      - JWT_SECRET_KEY=my-secret-key
+      - JWT_SECRET_KEY=$(openssl rand -hex 32)
     depends_on:
       postgres:
         condition: service_healthy
@@ -1446,11 +1446,13 @@ data:
   REDIS_URL: "redis://redis-service:6379/0"
   JWT_SECRET_KEY: "your-secret-key"
   BASIC_AUTH_USER: "admin"
-  BASIC_AUTH_PASSWORD: "changeme"
+  BASIC_AUTH_PASSWORD: "__REPLACE_ME__run_make_init-secrets-patch-env"
   MCPGATEWAY_UI_ENABLED: "true"
   MCPGATEWAY_ADMIN_API_ENABLED: "true"
   LOG_LEVEL: "INFO"
 ```
+
+`BASIC_AUTH_PASSWORD` is only enforced when `API_ALLOW_BASIC_AUTH` or `DOCS_ALLOW_BASIC_AUTH` is `true`. Replace the `__REPLACE_ME__...` placeholder with a strong value (e.g. `openssl rand -hex 32`) before enabling either — the gateway refuses to start with a placeholder, empty, or known-weak secret.
 
 ---
 

--- a/docs/docs/operations/default-password-fail-closed-migration.md
+++ b/docs/docs/operations/default-password-fail-closed-migration.md
@@ -1,0 +1,95 @@
+# Default Password Fail-Closed Migration
+
+`BASIC_AUTH_PASSWORD`, `PLATFORM_ADMIN_PASSWORD`, and `DEFAULT_USER_PASSWORD` now
+fail startup when they hold an empty, placeholder, or known-weak value (`changeme`
+and similar) **and the authentication feature that consumes them is enabled**.
+This document covers who is affected and how to migrate.
+
+> ℹ️ This is the password-side counterpart to the `JWT_SECRET_KEY` /
+> `AUTH_ENCRYPTION_SECRET` fail-closed enforcement. Unlike `AUTH_ENCRYPTION_SECRET`,
+> no data is encrypted under these passwords — rotation is a simple config update
+> and restart, no re-encryption script required. See
+> [`AUTH_ENCRYPTION_SECRET` Rotation](auth-encryption-secret-rotation.md) if you
+> also need to rotate that secret.
+
+---
+
+## Who is affected
+
+The check is feature-gated: it only fires when the credential's consuming
+authentication path is enabled.
+
+| Credential | Fails startup when | Consuming feature |
+|---|---|---|
+| `BASIC_AUTH_PASSWORD` | `API_ALLOW_BASIC_AUTH=true` or `DOCS_ALLOW_BASIC_AUTH=true` | HTTP Basic Auth on the API or `/docs` |
+| `PLATFORM_ADMIN_PASSWORD` | `EMAIL_AUTH_ENABLED=true` (the default) | Email/password authentication, platform-admin bootstrap |
+| `DEFAULT_USER_PASSWORD` | `EMAIL_AUTH_ENABLED=true` (the default) | Email/password authentication, default password detection |
+
+If the corresponding feature is disabled, the weak value is still accepted (with a
+warning) — nothing changes for deployments that never enabled that path.
+
+`EMAIL_AUTH_ENABLED` defaults to `true`, so most existing deployments are affected
+by the `PLATFORM_ADMIN_PASSWORD` / `DEFAULT_USER_PASSWORD` checks even if they never
+explicitly set that flag.
+
+A value is rejected if it is:
+
+- empty
+- an unset placeholder (`__REPLACE_ME__...` or `ReplaceMe_...`)
+- a known-weak value (`changeme`, `password`, `secret`, etc. — see `WEAK_VALUES` in
+  `mcpgateway/_security_constants.py`)
+
+---
+
+## Migration steps
+
+1. **Generate strong values** for every credential whose feature is enabled:
+
+   ```bash
+   # Repository checkout — patches .env in place, only touches weak/placeholder values
+   make init-secrets-patch-env
+
+   # Or generate values manually
+   python3 -c "import secrets; print(secrets.token_urlsafe(18))"
+   ```
+
+2. **Set the values** in whichever configuration source your deployment reads:
+   - `.env` file — patched automatically by `make init-secrets-patch-env`.
+   - Docker Compose — set `BASIC_AUTH_PASSWORD`, `PLATFORM_ADMIN_PASSWORD`,
+     `DEFAULT_USER_PASSWORD` in your `.env` or the compose environment block.
+   - Helm / Kubernetes — update the `mcpContextForge.secret.PLATFORM_ADMIN_PASSWORD`
+     / `DEFAULT_USER_PASSWORD` / `BASIC_AUTH_PASSWORD` values (or your Secret
+     object) before rolling out the new image.
+
+3. **Restart the gateway.** No database migration or re-encryption is required —
+   the check runs once at startup against the configured value.
+
+---
+
+## Verifying the migration
+
+Startup logs will show a `SecurityConfigurationError` naming the offending field if
+a credential still needs attention, for example:
+
+```
+mcpgateway.config.SecurityConfigurationError: platform_admin_password: known-weak/default value rejected. Run 'python -m mcpgateway.scripts.init_secrets' to generate strong values, or use 'make init-secrets-patch-env' to write them directly into .env.
+```
+
+A clean startup with no `SecurityConfigurationError` for these fields confirms the
+migration is complete.
+
+---
+
+## Rollback (not recommended)
+
+Downgrading to a version without this check re-enables startup with a default
+password if the consuming feature is on. This is a security regression — only use
+it in isolated, non-production environments.
+
+---
+
+## Related documentation
+
+- [Configuration Reference — Required: Change Before Use](../manage/configuration.md)
+- [`AUTH_ENCRYPTION_SECRET` Rotation](auth-encryption-secret-rotation.md)
+- `CHANGELOG.md` — Unreleased — Breaking Changes

--- a/docs/docs/overview/quick_start.md
+++ b/docs/docs/overview/quick_start.md
@@ -31,7 +31,7 @@ Pick an install method below, generate an auth token, then walk through a real t
     MCPGATEWAY_UI_ENABLED=true \
     MCPGATEWAY_ADMIN_API_ENABLED=true \
     PLATFORM_ADMIN_EMAIL=admin@example.com \
-    PLATFORM_ADMIN_PASSWORD=changeme \
+    PLATFORM_ADMIN_PASSWORD=quickstart-admin-change-me \
     PLATFORM_ADMIN_FULL_NAME="Platform Administrator" \
     uvx --from mcp-contextforge-gateway mcpgateway --host 0.0.0.0 --port 4444
 
@@ -78,7 +78,7 @@ Pick an install method below, generate an auth token, then walk through a real t
         export MCPGATEWAY_UI_ENABLED=true
         export MCPGATEWAY_ADMIN_API_ENABLED=true
         export PLATFORM_ADMIN_EMAIL=admin@example.com
-        export PLATFORM_ADMIN_PASSWORD=changeme
+        export PLATFORM_ADMIN_PASSWORD=quickstart-admin-change-me
         export PLATFORM_ADMIN_FULL_NAME="Platform Administrator"
         mcpgateway --host 0.0.0.0 --port 4444
         ```
@@ -120,7 +120,7 @@ Pick an install method below, generate an auth token, then walk through a real t
           -e HOST=0.0.0.0 \
           -e JWT_SECRET_KEY=my-test-key-but-now-longer-than-32-bytes \
           -e PLATFORM_ADMIN_EMAIL=admin@example.com \
-          -e PLATFORM_ADMIN_PASSWORD=changeme \
+          -e PLATFORM_ADMIN_PASSWORD=quickstart-admin-change-me \
           -e PLATFORM_ADMIN_FULL_NAME="Platform Administrator" \
           ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
         ```
@@ -136,7 +136,7 @@ Pick an install method below, generate an auth token, then walk through a real t
               -e DATABASE_URL=sqlite:////data/mcp.db \
               -e JWT_SECRET_KEY=my-test-key-but-now-longer-than-32-bytes \
               -e PLATFORM_ADMIN_EMAIL=admin@example.com \
-              -e PLATFORM_ADMIN_PASSWORD=changeme \
+              -e PLATFORM_ADMIN_PASSWORD=quickstart-admin-change-me \
               -e PLATFORM_ADMIN_FULL_NAME="Platform Administrator" \
               ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
             ```
@@ -158,7 +158,7 @@ Pick an install method below, generate an auth token, then walk through a real t
               -e DATABASE_URL=postgresql+psycopg://postgres:mysecretpassword@postgres:5432/mcp \
               -e JWT_SECRET_KEY=my-test-key-but-now-longer-than-32-bytes \
               -e PLATFORM_ADMIN_EMAIL=admin@example.com \
-              -e PLATFORM_ADMIN_PASSWORD=changeme \
+              -e PLATFORM_ADMIN_PASSWORD=quickstart-admin-change-me \
               -e PLATFORM_ADMIN_FULL_NAME="Platform Administrator" \
               ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
             ```

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1634,18 +1634,77 @@ class Settings(BaseSettings):
 
         return v
 
+    @staticmethod
+    def _enforce_secret_strength(
+        field_name: str,
+        value: str,
+        weak_secrets: set[str],
+        *,
+        min_length: int = 0,
+        min_entropy: float = 0.0,
+        check_placeholder: bool = False,
+        hint: str = "",
+    ) -> None:
+        """Raise ``SecurityConfigurationError`` if *value* fails any enabled check.
+
+        Used by ``validate_security_combinations`` for both unconditional secret
+        enforcement (JWT, encryption) and feature-gated password enforcement.
+
+        Args:
+            field_name: Config field name for the error message.
+            value: The secret or password value to check.
+            weak_secrets: Lower-cased set of known-weak values.
+            min_length: Minimum length (0 = skip check).
+            min_entropy: Minimum Shannon entropy (0.0 = skip check).
+            check_placeholder: Also reject empty and ``__REPLACE_ME__`` values.
+            hint: Extra text appended to the error message (e.g. rotation guide URL).
+        """
+        remediation = (
+            "Run 'python -m mcpgateway.scripts.init_secrets' to generate strong values, "
+            "or use 'make init-secrets-patch-env' to write them directly into .env."
+        )
+
+        if check_placeholder and not value.strip():
+            raise SecurityConfigurationError(
+                f"{field_name}: secret is empty. {remediation}{hint}"
+            )
+
+        if min_length and len(value) < min_length:
+            raise SecurityConfigurationError(
+                f"{field_name}: too short ({len(value)} chars, minimum {min_length}). "
+                f"{remediation}{hint}"
+            )
+
+        if check_placeholder and value.lower().startswith(("__replace_me__", "replaceme")):
+            raise SecurityConfigurationError(
+                f"{field_name}: unset placeholder (__REPLACE_ME__) rejected. "
+                f"{remediation}{hint}"
+            )
+
+        if value.lower() in weak_secrets:
+            raise SecurityConfigurationError(
+                f"{field_name}: known-weak/default value rejected. "
+                f"{remediation}{hint}"
+            )
+
+        if min_entropy:
+            entropy = calculate_entropy(value)
+            if entropy < min_entropy:
+                raise SecurityConfigurationError(
+                    f"{field_name}: low entropy (score {entropy:.2f} < {min_entropy}). "
+                    f"{remediation}{hint}"
+                )
+
     @model_validator(mode="after")
     def validate_security_combinations(self) -> Self:
         """Validate security setting combinations and raise on unsafe secrets.
 
-        Placeholder and weak/known secrets are rejected unconditionally in every
-        environment (development, staging, and production alike).  Some compose
-        sibling containers (e.g. ``register_fast_time``, ``prometheus_token``)
-        sign tokens with the raw ``JWT_SECRET_KEY`` environment variable outside
-        this validator, so per-process random generation cannot be used as a
-        fallback — gateway and sibling containers must share the same secret.
-        The only safe option is an unconditional hard-fail that forces operators
-        to provide a real secret before the process will start.
+        Secrets (``jwt_secret_key``, ``auth_encryption_secret``) are checked
+        unconditionally for empty, placeholder, weak, short, and low-entropy
+        values.  Password credentials (``basic_auth_password``,
+        ``platform_admin_password``, ``default_user_password``) are checked for
+        empty, placeholder, and known-weak values when their consuming
+        authentication feature is enabled (feature-gated fail-closed).
 
         Run ``python -m mcpgateway.scripts.init_secrets`` (or ``make init-secrets``
         for interactive use, ``make init-secrets-patch-env`` to write directly into
@@ -1655,59 +1714,49 @@ class Settings(BaseSettings):
             Itself.
 
         Raises:
-            SecurityConfigurationError: If jwt_secret_key or auth_encryption_secret
-                is unset (placeholder), matches a known-weak value, is shorter than
-                ``min_secret_length`` characters, or has low per-character entropy.
+            SecurityConfigurationError: If a secret or feature-gated password
+                fails its strength checks.
         """
-        # client_mode is intentionally NOT exempted — secret-strength enforcement
-        # is always active regardless of deployment profile.
         weak_secrets = {v.lower() for v in self.WEAK_VALUES}
-        env = str(self.environment).lower()
+        effective_min = max(self.min_secret_length, _MIN_SECRET_LENGTH)
+
+        # Unconditional: JWT + encryption secrets (full strength checks)
         for field_name, secret_field in (
             ("jwt_secret_key", self.jwt_secret_key),
             ("auth_encryption_secret", self.auth_encryption_secret),
         ):
-            val = secret_field.get_secret_value()
-
-            # For auth_encryption_secret failures, append the secrets rotation guide URL
-            # so operators upgrading from 1.0.7 know how to re-encrypt stored credentials.
-            rotation_hint = (
+            hint = (
                 "\nIf you have stored credentials encrypted under the old key, "
                 "you must rotate them before starting the gateway.\n"
                 "Rotation guide: docs/docs/operations/auth-encryption-secret-rotation.md"
                 if field_name == "auth_encryption_secret"
                 else ""
             )
+            self._enforce_secret_strength(
+                field_name, secret_field.get_secret_value(), weak_secrets,
+                min_length=effective_min, min_entropy=_MIN_ENTROPY,
+                check_placeholder=True, hint=hint,
+            )
 
-            if not val.strip():
-                raise SecurityConfigurationError(f"{field_name}: secret is empty. Set a real value (run 'python -m mcpgateway.scripts.init_secrets').")
+        # Feature-gated: password credentials (empty, placeholder, or weak)
+        if self.api_allow_basic_auth or self.docs_allow_basic_auth:
+            self._enforce_secret_strength(
+                "basic_auth_password",
+                self.basic_auth_password.get_secret_value(),
+                weak_secrets,
+                check_placeholder=True,
+            )
 
-            effective_min = max(self.min_secret_length, _MIN_SECRET_LENGTH)
-            if len(val) < effective_min:
-                raise SecurityConfigurationError(
-                    f"{field_name}: too short ({len(val)} chars, minimum {effective_min}). "
-                    "Run 'python -m mcpgateway.scripts.init_secrets' to generate strong values, "
-                    "or use 'make init-secrets-patch-env' to write them directly into .env." + rotation_hint
-                )
-
-            is_placeholder = val.lower().startswith("__replace_me__")
-            is_weak = val.lower() in weak_secrets
-            entropy = calculate_entropy(val)
-            is_low_entropy = entropy < _MIN_ENTROPY
-
-            if is_placeholder or is_weak or is_low_entropy:
-                if is_placeholder:
-                    reason = "unset placeholder (__REPLACE_ME__)"
-                elif is_weak:
-                    reason = "known-weak/default value"
-                else:
-                    reason = f"low entropy (score {entropy:.2f} < {_MIN_ENTROPY})"
-                raise SecurityConfigurationError(
-                    f"{field_name}: {reason} rejected in every environment (including '{env}'). "
-                    "Cross-process token consistency requires operators to supply a real secret before startup — "
-                    "no per-process random fallback is generated. "
-                    "Run 'python -m mcpgateway.scripts.init_secrets' to generate strong values, "
-                    "or use 'make init-secrets-patch-env' to write them directly into .env." + rotation_hint
+        if self.email_auth_enabled:
+            for pw_field, pw_secret in (
+                ("platform_admin_password", self.platform_admin_password),
+                ("default_user_password", self.default_user_password),
+            ):
+                self._enforce_secret_strength(
+                    pw_field,
+                    pw_secret.get_secret_value(),
+                    weak_secrets,
+                    check_placeholder=True,
                 )
 
         if not self.client_mode:
@@ -1904,7 +1953,7 @@ class Settings(BaseSettings):
         for name, value in critical_secrets.items():
             if name == "BASIC_AUTH_PASSWORD" and not (self.mcpgateway_ui_enabled or self.api_allow_basic_auth or self.docs_allow_basic_auth):
                 continue
-            is_sentinel = value in self.SENTINEL_VALUES or value.lower().startswith("__replace_me__")
+            is_sentinel = value in self.SENTINEL_VALUES or value.lower().startswith(("__replace_me__", "replaceme"))
 
             if is_sentinel:
                 error_msg = f"{name} is not configured. Running with default or empty values in production is prohibited as it leaves the gateway unprotected."

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1685,9 +1685,12 @@ class Settings(BaseSettings):
         Secrets (``jwt_secret_key``, ``auth_encryption_secret``) are checked
         unconditionally for empty, placeholder, weak, short, and low-entropy
         values.  Password credentials (``basic_auth_password``,
-        ``platform_admin_password``, ``default_user_password``) are checked for
-        empty, placeholder, and known-weak values when their consuming
-        authentication feature is enabled (feature-gated fail-closed).
+        empty, placeholder, known-weak, and too-short (below
+        ``password_min_length_user``, the OWASP baseline) values when their
+        consuming authentication feature is enabled (feature-gated fail-closed).
+        No entropy floor is applied to passwords: the Shannon-entropy check used
+        for random secrets is a poor signal for human-chosen passwords and the
+        length + known-weak-value checks already cover the realistic risk.
 
         Run ``python -m mcpgateway.scripts.init_secrets`` (or ``make init-secrets``
         for interactive use, ``make init-secrets-patch-env`` to write directly into
@@ -1725,12 +1728,13 @@ class Settings(BaseSettings):
                 hint=hint,
             )
 
-        # Feature-gated: password credentials (empty, placeholder, or weak)
+        # Feature-gated: password credentials (empty, placeholder, weak, or too short)
         if self.api_allow_basic_auth or self.docs_allow_basic_auth:
             self._enforce_secret_strength(
                 "basic_auth_password",
                 self.basic_auth_password.get_secret_value(),
                 weak_secrets,
+                min_length=self.password_min_length_user,
                 check_placeholder=True,
             )
 
@@ -1743,6 +1747,7 @@ class Settings(BaseSettings):
                     pw_field,
                     pw_secret.get_secret_value(),
                     weak_secrets,
+                    min_length=self.password_min_length_user,
                     check_placeholder=True,
                 )
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1659,41 +1659,24 @@ class Settings(BaseSettings):
             check_placeholder: Also reject empty and ``__REPLACE_ME__`` values.
             hint: Extra text appended to the error message (e.g. rotation guide URL).
         """
-        remediation = (
-            "Run 'python -m mcpgateway.scripts.init_secrets' to generate strong values, "
-            "or use 'make init-secrets-patch-env' to write them directly into .env."
-        )
+        remediation = "Run 'python -m mcpgateway.scripts.init_secrets' to generate strong values, or use 'make init-secrets-patch-env' to write them directly into .env."
 
         if check_placeholder and not value.strip():
-            raise SecurityConfigurationError(
-                f"{field_name}: secret is empty. {remediation}{hint}"
-            )
+            raise SecurityConfigurationError(f"{field_name}: secret is empty. {remediation}{hint}")
 
         if min_length and len(value) < min_length:
-            raise SecurityConfigurationError(
-                f"{field_name}: too short ({len(value)} chars, minimum {min_length}). "
-                f"{remediation}{hint}"
-            )
+            raise SecurityConfigurationError(f"{field_name}: too short ({len(value)} chars, minimum {min_length}). {remediation}{hint}")
 
         if check_placeholder and value.lower().startswith(("__replace_me__", "replaceme")):
-            raise SecurityConfigurationError(
-                f"{field_name}: unset placeholder (__REPLACE_ME__) rejected. "
-                f"{remediation}{hint}"
-            )
+            raise SecurityConfigurationError(f"{field_name}: unset placeholder (__REPLACE_ME__) rejected. {remediation}{hint}")
 
         if value.lower() in weak_secrets:
-            raise SecurityConfigurationError(
-                f"{field_name}: known-weak/default value rejected. "
-                f"{remediation}{hint}"
-            )
+            raise SecurityConfigurationError(f"{field_name}: known-weak/default value rejected. {remediation}{hint}")
 
         if min_entropy:
             entropy = calculate_entropy(value)
             if entropy < min_entropy:
-                raise SecurityConfigurationError(
-                    f"{field_name}: low entropy (score {entropy:.2f} < {min_entropy}). "
-                    f"{remediation}{hint}"
-                )
+                raise SecurityConfigurationError(f"{field_name}: low entropy (score {entropy:.2f} < {min_entropy}). {remediation}{hint}")
 
     @model_validator(mode="after")
     def validate_security_combinations(self) -> Self:
@@ -1733,9 +1716,13 @@ class Settings(BaseSettings):
                 else ""
             )
             self._enforce_secret_strength(
-                field_name, secret_field.get_secret_value(), weak_secrets,
-                min_length=effective_min, min_entropy=_MIN_ENTROPY,
-                check_placeholder=True, hint=hint,
+                field_name,
+                secret_field.get_secret_value(),
+                weak_secrets,
+                min_length=effective_min,
+                min_entropy=_MIN_ENTROPY,
+                check_placeholder=True,
+                hint=hint,
             )
 
         # Feature-gated: password credentials (empty, placeholder, or weak)

--- a/mcpgateway/scripts/init_secrets.py
+++ b/mcpgateway/scripts/init_secrets.py
@@ -86,10 +86,12 @@ _SECRET_FIELDS: dict[str, int] = {
     "JWT_SECRET_KEY": 32,  # nosec B105 — value is minimum byte length, not a password
     "AUTH_ENCRYPTION_SECRET": 32,  # nosec B105 — value is minimum byte length, not a password
     "BASIC_AUTH_PASSWORD": 18,  # nosec B105 — patched when "changeme" or placeholder; 18 bytes → 24 chars
+    "PLATFORM_ADMIN_PASSWORD": 18,  # nosec B105 — patched when "changeme" or placeholder; 18 bytes → 24 chars
+    "DEFAULT_USER_PASSWORD": 18,  # nosec B105 — patched when "changeme" or placeholder; 18 bytes → 24 chars
 }
 
 # Fields subject to the full compliance predicate (startup hard-fail): length + entropy enforced.
-# BASIC_AUTH_PASSWORD is excluded — Settings only warns on it, never hard-fails.
+# Password fields are excluded — Settings hard-fails only when the consuming feature is enabled.
 _STRONG_SECRET_FIELDS: frozenset[str] = frozenset({"JWT_SECRET_KEY", "AUTH_ENCRYPTION_SECRET"})
 
 # Fields where auto-rotation without a data-migration is irreversible.
@@ -108,7 +110,7 @@ def _is_strong_value(val: str, weak_values: frozenset[str]) -> bool:
     """
     if not val.strip():
         return False
-    if val.lower() in weak_values or val.lower().startswith("__replace_me__"):
+    if val.lower() in weak_values or val.lower().startswith(("__replace_me__", "replaceme")):
         return False
     if len(val) < _MIN_SECRET_LENGTH or calculate_entropy(val) < _MIN_ENTROPY:
         return False
@@ -207,15 +209,17 @@ def ensure_env_file_secrets(
     env_file: str = ".env",
     weak_values: frozenset[str] | None = None,
 ) -> dict[str, str]:
-    """Check JWT_SECRET_KEY, AUTH_ENCRYPTION_SECRET, and BASIC_AUTH_PASSWORD for weak or placeholder values.
+    """Check JWT_SECRET_KEY, AUTH_ENCRYPTION_SECRET, BASIC_AUTH_PASSWORD,
+    PLATFORM_ADMIN_PASSWORD, and DEFAULT_USER_PASSWORD for weak or placeholder
+    values.
 
     If weak values are detected, generates cryptographically strong replacements,
     merges them into *env_file* (creating the file if it does not exist), and
     patches ``os.environ`` so the running process picks them up without restart.
 
     Set ``MCPGATEWAY_AUTO_INIT_SECRETS=false`` to disable this behaviour (e.g.
-    when secrets are injected via Vault or Kubernetes secrets and disk writes
-    are undesirable).
+    when secrets are injected via Vault or Kubernetes secrets and disk writes are
+    undesirable).
 
     Returns a dict of ``{KEY: generated_value}`` for every key that was regenerated.
     Returns ``{}`` if all secrets are already strong or auto-init is disabled.
@@ -254,7 +258,7 @@ def ensure_env_file_secrets(
         env_val = os.environ.get(field)
         current = env_val if env_val is not None else _env_file_ci.get(field.lower(), "changeme")
         # Base checks apply to all fields: empty, known-weak name, placeholder.
-        is_non_compliant = not current.strip() or current.lower() in weak_values or current.lower().startswith("__replace_me__")
+        is_non_compliant = not current.strip() or current.lower() in weak_values or current.lower().startswith(("__replace_me__", "replaceme"))
         # Length and entropy checks apply only to secrets that Settings hard-fails on startup.
         if not is_non_compliant and field in _STRONG_SECRET_FIELDS:
             is_non_compliant = len(current) < effective_min or calculate_entropy(current) < _MIN_ENTROPY
@@ -371,9 +375,10 @@ def main() -> None:
         metavar="ENV_FILE",
         default=None,
         help=(
-            "Patch an existing env file in-place: replace only the JWT_SECRET_KEY and "
-            "AUTH_ENCRYPTION_SECRET lines that still hold placeholder or weak values; "
-            "all other lines are preserved unchanged. No-ops if those keys are already strong."
+            "Patch an existing env file in-place: replace JWT_SECRET_KEY, AUTH_ENCRYPTION_SECRET, "
+            "BASIC_AUTH_PASSWORD, PLATFORM_ADMIN_PASSWORD, and DEFAULT_USER_PASSWORD lines that "
+            "still hold placeholder or weak values; all other lines are preserved unchanged. "
+            "No-ops if those keys are already strong."
         ),
     )
     args = parser.parse_args()
@@ -400,6 +405,7 @@ def main() -> None:
         "AUTH_ENCRYPTION_SECRET": generate_token(32),
         "BASIC_AUTH_PASSWORD": generate_token(18),
         "PLATFORM_ADMIN_PASSWORD": generate_token(18),
+        "DEFAULT_USER_PASSWORD": generate_token(18),
     }
 
     output_lines = [f"{key}={val}" for key, val in secrets_map.items()]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,9 +82,13 @@ _force_safe_test_db_defaults()
 # ---------------------------------------------------------------------------
 _TEST_JWT_SECRET = "test-jwt-secret-DO-NOT-USE-IN-PRODUCTION-this-is-only-for-pytest-runs"  # nosec B105  # pragma: allowlist secret
 _TEST_ENC_SECRET = "test-enc-secret-DO-NOT-USE-IN-PRODUCTION-this-is-only-for-pytest-runs"  # nosec B105  # pragma: allowlist secret
+_TEST_ADMIN_PW = "T3stAdm!nP@ss#Xz9kPqR"  # nosec B105  # pragma: allowlist secret
+_TEST_USER_PW = "T3stUs3rP@ss#Xz9kPqR2"  # nosec B105  # pragma: allowlist secret
 
 os.environ.setdefault("JWT_SECRET_KEY", _TEST_JWT_SECRET)
 os.environ.setdefault("AUTH_ENCRYPTION_SECRET", _TEST_ENC_SECRET)
+os.environ.setdefault("PLATFORM_ADMIN_PASSWORD", _TEST_ADMIN_PW)
+os.environ.setdefault("DEFAULT_USER_PASSWORD", _TEST_USER_PW)
 
 
 def _force_minimal_main_app_features() -> None:

--- a/tests/scripts/test_init_secrets.py
+++ b/tests/scripts/test_init_secrets.py
@@ -234,6 +234,26 @@ class TestEnsureEnvFileSecrets:
         assert "AUTH_ENCRYPTION_SECRET" in generated
         assert len(generated["JWT_SECRET_KEY"]) == 43  # 32-byte token_urlsafe
 
+    def test_ensure_patches_platform_admin_password(self, tmp_path, monkeypatch):
+        """Patch mode replaces platform-admin and default password placeholders."""
+        env = tmp_path / ".env"
+        env.write_text(
+            "PLATFORM_ADMIN_PASSWORD=ReplaceMe_RunMakeSetup!\n"
+            "DEFAULT_USER_PASSWORD=changeme\n",
+            encoding="utf-8",
+        )
+        for field in ("PLATFORM_ADMIN_PASSWORD", "DEFAULT_USER_PASSWORD"):
+            monkeypatch.delenv(field, raising=False)
+        monkeypatch.setenv("MCPGATEWAY_AUTO_INIT_SECRETS", "true")
+
+        generated = ensure_env_file_secrets(env_file=str(env))
+        content = env.read_text(encoding="utf-8")
+
+        assert "PLATFORM_ADMIN_PASSWORD" in generated
+        assert "DEFAULT_USER_PASSWORD" in generated
+        assert f"PLATFORM_ADMIN_PASSWORD={generated['PLATFORM_ADMIN_PASSWORD']}" in content
+        assert f"DEFAULT_USER_PASSWORD={generated['DEFAULT_USER_PASSWORD']}" in content
+
     def test_ensure_patches_os_environ(self, tmp_path, monkeypatch):
         import os as _os
 

--- a/tests/test_config_security.py
+++ b/tests/test_config_security.py
@@ -72,6 +72,75 @@ def test_fail_closed_basic_auth_password_when_api_basic_auth_enabled():
         )
 
 
+def test_fail_closed_platform_admin_password_when_email_auth_enabled():
+    """Verify that default platform admin password fails closed when email auth is enabled."""
+    with pytest.raises(SecurityConfigurationError):
+        get_settings(
+            environment="production",
+            jwt_secret_key="secure-test-secret-32-characters-min",
+            auth_encryption_secret="another-secure-test-secret-32-chars",  # pragma: allowlist secret
+            email_auth_enabled=True,
+            platform_admin_password="changeme",  # pragma: allowlist secret
+            default_user_password="StrongUs3rP@ss!Xz9k",  # pragma: allowlist secret
+        )
+
+
+def test_fail_closed_default_user_password_when_email_auth_enabled():
+    """Verify that default user password fails closed when email auth is enabled."""
+    with pytest.raises(SecurityConfigurationError):
+        get_settings(
+            environment="production",
+            jwt_secret_key="secure-test-secret-32-characters-min",
+            auth_encryption_secret="another-secure-test-secret-32-chars",  # pragma: allowlist secret
+            email_auth_enabled=True,
+            platform_admin_password="StrongAdm!nP@ss#9kXz",  # pragma: allowlist secret
+            default_user_password="changeme",  # pragma: allowlist secret
+        )
+
+
+@pytest.mark.parametrize(
+    ("password_field", "feature_settings"),
+    [
+        ("basic_auth_password", {"api_allow_basic_auth": True, "email_auth_enabled": False}),
+        ("basic_auth_password", {"docs_allow_basic_auth": True, "email_auth_enabled": False}),
+        ("platform_admin_password", {"email_auth_enabled": True}),
+        ("default_user_password", {"email_auth_enabled": True}),
+    ],
+)
+@pytest.mark.parametrize("password", ["", "__REPLACE_ME__run_init-secrets_before_starting", "ReplaceMe_RunMakeSetup!"])
+def test_enabled_auth_rejects_empty_and_placeholder_passwords(password_field, feature_settings, password):  # noqa: ANN001
+    """Enabled authentication must reject empty and placeholder password values."""
+    passwords = {
+        "basic_auth_password": "StrongBasic!P@ss9Xz",
+        "platform_admin_password": "StrongAdm!nP@ss#9kXz",
+        "default_user_password": "StrongUs3rP@ss!Xz9k",
+    }
+    passwords[password_field] = password
+
+    with pytest.raises(SecurityConfigurationError):
+        get_settings(
+            jwt_secret_key="test-jwt-secret-DO-NOT-USE-IN-PRODUCTION-this-is-only-for-pytest-runs",  # pragma: allowlist secret
+            auth_encryption_secret="test-enc-secret-DO-NOT-USE-IN-PRODUCTION-this-is-only-for-pytest-runs",  # pragma: allowlist secret
+            **feature_settings,
+            **passwords,
+        )
+
+
+def test_weak_passwords_allowed_when_consuming_features_disabled():
+    """Weak passwords are allowed when their consuming features are off."""
+    cfg = get_settings(
+        environment="production",
+        jwt_secret_key="s3cure-T3st!Secr3t#32charsMin-Xz9",
+        auth_encryption_secret="an0ther-S3cure!T3st#Secret-32chX",  # pragma: allowlist secret
+        email_auth_enabled=False,
+        api_allow_basic_auth=False,
+        basic_auth_password="changeme",  # pragma: allowlist secret
+        platform_admin_password="changeme",  # pragma: allowlist secret
+        default_user_password="changeme",  # pragma: allowlist secret
+    )
+    assert cfg.basic_auth_password.get_secret_value() == "changeme"
+
+
 def test_proceed_development_mode():
     """Development environment now rejects weak secrets unconditionally (GHSA-8pcq-mx48-hjvj).
 

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -171,6 +171,7 @@ def test_csrf_cookie_name_default_matches_env_example():
     dummy_env = {
         "JWT_SECRET_KEY": _TEST_JWT_SECRET,
         "AUTH_ENCRYPTION_SECRET": _TEST_ENC_SECRET,
+        "EMAIL_AUTH_ENABLED": "false",
     }
 
     repo_root = os.path.join(os.path.dirname(__file__), "..", "..", "..")
@@ -208,6 +209,7 @@ def test_admin_csrf_cookie_name_matches_config_default():
     dummy_env = {
         "JWT_SECRET_KEY": _TEST_JWT_SECRET,
         "AUTH_ENCRYPTION_SECRET": _TEST_ENC_SECRET,
+        "EMAIL_AUTH_ENABLED": "false",
     }
 
     with patch.dict(os.environ, dummy_env, clear=True):
@@ -230,6 +232,7 @@ def test_oauth_router_csrf_cookie_name_matches_config_default():
     dummy_env = {
         "JWT_SECRET_KEY": _TEST_JWT_SECRET,
         "AUTH_ENCRYPTION_SECRET": _TEST_ENC_SECRET,
+        "EMAIL_AUTH_ENABLED": "false",
     }
 
     with patch.dict(os.environ, dummy_env, clear=True):
@@ -253,6 +256,7 @@ def test_admin_csrf_header_name_matches_config_default():
     dummy_env = {
         "JWT_SECRET_KEY": _TEST_JWT_SECRET,
         "AUTH_ENCRYPTION_SECRET": _TEST_ENC_SECRET,
+        "EMAIL_AUTH_ENABLED": "false",
     }
 
     with patch.dict(os.environ, dummy_env, clear=True):
@@ -273,6 +277,7 @@ def test_oauth_router_csrf_header_name_matches_config_default():
     dummy_env = {
         "JWT_SECRET_KEY": _TEST_JWT_SECRET,
         "AUTH_ENCRYPTION_SECRET": _TEST_ENC_SECRET,
+        "EMAIL_AUTH_ENABLED": "false",
     }
 
     with patch.dict(os.environ, dummy_env, clear=True):
@@ -608,6 +613,7 @@ def test_settings_default_values():
         "JWT_SECRET_KEY": _TEST_JWT_SECRET,
         "AUTH_ENCRYPTION_SECRET": _TEST_ENC_SECRET,
         "APP_DOMAIN": "http://localhost",
+        "EMAIL_AUTH_ENABLED": "false",  # Avoid password gate — this test checks field defaults, not auth
     }
 
     with patch.dict(os.environ, dummy_env, clear=True):
@@ -647,6 +653,7 @@ def test_skip_migrations_defaults_to_false():
     dummy_env = {
         "JWT_SECRET_KEY": _TEST_JWT_SECRET,
         "AUTH_ENCRYPTION_SECRET": _TEST_ENC_SECRET,
+        "EMAIL_AUTH_ENABLED": "false",
     }
     with patch.dict(os.environ, dummy_env, clear=True):
         settings = Settings(environment="development", _env_file=None)
@@ -658,6 +665,7 @@ def test_skip_migrations_env_true_flips_flag():
     dummy_env = {
         "JWT_SECRET_KEY": _TEST_JWT_SECRET,
         "AUTH_ENCRYPTION_SECRET": _TEST_ENC_SECRET,
+        "EMAIL_AUTH_ENABLED": "false",
         "MCPGATEWAY_SKIP_MIGRATIONS": "true",
     }
     with patch.dict(os.environ, dummy_env, clear=True):
@@ -670,6 +678,7 @@ def test_skip_migrations_env_false_keeps_flag_off():
     dummy_env = {
         "JWT_SECRET_KEY": _TEST_JWT_SECRET,
         "AUTH_ENCRYPTION_SECRET": _TEST_ENC_SECRET,
+        "EMAIL_AUTH_ENABLED": "false",
         "MCPGATEWAY_SKIP_MIGRATIONS": "false",
     }
     with patch.dict(os.environ, dummy_env, clear=True):


### PR DESCRIPTION
## Summary

Security hardening: extends the existing startup validation to also reject unset, placeholder, or default password values once their consuming authentication feature is enabled, and updates the affected deployment configs and docs accordingly.

## Breaking Changes

See `CHANGELOG.md` and the new migration guide (`docs/docs/operations/default-password-fail-closed-migration.md`) for affected environment variables and upgrade steps.

Closes: https://github.ibm.com/contextforge-org/internal_issues/issues/547