### PR TITLE
fix(notifications): preserve malformed downstream error context in client-facing ErrorData

### DIFF
--- a/mcpgateway/services/notification_service.py
+++ b/mcpgateway/services/notification_service.py
@@ -780,11 +780,11 @@ class NotificationService:
             try:
                 error = mcp_types.ErrorData.model_validate(payload["error"])
             except ValidationError as exc:
-                # Substituting INTERNAL_ERROR silently strips the original
-                # error context — operators would only see a generic
-                # message and have no way to trace what the downstream
-                # actually said. Log at warning + include the raw payload
-                # at debug so the trail isn't lost.
+                # Substituting INTERNAL_ERROR would otherwise strip the original
+                # error context — operators and clients would only see a generic
+                # message with no way to trace what the downstream actually
+                # said. Attach the raw payload as ``data`` so the trail reaches
+                # the client, and log at warning for the server-side trail.
                 logger.warning(
                     "Downstream error payload failed validation; substituting INTERNAL_ERROR: %s",
                     exc,
@@ -793,7 +793,7 @@ class NotificationService:
                 error = mcp_types.ErrorData(
                     code=mcp_types.INTERNAL_ERROR,
                     message="Malformed error from downstream",
-                    data=None,
+                    data=payload.get("error"),
                 )
             await responder.respond(error)
             return

--- a/tests/unit/mcpgateway/services/test_notification_service.py
+++ b/tests/unit/mcpgateway/services/test_notification_service.py
@@ -714,6 +714,30 @@ class TestServerInitiatedRequestCorrelation:
         assert captured["responded"].code == -32000
 
     @pytest.mark.asyncio
+    async def test_respond_with_payload_preserves_malformed_error_context(self):
+        """A downstream error that fails ``ErrorData`` validation still reaches
+        the client with its original payload attached as ``data``, instead of a
+        bare INTERNAL_ERROR that erases the downstream's actual failure."""
+        # Third-Party
+        from mcp.types import ErrorData, INTERNAL_ERROR
+
+        responder, captured = self._make_responder("req-bad-err")
+        with responder:
+            await NotificationService._respond_with_payload(
+                responder,
+                {
+                    "jsonrpc": "2.0",
+                    "id": "req-bad-err",
+                    "error": {"code": "timeout", "message": "upstream gave up"},
+                },
+            )
+        responded = captured["responded"]
+        assert isinstance(responded, ErrorData)
+        assert responded.code == INTERNAL_ERROR
+        assert responded.message == "Malformed error from downstream"
+        assert responded.data == {"code": "timeout", "message": "upstream gave up"}
+
+    @pytest.mark.asyncio
     async def test_respond_with_payload_falls_back_on_unparseable_result(self):
         """Garbage in ``result`` becomes an INTERNAL_ERROR ErrorData, not a crash."""
         # Third-Party


### PR DESCRIPTION
## Root cause
When a downstream error payload fails `ErrorData` validation, `_respond_with_payload` substituted a bare `INTERNAL_ERROR` with `data=None` — the original payload survived only in server logs (warning + debug). The comment on that path already acknowledged that operators would have no way to trace what the downstream actually said; the trail was preserved server-side but still erased on the client-facing surface, where the caller receives a fabricated error with zero context.

## Fix
Attach the raw downstream payload as `ErrorData.data` (typed `Any | None`, so a dict is schema-legal):

```python
error = mcp_types.ErrorData(
    code=mcp_types.INTERNAL_ERROR,
    message="Malformed error from downstream",
    data=payload.get("error"),
)
```

The warning/debug logs stay unchanged.

## Validation
- `pytest tests/unit/mcpgateway/services/test_notification_service.py` | sample size: `N=76` | key metrics: new regression test fails pre-fix (`responded.data == {...}` — data was `None`) → post-fix passes; full file green | result: `pass`
- Test: downstream sends a non-conformant error (`{"code": "timeout", "message": "upstream gave up"}`) → client receives `INTERNAL_ERROR` with the original payload attached as `data`
- `ruff check` on the touched file: clean

## Risk / Compatibility
- Additive only: the substitution path fires exactly as before; the only change is the `data` field now carries the original payload instead of `None`. Clients that never read `data` see identical behavior.
