### PR TITLE
fix(oauth): use TeamManagementService for team membership check in gateway access

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-04T11:35:24Z",
+  "generated_at": "2026-09-04T14:22:17Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1007,10 +1007,10 @@
     ],
     "docs/docs/architecture/adr/028-auth-caching.md": [
       {
-        "hashed_secret": "eda8f07985e2b7db25d2f15818410d696544d33f",
+        "hashed_secret": "4a6f993c65a8d0946e62ba3cb5006a9a1615f0aa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 57,
+        "line_number": 8,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1018,7 +1018,7 @@
         "hashed_secret": "4e5bc1605287fbb277825e7bbc61f06b673bc817",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 70,
+        "line_number": 74,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1026,15 +1026,7 @@
         "hashed_secret": "a8772222f1027d36898a1fcdd9ee49dcfe2fc9a6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 71,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6314dc2bebceaa82024c98974556769a6a4f474c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 72,
+        "line_number": 75,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1042,7 +1034,7 @@
         "hashed_secret": "5db8c92354caf195bc47229ec1da9e26053269f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 78,
+        "line_number": 76,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1050,7 +1042,7 @@
         "hashed_secret": "e340d79ff1184175ed44815db7440905ecb9a0dc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 79,
+        "line_number": 77,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1058,7 +1050,7 @@
         "hashed_secret": "27a0146f1e78bf478b4d1195062638742878dae5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 82,
+        "line_number": 80,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-04T09:25:46Z",
+  "generated_at": "2026-09-04T11:32:38Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1007,15 +1007,15 @@
     ],
     "docs/docs/architecture/adr/028-auth-caching.md": [
       {
-        "hashed_secret": "4e5bc1605287fbb277825e7bbc61f06b673bc817",
+        "hashed_secret": "eda8f07985e2b7db25d2f15818410d696544d33f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 69,
+        "line_number": 57,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "a8772222f1027d36898a1fcdd9ee49dcfe2fc9a6",
+        "hashed_secret": "4e5bc1605287fbb277825e7bbc61f06b673bc817",
         "is_secret": false,
         "is_verified": false,
         "line_number": 70,
@@ -1023,7 +1023,7 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "5db8c92354caf195bc47229ec1da9e26053269f9",
+        "hashed_secret": "a8772222f1027d36898a1fcdd9ee49dcfe2fc9a6",
         "is_secret": false,
         "is_verified": false,
         "line_number": 71,
@@ -1031,7 +1031,7 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "e340d79ff1184175ed44815db7440905ecb9a0dc",
+        "hashed_secret": "6314dc2bebceaa82024c98974556769a6a4f474c",
         "is_secret": false,
         "is_verified": false,
         "line_number": 72,
@@ -1039,10 +1039,26 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "5db8c92354caf195bc47229ec1da9e26053269f9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 73,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e340d79ff1184175ed44815db7440905ecb9a0dc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 74,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "27a0146f1e78bf478b4d1195062638742878dae5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 75,
+        "line_number": 77,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1114,7 +1130,7 @@
         "hashed_secret": "8a58a1abfb96461757181df6144e87984f3fb737",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 186,
+        "line_number": 187,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1122,7 +1138,7 @@
         "hashed_secret": "6357356babb60e56a10f966756c1523e768554c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 229,
+        "line_number": 230,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1130,7 +1146,7 @@
         "hashed_secret": "5237629943e0f8297ce640ac71466386c1d33111",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 230,
+        "line_number": 231,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1138,7 +1154,7 @@
         "hashed_secret": "bba01aaf8824007c006df1c0eacfb9489e509535",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 271,
+        "line_number": 272,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1146,7 +1162,7 @@
         "hashed_secret": "5c216af8faacfff02f8ee00326ecfcfb3334922f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 321,
+        "line_number": 322,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2194,7 +2210,7 @@
         "hashed_secret": "9b995dc4707426ba2e56b54a6877bda99a5e0376",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 393,
+        "line_number": 394,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2202,7 +2218,7 @@
         "hashed_secret": "29b8dca3de5ff27bcf8bd3b622adf9970f29381c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 470,
+        "line_number": 471,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2210,7 +2226,7 @@
         "hashed_secret": "d62bd0a3fef6be1bb3bb9078b323d87ac9f37f75",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 572,
+        "line_number": 573,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2218,7 +2234,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 702,
+        "line_number": 703,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2226,7 +2242,7 @@
         "hashed_secret": "f4793151b0607198d4de9b1ca458d3e25adf1cb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 704,
+        "line_number": 705,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-04T11:32:38Z",
+  "generated_at": "2026-09-04T11:35:24Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1042,7 +1042,7 @@
         "hashed_secret": "5db8c92354caf195bc47229ec1da9e26053269f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 73,
+        "line_number": 78,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1050,7 +1050,7 @@
         "hashed_secret": "e340d79ff1184175ed44815db7440905ecb9a0dc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 74,
+        "line_number": 79,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1058,7 +1058,7 @@
         "hashed_secret": "27a0146f1e78bf478b4d1195062638742878dae5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 77,
+        "line_number": 82,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/architecture/adr/028-auth-caching.md
+++ b/docs/docs/architecture/adr/028-auth-caching.md
@@ -4,6 +4,11 @@
 - *Date:* 2025-01-15
 - *Deciders:* Platform Team
 
+!!! note
+    A later role-cache extension added `{cache_prefix}auth:role:{email}:{team_id}` entries,
+    controlled by `AUTH_CACHE_ROLE_TTL` (default: 60 seconds). A cached non-membership is
+    represented internally by a negative sentinel and returned to callers as `None`.
+
 ## Context
 
 Under high-concurrency load testing (1000+ concurrent users), authentication became a significant performance bottleneck. Every authenticated request triggered 3-4 separate database queries via `asyncio.to_thread()`:
@@ -53,8 +58,7 @@ Implement a two-tier authentication caching system with Redis as the primary sto
 
    - `token_catalog_service.py:revoke_token()` - Invalidates revocation cache
    - `email_auth_service.py:change_password()` - Invalidates user cache
-   - `team_management_service.py:add_member_to_team/remove_member_from_team()` - Invalidates team and role caches
-   - `team_management_service.py:get_user_role_in_team()` - Reads from role cache (`auth:role:{email}:{team_id}`) with DB fallback
+   - `team_management_service.py:add_member_to_team/remove_member_from_team()` - Invalidates team cache
 
 4. **Configuration settings**
 
@@ -67,16 +71,10 @@ Implement a two-tier authentication caching system with Redis as the primary sto
 ### Cache Key Scheme
 
 ```
-{cache_prefix}auth:user:{email}           → User data JSON
-{cache_prefix}auth:team:{email}           → Personal team ID
-{cache_prefix}auth:role:{email}:{team_id} → Team role string (e.g. "owner", "member")
-```
-
-> **Note:** An empty string stored at the role key is a **negative sentinel** — it means "confirmed not a member" and avoids repeated DB misses.  `get_user_role_in_team()` converts `""` → `None` before returning, so callers always see `None` for non-members.  A cache miss (key absent) triggers a DB fallback query.
-
-```
-{cache_prefix}auth:revoke:{jti}           → "1" if revoked
-{cache_prefix}auth:ctx:{email}:{jti}      → Batched context JSON
+{cache_prefix}auth:user:{email}      → User data JSON
+{cache_prefix}auth:team:{email}      → Personal team ID
+{cache_prefix}auth:revoke:{jti}      → "1" if revoked
+{cache_prefix}auth:ctx:{email}:{jti} → Batched context JSON
 ```
 
 Default prefix: `mcpgw:` → `mcpgw:auth:ctx:admin@example.com:jti-123`

--- a/docs/docs/architecture/adr/028-auth-caching.md
+++ b/docs/docs/architecture/adr/028-auth-caching.md
@@ -53,7 +53,8 @@ Implement a two-tier authentication caching system with Redis as the primary sto
 
    - `token_catalog_service.py:revoke_token()` - Invalidates revocation cache
    - `email_auth_service.py:change_password()` - Invalidates user cache
-   - `team_management_service.py:add_member_to_team/remove_member_from_team()` - Invalidates team cache
+   - `team_management_service.py:add_member_to_team/remove_member_from_team()` - Invalidates team and role caches
+   - `team_management_service.py:get_user_role_in_team()` - Reads from role cache (`auth:role:{email}:{team_id}`) with DB fallback
 
 4. **Configuration settings**
 
@@ -66,10 +67,11 @@ Implement a two-tier authentication caching system with Redis as the primary sto
 ### Cache Key Scheme
 
 ```
-{cache_prefix}auth:user:{email}      → User data JSON
-{cache_prefix}auth:team:{email}      → Personal team ID
-{cache_prefix}auth:revoke:{jti}      → "1" if revoked
-{cache_prefix}auth:ctx:{email}:{jti} → Batched context JSON
+{cache_prefix}auth:user:{email}           → User data JSON
+{cache_prefix}auth:team:{email}           → Personal team ID
+{cache_prefix}auth:role:{email}:{team_id} → Team role string (e.g. "owner", "member")
+{cache_prefix}auth:revoke:{jti}           → "1" if revoked
+{cache_prefix}auth:ctx:{email}:{jti}      → Batched context JSON
 ```
 
 Default prefix: `mcpgw:` → `mcpgw:auth:ctx:admin@example.com:jti-123`

--- a/docs/docs/architecture/adr/028-auth-caching.md
+++ b/docs/docs/architecture/adr/028-auth-caching.md
@@ -70,6 +70,11 @@ Implement a two-tier authentication caching system with Redis as the primary sto
 {cache_prefix}auth:user:{email}           → User data JSON
 {cache_prefix}auth:team:{email}           → Personal team ID
 {cache_prefix}auth:role:{email}:{team_id} → Team role string (e.g. "owner", "member")
+```
+
+> **Note:** An empty string stored at the role key is a **negative sentinel** — it means "confirmed not a member" and avoids repeated DB misses.  `get_user_role_in_team()` converts `""` → `None` before returning, so callers always see `None` for non-members.  A cache miss (key absent) triggers a DB fallback query.
+
+```
 {cache_prefix}auth:revoke:{jti}           → "1" if revoked
 {cache_prefix}auth:ctx:{email}:{jti}      → Batched context JSON
 ```

--- a/docs/docs/architecture/oauth-design.md
+++ b/docs/docs/architecture/oauth-design.md
@@ -142,6 +142,7 @@ The gateway performs local validation of the token's audience before forwarding 
 -   Per-user learned-audience storage: `OAuthToken.learned_aud` / `learned_iss` in `mcpgateway/db.py`; write via `TokenStorageService.store_tokens` (called from `OAuthManager.complete_authorization_code_flow`); read via `TokenStorageService.get_user_learned_audience`.
 -   Precedence + advisory / authoritative split: `_validate_audience` in `mcpgateway/services/token_validation_service.py`.
 -   Trust model for the unverified JWT decode used at learning time: `_decode_token_claims_unverified` in `mcpgateway/services/oauth_manager.py`.
+-   Team membership check for `_enforce_gateway_access`: `TeamManagementService.get_user_role_in_team()` in `mcpgateway/services/team_management_service.py` — uses `auth_cache.get_user_role` with DB fallback, avoiding the detached-object problem of `EmailAuthService.get_user_by_email()`.
 
 !!! warning "Security: unverified JWT decode trust boundary"
     Audience extraction during auto-learning uses `_decode_token_claims_unverified`, which decodes the JWT **without cryptographic verification**. The extracted audience is used only for routing and learning — it is **not a security gate**. The immediate trust boundary is the TLS connection to the admin-configured token endpoint in response to a callback the gateway itself initiated. Authorization-relevant validation remains the upstream MCP server's responsibility (or, when configured, the gateway's own authoritative audience check).

--- a/docs/docs/manage/oauth-troubleshooting.md
+++ b/docs/docs/manage/oauth-troubleshooting.md
@@ -74,6 +74,7 @@ state_data = {
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/oauth/authorize/{gateway_id}` | GET | Initiates OAuth flow, redirects to provider |
+| `/vault/authorize/{server_id}` | GET | Per-user OAuth credential connection for team virtual servers (shared access control with `/oauth/authorize/{gateway_id}`) |
 | `/oauth/callback` | GET | Handles OAuth callback, exchanges code for tokens |
 | `/oauth/status/{gateway_id}` | GET | Returns OAuth configuration status |
 | `/oauth/fetch-tools/{gateway_id}` | POST | Fetches tools from MCP server after OAuth completion |

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -550,12 +550,15 @@ async def _enforce_gateway_access(
     if visibility == "team":
         if not gateway_team_id:
             raise HTTPException(status_code=403, detail="You don't have access to this gateway")
-        # First-Party
-        from mcpgateway.services.email_auth_service import EmailAuthService
+        # Use TeamManagementService.get_user_role_in_team() which checks the role cache
+        # (auth_cache.get_user_role) before hitting the DB. This avoids the broken
+        # user.is_team_member() path where EmailAuthService.get_user_by_email() returns a
+        # cache-reconstructed detached EmailUser with empty team_memberships.
+        from mcpgateway.services.team_management_service import TeamManagementService  # pylint: disable=import-outside-toplevel
 
-        auth_service = EmailAuthService(db)
-        user = await auth_service.get_user_by_email(requester_email)
-        if not user or not user.is_team_member(gateway_team_id):
+        team_service = TeamManagementService(db)
+        role = await team_service.get_user_role_in_team(requester_email, gateway_team_id)
+        if not role:
             raise HTTPException(status_code=403, detail="You don't have access to this gateway")
         return
 
@@ -567,12 +570,11 @@ async def _enforce_gateway_access(
     if gateway_owner and gateway_owner.strip().lower() == requester_email:
         return
     if gateway_team_id:
-        # First-Party
-        from mcpgateway.services.email_auth_service import EmailAuthService
+        # Same pattern as the team-visibility branch above.
+        from mcpgateway.services.team_management_service import TeamManagementService  # pylint: disable=import-outside-toplevel
 
-        auth_service = EmailAuthService(db)
-        user = await auth_service.get_user_by_email(requester_email)
-        if user and user.is_team_member(gateway_team_id):
+        role = await TeamManagementService(db).get_user_role_in_team(requester_email, gateway_team_id)
+        if role:
             return
 
     raise HTTPException(status_code=403, detail="You don't have access to this gateway")

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -39,6 +39,7 @@ from mcpgateway.schemas import EmailUserResponse
 from mcpgateway.services.dcr_service import DcrError, DcrService
 from mcpgateway.services.encryption_service import protect_oauth_config_for_storage
 from mcpgateway.services.oauth_manager import OAuthError, OAuthManager
+from mcpgateway.services.team_management_service import TeamManagementService
 from mcpgateway.services.token_storage_service import TokenStorageService
 
 # First-Party - CSP nonce support
@@ -557,8 +558,6 @@ async def _enforce_gateway_access(
     # (auth_cache.get_user_role) before hitting the DB. This avoids the broken
     # user.is_team_member() path where EmailAuthService.get_user_by_email() returns a
     # cache-reconstructed detached EmailUser with empty team_memberships.
-    from mcpgateway.services.team_management_service import TeamManagementService  # pylint: disable=import-outside-toplevel
-
     if visibility == "team":
         if not gateway_team_id:
             raise HTTPException(status_code=403, detail="You don't have access to this gateway")

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -547,17 +547,16 @@ async def _enforce_gateway_access(
     if visibility == "public":
         return
 
+    # Use TeamManagementService.get_user_role_in_team() which checks the role cache
+    # (auth_cache.get_user_role) before hitting the DB. This avoids the broken
+    # user.is_team_member() path where EmailAuthService.get_user_by_email() returns a
+    # cache-reconstructed detached EmailUser with empty team_memberships.
+    from mcpgateway.services.team_management_service import TeamManagementService  # pylint: disable=import-outside-toplevel
+
     if visibility == "team":
         if not gateway_team_id:
             raise HTTPException(status_code=403, detail="You don't have access to this gateway")
-        # Use TeamManagementService.get_user_role_in_team() which checks the role cache
-        # (auth_cache.get_user_role) before hitting the DB. This avoids the broken
-        # user.is_team_member() path where EmailAuthService.get_user_by_email() returns a
-        # cache-reconstructed detached EmailUser with empty team_memberships.
-        from mcpgateway.services.team_management_service import TeamManagementService  # pylint: disable=import-outside-toplevel
-
-        team_service = TeamManagementService(db)
-        role = await team_service.get_user_role_in_team(requester_email, gateway_team_id)
+        role = await TeamManagementService(db).get_user_role_in_team(requester_email, gateway_team_id)
         if not role:
             raise HTTPException(status_code=403, detail="You don't have access to this gateway")
         return
@@ -570,9 +569,6 @@ async def _enforce_gateway_access(
     if gateway_owner and gateway_owner.strip().lower() == requester_email:
         return
     if gateway_team_id:
-        # Same pattern as the team-visibility branch above.
-        from mcpgateway.services.team_management_service import TeamManagementService  # pylint: disable=import-outside-toplevel
-
         role = await TeamManagementService(db).get_user_role_in_team(requester_email, gateway_team_id)
         if role:
             return

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -501,6 +501,11 @@ async def _enforce_gateway_access(
 ) -> None:
     """Enforce gateway visibility and ownership checks for OAuth endpoints.
 
+    .. note::
+        ``TeamManagementService.get_user_role_in_team()`` commits the database
+        session (``db.commit()``) to release the idle transaction.  Callers must
+        not rely on uncommitted ORM state being preserved across this call.
+
     Args:
         gateway_id: Gateway identifier used for scoped ownership checks.
         gateway: Gateway record being accessed.

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -502,9 +502,10 @@ async def _enforce_gateway_access(
     """Enforce gateway visibility and ownership checks for OAuth endpoints.
 
     .. note::
-        ``TeamManagementService.get_user_role_in_team()`` commits the database
-        session (``db.commit()``) to release the idle transaction.  Callers must
-        not rely on uncommitted ORM state being preserved across this call.
+        ``TeamManagementService.get_user_role_in_team()`` may commit the
+        database session (``db.commit()``) on a cache miss to release the idle
+        transaction.  Callers must not rely on uncommitted ORM state being
+        preserved across this call.
 
     Args:
         gateway_id: Gateway identifier used for scoped ownership checks.

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -1737,7 +1737,7 @@ class TeamManagementService:
         """
         try:
             return get_auth_cache()
-        except ImportError:
+        except Exception:  # pylint: disable=broad-exception-caught
             return None
 
     def _get_admin_stats_cache(self):

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -1737,7 +1737,8 @@ class TeamManagementService:
         """
         try:
             return get_auth_cache()
-        except Exception:  # pylint: disable=broad-exception-caught
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.warning("Auth cache unavailable: %s", exc)
             return None
 
     def _get_admin_stats_cache(self):

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -327,7 +327,7 @@ class TestOAuthRouter:
         gateway = Mock(spec=Gateway)
         gateway.id = "gateway123"
         gateway.name = "Test Gateway"
-        gateway.url = "https://mcp.example.com"  # MCP server URL
+        gateway.url = "https://mcp.example.com/deep/path"  # MCP server URL
         gateway.visibility = "public"
         gateway.owner_email = None
         gateway.team_id = None  # No team restriction - allow all authenticated users
@@ -388,9 +388,10 @@ class TestOAuthRouter:
                 call_args = mock_oauth_manager.initiate_authorization_code_flow.call_args
                 assert call_args[0][0] == "gateway123"
                 assert call_args[1]["app_user_email"] == mock_current_user.get("email")
-                # oauth_config should have resource set to gateway.url
+                # oauth_config should have resource set to the origin of gateway.url,
+                # not the full URL — derive_resource_origin strips the path component.
                 oauth_config_passed = call_args[0][1]
-                assert oauth_config_passed["resource"] == mock_gateway.url
+                assert oauth_config_passed["resource"] == "https://mcp.example.com"
 
     @pytest.mark.asyncio
     async def test_initiate_oauth_flow_gateway_not_found(self, mock_db, mock_request, mock_current_user):
@@ -1791,6 +1792,51 @@ class TestOAuthAccessHelpers:
             with pytest.raises(HTTPException) as exc_info:
                 await _enforce_gateway_access("gateway123", gateway, {"email": "user@example.com", "is_admin": False}, mock_db, request=None)
         assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_enforce_gateway_access_team_visibility_cache_hit_member_allowed(self, mock_db):
+        """Regression: detached EmailUser (cache-hit) with empty team_memberships must not block access.
+
+        Constructs a scenario where EmailAuthService.get_user_by_email() would return a
+        cache-reconstructed EmailUser with team_memberships=[] (the old broken path).
+        The fix uses TeamManagementService.get_user_role_in_team() which checks the role
+        cache independently, so a non-None role should grant access regardless.
+        """
+        from mcpgateway.routers.oauth_router import _enforce_gateway_access
+
+        gateway = SimpleNamespace(visibility="team", owner_email=None, team_id="team-1")
+        with patch("mcpgateway.services.team_management_service.TeamManagementService.get_user_role_in_team", new_callable=AsyncMock, return_value="member") as mock_role:
+            # Simulate a detached EmailUser that would have been returned by the old path —
+            # the new code never calls EmailAuthService, so this simply confirms the old
+            # broken path is unreachable.
+            with patch("mcpgateway.services.email_auth_service.EmailAuthService") as mock_auth_cls:
+                mock_user = Mock()
+                mock_user.is_team_member = Mock(return_value=False)  # Would deny under old code
+                mock_auth_svc = Mock()
+                mock_auth_svc.get_user_by_email = AsyncMock(return_value=mock_user)
+                mock_auth_cls.return_value = mock_auth_svc
+
+                await _enforce_gateway_access("gateway123", gateway, {"email": "user@example.com", "is_admin": False}, mock_db, request=None)
+
+            # TeamManagementService was called (new path)
+            mock_role.assert_called_once_with("user@example.com", "team-1")
+            # EmailAuthService was NOT called (old path unreachable)
+            mock_auth_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_enforce_gateway_access_unknown_visibility_with_request_team_member_allowed(self, mock_db):
+        """Unknown-visibility fallback with a request object carrying token_teams.
+
+        Exercises the interaction between _resolve_token_teams_for_scope_check (triggered
+        when request is not None) and the unknown-visibility team-member check.
+        """
+        from mcpgateway.routers.oauth_router import _enforce_gateway_access
+
+        gateway = SimpleNamespace(visibility="internal", owner_email=None, team_id="team-1")
+        mock_request = Mock(spec=Request)
+        mock_request.state = SimpleNamespace(token_teams=["team-1"])
+        with patch("mcpgateway.services.team_management_service.TeamManagementService.get_user_role_in_team", new_callable=AsyncMock, return_value="developer"):
+            await _enforce_gateway_access("gateway123", gateway, {"email": "user@example.com", "is_admin": False}, mock_db, request=mock_request)
 
 
 class TestOAuthRouterAdditionalCoverage:
@@ -4377,3 +4423,84 @@ def test_oauth_callback_scope_non_string_non_list():
     else:
         scopes_list = []
     assert scopes_list == []
+
+
+# ---------------------------------------------------------------------------
+# Integration test: _enforce_gateway_access with warm role cache
+# ---------------------------------------------------------------------------
+
+
+class TestEnforceGatewayAccessCacheIntegration:
+    """Integration test exercising _enforce_gateway_access through TeamManagementService with cache.
+
+    Unlike the unit tests above (which mock get_user_role_in_team directly),
+    this test mocks at the cache layer to confirm the full call chain:
+    _enforce_gateway_access → TeamManagementService.get_user_role_in_team()
+    → _get_auth_cache().get_user_role() → cache hit (no DB fallback).
+    """
+
+    @pytest.mark.asyncio
+    async def test_team_visibility_warm_cache_grants_access(self):
+        """Warm auth_cache role entry grants access without DB query.
+
+        1. Mocks _get_auth_cache().get_user_role to return a cached role ("developer").
+        2. Calls _enforce_gateway_access with team-visibility gateway.
+        3. Asserts: access granted, no DB team_memberships query executed.
+        """
+        from mcpgateway.routers.oauth_router import _enforce_gateway_access
+
+        mock_db = Mock(spec=Session)
+        gateway = SimpleNamespace(visibility="team", owner_email=None, team_id="team-1")
+
+        mock_cache = AsyncMock()
+        mock_cache.get_user_role = AsyncMock(return_value="developer")
+        mock_cache.set_user_role = AsyncMock()
+
+        with patch("mcpgateway.services.team_management_service.get_auth_cache", return_value=mock_cache):
+            # Access should be granted via cached role — no exception raised
+            await _enforce_gateway_access(
+                "gateway123",
+                gateway,
+                {"email": "user@example.com", "is_admin": False},
+                mock_db,
+                request=None,
+            )
+
+        # Verify cache was consulted
+        mock_cache.get_user_role.assert_awaited_once_with("user@example.com", "team-1")
+
+    @pytest.mark.asyncio
+    async def test_team_visibility_cache_miss_falls_back_to_db(self):
+        """Cache miss triggers DB fallback and caches the result.
+
+        1. Mocks _get_auth_cache().get_user_role to return None (cache miss).
+        2. Mocks the DB query path to return a membership row.
+        3. Asserts: access granted via DB fallback, result cached.
+        """
+        from mcpgateway.routers.oauth_router import _enforce_gateway_access
+
+        mock_db = MagicMock(spec=Session)
+        gateway = SimpleNamespace(visibility="team", owner_email=None, team_id="team-1")
+
+        # Simulate a DB membership row returned by db.query().filter().first()
+        mock_membership = Mock()
+        mock_membership.role = "member"
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_membership
+
+        mock_cache = AsyncMock()
+        mock_cache.get_user_role = AsyncMock(return_value=None)  # Cache miss
+        mock_cache.set_user_role = AsyncMock()
+
+        with patch("mcpgateway.services.team_management_service.get_auth_cache", return_value=mock_cache):
+            await _enforce_gateway_access(
+                "gateway123",
+                gateway,
+                {"email": "user@example.com", "is_admin": False},
+                mock_db,
+                request=None,
+            )
+
+        # Cache was checked first
+        mock_cache.get_user_role.assert_awaited_once_with("user@example.com", "team-1")
+        # Result was cached after DB lookup
+        mock_cache.set_user_role.assert_awaited_once_with("user@example.com", "team-1", "member")

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -1824,8 +1824,9 @@ class TestOAuthAccessHelpers:
         gateway = SimpleNamespace(visibility="internal", owner_email=None, team_id="team-1")
         mock_request = Mock(spec=Request)
         mock_request.state = SimpleNamespace(token_teams=["team-1"])
-        with patch("mcpgateway.services.team_management_service.TeamManagementService.get_user_role_in_team", new_callable=AsyncMock, return_value="developer"):
+        with patch("mcpgateway.services.team_management_service.TeamManagementService.get_user_role_in_team", new_callable=AsyncMock, return_value="developer") as mock_role:
             await _enforce_gateway_access("gateway123", gateway, {"email": "user@example.com", "is_admin": False}, mock_db, request=mock_request)
+            mock_role.assert_called_once_with("user@example.com", "team-1")
 
 
 class TestOAuthRouterAdditionalCoverage:

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -21,7 +21,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 # First-Party
-from mcpgateway.db import Gateway
+from mcpgateway.db import EmailTeamMember, Gateway
 from mcpgateway.middleware.token_scoping import ResourceOwnershipResult
 from mcpgateway.routers.oauth_router import (
     ADMIN_CSRF_COOKIE_NAME,
@@ -1749,14 +1749,6 @@ class TestOAuthAccessHelpers:
             await _enforce_gateway_access("gateway123", gateway, {"email": "user@example.com", "is_admin": False}, mock_db, request=None)
 
         assert exc_info.value.status_code == 403
-
-    @pytest.mark.asyncio
-    async def test_enforce_gateway_access_team_visibility_member_allowed(self, mock_db):
-        from mcpgateway.routers.oauth_router import _enforce_gateway_access
-
-        gateway = SimpleNamespace(visibility="team", owner_email=None, team_id="team-1")
-        with patch("mcpgateway.services.team_management_service.TeamManagementService.get_user_role_in_team", new_callable=AsyncMock, return_value="owner"):
-            await _enforce_gateway_access("gateway123", gateway, {"email": "user@example.com", "is_admin": False}, mock_db, request=None)
 
     @pytest.mark.asyncio
     async def test_enforce_gateway_access_team_visibility_non_member_denied(self, mock_db):
@@ -4416,12 +4408,12 @@ def test_oauth_callback_scope_non_string_non_list():
 
 
 # ---------------------------------------------------------------------------
-# Integration test: _enforce_gateway_access with warm role cache
+# Cache-layer tests: _enforce_gateway_access with role cache
 # ---------------------------------------------------------------------------
 
 
-class TestEnforceGatewayAccessCacheIntegration:
-    """Integration test exercising _enforce_gateway_access through TeamManagementService with cache.
+class TestEnforceGatewayAccessCacheLayer:
+    """Cache-layer tests exercising _enforce_gateway_access through TeamManagementService.
 
     Unlike the unit tests above (which mock get_user_role_in_team directly),
     this test mocks at the cache layer to confirm the full call chain:
@@ -4494,6 +4486,14 @@ class TestEnforceGatewayAccessCacheIntegration:
 
         # Cache was checked first
         mock_cache.get_user_role.assert_awaited_once_with("user@example.com", "team-1")
+        mock_db.query.assert_called_once_with(EmailTeamMember)
+        criteria = mock_db.query.return_value.filter.call_args.args
+        assert len(criteria) == 3
+        assert criteria[0].left.compare(EmailTeamMember.__table__.c.user_email)
+        assert criteria[0].right.value == "user@example.com"
+        assert criteria[1].left.compare(EmailTeamMember.__table__.c.team_id)
+        assert criteria[1].right.value == "team-1"
+        assert str(criteria[2]) == "email_team_members.is_active IS true"
         # Result was cached after DB lookup
         mock_cache.set_user_role.assert_awaited_once_with("user@example.com", "team-1", "member")
 
@@ -4501,10 +4501,9 @@ class TestEnforceGatewayAccessCacheIntegration:
     async def test_team_visibility_negative_cache_denies_access(self):
         """Negative cache entry (empty string = 'not a member') must deny access.
 
-        TeamManagementService.get_user_role_in_team() stores empty string in
-        cache to represent 'no membership' (line 1778: ``cached_role if
-        cached_role else None``).  The empty string is falsy, so the production
-        code's ``if not role:`` check at oauth_router.py:561 must raise 403.
+        TeamManagementService.get_user_role_in_team() converts the cache's
+        empty-string negative marker to ``None``. The resulting falsy role must
+        be denied by ``_enforce_gateway_access``.
         """
         from mcpgateway.routers.oauth_router import _enforce_gateway_access
 

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -1795,33 +1795,22 @@ class TestOAuthAccessHelpers:
 
     @pytest.mark.asyncio
     async def test_enforce_gateway_access_team_visibility_cache_hit_member_allowed(self, mock_db):
-        """Regression: detached EmailUser (cache-hit) with empty team_memberships must not block access.
+        """Regression: the new TeamManagementService path must be the sole membership check.
 
-        Constructs a scenario where EmailAuthService.get_user_by_email() would return a
-        cache-reconstructed EmailUser with team_memberships=[] (the old broken path).
-        The fix uses TeamManagementService.get_user_role_in_team() which checks the role
-        cache independently, so a non-None role should grant access regardless.
+        Verifies that _enforce_gateway_access calls get_user_role_in_team (the
+        cache-aware path) and that the result determines access. If someone
+        reverted to the old EmailAuthService + user.is_team_member() pattern,
+        the patched get_user_role_in_team would never execute and the assertion
+        on mock_role would fail.
         """
         from mcpgateway.routers.oauth_router import _enforce_gateway_access
 
         gateway = SimpleNamespace(visibility="team", owner_email=None, team_id="team-1")
         with patch("mcpgateway.services.team_management_service.TeamManagementService.get_user_role_in_team", new_callable=AsyncMock, return_value="member") as mock_role:
-            # Simulate a detached EmailUser that would have been returned by the old path —
-            # the new code never calls EmailAuthService, so this simply confirms the old
-            # broken path is unreachable.
-            with patch("mcpgateway.services.email_auth_service.EmailAuthService") as mock_auth_cls:
-                mock_user = Mock()
-                mock_user.is_team_member = Mock(return_value=False)  # Would deny under old code
-                mock_auth_svc = Mock()
-                mock_auth_svc.get_user_by_email = AsyncMock(return_value=mock_user)
-                mock_auth_cls.return_value = mock_auth_svc
+            await _enforce_gateway_access("gateway123", gateway, {"email": "user@example.com", "is_admin": False}, mock_db, request=None)
 
-                await _enforce_gateway_access("gateway123", gateway, {"email": "user@example.com", "is_admin": False}, mock_db, request=None)
-
-            # TeamManagementService was called (new path)
+            # TeamManagementService was called with the correct args (new path)
             mock_role.assert_called_once_with("user@example.com", "team-1")
-            # EmailAuthService was NOT called (old path unreachable)
-            mock_auth_cls.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_enforce_gateway_access_unknown_visibility_with_request_team_member_allowed(self, mock_db):
@@ -4468,6 +4457,8 @@ class TestEnforceGatewayAccessCacheIntegration:
 
         # Verify cache was consulted
         mock_cache.get_user_role.assert_awaited_once_with("user@example.com", "team-1")
+        # DB must NOT be queried on a cache hit
+        mock_db.query.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_team_visibility_cache_miss_falls_back_to_db(self):
@@ -4504,3 +4495,38 @@ class TestEnforceGatewayAccessCacheIntegration:
         mock_cache.get_user_role.assert_awaited_once_with("user@example.com", "team-1")
         # Result was cached after DB lookup
         mock_cache.set_user_role.assert_awaited_once_with("user@example.com", "team-1", "member")
+
+    @pytest.mark.asyncio
+    async def test_team_visibility_negative_cache_denies_access(self):
+        """Negative cache entry (empty string = 'not a member') must deny access.
+
+        TeamManagementService.get_user_role_in_team() stores empty string in
+        cache to represent 'no membership' (line 1778: ``cached_role if
+        cached_role else None``).  The empty string is falsy, so the production
+        code's ``if not role:`` check at oauth_router.py:561 must raise 403.
+        """
+        from mcpgateway.routers.oauth_router import _enforce_gateway_access
+
+        mock_db = Mock(spec=Session)
+        gateway = SimpleNamespace(visibility="team", owner_email=None, team_id="team-1")
+
+        mock_cache = AsyncMock()
+        # Empty string = cached negative result ("not a member")
+        mock_cache.get_user_role = AsyncMock(return_value="")
+        mock_cache.set_user_role = AsyncMock()
+
+        with patch("mcpgateway.services.team_management_service.get_auth_cache", return_value=mock_cache):
+            with pytest.raises(HTTPException) as exc_info:
+                await _enforce_gateway_access(
+                    "gateway123",
+                    gateway,
+                    {"email": "outsider@example.com", "is_admin": False},
+                    mock_db,
+                    request=None,
+                )
+
+        assert exc_info.value.status_code == 403
+        # Cache was consulted (negative hit)
+        mock_cache.get_user_role.assert_awaited_once_with("outsider@example.com", "team-1")
+        # No DB fallback on a negative cache hit
+        mock_db.query.assert_not_called()

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -1753,17 +1753,19 @@ class TestOAuthAccessHelpers:
     async def test_enforce_gateway_access_team_visibility_member_allowed(self, mock_db):
         from mcpgateway.routers.oauth_router import _enforce_gateway_access
 
-        class _User:
-            def is_team_member(self, _team_id):
-                return True
+        gateway = SimpleNamespace(visibility="team", owner_email=None, team_id="team-1")
+        with patch("mcpgateway.services.team_management_service.TeamManagementService.get_user_role_in_team", new_callable=AsyncMock, return_value="owner"):
+            await _enforce_gateway_access("gateway123", gateway, {"email": "user@example.com", "is_admin": False}, mock_db, request=None)
 
-        class _AuthService:
-            async def get_user_by_email(self, _email):
-                return _User()
+    @pytest.mark.asyncio
+    async def test_enforce_gateway_access_team_visibility_non_member_denied(self, mock_db):
+        from mcpgateway.routers.oauth_router import _enforce_gateway_access
 
         gateway = SimpleNamespace(visibility="team", owner_email=None, team_id="team-1")
-        with patch("mcpgateway.services.email_auth_service.EmailAuthService", return_value=_AuthService()):
-            await _enforce_gateway_access("gateway123", gateway, {"email": "user@example.com", "is_admin": False}, mock_db, request=None)
+        with patch("mcpgateway.services.team_management_service.TeamManagementService.get_user_role_in_team", new_callable=AsyncMock, return_value=None):
+            with pytest.raises(HTTPException) as exc_info:
+                await _enforce_gateway_access("gateway123", gateway, {"email": "user@example.com", "is_admin": False}, mock_db, request=None)
+        assert exc_info.value.status_code == 403
 
     @pytest.mark.asyncio
     async def test_enforce_gateway_access_unknown_visibility_owner_allowed(self, mock_db):
@@ -1776,35 +1778,18 @@ class TestOAuthAccessHelpers:
     async def test_enforce_gateway_access_unknown_visibility_team_member_allowed(self, mock_db):
         from mcpgateway.routers.oauth_router import _enforce_gateway_access
 
-        class _User:
-            def is_team_member(self, _team_id):
-                return True
-
-        class _AuthService:
-            async def get_user_by_email(self, _email):
-                return _User()
-
         gateway = SimpleNamespace(visibility="internal", owner_email=None, team_id="team-1")
-        with patch("mcpgateway.services.email_auth_service.EmailAuthService", return_value=_AuthService()):
+        with patch("mcpgateway.services.team_management_service.TeamManagementService.get_user_role_in_team", new_callable=AsyncMock, return_value="member"):
             await _enforce_gateway_access("gateway123", gateway, {"email": "user@example.com", "is_admin": False}, mock_db, request=None)
 
     @pytest.mark.asyncio
     async def test_enforce_gateway_access_unknown_visibility_team_non_member_denied(self, mock_db):
         from mcpgateway.routers.oauth_router import _enforce_gateway_access
 
-        class _User:
-            def is_team_member(self, _team_id):
-                return False
-
-        class _AuthService:
-            async def get_user_by_email(self, _email):
-                return _User()
-
         gateway = SimpleNamespace(visibility="internal", owner_email=None, team_id="team-1")
-        with patch("mcpgateway.services.email_auth_service.EmailAuthService", return_value=_AuthService()):
+        with patch("mcpgateway.services.team_management_service.TeamManagementService.get_user_role_in_team", new_callable=AsyncMock, return_value=None):
             with pytest.raises(HTTPException) as exc_info:
                 await _enforce_gateway_access("gateway123", gateway, {"email": "user@example.com", "is_admin": False}, mock_db, request=None)
-
         assert exc_info.value.status_code == 403
 
 
@@ -2064,15 +2049,7 @@ class TestOAuthRouterAdditionalCoverage:
         }
         mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
 
-        class _User:
-            def is_team_member(self, _team_id):
-                return False
-
-        class _AuthService:
-            async def get_user_by_email(self, _email):
-                return _User()
-
-        with patch("mcpgateway.services.email_auth_service.EmailAuthService", return_value=_AuthService()):
+        with patch("mcpgateway.services.team_management_service.TeamManagementService.get_user_role_in_team", new_callable=AsyncMock, return_value=None):
             # First-Party
             from mcpgateway.routers.oauth_router import initiate_oauth_flow
 
@@ -2288,15 +2265,7 @@ class TestOAuthRouterAdditionalCoverage:
         mock_gateway.oauth_config = {"grant_type": "authorization_code", "client_id": "cid"}
         mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
 
-        class _User:
-            def is_team_member(self, _team_id):
-                return False
-
-        class _AuthService:
-            async def get_user_by_email(self, _email):
-                return _User()
-
-        with patch("mcpgateway.services.email_auth_service.EmailAuthService", return_value=_AuthService()):
+        with patch("mcpgateway.services.team_management_service.TeamManagementService.get_user_role_in_team", new_callable=AsyncMock, return_value=None):
             # First-Party
             from mcpgateway.routers.oauth_router import get_oauth_status
 

--- a/tests/unit/mcpgateway/routers/test_vault_router.py
+++ b/tests/unit/mcpgateway/routers/test_vault_router.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 from fastapi import HTTPException
+from fastapi.responses import RedirectResponse
 import pytest
 
 # First-Party
@@ -258,8 +259,6 @@ class TestVaultAuthorizeDenyPaths:
                     }
                     mock_oauth_cls.return_value = mock_oauth
 
-                    from fastapi.responses import RedirectResponse
-
                     response = await vault_authorize(
                         request=_make_request(),
                         server_id="srv-123",
@@ -292,8 +291,6 @@ class TestVaultAuthorizeDenyPaths:
                         "authorization_url": "https://idp.example.com/authorize?state=abc"
                     }
                     mock_oauth_cls.return_value = mock_oauth
-
-                    from fastapi.responses import RedirectResponse
 
                     response = await vault_authorize(
                         request=_make_request(),
@@ -377,8 +374,6 @@ class TestVaultAuthorizeDenyPaths:
                             "authorization_url": "https://idp.example.com/authorize?state=xyz"
                         }
                         mock_oauth_cls.return_value = mock_oauth
-
-                        from fastapi.responses import RedirectResponse
 
                         response = await vault_authorize(
                             request=_make_request(),

--- a/tests/unit/mcpgateway/routers/test_vault_router.py
+++ b/tests/unit/mcpgateway/routers/test_vault_router.py
@@ -348,6 +348,50 @@ class TestVaultAuthorizeDenyPaths:
         assert exc_info.value.status_code == 403
         mock_resolve.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_team_member_cache_hit_allowed(self):
+        """Team member with cache-hit role (no DB query) gets 302 redirect.
+
+        Regression test: confirms the vault_authorize path uses
+        _enforce_gateway_access with TeamManagementService.get_user_role_in_team()
+        (cache-aware) rather than the old EmailAuthService.get_user_by_email() +
+        user.is_team_member() path that failed on detached cache-reconstructed users.
+        """
+        db = MagicMock()
+        db.get.return_value = _make_server()
+        gateway = _make_gateway(visibility="team", team_id="engineering")
+
+        alice = _make_user(email="alice@corp.com", is_admin=False, token_teams=["engineering"])
+
+        with patch("mcpgateway.routers.vault_router._resolve_oauth_gateway", return_value=gateway):
+            with patch("mcpgateway.routers.vault_router._check_server_visibility", return_value=True):
+                # Let _enforce_gateway_access run for real — it will call TeamManagementService
+                with patch(
+                    "mcpgateway.services.team_management_service.TeamManagementService.get_user_role_in_team",
+                    new_callable=AsyncMock,
+                    return_value="member",  # Cache-hit returns role
+                ) as mock_role:
+                    with patch("mcpgateway.routers.vault_router.OAuthManager") as mock_oauth_cls:
+                        mock_oauth = AsyncMock()
+                        mock_oauth.initiate_authorization_code_flow.return_value = {
+                            "authorization_url": "https://idp.example.com/authorize?state=xyz"
+                        }
+                        mock_oauth_cls.return_value = mock_oauth
+
+                        from fastapi.responses import RedirectResponse
+
+                        response = await vault_authorize(
+                            request=_make_request(),
+                            server_id="srv-123",
+                            gateway_url=None,
+                            db=db,
+                            current_user=alice,
+                        )
+
+                    assert isinstance(response, RedirectResponse)
+                    assert response.status_code == 302
+                    mock_role.assert_called_once_with("alice@corp.com", "engineering")
+
 
 # ---------------------------------------------------------------------------
 # Round-7 coverage: _resolve_oauth_gateway preferred_url not found (line 79),

--- a/tests/unit/mcpgateway/routers/test_vault_router.py
+++ b/tests/unit/mcpgateway/routers/test_vault_router.py
@@ -392,6 +392,37 @@ class TestVaultAuthorizeDenyPaths:
                     assert response.status_code == 302
                     mock_role.assert_called_once_with("alice@corp.com", "engineering")
 
+    @pytest.mark.asyncio
+    async def test_team_member_cache_miss_denied(self):
+        """Non-member denied via get_user_role_in_team returning None through vault path.
+
+        Deny-path counterpart to test_team_member_cache_hit_allowed. Confirms
+        vault_authorize surfaces the 403 from _enforce_gateway_access when the
+        caller has no role in the gateway's team (cache returns None).
+        """
+        db = MagicMock()
+        db.get.return_value = _make_server()
+        gateway = _make_gateway(visibility="team", team_id="engineering")
+
+        outsider = _make_user(email="outsider@corp.com", is_admin=False, token_teams=[])
+
+        with patch("mcpgateway.routers.vault_router._resolve_oauth_gateway", return_value=gateway):
+            with patch("mcpgateway.routers.vault_router._check_server_visibility", return_value=True):
+                with patch(
+                    "mcpgateway.services.team_management_service.TeamManagementService.get_user_role_in_team",
+                    new_callable=AsyncMock,
+                    return_value=None,
+                ):
+                    with pytest.raises(HTTPException) as exc_info:
+                        await vault_authorize(
+                            request=_make_request(),
+                            server_id="srv-123",
+                            gateway_url=None,
+                            db=db,
+                            current_user=outsider,
+                        )
+        assert exc_info.value.status_code == 403
+
 
 # ---------------------------------------------------------------------------
 # Round-7 coverage: _resolve_oauth_gateway preferred_url not found (line 79),

--- a/tests/unit/mcpgateway/services/test_team_management_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_team_management_service_coverage.py
@@ -10,7 +10,7 @@ Coverage tests for mcpgateway.services.team_management_service — missing branc
 import asyncio
 import base64
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 import orjson
@@ -18,7 +18,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 # First-Party
-from mcpgateway.db import EmailTeam, EmailTeamJoinRequest, EmailTeamMember, EmailTeamMemberHistory, EmailUser
+from mcpgateway.db import EmailTeam, EmailTeamJoinRequest, EmailTeamMember, EmailUser
 from mcpgateway.services.team_management_service import TeamManagementService, TeamMemberLimitExceededError
 
 
@@ -629,11 +629,17 @@ class TestGetTeamMembersEdge:
 
 
 class TestCacheGetters:
-    def test_auth_cache_import_error(self, svc):
-        """ImportError in _get_auth_cache returns None."""
-        with patch("mcpgateway.services.team_management_service.get_auth_cache", side_effect=ImportError("mocked")):
+    def test_auth_cache_factory_error_logs_and_returns_none(self, svc):
+        """Unexpected auth-cache factory failures degrade with an operator signal."""
+        error = RuntimeError("redis unavailable")
+        with (
+            patch("mcpgateway.services.team_management_service.get_auth_cache", side_effect=error),
+            patch("mcpgateway.services.team_management_service.logger.warning") as mock_warning,
+        ):
             result = svc._get_auth_cache()
+
         assert result is None
+        mock_warning.assert_called_once_with("Auth cache unavailable: %s", error)
 
     def test_admin_stats_cache_import_error(self, svc):
         """ImportError in _get_admin_stats_cache returns None."""
@@ -691,6 +697,23 @@ class TestGetUserRoleCache:
             result = await svc.get_user_role_in_team("u@t.com", "t1")
         assert result == "member"
         mock_cache.set_user_role.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_without_membership_stores_negative_result(self, svc, db):
+        """A confirmed DB miss is cached distinctly from a cache miss."""
+        mock_cache = MagicMock()
+        mock_cache.get_user_role = AsyncMock(return_value=None)
+        mock_cache.set_user_role = AsyncMock()
+
+        mock_query = MagicMock()
+        mock_query.filter.return_value.first.return_value = None
+        db.query = MagicMock(return_value=mock_query)
+
+        with patch.object(svc, "_get_auth_cache", return_value=mock_cache):
+            result = await svc.get_user_role_in_team("u@t.com", "t1")
+
+        assert result is None
+        mock_cache.set_user_role.assert_awaited_once_with("u@t.com", "t1", None)
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Team-visibility gateway OAuth flows (`/oauth/authorize` and `/vault/authorize`) return **403 "You don't have access to this gateway"** for team members when the user object is served from the auth cache.

## Root Cause

`_enforce_gateway_access` called `user.is_team_member()` on an `EmailUser` returned by `EmailAuthService.get_user_by_email()`. On a cache hit, this returns a detached SQLAlchemy object whose `team_memberships` relationship cannot lazy-load (no session), so `is_team_member()` always returns `False`.

## Fix

Replace `EmailAuthService.get_user_by_email()` + `user.is_team_member()` with `TeamManagementService.get_user_role_in_team()`, which checks the existing role cache (`auth_cache.get_user_role`) with DB fallback. This is the same pattern used by `PermissionService._is_team_member()` and avoids the detached-object problem entirely.

Both the `visibility == "team"` branch and the unknown-visibility fallback branch are fixed.

## Impact

- `GET /oauth/authorize/{gateway_id}` — admin one-time OAuth bootstrap for team gateways
- `GET /vault/authorize/{server_id}` — per-user OAuth credential connection for team servers
- `vault_router.py` imports `_enforce_gateway_access` from `oauth_router.py`, so both are fixed

Fixes #6590