### PR TITLE
fix(oauth): mint callback CSRF fallback token via csrf_service

### DIFF
--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -36,6 +36,7 @@ from mcpgateway.db import Gateway, get_db, Permissions
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
 from mcpgateway.middleware.token_scoping import ResourceOwnershipResult, token_scoping_middleware
 from mcpgateway.schemas import EmailUserResponse
+from mcpgateway.services.csrf_service import get_csrf_service
 from mcpgateway.services.dcr_service import DcrError, DcrService
 from mcpgateway.services.encryption_service import protect_oauth_config_for_storage
 from mcpgateway.services.oauth_manager import OAuthError, OAuthManager
@@ -1070,10 +1071,12 @@ async def oauth_callback(
         )
 
         # Legacy admin UI: return full page with fetch-tools button.
-        # Generate CSRF token early so it can be embedded in the JS literal
+        # Generate CSRF token early so it can be embedded in the JS literal.
+        # CSRFMiddleware validates by recomputing an HMAC of (user_id, session_id), so mint via
+        # csrf_service rather than a random value, bound to the session_jwt issued below.
         csrf_token = request.cookies.get(ADMIN_CSRF_COOKIE_NAME, "")
         if not isinstance(csrf_token, str) or not re.match(r"^[A-Za-z0-9_=-]{32,}$", csrf_token):
-            csrf_token = secrets.token_urlsafe(32)
+            csrf_token = get_csrf_service().generate_csrf_token(app_user_email, jwt_payload["jti"])
 
         html_content = f"""
         <!DOCTYPE html>

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -768,6 +768,56 @@ class TestOAuthRouter:
                 assert oauth_config_passed["resource"] == "https://mcp.example.com"  # Normalized URL
 
     @pytest.mark.asyncio
+    async def test_oauth_callback_csrf_token_validates_against_csrf_service(self, mock_db, mock_request, mock_gateway):
+        """The fetch-tools page's CSRF token must satisfy CSRFMiddleware.
+
+        CSRFMiddleware validates by recomputing an HMAC of (user_id, session_id). The page
+        previously minted a random secrets.token_urlsafe() value, which could never match, so
+        the Fetch Tools button always failed with "CSRF validation failed". Regression guard:
+        the emitted token must validate for the identity carried by the session JWT issued
+        alongside it.
+        """
+        # Standard
+        import base64
+        import json
+
+        # First-Party
+        from mcpgateway.services.csrf_service import get_csrf_service
+
+        state_data = {"gateway_id": "gateway123", "app_user_email": "test@example.com", "nonce": "abc123"}
+        state = base64.urlsafe_b64encode(json.dumps(state_data).encode() + b"x" * 32).decode()
+
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        token_result = {"user_id": "oauth_user_123", "app_user_email": "test@example.com", "expires_at": "2024-01-01T12:00:00", "token_aud": None, "state_data": {"app_user_email": "test@example.com", "team_id": None}}
+
+        with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_manager_class:
+            mock_oauth_manager = Mock()
+            mock_oauth_manager.resolve_gateway_id_from_state = AsyncMock(return_value="gateway123")
+            mock_oauth_manager.complete_authorization_code_flow = AsyncMock(return_value=token_result)
+            mock_oauth_manager_class.return_value = mock_oauth_manager
+
+            with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
+                # First-Party
+                from mcpgateway.routers.oauth_router import oauth_callback
+
+                result = await oauth_callback(code="auth_code_123", state=state, request=mock_request, db=mock_db)
+
+        cookies = {}
+        for header in result.headers.getlist("set-cookie"):
+            name, _, rest = header.partition("=")
+            cookies[name.strip()] = rest.split(";")[0]
+
+        csrf_token = cookies["mcpgateway_csrf_token"]
+
+        # The session JWT issued by the same response carries the identity the middleware binds to.
+        jwt_payload = json.loads(base64.urlsafe_b64decode(cookies["jwt_token"].split(".")[1] + "=="))
+
+        assert get_csrf_service().validate_csrf_token(csrf_token, jwt_payload["email"], jwt_payload["jti"]) is True
+        # The same token is embedded in the page so the button's fetch() sends a matching header.
+        assert csrf_token in result.body.decode()
+
+    @pytest.mark.asyncio
     async def test_oauth_callback_redirects_to_allowed_external_origin_without_cookies(self, mock_db, mock_request, mock_gateway):
         """Successful callback redirects externally without gateway-scoped cookies."""
         from mcpgateway.routers.oauth_router import oauth_callback


### PR DESCRIPTION
## Problem

The OAuth callback page ("Fetch Tools from MCP Server") reuses an existing `mcpgateway_csrf_token` cookie when one is present, and otherwise falls back to `secrets.token_urlsafe(32)`.

`CSRFMiddleware` validates that token by recomputing an HMAC-SHA256 of `(user_id, session_id)` via `csrf_service`. A random base64url string can never equal an HMAC hex digest — different alphabet, different length — so whenever the fallback is taken, the button fails with `{"detail":"CSRF validation failed","code":"CSRF_TOKEN_INVALID"}`.

This is why it reproduces inconsistently: it works if you happen to arrive with a valid CSRF cookie (for example an active admin UI session) and fails otherwise. Users reaching the callback without that cookie hit it every time.

## Fix

Mint the fallback through `csrf_service`, bound to the identity carried by the session JWT issued in the same response, so the page and the middleware derive the same value.

```python
 csrf_token = request.cookies.get(ADMIN_CSRF_COOKIE_NAME, "")
 if not isinstance(csrf_token, str) or not re.match(r"^[A-Za-z0-9_=-]{32,}$", csrf_token):
-    csrf_token = secrets.token_urlsafe(32)
+    csrf_token = get_csrf_service().generate_csrf_token(app_user_email, jwt_payload["jti"])
```

The reuse branch is unchanged, so the working path keeps its existing behaviour.

## Testing

Added `test_oauth_callback_csrf_token_validates_against_csrf_service`, which asserts the emitted token validates for the session the response issues. Verified it fails on the previous code and passes on this change. Existing oauth-router and CSRF suites pass.