### PR TITLE
fix(gateway): skip invalid resource templates instead of dropping the batch

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -7177,8 +7177,17 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                                 if "content" not in resource_template_data:
                                     resource_template_data["content"] = ""
 
-                                resources.append(ResourceCreate.model_validate(resource_template_data))
-                                resource_templates.append(ResourceCreate.model_validate(resource_template_data))
+                                try:
+                                    validated_template = ResourceCreate.model_validate(resource_template_data)
+                                except Exception as exc:
+                                    logger.warning(
+                                        "Skipping resource template %s: %s",
+                                        resource_template_data.get("uriTemplate") or resource_template_data.get("uri"),
+                                        exc,
+                                    )
+                                    continue
+                                resources.append(validated_template)
+                                resource_templates.append(validated_template)
                             logger.info("Fetched %s resource templates from gateway", len(resource_templates))
                         except Exception as e:
                             logger.warning("Failed to fetch resource templates: %s", e)
@@ -7357,9 +7366,18 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                                 if "content" not in resource_template_data:
                                     resource_template_data["content"] = ""
 
-                                resources.append(ResourceCreate.model_validate(resource_template_data))
-                                resource_templates.append(ResourceCreate.model_validate(resource_template_data))
-                            logger.info("Fetched %s resource templates from gateway", len(raw_resources_templates))
+                                try:
+                                    validated_template = ResourceCreate.model_validate(resource_template_data)
+                                except Exception as exc:
+                                    logger.warning(
+                                        "Skipping resource template %s: %s",
+                                        resource_template_data.get("uriTemplate") or resource_template_data.get("uri"),
+                                        exc,
+                                    )
+                                    continue
+                                resources.append(validated_template)
+                                resource_templates.append(validated_template)
+                            logger.info("Fetched %s resource templates from gateway", len(resource_templates))
                         except Exception as ei:
                             logger.warning("Failed to fetch resource templates: %s", ei)
 
@@ -7529,8 +7547,17 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                                 if "content" not in resource_template_data:
                                     resource_template_data["content"] = ""
 
-                                resources.append(ResourceCreate.model_validate(resource_template_data))
-                                resource_templates.append(ResourceCreate.model_validate(resource_template_data))
+                                try:
+                                    validated_template = ResourceCreate.model_validate(resource_template_data)
+                                except Exception as exc:
+                                    logger.warning(
+                                        "Skipping resource template %s: %s",
+                                        resource_template_data.get("uriTemplate") or resource_template_data.get("uri"),
+                                        exc,
+                                    )
+                                    continue
+                                resources.append(validated_template)
+                                resource_templates.append(validated_template)
                             logger.info("Fetched %s resource templates from gateway", len(resource_templates))
                         except Exception as e:
                             logger.warning("Failed to fetch resource templates: %s", e)

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -3815,6 +3815,59 @@ class TestGatewayRefresh:
         assert by_name["customer_data"].extension_metadata == {MCP_UI_EXTENSION: {"resourceUri": "ui://widgets/customer-search"}}
         assert by_name["customer_record"].extension_metadata == {MCP_UI_EXTENSION: {"resourceUri": "ui://widgets/customer-record"}}
 
+    @pytest.mark.asyncio
+    async def test_resource_template_validation_failure_does_not_drop_siblings(self, gateway_service):
+        """A template whose uriTemplate fails validation is skipped, not batch-fatal.
+
+        RFC 6570 list-expansion templates (e.g. ``{?offset,limit}``) contain a comma,
+        which the default ``validation_safe_uri_pattern`` rejects. The ingest loop used
+        to validate the whole batch inside one try, so the invalid template and every
+        template listed after it were silently dropped.
+        """
+        mock_session = AsyncMock()
+        mock_init = MagicMock()
+        mock_init.capabilities.model_dump.return_value = {"resources": {"subscribe": False}}
+        mock_session.initialize.return_value = mock_init
+
+        tool = MagicMock()
+        tool.model_dump.return_value = {"name": "valid_tool", "description": "ok", "inputSchema": {}}
+        mock_list_tools = MagicMock()
+        mock_list_tools.tools = [tool]
+        mock_session.list_tools.return_value = mock_list_tools
+
+        mock_session.list_resources.return_value = MagicMock(resources=[])
+
+        invalid_template = MagicMock()
+        invalid_template.model_dump.return_value = {
+            "uriTemplate": "stub://sliced/{section}{?offset,limit}",
+            "name": "sliced",
+        }
+        valid_template = MagicMock()
+        valid_template.model_dump.return_value = {
+            "uriTemplate": "https://example.com/items/{item_id}",
+            "name": "items",
+        }
+        mock_list_templates = MagicMock()
+        mock_list_templates.resourceTemplates = [invalid_template, valid_template]
+        mock_session.list_resource_templates.return_value = mock_list_templates
+
+        mock_session.list_prompts.return_value = MagicMock(prompts=[])
+
+        mock_sse_cm = AsyncMock()
+        mock_sse_cm.__aenter__.return_value = (MagicMock(), MagicMock())
+        mock_sse_cm.__aexit__.return_value = None
+
+        mock_client_cm = AsyncMock()
+        mock_client_cm.__aenter__.return_value = mock_session
+        mock_client_cm.__aexit__.return_value = None
+
+        with patch("mcpgateway.services.gateway_service.sse_client", return_value=mock_sse_cm):
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=mock_client_cm):
+                _capabilities, _tools, resources, _prompts, _errors = await gateway_service.connect_to_sse_server("https://test.example.com")
+
+        assert [resource.name for resource in resources] == ["items"]
+        assert resources[0].uri_template == "https://example.com/items/{item_id}"
+
     def test_validate_tools_all_invalid(self, gateway_service):
         """Test failure when all tools are invalid."""
         tools = [


### PR DESCRIPTION
Fixes [#6623](https://github.com/IBM/mcp-context-forge/issues/6623)

## Summary

When a federated gateway is registered or refreshed, its resource templates are ingested inside **one `try` per batch**. The first template whose `uriTemplate` fails `SecurityValidator.validate_uri` (the default `validation_safe_uri_pattern` rejects RFC 6570 list expansions like `{?offset,limit}` because of the comma) raises out of the `for` loop, so that template and every template listed after it are silently dropped, and the `Fetched %s resource templates from gateway` INFO line is never emitted. The only signal is a single `Failed to fetch resource templates` WARNING.

## Root Cause

The per-template `ResourceCreate.model_validate()` calls are not isolated from the batch-level `try` that guards the `list_resource_templates()` transport call. A `ValidationError` from one template propagates to the batch handler and aborts ingestion of the remaining templates. The same two-line append pair is byte-identical at three sites (`connect_to_sse_server`, `connect_to_streamablehttp_server`, `_connect_to_sse_server_without_validation`).

## Fix

Validate each template inside its own `try` and `continue` on failure, logging a WARNING that names the skipped template URI; the outer `try` still covers transport failures of `list_resource_templates()`. Well-formed sibling templates now survive, matching the per-item handling the prompts ingest path already uses. The SSE connect INFO line also reports the surviving count instead of the raw count, so the log no longer counts skipped templates as fetched.

Admitting RFC 6570 operator characters when validating a **template** (as opposed to a URI) is a validation-policy change and is deliberately left out of this PR.