### PR TITLE
feat(sso): add SSO_ALLOW_PROVIDER_LINKING for cross-provider login (#6431)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1700,6 +1700,9 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # Allow an existing account (matched by verified email) to sign in through a
 # different trusted SSO provider, rebinding it to the new provider. Only applies
 # to email-verified logins that already pass trusted-domain policy.
+# This is a single global switch for ALL configured providers, not scoped to a
+# specific trusted pair — enabling it allows relinking between any two providers
+# on this gateway. Admin status is re-vetted against the new provider on relink.
 # Default false: one email is bound to one provider; cross-provider sign-in is refused.
 # SSO_ALLOW_PROVIDER_LINKING=false
 

--- a/.env.example
+++ b/.env.example
@@ -1697,6 +1697,12 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # Keep local admin authentication when SSO is enabled
 # SSO_PRESERVE_ADMIN_AUTH=true
 
+# Allow an existing account (matched by verified email) to sign in through a
+# different trusted SSO provider, rebinding it to the new provider. Only applies
+# to email-verified logins that already pass trusted-domain policy.
+# Default false: one email is bound to one provider; cross-provider sign-in is refused.
+# SSO_ALLOW_PROVIDER_LINKING=false
+
 # Bootstrap Behavior: Auto-disable providers not in environment config
 # When true: Providers configured in database but missing from SSO_*_ENABLED
 #            environment variables will be automatically disabled during bootstrap.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-09T14:53:12Z",
+  "generated_at": "2026-09-10T13:37:04Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -224,7 +224,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2290,
+        "line_number": 2294,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -232,7 +232,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2378,
+        "line_number": 2382,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -240,7 +240,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2728,
+        "line_number": 2732,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -248,7 +248,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4093,
+        "line_number": 4097,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -256,7 +256,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4184,
+        "line_number": 4188,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -264,7 +264,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4227,
+        "line_number": 4231,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -272,7 +272,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4232,
+        "line_number": 4236,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -280,7 +280,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4237,
+        "line_number": 4241,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1902,7 +1902,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 493,
+        "line_number": 494,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1910,7 +1910,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 936,
+        "line_number": 937,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1918,7 +1918,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1414,
+        "line_number": 1415,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1926,7 +1926,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1446,
+        "line_number": 1447,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -1934,7 +1934,7 @@
         "hashed_secret": "424ca52f87120d5dd4475b0b4aaed10adc379fb9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1450,
+        "line_number": 1451,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2656,7 +2656,7 @@
         "hashed_secret": "d8aae2c7a30fa154c7bf3e7c32ca32212f9320d1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 316,
+        "line_number": 319,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2664,7 +2664,7 @@
         "hashed_secret": "c303df00cd0a72b21c62900b758b06fc541664ce",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 337,
+        "line_number": 340,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2672,7 +2672,7 @@
         "hashed_secret": "e3881428d6c5f285fdd894d8e2892629651a78dd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 355,
+        "line_number": 358,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2680,7 +2680,7 @@
         "hashed_secret": "0fecd742545413abec6ab7e27c3aeecf00c534a7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 414,
+        "line_number": 417,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2688,7 +2688,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 453,
+        "line_number": 456,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2696,7 +2696,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 632,
+        "line_number": 635,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2704,7 +2704,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 777,
+        "line_number": 780,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2712,7 +2712,7 @@
         "hashed_secret": "5c216af8faacfff02f8ee00326ecfcfb3334922f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 799,
+        "line_number": 802,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2720,7 +2720,7 @@
         "hashed_secret": "157b314984dacdea10427c1ae3a856d286318e0d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 902,
+        "line_number": 905,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@ Release 1.0.10 consolidates **10 PRs** focused on **OAuth security and reliabili
 | [#6658](https://github.com/IBM/mcp-context-forge/pull/6658) | update Python and Node.js dependencies, rebuild the Admin UI bundle, and bump `fast-uri` to address four high-severity advisories |
 
 
+### Fixed
+
+- **SSO cross-provider relink misconfiguration and admin carryover** ([#6431](https://github.com/IBM/mcp-context-forge/issues/6431)) - Cross-provider sign-in for an already-linked email is now gated behind an explicit, fail-closed `SSO_ALLOW_PROVIDER_LINKING` setting (default `false`) instead of an always-on, misleadingly-logged auto-link. When linking is enabled, relinking now re-vets admin status against the new provider and demotes regardless of how admin was originally granted (`api`, manual, or `sso`), closing a privilege-carryover path where a manually-granted admin could relink to a provider that never vets for admin and silently keep `*` permissions. The refuse-path log message wording changed from "account-linking required" to "login refused"; update any log-based alerting that matched the old string.
+
 ## [1.0.9] - 2026-08-31 - mTLS, OAuth Quick Wins, Tool Preview, Catalog Actions, and Security Hardening
 
 ### Overview

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -477,6 +477,7 @@ When `SMTP_ENABLED=false`, reset requests are accepted but no email is delivered
 | `SSO_AUTO_CREATE_USERS`       | Automatically create users from SSO providers    | `true`                | bool    |
 | `SSO_TRUSTED_DOMAINS`         | Trusted email domains (JSON array)               | `[]`                  | JSON array |
 | `SSO_PRESERVE_ADMIN_AUTH`     | Preserve local admin authentication when SSO enabled | `true`            | bool    |
+| `SSO_ALLOW_PROVIDER_LINKING`  | Let a verified email sign in via a different trusted provider (rebinds) | `false`     | bool    |
 | `SSO_REQUIRE_ADMIN_APPROVAL`  | Require admin approval for new SSO registrations | `false`               | bool    |
 | `SSO_ISSUERS`                 | Optional JSON array of issuer URLs for SSO providers | (none)            | JSON array |
 | `SSO_AUTO_ADMIN_DOMAINS`      | Email domains that automatically get admin privileges | `[]`             | JSON array |

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -477,7 +477,7 @@ When `SMTP_ENABLED=false`, reset requests are accepted but no email is delivered
 | `SSO_AUTO_CREATE_USERS`       | Automatically create users from SSO providers    | `true`                | bool    |
 | `SSO_TRUSTED_DOMAINS`         | Trusted email domains (JSON array)               | `[]`                  | JSON array |
 | `SSO_PRESERVE_ADMIN_AUTH`     | Preserve local admin authentication when SSO enabled | `true`            | bool    |
-| `SSO_ALLOW_PROVIDER_LINKING`  | Let a verified email sign in via a different trusted provider (rebinds) | `false`     | bool    |
+| `SSO_ALLOW_PROVIDER_LINKING`  | Let a verified email sign in via a different trusted provider (rebinds). Global switch across all providers, not scoped to a pair; admin status is re-vetted against the new provider on relink. | `false`     | bool    |
 | `SSO_REQUIRE_ADMIN_APPROVAL`  | Require admin approval for new SSO registrations | `false`               | bool    |
 | `SSO_ISSUERS`                 | Optional JSON array of issuer URLs for SSO providers | (none)            | JSON array |
 | `SSO_AUTO_ADMIN_DOMAINS`      | Email domains that automatically get admin privileges | `[]`             | JSON array |

--- a/docs/docs/manage/sso.md
+++ b/docs/docs/manage/sso.md
@@ -254,6 +254,9 @@ Response:
     - The SSO login endpoint sets an HTTP-only `sso_session_id` cookie and binds OAuth `state` to that browser session. The callback must present the same cookie or authentication is rejected.
     - Optional `scopes` supplied to `/auth/sso/login/{provider}` must be a subset of the provider's configured scope policy. Out-of-policy scopes are rejected with HTTP `400`.
 
+!!! important "One Email, One Provider"
+    A verified email is bound to the SSO provider it first signed in through. Signing in again with the same email from a *different* provider is refused by default (`SSO_ALLOW_PROVIDER_LINKING=false`) to stop account takeover via an unvetted provider. Set `SSO_ALLOW_PROVIDER_LINKING=true` to allow relinking — this is a global switch across all configured providers, not scoped to a specific pair, and admin status is always re-vetted against the new provider on relink (see [Configuration Reference](configuration.md)).
+
 ## Provider Configuration
 
 ### GitHub OAuth Setup

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -590,6 +590,9 @@ class Settings(BaseSettings):
         description=(
             "Allow an existing account (matched by verified email) to sign in through a different trusted SSO provider, "
             "rebinding it to the new provider. Only applies to email-verified logins that already pass trusted-domain policy. "
+            "This is a single global switch for ALL configured providers, not scoped to a specific trusted pair — enabling it "
+            "allows relinking between any two providers on this gateway. Admin status is re-vetted against the new provider "
+            "on relink regardless of how admin was originally granted, so a non-admin-granting provider cannot inherit admin. "
             "Default: false (one email is bound to one provider; cross-provider sign-in is refused)."
         ),
     )

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -585,6 +585,14 @@ class Settings(BaseSettings):
     sso_auto_create_users: bool = Field(default=True, description="Automatically create users from SSO providers")
     sso_trusted_domains: Annotated[list[str], NoDecode] = Field(default_factory=list, description="Trusted email domains (CSV or JSON list)")
     sso_preserve_admin_auth: bool = Field(default=True, description="Preserve local admin authentication when SSO is enabled")
+    sso_allow_provider_linking: bool = Field(
+        default=False,
+        description=(
+            "Allow an existing account (matched by verified email) to sign in through a different trusted SSO provider, "
+            "rebinding it to the new provider. Only applies to email-verified logins that already pass trusted-domain policy. "
+            "Default: false (one email is bound to one provider; cross-provider sign-in is refused)."
+        ),
+    )
     sso_auto_disable_unconfigured_providers: bool = Field(
         default=False,
         description=(

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -2178,9 +2178,7 @@ class SSOService:
                     # Do NOT change admin_origin if already admin - preserve manual/API grants
                 elif current_is_admin and (current_admin_origin == "sso" or provider_relinked):
                     # No longer in admin groups, or relinked to a provider that doesn't grant admin.
-                    logger.warning(
-                        "Revoking is_admin for %s (admin_origin=%s, relinked=%s)", SecurityValidator.sanitize_log_message(email), current_admin_origin, provider_relinked
-                    )
+                    logger.warning("Revoking is_admin for %s (admin_origin=%s, relinked=%s)", SecurityValidator.sanitize_log_message(email), current_admin_origin, provider_relinked)
                     user.is_admin = False
                     user.admin_origin = None
                     current_is_admin = False

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -2124,8 +2124,7 @@ class SSOService:
                     # between callback and this call, or an id-casing mismatch) — refusing here
                     # keeps the relink admin-carryover guard (below) from being silently skipped.
                     logger.warning(
-                        "SSO authenticate_or_create_user: refusing login for email '%s' — incoming provider '%s' could not be resolved, "
-                        "so admin status cannot be re-vetted for a relink from '%s'.",
+                        "SSO authenticate_or_create_user: refusing login for email '%s' — incoming provider '%s' could not be resolved, so admin status cannot be re-vetted for a relink from '%s'.",
                         email,
                         incoming_provider,
                         current_auth_provider,

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -2119,6 +2119,18 @@ class SSOService:
             if user.auth_provider and current_auth_provider != incoming_provider:
                 # Email is already verified (gated above) and within trusted-domain policy,
                 # so linking here only ever rebinds a trusted, verified identity.
+                if provider is None:
+                    # Can't re-vet admin status against a provider we can't resolve (deleted
+                    # between callback and this call, or an id-casing mismatch) — refusing here
+                    # keeps the relink admin-carryover guard (below) from being silently skipped.
+                    logger.warning(
+                        "SSO authenticate_or_create_user: refusing login for email '%s' — incoming provider '%s' could not be resolved, "
+                        "so admin status cannot be re-vetted for a relink from '%s'.",
+                        email,
+                        incoming_provider,
+                        current_auth_provider,
+                    )
+                    return None
                 if not settings.sso_allow_provider_linking:
                     logger.warning(
                         "SSO authenticate_or_create_user: login refused for email '%s' — it is bound to provider '%s' and sign-in came from '%s'. "
@@ -2185,18 +2197,24 @@ class SSOService:
 
             self.db.commit()
 
-            if provider_ctx and self._should_sync_roles(provider_id, provider_metadata):
-                role_assignments = await self._map_groups_to_roles(email, user_info.get("groups", []), provider_ctx)
-                await self._sync_user_roles(email, role_assignments, provider_ctx)
-                # Belt-and-suspenders: if role sync assigned platform_admin but is_admin is still False
-                # (e.g. user existed before the generic OIDC fix was deployed), promote now.
-                if not current_is_admin and any(ra.get("role_name") == "platform_admin" for ra in role_assignments):
-                    logger.info("Promoting is_admin for %s — platform_admin role assigned via role_mappings", SecurityValidator.sanitize_log_message(email))
-                    user.is_admin = True
-                    user.admin_origin = "sso"
-                    current_is_admin = True
-                    self.db.commit()
-            await self._apply_team_mapping(email, user_info, provider)
+            try:
+                if provider_ctx and self._should_sync_roles(provider_id, provider_metadata):
+                    role_assignments = await self._map_groups_to_roles(email, user_info.get("groups", []), provider_ctx)
+                    await self._sync_user_roles(email, role_assignments, provider_ctx)
+                    # Belt-and-suspenders: if role sync assigned platform_admin but is_admin is still False
+                    # (e.g. user existed before the generic OIDC fix was deployed), promote now.
+                    if not current_is_admin and any(ra.get("role_name") == "platform_admin" for ra in role_assignments):
+                        logger.info("Promoting is_admin for %s — platform_admin role assigned via role_mappings", SecurityValidator.sanitize_log_message(email))
+                        user.is_admin = True
+                        user.admin_origin = "sso"
+                        current_is_admin = True
+                        self.db.commit()
+                await self._apply_team_mapping(email, user_info, provider)
+            finally:
+                # Row was mutated above (auth_provider relink, last_login, is_admin sync);
+                # drop the stale cached copy so the next read reflects the committed state,
+                # even if role sync or team mapping above raised.
+                await self.auth_service._invalidate_user_auth_cache(email)  # pylint: disable=protected-access
 
             user_email = getattr(user, "email", None)
             if isinstance(user_email, str) and user_email.strip():
@@ -2204,10 +2222,6 @@ class SSOService:
             resolved_full_name = current_full_name
             resolved_auth_provider = current_auth_provider
             resolved_is_admin = current_is_admin
-
-            # Row was mutated above (auth_provider relink, last_login, is_admin sync);
-            # drop the stale cached copy so the next read reflects the committed state.
-            await self.auth_service._invalidate_user_auth_cache(email)  # pylint: disable=protected-access
         else:
             # Auto-create user if enabled
             if not provider or not provider.auto_create_users:

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -2115,6 +2115,7 @@ class SSOService:
             current_is_admin = bool(user.is_admin)
             current_admin_origin = user.admin_origin
 
+            provider_relinked = False
             if user.auth_provider and current_auth_provider != incoming_provider:
                 # Email is already verified (gated above) and within trusted-domain policy,
                 # so linking here only ever rebinds a trusted, verified identity.
@@ -2135,6 +2136,7 @@ class SSOService:
                 )
                 user.auth_provider = incoming_provider
                 current_auth_provider = incoming_provider
+                provider_relinked = True
 
             provider_id: Optional[str] = None
             provider_metadata: Dict[str, Any] = {}
@@ -2158,10 +2160,11 @@ class SSOService:
             user.email_verified = self._is_email_verified_claim(user_info)
             user.last_login = utc_now()
 
-            # Synchronize is_admin status based on current group membership
-            # Track origin to support both promotion AND demotion for SSO-granted admins
-            # Manual/API grants are "sticky" - never auto-demoted by SSO
-            # Only users with admin_origin="sso" can be demoted on login
+            # Synchronize is_admin status based on current group membership.
+            # Manual/API grants are sticky - only admin_origin="sso" is auto-demoted on a
+            # same-provider login. A relink is the exception: it always re-vets against the
+            # new provider so an admin can't inherit "*" by relinking to a provider that
+            # never vets for admin (issue #6431).
             if provider_ctx:
                 should_be_admin = self._should_user_be_admin(email, user_info, provider_ctx)
                 if should_be_admin:
@@ -2173,9 +2176,11 @@ class SSOService:
                         user.admin_origin = "sso"
                         current_is_admin = True
                     # Do NOT change admin_origin if already admin - preserve manual/API grants
-                elif current_is_admin and current_admin_origin == "sso":
-                    # User was SSO admin but no longer in admin groups - revoke access
-                    logger.info("Revoking is_admin for %s - removed from SSO admin groups", SecurityValidator.sanitize_log_message(email))
+                elif current_is_admin and (current_admin_origin == "sso" or provider_relinked):
+                    # No longer in admin groups, or relinked to a provider that doesn't grant admin.
+                    logger.warning(
+                        "Revoking is_admin for %s (admin_origin=%s, relinked=%s)", SecurityValidator.sanitize_log_message(email), current_admin_origin, provider_relinked
+                    )
                     user.is_admin = False
                     user.admin_origin = None
                     current_is_admin = False

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -2114,13 +2114,25 @@ class SSOService:
             current_admin_origin = user.admin_origin
 
             if user.auth_provider and current_auth_provider != incoming_provider:
-                logger.warning(
-                    "SSO authenticate_or_create_user: account-linking required for email '%s' (existing provider='%s', incoming='%s').",
+                # Email is already verified (gated above) and within trusted-domain policy,
+                # so linking here only ever rebinds a trusted, verified identity.
+                if not settings.sso_allow_provider_linking:
+                    logger.warning(
+                        "SSO authenticate_or_create_user: login refused for email '%s' — it is bound to provider '%s' and sign-in came from '%s'. "
+                        "One email maps to one provider unless SSO_ALLOW_PROVIDER_LINKING is enabled.",
+                        email,
+                        current_auth_provider,
+                        incoming_provider,
+                    )
+                    return None
+                logger.info(
+                    "SSO authenticate_or_create_user: relinking email '%s' from provider '%s' to '%s' (SSO_ALLOW_PROVIDER_LINKING enabled).",
                     email,
                     current_auth_provider,
                     incoming_provider,
                 )
-                return None
+                user.auth_provider = incoming_provider
+                current_auth_provider = incoming_provider
 
             provider_id: Optional[str] = None
             provider_metadata: Dict[str, Any] = {}

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -2104,8 +2104,10 @@ class SSOService:
         resolved_auth_provider = incoming_provider
         resolved_is_admin = False
 
-        # Check if user exists
-        user = await self.auth_service.get_user_by_email(email)
+        # Mutation path: use a session-attached row (not the cached, detached copy
+        # get_user_by_email returns) so relink/last_login/is_admin writes below are
+        # tracked and durable across self.db.commit().
+        user = self.auth_service._fetch_user_from_db(email)  # pylint: disable=protected-access
 
         if user:
             current_full_name = user.full_name or resolved_full_name
@@ -2199,6 +2201,10 @@ class SSOService:
             resolved_full_name = current_full_name
             resolved_auth_provider = current_auth_provider
             resolved_is_admin = current_is_admin
+
+            # Row was mutated above (auth_provider relink, last_login, is_admin sync);
+            # drop the stale cached copy so the next read reflects the committed state.
+            await self.auth_service._invalidate_user_auth_cache(email)  # pylint: disable=protected-access
         else:
             # Auto-create user if enabled
             if not provider or not provider.auto_create_users:

--- a/tests/unit/mcpgateway/services/test_sso_approval_workflow.py
+++ b/tests/unit/mcpgateway/services/test_sso_approval_workflow.py
@@ -49,10 +49,9 @@ class TestSSOApprovalWorkflow:
             # Mock database queries
             sso_service.db.execute.return_value.scalar_one_or_none.return_value = None  # No existing pending approval
 
-            # Mock get_user_by_email to return None (new user)
+            # Mock the session-attached lookup used by SSO mutations.
             with patch.object(sso_service, "auth_service") as mock_auth_service:
-                # For async methods, need to use AsyncMock
-                mock_auth_service.get_user_by_email = AsyncMock(return_value=None)
+                mock_auth_service._fetch_user_from_db = MagicMock(return_value=None)
 
                 # Mock get_provider
                 with patch.object(sso_service, "get_provider") as mock_get_provider:
@@ -83,10 +82,9 @@ class TestSSOApprovalWorkflow:
             mock_pending.is_expired.return_value = False
             sso_service.db.execute.return_value.scalar_one_or_none.side_effect = [mock_pending, mock_pending]
 
-            # Mock get_user_by_email to return None (new user)
+            # Mock the session-attached lookup used by SSO mutations.
             with patch.object(sso_service, "auth_service") as mock_auth_service:
-                # For async methods, need to use AsyncMock
-                mock_auth_service.get_user_by_email = AsyncMock(return_value=None)
+                mock_auth_service._fetch_user_from_db = MagicMock(return_value=None)
 
                 # Mock user creation
                 mock_user = MagicMock()
@@ -133,10 +131,9 @@ class TestSSOApprovalWorkflow:
             mock_pending.status = "rejected"
             sso_service.db.execute.return_value.scalar_one_or_none.return_value = mock_pending
 
-            # Mock get_user_by_email to return None (new user)
+            # Mock the session-attached lookup used by SSO mutations.
             with patch.object(sso_service, "auth_service") as mock_auth_service:
-                # For async methods, need to use AsyncMock
-                mock_auth_service.get_user_by_email = AsyncMock(return_value=None)
+                mock_auth_service._fetch_user_from_db = MagicMock(return_value=None)
 
                 # Mock get_provider
                 with patch.object(sso_service, "get_provider") as mock_get_provider:

--- a/tests/unit/mcpgateway/services/test_sso_entra_role_mapping.py
+++ b/tests/unit/mcpgateway/services/test_sso_entra_role_mapping.py
@@ -31,6 +31,7 @@ def sso_service(mock_db_session):
     """Create SSO service instance with mock dependencies."""
     with patch("mcpgateway.services.sso_service.EmailAuthService"):
         service = SSOService(mock_db_session)
+        service.auth_service._invalidate_user_auth_cache = AsyncMock()
         return service
 
 
@@ -815,7 +816,7 @@ class TestIsAdminSyncOnLogin:
         mock_user.get_teams.return_value = []
 
         # Mock auth service to return existing user
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=mock_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=mock_user)
         sso_service.get_provider = MagicMock(return_value=entra_provider)
 
         # User info with admin group
@@ -863,7 +864,7 @@ class TestIsAdminSyncOnLogin:
         mock_user.get_teams.return_value = []
 
         # Mock auth service to return existing user
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=mock_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=mock_user)
         sso_service.get_provider = MagicMock(return_value=entra_provider)
 
         # User info WITHOUT admin group
@@ -916,7 +917,7 @@ class TestIsAdminSyncOnLogin:
         type(mock_user).is_admin = property(lambda self: original_is_admin, track_is_admin_set)
 
         # Mock auth service to return existing user
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=mock_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=mock_user)
         sso_service.get_provider = MagicMock(return_value=entra_provider)
 
         # User info with admin group (status should match)
@@ -963,7 +964,7 @@ class TestIsAdminSyncOnLogin:
         mock_user.get_teams.return_value = []
 
         # Mock auth service to return existing user
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=mock_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=mock_user)
         sso_service.get_provider = MagicMock(return_value=entra_provider)
 
         # User info WITHOUT admin group (removed from admin)
@@ -1046,7 +1047,7 @@ class TestGenericOIDCBeltAndSuspendersPromotion:
         mock_user.email_verified = True
         mock_user.get_teams.return_value = []
 
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=mock_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=mock_user)
         sso_service.get_provider = MagicMock(return_value=generic_provider)
 
         # Empty role_mappings so _should_user_be_admin returns False for this user,
@@ -1096,7 +1097,7 @@ class TestGenericOIDCBeltAndSuspendersPromotion:
         mock_user.email_verified = True
         mock_user.get_teams.return_value = []
 
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=mock_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=mock_user)
         sso_service.get_provider = MagicMock(return_value=generic_provider)
 
         developer_assignment = [{"role_name": "developer", "scope": "team", "scope_id": None}]
@@ -1137,7 +1138,7 @@ class TestGenericOIDCBeltAndSuspendersPromotion:
         mock_user.email_verified = True
         mock_user.get_teams.return_value = []
 
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=mock_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=mock_user)
         sso_service.get_provider = MagicMock(return_value=generic_provider)
 
         # role_mappings maps the user's group to platform_admin → _should_user_be_admin returns True

