### PR TITLE
feat(teams): expose search_query filter on GET /v1/teams/

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-08T10:01:50Z",
+  "generated_at": "2026-09-08T12:15:28Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1884,7 +1884,7 @@
         "hashed_secret": "91174c4e6859da80df4e7ce9d45b35501f591210",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1900,
+        "line_number": 1905,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1892,7 +1892,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1941,
+        "line_number": 1946,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/manage/api-usage.md
+++ b/docs/docs/manage/api-usage.md
@@ -1882,6 +1882,7 @@ curl -s -H "Authorization: Bearer $TOKEN" $BASE_URL/teams | jq '.'
 | `limit` | int | `50` | Maximum number of teams to return (capped by `PAGINATION_MAX_PAGE_SIZE`). |
 | `cursor` | string | – | Opaque cursor for cursor-based pagination. |
 | `include_pagination` | bool | `false` | When `true`, return cursor metadata instead of a total count. |
+| `search_query` | string | – | Case-insensitive substring filter on team name, slug, or description (max 500 chars). Admins filter server-side; non-admins filter their own team list locally. |
 
 ```bash
 # Offset-based pagination
@@ -1891,6 +1892,10 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 # Cursor-based pagination (returns CursorPaginatedTeamsResponse)
 curl -s -H "Authorization: Bearer $TOKEN" \
   "$BASE_URL/teams?include_pagination=true" | jq '.'
+
+# Search teams by name, slug, or description
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/teams?search_query=engineering" | jq '.'
 ```
 
 **Response with `include_pagination=true` (`CursorPaginatedTeamsResponse`):**

--- a/docs/docs/manage/teams.md
+++ b/docs/docs/manage/teams.md
@@ -139,6 +139,45 @@ if __name__ == "__main__":
 
 ---
 
+## Listing and Searching Teams
+
+The `GET /v1/teams/` endpoint returns the teams visible to the caller.
+
+| Query parameter | Type | Default | Description |
+|----------------|------|---------|-------------|
+| `skip` | int | `0` | Number of teams to skip (offset-based pagination). |
+| `limit` | int | `50` | Maximum teams to return (capped by `PAGINATION_MAX_PAGE_SIZE`). |
+| `cursor` | string | – | Opaque cursor for cursor-based pagination. |
+| `include_pagination` | bool | `false` | When `true`, response includes `nextCursor` instead of `total`. |
+| `search_query` | string | – | Case-insensitive substring filter on name, slug, or description (max 500 chars). |
+
+**Visibility rules:**
+
+- **Platform admins** see all non-personal teams plus their own personal team. `search_query` is applied server-side via SQL.
+- **Regular users** see only teams they belong to. `search_query` filters the result locally.
+
+```bash
+# List your teams
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/v1/teams/" | jq '.teams[].name'
+
+# Search by name, slug, or description
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/v1/teams/?search_query=engineering" | jq '.teams[].name'
+
+# Paginate with offset
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/v1/teams/?skip=50&limit=25" | jq '.'
+
+# Cursor-based pagination
+CURSOR=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/v1/teams/?include_pagination=true" | jq -r '.nextCursor')
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/v1/teams/?include_pagination=true&cursor=$CURSOR" | jq '.'
+```
+
+---
+
 ## Operational Tips
 
 - Generate deterministic team UUIDs and manage them via export/import or admin APIs so they're stable across environments.

