### PR TITLE
fix(charts): unblock PGO deployment on OpenShift

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-31T10:37:33Z",
+  "generated_at": "2026-09-01T00:04:00Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1510,7 +1510,7 @@
         "hashed_secret": "602a3bcd9e73d7abd64dc26b0cb407e963c9f806",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 188,
+        "line_number": 191,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1518,7 +1518,7 @@
         "hashed_secret": "de7c0d0731b4b25d51e1d5025b8559d073d3c0e7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 353,
+        "line_number": 356,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1526,7 +1526,7 @@
         "hashed_secret": "d09a50d86d7403a4bc3ee1823f91ec14fb14acd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 362,
+        "line_number": 365,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1534,7 +1534,7 @@
         "hashed_secret": "2bdb52a577a3b6376b125fa94bfa4366a53c5ea0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 364,
+        "line_number": 367,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1542,7 +1542,7 @@
         "hashed_secret": "ae0131d240ba7cc32be22b778cb4a62ccfbd3660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 370,
+        "line_number": 373,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1550,7 +1550,7 @@
         "hashed_secret": "7e15bb5c01e7dd56499e37c634cf791d3a519aee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 581,
+        "line_number": 584,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ansible/ocp/playbooks/deploy.yml
+++ b/ansible/ocp/playbooks/deploy.yml
@@ -39,6 +39,30 @@
       failed_when: confirm.user_input | lower not in ['yes', 'y']
       when: not (skip_confirm | default(false) | bool)
 
+    # Pre-create the gateway secret with Helm ownership labels so the migration
+    # hook pod finds it immediately (before Helm creates regular resources).
+    - name: Load secrets values file
+      ansible.builtin.include_vars:
+        file: "{{ ocp_secrets }}"
+        name: secret_values
+
+    - name: Pre-create gateway secret with Helm ownership labels
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ ocp_namespace }}-mcp-stack-gateway-secret"
+            namespace: "{{ ocp_namespace }}"
+            labels:
+              app.kubernetes.io/managed-by: Helm
+            annotations:
+              meta.helm.sh/release-name: "{{ ocp_namespace }}"
+              meta.helm.sh/release-namespace: "{{ ocp_namespace }}"
+          stringData: "{{ dict(secret_values.mcpContextForge.secret | dict2items | map(attribute='key') | list | zip(secret_values.mcpContextForge.secret | dict2items | map(attribute='value') | map('string') | list)) }}"
+      no_log: true
+
     - name: Install ContextForge Helm chart
       ansible.builtin.command:
         cmd: >

--- a/ansible/ocp/playbooks/deploy.yml
+++ b/ansible/ocp/playbooks/deploy.yml
@@ -45,6 +45,43 @@
       ansible.builtin.include_vars:
         file: "{{ ocp_secrets }}"
         name: secret_values
+      no_log: true
+
+    # Derive the secret name from the chart's own mcp-stack.fullname helper so
+    # it always matches what Helm renders, regardless of the release name.
+    - name: Derive gateway secret name from chart template
+      ansible.builtin.command:
+        cmd: >
+          helm template {{ ocp_namespace }} {{ ocp_chart_path }}
+          -n {{ ocp_namespace }}
+          -f {{ ocp_values }}
+          -f {{ ocp_secrets }}
+          --show-only templates/secret-gateway.yaml
+      register: gateway_secret_template
+      changed_when: false
+      no_log: true
+
+    - name: Parse gateway secret name from template output
+      ansible.builtin.set_fact:
+        gateway_secret_name: >-
+          {{ (gateway_secret_template.stdout | from_yaml).metadata.name }}
+
+    - name: Expand secret dict to items (single pass)
+      ansible.builtin.set_fact:
+        gateway_secret_items: "{{ secret_values.mcpContextForge.secret | dict2items }}"
+      no_log: true
+
+    - name: Coerce secret values to strings
+      ansible.builtin.set_fact:
+        gateway_secret_data: >-
+          {{ dict(gateway_secret_items | map(attribute='key') | list
+             | zip(gateway_secret_items
+               | map(attribute='value')
+               | map('string')
+               | map('regex_replace', '^True$', 'true')
+               | map('regex_replace', '^False$', 'false')
+               | list)) }}
+      no_log: true
 
     - name: Pre-create gateway secret with Helm ownership labels
       kubernetes.core.k8s:
@@ -53,14 +90,14 @@
           apiVersion: v1
           kind: Secret
           metadata:
-            name: "{{ ocp_namespace }}-mcp-stack-gateway-secret"
+            name: "{{ gateway_secret_name }}"
             namespace: "{{ ocp_namespace }}"
             labels:
               app.kubernetes.io/managed-by: Helm
             annotations:
               meta.helm.sh/release-name: "{{ ocp_namespace }}"
               meta.helm.sh/release-namespace: "{{ ocp_namespace }}"
