### PR TITLE
feat: return per-caller OAuth token status from /oauth/status

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-10T14:52:26Z",
+  "generated_at": "2026-09-11T10:56:50Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -298,7 +298,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1085,
+        "line_number": 1092,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1087,
+        "line_number": 1094,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "db69d9215c29ae2f2e4ead587890a9f8455059dd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1161,
+        "line_number": 1168,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +322,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1740,
+        "line_number": 1747,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -330,7 +330,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1959,
+        "line_number": 1966,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -338,7 +338,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6142,
+        "line_number": 6149,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -346,7 +346,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6652,
+        "line_number": 6659,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -354,7 +354,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6664,
+        "line_number": 6671,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -362,7 +362,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6736,
+        "line_number": 6743,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -370,7 +370,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7152,
+        "line_number": 7159,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -378,7 +378,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7842,
+        "line_number": 7849,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2148,7 +2148,7 @@
         "hashed_secret": "9b995dc4707426ba2e56b54a6877bda99a5e0376",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 394,
+        "line_number": 423,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2156,7 +2156,7 @@
         "hashed_secret": "29b8dca3de5ff27bcf8bd3b622adf9970f29381c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 471,
+        "line_number": 500,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2164,7 +2164,7 @@
         "hashed_secret": "d62bd0a3fef6be1bb3bb9078b323d87ac9f37f75",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 573,
+        "line_number": 602,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2172,7 +2172,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 703,
+        "line_number": 732,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2180,7 +2180,7 @@
         "hashed_secret": "f4793151b0607198d4de9b1ca458d3e25adf1cb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 705,
+        "line_number": 734,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/Makefile
+++ b/Makefile
@@ -901,7 +901,7 @@ clean:
 # help: query-log-clear      - Clear database query log files
 
 .PHONY: smoketest test-mcp-cli test-mcp-rbac test-mcp-plugin-parity test-mcp-access-matrix \
-	test-mcp-session-isolation test-mcp-session-isolation-load test-e2e-sso \
+	test-mcp-session-isolation test-mcp-session-isolation-load test-e2e-sso test-oauth-status-live \
 	test-live-gateway test test-verbose test-profile coverage test-docs pytest-examples \
 	test-curl htmlcov doctest doctest-verbose doctest-coverage doctest-check test-db-perf \
 	test-db-perf-verbose 2025-11-25 2025-11-25-core 2025-11-25-tasks 2025-11-25-auth \
@@ -997,6 +997,13 @@ test-mcp-session-isolation: uv  ## MCP session/auth isolation tests for the Rust
 	@$(UV_BIN) run pytest tests/live_gateway/e2e_rust/test_mcp_session_isolation.py -v -s --tb=short \
 		|| { echo "❌ MCP session/auth isolation tests failed!"; exit 1; }
 	@echo "✅ MCP session/auth isolation tests passed!"
+
+test-oauth-status-live: uv  ## Black-box test for GET /oauth/status[/{id}] against a running gateway + its Postgres
+	@echo "🧪 Running OAuth status endpoint live tests against $${MCP_CLI_BASE_URL:-http://localhost:8080}..."
+	@echo "   Requires: docker-compose stack (postgres exposed on localhost:5433, the default)"
+	@$(UV_BIN) run pytest tests/live_gateway/mcp/test_oauth_status_live.py -v -s --tb=short \
+		|| { echo "❌ OAuth status live tests failed!"; exit 1; }
+	@echo "✅ OAuth status live tests passed!"
 
 test-e2e-sso: uv  ## E2E tests requiring a live Keycloak SSO identity provider
 	@echo "🔐 Running SSO-dependent E2E tests against $${MCP_CLI_BASE_URL:-http://localhost:8080}..."