--- a/tests/unit/mcpgateway/services/test_sso_service.py
+++ b/tests/unit/mcpgateway/services/test_sso_service.py
@@ -3584,6 +3584,7 @@ class TestAuthenticateOrCreateUser:
             mock_settings.sso_google_admin_domains = []
             mock_settings.sso_entra_admin_groups = []
             mock_settings.sso_entra_sync_roles_on_login = False
+            mock_settings.sso_allow_provider_linking = False
             result = await sso_service.authenticate_or_create_user(
                 {
                     "email": "user@test.com",
@@ -3954,6 +3955,60 @@ class TestAuthenticateOrCreateUser:
 
         assert existing_user.is_admin is False
         assert existing_user.admin_origin is None
+
+    @pytest.mark.asyncio
+    async def test_cross_provider_login_refused_when_linking_disabled(self, sso_service, mock_db):
+        """Existing email bound to another provider is refused (secure default)."""
+        existing_user = SimpleNamespace(
+            email="user@test.com",
+            full_name="User",
+            auth_provider="provider-a",
+            email_verified=True,
+            last_login=None,
+            is_admin=False,
+            admin_origin=None,
+        )
+        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=existing_user)
+        sso_service.get_provider = lambda _id: _make_provider(id="provider-b")
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_settings.sso_allow_provider_linking = False
+            result = await sso_service.authenticate_or_create_user(
+                {"email": "user@test.com", "full_name": "User", "provider": "provider-b", "email_verified": True}
+            )
+
+        assert result is None
+        assert existing_user.auth_provider == "provider-a"
+
+    @pytest.mark.asyncio
+    async def test_cross_provider_login_relinks_when_enabled(self, sso_service, mock_db):
+        """With SSO_ALLOW_PROVIDER_LINKING, a verified email rebinds to the new provider."""
+        existing_user = SimpleNamespace(
+            email="user@test.com",
+            full_name="User",
+            auth_provider="provider-a",
+            email_verified=True,
+            last_login=None,
+            is_admin=False,
+            admin_origin=None,
+        )
+        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=existing_user)
+        sso_service.get_provider = lambda _id: _make_provider(id="provider-b")
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings, patch("mcpgateway.services.sso_service.create_jwt_token", new_callable=AsyncMock) as mock_jwt:
+            mock_settings.sso_allow_provider_linking = True
+            mock_settings.sso_auto_admin_domains = []
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_entra_sync_roles_on_login = False
+            mock_jwt.return_value = "jwt-token"
+            result = await sso_service.authenticate_or_create_user(
+                {"email": "user@test.com", "full_name": "User", "provider": "provider-b", "email_verified": True}
+            )
+
+        assert result == "jwt-token"
+        assert existing_user.auth_provider == "provider-b"
 
     @pytest.mark.asyncio
     async def test_new_user_auto_create(self, sso_service, mock_db):