-          stringData: "{{ dict(secret_values.mcpContextForge.secret | dict2items | map(attribute='key') | list | zip(secret_values.mcpContextForge.secret | dict2items | map(attribute='value') | map('string') | list)) }}"
+          stringData: "{{ gateway_secret_data }}"
       no_log: true
 
     - name: Install ContextForge Helm chart

--- a/ansible/ocp/playbooks/setup.yml
+++ b/ansible/ocp/playbooks/setup.yml
@@ -65,6 +65,14 @@
       ansible.builtin.debug:
         msg: "Namespace: {{ 'created' if ns_result.changed else 'already exists' }}"
 
+    # Step 2b: Grant nonroot-v2 SCC to default service account (required for Redis UID 999).
+    # nonroot-v2 allows any non-root UID (covers 999) and still permits seccompProfile,
+    # so it is narrower than anyuid and avoids root-escalation risk (CWE-250).
+    - name: Grant nonroot-v2 SCC to default service account
+      ansible.builtin.command:
+        cmd: oc adm policy add-scc-to-user nonroot-v2 -z default -n {{ ocp_namespace }}
+      changed_when: false
+
     # Step 3: Apply PostgresCluster CR
     - name: Check if PostgresCluster is already running
       kubernetes.core.k8s_info:

--- a/charts/mcp-stack/profiles/ocp/values-pgo.yaml
+++ b/charts/mcp-stack/profiles/ocp/values-pgo.yaml
@@ -292,6 +292,12 @@ migration:
   hookPhase: "pre-install,pre-upgrade"
   hostKey: "host"
   portKey: "port"
+  # Must match mcpContextForge.image.tag. A pinned default here would migrate the
+  # schema to an older head than the gateway expects, crashlooping the gateway pods.
+  image:
+    repository: ghcr.io/ibm/mcp-context-forge
+    tag: latest
+    pullPolicy: Always
   # OpenShift SCC: let OCP assign UID from its allowed range (1000740000-1000749999)
   podSecurityContext:
     runAsNonRoot: true

--- a/charts/mcp-stack/templates/_helpers.tpl
+++ b/charts/mcp-stack/templates/_helpers.tpl
@@ -123,3 +123,28 @@ failureThreshold:    {{ $p.failureThreshold    | default 3 }}
 {{- include "helpers.renderProbe" (dict "probe" $p "root" .root) }}
 {{- end }}
 {{- end }}
+
+{{- /* --------------------------------------------------------------------
+     Helper: mcp-stack.registrationEnv
+     Environment for the registration hook Jobs.
+
+     These Jobs run `python -m mcpgateway.utils.create_jwt_token`, which
+     imports mcpgateway.config at module load. That import validates the
+     full settings model and aborts when JWT_SECRET_KEY is still the
+     "__REPLACE_ME__" placeholder, before the --secret flag is ever read.
+     Without this env the token command dies, the shell captures an empty
+     TOKEN, and every API call from the hook returns 401.
+     -------------------------------------------------------------------- */}}
+{{- define "mcp-stack.registrationEnv" -}}
+env:
+  - name: JWT_SECRET_KEY
+    valueFrom:
+      secretKeyRef:
+        name: {{ include "mcp-stack.fullname" . }}-gateway-secret
+        key: JWT_SECRET_KEY
+  - name: AUTH_ENCRYPTION_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: {{ include "mcp-stack.fullname" . }}-gateway-secret
+        key: AUTH_ENCRYPTION_SECRET
+{{- end }}

--- a/charts/mcp-stack/templates/registration-jobs.yaml
+++ b/charts/mcp-stack/templates/registration-jobs.yaml
@@ -35,6 +35,7 @@ spec:
         - name: register-fast-time
           image: {{ $registrationImage | quote }}
           imagePullPolicy: {{ .Values.testing.registration.image.pullPolicy }}