--- a/mcpgateway/routers/teams.py
+++ b/mcpgateway/routers/teams.py
@@ -233,6 +233,12 @@ async def list_teams(
         total = 0
         scoped_team_ids = extract_token_team_ids(current_user_ctx)
 
+        # Normalise empty string to None so both admin (SQL) and non-admin (in-memory)
+        # paths treat "no filter" identically. Without this, admin would forward "" to the
+        # service while non-admin's falsy guard silently discards it — two different contracts
+        # for the same input.
+        search_query = search_query or None
+
         # Check admin permissions using PermissionService (handles both is_admin flag and RBAC)
         permission_service = PermissionService(db)
         has_admin_team_access = await permission_service.check_platform_admin_permission(
@@ -259,16 +265,22 @@ async def list_teams(
             # Result is tuple (list, next_cursor)
             teams_data, next_cursor = result
 
-            # Get accurate total count for API consumers
-            total = await service.get_teams_count(personal_owner_email=current_user_ctx["email"], team_ids=scoped_team_ids, search_query=search_query)
+            # Get accurate total count for API consumers (not needed for cursor pagination
+            # because CursorPaginatedTeamsResponse has no total field — skip the DB round-trip).
+            if not include_pagination:
+                total = await service.get_teams_count(personal_owner_email=current_user_ctx["email"], team_ids=scoped_team_ids, search_query=search_query)
         else:
-            # Fallback to user teams and apply pagination locally
+            # Fallback to user teams and apply pagination locally.
+            # Scope narrowing (scoped_team_ids) is applied BEFORE search so out-of-scope
+            # teams can never be surfaced by a search_query match.
             user_teams = await service.get_user_teams(current_user_ctx["email"], include_personal=True)
             if scoped_team_ids is not None:
                 allowed_team_ids = set(scoped_team_ids)
                 user_teams = [team for team in user_teams if str(team.id) in allowed_team_ids]
             if search_query:
                 needle = search_query.lower()
+                # Keep fields in sync with _apply_team_list_filters(search_description=True)
+                # in team_management_service.py — name, slug, description.
                 user_teams = [team for team in user_teams if needle in team.name.lower() or needle in team.slug.lower() or needle in (team.description or "").lower()]
             total = len(user_teams)
             teams_data = user_teams[skip : skip + limit]

--- a/mcpgateway/routers/teams.py
+++ b/mcpgateway/routers/teams.py
@@ -199,6 +199,7 @@ async def list_teams(
     limit: int = Query(50, ge=1, le=settings.pagination_max_page_size, description="Number of teams to return"),
     cursor: QueryPaginationCursorGeneric = None,
     include_pagination: bool = Query(False, description="Include pagination metadata (cursor)"),
+    search_query: Optional[str] = Query(None, max_length=500, description="Filter teams by a substring of name, slug, or description"),
     current_user_ctx: dict = Depends(get_current_user_with_permissions),
     db: Session = Depends(get_db),
 ) -> Union[TeamListResponse, CursorPaginatedTeamsResponse]:
@@ -206,12 +207,15 @@ async def list_teams(
 
     - Administrators see all non-personal teams plus their own personal team (paginated)
     - Regular users see only teams they are a member of (paginated client-side)
+    - search_query, when set, narrows either population to teams whose name, slug, or
+      description contains it (case-insensitive)
 
     Args:
         skip: Number of teams to skip for pagination
         limit: Maximum number of teams to return
         cursor: Pagination cursor
         include_pagination: Include pagination metadata
+        search_query: Substring filter on name/slug/description
         current_user_ctx: Current user context with permissions and database session
         db: Database session
 
@@ -250,18 +254,22 @@ async def list_teams(
                 cursor=cursor,
                 personal_owner_email=current_user_ctx["email"],
                 team_ids=scoped_team_ids,
+                search_query=search_query,
             )
             # Result is tuple (list, next_cursor)
             teams_data, next_cursor = result
 
             # Get accurate total count for API consumers
-            total = await service.get_teams_count(personal_owner_email=current_user_ctx["email"], team_ids=scoped_team_ids)
+            total = await service.get_teams_count(personal_owner_email=current_user_ctx["email"], team_ids=scoped_team_ids, search_query=search_query)
         else:
             # Fallback to user teams and apply pagination locally
             user_teams = await service.get_user_teams(current_user_ctx["email"], include_personal=True)
             if scoped_team_ids is not None:
                 allowed_team_ids = set(scoped_team_ids)
                 user_teams = [team for team in user_teams if str(team.id) in allowed_team_ids]
+            if search_query:
+                needle = search_query.lower()
+                user_teams = [team for team in user_teams if needle in team.name.lower() or needle in team.slug.lower() or needle in (team.description or "").lower()]
             total = len(user_teams)
             teams_data = user_teams[skip : skip + limit]
 

--- a/mcpgateway/routers/teams.py
+++ b/mcpgateway/routers/teams.py
@@ -233,10 +233,9 @@ async def list_teams(
         total = 0
         scoped_team_ids = extract_token_team_ids(current_user_ctx)
 
-        # Normalise empty string to None so both admin (SQL) and non-admin (in-memory)
-        # paths treat "no filter" identically. Without this, admin would forward "" to the
-        # service while non-admin's falsy guard silently discards it — two different contracts
-        # for the same input.
+        # Normalise empty string to None so the value passed downstream is always either a
+        # non-empty string or None — never an empty string that could be misread as an
+        # explicit filter by future callers.
         search_query = search_query or None
 
         # Check admin permissions using PermissionService (handles both is_admin flag and RBAC)

--- a/mcpgateway/routers/teams.py
+++ b/mcpgateway/routers/teams.py
@@ -304,7 +304,7 @@ async def list_teams(
 
         return TeamListResponse(teams=team_responses, total=total)
     except Exception as e:
-        logger.error(f"Error listing teams: {e}")
+        logger.error(f"Error listing teams: {SecurityValidator.sanitize_log_message(str(e))}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list teams")
 
 

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -2028,7 +2028,7 @@ class TeamManagementService:
             include_inactive: Whether to include inactive teams
             visibility_filter: Filter by visibility (private, team, public)
             include_personal: Whether to include personal teams
-            search_query: Search term for name/slug
+            search_query: Search term for name/slug/description
             personal_owner_email: When set (and include_personal=False), includes this user's personal team in the count
             team_ids: When set, restrict the count to these team IDs. An empty list matches no teams.
 
@@ -2042,6 +2042,7 @@ class TeamManagementService:
             visibility_filter=visibility_filter,
             search_query=search_query,
             personal_owner_email=personal_owner_email,
+            search_description=True,
         )
 
         if team_ids is not None:

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -1891,10 +1891,18 @@ class TeamManagementService:
             query = query.where(EmailTeam.visibility == visibility_filter)
 
         if search_query:
-            search_term = f"%{search_query}%"
-            predicates = [EmailTeam.name.ilike(search_term), EmailTeam.slug.ilike(search_term)]
+            # Escape LIKE metacharacters so % and _ in user input are treated as literals,
+            # not SQL wildcards. Without this, search_query="ops_team" would match "ops-team"
+            # (underscore wildcard), and search_query="%" would return every row — breaking
+            # the documented "literal substring" contract and diverging from the non-admin
+            # in-memory filter (plain Python substring, no wildcard expansion).
+            search_term = f"%{TeamManagementService._escape_like(search_query)}%"
+            predicates = [
+                EmailTeam.name.ilike(search_term, escape="\\"),
+                EmailTeam.slug.ilike(search_term, escape="\\"),
+            ]
             if search_description:
-                predicates.append(EmailTeam.description.ilike(search_term))
+                predicates.append(EmailTeam.description.ilike(search_term, escape="\\"))
             query = query.where(or_(*predicates))
 
         return query

--- a/tests/integration/test_team_search_query_sql.py
+++ b/tests/integration/test_team_search_query_sql.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/integration/test_team_search_query_sql.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Integration tests verifying that TeamManagementService.list_teams and get_teams_count
+actually filter rows via SQL when search_query is set — not just mock the service layer.
+
+These tests use a real in-memory SQLite database so the SQL WHERE clauses are exercised
+end-to-end, catching any regression where search_description or search_query is dropped
+from the query before the ORM executes it.
+"""
+
+from __future__ import annotations
+
+# Third-Party
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session as OrmSession
+
+# First-Party
+from mcpgateway.db import Base, EmailTeam
+from mcpgateway.services.team_management_service import TeamManagementService
+
+
+@pytest.fixture
+def db_with_teams():
+    """Real in-memory SQLite DB with three seeded teams for search tests."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    with OrmSession(engine) as db:
+        db.add_all(
+            [
+                EmailTeam(
+                    id="id-eng",
+                    name="Engineering",
+                    slug="engineering",
+                    description="Core platform engineering team",
+                    created_by="admin@example.com",
+                    is_personal=False,
+                    is_active=True,
+                ),
+                EmailTeam(
+                    id="id-ops",
+                    name="Ops Team",
+                    slug="ops-team",
+                    description="Escalates to rocket-squad on call",
+                    created_by="admin@example.com",
+                    is_personal=False,
+                    is_active=True,
+                ),
+                EmailTeam(
+                    id="id-rocket",
+                    name="Rocket Squad",
+                    slug="rocket-squad",
+                    description="First responder on-call rotation",
+                    created_by="admin@example.com",
+                    is_personal=False,
+                    is_active=True,
+                ),
+            ]
+        )
+        db.commit()
+        yield db
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_list_teams_sql_filters_by_name(db_with_teams):
+    """list_teams SQL WHERE matches teams whose name contains the query."""
+    svc = TeamManagementService(db_with_teams)
+    teams, _ = await svc.list_teams(search_query="engineering")
+    assert len(teams) == 1
+    assert teams[0].id == "id-eng"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_list_teams_sql_filters_by_slug(db_with_teams):
+    """list_teams SQL WHERE matches teams whose slug contains the query (case-insensitive)."""
+    svc = TeamManagementService(db_with_teams)
+    teams, _ = await svc.list_teams(search_query="ROCKET")
+    assert any(t.id == "id-rocket" for t in teams)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_list_teams_sql_filters_by_description(db_with_teams):
+    """list_teams SQL WHERE matches teams whose description contains the query."""
+    svc = TeamManagementService(db_with_teams)
+    # "rocket-squad" appears in Ops Team's description, not in its name or slug.
+    teams, _ = await svc.list_teams(search_query="rocket-squad")
+    ids = {t.id for t in teams}
+    assert "id-ops" in ids
+    assert "id-rocket" in ids  # also matches name/slug
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_teams_count_matches_list_teams_for_description_query(db_with_teams):
+    """get_teams_count and list_teams must agree when search_query matches only via description.
+
+    Regression for the count/list mismatch: previously get_teams_count did not pass
+    search_description=True, so it under-counted description-only matches while list_teams
+    returned them — causing paginated callers to see a total lower than actual results.
+    """
+    svc = TeamManagementService(db_with_teams)
+    teams, _ = await svc.list_teams(search_query="rocket-squad")
+    count = await svc.get_teams_count(search_query="rocket-squad")
+    assert count == len(teams), f"list_teams returned {len(teams)} but get_teams_count returned {count}"

--- a/tests/integration/test_team_search_query_sql.py
+++ b/tests/integration/test_team_search_query_sql.py
@@ -112,3 +112,31 @@ async def test_get_teams_count_matches_list_teams_for_description_query(db_with_
     teams, _ = await svc.list_teams(search_query="rocket-squad")
     count = await svc.get_teams_count(search_query="rocket-squad")
     assert count == len(teams), f"list_teams returned {len(teams)} but get_teams_count returned {count}"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_list_teams_like_wildcard_percent_is_literal(db_with_teams):
+    """Regression: search_query='%' must NOT match every team.
+
+    Without _escape_like(), '%' is a SQL wildcard and returns all rows — a trivial
+    data-enumeration vector for any caller who can use the search parameter.
+    """
+    svc = TeamManagementService(db_with_teams)
+    teams, _ = await svc.list_teams(search_query="%")
+    assert len(teams) == 0, f"'%' must not wildcard-match all teams, got {len(teams)}"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_list_teams_like_wildcard_underscore_is_literal(db_with_teams):
+    """Regression: search_query='ops_team' must NOT match 'ops-team' via underscore wildcard.
+
+    Without _escape_like(), '_' matches any single character, so 'ops_team' would match
+    'ops-team' (the hyphen) — violating the literal-substring contract and causing
+    admin/SQL results to diverge from the non-admin in-memory filter.
+    """
+    svc = TeamManagementService(db_with_teams)
+    # The fixture has "ops-team" (slug) — an unescaped underscore would match it.
+    teams, _ = await svc.list_teams(search_query="ops_team")
+    assert len(teams) == 0, f"'ops_team' must not wildcard-match 'ops-team', got {len(teams)}"

--- a/tests/integration/test_team_search_query_sql.py
+++ b/tests/integration/test_team_search_query_sql.py
@@ -77,10 +77,14 @@ async def test_list_teams_sql_filters_by_name(db_with_teams):
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_list_teams_sql_filters_by_slug(db_with_teams):
-    """list_teams SQL WHERE matches teams whose slug contains the query (case-insensitive)."""
+    """list_teams SQL WHERE matches teams whose slug contains the query (case-insensitive).
+
+    "ROCKET" matches id-rocket by name/slug AND id-ops by description
+    ("Escalates to rocket-squad on call"). Both must appear.
+    """
     svc = TeamManagementService(db_with_teams)
     teams, _ = await svc.list_teams(search_query="ROCKET")
-    assert any(t.id == "id-rocket" for t in teams)
+    assert {t.id for t in teams} == {"id-rocket", "id-ops"}
 
 
 @pytest.mark.integration

--- a/tests/unit/mcpgateway/routers/test_teams.py
+++ b/tests/unit/mcpgateway/routers/test_teams.py
@@ -463,13 +463,13 @@ class TestTeamsRouter:
 
             from mcpgateway.routers.teams import list_teams
 
-            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, current_user_ctx=mock_admin_context, db=mock_db)
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query=None, current_user_ctx=mock_admin_context, db=mock_db)
 
             assert len(result.teams) == 1
             assert result.teams[0].id == mock_team.id
             # personal_owner_email must be forwarded so an admin sees their own personal team (issue #5391)
-            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com", team_ids=None)
-            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com", team_ids=None)
+            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com", team_ids=None, search_query=None)
+            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com", team_ids=None, search_query=None)
 
     @pytest.mark.asyncio
     async def test_list_teams_scoped_admin_forwards_team_ids_to_query_and_count(self, mock_admin_context, mock_team, mock_db):
@@ -486,12 +486,12 @@ class TestTeamsRouter:
 
             from mcpgateway.routers.teams import list_teams
 
-            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, current_user_ctx=scoped_context, db=mock_db)
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query=None, current_user_ctx=scoped_context, db=mock_db)
 
             assert len(result.teams) == 1
             assert result.teams[0].id == "team-b"
-            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com", team_ids=["team-b", "team-c"])
-            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com", team_ids=["team-b", "team-c"])
+            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com", team_ids=["team-b", "team-c"], search_query=None)
+            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com", team_ids=["team-b", "team-c"], search_query=None)
 
     @pytest.mark.asyncio
     async def test_list_teams_public_only_admin_token_returns_no_fallback_teams(self, mock_admin_context, mock_team, mock_db):
@@ -508,7 +508,7 @@ class TestTeamsRouter:
 
             from mcpgateway.routers.teams import list_teams
 
-            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, current_user_ctx=public_only_context, db=mock_db)
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query=None, current_user_ctx=public_only_context, db=mock_db)
 
             assert result.teams == []
             assert result.total == 0