--- a/tests/unit/mcpgateway/services/test_sso_service.py
+++ b/tests/unit/mcpgateway/services/test_sso_service.py
@@ -3575,7 +3575,7 @@ class TestAuthenticateOrCreateUser:
             is_admin=False,
             admin_origin=None,
         )
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=existing_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=existing_user)
         sso_service.get_provider = lambda _id: _make_provider()
 
         with patch("mcpgateway.services.sso_service.settings") as mock_settings:
@@ -3606,7 +3606,7 @@ class TestAuthenticateOrCreateUser:
             is_admin=False,
             admin_origin=None,
         )
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=existing_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=existing_user)
         sso_service.get_provider = lambda _id: _make_provider()
 
         with patch("mcpgateway.services.sso_service.settings") as mock_settings, patch("mcpgateway.services.sso_service.create_jwt_token", new_callable=AsyncMock) as mock_jwt:
@@ -3641,7 +3641,7 @@ class TestAuthenticateOrCreateUser:
             admin_origin=None,
         )
         provider = _make_provider(team_mapping={"engineering": "team-1"})
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=existing_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=existing_user)
         sso_service.get_provider = lambda _id: provider
         sso_service._apply_team_mapping = AsyncMock()
 
@@ -3676,7 +3676,7 @@ class TestAuthenticateOrCreateUser:
             is_admin=False,
             admin_origin=None,
         )
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=existing_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=existing_user)
         sso_service.get_provider = lambda _id: _make_provider()
 
         result = await sso_service.authenticate_or_create_user(
@@ -3707,7 +3707,7 @@ class TestAuthenticateOrCreateUser:
             is_admin=False,
             admin_origin=None,
         )
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=existing_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=existing_user)
         sso_service.get_provider = lambda _id: _make_provider()
 
         with patch("mcpgateway.services.sso_service.settings") as mock_settings, patch("mcpgateway.services.sso_service.create_jwt_token", new_callable=AsyncMock) as mock_jwt:
@@ -3739,7 +3739,7 @@ class TestAuthenticateOrCreateUser:
             is_admin=False,
             admin_origin=None,
         )
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=existing_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=existing_user)
         sso_service.get_provider = lambda _id: _make_provider(trusted_domains=["trusted.com"])
 
         result = await sso_service.authenticate_or_create_user(
@@ -3765,7 +3765,7 @@ class TestAuthenticateOrCreateUser:
             is_admin=False,
             admin_origin=None,
         )
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=existing_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=existing_user)
         sso_service.get_provider = lambda _id: _make_provider()
 
         with patch("mcpgateway.services.sso_service.settings") as mock_settings, patch("mcpgateway.services.sso_service.create_jwt_token", new_callable=AsyncMock) as mock_jwt:
@@ -3786,7 +3786,7 @@ class TestAuthenticateOrCreateUser:
             )
 
         assert result == "jwt-token"
-        sso_service.auth_service.get_user_by_email.assert_awaited_once_with("user@test.com")
+        sso_service.auth_service._fetch_user_from_db.assert_called_once_with("user@test.com")
         token_payload = mock_jwt.await_args.args[0]
         assert token_payload["sub"] == "550e8400-e29b-41d4-a716-446655440001"
         assert "email" not in token_payload
@@ -3858,7 +3858,7 @@ class TestAuthenticateOrCreateUser:
 
         existing_user = _GuardedUser()
         provider = _GuardedProvider()
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=existing_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=existing_user)
         sso_service.get_provider = lambda _id: provider
         sso_service._map_groups_to_roles = AsyncMock(return_value=[])
         sso_service._sync_user_roles = AsyncMock()