+          {{- include "mcp-stack.registrationEnv" . | nindent 10 }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -178,6 +179,7 @@ spec:
         - name: register-a2a-echo
           image: {{ $registrationImage | quote }}
           imagePullPolicy: {{ .Values.testing.registration.image.pullPolicy }}
+          {{- include "mcp-stack.registrationEnv" . | nindent 10 }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -288,6 +290,7 @@ spec:
         - name: register-benchmark
           image: {{ $registrationImage | quote }}
           imagePullPolicy: {{ .Values.testing.registration.image.pullPolicy }}
+          {{- include "mcp-stack.registrationEnv" . | nindent 10 }}
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/charts/mcp-stack/templates/testing-stack.yaml
+++ b/charts/mcp-stack/templates/testing-stack.yaml
@@ -137,6 +137,7 @@ spec:
         - name: generate-jwt
           image: "{{ .Values.testing.registration.image.repository }}:{{ .Values.testing.registration.image.tag }}"
           imagePullPolicy: {{ .Values.testing.registration.image.pullPolicy }}
+          {{- include "mcp-stack.registrationEnv" . | nindent 10 }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -268,6 +269,7 @@ spec:
         - name: generate-jwt
           image: "{{ .Values.testing.registration.image.repository }}:{{ .Values.testing.registration.image.tag }}"
           imagePullPolicy: {{ .Values.testing.registration.image.pullPolicy }}
+          {{- include "mcp-stack.registrationEnv" . | nindent 10 }}
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/docs/docs/deployment/openshift-pgo.md
+++ b/docs/docs/deployment/openshift-pgo.md
@@ -79,7 +79,7 @@ If you don't need HA or automated backups (dev/test, POCs, teams without cluster
 
 The following tools must be installed locally before you begin:
 
-1. **`oc` CLI** — with cluster access (developer or admin). Log in before running any commands:
+1. **`oc` CLI** — with **cluster-admin** (or equivalent) privileges. The setup playbook runs `oc adm policy add-scc-to-user nonroot-v2` to grant the Redis pod permission to run as UID 999 — this requires cluster-admin. Log in before running any commands:
    ```bash
    oc login <api-url>
    oc whoami   # verify
@@ -167,6 +167,9 @@ testing:
 ## Deployment steps
 
 The Make commands below wrap Ansible playbooks (`ansible/ocp/playbooks/`). You can also run the playbooks directly — see [ansible/ocp/README.md](https://github.com/IBM/mcp-context-forge/blob/main/ansible/ocp/README.md) for details.
+
+**Prerequisite: Create a namespace**
+`oc new-project <namespace-change-me>`
 
 **Step 1 — Create Docker Hub pull secret** (one-time per namespace):
 


### PR DESCRIPTION
Fixes three issues that prevent a fresh Helm PGO deployment on OpenShift from reaching a working state. Each one was hit in order while deploying from the parent branch, and each blocks the next.

## 1. Migration job ran a different image than the gateway

`profiles/ocp/values-pgo.yaml` overrides the migration `hookPhase`, `hostKey`, `portKey` and `podSecurityContext`, but not `image.tag`. The migration job therefore fell back to the chart default (`v1.0.8`) while the gateway ran `latest`.

The migration stamped the schema at `e4f5a6b7c8d9` (the v1.0.8 head) while the gateway expected `9935d863930b`, so all three gateway pods entered `CrashLoopBackOff` with:

```
MCPGATEWAY_SKIP_MIGRATIONS=true but schema is not at head.
```

Pins the migration image to match the gateway image.

## 2. Registration hook Jobs could not mint a token

The registration Jobs run `python -m mcpgateway.utils.create_jwt_token` in a container with no environment. That command imports `mcpgateway.config` at module load, which validates the settings model and aborts on the placeholder secrets before the `--secret` flag is ever read:

```
SecurityConfigurationError: jwt_secret_key: unset placeholder (__REPLACE_ME__)
rejected in every environment
```

Because the script captures the token with `2>/dev/null`, the error is invisible: `TOKEN` comes back empty, requests go out as `Bearer `, and every API call returns 401. The only visible symptom is `helm install` failing on the post-install hook:

```
Error: INSTALLATION FAILED: failed post-install: resource
Job/contextforge/contextforge-mcp-stack-register-fast-time not ready
```

## 3. Locust init containers had the same gap

`testing-stack.yaml` runs the same command in the `generate-jwt` init containers for both the Locust master and workers. With `set -eu` the failed command substitution aborts the container, leaving all four Locust pods in `Init:Error`.

## Change

Adds a shared `mcp-stack.registrationEnv` helper supplying `JWT_SECRET_KEY` and `AUTH_ENCRYPTION_SECRET` from the gateway secret, applied to the three registration Jobs and both `generate-jwt` init containers. Both variables are required: `JWT_SECRET_KEY` alone still fails validation on `auth_encryption_secret`.

Note that items 2 and 3 are in the base chart rather than the OCP profile, so they affect any deployment running an image whose config validation rejects placeholder secrets, not only OpenShift.

## Verification

Deployed on OCP 4.22.2 with CrunchyData PGO 5.8.9, 3 workers at 16 CPU / 32Gi, storage class `nfs-client`:

- `helm install` completes, playbook reports `failed=0`
- 3 gateway, 3 NGINX, Redis and 2 fast-time-server pods reach Ready
- Registration creates the `fast_time` gateway and virtual server, 2 tools discovered
- Route serves `/health` and the admin login page
- Locust master and all 3 workers connect, benchmark runs at 0% failures

`helm lint` passes.