@@ -537,13 +537,13 @@ class TestTeamsRouter:
 
             from mcpgateway.routers.teams import list_teams
 
-            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, current_user_ctx=mock_admin_context, db=mock_db)
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query=None, current_user_ctx=mock_admin_context, db=mock_db)
 
             assert len(result.teams) == 1
             assert result.teams[0].id == personal_team.id
             assert result.total == 1
-            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com", team_ids=None)
-            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com", team_ids=None)
+            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com", team_ids=None, search_query=None)
+            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com", team_ids=None, search_query=None)
 
     @pytest.mark.asyncio
     async def test_list_teams_admin_with_cursor_pagination(self, mock_admin_context, mock_team, mock_db):
@@ -561,7 +561,7 @@ class TestTeamsRouter:
 
             from mcpgateway.routers.teams import list_teams
 
-            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=True, current_user_ctx=mock_admin_context, db=mock_db)
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=True, search_query=None, current_user_ctx=mock_admin_context, db=mock_db)
 
             # With include_pagination=True, should return CursorPaginatedTeamsResponse
             assert hasattr(result, "teams")
@@ -584,7 +584,7 @@ class TestTeamsRouter:
 
             from mcpgateway.routers.teams import list_teams
 
-            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, current_user_ctx=mock_user_context, db=mock_db)
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query=None, current_user_ctx=mock_user_context, db=mock_db)
 
             assert len(result.teams) == 1
             assert result.total == 1