@@ -3901,7 +3901,7 @@ class TestAuthenticateOrCreateUser:
             is_admin=False,
             admin_origin=None,
         )
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=existing_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=existing_user)
         sso_service.get_provider = lambda _id: _make_provider()
 
         with patch("mcpgateway.services.sso_service.settings") as mock_settings, patch("mcpgateway.services.sso_service.create_jwt_token", new_callable=AsyncMock) as mock_jwt:
@@ -3934,7 +3934,7 @@ class TestAuthenticateOrCreateUser:
             is_admin=True,
             admin_origin="sso",
         )
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=existing_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=existing_user)
         sso_service.get_provider = lambda _id: _make_provider()
 
         with patch("mcpgateway.services.sso_service.settings") as mock_settings, patch("mcpgateway.services.sso_service.create_jwt_token", new_callable=AsyncMock) as mock_jwt:
@@ -3968,7 +3968,7 @@ class TestAuthenticateOrCreateUser:
             is_admin=False,
             admin_origin=None,
         )
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=existing_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=existing_user)
         sso_service.get_provider = lambda _id: _make_provider(id="provider-b")
 
         with patch("mcpgateway.services.sso_service.settings") as mock_settings:
@@ -3992,7 +3992,7 @@ class TestAuthenticateOrCreateUser:
             is_admin=False,
             admin_origin=None,
         )
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=existing_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=existing_user)
         sso_service.get_provider = lambda _id: _make_provider(id="provider-b")
 
         with patch("mcpgateway.services.sso_service.settings") as mock_settings, patch("mcpgateway.services.sso_service.create_jwt_token", new_callable=AsyncMock) as mock_jwt:
@@ -4012,7 +4012,7 @@ class TestAuthenticateOrCreateUser:
 
     @pytest.mark.asyncio
     async def test_new_user_auto_create(self, sso_service, mock_db):
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         new_user = SimpleNamespace(
             email="new@test.com",
             full_name="New User",
@@ -4051,7 +4051,7 @@ class TestAuthenticateOrCreateUser:
         Regression guard for https://github.com/IBM/mcp-context-forge/issues/3253
         (same root cause as Entra ID).
         """
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         new_user = SimpleNamespace(
             email="new@test.com",
             full_name="New User",
@@ -4091,7 +4091,7 @@ class TestAuthenticateOrCreateUser:
         the userinfo response.  Absence of the claim should be treated as a
         pass-through, not a rejection.
         """
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         new_user = SimpleNamespace(
             email="user@company.com",
             full_name="Entra User",
@@ -4128,7 +4128,7 @@ class TestAuthenticateOrCreateUser:
     @pytest.mark.asyncio
     async def test_new_user_with_role_assignments_triggers_sync(self, sso_service, mock_db):
         """New user flow should apply role assignments when mapping returns results."""
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         sso_service.auth_service.create_user = AsyncMock(
             return_value=SimpleNamespace(
                 email="new@test.com",
@@ -4188,7 +4188,7 @@ class TestAuthenticateOrCreateUser:
                 return self._provider_metadata
 
         provider = _GuardedProvider()
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         sso_service.get_provider = lambda _id: provider
         sso_service._map_groups_to_roles = AsyncMock(return_value=[])
         sso_service._sync_user_roles = AsyncMock()
@@ -4227,7 +4227,7 @@ class TestAuthenticateOrCreateUser:
 
     @pytest.mark.asyncio
     async def test_new_user_no_auto_create(self, sso_service, mock_db):
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         sso_service.get_provider = lambda _id: _make_provider(auto_create_users=False)
 
         result = await sso_service.authenticate_or_create_user(
@@ -4241,7 +4241,7 @@ class TestAuthenticateOrCreateUser:
 
     @pytest.mark.asyncio
     async def test_new_user_untrusted_domain(self, sso_service, mock_db):
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         sso_service.get_provider = lambda _id: _make_provider(trusted_domains=["trusted.com"])
 
         result = await sso_service.authenticate_or_create_user(
@@ -4256,7 +4256,7 @@ class TestAuthenticateOrCreateUser:
     @pytest.mark.asyncio
     async def test_new_user_admin_approval_pending(self, sso_service, mock_db):
         """Admin approval required + no existing pending -> creates pending request."""
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         sso_service.get_provider = lambda _id: _make_provider()
         mock_db.execute.return_value.scalar_one_or_none.return_value = None  # No existing pending
 
@@ -4281,7 +4281,7 @@ class TestAuthenticateOrCreateUser:
     @pytest.mark.asyncio
     async def test_new_user_admin_approval_still_pending(self, sso_service, mock_db):
         """Existing pending approval that hasn't expired."""
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         sso_service.get_provider = lambda _id: _make_provider()
         pending = SimpleNamespace(status="pending", is_expired=lambda: False)
         mock_db.execute.return_value.scalar_one_or_none.return_value = pending
@@ -4302,7 +4302,7 @@ class TestAuthenticateOrCreateUser:
     @pytest.mark.asyncio
     async def test_new_user_admin_approval_expired_pending_renews_request(self, sso_service, mock_db):
         """Expired pending approvals are renewed and still denied until admin action."""
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         sso_service.get_provider = lambda _id: _make_provider()
         pending = SimpleNamespace(
             status="pending",
@@ -4340,7 +4340,7 @@ class TestAuthenticateOrCreateUser:
     @pytest.mark.asyncio
     async def test_new_user_rejects_unverified_email_claim(self, sso_service, mock_db):
         """SSO logins with explicit unverified email claims are rejected."""
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         sso_service.get_provider = lambda _id: _make_provider()
 
         result = await sso_service.authenticate_or_create_user(
@@ -4356,7 +4356,7 @@ class TestAuthenticateOrCreateUser:
     @pytest.mark.asyncio
     async def test_new_user_admin_approval_rejected(self, sso_service, mock_db):
         """Existing pending approval that was rejected."""
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         sso_service.get_provider = lambda _id: _make_provider()
         pending = SimpleNamespace(status="rejected", is_expired=lambda: False)
         mock_db.execute.return_value.scalar_one_or_none.return_value = pending
@@ -4375,7 +4375,7 @@ class TestAuthenticateOrCreateUser:
 
     @pytest.mark.asyncio
     async def test_new_user_admin_approval_approved_but_expired(self, sso_service, mock_db):
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         sso_service.get_provider = lambda _id: _make_provider()
         pending = SimpleNamespace(status="approved", is_expired=lambda: True)
         mock_db.execute.return_value.scalar_one_or_none.return_value = pending
@@ -4396,7 +4396,7 @@ class TestAuthenticateOrCreateUser:
 
     @pytest.mark.asyncio
     async def test_new_user_admin_approval_status_expired_renews_request(self, sso_service, mock_db):
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         sso_service.get_provider = lambda _id: _make_provider()
         pending = SimpleNamespace(
             status="expired",
@@ -4433,7 +4433,7 @@ class TestAuthenticateOrCreateUser:
 
     @pytest.mark.asyncio
     async def test_new_user_admin_approval_completed_denied(self, sso_service, mock_db):
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         sso_service.get_provider = lambda _id: _make_provider()
         pending = SimpleNamespace(status="completed", is_expired=lambda: False)
         mock_db.execute.return_value.scalar_one_or_none.return_value = pending
@@ -4452,7 +4452,7 @@ class TestAuthenticateOrCreateUser:
 
     @pytest.mark.asyncio
     async def test_new_user_admin_approval_unknown_status_denied(self, sso_service, mock_db):
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         sso_service.get_provider = lambda _id: _make_provider()
         pending = SimpleNamespace(status="mystery", is_expired=lambda: False)
         mock_db.execute.return_value.scalar_one_or_none.return_value = pending
@@ -4477,7 +4477,7 @@ class TestAuthenticateOrCreateUser:
     @pytest.mark.asyncio
     async def test_new_user_admin_approval_approved(self, sso_service, mock_db):
         """Existing pending approval that was approved -> user gets created."""
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         sso_service.get_provider = lambda _id: _make_provider()
         new_user = SimpleNamespace(
             email="new@test.com",
@@ -4517,7 +4517,7 @@ class TestAuthenticateOrCreateUser:
     @pytest.mark.asyncio
     async def test_new_user_create_fails(self, sso_service, mock_db):
         """create_user returns None -> returns None."""
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         sso_service.auth_service.create_user = AsyncMock(return_value=None)
         sso_service.get_provider = lambda _id: _make_provider()
 
@@ -4550,7 +4550,7 @@ class TestAuthenticateOrCreateUser:
             is_admin=False,
             admin_origin=None,
         )
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=existing_user)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=existing_user)
         sso_service.get_provider = lambda _id: _make_provider(provider_metadata={"sync_roles": True, "role_mappings": {}})
         sso_service._map_groups_to_roles = AsyncMock(return_value=[])
         sso_service._sync_user_roles = AsyncMock()

--- a/tests/unit/mcpgateway/services/test_sso_service.py
+++ b/tests/unit/mcpgateway/services/test_sso_service.py
@@ -3969,6 +3969,7 @@ class TestAuthenticateOrCreateUser:
             admin_origin=None,
         )
         sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=existing_user)
+        sso_service.auth_service._invalidate_user_auth_cache = AsyncMock()
         sso_service.get_provider = lambda _id: _make_provider(id="provider-b")
 
         with patch("mcpgateway.services.sso_service.settings") as mock_settings:
@@ -3979,6 +3980,7 @@ class TestAuthenticateOrCreateUser:
 
         assert result is None
         assert existing_user.auth_provider == "provider-a"
+        sso_service.auth_service._invalidate_user_auth_cache.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_cross_provider_login_relinks_when_enabled(self, sso_service, mock_db):
@@ -3993,6 +3995,7 @@ class TestAuthenticateOrCreateUser:
             admin_origin=None,
         )
         sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=existing_user)
+        sso_service.auth_service._invalidate_user_auth_cache = AsyncMock()
         sso_service.get_provider = lambda _id: _make_provider(id="provider-b")
 
         with patch("mcpgateway.services.sso_service.settings") as mock_settings, patch("mcpgateway.services.sso_service.create_jwt_token", new_callable=AsyncMock) as mock_jwt:
@@ -4009,6 +4012,45 @@ class TestAuthenticateOrCreateUser:
 
         assert result == "jwt-token"
         assert existing_user.auth_provider == "provider-b"
+        sso_service.auth_service._invalidate_user_auth_cache.assert_awaited_once_with("user@test.com")
+
+    @pytest.mark.asyncio
+    async def test_relink_demotes_api_origin_admin_when_new_provider_grants_no_admin(self, sso_service, mock_db):
+        """Relinking an API/manually-granted admin to a provider that doesn't vet for admin must demote.
+
+        Regression test for the relink admin-carryover finding: admin_origin="api" previously
+        only demoted for admin_origin="sso", so an admin relinked to an unvetted provider kept
+        full "*" permissions.
+        """
+        existing_user = SimpleNamespace(
+            email="user@test.com",
+            full_name="User",
+            auth_provider="provider-a",
+            email_verified=True,
+            last_login=None,
+            is_admin=True,
+            admin_origin="api",
+        )
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=existing_user)
+        sso_service.auth_service._invalidate_user_auth_cache = AsyncMock()
+        sso_service.get_provider = lambda _id: _make_provider(id="provider-b")
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings, patch("mcpgateway.services.sso_service.create_jwt_token", new_callable=AsyncMock) as mock_jwt:
+            mock_settings.sso_allow_provider_linking = True
+            mock_settings.sso_auto_admin_domains = []
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_entra_sync_roles_on_login = False
+            mock_jwt.return_value = "jwt-token"
+            result = await sso_service.authenticate_or_create_user(
+                {"email": "user@test.com", "full_name": "User", "provider": "provider-b", "email_verified": True}
+            )
+
+        assert result == "jwt-token"
+        assert existing_user.auth_provider == "provider-b"
+        assert existing_user.is_admin is False
+        assert existing_user.admin_origin is None
 
     @pytest.mark.asyncio
     async def test_new_user_auto_create(self, sso_service, mock_db):

--- a/tests/unit/mcpgateway/services/test_sso_service.py
+++ b/tests/unit/mcpgateway/services/test_sso_service.py
@@ -3983,6 +3983,39 @@ class TestAuthenticateOrCreateUser:
         sso_service.auth_service._invalidate_user_auth_cache.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_cross_provider_login_refused_when_provider_unresolved(self, sso_service, mock_db):
+        """Relink is refused when the incoming provider can't be resolved, even with linking enabled.
+
+        Regression test: previously an unresolved provider (deleted, or an id-casing
+        mismatch) let the relink proceed while silently skipping the admin re-vetting
+        block, since that block only runs `if provider_ctx`, which requires a resolved
+        provider. Refusing here closes that gap.
+        """
+        existing_user = SimpleNamespace(
+            email="user@test.com",
+            full_name="User",
+            auth_provider="provider-a",
+            email_verified=True,
+            last_login=None,
+            is_admin=True,
+            admin_origin="api",
+        )
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=existing_user)
+        sso_service.auth_service._invalidate_user_auth_cache = AsyncMock()
+        sso_service.get_provider = lambda _id: None
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_settings.sso_allow_provider_linking = True
+            result = await sso_service.authenticate_or_create_user(
+                {"email": "user@test.com", "full_name": "User", "provider": "provider-b", "email_verified": True}
+            )
+
+        assert result is None
+        assert existing_user.auth_provider == "provider-a"
+        assert existing_user.is_admin is True
+        sso_service.auth_service._invalidate_user_auth_cache.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_cross_provider_login_relinks_when_enabled(self, sso_service, mock_db):
         """With SSO_ALLOW_PROVIDER_LINKING, a verified email rebinds to the new provider."""
         existing_user = SimpleNamespace(
@@ -4051,6 +4084,43 @@ class TestAuthenticateOrCreateUser:
         assert existing_user.auth_provider == "provider-b"
         assert existing_user.is_admin is False
         assert existing_user.admin_origin is None
+
+    @pytest.mark.asyncio
+    async def test_relink_promotes_when_new_provider_grants_admin(self, sso_service, mock_db):
+        """Relinking a non-admin to a provider that vets them for admin must grant it.
+
+        Mirror of test_relink_demotes_api_origin_admin_when_new_provider_grants_no_admin:
+        the admin-sync block on relink must also grant, not just revoke.
+        """
+        existing_user = SimpleNamespace(
+            email="user@test.com",
+            full_name="User",
+            auth_provider="provider-a",
+            email_verified=True,
+            last_login=None,
+            is_admin=False,
+            admin_origin=None,
+        )
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=existing_user)
+        sso_service.auth_service._invalidate_user_auth_cache = AsyncMock()
+        sso_service.get_provider = lambda _id: _make_provider(id="provider-b")
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings, patch("mcpgateway.services.sso_service.create_jwt_token", new_callable=AsyncMock) as mock_jwt:
+            mock_settings.sso_allow_provider_linking = True
+            mock_settings.sso_auto_admin_domains = ["test.com"]
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_entra_sync_roles_on_login = False
+            mock_jwt.return_value = "jwt-token"
+            result = await sso_service.authenticate_or_create_user(
+                {"email": "user@test.com", "full_name": "User", "provider": "provider-b", "email_verified": True}
+            )
+
+        assert result == "jwt-token"
+        assert existing_user.auth_provider == "provider-b"
+        assert existing_user.is_admin is True
+        assert existing_user.admin_origin == "sso"
 
     @pytest.mark.asyncio
     async def test_new_user_auto_create(self, sso_service, mock_db):


### PR DESCRIPTION
## Summary

Fixes #6431. A user already provisioned under one SSO provider could not sign in
through a second provider: `SSOService.authenticate_or_create_user`
(`mcpgateway/services/sso_service.py`) returned `None`, the interactive login ended
at `/admin/login?error=user_creation_failed`, and the log said *"account-linking
required"* — for a feature that **does not exist** in the codebase, with **no
setting** to control it. Because both the interactive router (`routers/sso.py`) and
external-IdP token auth (`utils/verify_credentials.py`) funnel through this one
function, editing `auth_provider` in the DB only moved the failure to the other path.

Rejecting a second provider by default is the security-correct behaviour for identity
binding (auto-linking by email is an account-takeover vector), so the default is kept.
This PR adds a config-gated opt-in for operators who already trust both providers.

## What changed

- **`config.py`** — new `SSO_ALLOW_PROVIDER_LINKING` (default `false`, fail-closed).
- **`sso_service.py`** — at the single chokepoint both paths route through:
  - setting **off** (default): still refuse, but the log now names the real policy
    and setting instead of a phantom linking flow;
  - setting **on**: rebind `auth_provider` to the incoming provider and continue.
    Email is already verified (upstream `_is_email_verified_claim` gate) and passes
    trusted-domain policy before this point, so linking only ever rebinds a trusted,
    verified identity.
- **`.env.example` / `docs/docs/manage/configuration.md`** — document the setting.
- **tests** — deny-path regression (refused + no rebind when disabled) and happy-path
  (rebinds when enabled); existing `test_existing_user` updated to stub the new
  setting to its `False` default (its reject-on-mismatch contract is preserved).
- `.secrets.baseline` regenerated by the detect-secrets pre-commit hook (line-number
  shift from the `.env.example` addition; no new secrets).

## Acceptance

- `SSO_ALLOW_PROVIDER_LINKING=false` (default): cross-provider sign-in refused; log no
  longer references a non-existent linking feature.
- `SSO_ALLOW_PROVIDER_LINKING=true`: cross-provider sign-in for a verified email
  rebinds `auth_provider` and succeeds on both the interactive and external-IdP paths.
- Unverified email still refused regardless of the setting (upstream gate).

## Testing

- `tests/unit/mcpgateway/services/test_sso_service.py` — full file green.
- Related `test_sso_router.py`, `test_sso_entra_role_mapping.py`,
  `test_sso_approval_workflow.py` — 94 passed.

## Notes / out of scope

- The distinct user-facing error code (surfacing a `provider_conflict` message to the
  browser) is not included: it needs reason-plumbing through both callers, and the
  honest operator log already states the required action. Can follow up if a UI story
  needs the specific message.
- Reproducible today with two interactive OIDC providers returning the same verified
  email. The API→interactive variant additionally depends on #6396/#6432.
