### PR TITLE
fix: remove deprecated PUT user endpoint references

### DIFF
--- a/docs/docs/architecture/multitenancy.md
+++ b/docs/docs/architecture/multitenancy.md
@@ -793,7 +793,7 @@ ContextForge now supports:
   - `POST /auth/email/reset-password/{token}`
 - Admin unlock flow:
   - `POST /auth/email/admin/users/{email}/unlock`
-- Admin password reset via UI and API (`PUT /auth/email/admin/users/{email}`)
+- Admin password reset via UI and API (`PATCH /auth/email/admin/users/{email}`)
 
 Operational guidance, Kubernetes recovery commands, emergency SQL procedures, and
 SMTP/reset configuration are documented in:

--- a/docs/docs/manage/password-management.md
+++ b/docs/docs/manage/password-management.md
@@ -44,7 +44,7 @@ reset tokens are still generated, but no email is delivered.
 In this mode, recovery options are:
 
 1. Use **Admin -> Users** to set a new password directly.
-2. Use admin API `PUT /auth/email/admin/users/{email}` to set a new password.
+2. Use admin API `PATCH /auth/email/admin/users/{email}` to set a new password.
 3. For break-glass scenarios, use the database recovery steps below.
 
 ## Admin UI Reset & Unlock
@@ -77,7 +77,7 @@ curl -X PATCH "http://localhost:4444/auth/email/admin/users/admin-b%40example.co
 ### Reset user password
 
 ```bash
-curl -X PUT "http://localhost:4444/auth/email/admin/users/user%40example.com" \
+curl -X PATCH "http://localhost:4444/auth/email/admin/users/user%40example.com" \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{

--- a/tests/unit/mcpgateway/routers/test_email_auth_router.py
+++ b/tests/unit/mcpgateway/routers/test_email_auth_router.py
@@ -590,7 +590,6 @@ async def test_admin_create_user_default_password_enforcement():
     mock_db.commit.assert_called()
 
 
-@pytest.mark.skip(reason="Sunset date reached (Aug 16, 2026) for deprecated PUT endpoint cleanup. See issue #2754. This test blocks on main branch, not related to current PR changes.")
 @pytest.mark.asyncio
 async def test_admin_get_update_delete_user():
     # First-Party


### PR DESCRIPTION
## Summary

- Re-enable the admin user update test after the deprecated PUT endpoint sunset.
- Update documentation references from PUT to PATCH.

Closes #6287

## Testing

- `pytest tests/unit/mcpgateway/routers/test_email_auth_router.py::test_admin_get_update_delete_user` — 1 passed
- `git diff --check` — passed
- `make lint` — completed with unrelated pre-existing markdownlint issues
- `make test` — not run because `uv` was unavailable in the local environment

## Notes

The changes are limited to the test and documentation updates requested by #6287.