@@ -625,7 +625,7 @@ class TestTeamsRouter:
             from mcpgateway.routers.teams import list_teams
 
             # Test pagination - skip 5, limit 3
-            result = await list_teams(skip=5, limit=3, cursor=None, include_pagination=False, current_user_ctx=mock_user_context, db=mock_db)
+            result = await list_teams(skip=5, limit=3, cursor=None, include_pagination=False, search_query=None, current_user_ctx=mock_user_context, db=mock_db)
 
             assert len(result.teams) == 3
             assert result.total == 10
@@ -654,12 +654,12 @@ class TestTeamsRouter:
 
             from mcpgateway.routers.teams import list_teams
 
-            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, current_user_ctx=mock_sso_platform_admin_context, db=mock_db)
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query=None, current_user_ctx=mock_sso_platform_admin_context, db=mock_db)
 
             # SSO platform_admin should see all teams (admin path)
             assert len(result.teams) == 1
             assert result.teams[0].id == mock_team.id
-            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="sso-admin@example.com", team_ids=None)
+            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="sso-admin@example.com", team_ids=None, search_query=None)
             mock_perm_service.check_platform_admin_permission.assert_called_once_with(
                 mock_sso_platform_admin_context["email"],
                 token_teams=mock_sso_platform_admin_context.get("token_teams"),
@@ -686,7 +686,7 @@ class TestTeamsRouter:
 
             from mcpgateway.routers.teams import list_teams
 
-            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, current_user_ctx=mock_user_context, db=mock_db)
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query=None, current_user_ctx=mock_user_context, db=mock_db)
 
             assert len(result.teams) == 1
             assert result.teams[0].id == own_team.id
@@ -708,12 +708,12 @@ class TestTeamsRouter:
 
             from mcpgateway.routers.teams import list_teams
 
-            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, current_user_ctx=mock_admin_context, db=mock_db)
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query=None, current_user_ctx=mock_admin_context, db=mock_db)
 
             assert result.teams == []
             assert result.total == 0
-            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com", team_ids=None)
-            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com", team_ids=None)
+            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com", team_ids=None, search_query=None)
+            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com", team_ids=None, search_query=None)
 
     @pytest.mark.asyncio
     async def test_list_teams_sso_platform_admin_includes_own_personal_team(self, mock_sso_platform_admin_context, mock_team, mock_db):
@@ -740,13 +740,13 @@ class TestTeamsRouter:
 
             from mcpgateway.routers.teams import list_teams
 
-            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, current_user_ctx=mock_sso_platform_admin_context, db=mock_db)
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query=None, current_user_ctx=mock_sso_platform_admin_context, db=mock_db)
 
             assert len(result.teams) == 1
             assert result.teams[0].id == personal_team.id
             # The caller's own email (not a client-supplied value) scopes the personal team.
-            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="sso-admin@example.com", team_ids=None)
-            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="sso-admin@example.com", team_ids=None)
+            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="sso-admin@example.com", team_ids=None, search_query=None)
+            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="sso-admin@example.com", team_ids=None, search_query=None)
 
     @pytest.mark.asyncio
     async def test_create_team_sso_platform_admin_bypass_limits(self, mock_sso_platform_admin_context, mock_team, mock_db):
