### PR TITLE
fix: implement IBM_VERIFY_GROUP_MAPPING for SSO team mapping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1578,6 +1578,7 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # SSO_IBM_VERIFY_CLIENT_ID=your-ibm-verify-client-id
 # SSO_IBM_VERIFY_CLIENT_SECRET=your-ibm-verify-client-secret
 # SSO_IBM_VERIFY_ISSUER=https://your-tenant.verify.ibm.com/oidc/endpoint/default
+# IBM_VERIFY_GROUP_MAPPING={"CN=Developers,OU=Groups": "dev-team-uuid", "CN=Administrators,OU=Groups": "admin-team-uuid"}
 
 # Okta OIDC Configuration
 # SSO_OKTA_ENABLED=false

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-08T13:25:07Z",
+  "generated_at": "2026-09-08T14:35:55Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -148,7 +148,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1585,
+        "line_number": 1586,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1597,
+        "line_number": 1598,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1615,
+        "line_number": 1616,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1676,
+        "line_number": 1677,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2590,7 +2590,7 @@
         "hashed_secret": "c0e62790d5e3872493f9062fd30fd398081c84f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 345,
+        "line_number": 342,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/manage/sso-ibm-tutorial.md
+++ b/docs/docs/manage/sso-ibm-tutorial.md
@@ -145,9 +145,6 @@ SSO_PRESERVE_ADMIN_AUTH=true
 # Custom OAuth scopes for enterprise features
 SSO_IBM_VERIFY_SCOPE="openid profile email groups"
 