--- a/docs/docs/manage/oauth-troubleshooting.md
+++ b/docs/docs/manage/oauth-troubleshooting.md
@@ -76,7 +76,7 @@ state_data = {
 | `/oauth/authorize/{gateway_id}` | GET | Initiates OAuth flow, redirects to provider |
 | `/vault/authorize/{server_id}` | GET | Per-user OAuth credential connection for team virtual servers (shared access control with `/oauth/authorize/{gateway_id}`) |
 | `/oauth/callback` | GET | Handles OAuth callback, exchanges code for tokens |
-| `/oauth/status/{gateway_id}` | GET | Returns OAuth configuration status; for `authorization_code` gateways also includes the caller's own `user_token_status` (valid/near_expiry/expired/missing) |
+| `/oauth/status/{gateway_id}` | GET | Returns OAuth configuration status; for `authorization_code` gateways also includes the caller's own `user_token_status` (valid/near_expiry/expired/missing/unknown) |
 | `/oauth/status?gateway_ids=a&gateway_ids=b` | GET | Batch equivalent of the above, keyed by gateway id, so a grid of cards issues one request instead of N |
 | `/oauth/fetch-tools/{gateway_id}` | POST | Fetches tools from MCP server after OAuth completion |
 | `/oauth/registered-clients` | GET | Lists all DCR-registered OAuth clients. Requires `admin.oauth_clients:read` and un-narrowed platform admin access |
@@ -84,6 +84,34 @@ state_data = {
 | `/oauth/registered-clients/{client_id}` | DELETE | Deletes a registered OAuth client. Requires `admin.oauth_clients:delete` and un-narrowed platform admin access |
 
 > **Note**: The three `/oauth/registered-clients*` endpoints manage DCR client records that are stored globally, with no team association. Because there is no team scope to narrow into, these endpoints require an un-narrowed admin token — an admin API/legacy token carrying a `token_teams` narrowing claim (or a public-only admin token) receives `403 Forbidden` with `"OAuth client management requires un-narrowed admin access"`. Admin session tokens (e.g. the interactive Admin UI) resolve their teams from the database and cannot be narrowed, so this does not change UI behavior. These routes also require a named RBAC permission — `admin.oauth_clients:read` for the two `GET` routes and `admin.oauth_clients:delete` for `DELETE` — with admin bypass disabled, so the caller's roles must actually carry the permission (the `platform_admin` role does, via `*`).
+
+### `user_token_status` shape
+
+For `authorization_code` gateways, both status endpoints attach a `user_token_status` object derived from the **authenticated caller's own identity** — never a client-supplied user — and never containing a token value:
+
+```json
+"user_token_status": {
+  "status": "valid",
+  "authorized": true,
+  "scopes": ["read", "write"],
+  "expires_at": "2026-01-01T00:00:00",
+  "updated_at": "2025-12-31T23:00:00"
+}
+```
+
+| `status` | `authorized` | Meaning |
+|----------|--------------|---------|
+| `valid` | `true` | A stored token exists and is not within the near-expiry window |
+| `near_expiry` | `true` | A stored token exists but expires within 300 seconds |
+| `expired` | `false` | A stored token exists but its expiry has already passed |
+| `missing` | `false` | No token is stored for this caller/gateway — they have never completed the OAuth flow |
+| `unknown` | `false` | The token lookup itself failed (backend error, Vault outage, or a batch request that timed out) — distinct from `missing` so a UI doesn't mistake a transient outage for "never authorized" and prompt a fresh OAuth flow with the IdP |
+
+`scopes`, `expires_at`, and `updated_at` are only present when a token record exists (`valid`/`near_expiry`/`expired`); `missing` and `unknown` return just `status` and `authorized`.
+
+### Batch endpoint limits
+
+`GET /oauth/status?gateway_ids=a&gateway_ids=b&...` accepts the `gateway_ids` query parameter repeated once per id (deduplicated server-side), caps a single request at 100 ids, and rejects an empty or over-limit request with `400 Bad Request`. Ids that don't exist or aren't visible to the caller are **silently omitted** from the response rather than failing the whole batch — a client should only render cards for ids present in the response body. The per-caller token lookup for the whole batch is bounded by an internal timeout; if it's exceeded, any gateway id still pending reports `user_token_status.status: "unknown"` rather than leaving the request hanging.
 
 ---
 

--- a/docs/docs/manage/oauth-troubleshooting.md
+++ b/docs/docs/manage/oauth-troubleshooting.md
@@ -76,7 +76,8 @@ state_data = {
 | `/oauth/authorize/{gateway_id}` | GET | Initiates OAuth flow, redirects to provider |
 | `/vault/authorize/{server_id}` | GET | Per-user OAuth credential connection for team virtual servers (shared access control with `/oauth/authorize/{gateway_id}`) |
 | `/oauth/callback` | GET | Handles OAuth callback, exchanges code for tokens |
-| `/oauth/status/{gateway_id}` | GET | Returns OAuth configuration status |
+| `/oauth/status/{gateway_id}` | GET | Returns OAuth configuration status; for `authorization_code` gateways also includes the caller's own `user_token_status` (valid/near_expiry/expired/missing) |
+| `/oauth/status?gateway_ids=a&gateway_ids=b` | GET | Batch equivalent of the above, keyed by gateway id, so a grid of cards issues one request instead of N |
 | `/oauth/fetch-tools/{gateway_id}` | POST | Fetches tools from MCP server after OAuth completion |
 | `/oauth/registered-clients` | GET | Lists all DCR-registered OAuth clients. Requires `admin.oauth_clients:read` and un-narrowed platform admin access |
 | `/oauth/registered-clients/{gateway_id}` | GET | Gets registered client for specific gateway. Requires `admin.oauth_clients:read` and un-narrowed platform admin access |

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -148,6 +148,12 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     # permissions list does not include gateways.read is rejected at the middleware
     # layer rather than reaching the handler and failing there.
     ("GET", re.compile(r"^/vault/authorize/[^/]+(?:$|/)"), Permissions.GATEWAYS_READ),
+    # OAuth per-caller token status (oauth_router, prefix="/oauth") - single-gateway
+    # and batch variants. The handler enforces gateway-level access via
+    # _enforce_gateway_access, so this entry adds defence-in-depth only: it ensures a
+    # server-scoped API token whose permissions list does not include gateways.read is
+    # rejected at the middleware layer rather than reaching the handler and failing there.
+    ("GET", re.compile(r"^/oauth/status(?:$|/)"), Permissions.GATEWAYS_READ),
     # OAuth DCR registered-client management (oauth_router, prefix="/oauth").
     # Registered clients are global rows with no team column, so these map to
     # admin-category permissions; the handlers additionally require an

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -894,7 +894,7 @@ class TokenScopingMiddleware:
         return method == "DELETE" and bool(_TARGETED_MISSING_DELETE_PATTERN.fullmatch(normalized_path))
 
     def _check_resource_team_ownership(  # noqa: PLR0911  # pylint: disable=too-many-return-statements
-        self, request_path: str, token_teams: list, db=None, _user_email: str = None
+        self, request_path: str, token_teams: list, db=None, _user_email: str = None, preloaded_gateway=None
     ) -> ResourceOwnershipResult:
         """
         Check if the requested resource is accessible by the token.
@@ -922,6 +922,12 @@ class TokenScopingMiddleware:
             token_teams: List of team IDs from the token (empty list = public-only token)
             db: Optional database session. If provided, caller manages lifecycle.
                 If None, creates and manages its own session.
+            preloaded_gateway: Optional already-fetched ``Gateway`` row. When the
+                path resolves to a gateway resource and this row's ``id`` matches
+                the path's resource id, it is reused instead of issuing another
+                ``SELECT`` - lets a caller that already loaded the gateway (e.g. a
+                batch endpoint that bulk-fetched many gateways) avoid a redundant
+                per-id re-fetch here.
 
         Returns:
             ResourceOwnershipResult: Allowed, missing, or denied ownership result.
@@ -1189,7 +1195,10 @@ class TokenScopingMiddleware:
 
             # CHECK GATEWAYS
             if resource_type == "gateway":
-                gateway = db.execute(select(Gateway).where(Gateway.id == resource_id)).scalar_one_or_none()
+                if preloaded_gateway is not None and getattr(preloaded_gateway, "id", None) == resource_id:
+                    gateway = preloaded_gateway
+                else:
+                    gateway = db.execute(select(Gateway).where(Gateway.id == resource_id)).scalar_one_or_none()
 
                 if not gateway:
                     logger.warning(f"Gateway {SecurityValidator.sanitize_log_message(resource_id)} not found in database")

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -1333,6 +1333,44 @@ def custom_redirect_after_callback(url: str, status_code: int) -> RedirectRespon
     return RedirectResponse(url=url, status_code=status_code, headers={"Referrer-Policy": "no-referrer"})
 
 
+async def _get_caller_token_status(db: Session, current_user: Any, gateway_id: str) -> Dict[str, Any]:
+    """Look up the caller's own OAuth token state for a gateway.
+
+    Wires the already-implemented ``TokenStorageService.get_token_info`` into
+    the status endpoints. Never returns token values - only metadata about
+    whether a token exists and its freshness.
+
+    Args:
+        db: Active database session.
+        current_user: Authenticated requester context (dict or EmailUserResponse).
+        gateway_id: Gateway identifier to look up.
+
+    Returns:
+        Dict with ``authorized`` (bool) and ``status`` (one of "missing",
+        "valid", "near_expiry", "expired"), plus ``scopes``, ``expires_at``
+        and ``updated_at`` when a token is stored.
+    """
+    requester_email = get_user_email(current_user)
+    if requester_email == "unknown" or not requester_email.strip():
+        return {"status": "missing", "authorized": False}
+
+    user_context = _build_user_context(current_user)
+    token_storage = TokenStorageService(db, user_context)
+    info = await token_storage.get_token_info(gateway_id, requester_email)
+
+    if not info:
+        return {"status": "missing", "authorized": False}
+
+    status = info.get("status", "missing")
+    return {
+        "status": status,
+        "authorized": status in ("valid", "near_expiry"),
+        "scopes": info.get("scopes"),
+        "expires_at": info.get("expires_at"),
+        "updated_at": info.get("updated_at"),
+    }
+
+
 @oauth_router.get("/status/{gateway_id}")
 async def get_oauth_status(
     gateway_id: str,
@@ -1344,6 +1382,10 @@ async def get_oauth_status(
 
     Requires authentication and authorization to prevent information disclosure
     about gateway OAuth configuration (client IDs, scopes, etc.).
+
+    For the authorization_code grant, also reports the *caller's own* token
+    state (``user_token_status``), derived from authenticated identity - never
+    a client-supplied user. This is per-caller and never shared across users.
 
     Args:
         gateway_id: ID of the gateway
@@ -1374,8 +1416,6 @@ async def get_oauth_status(
         grant_type = oauth_config.get("grant_type")
 
         if grant_type == "authorization_code":
-            # For now, return basic info - in a real implementation you might want to
-            # show authorized users, token status, etc.
             return {
                 "oauth_enabled": True,
                 "grant_type": grant_type,
@@ -1384,6 +1424,7 @@ async def get_oauth_status(
                 "authorization_url": oauth_config.get("authorization_url"),
                 "redirect_uri": oauth_config.get("redirect_uri"),
                 "message": "Gateway configured for Authorization Code flow",
+                "user_token_status": await _get_caller_token_status(db, current_user, gateway_id),
             }
         else:
             return {
@@ -1399,6 +1440,54 @@ async def get_oauth_status(
     except Exception as e:
         logger.error(f"Failed to get OAuth status: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to get OAuth status")
+
+
+OAUTH_STATUS_BATCH_MAX_IDS = 100
+
+
+@oauth_router.get("/status")
+async def get_oauth_status_batch(
+    request: Request,
+    gateway_ids: Annotated[list[str], Query(description="Gateway ids to look up; repeat the parameter for multiple ids")],
+    current_user: dict = Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+) -> Dict[str, Dict[str, Any]]:
+    """Get OAuth status for multiple gateways in a single call.
+
+    Batched equivalent of ``GET /oauth/status/{gateway_id}`` so a grid of
+    cards (catalog, gateways list) can render caller-scoped OAuth state
+    without issuing one request per card.
+
+    Args:
+        request: Incoming request with token-scoping context.
+        gateway_ids: Gateway identifiers to look up (repeated query param).
+        current_user: Authenticated user (enforces authentication).
+        db: Database session.
+
+    Returns:
+        Mapping of gateway_id to the same payload ``GET /oauth/status/{gateway_id}``
+        returns. Gateway ids that don't exist or aren't visible to the caller
+        are omitted rather than failing the whole batch.
+
+    Raises:
+        HTTPException: If no gateway ids are supplied, or more than
+            ``OAUTH_STATUS_BATCH_MAX_IDS`` are requested at once.
+    """
+    if not gateway_ids:
+        raise HTTPException(status_code=400, detail="gateway_ids is required")
+
+    deduped_ids = list(dict.fromkeys(gateway_ids))
+    if len(deduped_ids) > OAUTH_STATUS_BATCH_MAX_IDS:
+        raise HTTPException(status_code=400, detail=f"Too many gateway_ids requested (max {OAUTH_STATUS_BATCH_MAX_IDS})")
+
+    results: Dict[str, Dict[str, Any]] = {}
+    for gateway_id in deduped_ids:
+        try:
+            results[gateway_id] = await get_oauth_status(gateway_id, request, current_user, db)
+        except HTTPException:
+            # Not found / not accessible to this caller - omit rather than failing the batch.
+            continue
+    return results
 
 
 async def _fetch_tools_via_token_exchange(

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -539,6 +539,7 @@ async def _enforce_gateway_access(
                 token_teams,
                 db=db,
                 _user_email=requester_email,
+                preloaded_gateway=gateway,
             )
             is not ResourceOwnershipResult.ALLOWED
         ):

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -12,6 +12,7 @@ This module handles OAuth 2.0 Authorization Code flow endpoints including:
 """
 
 # Standard
+import asyncio
 from html import escape
 import json
 import logging
@@ -1334,6 +1335,39 @@ def custom_redirect_after_callback(url: str, status_code: int) -> RedirectRespon
     return RedirectResponse(url=url, status_code=status_code, headers={"Referrer-Policy": "no-referrer"})
 
 
+def _token_info_to_status_payload(info: Any) -> Dict[str, Any]:
+    """Convert a ``get_token_info()``/``get_token_info_bulk()`` result into the public ``user_token_status`` shape.
+
+    Three input shapes are distinguished so a backend outage never reads the same as a
+    caller who genuinely never authorized:
+
+    * ``dict`` - a stored token record; its ``status`` field is surfaced as-is.
+    * ``None`` - no token stored for this caller/gateway -> ``"missing"``.
+    * ``Exception`` - the lookup itself failed (DB error, Vault outage, batch timeout)
+      -> ``"unknown"``, so a UI doesn't mistake a transient outage for "never authorized"
+      and prompt a fresh OAuth flow with the IdP.
+
+    Args:
+        info: A token-info dict, ``None``, or a caught ``Exception`` instance.
+
+    Returns:
+        Dict with ``status`` and ``authorized``, plus ``scopes``/``expires_at``/``updated_at``
+        when ``info`` is a dict.
+    """
+    if isinstance(info, BaseException):
+        return {"status": "unknown", "authorized": False}
+    if info is None:
+        return {"status": "missing", "authorized": False}
+    status = info.get("status", "missing")
+    return {
+        "status": status,
+        "authorized": status in ("valid", "near_expiry"),
+        "scopes": info.get("scopes"),
+        "expires_at": info.get("expires_at"),
+        "updated_at": info.get("updated_at"),
+    }
+
+
 async def _get_caller_token_status(db: Session, current_user: Any, gateway_id: str, *, token_storage: Optional[TokenStorageService] = None) -> Dict[str, Any]:
     """Look up the caller's own OAuth token state for a gateway.
 
@@ -1351,8 +1385,8 @@ async def _get_caller_token_status(db: Session, current_user: Any, gateway_id: s
 
     Returns:
         Dict with ``authorized`` (bool) and ``status`` (one of "missing",
-        "valid", "near_expiry", "expired"), plus ``scopes``, ``expires_at``
-        and ``updated_at`` when a token is stored.
+        "valid", "near_expiry", "expired", "unknown"), plus ``scopes``,
+        ``expires_at`` and ``updated_at`` when a token is stored.
     """
     requester_email = get_user_email(current_user)
     if requester_email == "unknown" or not requester_email.strip():
@@ -1364,22 +1398,13 @@ async def _get_caller_token_status(db: Session, current_user: Any, gateway_id: s
     try:
         info = await token_storage.get_token_info(gateway_id, requester_email)
     except Exception as e:
-        # The backend already logs its own failure; this line ties it to the caller/gateway
-        # so a transient lookup failure is distinguishable in logs from a genuinely missing token.
-        logger.error("OAuth token status lookup failed for gateway=%s user=%s: %s", gateway_id, requester_email, str(e))
-        return {"status": "missing", "authorized": False}
+        # The backend already logs its own failure; this ties it to the caller/gateway with a
+        # traceback so a transient lookup failure is distinguishable in logs from a genuinely
+        # missing token - and, via "unknown" below, distinguishable to the client too.
+        logger.exception("OAuth token status lookup failed for gateway=%s user=%s: %s", gateway_id, requester_email, str(e))
+        return _token_info_to_status_payload(e)
 
-    if not info:
-        return {"status": "missing", "authorized": False}
-
-    status = info.get("status", "missing")
-    return {
-        "status": status,
-        "authorized": status in ("valid", "near_expiry"),
-        "scopes": info.get("scopes"),
-        "expires_at": info.get("expires_at"),
-        "updated_at": info.get("updated_at"),
-    }
+    return _token_info_to_status_payload(info)
 
 
 def _build_oauth_status_payload(gateway: Gateway) -> Dict[str, Any]:
@@ -1472,11 +1497,18 @@ async def get_oauth_status(
 
 OAUTH_STATUS_BATCH_MAX_IDS = 100
 
+# Upper bound on how long the batch endpoint will wait for the whole
+# get_token_info_bulk() call, so a slow/unresponsive backend (worst case:
+# OAUTH_STATUS_BATCH_MAX_IDS sequential per-id Vault lookups, each retried
+# with exponential backoff) can't hold the request open indefinitely. On
+# timeout every pending id reports "unknown" rather than failing the batch.
+OAUTH_STATUS_BATCH_TOKEN_LOOKUP_TIMEOUT_SECONDS = 15.0
+
 
 @oauth_router.get("/status")
 async def get_oauth_status_batch(
     request: Request,
-    gateway_ids: Annotated[list[str], Query(description="Gateway ids to look up; repeat the parameter for multiple ids")],
+    gateway_ids: Annotated[Optional[list[str]], Query(description="Gateway ids to look up; repeat the parameter for multiple ids")] = None,
     current_user: dict = Depends(get_current_user_with_permissions),
     db: Session = Depends(get_db),
 ) -> Dict[str, Dict[str, Any]]:
@@ -1504,17 +1536,15 @@ async def get_oauth_status_batch(
     if not gateway_ids:
         raise HTTPException(status_code=400, detail="gateway_ids is required")
 
-    deduped_ids = list(dict.fromkeys(gateway_ids))
+    deduped_ids = list(dict.fromkeys(gateway_ids))  # gateway_ids is non-empty here (checked above)
     if len(deduped_ids) > OAUTH_STATUS_BATCH_MAX_IDS:
         raise HTTPException(status_code=400, detail=f"Too many gateway_ids requested (max {OAUTH_STATUS_BATCH_MAX_IDS})")
 
-    # Single query for all requested gateways, and one TokenStorageService reused across
-    # the loop, instead of get_oauth_status()'s per-id gateway SELECT + TokenStorageService
-    # construction - the batch route exists specifically to avoid N+1 round trips.
+    # Single query for all requested gateways - the batch route exists specifically
+    # to avoid N+1 round trips.
     gateways_by_id = {gw.id: gw for gw in db.execute(select(Gateway).where(Gateway.id.in_(deduped_ids))).scalars().all()}
-    token_storage = TokenStorageService(db, _build_user_context(current_user))
 
-    results: Dict[str, Dict[str, Any]] = {}
+    accessible: Dict[str, Gateway] = {}
     for gateway_id in deduped_ids:
         gateway = gateways_by_id.get(gateway_id)
         if not gateway:
@@ -1532,14 +1562,52 @@ async def get_oauth_status_batch(
             logger.exception("OAuth status batch: access check raised for gateway=%s", gateway_id)
             continue
 
+        accessible[gateway_id] = gateway
+
+    results: Dict[str, Dict[str, Any]] = {}
+    auth_code_ids: list[str] = []
+    for gateway_id, gateway in accessible.items():
         try:
             payload = _build_oauth_status_payload(gateway)
-            if payload.get("grant_type") == "authorization_code":
-                payload["user_token_status"] = await _get_caller_token_status(db, current_user, gateway_id, token_storage=token_storage)
-            results[gateway_id] = payload
         except Exception:
             logger.exception("OAuth status batch: failed to build status for gateway=%s", gateway_id)
             continue
+        results[gateway_id] = payload
+        if payload.get("grant_type") == "authorization_code":
+            auth_code_ids.append(gateway_id)
+
+    if not auth_code_ids:
+        return results
+
+    requester_email = get_user_email(current_user)
+    if requester_email == "unknown" or not requester_email.strip():
+        for gateway_id in auth_code_ids:
+            results[gateway_id]["user_token_status"] = {"status": "missing", "authorized": False}
+        return results
+
+    # One bulk token-info lookup for the whole batch instead of one per gateway id -
+    # the DB backend answers this with a single query; other backends fall back to
+    # AbstractTokenBackend's default per-id loop. Bounded by a timeout so a slow or
+    # unresponsive backend can't hold the request open indefinitely (see constant docstring).
+    token_storage = TokenStorageService(db, _build_user_context(current_user))
+    try:
+        bulk_token_info = await asyncio.wait_for(
+            token_storage.get_token_info_bulk(auth_code_ids, requester_email),
+            timeout=OAUTH_STATUS_BATCH_TOKEN_LOOKUP_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        logger.error(
+            "OAuth status batch: token lookup timed out after %.0fs for %d gateway(s)",
+            OAUTH_STATUS_BATCH_TOKEN_LOOKUP_TIMEOUT_SECONDS,
+            len(auth_code_ids),
+        )
+        bulk_token_info = {gateway_id: TimeoutError("OAuth status batch token lookup timed out") for gateway_id in auth_code_ids}
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.exception("OAuth status batch: bulk token lookup failed")
+        bulk_token_info = {gateway_id: exc for gateway_id in auth_code_ids}
+
+    for gateway_id in auth_code_ids:
+        results[gateway_id]["user_token_status"] = _token_info_to_status_payload(bulk_token_info.get(gateway_id))
 
     return results
 

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -1528,8 +1528,8 @@ async def get_oauth_status_batch(
                 logger.error("OAuth status batch: access check failed for gateway=%s: %s", gateway_id, exc.detail)
             # Not accessible to this caller (or a lookup failure, logged above) - omit rather than failing the batch.
             continue
-        except Exception as exc:
-            logger.error("OAuth status batch: access check raised for gateway=%s: %s", gateway_id, str(exc))
+        except Exception:
+            logger.exception("OAuth status batch: access check raised for gateway=%s", gateway_id)
             continue
 
         try:
@@ -1537,8 +1537,8 @@ async def get_oauth_status_batch(
             if payload.get("grant_type") == "authorization_code":
                 payload["user_token_status"] = await _get_caller_token_status(db, current_user, gateway_id, token_storage=token_storage)
             results[gateway_id] = payload
-        except Exception as exc:
-            logger.error("OAuth status batch: failed to build status for gateway=%s: %s", gateway_id, str(exc))
+        except Exception:
+            logger.exception("OAuth status batch: failed to build status for gateway=%s", gateway_id)
             continue
 
     return results

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -1333,7 +1333,7 @@ def custom_redirect_after_callback(url: str, status_code: int) -> RedirectRespon
     return RedirectResponse(url=url, status_code=status_code, headers={"Referrer-Policy": "no-referrer"})
 
 
-async def _get_caller_token_status(db: Session, current_user: Any, gateway_id: str) -> Dict[str, Any]:
+async def _get_caller_token_status(db: Session, current_user: Any, gateway_id: str, *, token_storage: Optional[TokenStorageService] = None) -> Dict[str, Any]:
     """Look up the caller's own OAuth token state for a gateway.
 
     Wires the already-implemented ``TokenStorageService.get_token_info`` into
@@ -1344,6 +1344,9 @@ async def _get_caller_token_status(db: Session, current_user: Any, gateway_id: s
         db: Active database session.
         current_user: Authenticated requester context (dict or EmailUserResponse).
         gateway_id: Gateway identifier to look up.
+        token_storage: Optional pre-built ``TokenStorageService`` to reuse across
+            multiple lookups (batch endpoint) instead of constructing a new one
+            per gateway.
 
     Returns:
         Dict with ``authorized`` (bool) and ``status`` (one of "missing",
@@ -1354,9 +1357,16 @@ async def _get_caller_token_status(db: Session, current_user: Any, gateway_id: s
     if requester_email == "unknown" or not requester_email.strip():
         return {"status": "missing", "authorized": False}
 
-    user_context = _build_user_context(current_user)
-    token_storage = TokenStorageService(db, user_context)
-    info = await token_storage.get_token_info(gateway_id, requester_email)
+    if token_storage is None:
+        token_storage = TokenStorageService(db, _build_user_context(current_user))
+
+    try:
+        info = await token_storage.get_token_info(gateway_id, requester_email)
+    except Exception as e:
+        # The backend already logs its own failure; this line ties it to the caller/gateway
+        # so a transient lookup failure is distinguishable in logs from a genuinely missing token.
+        logger.error("OAuth token status lookup failed for gateway=%s user=%s: %s", gateway_id, requester_email, str(e))
+        return {"status": "missing", "authorized": False}
 
     if not info:
         return {"status": "missing", "authorized": False}
@@ -1368,6 +1378,45 @@ async def _get_caller_token_status(db: Session, current_user: Any, gateway_id: s
         "scopes": info.get("scopes"),
         "expires_at": info.get("expires_at"),
         "updated_at": info.get("updated_at"),
+    }
+
+
+def _build_oauth_status_payload(gateway: Gateway) -> Dict[str, Any]:
+    """Build the OAuth config portion of a gateway's status payload (no I/O).
+
+    Shared by the single-gateway and batch status endpoints so the two never
+    drift. Caller is responsible for gateway lookup, access enforcement, and
+    attaching ``user_token_status`` for ``authorization_code`` grants.
+
+    Args:
+        gateway: Gateway record with ``oauth_config`` already loaded.
+
+    Returns:
+        Dict describing OAuth enablement and, when configured, grant details.
+    """
+    if not gateway.oauth_config:
+        return {"oauth_enabled": False, "message": "Gateway is not configured for OAuth"}
+
+    oauth_config = gateway.oauth_config
+    grant_type = oauth_config.get("grant_type")
+
+    if grant_type == "authorization_code":
+        return {
+            "oauth_enabled": True,
+            "grant_type": grant_type,
+            "client_id": oauth_config.get("client_id"),
+            "scopes": oauth_config.get("scopes", []),
+            "authorization_url": oauth_config.get("authorization_url"),
+            "redirect_uri": oauth_config.get("redirect_uri"),
+            "message": "Gateway configured for Authorization Code flow",
+        }
+
+    return {
+        "oauth_enabled": True,
+        "grant_type": grant_type,
+        "client_id": oauth_config.get("client_id"),
+        "scopes": oauth_config.get("scopes", []),
+        "message": f"Gateway configured for {grant_type} flow",
     }
 
 
@@ -1408,32 +1457,10 @@ async def get_oauth_status(
 
         await _enforce_gateway_access(gateway_id, gateway, current_user, db, request=request)
 
-        if not gateway.oauth_config:
-            return {"oauth_enabled": False, "message": "Gateway is not configured for OAuth"}
-
-        # Get OAuth configuration info
-        oauth_config = gateway.oauth_config
-        grant_type = oauth_config.get("grant_type")
-
-        if grant_type == "authorization_code":
-            return {
-                "oauth_enabled": True,
-                "grant_type": grant_type,
-                "client_id": oauth_config.get("client_id"),
-                "scopes": oauth_config.get("scopes", []),
-                "authorization_url": oauth_config.get("authorization_url"),
-                "redirect_uri": oauth_config.get("redirect_uri"),
-                "message": "Gateway configured for Authorization Code flow",
-                "user_token_status": await _get_caller_token_status(db, current_user, gateway_id),
-            }
-        else:
-            return {
-                "oauth_enabled": True,
-                "grant_type": grant_type,
-                "client_id": oauth_config.get("client_id"),
-                "scopes": oauth_config.get("scopes", []),
-                "message": f"Gateway configured for {grant_type} flow",
-            }
+        payload = _build_oauth_status_payload(gateway)
+        if payload.get("grant_type") == "authorization_code":
+            payload["user_token_status"] = await _get_caller_token_status(db, current_user, gateway_id)
+        return payload
 
     except HTTPException:
         raise
@@ -1480,13 +1507,39 @@ async def get_oauth_status_batch(
     if len(deduped_ids) > OAUTH_STATUS_BATCH_MAX_IDS:
         raise HTTPException(status_code=400, detail=f"Too many gateway_ids requested (max {OAUTH_STATUS_BATCH_MAX_IDS})")
 
+    # Single query for all requested gateways, and one TokenStorageService reused across
+    # the loop, instead of get_oauth_status()'s per-id gateway SELECT + TokenStorageService
+    # construction - the batch route exists specifically to avoid N+1 round trips.
+    gateways_by_id = {gw.id: gw for gw in db.execute(select(Gateway).where(Gateway.id.in_(deduped_ids))).scalars().all()}
+    token_storage = TokenStorageService(db, _build_user_context(current_user))
+
     results: Dict[str, Dict[str, Any]] = {}
     for gateway_id in deduped_ids:
-        try:
-            results[gateway_id] = await get_oauth_status(gateway_id, request, current_user, db)
-        except HTTPException:
-            # Not found / not accessible to this caller - omit rather than failing the batch.
+        gateway = gateways_by_id.get(gateway_id)
+        if not gateway:
+            # Not found - omit rather than failing the batch.
             continue
+
+        try:
+            await _enforce_gateway_access(gateway_id, gateway, current_user, db, request=request)
+        except HTTPException as exc:
+            if exc.status_code >= 500:
+                logger.error("OAuth status batch: access check failed for gateway=%s: %s", gateway_id, exc.detail)
+            # Not accessible to this caller (or a lookup failure, logged above) - omit rather than failing the batch.
+            continue
+        except Exception as exc:
+            logger.error("OAuth status batch: access check raised for gateway=%s: %s", gateway_id, str(exc))
+            continue
+
+        try:
+            payload = _build_oauth_status_payload(gateway)
+            if payload.get("grant_type") == "authorization_code":
+                payload["user_token_status"] = await _get_caller_token_status(db, current_user, gateway_id, token_storage=token_storage)
+            results[gateway_id] = payload
+        except Exception as exc:
+            logger.error("OAuth status batch: failed to build status for gateway=%s: %s", gateway_id, str(exc))
+            continue
+
     return results
 
 

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -1447,6 +1447,7 @@ def _build_oauth_status_payload(gateway: Gateway) -> Dict[str, Any]:
 
 
 @oauth_router.get("/status/{gateway_id}")
+@require_permission(Permissions.GATEWAYS_READ)
 async def get_oauth_status(
     gateway_id: str,
     request: Request,
@@ -1506,6 +1507,7 @@ OAUTH_STATUS_BATCH_TOKEN_LOOKUP_TIMEOUT_SECONDS = 15.0
 
 
 @oauth_router.get("/status")
+@require_permission(Permissions.GATEWAYS_READ)
 async def get_oauth_status_batch(
     request: Request,
     gateway_ids: Annotated[Optional[list[str]], Query(description="Gateway ids to look up; repeat the parameter for multiple ids")] = None,

--- a/mcpgateway/services/token_backends/base.py
+++ b/mcpgateway/services/token_backends/base.py
@@ -158,7 +158,11 @@ class AbstractTokenBackend(ABC):
         - status: "valid" | "expired" | "near_expiry"
         - updated_at: str (ISO-8601)
 
-        Returns None if no token found.
+        Returns None only when no token is stored for this identity.
+        An unexpected backend failure (DB error, Vault outage) must be
+        logged and re-raised, not swallowed to None - callers surfacing
+        this through a user-facing status field need to distinguish
+        "never authorized" from "lookup failed".
         Does NOT return actual token values.
         """
 

--- a/mcpgateway/services/token_backends/base.py
+++ b/mcpgateway/services/token_backends/base.py
@@ -166,6 +166,44 @@ class AbstractTokenBackend(ABC):
         Does NOT return actual token values.
         """
 
+    async def get_token_info_bulk(
+        self,
+        gateway_ids: list[str],
+        team_id: str,  # Team identifier from user context
+        app_user_email: str,
+    ) -> dict[str, dict | Exception | None]:
+        """
+        Bulk-lookup non-sensitive token metadata for multiple gateways at once.
+
+        Default implementation loops over ``gateway_ids`` calling ``get_token_info()``
+        for each, isolating one gateway's failure from the rest of the batch by
+        capturing the raised exception as that id's value instead of propagating it -
+        callers distinguish a captured exception ("lookup failed") from a plain
+        ``None`` ("never authorized") the same way they distinguish those two
+        outcomes from ``get_token_info()`` itself.
+
+        Backends that can express this as a single query (e.g. ``DatabaseTokenBackend``)
+        should override this for a true bulk fetch instead of N round trips - that is
+        the whole point of this method existing separately from a caller-side loop
+        over ``get_token_info()``.
+
+        Args:
+            gateway_ids: Gateway identifiers to look up.
+            team_id: Team identifier (semantics as in ``get_token_info()``).
+            app_user_email: ContextForge user email.
+
+        Returns:
+            Mapping of gateway_id to: the ``get_token_info()`` result dict, ``None``
+            (no token stored), or the caught ``Exception`` instance (lookup failed).
+        """
+        results: dict[str, dict | Exception | None] = {}
+        for gateway_id in gateway_ids:
+            try:
+                results[gateway_id] = await self.get_token_info(gateway_id, team_id, app_user_email)
+            except Exception as e:  # pylint: disable=broad-except
+                results[gateway_id] = e
+        return results
+
     @abstractmethod
     async def revoke_user_tokens(
         self,

--- a/mcpgateway/services/token_backends/db_backend.py
+++ b/mcpgateway/services/token_backends/db_backend.py
@@ -315,6 +315,73 @@ class DatabaseTokenBackend(AbstractTokenBackend):
             logger.error("Failed to get token info: %s", str(e))
             raise
 
+    async def get_token_info_bulk(
+        self,
+        gateway_ids: list[str],
+        team_id: str,  # ← Phase 1: Accepted but NOT used
+        app_user_email: str,
+    ) -> dict[str, dict | Exception | None]:
+        """Bulk-lookup non-sensitive token metadata for multiple gateways.
+
+        Overrides the loop-based default in :class:`AbstractTokenBackend` with a
+        single ``WHERE gateway_id IN (...) AND app_user_email = :email`` query, so a
+        batch status request issues one round trip regardless of how many gateway
+        ids it covers.
+
+        Phase 1: team_id parameter is IGNORED (matches get_token_info()).
+
+        Args:
+            gateway_ids: Gateway IDs to look up.
+            team_id: Team identifier (IGNORED in Phase 1).
+            app_user_email: ContextForge user email.
+
+        Returns:
+            Mapping of gateway_id to the same dict get_token_info() returns, or
+            None for ids with no stored token. Ids with no matching row are simply
+            absent from the underlying query result and mapped to None below.
+
+        Raises:
+            Exception: Propagated from the underlying database query on failure -
+                a single query backs the whole batch, so a DB error is not
+                isolated to one id the way the default per-item loop would.
+        """
+        if not gateway_ids:
+            return {}
+
+        try:
+            token_records = self.db.execute(select(OAuthToken).where(OAuthToken.gateway_id.in_(gateway_ids), OAuthToken.app_user_email == app_user_email)).scalars().all()
+        except Exception as e:
+            logger.error("Failed to get bulk token info: %s", str(e))
+            raise
+
+        records_by_gateway = {record.gateway_id: record for record in token_records}
+
+        results: dict[str, dict | Exception | None] = {}
+        for gateway_id in gateway_ids:
+            token_record = records_by_gateway.get(gateway_id)
+            if not token_record:
+                results[gateway_id] = None
+                continue
+
+            is_expired = self._is_token_expired(token_record, 0)
+            is_near_expiry = not is_expired and self._is_token_expired(token_record, 300)
+
+            if is_expired:
+                status = "expired"
+            elif is_near_expiry:
+                status = "near_expiry"
+            else:
+                status = "valid"
+
+            results[gateway_id] = {
+                "scopes": token_record.scopes,
+                "expires_at": token_record.expires_at.isoformat() if token_record.expires_at else None,
+                "status": status,
+                "updated_at": token_record.updated_at.isoformat(),
+            }
+
+        return results
+
     async def revoke_user_tokens(
         self,
         gateway_id: str,

--- a/mcpgateway/services/token_backends/db_backend.py
+++ b/mcpgateway/services/token_backends/db_backend.py
@@ -267,13 +267,24 @@ class DatabaseTokenBackend(AbstractTokenBackend):
 
         Phase 1: team_id parameter is IGNORED.
 
+        Returns ``None`` only when no token record exists for this
+        (gateway_id, app_user_email) pair. An unexpected failure (e.g. a DB
+        error) is logged and re-raised rather than swallowed to ``None``, so
+        callers exposing this through a user-facing status field (see
+        ``mcpgateway.routers.oauth_router._get_caller_token_status``) can
+        distinguish "never authorized" from "lookup failed" - the two read
+        identically to a caller if both collapse to ``None``.
+
         Args:
             gateway_id: Gateway ID
             team_id: Team identifier (IGNORED in Phase 1)
             app_user_email: ContextForge user email
 
         Returns:
-            Token info dict or None
+            Token info dict, or None if no token is stored.
+
+        Raises:
+            Exception: Propagated from the underlying database query on failure.
         """
         try:
             # PHASE 1: Query by (gateway_id, app_user_email) - team_id IGNORED
@@ -302,7 +313,7 @@ class DatabaseTokenBackend(AbstractTokenBackend):
 
         except Exception as e:
             logger.error("Failed to get token info: %s", str(e))
-            return None
+            raise
 
     async def revoke_user_tokens(
         self,

--- a/mcpgateway/services/token_backends/vault_backend.py
+++ b/mcpgateway/services/token_backends/vault_backend.py
@@ -587,13 +587,26 @@ class VaultTokenBackend(AbstractTokenBackend):
     ) -> dict | None:
         """Get non-sensitive token metadata from Vault.
 
+        Returns ``None`` only when no token record exists for this
+        (gateway_id, app_user_email) pair. A Vault connectivity/auth failure
+        is logged and re-raised rather than swallowed to ``None``, matching
+        ``DatabaseTokenBackend.get_token_info`` - so callers exposing this
+        through a user-facing status field (see
+        ``mcpgateway.routers.oauth_router._get_caller_token_status``) can
+        distinguish "never authorized" from "lookup failed" instead of both
+        collapsing to the same "missing" state during an outage.
+
         Args:
             gateway_id: Gateway ID
             team_id: Team identifier
             app_user_email: ContextForge user email
 
         Returns:
-            Token info dict or None
+            Token info dict, or None if no token is stored.
+
+        Raises:
+            VaultConnectionError: Propagated when Vault is unreachable.
+            VaultAuthError: Propagated when Vault authentication fails.
         """
         try:
             mcp_url = self._resolve_mcp_url(gateway_id)
@@ -626,12 +639,12 @@ class VaultTokenBackend(AbstractTokenBackend):
 
         except (VaultConnectionError, VaultAuthError) as e:
             logger.warning(
-                "Vault unavailable in get_token_info for gateway %s, user %s: %s",
+                "Vault unavailable in get_token_info for gateway %s, user %s: %s — re-raising so callers can distinguish this from a genuinely missing token",
                 SecurityValidator.sanitize_log_message(gateway_id),
                 SecurityValidator.sanitize_log_message(app_user_email),
                 str(e),
             )
-            return None
+            raise
 
     async def revoke_user_tokens(
         self,

--- a/mcpgateway/services/token_storage_service.py
+++ b/mcpgateway/services/token_storage_service.py
@@ -353,6 +353,35 @@ class TokenStorageService:
             app_user_email=app_user_email,
         )
 
+    async def get_token_info_bulk(
+        self,
+        gateway_ids: list[str],
+        app_user_email: str,
+    ) -> Dict[str, Any]:
+        """Get information about stored OAuth tokens for multiple gateways at once.
+
+        ``team_id`` is resolved once from ``self.user_context`` (the authenticated
+        caller's JWT) rather than per gateway_id, since ``_get_team_id`` derives it
+        solely from the caller's own team claim - identical for every id in the batch.
+
+        Args:
+            gateway_ids: IDs of the gateways to look up.
+            app_user_email: ContextForge user email.
+
+        Returns:
+            Mapping of gateway_id to: the get_token_info() result dict, None (no
+            token stored), or the caught Exception instance (lookup failed) - see
+            ``AbstractTokenBackend.get_token_info_bulk``.
+        """
+        if not gateway_ids:
+            return {}
+        team_id = self._get_team_id(gateway_ids[0], app_user_email)
+        return await self._backend.get_token_info_bulk(
+            gateway_ids=gateway_ids,
+            team_id=team_id,
+            app_user_email=app_user_email,
+        )
+
     async def revoke_user_tokens(
         self,
         gateway_id: str,

--- a/tests/live_gateway/README.md
+++ b/tests/live_gateway/README.md
@@ -31,6 +31,7 @@ Specific subsuites need additional services on top:
 | Subdir | Extra requirement | How to start |
 |---|---|---|
 | `mcp/` | gateway with MCP transports registered | `make testing-up` (default profile) |
+| `mcp/test_oauth_status_live.py` | Postgres reachable at `localhost:5433` (the compose default) | `make testing-up` |
 | `sso/` | Keycloak (jwks tests) and/or Entra ID (entra tests) | `docker compose --profile sso up -d` for Keycloak; `AZURE_*` env vars for Entra |
 | `e2e_rust/` | gateway built with the Rust transport (edge or full mode) | `make testing-up` with the Rust profile, or rebuild compose images with Rust enabled |
 
@@ -50,6 +51,7 @@ make test-mcp-plugin-parity        # tests/live_gateway/mcp/test_mcp_plugin_pari
 make test-mcp-access-matrix        # tests/live_gateway/e2e_rust/test_mcp_access_matrix.py
 make test-mcp-session-isolation    # tests/live_gateway/e2e_rust/test_mcp_session_isolation.py
 make test-e2e-sso                  # tests/live_gateway/sso/
+make test-oauth-status-live        # tests/live_gateway/mcp/test_oauth_status_live.py
 
 # Or run a specific file directly via uv
 uv run --extra plugins pytest tests/live_gateway/mcp/test_langfuse_traces.py -v

--- a/tests/live_gateway/mcp/test_oauth_status_live.py
+++ b/tests/live_gateway/mcp/test_oauth_status_live.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/live_gateway/mcp/test_oauth_status_live.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Black-box test for the per-caller OAuth token status endpoints.
+
+Exercises ``GET /oauth/status/{gateway_id}`` and the batch
+``GET /oauth/status`` against a running gateway (``make testing-up``),
+writing directly to the compose Postgres instance the gateway container
+reads from - the same approach used by the PR's manual test script
+(create gateway row, seed a token via ``DatabaseTokenBackend``, curl the
+endpoint, verify per-user isolation) but automated.
+"""
+
+from __future__ import annotations
+
+# Standard
+import asyncio
+import os
+import uuid
+
+# Third-Party
+import httpx
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# First-Party
+from mcpgateway.config import settings
+from mcpgateway.db import EmailUser, Gateway, OAuthToken
+from mcpgateway.services.token_backends.db_backend import DatabaseTokenBackend
+from mcpgateway.utils.create_slug import slugify
+from tests.helpers.auth import make_test_jwt
+from tests.live_gateway.helpers.mcp_test_helpers import BASE_URL, JWT_SECRET, skip_no_gateway
+
+LIVE_DB_URL = os.getenv(
+    "LIVE_GATEWAY_DB_URL",
+    "postgresql+psycopg://postgres:mysecretpassword@localhost:5433/mcp",
+)
+
+SECOND_USER_EMAIL = "oauth-status-live-second-user@example.com"
+
+
+def _db_reachable() -> bool:
+    try:
+        engine = create_engine(LIVE_DB_URL)
+        with engine.connect():
+            return True
+    except Exception:
+        return False
+
+
+skip_no_db = pytest.mark.skipif(not _db_reachable(), reason=f"Postgres not reachable at {LIVE_DB_URL}")
+pytestmark = [pytest.mark.e2e, skip_no_gateway, skip_no_db]
+
+
+@pytest.fixture(scope="module")
+def db_session():
+    """Session bound directly to the compose Postgres instance (bypasses pgbouncer)."""
+    engine = create_engine(LIVE_DB_URL)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+@pytest.fixture(scope="module")
+def oauth_gateway(db_session):
+    """Insert an authorization_code OAuth gateway row directly.
+
+    ``POST /gateways`` actively probes the URL and rolls back if it isn't a
+    real MCP server, so the status endpoints are exercised against a row
+    inserted directly - the same workaround the PR's manual test uses.
+    """
+    name = f"oauth-status-live-{uuid.uuid4().hex[:8]}"
+    gateway = Gateway(
+        id=uuid.uuid4().hex,
+        name=name,
+        slug=slugify(name),
+        url="https://mcp.example.com",
+        capabilities={},
+        visibility="public",
+        oauth_config={
+            "grant_type": "authorization_code",
+            "client_id": "test-client",
+            "client_secret": "test-secret",  # pragma: allowlist secret
+            "authorization_url": "https://idp.example.com/authorize",
+            "token_url": "https://idp.example.com/token",
+            "redirect_uri": "http://localhost:8080/oauth/callback",
+            "scopes": ["read"],
+        },
+    )
+    db_session.add(gateway)
+    db_session.commit()
+    gateway_id = gateway.id
+
+    yield gateway_id
+
+    db_session.query(OAuthToken).filter(OAuthToken.gateway_id == gateway_id).delete()
+    db_session.query(Gateway).filter(Gateway.id == gateway_id).delete()
+    db_session.commit()
+
+
+@pytest.fixture(scope="module")
+def second_user(db_session):
+    """A second, non-admin user distinct from the bootstrapped platform admin."""
+    existing = db_session.query(EmailUser).filter_by(email=SECOND_USER_EMAIL).first()
+    if existing is None:
+        db_session.add(
+            EmailUser(
+                email=SECOND_USER_EMAIL,
+                password_hash="",  # pragma: allowlist secret
+                full_name="OAuth Status Live Second User",
+                is_admin=False,
+            )
+        )
+        db_session.commit()
+    return SECOND_USER_EMAIL
+
+
+def _seed_token(db_session, gateway_id: str, app_user_email: str, expires_in: int) -> None:
+    backend = DatabaseTokenBackend(db_session, settings)
+    asyncio.run(
+        backend.store_tokens(
+            gateway_id=gateway_id,
+            team_id=None,
+            user_id="idp-user-1",
+            app_user_email=app_user_email,
+            access_token="fake-access-token",  # pragma: allowlist secret
+            refresh_token=None,
+            expires_in=expires_in,
+            scopes=["read"],
+        )
+    )
+
+
+def _get_status(gateway_id: str, token: str) -> httpx.Response:
+    return httpx.get(
+        f"{BASE_URL}/oauth/status/{gateway_id}",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10.0,
+    )
+
+
+def test_missing_before_authorization(oauth_gateway: str) -> None:
+    """A caller who has never completed the OAuth flow sees status 'missing'."""
+    token = make_test_jwt("admin@example.com", is_admin=True, teams=None, secret=JWT_SECRET)
+    response = _get_status(oauth_gateway, token)
+
+    assert response.status_code == 200, response.text
+    user_status = response.json()["user_token_status"]
+    assert user_status["status"] == "missing"
+    assert user_status["authorized"] is False
+
+
+@pytest.mark.parametrize(
+    ("expires_in", "expected_status"),
+    [(3600, "valid"), (60, "near_expiry"), (-60, "expired")],
+)
+def test_status_reflects_token_freshness(db_session, oauth_gateway: str, expires_in: int, expected_status: str) -> None:
+    """Status tracks the seeded token's expiry across valid/near_expiry/expired."""
+    _seed_token(db_session, oauth_gateway, "admin@example.com", expires_in)
+    token = make_test_jwt("admin@example.com", is_admin=True, teams=None, secret=JWT_SECRET)
+    response = _get_status(oauth_gateway, token)
+
+    assert response.status_code == 200, response.text
+    user_status = response.json()["user_token_status"]
+    assert user_status["status"] == expected_status
+    assert user_status["authorized"] is (expected_status in ("valid", "near_expiry"))
+
+
+def test_per_user_isolation(db_session, oauth_gateway: str, second_user: str) -> None:
+    """A second user must see 'missing' even though the admin has a valid token on the same gateway."""
+    _seed_token(db_session, oauth_gateway, "admin@example.com", 3600)
+
+    other_token = make_test_jwt(second_user, is_admin=False, teams=[], secret=JWT_SECRET)
+    response = _get_status(oauth_gateway, other_token)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["user_token_status"]["status"] == "missing"
+
+
+def test_batch_endpoint_omits_unknown_ids(oauth_gateway: str) -> None:
+    """The batch endpoint returns the real gateway and silently omits an unknown id."""
+    token = make_test_jwt("admin@example.com", is_admin=True, teams=None, secret=JWT_SECRET)
+    response = httpx.get(
+        f"{BASE_URL}/oauth/status",
+        params=[("gateway_ids", oauth_gateway), ("gateway_ids", "nonexistent-id")],
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10.0,
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert oauth_gateway in body
+    assert "nonexistent-id" not in body

--- a/tests/live_gateway/mcp/test_oauth_status_live.py
+++ b/tests/live_gateway/mcp/test_oauth_status_live.py
@@ -29,6 +29,7 @@ from sqlalchemy.orm import sessionmaker
 # First-Party
 from mcpgateway.config import settings
 from mcpgateway.db import EmailUser, Gateway, OAuthToken
+from mcpgateway.services.role_service import RoleService
 from mcpgateway.services.token_backends.db_backend import DatabaseTokenBackend
 from mcpgateway.utils.create_slug import slugify
 from tests.helpers.auth import make_test_jwt
@@ -40,6 +41,7 @@ LIVE_DB_URL = os.getenv(
 )
 
 SECOND_USER_EMAIL = "oauth-status-live-second-user@example.com"
+NO_PERMISSION_USER_EMAIL = "oauth-status-live-no-permission-user@example.com"
 
 
 def _db_reachable() -> bool:
@@ -104,7 +106,14 @@ def oauth_gateway(db_session):
 
 @pytest.fixture(scope="module")
 def second_user(db_session):
-    """A second, non-admin user distinct from the bootstrapped platform admin."""
+    """A second, non-admin user distinct from the bootstrapped platform admin.
+
+    Holds the global, system-seeded ``platform_viewer`` role so it carries
+    ``gateways.read`` - required by the ``@require_permission`` gate on both
+    OAuth status routes - without granting any gateway ownership. This lets
+    the isolation and visibility scenarios reach the per-user/private-gateway
+    logic in the handlers instead of being turned away at the RBAC gate.
+    """
     existing = db_session.query(EmailUser).filter_by(email=SECOND_USER_EMAIL).first()
     created_here = existing is None
     if created_here:
@@ -118,10 +127,48 @@ def second_user(db_session):
         )
         db_session.commit()
 
+    role_service = RoleService(db_session)
+    role = asyncio.run(role_service.get_role_by_name("platform_viewer", "global"))
+    assignment_created = False
+    if role is not None and asyncio.run(role_service.get_user_role_assignment(SECOND_USER_EMAIL, role.id, "global", None)) is None:
+        asyncio.run(role_service.assign_role_to_user(SECOND_USER_EMAIL, role.id, "global", None, granted_by="admin@example.com"))
+        assignment_created = True
+
     yield SECOND_USER_EMAIL
 
+    if assignment_created and role is not None:
+        asyncio.run(role_service.revoke_role_from_user(SECOND_USER_EMAIL, role.id, "global", None))
     if created_here:
         db_session.query(EmailUser).filter_by(email=SECOND_USER_EMAIL).delete()
+        db_session.commit()
+
+
+@pytest.fixture(scope="module")
+def no_permission_user(db_session):
+    """A role-less, non-admin user - has no ``gateways.read`` permission at all.
+
+    Used for the explicit no-permission 403 coverage on both OAuth status
+    routes, kept separate from ``second_user`` (which now holds
+    ``gateways.read`` so it can exercise per-user isolation and private-gateway
+    visibility instead of being blocked by RBAC).
+    """
+    existing = db_session.query(EmailUser).filter_by(email=NO_PERMISSION_USER_EMAIL).first()
+    created_here = existing is None
+    if created_here:
+        db_session.add(
+            EmailUser(
+                email=NO_PERMISSION_USER_EMAIL,
+                password_hash="",  # pragma: allowlist secret
+                full_name="OAuth Status Live No Permission User",
+                is_admin=False,
+            )
+        )
+        db_session.commit()
+
+    yield NO_PERMISSION_USER_EMAIL
+
+    if created_here:
+        db_session.query(EmailUser).filter_by(email=NO_PERMISSION_USER_EMAIL).delete()
         db_session.commit()
 
 
@@ -237,7 +284,7 @@ def test_batch_endpoint_omits_unknown_ids(oauth_gateway: str) -> None:
 
 
 def test_private_gateway_denies_non_owner(private_gateway: str, second_user: str) -> None:
-    """A caller who isn't the owner of a private gateway gets 403 from the single-gateway endpoint."""
+    """A caller who isn't the owner of a private gateway, but does hold ``gateways.read``, gets 403 from the single-gateway endpoint due to private-gateway visibility, not RBAC."""
     other_token = make_test_jwt(second_user, is_admin=False, teams=[], secret=JWT_SECRET)
     response = _get_status(private_gateway, other_token)
 
@@ -256,3 +303,24 @@ def test_batch_endpoint_omits_private_gateway_for_non_owner(private_gateway: str
 
     assert response.status_code == 200, response.text
     assert private_gateway not in response.json()
+
+
+def test_single_endpoint_denies_no_permission_user(oauth_gateway: str, no_permission_user: str) -> None:
+    """A caller with no ``gateways.read`` permission at all gets 403 from the single-gateway endpoint, even for a public gateway."""
+    other_token = make_test_jwt(no_permission_user, is_admin=False, teams=[], secret=JWT_SECRET)
+    response = _get_status(oauth_gateway, other_token)
+
+    assert response.status_code == 403, response.text
+
+
+def test_batch_endpoint_denies_no_permission_user(oauth_gateway: str, no_permission_user: str) -> None:
+    """A caller with no ``gateways.read`` permission at all gets 403 from the batch endpoint, even for a public gateway."""
+    other_token = make_test_jwt(no_permission_user, is_admin=False, teams=[], secret=JWT_SECRET)
+    response = httpx.get(
+        f"{BASE_URL}/oauth/status",
+        params=[("gateway_ids", oauth_gateway)],
+        headers={"Authorization": f"Bearer {other_token}"},
+        timeout=10.0,
+    )
+
+    assert response.status_code == 403, response.text

--- a/tests/live_gateway/mcp/test_oauth_status_live.py
+++ b/tests/live_gateway/mcp/test_oauth_status_live.py
@@ -36,7 +36,7 @@ from tests.live_gateway.helpers.mcp_test_helpers import BASE_URL, JWT_SECRET, sk
 
 LIVE_DB_URL = os.getenv(
     "LIVE_GATEWAY_DB_URL",
-    "postgresql+psycopg://postgres:mysecretpassword@localhost:5433/mcp",
+    "postgresql+psycopg://postgres:mysecretpassword@localhost:5433/mcp",  # pragma: allowlist secret
 )
 
 SECOND_USER_EMAIL = "oauth-status-live-second-user@example.com"

--- a/tests/live_gateway/mcp/test_oauth_status_live.py
+++ b/tests/live_gateway/mcp/test_oauth_status_live.py
@@ -106,7 +106,8 @@ def oauth_gateway(db_session):
 def second_user(db_session):
     """A second, non-admin user distinct from the bootstrapped platform admin."""
     existing = db_session.query(EmailUser).filter_by(email=SECOND_USER_EMAIL).first()
-    if existing is None:
+    created_here = existing is None
+    if created_here:
         db_session.add(
             EmailUser(
                 email=SECOND_USER_EMAIL,
@@ -116,7 +117,45 @@ def second_user(db_session):
             )
         )
         db_session.commit()
-    return SECOND_USER_EMAIL
+
+    yield SECOND_USER_EMAIL
+
+    if created_here:
+        db_session.query(EmailUser).filter_by(email=SECOND_USER_EMAIL).delete()
+        db_session.commit()
+
+
+@pytest.fixture(scope="module")
+def private_gateway(db_session):
+    """A private, admin-owned OAuth gateway - used to exercise the deny path for a non-owner caller."""
+    name = f"oauth-status-live-private-{uuid.uuid4().hex[:8]}"
+    gateway = Gateway(
+        id=uuid.uuid4().hex,
+        name=name,
+        slug=slugify(name),
+        url="https://mcp-private.example.com",
+        capabilities={},
+        visibility="private",
+        owner_email="admin@example.com",
+        oauth_config={
+            "grant_type": "authorization_code",
+            "client_id": "test-client",
+            "client_secret": "test-secret",  # pragma: allowlist secret
+            "authorization_url": "https://idp.example.com/authorize",
+            "token_url": "https://idp.example.com/token",
+            "redirect_uri": "http://localhost:8080/oauth/callback",
+            "scopes": ["read"],
+        },
+    )
+    db_session.add(gateway)
+    db_session.commit()
+    gateway_id = gateway.id
+
+    yield gateway_id
+
+    db_session.query(OAuthToken).filter(OAuthToken.gateway_id == gateway_id).delete()
+    db_session.query(Gateway).filter(Gateway.id == gateway_id).delete()
+    db_session.commit()
 
 
 def _seed_token(db_session, gateway_id: str, app_user_email: str, expires_in: int) -> None:
@@ -195,3 +234,25 @@ def test_batch_endpoint_omits_unknown_ids(oauth_gateway: str) -> None:
     body = response.json()
     assert oauth_gateway in body
     assert "nonexistent-id" not in body
+
+
+def test_private_gateway_denies_non_owner(private_gateway: str, second_user: str) -> None:
+    """A caller who isn't the owner of a private gateway gets 403 from the single-gateway endpoint."""
+    other_token = make_test_jwt(second_user, is_admin=False, teams=[], secret=JWT_SECRET)
+    response = _get_status(private_gateway, other_token)
+
+    assert response.status_code == 403, response.text
+
+
+def test_batch_endpoint_omits_private_gateway_for_non_owner(private_gateway: str, second_user: str) -> None:
+    """The batch endpoint silently omits a private gateway the caller doesn't own, rather than 403ing the whole batch."""
+    other_token = make_test_jwt(second_user, is_admin=False, teams=[], secret=JWT_SECRET)
+    response = httpx.get(
+        f"{BASE_URL}/oauth/status",
+        params=[("gateway_ids", private_gateway)],
+        headers={"Authorization": f"Bearer {other_token}"},
+        timeout=10.0,
+    )
+
+    assert response.status_code == 200, response.text
+    assert private_gateway not in response.json()

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -2149,6 +2149,50 @@ def test_check_resource_team_ownership_gateway_private_denies_non_owner():
     assert middleware._check_resource_team_ownership("/gateways/a1b2c3d4", ["team-1"], db=db, _user_email="other@example.com") is ResourceOwnershipResult.DENIED
 
 
+def test_check_resource_team_ownership_gateway_reuses_preloaded_gateway():
+    """A matching preloaded_gateway must be reused instead of re-SELECTing the row.
+
+    Regression test for the oauth/status batch endpoint (#6620): a caller that already
+    bulk-fetched N gateways shouldn't pay for a second per-id SELECT here just to redo
+    the ownership check.
+    """
+    middleware = TokenScopingMiddleware()
+    db = MagicMock()
+
+    gateway = MagicMock()
+    gateway.id = "a1b2c3d4"
+    gateway.visibility = "public"
+
+    result = middleware._check_resource_team_ownership("/gateways/a1b2c3d4", ["team-1"], db=db, _user_email="user@example.com", preloaded_gateway=gateway)
+
+    assert result is ResourceOwnershipResult.ALLOWED
+    db.execute.assert_not_called()
+
+
+def test_check_resource_team_ownership_gateway_ignores_mismatched_preloaded_gateway():
+    """A preloaded_gateway whose id doesn't match the path's resource id must be ignored,
+    falling back to the normal DB lookup rather than checking the wrong gateway's ACL."""
+    middleware = TokenScopingMiddleware()
+    db = MagicMock()
+
+    stale_preloaded = MagicMock()
+    stale_preloaded.id = "different-id"
+    stale_preloaded.visibility = "public"
+
+    actual_gateway = MagicMock()
+    actual_gateway.id = "a1b2c3d4"
+    actual_gateway.visibility = "private"
+    actual_gateway.owner_email = "owner@example.com"
+    db.execute.return_value.scalar_one_or_none.return_value = actual_gateway
+
+    result = middleware._check_resource_team_ownership(
+        "/gateways/a1b2c3d4", ["team-1"], db=db, _user_email="other@example.com", preloaded_gateway=stale_preloaded
+    )
+
+    db.execute.assert_called_once()
+    assert result is ResourceOwnershipResult.DENIED
+
+
 def test_check_resource_team_ownership_unknown_resource_type_denies(monkeypatch):
     """Unknown resource types should be denied by default."""
     # Standard

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -414,6 +414,23 @@ class TestTokenScopingMiddleware:
         assert middleware._check_permission_restrictions("/oauth/registered-clients/c1", "DELETE", ["*"]) is True
 
     @pytest.mark.asyncio
+    async def test_oauth_status_paths_require_gateways_read(self, middleware):
+        """GET /oauth/status/{gateway_id} and the batch GET /oauth/status are mapped to
+        gateways.read, matching the /vault/authorize/{id} pattern (#6620 review).
+
+        Without this entry, a scoped API token (as opposed to a session token) would be
+        default-denied here before ever reaching _enforce_gateway_access's per-gateway check.
+        """
+        assert middleware._check_permission_restrictions("/oauth/status/gw1", "GET", [Permissions.GATEWAYS_READ]) is True
+        assert middleware._check_permission_restrictions("/oauth/status", "GET", [Permissions.GATEWAYS_READ]) is True
+
+        assert middleware._check_permission_restrictions("/oauth/status/gw1", "GET", ["*"]) is True
+        assert middleware._check_permission_restrictions("/oauth/status", "GET", ["*"]) is True
+
+        assert middleware._check_permission_restrictions("/oauth/status/gw1", "GET", [Permissions.TOOLS_READ]) is False
+        assert middleware._check_permission_restrictions("/oauth/status", "GET", [Permissions.TOOLS_READ]) is False
+
+    @pytest.mark.asyncio
     async def test_other_oauth_paths_still_default_deny(self, middleware):
         """Adding registered-client mappings must not open other /oauth routes to scoped tokens."""
         assert middleware._check_permission_restrictions("/oauth/authorize/gw1", "GET", [Permissions.ADMIN_OAUTH_CLIENTS_READ]) is False

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -36,6 +36,22 @@ from mcpgateway.services.oauth_manager import OAuthError
 from mcpgateway.utils.oauth_resource import derive_resource_origin
 
 
+class _AttrDict(dict):
+    """dict subclass exposing keys as attributes.
+
+    ``@require_permission`` requires ``isinstance(current_user, dict)`` (it's a real
+    dict at runtime - see ``get_current_user_with_permissions``), while some router
+    helpers and test assertions use attribute access (``user.email``). This satisfies
+    both without duplicating fixtures per access style.
+    """
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+
 class TestDeriveResourceOrigin:
     """Tests for derive_resource_origin (origin-extraction fallback for auto-derived resource)."""
 
@@ -344,14 +360,14 @@ class TestOAuthRouter:
 
     @pytest.fixture
     def mock_current_user(self):
-        """Create mock current user."""
-        user = Mock(spec=EmailUserResponse)
-        user.get = Mock(return_value="test@example.com")
-        user.email = "test@example.com"
-        user.full_name = "Test User"
-        user.is_active = True
-        user.is_admin = False
-        return user
+        """Create mock current user.
+
+        A real dict (not ``Mock(spec=EmailUserResponse)``) since ``get_oauth_status``/
+        ``get_oauth_status_batch`` are RBAC-decorated (``@require_permission``), which
+        requires ``isinstance(current_user, dict)`` - matching the actual runtime type
+        returned by ``get_current_user_with_permissions``.
+        """
+        return _AttrDict(email="test@example.com", full_name="Test User", is_active=True, is_admin=False)
 
     @pytest.mark.asyncio
     async def test_initiate_oauth_flow_success(self, mock_db, mock_request, mock_gateway, mock_current_user):
@@ -1162,7 +1178,7 @@ class TestOAuthRouter:
         from mcpgateway.routers.oauth_router import get_oauth_status
 
         # Execute (now requires current_user for authentication)
-        result = await get_oauth_status("gateway123", mock_request, mock_current_user, mock_db)
+        result = await get_oauth_status("gateway123", mock_request, current_user=mock_current_user, db=mock_db)
 
         # Assert
         assert result["oauth_enabled"] is True
@@ -1184,7 +1200,7 @@ class TestOAuthRouter:
         from mcpgateway.routers.oauth_router import get_oauth_status
 
         # Execute (now requires current_user for authentication)
-        result = await get_oauth_status("gateway123", mock_request, mock_current_user, mock_db)
+        result = await get_oauth_status("gateway123", mock_request, current_user=mock_current_user, db=mock_db)
 
         # Assert
         assert result["oauth_enabled"] is False
@@ -1197,7 +1213,7 @@ class TestOAuthRouter:
         from mcpgateway.routers.oauth_router import get_oauth_status
 
         with pytest.raises(HTTPException) as exc_info:
-            await get_oauth_status("gateway123", mock_request, mock_current_user, mock_db)
+            await get_oauth_status("gateway123", mock_request, current_user=mock_current_user, db=mock_db)
 
         assert exc_info.value.status_code == 404
 
@@ -1211,7 +1227,7 @@ class TestOAuthRouter:
 
         from mcpgateway.routers.oauth_router import get_oauth_status
 
-        result = await get_oauth_status("gateway123", mock_request, mock_current_user, mock_db)
+        result = await get_oauth_status("gateway123", mock_request, current_user=mock_current_user, db=mock_db)
 
         assert result["grant_type"] == "client_credentials"
         assert "configured for client_credentials" in result["message"]
@@ -1223,7 +1239,7 @@ class TestOAuthRouter:
         from mcpgateway.routers.oauth_router import get_oauth_status
 
         with pytest.raises(HTTPException) as exc_info:
-            await get_oauth_status("gateway123", mock_request, mock_current_user, mock_db)
+            await get_oauth_status("gateway123", mock_request, current_user=mock_current_user, db=mock_db)
 
         assert exc_info.value.status_code == 500
 
@@ -1248,7 +1264,7 @@ class TestOAuthRouter:
             mock_token_storage.get_token_info = AsyncMock(return_value=backend_info)
             mock_token_storage_class.return_value = mock_token_storage
 
-            result = await get_oauth_status("gateway123", mock_request, mock_current_user, mock_db)
+            result = await get_oauth_status("gateway123", mock_request, current_user=mock_current_user, db=mock_db)
 
         assert result["user_token_status"]["status"] == expected_status
         assert result["user_token_status"]["authorized"] is expected_authorized
@@ -1259,9 +1275,7 @@ class TestOAuthRouter:
         """Each caller only ever gets their own token state - lookup is keyed by the authenticated caller's email."""
         mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
 
-        other_user = Mock(spec=EmailUserResponse)
-        other_user.email = "other@example.com"
-        other_user.is_admin = False
+        other_user = _AttrDict(email="other@example.com", is_admin=False)
 
         from mcpgateway.routers.oauth_router import get_oauth_status
 
@@ -1270,7 +1284,7 @@ class TestOAuthRouter:
             mock_token_storage.get_token_info = AsyncMock(return_value=None)
             mock_token_storage_class.return_value = mock_token_storage
 
-            await get_oauth_status("gateway123", mock_request, other_user, mock_db)
+            await get_oauth_status("gateway123", mock_request, current_user=other_user, db=mock_db)
 
         mock_token_storage.get_token_info.assert_awaited_once_with("gateway123", "other@example.com")
 
@@ -1290,7 +1304,7 @@ class TestOAuthRouter:
             mock_token_storage_class.return_value = mock_token_storage
 
             with patch("mcpgateway.routers.oauth_router.logger") as mock_logger:
-                result = await get_oauth_status("gateway123", mock_request, mock_current_user, mock_db)
+                result = await get_oauth_status("gateway123", mock_request, current_user=mock_current_user, db=mock_db)
 
         assert result["user_token_status"] == {"status": "unknown", "authorized": False}
         mock_logger.exception.assert_called_once()
@@ -1320,7 +1334,7 @@ class TestOAuthRouter:
             mock_token_storage.get_token_info_bulk = AsyncMock(side_effect=lambda gateway_ids, app_user_email: {gid: None for gid in gateway_ids})
             mock_token_storage_class.return_value = mock_token_storage
 
-            result = await get_oauth_status_batch(mock_request, ["gateway123", "gateway123"], mock_current_user, mock_db)
+            result = await get_oauth_status_batch(mock_request, ["gateway123", "gateway123"], current_user=mock_current_user, db=mock_db)
 
         # Duplicate ids are deduped
         assert list(result.keys()) == ["gateway123"]
@@ -1339,7 +1353,7 @@ class TestOAuthRouter:
             mock_token_storage.get_token_info_bulk = AsyncMock(side_effect=lambda gateway_ids, app_user_email: {gid: None for gid in gateway_ids})
             mock_token_storage_class.return_value = mock_token_storage
 
-            result = await get_oauth_status_batch(mock_request, ["gateway123", "gateway123"], mock_current_user, mock_db)
+            result = await get_oauth_status_batch(mock_request, ["gateway123", "gateway123"], current_user=mock_current_user, db=mock_db)
 
         assert mock_db.execute.call_count == 1
         mock_token_storage_class.assert_called_once()
@@ -1378,7 +1392,7 @@ class TestOAuthRouter:
             mock_token_storage.get_token_info_bulk = AsyncMock(side_effect=lambda gateway_ids, app_user_email: {gid: None for gid in gateway_ids})
             mock_token_storage_class.return_value = mock_token_storage
 
-            result = await get_oauth_status_batch(mock_request, [gw1.id, gw2.id], mock_current_user, mock_db)
+            result = await get_oauth_status_batch(mock_request, [gw1.id, gw2.id], current_user=mock_current_user, db=mock_db)
 
         assert mock_db.execute.call_count == 1
         assert set(result.keys()) == {gw1.id, gw2.id}
@@ -1412,7 +1426,7 @@ class TestOAuthRouter:
             mock_token_storage.get_token_info_bulk = AsyncMock(side_effect=lambda gateway_ids, app_user_email: {gid: None for gid in gateway_ids})
             mock_token_storage_class.return_value = mock_token_storage
 
-            result = await get_oauth_status_batch(mock_request, [own_gateway.id, others_gateway.id], mock_current_user, mock_db)
+            result = await get_oauth_status_batch(mock_request, [own_gateway.id, others_gateway.id], current_user=mock_current_user, db=mock_db)
 
         assert set(result.keys()) == {own_gateway.id}
 
@@ -1432,7 +1446,7 @@ class TestOAuthRouter:
 
         from mcpgateway.routers.oauth_router import get_oauth_status_batch
 
-        result = await get_oauth_status_batch(mock_request, [gateway.id], mock_current_user, mock_db)
+        result = await get_oauth_status_batch(mock_request, [gateway.id], current_user=mock_current_user, db=mock_db)
 
         assert result[gateway.id]["grant_type"] == "client_credentials"
         assert "user_token_status" not in result[gateway.id]
@@ -1444,7 +1458,7 @@ class TestOAuthRouter:
 
         from mcpgateway.routers.oauth_router import get_oauth_status_batch
 
-        result = await get_oauth_status_batch(mock_request, ["missing1", "missing2"], mock_current_user, mock_db)
+        result = await get_oauth_status_batch(mock_request, ["missing1", "missing2"], current_user=mock_current_user, db=mock_db)
 
         assert result == {}
 
@@ -1457,7 +1471,7 @@ class TestOAuthRouter:
 
         with patch("mcpgateway.routers.oauth_router._enforce_gateway_access", new=AsyncMock(side_effect=HTTPException(status_code=500, detail="boom"))):
             with patch("mcpgateway.routers.oauth_router.logger") as mock_logger:
-                result = await get_oauth_status_batch(mock_request, ["gateway123"], mock_current_user, mock_db)
+                result = await get_oauth_status_batch(mock_request, ["gateway123"], current_user=mock_current_user, db=mock_db)
 
         assert result == {}
         mock_logger.error.assert_called_once()
@@ -1471,7 +1485,7 @@ class TestOAuthRouter:
 
         with patch("mcpgateway.routers.oauth_router._enforce_gateway_access", new=AsyncMock(side_effect=HTTPException(status_code=403, detail="nope"))):
             with patch("mcpgateway.routers.oauth_router.logger") as mock_logger:
-                result = await get_oauth_status_batch(mock_request, ["gateway123"], mock_current_user, mock_db)
+                result = await get_oauth_status_batch(mock_request, ["gateway123"], current_user=mock_current_user, db=mock_db)
 
         assert result == {}
         mock_logger.error.assert_not_called()
@@ -1486,7 +1500,7 @@ class TestOAuthRouter:
 
         with patch("mcpgateway.routers.oauth_router._enforce_gateway_access", new=AsyncMock(side_effect=RuntimeError("db unavailable"))):
             with patch("mcpgateway.routers.oauth_router.logger") as mock_logger:
-                result = await get_oauth_status_batch(mock_request, ["gateway123"], mock_current_user, mock_db)
+                result = await get_oauth_status_batch(mock_request, ["gateway123"], current_user=mock_current_user, db=mock_db)
 
         assert result == {}
         mock_logger.exception.assert_called_once()
@@ -1501,7 +1515,7 @@ class TestOAuthRouter:
 
         with patch("mcpgateway.routers.oauth_router._build_oauth_status_payload", side_effect=RuntimeError("boom")):
             with patch("mcpgateway.routers.oauth_router.logger") as mock_logger:
-                result = await get_oauth_status_batch(mock_request, ["gateway123"], mock_current_user, mock_db)
+                result = await get_oauth_status_batch(mock_request, ["gateway123"], current_user=mock_current_user, db=mock_db)
 
         assert result == {}
         mock_logger.exception.assert_called_once()
@@ -1511,7 +1525,7 @@ class TestOAuthRouter:
         from mcpgateway.routers.oauth_router import get_oauth_status_batch
 
         with pytest.raises(HTTPException) as exc_info:
-            await get_oauth_status_batch(mock_request, [], mock_current_user, mock_db)
+            await get_oauth_status_batch(mock_request, [], current_user=mock_current_user, db=mock_db)
 
         assert exc_info.value.status_code == 400
 
@@ -1522,7 +1536,7 @@ class TestOAuthRouter:
         too_many = [f"gw{i}" for i in range(OAUTH_STATUS_BATCH_MAX_IDS + 1)]
 
         with pytest.raises(HTTPException) as exc_info:
-            await get_oauth_status_batch(mock_request, too_many, mock_current_user, mock_db)
+            await get_oauth_status_batch(mock_request, too_many, current_user=mock_current_user, db=mock_db)
 
         assert exc_info.value.status_code == 400
 
@@ -1555,7 +1569,7 @@ class TestOAuthRouter:
             mock_token_storage.get_token_info_bulk = AsyncMock(return_value={gw1.id: {"scopes": ["read"], "expires_at": None, "status": "valid", "updated_at": "2026-01-01T00:00:00"}, gw2.id: None})
             mock_token_storage_class.return_value = mock_token_storage
 
-            result = await get_oauth_status_batch(mock_request, [gw1.id, gw2.id], mock_current_user, mock_db)
+            result = await get_oauth_status_batch(mock_request, [gw1.id, gw2.id], current_user=mock_current_user, db=mock_db)
 
         mock_token_storage.get_token_info_bulk.assert_awaited_once_with([gw1.id, gw2.id], mock_current_user.email)
         mock_token_storage.get_token_info.assert_not_called()
@@ -1591,7 +1605,7 @@ class TestOAuthRouter:
             mock_token_storage.get_token_info_bulk = AsyncMock(return_value={gw1.id: None, gw2.id: RuntimeError("vault unavailable")})
             mock_token_storage_class.return_value = mock_token_storage
 
-            result = await get_oauth_status_batch(mock_request, [gw1.id, gw2.id], mock_current_user, mock_db)
+            result = await get_oauth_status_batch(mock_request, [gw1.id, gw2.id], current_user=mock_current_user, db=mock_db)
 
         assert result[gw1.id]["user_token_status"] == {"status": "missing", "authorized": False}
         assert result[gw2.id]["user_token_status"] == {"status": "unknown", "authorized": False}
@@ -1620,10 +1634,47 @@ class TestOAuthRouter:
 
             with patch("mcpgateway.routers.oauth_router.OAUTH_STATUS_BATCH_TOKEN_LOOKUP_TIMEOUT_SECONDS", 0.01):
                 with patch("mcpgateway.routers.oauth_router.logger") as mock_logger:
-                    result = await get_oauth_status_batch(mock_request, ["gateway123"], mock_current_user, mock_db)
+                    result = await get_oauth_status_batch(mock_request, ["gateway123"], current_user=mock_current_user, db=mock_db)
 
         assert result["gateway123"]["user_token_status"] == {"status": "unknown", "authorized": False}
         mock_logger.error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_oauth_status_denied_without_gateways_read_permission(self, mock_db, mock_request):
+        """A caller without gateways.read is rejected by the @require_permission decorator
+        before the handler's own ownership/visibility checks ever run (Layer 2 RBAC,
+        review #6620): Layer 1 token scoping and the per-gateway ownership check are
+        necessary but not sufficient - a visible gateway must not leak OAuth config and
+        per-caller token state to a principal who lacks gateways.read."""
+        from mcpgateway.routers.oauth_router import get_oauth_status
+
+        with patch("mcpgateway.middleware.rbac.PermissionService") as mock_permission_service_class:
+            mock_permission_service = Mock()
+            mock_permission_service.check_permission = AsyncMock(return_value=False)
+            mock_permission_service_class.return_value = mock_permission_service
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_oauth_status("gateway123", mock_request, current_user={"email": "no-perms@example.com", "is_admin": False}, db=mock_db)
+
+        assert exc_info.value.status_code == 403
+        mock_db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_oauth_status_batch_denied_without_gateways_read_permission(self, mock_db, mock_request):
+        """Same RBAC gate applies to the batch endpoint - a caller without gateways.read
+        is rejected before any per-gateway visibility check or gateway lookup runs."""
+        from mcpgateway.routers.oauth_router import get_oauth_status_batch
+
+        with patch("mcpgateway.middleware.rbac.PermissionService") as mock_permission_service_class:
+            mock_permission_service = Mock()
+            mock_permission_service.check_permission = AsyncMock(return_value=False)
+            mock_permission_service_class.return_value = mock_permission_service
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_oauth_status_batch(mock_request, ["gateway123"], current_user={"email": "no-perms@example.com", "is_admin": False}, db=mock_db)
+
+        assert exc_info.value.status_code == 403
+        mock_db.execute.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_fetch_tools_after_oauth_success(self, mock_db, mock_current_user):
@@ -2696,7 +2747,7 @@ class TestOAuthRouterAdditionalCoverage:
             from mcpgateway.routers.oauth_router import get_oauth_status
 
             with pytest.raises(HTTPException) as exc_info:
-                await get_oauth_status("gateway123", mock_request, {"email": "user@example.com"}, mock_db)
+                await get_oauth_status("gateway123", mock_request, current_user={"email": "user@example.com"}, db=mock_db)
 
         assert exc_info.value.status_code == 403
 

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -1275,9 +1275,28 @@ class TestOAuthRouter:
         mock_token_storage.get_token_info.assert_awaited_once_with("gateway123", "other@example.com")
 
     @pytest.mark.asyncio
+    async def test_get_oauth_status_user_token_status_lookup_failure_logs_and_reads_missing(self, mock_db, mock_gateway, mock_current_user, mock_request):
+        """A backend lookup failure (e.g. a DB error) is logged, distinguishing it from a genuinely missing token in logs,
+        while still surfacing the same safe "missing"/unauthorized shape to the client rather than a 500."""
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        from mcpgateway.routers.oauth_router import get_oauth_status
+
+        with patch("mcpgateway.routers.oauth_router.TokenStorageService") as mock_token_storage_class:
+            mock_token_storage = Mock()
+            mock_token_storage.get_token_info = AsyncMock(side_effect=RuntimeError("db unavailable"))
+            mock_token_storage_class.return_value = mock_token_storage
+
+            with patch("mcpgateway.routers.oauth_router.logger") as mock_logger:
+                result = await get_oauth_status("gateway123", mock_request, mock_current_user, mock_db)
+
+        assert result["user_token_status"] == {"status": "missing", "authorized": False}
+        mock_logger.error.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_get_oauth_status_batch_success(self, mock_db, mock_gateway, mock_current_user, mock_request):
         """Batch endpoint returns the same per-gateway payload as the single endpoint, keyed by gateway id."""
-        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+        mock_db.execute.return_value.scalars.return_value.all.return_value = [mock_gateway]
 
         from mcpgateway.routers.oauth_router import get_oauth_status_batch
 
@@ -1294,15 +1313,61 @@ class TestOAuthRouter:
         assert result["gateway123"]["user_token_status"]["status"] == "missing"
 
     @pytest.mark.asyncio
+    async def test_get_oauth_status_batch_single_gateway_query(self, mock_db, mock_gateway, mock_current_user, mock_request):
+        """Batch endpoint issues one Gateway SELECT and one TokenStorageService for the whole batch, not one per id."""
+        mock_db.execute.return_value.scalars.return_value.all.return_value = [mock_gateway]
+
+        from mcpgateway.routers.oauth_router import get_oauth_status_batch
+
+        with patch("mcpgateway.routers.oauth_router.TokenStorageService") as mock_token_storage_class:
+            mock_token_storage = Mock()
+            mock_token_storage.get_token_info = AsyncMock(return_value=None)
+            mock_token_storage_class.return_value = mock_token_storage
+
+            result = await get_oauth_status_batch(mock_request, ["gateway123", "gateway123"], mock_current_user, mock_db)
+
+        assert mock_db.execute.call_count == 1
+        mock_token_storage_class.assert_called_once()
+        assert result["gateway123"]["oauth_enabled"] is True
+
+    @pytest.mark.asyncio
     async def test_get_oauth_status_batch_omits_inaccessible_gateways(self, mock_db, mock_current_user, mock_request):
         """A gateway id that 404s or 403s for this caller is silently dropped, not surfaced as a batch failure."""
-        mock_db.execute.return_value.scalar_one_or_none.return_value = None  # every id -> gateway not found
+        mock_db.execute.return_value.scalars.return_value.all.return_value = []  # every id -> gateway not found
 
         from mcpgateway.routers.oauth_router import get_oauth_status_batch
 
         result = await get_oauth_status_batch(mock_request, ["missing1", "missing2"], mock_current_user, mock_db)
 
         assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_get_oauth_status_batch_logs_access_check_server_errors(self, mock_db, mock_gateway, mock_current_user, mock_request):
+        """A 5xx from the per-gateway access check is logged and omitted, not silently swallowed like a 404/403."""
+        mock_db.execute.return_value.scalars.return_value.all.return_value = [mock_gateway]
+
+        from mcpgateway.routers.oauth_router import get_oauth_status_batch
+
+        with patch("mcpgateway.routers.oauth_router._enforce_gateway_access", new=AsyncMock(side_effect=HTTPException(status_code=500, detail="boom"))):
+            with patch("mcpgateway.routers.oauth_router.logger") as mock_logger:
+                result = await get_oauth_status_batch(mock_request, ["gateway123"], mock_current_user, mock_db)
+
+        assert result == {}
+        mock_logger.error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_oauth_status_batch_does_not_log_404_or_403(self, mock_db, mock_gateway, mock_current_user, mock_request):
+        """A 404/403 from the per-gateway access check is omitted without an error log - it's an expected outcome, not a fault."""
+        mock_db.execute.return_value.scalars.return_value.all.return_value = [mock_gateway]
+
+        from mcpgateway.routers.oauth_router import get_oauth_status_batch
+
+        with patch("mcpgateway.routers.oauth_router._enforce_gateway_access", new=AsyncMock(side_effect=HTTPException(status_code=403, detail="nope"))):
+            with patch("mcpgateway.routers.oauth_router.logger") as mock_logger:
+                result = await get_oauth_status_batch(mock_request, ["gateway123"], mock_current_user, mock_db)
+
+        assert result == {}
+        mock_logger.error.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_oauth_status_batch_requires_gateway_ids(self, mock_db, mock_current_user, mock_request):

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -1486,7 +1486,7 @@ class TestOAuthRouter:
                 result = await get_oauth_status_batch(mock_request, ["gateway123"], mock_current_user, mock_db)
 
         assert result == {}
-        mock_logger.error.assert_called_once()
+        mock_logger.exception.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_get_oauth_status_batch_logs_and_omits_on_payload_build_error(self, mock_db, mock_gateway, mock_current_user, mock_request):
@@ -1501,7 +1501,7 @@ class TestOAuthRouter:
                 result = await get_oauth_status_batch(mock_request, ["gateway123"], mock_current_user, mock_db)
 
         assert result == {}
-        mock_logger.error.assert_called_once()
+        mock_logger.exception.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_get_oauth_status_batch_requires_gateway_ids(self, mock_db, mock_current_user, mock_request):

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -1294,6 +1294,19 @@ class TestOAuthRouter:
         mock_logger.error.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_get_caller_token_status_unknown_identity_short_circuits(self, mock_db):
+        """A caller with no resolvable email (missing/empty email and sub) is reported as
+        an unauthorized/missing token without ever reaching TokenStorageService - there's no
+        identity to key the per-caller lookup on."""
+        from mcpgateway.routers.oauth_router import _get_caller_token_status
+
+        with patch("mcpgateway.routers.oauth_router.TokenStorageService") as mock_token_storage_class:
+            result = await _get_caller_token_status(mock_db, {}, "gateway123")
+
+        assert result == {"status": "missing", "authorized": False}
+        mock_token_storage_class.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_get_oauth_status_batch_success(self, mock_db, mock_gateway, mock_current_user, mock_request):
         """Batch endpoint returns the same per-gateway payload as the single endpoint, keyed by gateway id."""
         mock_db.execute.return_value.scalars.return_value.all.return_value = [mock_gateway]
@@ -1368,6 +1381,36 @@ class TestOAuthRouter:
 
         assert result == {}
         mock_logger.error.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_oauth_status_batch_logs_and_omits_on_non_http_access_check_error(self, mock_db, mock_gateway, mock_current_user, mock_request):
+        """A non-HTTPException raised by the access check (e.g. a DB error) is logged and the
+        gateway is omitted from the batch, rather than failing the whole request."""
+        mock_db.execute.return_value.scalars.return_value.all.return_value = [mock_gateway]
+
+        from mcpgateway.routers.oauth_router import get_oauth_status_batch
+
+        with patch("mcpgateway.routers.oauth_router._enforce_gateway_access", new=AsyncMock(side_effect=RuntimeError("db unavailable"))):
+            with patch("mcpgateway.routers.oauth_router.logger") as mock_logger:
+                result = await get_oauth_status_batch(mock_request, ["gateway123"], mock_current_user, mock_db)
+
+        assert result == {}
+        mock_logger.error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_oauth_status_batch_logs_and_omits_on_payload_build_error(self, mock_db, mock_gateway, mock_current_user, mock_request):
+        """A failure while building an individual gateway's status payload (or its
+        user_token_status) is logged and that gateway is omitted, not surfaced as a batch failure."""
+        mock_db.execute.return_value.scalars.return_value.all.return_value = [mock_gateway]
+
+        from mcpgateway.routers.oauth_router import get_oauth_status_batch
+
+        with patch("mcpgateway.routers.oauth_router._build_oauth_status_payload", side_effect=RuntimeError("boom")):
+            with patch("mcpgateway.routers.oauth_router.logger") as mock_logger:
+                result = await get_oauth_status_batch(mock_request, ["gateway123"], mock_current_user, mock_db)
+
+        assert result == {}
+        mock_logger.error.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_get_oauth_status_batch_requires_gateway_ids(self, mock_db, mock_current_user, mock_request):

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -1275,9 +1275,11 @@ class TestOAuthRouter:
         mock_token_storage.get_token_info.assert_awaited_once_with("gateway123", "other@example.com")
 
     @pytest.mark.asyncio
-    async def test_get_oauth_status_user_token_status_lookup_failure_logs_and_reads_missing(self, mock_db, mock_gateway, mock_current_user, mock_request):
-        """A backend lookup failure (e.g. a DB error) is logged, distinguishing it from a genuinely missing token in logs,
-        while still surfacing the same safe "missing"/unauthorized shape to the client rather than a 500."""
+    async def test_get_oauth_status_user_token_status_lookup_failure_logs_and_reads_unknown(self, mock_db, mock_gateway, mock_current_user, mock_request):
+        """A backend lookup failure (e.g. a DB error) is logged with a traceback, distinguishing it
+        from a genuinely missing token in logs, while surfacing "unknown"/unauthorized to the client
+        rather than a 500 - and rather than the same "missing" shape a never-authorized caller sees,
+        so a UI doesn't mistake a transient outage for "never authorized" and prompt a fresh OAuth flow."""
         mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
 
         from mcpgateway.routers.oauth_router import get_oauth_status
@@ -1290,8 +1292,8 @@ class TestOAuthRouter:
             with patch("mcpgateway.routers.oauth_router.logger") as mock_logger:
                 result = await get_oauth_status("gateway123", mock_request, mock_current_user, mock_db)
 
-        assert result["user_token_status"] == {"status": "missing", "authorized": False}
-        mock_logger.error.assert_called_once()
+        assert result["user_token_status"] == {"status": "unknown", "authorized": False}
+        mock_logger.exception.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_get_caller_token_status_unknown_identity_short_circuits(self, mock_db):
@@ -1315,7 +1317,7 @@ class TestOAuthRouter:
 
         with patch("mcpgateway.routers.oauth_router.TokenStorageService") as mock_token_storage_class:
             mock_token_storage = Mock()
-            mock_token_storage.get_token_info = AsyncMock(return_value=None)
+            mock_token_storage.get_token_info_bulk = AsyncMock(side_effect=lambda gateway_ids, app_user_email: {gid: None for gid in gateway_ids})
             mock_token_storage_class.return_value = mock_token_storage
 
             result = await get_oauth_status_batch(mock_request, ["gateway123", "gateway123"], mock_current_user, mock_db)
@@ -1334,13 +1336,14 @@ class TestOAuthRouter:
 
         with patch("mcpgateway.routers.oauth_router.TokenStorageService") as mock_token_storage_class:
             mock_token_storage = Mock()
-            mock_token_storage.get_token_info = AsyncMock(return_value=None)
+            mock_token_storage.get_token_info_bulk = AsyncMock(side_effect=lambda gateway_ids, app_user_email: {gid: None for gid in gateway_ids})
             mock_token_storage_class.return_value = mock_token_storage
 
             result = await get_oauth_status_batch(mock_request, ["gateway123", "gateway123"], mock_current_user, mock_db)
 
         assert mock_db.execute.call_count == 1
         mock_token_storage_class.assert_called_once()
+        mock_token_storage.get_token_info_bulk.assert_awaited_once()
         assert result["gateway123"]["oauth_enabled"] is True
 
     @pytest.mark.asyncio
@@ -1372,7 +1375,7 @@ class TestOAuthRouter:
 
         with patch("mcpgateway.routers.oauth_router.TokenStorageService") as mock_token_storage_class:
             mock_token_storage = Mock()
-            mock_token_storage.get_token_info = AsyncMock(return_value=None)
+            mock_token_storage.get_token_info_bulk = AsyncMock(side_effect=lambda gateway_ids, app_user_email: {gid: None for gid in gateway_ids})
             mock_token_storage_class.return_value = mock_token_storage
 
             result = await get_oauth_status_batch(mock_request, [gw1.id, gw2.id], mock_current_user, mock_db)
@@ -1406,7 +1409,7 @@ class TestOAuthRouter:
 
         with patch("mcpgateway.routers.oauth_router.TokenStorageService") as mock_token_storage_class:
             mock_token_storage = Mock()
-            mock_token_storage.get_token_info = AsyncMock(return_value=None)
+            mock_token_storage.get_token_info_bulk = AsyncMock(side_effect=lambda gateway_ids, app_user_email: {gid: None for gid in gateway_ids})
             mock_token_storage_class.return_value = mock_token_storage
 
             result = await get_oauth_status_batch(mock_request, [own_gateway.id, others_gateway.id], mock_current_user, mock_db)
@@ -1522,6 +1525,105 @@ class TestOAuthRouter:
             await get_oauth_status_batch(mock_request, too_many, mock_current_user, mock_db)
 
         assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_get_oauth_status_batch_uses_bulk_token_lookup_not_per_id(self, mock_db, mock_current_user, mock_request):
+        """The batch endpoint calls get_token_info_bulk() once for every authorization_code
+        gateway id, not get_token_info() once per id - this is the fix for the batch endpoint's
+        N+1 token lookup (review #6620)."""
+        gw1 = Mock(spec=Gateway)
+        gw1.id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        gw1.visibility = "public"
+        gw1.owner_email = None
+        gw1.team_id = None
+        gw1.oauth_config = {"grant_type": "authorization_code", "client_id": "cid1", "scopes": ["read"], "authorization_url": "https://idp.example.com/authorize", "redirect_uri": "https://gw.example.com/callback"}
+
+        gw2 = Mock(spec=Gateway)
+        gw2.id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        gw2.visibility = "public"
+        gw2.owner_email = None
+        gw2.team_id = None
+        gw2.oauth_config = {"grant_type": "authorization_code", "client_id": "cid2", "scopes": ["read"], "authorization_url": "https://idp.example.com/authorize", "redirect_uri": "https://gw.example.com/callback"}
+
+        mock_db.execute.return_value.scalars.return_value.all.return_value = [gw1, gw2]
+
+        from mcpgateway.routers.oauth_router import get_oauth_status_batch
+
+        with patch("mcpgateway.routers.oauth_router.TokenStorageService") as mock_token_storage_class:
+            mock_token_storage = Mock()
+            mock_token_storage.get_token_info = AsyncMock()  # must not be called
+            mock_token_storage.get_token_info_bulk = AsyncMock(return_value={gw1.id: {"scopes": ["read"], "expires_at": None, "status": "valid", "updated_at": "2026-01-01T00:00:00"}, gw2.id: None})
+            mock_token_storage_class.return_value = mock_token_storage
+
+            result = await get_oauth_status_batch(mock_request, [gw1.id, gw2.id], mock_current_user, mock_db)
+
+        mock_token_storage.get_token_info_bulk.assert_awaited_once_with([gw1.id, gw2.id], mock_current_user.email)
+        mock_token_storage.get_token_info.assert_not_called()
+        assert result[gw1.id]["user_token_status"]["status"] == "valid"
+        assert result[gw2.id]["user_token_status"]["status"] == "missing"
+
+    @pytest.mark.asyncio
+    async def test_get_oauth_status_batch_one_id_lookup_failure_reports_unknown_others_unaffected(self, mock_db, mock_current_user, mock_request):
+        """A per-id failure captured by get_token_info_bulk() (e.g. the default loop-based
+        implementation isolating one Vault lookup's failure) surfaces as "unknown" for that
+        id only - a backend outage on one gateway doesn't read as "never authorized" and
+        doesn't take down the rest of the batch."""
+        gw1 = Mock(spec=Gateway)
+        gw1.id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        gw1.visibility = "public"
+        gw1.owner_email = None
+        gw1.team_id = None
+        gw1.oauth_config = {"grant_type": "authorization_code", "client_id": "cid1", "scopes": ["read"], "authorization_url": "https://idp.example.com/authorize", "redirect_uri": "https://gw.example.com/callback"}
+
+        gw2 = Mock(spec=Gateway)
+        gw2.id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        gw2.visibility = "public"
+        gw2.owner_email = None
+        gw2.team_id = None
+        gw2.oauth_config = {"grant_type": "authorization_code", "client_id": "cid2", "scopes": ["read"], "authorization_url": "https://idp.example.com/authorize", "redirect_uri": "https://gw.example.com/callback"}
+
+        mock_db.execute.return_value.scalars.return_value.all.return_value = [gw1, gw2]
+
+        from mcpgateway.routers.oauth_router import get_oauth_status_batch
+
+        with patch("mcpgateway.routers.oauth_router.TokenStorageService") as mock_token_storage_class:
+            mock_token_storage = Mock()
+            mock_token_storage.get_token_info_bulk = AsyncMock(return_value={gw1.id: None, gw2.id: RuntimeError("vault unavailable")})
+            mock_token_storage_class.return_value = mock_token_storage
+
+            result = await get_oauth_status_batch(mock_request, [gw1.id, gw2.id], mock_current_user, mock_db)
+
+        assert result[gw1.id]["user_token_status"] == {"status": "missing", "authorized": False}
+        assert result[gw2.id]["user_token_status"] == {"status": "unknown", "authorized": False}
+
+    @pytest.mark.asyncio
+    async def test_get_oauth_status_batch_bulk_lookup_timeout_reports_unknown(self, mock_db, mock_gateway, mock_current_user, mock_request):
+        """A get_token_info_bulk() call that exceeds OAUTH_STATUS_BATCH_TOKEN_LOOKUP_TIMEOUT_SECONDS
+        is abandoned rather than holding the request open - every pending id reports "unknown"
+        instead of the whole batch endpoint hanging or failing (review #6620: worst case is
+        OAUTH_STATUS_BATCH_MAX_IDS sequential per-id Vault lookups, each retried with backoff)."""
+        # Standard
+        import asyncio
+
+        mock_db.execute.return_value.scalars.return_value.all.return_value = [mock_gateway]
+
+        from mcpgateway.routers.oauth_router import get_oauth_status_batch
+
+        async def _never_completes(*_args, **_kwargs):
+            await asyncio.sleep(10)
+            return {}
+
+        with patch("mcpgateway.routers.oauth_router.TokenStorageService") as mock_token_storage_class:
+            mock_token_storage = Mock()
+            mock_token_storage.get_token_info_bulk = _never_completes
+            mock_token_storage_class.return_value = mock_token_storage
+
+            with patch("mcpgateway.routers.oauth_router.OAUTH_STATUS_BATCH_TOKEN_LOOKUP_TIMEOUT_SECONDS", 0.01):
+                with patch("mcpgateway.routers.oauth_router.logger") as mock_logger:
+                    result = await get_oauth_status_batch(mock_request, ["gateway123"], mock_current_user, mock_db)
+
+        assert result["gateway123"]["user_token_status"] == {"status": "unknown", "authorized": False}
+        mock_logger.error.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_fetch_tools_after_oauth_success(self, mock_db, mock_current_user):

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -1344,6 +1344,97 @@ class TestOAuthRouter:
         assert result["gateway123"]["oauth_enabled"] is True
 
     @pytest.mark.asyncio
+    async def test_get_oauth_status_batch_single_gateway_query_real_hex_ids(self, mock_db, mock_current_user, mock_request):
+        """Regression test: with real Gateway.id-shaped ids (32-char hex, as uuid4().hex
+        produces - unlike "gateway123" above, which never matches _RESOURCE_PATTERNS'
+        [a-f0-9\\-]+ regex and so never exercises the per-id ownership recheck), the batch
+        endpoint must still issue exactly one Gateway SELECT for the whole batch. The per-id
+        ownership recheck inside _enforce_gateway_access -> _check_resource_team_ownership
+        has to reuse the already-loaded gateway (preloaded_gateway) instead of re-fetching it,
+        or this regresses to N+1 for any non-admin or narrowed-admin caller."""
+        gw1 = Mock(spec=Gateway)
+        gw1.id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        gw1.visibility = "public"
+        gw1.owner_email = None
+        gw1.team_id = None
+        gw1.oauth_config = {"grant_type": "authorization_code", "client_id": "cid1", "scopes": ["read"], "authorization_url": "https://idp.example.com/authorize", "redirect_uri": "https://gw.example.com/callback"}
+
+        gw2 = Mock(spec=Gateway)
+        gw2.id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        gw2.visibility = "public"
+        gw2.owner_email = None
+        gw2.team_id = None
+        gw2.oauth_config = {"grant_type": "authorization_code", "client_id": "cid2", "scopes": ["read"], "authorization_url": "https://idp.example.com/authorize", "redirect_uri": "https://gw.example.com/callback"}
+
+        mock_db.execute.return_value.scalars.return_value.all.return_value = [gw1, gw2]
+
+        from mcpgateway.routers.oauth_router import get_oauth_status_batch
+
+        with patch("mcpgateway.routers.oauth_router.TokenStorageService") as mock_token_storage_class:
+            mock_token_storage = Mock()
+            mock_token_storage.get_token_info = AsyncMock(return_value=None)
+            mock_token_storage_class.return_value = mock_token_storage
+
+            result = await get_oauth_status_batch(mock_request, [gw1.id, gw2.id], mock_current_user, mock_db)
+
+        assert mock_db.execute.call_count == 1
+        assert set(result.keys()) == {gw1.id, gw2.id}
+
+    @pytest.mark.asyncio
+    async def test_get_oauth_status_batch_private_visibility_owner_included_non_owner_omitted(self, mock_current_user, mock_request):
+        """The batch endpoint's ownership check exercises the private-visibility branch, not just
+        the public fixtures used elsewhere: the caller's own private gateway is included, and a
+        private gateway owned by someone else is silently omitted rather than failing the batch."""
+        own_gateway = Mock(spec=Gateway)
+        own_gateway.id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        own_gateway.visibility = "private"
+        own_gateway.owner_email = mock_current_user.email
+        own_gateway.team_id = None
+        own_gateway.oauth_config = {"grant_type": "authorization_code", "client_id": "cid1", "scopes": ["read"], "authorization_url": "https://idp.example.com/authorize", "redirect_uri": "https://gw.example.com/callback"}
+
+        others_gateway = Mock(spec=Gateway)
+        others_gateway.id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        others_gateway.visibility = "private"
+        others_gateway.owner_email = "someone-else@example.com"
+        others_gateway.team_id = None
+        others_gateway.oauth_config = {"grant_type": "authorization_code", "client_id": "cid2", "scopes": ["read"], "authorization_url": "https://idp.example.com/authorize", "redirect_uri": "https://gw.example.com/callback"}
+
+        mock_db = Mock(spec=Session)
+        mock_db.execute.return_value.scalars.return_value.all.return_value = [own_gateway, others_gateway]
+
+        from mcpgateway.routers.oauth_router import get_oauth_status_batch
+
+        with patch("mcpgateway.routers.oauth_router.TokenStorageService") as mock_token_storage_class:
+            mock_token_storage = Mock()
+            mock_token_storage.get_token_info = AsyncMock(return_value=None)
+            mock_token_storage_class.return_value = mock_token_storage
+
+            result = await get_oauth_status_batch(mock_request, [own_gateway.id, others_gateway.id], mock_current_user, mock_db)
+
+        assert set(result.keys()) == {own_gateway.id}
+
+    @pytest.mark.asyncio
+    async def test_get_oauth_status_batch_non_authorization_code_grant_omits_user_token_status(self, mock_current_user, mock_request):
+        """A non-authorization_code gateway in the batch still reports oauth_enabled config,
+        but user_token_status stays omitted - there's no per-caller token state to report."""
+        gateway = Mock(spec=Gateway)
+        gateway.id = "cccccccccccccccccccccccccccccc"
+        gateway.visibility = "public"
+        gateway.owner_email = None
+        gateway.team_id = None
+        gateway.oauth_config = {"grant_type": "client_credentials", "client_id": "cid"}
+
+        mock_db = Mock(spec=Session)
+        mock_db.execute.return_value.scalars.return_value.all.return_value = [gateway]
+
+        from mcpgateway.routers.oauth_router import get_oauth_status_batch
+
+        result = await get_oauth_status_batch(mock_request, [gateway.id], mock_current_user, mock_db)
+
+        assert result[gateway.id]["grant_type"] == "client_credentials"
+        assert "user_token_status" not in result[gateway.id]
+
+    @pytest.mark.asyncio
     async def test_get_oauth_status_batch_omits_inaccessible_gateways(self, mock_db, mock_current_user, mock_request):
         """A gateway id that 404s or 403s for this caller is silently dropped, not surfaced as a batch failure."""
         mock_db.execute.return_value.scalars.return_value.all.return_value = []  # every id -> gateway not found

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -1228,6 +1228,103 @@ class TestOAuthRouter:
         assert exc_info.value.status_code == 500
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "backend_info,expected_status,expected_authorized",
+        [
+            ({"scopes": ["read"], "expires_at": "2030-01-01T00:00:00", "status": "valid", "updated_at": "2026-01-01T00:00:00"}, "valid", True),
+            ({"scopes": ["read"], "expires_at": "2026-01-01T00:04:00", "status": "near_expiry", "updated_at": "2026-01-01T00:00:00"}, "near_expiry", True),
+            ({"scopes": ["read"], "expires_at": "2020-01-01T00:00:00", "status": "expired", "updated_at": "2026-01-01T00:00:00"}, "expired", False),
+            (None, "missing", False),
+        ],
+    )
+    async def test_get_oauth_status_includes_user_token_status(self, mock_db, mock_gateway, mock_current_user, mock_request, backend_info, expected_status, expected_authorized):
+        """user_token_status reflects the caller's own stored token state, sourced from TokenStorageService."""
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        from mcpgateway.routers.oauth_router import get_oauth_status
+
+        with patch("mcpgateway.routers.oauth_router.TokenStorageService") as mock_token_storage_class:
+            mock_token_storage = Mock()
+            mock_token_storage.get_token_info = AsyncMock(return_value=backend_info)
+            mock_token_storage_class.return_value = mock_token_storage
+
+            result = await get_oauth_status("gateway123", mock_request, mock_current_user, mock_db)
+
+        assert result["user_token_status"]["status"] == expected_status
+        assert result["user_token_status"]["authorized"] is expected_authorized
+        mock_token_storage.get_token_info.assert_awaited_once_with("gateway123", mock_current_user.email)
+
+    @pytest.mark.asyncio
+    async def test_get_oauth_status_user_token_status_not_shared_across_users(self, mock_db, mock_gateway, mock_request):
+        """Each caller only ever gets their own token state - lookup is keyed by the authenticated caller's email."""
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        other_user = Mock(spec=EmailUserResponse)
+        other_user.email = "other@example.com"
+        other_user.is_admin = False
+
+        from mcpgateway.routers.oauth_router import get_oauth_status
+
+        with patch("mcpgateway.routers.oauth_router.TokenStorageService") as mock_token_storage_class:
+            mock_token_storage = Mock()
+            mock_token_storage.get_token_info = AsyncMock(return_value=None)
+            mock_token_storage_class.return_value = mock_token_storage
+
+            await get_oauth_status("gateway123", mock_request, other_user, mock_db)
+
+        mock_token_storage.get_token_info.assert_awaited_once_with("gateway123", "other@example.com")
+
+    @pytest.mark.asyncio
+    async def test_get_oauth_status_batch_success(self, mock_db, mock_gateway, mock_current_user, mock_request):
+        """Batch endpoint returns the same per-gateway payload as the single endpoint, keyed by gateway id."""
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        from mcpgateway.routers.oauth_router import get_oauth_status_batch
+
+        with patch("mcpgateway.routers.oauth_router.TokenStorageService") as mock_token_storage_class:
+            mock_token_storage = Mock()
+            mock_token_storage.get_token_info = AsyncMock(return_value=None)
+            mock_token_storage_class.return_value = mock_token_storage
+
+            result = await get_oauth_status_batch(mock_request, ["gateway123", "gateway123"], mock_current_user, mock_db)
+
+        # Duplicate ids are deduped
+        assert list(result.keys()) == ["gateway123"]
+        assert result["gateway123"]["oauth_enabled"] is True
+        assert result["gateway123"]["user_token_status"]["status"] == "missing"
+
+    @pytest.mark.asyncio
+    async def test_get_oauth_status_batch_omits_inaccessible_gateways(self, mock_db, mock_current_user, mock_request):
+        """A gateway id that 404s or 403s for this caller is silently dropped, not surfaced as a batch failure."""
+        mock_db.execute.return_value.scalar_one_or_none.return_value = None  # every id -> gateway not found
+
+        from mcpgateway.routers.oauth_router import get_oauth_status_batch
+
+        result = await get_oauth_status_batch(mock_request, ["missing1", "missing2"], mock_current_user, mock_db)
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_get_oauth_status_batch_requires_gateway_ids(self, mock_db, mock_current_user, mock_request):
+        from mcpgateway.routers.oauth_router import get_oauth_status_batch
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_oauth_status_batch(mock_request, [], mock_current_user, mock_db)
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_get_oauth_status_batch_rejects_too_many_ids(self, mock_db, mock_current_user, mock_request):
+        from mcpgateway.routers.oauth_router import get_oauth_status_batch, OAUTH_STATUS_BATCH_MAX_IDS
+
+        too_many = [f"gw{i}" for i in range(OAUTH_STATUS_BATCH_MAX_IDS + 1)]
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_oauth_status_batch(mock_request, too_many, mock_current_user, mock_db)
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
     async def test_fetch_tools_after_oauth_success(self, mock_db, mock_current_user):
         """Test successful tools fetching after OAuth."""
         # Setup

--- a/tests/unit/mcpgateway/services/test_token_storage_service.py
+++ b/tests/unit/mcpgateway/services/test_token_storage_service.py
@@ -828,9 +828,10 @@ async def test_get_token_info_not_found(service, mock_db):
 
 @pytest.mark.asyncio
 async def test_get_token_info_exception(service, mock_db):
+    """A backend failure propagates rather than collapsing to None, which is reserved for "no token stored"."""
     mock_db.execute.side_effect = Exception("DB error")
-    result = await service.get_token_info("gw-1", "user@test.com")
-    assert result is None
+    with pytest.raises(Exception, match="DB error"):
+        await service.get_token_info("gw-1", "user@test.com")
 
 
 # ---------- revoke_user_tokens ----------

--- a/tests/unit/mcpgateway/services/test_token_storage_service.py
+++ b/tests/unit/mcpgateway/services/test_token_storage_service.py
@@ -834,6 +834,33 @@ async def test_get_token_info_exception(service, mock_db):
         await service.get_token_info("gw-1", "user@test.com")
 
 
+# ---------- get_token_info_bulk ----------
+
+
+@pytest.mark.asyncio
+async def test_get_token_info_bulk_delegates_with_team_id_from_first_id(service):
+    """get_token_info_bulk resolves team_id once (from _get_team_id, which is keyed only on the
+    caller's own JWT teams claim - identical for every id in the batch) and forwards it plus all
+    gateway_ids to the backend's get_token_info_bulk in one call."""
+    service._backend.get_token_info_bulk = AsyncMock(return_value={"gw-1": {"status": "valid"}, "gw-2": None})
+
+    result = await service.get_token_info_bulk(["gw-1", "gw-2"], "user@test.com")
+
+    assert result == {"gw-1": {"status": "valid"}, "gw-2": None}
+    service._backend.get_token_info_bulk.assert_awaited_once_with(gateway_ids=["gw-1", "gw-2"], team_id="team1", app_user_email="user@test.com")
+
+
+@pytest.mark.asyncio
+async def test_get_token_info_bulk_empty_ids_short_circuits(service):
+    """An empty gateway_ids list returns {} without calling the backend."""
+    service._backend.get_token_info_bulk = AsyncMock()
+
+    result = await service.get_token_info_bulk([], "user@test.com")
+
+    assert result == {}
+    service._backend.get_token_info_bulk.assert_not_called()
+
+
 # ---------- revoke_user_tokens ----------
 
 

--- a/tests/unit/mcpgateway/services/test_vault_token_backend.py
+++ b/tests/unit/mcpgateway/services/test_vault_token_backend.py
@@ -2313,20 +2313,20 @@ async def test_r7_get_user_auth_headers_vault_auth_error():
 
 @pytest.mark.asyncio
 async def test_r7_get_token_info_vault_connection_error():
-    """get_token_info returns None on VaultConnectionError (lines 563-564,570)."""
+    """get_token_info re-raises VaultConnectionError so a Vault outage is distinguishable from a missing token."""
     backend, _ = _make_backend_r7()
     with patch.object(backend, "_vault_request", side_effect=VaultConnectionError("Vault down")):
-        result = await backend.get_token_info("gw-1", "team-1", "alice@example.com")
-    assert result is None
+        with pytest.raises(VaultConnectionError):
+            await backend.get_token_info("gw-1", "team-1", "alice@example.com")
 
 
 @pytest.mark.asyncio
 async def test_r7_get_token_info_vault_auth_error():
-    """get_token_info returns None on VaultAuthError (lines 563-564,570)."""
+    """get_token_info re-raises VaultAuthError so a Vault outage is distinguishable from a missing token."""
     backend, _ = _make_backend_r7()
     with patch.object(backend, "_vault_request", side_effect=VaultAuthError("Token invalid")):
-        result = await backend.get_token_info("gw-1", "team-1", "alice@example.com")
-    assert result is None
+        with pytest.raises(VaultAuthError):
+            await backend.get_token_info("gw-1", "team-1", "alice@example.com")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/services/token_backends/test_base.py
+++ b/tests/unit/mcpgateway/services/token_backends/test_base.py
@@ -124,3 +124,68 @@ async def test_get_user_auth_headers_default_returns_none():
     backend = _Concrete()
     result = await backend.get_user_auth_headers("gw-1", "team-1", "alice@example.com")
     assert result is None
+
+
+class TestGetTokenInfoBulkDefault:
+    """Tests for AbstractTokenBackend's default (loop-based) get_token_info_bulk."""
+
+    @staticmethod
+    def _make_backend(get_token_info):
+        from mcpgateway.services.token_backends.base import AbstractTokenBackend
+
+        class _Concrete(AbstractTokenBackend):
+            """Minimal concrete backend for testing the default bulk loop."""
+
+            async def store_tokens(self, *a, **kw):
+                """Stub."""
+
+            async def get_user_token(self, *a, **kw):
+                """Stub."""
+
+            async def get_token_info(self, *a, **kw):
+                """Stub - overridden per-instance below."""
+
+            async def revoke_user_tokens(self, *a, **kw):
+                """Stub."""
+
+            async def cleanup_expired_tokens(self, *a, **kw):
+                """Stub."""
+
+            async def get_user_learned_audience(self, *a, **kw):
+                """Stub."""
+
+        backend = _Concrete()
+        backend.get_token_info = get_token_info
+        return backend
+
+    @pytest.mark.asyncio
+    async def test_default_bulk_loops_over_get_token_info(self):
+        """Without a backend override, get_token_info_bulk loops over get_token_info() per id."""
+        # Standard
+        from unittest.mock import AsyncMock
+
+        get_token_info = AsyncMock(side_effect=[{"status": "valid"}, None])
+        backend = self._make_backend(get_token_info)
+
+        result = await backend.get_token_info_bulk(["gw-1", "gw-2"], "team-1", "alice@example.com")
+
+        assert result == {"gw-1": {"status": "valid"}, "gw-2": None}
+        assert get_token_info.await_count == 2
+        get_token_info.assert_any_await("gw-1", "team-1", "alice@example.com")
+        get_token_info.assert_any_await("gw-2", "team-1", "alice@example.com")
+
+    @pytest.mark.asyncio
+    async def test_default_bulk_isolates_one_id_failure_from_the_rest(self):
+        """One id's get_token_info() failure is captured as that id's value, not propagated -
+        the rest of the batch still gets a real answer instead of the whole call failing."""
+        # Standard
+        from unittest.mock import AsyncMock
+
+        boom = RuntimeError("backend unavailable")
+        get_token_info = AsyncMock(side_effect=[{"status": "valid"}, boom])
+        backend = self._make_backend(get_token_info)
+
+        result = await backend.get_token_info_bulk(["gw-ok", "gw-fails"], "team-1", "alice@example.com")
+
+        assert result["gw-ok"] == {"status": "valid"}
+        assert result["gw-fails"] is boom

--- a/tests/unit/mcpgateway/services/token_backends/test_db_backend.py
+++ b/tests/unit/mcpgateway/services/token_backends/test_db_backend.py
@@ -622,6 +622,61 @@ async def test_get_token_info_exception(backend_with_encryption, mock_db):
         mock_logger.error.assert_called_once()
 
 
+# ---------- get_token_info_bulk ----------
+
+
+@pytest.mark.asyncio
+async def test_get_token_info_bulk_empty_ids_short_circuits(backend_with_encryption, mock_db):
+    """An empty gateway_ids list returns {} without issuing a query."""
+    result = await backend_with_encryption.get_token_info_bulk(gateway_ids=[], team_id="team-1", app_user_email="user@test.com")
+
+    assert result == {}
+    mock_db.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_token_info_bulk_single_query_mixed_results(backend_with_encryption, mock_db):
+    """One query answers the whole batch: ids with a stored token get metadata, ids with no
+    matching row map to None - this is the fix for the batch endpoint's N+1 token lookup."""
+    found = _make_token_record(gateway_id="gw-1", expires_at=datetime.now(timezone.utc) + timedelta(hours=1))
+    mock_db.execute.return_value.scalars.return_value.all.return_value = [found]
+
+    result = await backend_with_encryption.get_token_info_bulk(gateway_ids=["gw-1", "gw-2"], team_id="team-1", app_user_email="user@test.com")
+
+    assert mock_db.execute.call_count == 1
+    assert result["gw-2"] is None
+    assert result["gw-1"] is not None
+    assert result["gw-1"]["status"] == "valid"
+    assert "access_token" not in result["gw-1"]
+
+
+@pytest.mark.asyncio
+async def test_get_token_info_bulk_marks_expired_and_near_expiry(backend_with_encryption, mock_db):
+    """Status classification (expired/near_expiry/valid) matches the single-item get_token_info()."""
+    expired = _make_token_record(gateway_id="gw-expired", expires_at=datetime.now(timezone.utc) - timedelta(seconds=10))
+    near_expiry = _make_token_record(gateway_id="gw-near", expires_at=datetime.now(timezone.utc) + timedelta(seconds=60))
+    mock_db.execute.return_value.scalars.return_value.all.return_value = [expired, near_expiry]
+
+    result = await backend_with_encryption.get_token_info_bulk(gateway_ids=["gw-expired", "gw-near"], team_id="team-1", app_user_email="user@test.com")
+
+    assert result["gw-expired"]["status"] == "expired"
+    assert result["gw-near"]["status"] == "near_expiry"
+
+
+@pytest.mark.asyncio
+async def test_get_token_info_bulk_exception(backend_with_encryption, mock_db):
+    """A query failure logs and re-raises rather than swallowing to an empty/partial result -
+    the whole batch's token status is backed by this one query, so a failure here should not
+    silently read as "no gateway in the batch has a token"."""
+    mock_db.execute.side_effect = Exception("Database error")
+
+    with patch("mcpgateway.services.token_backends.db_backend.logger") as mock_logger:
+        with pytest.raises(Exception, match="Database error"):
+            await backend_with_encryption.get_token_info_bulk(gateway_ids=["gw-1"], team_id="team-1", app_user_email="user@test.com")
+
+        mock_logger.error.assert_called_once()
+
+
 @pytest.mark.asyncio
 async def test_refresh_token_with_client_secret_decrypt_failure(backend_with_encryption, mock_db):
     """Test refresh fails closed when client_secret decryption returns None (PR #5244 behavior)."""

--- a/tests/unit/mcpgateway/services/token_backends/test_db_backend.py
+++ b/tests/unit/mcpgateway/services/token_backends/test_db_backend.py
@@ -603,18 +603,23 @@ async def test_get_token_info_expired_token(backend_with_encryption, mock_db):
 
 @pytest.mark.asyncio
 async def test_get_token_info_exception(backend_with_encryption, mock_db):
-    """Test get_token_info handles exceptions gracefully."""
+    """get_token_info logs and re-raises on failure rather than returning None.
+
+    None is reserved for "no token stored" - collapsing a lookup failure into the same
+    value would make it indistinguishable from "never authorized" to callers exposing
+    this through a user-facing status field.
+    """
     mock_db.execute.side_effect = Exception("Database error")
 
     with patch("mcpgateway.services.token_backends.db_backend.logger") as mock_logger:
-        result = await backend_with_encryption.get_token_info(
-            gateway_id="gw-1",
-            team_id="team-1",
-            app_user_email="user@test.com",
-        )
+        with pytest.raises(Exception, match="Database error"):
+            await backend_with_encryption.get_token_info(
+                gateway_id="gw-1",
+                team_id="team-1",
+                app_user_email="user@test.com",
+            )
 
         mock_logger.error.assert_called_once()
-        assert result is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

  Wired `TokenStorageService.get_token_info` (already implemented, previously unused) into `mcpgateway/routers/oauth_router.py`.

  ### `GET /oauth/status/{gateway_id}`

  For `authorization_code` gateways, now includes a `user_token_status` field derived from the **authenticated caller's own identity** (never a client-supplied user param):

  ```json
  "user_token_status": {
    "status": "valid" | "near_expiry" | "expired" | "missing",
    "authorized": true,
    "scopes": ["read", "write"],
    "expires_at": "2026-01-01T00:00:00",
    "updated_at": "2026-01-01T00:00:00"
  }
  ```

  - No token values are ever returned.
  - Existing config fields (`client_id`, `scopes`, `authorization_url`, etc.) are unchanged for backward compatibility.

  ### `GET /oauth/status?gateway_ids=a&gateway_ids=b&...` (new)

  Batch equivalent so a grid of cards issues one request instead of N.

  - Reuses the single-gateway handler internally.
  - Dedupes ids, caps the batch at 100.
  - Silently omits ids that 404 or aren't visible to the caller, rather than failing the whole batch.

  ### Tests

  All 216 tests in `test_oauth_router.py` pass. `make ruff interrogate pylint` is clean (100% docstring coverage, 10.00/10 pylint).

  ### Scope

  Backend-only, no UI. Diff is scoped to 2 files (~91 insertions in the router, ~100 lines of tests). Per the issue, this unblocks
  #5592, #3876, #3850, and the catalog card states in #5967.
  
  ## Manual Test

  Prereqs: `make dev` running, venv activated, secrets patched (`make init-secrets-patch-env`).

  ### 1. Get a bearer token for a real user

  The server enforces strict "user must exist in DB". `admin@example.com` is the bootstrapped platform admin. Don't `source .env` directly - it contains JSON/regex values that break bash parsing. Pull just the one variable you need:

  ```bash
  export JWT_SECRET_KEY=$(grep -E '^JWT_SECRET_KEY=' .env | head -1 | cut -d= -f2-)

  export TOKEN=$(python -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 60 --secret "$JWT_SECRET_KEY" 2>/dev/null)
  ```

  ### 2. Create a test gateway directly in the DB

  `POST /gateways` actively probes the URL and rolls back if it's not a real MCP server, so insert the row directly instead:

  ```bash
  cat > /tmp/create_test_gateway.py <<'PYEOF'
  from mcpgateway.db import SessionLocal, Gateway
  from mcpgateway.utils.create_slug import slugify
  import uuid

  db = SessionLocal()
  name = 'oauth-status-manual-test'
  gw = Gateway(
      id=uuid.uuid4().hex, name=name, slug=slugify(name),
      url='https://mcp.example.com', capabilities={}, visibility='public',
      oauth_config={
          'grant_type': 'authorization_code', 'client_id': 'cid', 'client_secret': 'csecret',
          'authorization_url': 'https://idp.example.com/authorize',
          'token_url': 'https://idp.example.com/token',
          'redirect_uri': 'http://localhost:8000/oauth/callback', 'scopes': ['read'],
      },
  )
  db.add(gw); db.commit()
  print('GATEWAY_ID=' + gw.id)
  db.close()
  PYEOF

  python3 /tmp/create_test_gateway.py
  ```

  Copy the printed id:

  ```bash
  export GW_ID=<the id printed above>
  ```

  ### 3. Check status before authorizing — expect `missing`

  ```bash
  curl -s http://localhost:8000/oauth/status/$GW_ID -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
  ```

  ### 4. Seed a token to simulate a completed OAuth flow

  ```bash
  cat > /tmp/seed_oauth_token.py <<'PYEOF'
  import asyncio
  import os
  from mcpgateway.db import SessionLocal
  from mcpgateway.services.token_backends.db_backend import DatabaseTokenBackend
  from mcpgateway.config import settings

  GW_ID = os.environ["GW_ID"]
  EXPIRES_IN = int(os.environ.get("EXPIRES_IN", "3600"))  # 3600=valid, 60=near_expiry, -60=expired

  async def seed():
      db = SessionLocal()
      backend = DatabaseTokenBackend(db, settings)
      await backend.store_tokens(
          gateway_id=GW_ID, team_id=None, user_id="idp-user-1",
          app_user_email="admin@example.com", access_token="fake-access",
          refresh_token=None, expires_in=EXPIRES_IN, scopes=["read"],
      )
      db.close()
      print(f"seeded token for gateway={GW_ID} expires_in={EXPIRES_IN}")

  asyncio.run(seed())
  PYEOF

  python3 /tmp/seed_oauth_token.py
  ```

  Re-check status — expect `valid`:

  ```bash
  curl -s http://localhost:8000/oauth/status/$GW_ID -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
  ```

  Try the other states by overriding `EXPIRES_IN`:

  ```bash
  EXPIRES_IN=60 python3 /tmp/seed_oauth_token.py     # near_expiry (<5 min left)

  EXPIRES_IN=-60 python3 /tmp/seed_oauth_token.py    # expired
  ```

  ### 5. Batch endpoint — a real id plus a nonexistent one

  ```bash
  curl -s "http://localhost:8000/oauth/status?gateway_ids=$GW_ID&gateway_ids=nonexistent-id" -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
  ```

  Only `$GW_ID` should appear in the response — `nonexistent-id` is silently omitted rather than failing the whole batch.

  ### 6. Per-user isolation — a second user must see `missing`

  ```bash
  cat > /tmp/create_second_user.py <<'PYEOF'
  from mcpgateway.db import SessionLocal, EmailUser
  db = SessionLocal()
  if not db.query(EmailUser).filter_by(email='other@example.com').first():
      db.add(EmailUser(email='other@example.com', password_hash='', full_name='Other User', is_admin=False))
      db.commit()
  db.close()
  PYEOF

  python3 /tmp/create_second_user.py

  export TOKEN2=$(python -m mcpgateway.utils.create_jwt_token --username other@example.com --exp 60 --secret "$JWT_SECRET_KEY" 2>/dev/null)

  curl -s http://localhost:8000/oauth/status/$GW_ID -H "Authorization: Bearer $TOKEN2" | python3 -m json.tool
  ```

  `other@example.com` should see `"status": "missing"` even though `admin@example.com` has a valid token on the same gateway.

  ### Cleanup

  ```bash
  curl -s -X DELETE http://localhost:8000/gateways/$GW_ID -H "Authorization: Bearer $TOKEN"
  ```