@@ -823,6 +823,112 @@ class TestTeamsRouter:
             assert call_kwargs["skip_limits"] is True
 
     @pytest.mark.asyncio
+    async def test_list_teams_admin_forwards_search_query(self, mock_admin_context, mock_team, mock_db):
+        """Admin branch: search_query is forwarded to both list_teams and get_teams_count, and only matches come back."""
+        with mock_permission_check(is_admin=True), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
+            mock_service = AsyncMock(spec=TeamManagementService)
+            mock_service.list_teams = AsyncMock(return_value=([mock_team], None))
+            mock_service.get_teams_count = AsyncMock(return_value=1)
+            mock_service.get_member_counts_batch_cached = AsyncMock(return_value={str(mock_team.id): 1})
+            MockService.return_value = mock_service
+
+            from mcpgateway.routers.teams import list_teams
+
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query="test", current_user_ctx=mock_admin_context, db=mock_db)
+
+            assert len(result.teams) == 1
+            assert result.teams[0].id == mock_team.id
+            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com", team_ids=None, search_query="test")
+            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com", team_ids=None, search_query="test")
+
+    @pytest.mark.asyncio
+    async def test_list_teams_admin_search_query_no_match_returns_empty(self, mock_admin_context, mock_db):
+        """Admin branch: a search_query with no matching team returns an empty list, not a 404."""
+        with mock_permission_check(is_admin=True), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
+            mock_service = AsyncMock(spec=TeamManagementService)
+            mock_service.list_teams = AsyncMock(return_value=([], None))
+            mock_service.get_teams_count = AsyncMock(return_value=0)
+            mock_service.get_member_counts_batch_cached = AsyncMock(return_value={})
+            MockService.return_value = mock_service
+
+            from mcpgateway.routers.teams import list_teams
+
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query="no-such-team", current_user_ctx=mock_admin_context, db=mock_db)
+
+            assert result.teams == []
+            assert result.total == 0
+
+    @pytest.mark.asyncio
+    async def test_list_teams_regular_user_search_query_filters_locally_by_name(self, mock_user_context, mock_team, mock_public_team, mock_db):
+        """Non-admin branch: search_query narrows the caller's own teams via local name/slug filtering."""
+        mock_team.name = "Rocket Squad"
+        mock_team.slug = "rocket-squad"
+        mock_public_team.name = "Unrelated Team"
+        mock_public_team.slug = "unrelated-team"
+
+        with mock_permission_check(is_admin=False), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
+            mock_service = AsyncMock(spec=TeamManagementService)
+            mock_service.get_user_teams = AsyncMock(return_value=[mock_team, mock_public_team])
+            mock_service.get_member_counts_batch_cached = AsyncMock(return_value={str(mock_team.id): 1})
+            MockService.return_value = mock_service
+
+            from mcpgateway.routers.teams import list_teams
+
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query="rocket", current_user_ctx=mock_user_context, db=mock_db)
+
+            assert result.total == 1
+            assert result.teams[0].id == mock_team.id
+
+    @pytest.mark.asyncio
+    async def test_list_teams_regular_user_search_query_matches_description(self, mock_user_context, mock_team, mock_public_team, mock_db):
+        """Non-admin branch: a team whose description (not name/slug) contains the search string is matched too."""
+        mock_team.name = "Some Team"
+        mock_team.slug = "some-team"
+        mock_team.description = "Owns the rocket-squad integration"
+        mock_public_team.name = "Other Team"
+        mock_public_team.slug = "other-team"
+        mock_public_team.description = "Nothing related"
+
+        with mock_permission_check(is_admin=False), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
+            mock_service = AsyncMock(spec=TeamManagementService)
+            mock_service.get_user_teams = AsyncMock(return_value=[mock_team, mock_public_team])
+            mock_service.get_member_counts_batch_cached = AsyncMock(return_value={str(mock_team.id): 1})
+            MockService.return_value = mock_service
+
+            from mcpgateway.routers.teams import list_teams
+
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query="rocket-squad", current_user_ctx=mock_user_context, db=mock_db)
+
+            assert result.total == 1
+            assert result.teams[0].id == mock_team.id
+
+    @pytest.mark.asyncio
+    async def test_list_teams_regular_user_search_query_matches_across_name_and_description(self, mock_user_context, mock_team, mock_public_team, mock_db):
+        """Non-admin branch: the substring filter matches both an exact name and an incidental description mention, per _apply_team_list_filters(search_description=True) semantics."""
+        mock_team.name = "rocket-squad"
+        mock_team.slug = "rocket-squad"
+        mock_team.description = None
+        mock_public_team.name = "Ops Team"
+        mock_public_team.slug = "ops-team"
+        mock_public_team.description = "Escalates to rocket-squad when paged"
+
+        with mock_permission_check(is_admin=False), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
+            mock_service = AsyncMock(spec=TeamManagementService)
+            mock_service.get_user_teams = AsyncMock(return_value=[mock_team, mock_public_team])
+            mock_service.get_member_counts_batch_cached = AsyncMock(return_value={str(mock_team.id): 1, str(mock_public_team.id): 1})
+            MockService.return_value = mock_service
+
+            from mcpgateway.routers.teams import list_teams
+
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query="rocket-squad", current_user_ctx=mock_user_context, db=mock_db)
+
+            # Both the exact name match and the incidental description mention match the substring
+            # filter (matches _apply_team_list_filters(search_description=True) semantics) — this
+            # confirms the filter is a real substring scan, not an exact-field check.
+            result_ids = {team.id for team in result.teams}
+            assert result_ids == {mock_team.id, mock_public_team.id}
+
+    @pytest.mark.asyncio
     async def test_list_teams_error(self, mock_user_context, mock_db):
         """Test listing teams with error."""
         with patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
@@ -833,7 +939,7 @@ class TestTeamsRouter:
             from mcpgateway.routers.teams import list_teams
 
             with pytest.raises(HTTPException) as exc_info:
-                await list_teams(skip=0, limit=50, current_user_ctx=mock_user_context, db=mock_db)
+                await list_teams(skip=0, limit=50, search_query=None, current_user_ctx=mock_user_context, db=mock_db)
 
             assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
             assert "Failed to list teams" in str(exc_info.value.detail)

--- a/tests/unit/mcpgateway/routers/test_teams.py
+++ b/tests/unit/mcpgateway/routers/test_teams.py
@@ -547,7 +547,11 @@ class TestTeamsRouter:
 
     @pytest.mark.asyncio
     async def test_list_teams_admin_with_cursor_pagination(self, mock_admin_context, mock_team, mock_db):
-        """Test listing teams as admin with include_pagination=True returns cursor format."""
+        """Test listing teams as admin with include_pagination=True returns cursor format.
+
+        get_teams_count must NOT be called — CursorPaginatedTeamsResponse has no total field
+        so the DB round-trip is wasted.
+        """
         teams = [mock_team]
         next_cursor = "eyJjcmVhdGVkX2F0IjogIjIwMjYtMDEtMTQiLCAiaWQiOiAiMTIzIn0="  # Base64 encoded cursor  # pragma: allowlist secret
 
@@ -568,6 +572,8 @@ class TestTeamsRouter:
             assert hasattr(result, "next_cursor")
             assert len(result.teams) == 1
             assert result.next_cursor == next_cursor
+            # S-001: get_teams_count must NOT be called for cursor pagination
+            mock_service.get_teams_count.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_list_teams_regular_user(self, mock_user_context, mock_team, mock_db):
@@ -930,8 +936,11 @@ class TestTeamsRouter:
 
     @pytest.mark.asyncio
     async def test_list_teams_admin_empty_string_search_query(self, mock_admin_context, mock_team, mock_db):
-        """Admin branch: empty-string search_query is passed through to the service unchanged
-        (falsy check is non-admin only; admin always forwards, letting the service decide)."""
+        """Empty-string search_query is normalised to None before both branches (FI-001).
+
+        The handler does ``search_query = search_query or None`` at entry so both admin (SQL)
+        and non-admin (in-memory) paths receive None and behave identically.
+        """
         with mock_permission_check(is_admin=True), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
             mock_service = AsyncMock(spec=TeamManagementService)
             mock_service.list_teams = AsyncMock(return_value=([mock_team], None))
@@ -943,15 +952,15 @@ class TestTeamsRouter:
 
             result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query="", current_user_ctx=mock_admin_context, db=mock_db)
 
-            # Empty string is forwarded as-is — the service treats it as "no filter" internally.
-            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com", team_ids=None, search_query="")
-            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com", team_ids=None, search_query="")
+            # "" is normalised to None before forwarding — service receives None, not "".
+            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com", team_ids=None, search_query=None)
+            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com", team_ids=None, search_query=None)
             assert len(result.teams) == 1
 
     @pytest.mark.asyncio
     async def test_list_teams_non_admin_empty_string_search_query_skips_filter(self, mock_user_context, mock_team, mock_public_team, mock_db):
-        """Non-admin branch: empty-string search_query is falsy so the local filter is skipped
-        and all of the caller's teams are returned unchanged."""
+        """Non-admin branch: empty-string normalised to None, so local filter is skipped
+        and all of the caller's teams are returned unchanged (same outcome as admin path)."""
         with mock_permission_check(is_admin=False), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
             mock_service = AsyncMock(spec=TeamManagementService)
             mock_service.get_user_teams = AsyncMock(return_value=[mock_team, mock_public_team])
@@ -962,7 +971,7 @@ class TestTeamsRouter:
 
             result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query="", current_user_ctx=mock_user_context, db=mock_db)
 
-            # Falsy search_query → no filter applied → all teams returned.
+            # "" → None → falsy guard skips filter → all teams returned.
             assert result.total == 2
 
     @pytest.mark.asyncio
@@ -1009,6 +1018,67 @@ class TestTeamsRouter:
 
             assert result.total == 1
             assert result.teams[0].id == mock_team.id
+
+    @pytest.mark.asyncio
+    async def test_list_teams_admin_cursor_pagination_with_search_query(self, mock_admin_context, mock_team, mock_db):
+        """S-004: cursor-pagination (include_pagination=True) with a non-None search_query.
+
+        search_query must be forwarded to list_teams and get_teams_count must NOT be called
+        (CursorPaginatedTeamsResponse has no total field).
+        """
+        next_cursor = "eyJjcmVhdGVkX2F0IjogIjIwMjYtMDEtMTQiLCAiaWQiOiAiMTIzIn0="  # pragma: allowlist secret
+
+        with mock_permission_check(is_admin=True), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
+            mock_service = AsyncMock(spec=TeamManagementService)
+            mock_service.list_teams = AsyncMock(return_value=([mock_team], next_cursor))
+            mock_service.get_teams_count = AsyncMock(return_value=1)
+            mock_service.get_member_counts_batch_cached = AsyncMock(return_value={str(mock_team.id): 1})
+            MockService.return_value = mock_service
+
+            from mcpgateway.routers.teams import list_teams
+
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=True, search_query="engineering", current_user_ctx=mock_admin_context, db=mock_db)
+
+            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com", team_ids=None, search_query="engineering")
+            mock_service.get_teams_count.assert_not_called()
+            assert result.next_cursor == next_cursor
+            assert len(result.teams) == 1
+
+    @pytest.mark.asyncio
+    async def test_list_teams_non_admin_scoped_token_search_query_cannot_leak_out_of_scope(self, mock_user_context, mock_team, mock_public_team, mock_db):
+        """FI-002: scoped token (token_teams set) + search_query must not surface out-of-scope teams.
+
+        Scope narrowing is applied BEFORE the search filter. A search_query matching an
+        out-of-scope team's name must not include it in results.
+        """
+        in_scope_team = mock_team
+        in_scope_team.name = "Alpha Engineering"
+        in_scope_team.slug = "alpha-engineering"
+        in_scope_team.description = None
+
+        out_of_scope_team = mock_public_team
+        out_of_scope_team.name = "Beta Engineering"
+        out_of_scope_team.slug = "beta-engineering"
+        out_of_scope_team.description = None
+
+        # Token scoped to only the in-scope team
+        scoped_context = {**mock_user_context, "token_teams": [{"id": str(in_scope_team.id)}]}
+
+        with mock_permission_check(is_admin=False), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
+            mock_service = AsyncMock(spec=TeamManagementService)
+            # Service returns both teams as if the user is a member of both
+            mock_service.get_user_teams = AsyncMock(return_value=[in_scope_team, out_of_scope_team])
+            mock_service.get_member_counts_batch_cached = AsyncMock(return_value={str(in_scope_team.id): 1})
+            MockService.return_value = mock_service
+
+            from mcpgateway.routers.teams import list_teams
+
+            # "engineering" matches BOTH teams by name — but only in-scope team must be returned
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query="engineering", current_user_ctx=scoped_context, db=mock_db)
+
+            result_ids = {t.id for t in result.teams}
+            assert str(in_scope_team.id) in result_ids, "In-scope matching team must be returned"
+            assert str(out_of_scope_team.id) not in result_ids, "Out-of-scope team must not leak even if name matches search_query"
 
     @pytest.mark.asyncio
     async def test_list_teams_error(self, mock_user_context, mock_db):