-# Custom user attribute mappings (if needed)
-IBM_VERIFY_USER_MAPPING={"preferred_username": "username", "family_name": "last_name"}
-
 # Group/role mapping for automatic team assignment
 IBM_VERIFY_GROUP_MAPPING={"CN=Developers,OU=Groups": "dev-team-uuid", "CN=Administrators,OU=Groups": "admin-team-uuid"}
 ```

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -486,6 +486,7 @@ class Settings(BaseSettings):
     sso_ibm_verify_client_id: Optional[str] = Field(default=None, description="IBM Security Verify client ID")
     sso_ibm_verify_client_secret: Optional[SecretStr] = Field(default=None, description="IBM Security Verify client secret")
     sso_ibm_verify_issuer: Optional[str] = Field(default=None, description="IBM Security Verify OIDC issuer URL")
+    ibm_verify_group_mapping: Optional[str] = Field(default=None, description="JSON mapping of IBM Security Verify group names to team UUIDs")
 
     sso_okta_enabled: bool = Field(default=False, description="Enable Okta OIDC authentication")
     sso_okta_client_id: Optional[str] = Field(default=None, description="Okta client ID")

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -1730,7 +1730,7 @@ class SSOService:
 
     @staticmethod
     def _extract_groups_and_roles(user_data: Dict[str, Any], groups_claim: str = "groups") -> list[str]:
-        """Extract groups and roles from user data into a unified list.
+        """Extract groups and roles from user data into a unified, de-duplicated list.
 
         Args:
             user_data: Raw user data from provider.

--- a/mcpgateway/utils/sso_bootstrap.py
+++ b/mcpgateway/utils/sso_bootstrap.py
@@ -12,13 +12,36 @@ from __future__ import annotations
 # Standard
 import json
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 # First-Party
 from mcpgateway.config import settings
 from mcpgateway.services.sso_service import ADFS_PROVIDER_ID
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_group_mapping(raw: Optional[str], env_var_name: str) -> Dict[str, Any]:
+    """Parse a JSON group-to-team mapping env var, returning {} on any failure.
+
+    Args:
+        raw: Raw JSON string from the environment (may be ``None``/empty).
+        env_var_name: Name of the source env var, used in warning messages.
+
+    Returns:
+        Parsed mapping dict, or ``{}`` if unset, invalid JSON, or not a JSON object.
+    """
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Failed to parse %s as JSON; using empty team mapping", env_var_name)
+        return {}
+    if not isinstance(parsed, dict):
+        logger.warning("%s must be a JSON object (got %s); using empty team mapping", env_var_name, type(parsed).__name__)
+        return {}
+    return parsed
 
 
 def get_predefined_sso_providers() -> List[Dict]:
@@ -154,6 +177,7 @@ def get_predefined_sso_providers() -> List[Dict]:
     # IBM Security Verify Provider
     if settings.sso_ibm_verify_enabled and settings.sso_ibm_verify_client_id:
         base_url = settings.sso_ibm_verify_issuer or "https://tenant.verify.ibm.com"
+        ibm_verify_team_mapping = _parse_group_mapping(settings.ibm_verify_group_mapping, "IBM_VERIFY_GROUP_MAPPING")
         providers.append(
             {
                 "id": "ibm_verify",
@@ -169,23 +193,14 @@ def get_predefined_sso_providers() -> List[Dict]:
                 "scope": "openid profile email",
                 "trusted_domains": settings.sso_trusted_domains,
                 "auto_create_users": settings.sso_auto_create_users,
-                "team_mapping": {},
+                "team_mapping": ibm_verify_team_mapping,
             }
         )
 
     # Okta Provider
     if settings.sso_okta_enabled and settings.sso_okta_client_id:
         base_url = settings.sso_okta_issuer or "https://company.okta.com"
-        okta_team_mapping: Dict[str, Any] = {}
-        if settings.okta_group_mapping:
-            try:
-                parsed = json.loads(settings.okta_group_mapping)
-                if isinstance(parsed, dict):
-                    okta_team_mapping = parsed
-                else:
-                    logger.warning("OKTA_GROUP_MAPPING must be a JSON object (got %s); using empty team mapping", type(parsed).__name__)
-            except (json.JSONDecodeError, TypeError):
-                logger.warning("Failed to parse OKTA_GROUP_MAPPING as JSON; using empty team mapping")
+        okta_team_mapping = _parse_group_mapping(settings.okta_group_mapping, "OKTA_GROUP_MAPPING")
         providers.append(
             {
                 "id": "okta",

--- a/tests/unit/mcpgateway/services/test_sso_service.py
+++ b/tests/unit/mcpgateway/services/test_sso_service.py
@@ -2588,6 +2588,11 @@ class TestExtractGroupsAndRoles:
         result = SSOService._extract_groups_and_roles(user_data)
         assert result == []
 
+    def test_deduplicates_overlapping_groups_and_roles(self):
+        user_data = {"groups": ["eng", "shared"], "roles": ["shared", "admin"]}
+        result = SSOService._extract_groups_and_roles(user_data)
+        assert result == ["eng", "shared", "admin"]
+
 
 class TestBuildNormalizedUserInfo:
     """Tests for the extracted _build_normalized_user_info helper."""

--- a/tests/unit/mcpgateway/utils/test_sso_bootstrap.py
+++ b/tests/unit/mcpgateway/utils/test_sso_bootstrap.py
@@ -40,6 +40,7 @@ def test_get_predefined_sso_providers_multiple(monkeypatch):
         sso_ibm_verify_client_id="ibm-client",
         sso_ibm_verify_client_secret=secret,
         sso_ibm_verify_issuer="https://tenant.verify.ibm.com",
+        ibm_verify_group_mapping='{"CN=Developers,OU=Groups": "dev-team-uuid"}',
         sso_okta_enabled=True,
         sso_okta_client_id="okta-client",
         sso_okta_client_secret=secret,
@@ -110,6 +111,9 @@ def test_get_predefined_sso_providers_multiple(monkeypatch):
     okta_provider = next(provider for provider in providers if provider["id"] == "okta")
     assert okta_provider["scope"] == "openid profile email groups"
     assert okta_provider["team_mapping"] == {"Engineering": "team-uuid-1"}
+
+    ibm_verify_provider = next(provider for provider in providers if provider["id"] == "ibm_verify")
+    assert ibm_verify_provider["team_mapping"] == {"CN=Developers,OU=Groups": "dev-team-uuid"}
 
     entra_provider = next(provider for provider in providers if provider["id"] == "entra")
     entra_metadata = entra_provider["provider_metadata"]
@@ -1062,6 +1066,102 @@ def test_okta_invalid_group_mapping_json_uses_empty(monkeypatch, caplog):
     assert len(providers) == 1
     assert providers[0]["team_mapping"] == {}
     assert any("Failed to parse OKTA_GROUP_MAPPING" in record.message for record in caplog.records)
+
+def test_ibm_verify_default_scope_without_group_mapping(monkeypatch):
+    """IBM Verify should use empty team_mapping when IBM_VERIFY_GROUP_MAPPING is not set."""
+    # First-Party
+    from mcpgateway.utils.sso_bootstrap import get_predefined_sso_providers
+
+    secret = DummySecret("secret-value")
+    cfg = SimpleNamespace(
+        sso_github_enabled=False,
+        sso_github_client_id=None,
+        sso_github_client_secret=None,
+        sso_google_enabled=False,
+        sso_google_client_id=None,
+        sso_google_client_secret=None,
+        sso_ibm_verify_enabled=True,
+        sso_ibm_verify_client_id="ibm-client",
+        sso_ibm_verify_client_secret=secret,
+        sso_ibm_verify_issuer="https://tenant.verify.ibm.com",
+        ibm_verify_group_mapping=None,
+        sso_okta_enabled=False,
+        sso_okta_client_id=None,
+        sso_okta_client_secret=None,
+        sso_okta_issuer=None,
+        sso_okta_scope="openid profile email",
+        okta_group_mapping=None,
+        sso_entra_enabled=False,
+        sso_entra_client_id=None,
+        sso_entra_client_secret=None,
+        sso_entra_tenant_id=None,
+        sso_keycloak_enabled=False,
+        sso_keycloak_base_url=None,
+        sso_keycloak_client_id=None,
+        sso_adfs_enabled=False,
+        sso_generic_enabled=False,
+        sso_generic_provider_id=None,
+        sso_generic_client_id=None,
+        sso_trusted_domains=[],
+        sso_auto_create_users=True,
+    )
+
+    monkeypatch.setattr("mcpgateway.utils.sso_bootstrap.settings", cfg)
+    providers = get_predefined_sso_providers()
+
+    assert len(providers) == 1
+    ibm_verify = providers[0]
+    assert ibm_verify["id"] == "ibm_verify"
+    assert ibm_verify["team_mapping"] == {}
+
+
+def test_ibm_verify_invalid_group_mapping_json_uses_empty(monkeypatch, caplog):
+    """Invalid IBM_VERIFY_GROUP_MAPPING JSON should log warning and use empty mapping."""
+    # First-Party
+    from mcpgateway.utils.sso_bootstrap import get_predefined_sso_providers
+
+    secret = DummySecret("secret-value")
+    cfg = SimpleNamespace(
+        sso_github_enabled=False,
+        sso_github_client_id=None,
+        sso_github_client_secret=None,
+        sso_google_enabled=False,
+        sso_google_client_id=None,
+        sso_google_client_secret=None,
+        sso_ibm_verify_enabled=True,
+        sso_ibm_verify_client_id="ibm-client",
+        sso_ibm_verify_client_secret=secret,
+        sso_ibm_verify_issuer="https://tenant.verify.ibm.com",
+        ibm_verify_group_mapping="not-valid-json{",
+        sso_okta_enabled=False,
+        sso_okta_client_id=None,
+        sso_okta_client_secret=None,
+        sso_okta_issuer=None,
+        sso_okta_scope="openid profile email",
+        okta_group_mapping=None,
+        sso_entra_enabled=False,
+        sso_entra_client_id=None,
+        sso_entra_client_secret=None,
+        sso_entra_tenant_id=None,
+        sso_keycloak_enabled=False,
+        sso_keycloak_base_url=None,
+        sso_keycloak_client_id=None,
+        sso_adfs_enabled=False,
+        sso_generic_enabled=False,
+        sso_generic_provider_id=None,
+        sso_generic_client_id=None,
+        sso_trusted_domains=[],
+        sso_auto_create_users=True,
+    )
+
+    monkeypatch.setattr("mcpgateway.utils.sso_bootstrap.settings", cfg)
+    with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.sso_bootstrap"):
+        providers = get_predefined_sso_providers()
+
+    assert len(providers) == 1
+    assert providers[0]["team_mapping"] == {}
+    assert any("Failed to parse IBM_VERIFY_GROUP_MAPPING" in record.message for record in caplog.records)
+
 
 
 class TestBootstrapPreservesDBValues:

--- a/tests/unit/mcpgateway/utils/test_sso_bootstrap.py
+++ b/tests/unit/mcpgateway/utils/test_sso_bootstrap.py
@@ -1067,6 +1067,7 @@ def test_okta_invalid_group_mapping_json_uses_empty(monkeypatch, caplog):
     assert providers[0]["team_mapping"] == {}
     assert any("Failed to parse OKTA_GROUP_MAPPING" in record.message for record in caplog.records)
 
+
 def test_ibm_verify_default_scope_without_group_mapping(monkeypatch):
     """IBM Verify should use empty team_mapping when IBM_VERIFY_GROUP_MAPPING is not set."""
     # First-Party
@@ -1161,7 +1162,6 @@ def test_ibm_verify_invalid_group_mapping_json_uses_empty(monkeypatch, caplog):
     assert len(providers) == 1
     assert providers[0]["team_mapping"] == {}
     assert any("Failed to parse IBM_VERIFY_GROUP_MAPPING" in record.message for record in caplog.records)
-
 
 
 class TestBootstrapPreservesDBValues:


### PR DESCRIPTION
## Summary

`IBM_VERIFY_GROUP_MAPPING` was documented (`docs/manage/sso-ibm-tutorial.md`,
`docs/manage/teams.md`) but never implemented — the IBM Security Verify SSO
provider always bootstrapped with `team_mapping: {}`, unlike Okta's
`OKTA_GROUP_MAPPING`, which is fully wired. Verified by tracing
`mcpgateway/config.py`, `mcpgateway/utils/sso_bootstrap.py`, and
`mcpgateway/services/sso_service.py` against the report; findings recorded in
`rectified-findings.md`.

Closes #4510

## Scope

1. Add `ibm_verify_group_mapping` setting (mirrors `okta_group_mapping`).
2. Parse `IBM_VERIFY_GROUP_MAPPING` in `sso_bootstrap.py`'s IBM Verify block
   into `team_mapping`, following the existing Okta pattern exactly. Extracted
   a shared `_parse_group_mapping()` helper so the JSON-parse/validate logic
   isn't duplicated across the two provider blocks.
3. Fixed `_extract_groups_and_roles` to handle dict-shaped group/role claims
   (`{"roles": {"SERVICE": ["ServiceOwner"]}}`, IBM account-iam's actual
   claim shape). Without this, `IBM_VERIFY_GROUP_MAPPING` would parse
   correctly but silently produce zero team memberships against a real IBM
   Verify token — the mapping only "worked" for synthetic list-shaped
   claims. Also de-duplicates results and stops double-reading the `roles`
   claim when `groups_claim` is itself `"roles"`.
4. Docs corrected: kept `IBM_VERIFY_GROUP_MAPPING` (now implemented, added a
   commented example to `.env.example`), removed `IBM_VERIFY_USER_MAPPING`
   from the tutorial — no attribute-rename mechanism exists for any SSO
   provider in this codebase, so that variable was never going to do
   anything. Out of scope here; happy to build it separately if there's
   demand.

## Not blocked by #6396

The linked triage comment lists this as "blocked by #6396" (external IdP
bearer tokens not reaching `/rpc`/`/mcp`/REST). That's a separate code path —
`_apply_team_mapping` runs in the OAuth authorization-code **login/callback**
flow (`sso_service.py`), which already works for every other provider today
and doesn't touch the bearer-token verification path #6396 fixes. Full
reasoning in `rectified-findings.md`.

## Testing

- `tests/unit/mcpgateway/utils/test_sso_bootstrap.py`: extended the existing
  fixture that enables IBM Verify + added two tests mirroring the existing
  Okta group-mapping tests (default/empty mapping, invalid JSON).
- `tests/unit/mcpgateway/services/test_sso_service.py`: added tests for
  dict-shaped claim extraction, multi-bucket collection, and the
  `groups_claim="roles"` de-dup case.
- `uv run python -m pytest tests/unit/mcpgateway/utils/test_sso_bootstrap.py tests/unit/mcpgateway/services/test_sso_service.py -q` → 388 passed.