--- a/tests/unit/mcpgateway/routers/test_teams.py
+++ b/tests/unit/mcpgateway/routers/test_teams.py
@@ -929,6 +929,88 @@ class TestTeamsRouter:
             assert result_ids == {mock_team.id, mock_public_team.id}
 
     @pytest.mark.asyncio
+    async def test_list_teams_admin_empty_string_search_query(self, mock_admin_context, mock_team, mock_db):
+        """Admin branch: empty-string search_query is passed through to the service unchanged
+        (falsy check is non-admin only; admin always forwards, letting the service decide)."""
+        with mock_permission_check(is_admin=True), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
+            mock_service = AsyncMock(spec=TeamManagementService)
+            mock_service.list_teams = AsyncMock(return_value=([mock_team], None))
+            mock_service.get_teams_count = AsyncMock(return_value=1)
+            mock_service.get_member_counts_batch_cached = AsyncMock(return_value={str(mock_team.id): 1})
+            MockService.return_value = mock_service
+
+            from mcpgateway.routers.teams import list_teams
+
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query="", current_user_ctx=mock_admin_context, db=mock_db)
+
+            # Empty string is forwarded as-is — the service treats it as "no filter" internally.
+            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com", team_ids=None, search_query="")
+            mock_service.get_teams_count.assert_called_once_with(personal_owner_email="admin@example.com", team_ids=None, search_query="")
+            assert len(result.teams) == 1
+
+    @pytest.mark.asyncio
+    async def test_list_teams_non_admin_empty_string_search_query_skips_filter(self, mock_user_context, mock_team, mock_public_team, mock_db):
+        """Non-admin branch: empty-string search_query is falsy so the local filter is skipped
+        and all of the caller's teams are returned unchanged."""
+        with mock_permission_check(is_admin=False), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
+            mock_service = AsyncMock(spec=TeamManagementService)
+            mock_service.get_user_teams = AsyncMock(return_value=[mock_team, mock_public_team])
+            mock_service.get_member_counts_batch_cached = AsyncMock(return_value={str(mock_team.id): 1, str(mock_public_team.id): 1})
+            MockService.return_value = mock_service
+
+            from mcpgateway.routers.teams import list_teams
+
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query="", current_user_ctx=mock_user_context, db=mock_db)
+
+            # Falsy search_query → no filter applied → all teams returned.
+            assert result.total == 2
+
+    @pytest.mark.asyncio
+    async def test_list_teams_admin_search_query_case_insensitive_slug(self, mock_admin_context, mock_team, mock_db):
+        """Admin branch: search_query is case-insensitive — uppercase query matches lowercase slug."""
+        mock_team.name = "Rocket Squad"
+        mock_team.slug = "rocket-squad"
+
+        with mock_permission_check(is_admin=True), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
+            mock_service = AsyncMock(spec=TeamManagementService)
+            mock_service.list_teams = AsyncMock(return_value=([mock_team], None))
+            mock_service.get_teams_count = AsyncMock(return_value=1)
+            mock_service.get_member_counts_batch_cached = AsyncMock(return_value={str(mock_team.id): 1})
+            MockService.return_value = mock_service
+
+            from mcpgateway.routers.teams import list_teams
+
+            # Uppercase query must still be forwarded; case folding is the service's responsibility.
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query="ROCKET", current_user_ctx=mock_admin_context, db=mock_db)
+
+            mock_service.list_teams.assert_called_once_with(limit=50, offset=0, cursor=None, personal_owner_email="admin@example.com", team_ids=None, search_query="ROCKET")
+            assert len(result.teams) == 1
+            assert result.teams[0].slug == "rocket-squad"
+
+    @pytest.mark.asyncio
+    async def test_list_teams_non_admin_search_query_case_insensitive_slug(self, mock_user_context, mock_team, mock_public_team, mock_db):
+        """Non-admin branch: local filter is case-insensitive — ROCKET matches slug rocket-squad."""
+        mock_team.name = "Rocket Squad"
+        mock_team.slug = "rocket-squad"
+        mock_team.description = None
+        mock_public_team.name = "Ops Team"
+        mock_public_team.slug = "ops-team"
+        mock_public_team.description = None
+
+        with mock_permission_check(is_admin=False), patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
+            mock_service = AsyncMock(spec=TeamManagementService)
+            mock_service.get_user_teams = AsyncMock(return_value=[mock_team, mock_public_team])
+            mock_service.get_member_counts_batch_cached = AsyncMock(return_value={str(mock_team.id): 1})
+            MockService.return_value = mock_service
+
+            from mcpgateway.routers.teams import list_teams
+
+            result = await list_teams(skip=0, limit=50, cursor=None, include_pagination=False, search_query="ROCKET", current_user_ctx=mock_user_context, db=mock_db)
+
+            assert result.total == 1
+            assert result.teams[0].id == mock_team.id
+
+    @pytest.mark.asyncio
     async def test_list_teams_error(self, mock_user_context, mock_db):
         """Test listing teams with error."""
         with patch("mcpgateway.routers.teams.TeamManagementService") as MockService:
@@ -955,34 +1037,9 @@ class TestTeamsRouter:
             mock_service.get_user_role_in_team = AsyncMock(return_value="member")
             MockService.return_value = mock_service
 
-            # Mock the entire decorated function to bypass RBAC
-            from mcpgateway.routers.teams import TeamResponse
+            from mcpgateway.routers.teams import get_team
 
-            async def mock_get_team(team_id, current_user, db):
-                _ = TeamManagementService(db)
-                team = await mock_service.get_team_by_id(team_id)
-                if not team:
-                    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
-                user_role = await mock_service.get_user_role_in_team(current_user["email"], team_id)
-                if not user_role:
-                    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
-                return TeamResponse(
-                    id=team.id,
-                    name=team.name,
-                    slug=team.slug,
-                    description=team.description,
-                    created_by=team.created_by,
-                    is_personal=team.is_personal,
-                    visibility=team.visibility,
-                    max_members=team.max_members,
-                    member_count=team.get_member_count(),
-                    created_at=team.created_at,
-                    updated_at=team.updated_at,
-                    is_active=team.is_active,
-                )
-
-            with patch("mcpgateway.routers.teams.get_team", new=mock_get_team):
-                result = await mock_get_team(team_id, mock_user_context, mock_db)
+            result = await get_team(team_id, current_user=mock_user_context, db=mock_db)
 
             assert result.id == mock_team.id
             assert result.name == mock_team.name

--- a/tests/unit/mcpgateway/services/test_team_management_service.py
+++ b/tests/unit/mcpgateway/services/test_team_management_service.py
@@ -1371,6 +1371,34 @@ class TestTeamManagementService:
         assert empty_count == 0
         assert unfiltered_count >= 2
 
+    @pytest.mark.asyncio
+    async def test_get_teams_count_search_query_includes_description(self):
+        """Regression for count/list mismatch: get_teams_count must use search_description=True
+        so a search_query that matches only via description is counted the same way list_teams
+        returns it. Previously get_teams_count defaulted search_description=False, causing
+        total to under-count when description-only matches existed."""
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import Session as OrmSession
+
+        from mcpgateway.db import Base
+
+        engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+        Base.metadata.create_all(engine)
+        with OrmSession(engine) as db:
+            db.add_all(
+                [
+                    EmailTeam(id="id-desc", name="Alpha Team", slug="alpha-team", description="owns the rocket-squad integration", created_by="o@example.com", is_personal=False),
+                    EmailTeam(id="id-other", name="Beta Team", slug="beta-team", description="unrelated", created_by="o@example.com", is_personal=False),
+                ]
+            )
+            db.commit()
+
+            svc = TeamManagementService(db)
+            # search_query matches only via description — must return 1, not 0.
+            count = await svc.get_teams_count(search_query="rocket-squad")
+
+        assert count == 1, f"Expected 1 (description match), got {count}"
+
     # =========================================================================
     # Discovery and Join Request Tests
     # =========================================================================


### PR DESCRIPTION
## Problem

`GET /v1/teams/` has no filtering support. A caller who wants to find one specific team (e.g. to resolve a team by name before creating a resource under it) has no option but to page through the entire list with `skip`/`limit` until a name match turns up or the list is exhausted.

That doesn't scale:

- Teams are returned newest-first, so an older team can sit arbitrarily deep in the list — there's no bound on how many pages a correct lookup may need.
- Callers are left choosing between an unbounded pagination loop (hundreds of round-trips on an instance with 100k+ teams) or an arbitrary page cap that can silently miss a legitimate, older team.

The filtering this needs already exists: `TeamManagementService.list_teams(..., search_query=...)` does a case-insensitive substring match across `name`/`slug`/`description` (`_apply_team_list_filters(..., search_description=True)`), and it's already wired up on the admin-only `POST /admin/teams/search` route (`admin.py`). It was just never exposed on the public `GET /v1/teams/` route, so non-admin API consumers have no equivalent.

Closes #6651

## Solution

Add an optional `search_query` query parameter to `GET /v1/teams/` (`mcpgateway/routers/teams.py`), reusing the existing service-layer filter rather than adding new filtering logic:

- **Admin-scoped callers** (`has_admin_team_access`): `search_query` is threaded into the existing `service.list_teams(...)` and `service.get_teams_count(...)` calls, the same way `personal_owner_email`/`team_ids` already are.
- **Regular (non-admin) callers**, who fall back to `service.get_user_teams(...)` with local slicing: the same case-insensitive substring filter (name, slug, description) is applied to their own team list before pagination, so both code paths behave consistently.
- No match returns `200` with an empty list (not `404`).
- The parameter is optional and defaults to `None`, so existing callers are unaffected.

## Testing

Added to `tests/unit/mcpgateway/routers/test_teams.py`:

- Admin caller with `search_query` set — asserts the filter is forwarded to `service.list_teams`/`get_teams_count` and only matching teams are returned.
- Admin caller whose `search_query` matches nothing — empty result, still `200`.
- Non-admin caller filtering their own teams by name.
- Non-admin caller matching on `description` (not just name/slug).
- Non-admin caller with a `search_query` that matches one team by name and a different team by description substring — both are returned together, confirming the OR-across-fields substring semantics match `_apply_team_list_filters(search_description=True)`.

Full existing `test_teams.py` suite passes alongside the new tests (no regressions to the other `list_teams` behavior).
