### PR TITLE
fix: expose APP_DOMAIN-derived url on ServerRead

### DIFF
--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -4899,10 +4899,7 @@ class ServerRead(BaseModelWithConfigDict):
     enabled: bool
     url: Optional[str] = Field(
         None,
-        description=(
-            "Fully-qualified MCP endpoint URL for this virtual server, derived from APP_DOMAIN "
-            "(same base URL OAuth's redirect_uri default uses). None if APP_DOMAIN isn't a usable URL."
-        ),
+        description=("Fully-qualified MCP endpoint URL for this virtual server, derived from APP_DOMAIN (same base URL OAuth's redirect_uri default uses). None if APP_DOMAIN isn't a usable URL."),
     )
     associated_tools: List[str] = []
     associated_tool_ids: List[str] = []

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -4897,6 +4897,13 @@ class ServerRead(BaseModelWithConfigDict):
     updated_at: datetime
     # is_active: bool
     enabled: bool
+    url: Optional[str] = Field(
+        None,
+        description=(
+            "Fully-qualified MCP endpoint URL for this virtual server, derived from APP_DOMAIN "
+            "(same base URL OAuth's redirect_uri default uses). None if APP_DOMAIN isn't a usable URL."
+        ),
+    )
     associated_tools: List[str] = []
     associated_tool_ids: List[str] = []
     associated_resources: List[str] = []

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -4899,7 +4899,11 @@ class ServerRead(BaseModelWithConfigDict):
     enabled: bool
     url: Optional[str] = Field(
         None,
-        description=("Fully-qualified MCP endpoint URL for this virtual server, derived from APP_DOMAIN (same base URL OAuth's redirect_uri default uses). None if APP_DOMAIN isn't a usable URL."),
+        description=(
+            "Fully-qualified MCP endpoint URL for this virtual server, derived from APP_DOMAIN. "
+            "This value is also the RFC 8707 OAuth resource/audience identifier; keep its path format stable "
+            "and use a separate function for any future display-only path change. None if APP_DOMAIN isn't a usable URL."
+        ),
     )
     associated_tools: List[str] = []
     associated_tool_ids: List[str] = []

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -46,10 +46,10 @@ from mcpgateway.services.metrics_cleanup_service import delete_metrics_in_batche
 from mcpgateway.services.performance_tracker import get_performance_tracker
 from mcpgateway.services.structured_logger import get_structured_logger
 from mcpgateway.services.team_management_service import TeamManagementService
-from mcpgateway.transports.streamablehttp_transport import _build_server_resource_url
 from mcpgateway.utils.admin_check import is_admin_bypass_granted
 from mcpgateway.utils.metrics_common import build_top_performers
 from mcpgateway.utils.pagination import unified_paginate
+from mcpgateway.utils.server_urls import build_server_mcp_url
 from mcpgateway.utils.sqlalchemy_modifier import json_contains_tag_expr
 
 # ---------------------------------------------------------------------------
@@ -414,9 +414,9 @@ class ServerService(BaseService):
             "enabled": server.enabled,
             # Same APP_DOMAIN-derived base URL OAuth's redirect_uri default and
             # the RFC 8707/9728 resource URL already use — see
-            # _build_server_resource_url's docstring for why this must come
-            # from settings.app_domain rather than the request's Host header.
-            "url": _build_server_resource_url(scope=None, server_id=server.id) or None,
+            # build_server_mcp_url's docstring for why this must come from
+            # settings.app_domain rather than the request's Host header.
+            "url": build_server_mcp_url(server.id) or None,
             "created_at": server.created_at,
             "updated_at": server.updated_at,
             "team_id": server.team_id,

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -49,7 +49,7 @@ from mcpgateway.services.team_management_service import TeamManagementService
 from mcpgateway.utils.admin_check import is_admin_bypass_granted
 from mcpgateway.utils.metrics_common import build_top_performers
 from mcpgateway.utils.pagination import unified_paginate
-from mcpgateway.utils.server_urls import build_server_mcp_url
+from mcpgateway.utils.server_urls import build_server_display_url
 from mcpgateway.utils.sqlalchemy_modifier import json_contains_tag_expr
 
 # ---------------------------------------------------------------------------
@@ -413,10 +413,11 @@ class ServerService(BaseService):
             "icon": server.icon,
             "enabled": server.enabled,
             # Same APP_DOMAIN-derived base URL OAuth's redirect_uri default and
-            # the RFC 8707/9728 resource URL already use — see
-            # build_server_mcp_url's docstring for why this must come from
-            # settings.app_domain rather than the request's Host header.
-            "url": build_server_mcp_url(server.id) or None,
+            # the RFC 8707/9728 resource URL already use, plus APP_ROOT_PATH so
+            # the URL is actually reachable when the gateway is mounted under a
+            # subpath — see build_server_display_url's docstring for why this
+            # must come from settings rather than the request's Host header.
+            "url": build_server_display_url(server.id) or None,
             "created_at": server.created_at,
             "updated_at": server.updated_at,
             "team_id": server.team_id,

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -46,6 +46,7 @@ from mcpgateway.services.metrics_cleanup_service import delete_metrics_in_batche
 from mcpgateway.services.performance_tracker import get_performance_tracker
 from mcpgateway.services.structured_logger import get_structured_logger
 from mcpgateway.services.team_management_service import TeamManagementService
+from mcpgateway.transports.streamablehttp_transport import _build_server_resource_url
 from mcpgateway.utils.admin_check import is_admin_bypass_granted
 from mcpgateway.utils.metrics_common import build_top_performers
 from mcpgateway.utils.pagination import unified_paginate
@@ -411,6 +412,11 @@ class ServerService(BaseService):
             "description": server.description,
             "icon": server.icon,
             "enabled": server.enabled,
+            # Same APP_DOMAIN-derived base URL OAuth's redirect_uri default and
+            # the RFC 8707/9728 resource URL already use — see
+            # _build_server_resource_url's docstring for why this must come
+            # from settings.app_domain rather than the request's Host header.
+            "url": _build_server_resource_url(scope=None, server_id=server.id) or None,
             "created_at": server.created_at,
             "updated_at": server.updated_at,
             "team_id": server.team_id,

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -104,6 +104,7 @@ from mcpgateway.utils.internal_http import post_rpc_in_process
 from mcpgateway.utils.log_sanitizer import sanitize_for_log
 from mcpgateway.utils.orjson_response import ORJSONResponse
 from mcpgateway.utils.passthrough_headers import compute_passthrough_headers_cached
+from mcpgateway.utils.server_urls import build_server_mcp_url
 from mcpgateway.utils.trace_context import set_trace_context_from_teams, set_trace_session_id
 from mcpgateway.utils.verify_credentials import (
     _resolve_auth_header_name,
@@ -987,14 +988,7 @@ def _build_server_resource_url(scope: Scope, server_id: str) -> str:
         Fully-qualified resource URL string, or ``""`` if construction fails.
     """
     del scope  # intentionally ignored — see docstring
-    try:
-        raw = str(settings.app_domain).rstrip("/")
-    except (AttributeError, ValueError) as exc:
-        logger.warning("settings.app_domain is not a usable URL: %s: %s", type(exc).__name__, exc)
-        return ""
-    if not raw:
-        return ""
-    return f"{raw}/servers/{server_id}/mcp"
+    return build_server_mcp_url(server_id)
 
 
 def _build_resource_metadata_url(scope: Scope, server_id: str) -> str:

--- a/mcpgateway/utils/server_urls.py
+++ b/mcpgateway/utils/server_urls.py
@@ -26,6 +26,11 @@ logger = logging.getLogger(__name__)
 def build_server_mcp_url(server_id: str) -> str:
     """Construct the canonical, fully-qualified MCP endpoint URL for a virtual server.
 
+    This URL is also the RFC 8707 OAuth resource/audience identifier used for
+    token validation and persisted learned audiences. Keep its path format
+    stable; a future display-only path change must use a separate function so
+    existing OAuth tokens and persisted audiences remain valid.
+
     .. important::
         The base URL is derived from :data:`settings.app_domain`, **not** any
         inbound ``Host`` / ``X-Forwarded-Host`` header. Both are

--- a/mcpgateway/utils/server_urls.py
+++ b/mcpgateway/utils/server_urls.py
@@ -56,3 +56,38 @@ def build_server_mcp_url(server_id: str) -> str:
     if not raw:
         return ""
     return f"{raw}/servers/{server_id}/mcp"
+
+
+def build_server_display_url(server_id: str) -> str:
+    """Construct the human-facing, actually-reachable MCP endpoint URL for a virtual server.
+
+    :func:`build_server_mcp_url` deliberately omits ``settings.app_root_path``
+    because its output is also the RFC 8707/9728 OAuth resource/audience
+    identifier, whose path shape must stay stable for already-issued tokens
+    and persisted audiences. That omission makes it unusable as-is for
+    display purposes: when the gateway is reverse-proxied under a subpath
+    (``APP_ROOT_PATH=/gateway``), the URL a user is shown or copies into
+    their MCP client config must include that prefix to actually resolve.
+
+    Use this helper anywhere the URL is shown to a user or copied into
+    client config (e.g. ``ServerRead.url``); use
+    :func:`build_server_mcp_url` anywhere the value participates in OAuth
+    resource binding or audience validation.
+
+    Args:
+        server_id: Virtual-server identifier.
+
+    Returns:
+        Fully-qualified, reachable MCP endpoint URL string, or ``""`` if
+        ``settings.app_domain`` isn't a usable URL.
+    """
+    try:
+        raw = str(settings.app_domain).rstrip("/")
+    except (AttributeError, ValueError) as exc:
+        logger.warning("settings.app_domain is not a usable URL: %s: %s", type(exc).__name__, exc)
+        return ""
+    if not raw:
+        return ""
+    root_path = str(getattr(settings, "app_root_path", "") or "").strip("/")
+    base = f"{raw}/{root_path}" if root_path else raw
+    return f"{base}/servers/{server_id}/mcp"

--- a/mcpgateway/utils/server_urls.py
+++ b/mcpgateway/utils/server_urls.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/utils/server_urls.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+APP_DOMAIN-derived URL construction for virtual servers.
+
+Kept as a standalone leaf module (only mcpgateway.config as a dependency) so
+it can be imported from low-level modules like services/server_service.py
+without pulling in transports/streamablehttp_transport.py's own import graph,
+which reaches back into middleware/auth and would otherwise form a circular
+import (server_service -> streamablehttp_transport -> middleware.rbac ->
+middleware -> middleware.token_scoping -> auth -> ... -> services ->
+gateway_service -> server_service).
+"""
+
+# Standard
+import logging
+
+# First-Party
+from mcpgateway.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def build_server_mcp_url(server_id: str) -> str:
+    """Construct the canonical, fully-qualified MCP endpoint URL for a virtual server.
+
+    .. important::
+        The base URL is derived from :data:`settings.app_domain`, **not** any
+        inbound ``Host`` / ``X-Forwarded-Host`` header. Both are
+        caller-controlled (any client can send an arbitrary ``Host``; a
+        permissive proxy can forward one too), so trusting them here would
+        let a client spoof the URL a caller is told to use.
+        ``settings.app_domain`` is operator-set at deployment time and
+        therefore a safe trust anchor. Operators MUST set it to the gateway's
+        public URL for the returned URL to actually be reachable.
+
+    Args:
+        server_id: Virtual-server identifier.
+
+    Returns:
+        Fully-qualified MCP endpoint URL string, or ``""`` if
+        ``settings.app_domain`` isn't a usable URL.
+    """
+    try:
+        raw = str(settings.app_domain).rstrip("/")
+    except (AttributeError, ValueError) as exc:
+        logger.warning("settings.app_domain is not a usable URL: %s: %s", type(exc).__name__, exc)
+        return ""
+    if not raw:
+        return ""
+    return f"{raw}/servers/{server_id}/mcp"

--- a/tests/unit/mcpgateway/services/test_server_service.py
+++ b/tests/unit/mcpgateway/services/test_server_service.py
@@ -3846,11 +3846,22 @@ class TestConvertServerToReadUrl:
     def test_url_derived_from_app_domain(self, server_service, monkeypatch):
         """url is APP_DOMAIN + /servers/{id}/mcp, regardless of any request context."""
         monkeypatch.setattr(settings, "app_domain", "https://gateway.example.com")
+        monkeypatch.setattr(settings, "app_root_path", "")
         server = self._make_server(server_id="srv-42")
 
         result = server_service.convert_server_to_read(server, include_metrics=False)
 
         assert result.url == "https://gateway.example.com/servers/srv-42/mcp"
+
+    def test_url_includes_app_root_path(self, server_service, monkeypatch):
+        """url includes APP_ROOT_PATH so it's actually reachable when the gateway is mounted under a subpath."""
+        monkeypatch.setattr(settings, "app_domain", "https://gateway.example.com")
+        monkeypatch.setattr(settings, "app_root_path", "/gateway")
+        server = self._make_server(server_id="srv-42")
+
+        result = server_service.convert_server_to_read(server, include_metrics=False)
+
+        assert result.url == "https://gateway.example.com/gateway/servers/srv-42/mcp"
 
     def test_url_none_when_app_domain_unusable(self, server_service, monkeypatch):
         """url is None (not a broken string) when APP_DOMAIN can't be stringified."""

--- a/tests/unit/mcpgateway/services/test_server_service.py
+++ b/tests/unit/mcpgateway/services/test_server_service.py
@@ -3787,3 +3787,81 @@ class TestConvertServerToReadAssociatedToolIds:
             assert len(server_result.associated_prompts) == 1
             assert "prompt-1" in server_result.associated_prompts
             assert "prompt-2" not in server_result.associated_prompts
+
+
+# --------------------------------------------------------------------------- #
+#  convert_server_to_read: url                                                #
+# --------------------------------------------------------------------------- #
+
+
+class TestConvertServerToReadUrl:
+    """Verify url is derived from APP_DOMAIN in convert_server_to_read, not the caller's Host header.
+
+    mcp-context-forge#6632: the web UI previously built this URL client-side
+    from window.location.origin, which is wrong in any split deployment where
+    the web UI's own origin differs from the gateway's public APP_DOMAIN.
+    """
+
+    @pytest.fixture
+    def server_service(self):
+        return ServerService()
+
+    def _make_server(self, server_id="srv-1"):
+        # Standard
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            id=server_id,
+            name="test",
+            description="desc",
+            icon=None,
+            enabled=True,
+            created_at="2025-01-01T00:00:00",
+            updated_at="2025-01-01T00:00:00",
+            team_id=None,
+            team=None,
+            owner_email=None,
+            visibility="public",
+            created_by="admin",
+            modified_by=None,
+            tags=[],
+            tools=[],
+            resources=[],
+            prompts=[],
+            a2a_agents=[],
+            metrics=[],
+            oauth_enabled=False,
+            oauth_config=None,
+            created_from_ip=None,
+            created_via=None,
+            created_user_agent=None,
+            modified_from_ip=None,
+            modified_via=None,
+            modified_user_agent=None,
+            import_batch_id=None,
+            federation_source=None,
+            version=1,
+        )
+
+    def test_url_derived_from_app_domain(self, server_service, monkeypatch):
+        """url is APP_DOMAIN + /servers/{id}/mcp, regardless of any request context."""
+        monkeypatch.setattr(settings, "app_domain", "https://gateway.example.com")
+        server = self._make_server(server_id="srv-42")
+
+        result = server_service.convert_server_to_read(server, include_metrics=False)
+
+        assert result.url == "https://gateway.example.com/servers/srv-42/mcp"
+
+    def test_url_none_when_app_domain_unusable(self, server_service, monkeypatch):
+        """url is None (not a broken string) when APP_DOMAIN can't be stringified."""
+
+        class Exploding:
+            def __str__(self):
+                raise AttributeError("no __str__ for you")
+
+        monkeypatch.setattr(settings, "app_domain", Exploding())
+        server = self._make_server()
+
+        result = server_service.convert_server_to_read(server, include_metrics=False)
+
+        assert result.url is None


### PR DESCRIPTION
 Fixes [#6632](https://github.com/IBM/mcp-context-forge/issues/6632)

## Summary
`ServerRead` exposed no field indicating where a virtual server's MCP endpoint actually lives. contextforge-web-ui's `getVirtualServerEndpoint` was constructing that URL client-side from `window.location.origin` (`src/components/gateways/utils.ts`) — the same class of bug already fixed for OAuth's `redirect_uri` default (#6556): the web UI's own origin isn't necessarily where the gateway serves its endpoints in a split deployment, so the value shown to users (and copied into their MCP client config) can silently point at the wrong host.

  Flagged in review on contextforge-web-ui#101 and filed as #6632:
  > `getVirtualServerEndpoint` (`src/components/gateways/utils.ts:21-27`)
  > still builds the virtual server's MCP endpoint as
  > `${window.location.origin}/servers/{id}/mcp`, the same assumption
  > about who owns the origin that this PR removes from `redirect_uri`.

  ## Changes

  - **`mcpgateway/schemas.py`**: add `url: Optional[str]` to `ServerRead`.
  - **`mcpgateway/services/server_service.py`**: `convert_server_to_read` populates it via the existing `_build_server_resource_url` helper (`transports/streamablehttp_transport.py`) — the same `APP_DOMAIN`-derived base URL already used for RFC 8707/9728 resource binding — rather than adding a third copy of that computation. Falls back to `None` (not a broken empty string) if `APP_DOMAIN` isn't a usable URL.
  - Tests: `TestConvertServerToReadUrl` in `test_server_service.py` covers the happy path and the `APP_DOMAIN`-unusable fallback.

Once this lands, contextforge-web-ui can switch `getVirtualServerEndpoint` to use `server.url` instead of guessing from `window.location.origin`.

  ## Test plan

  - [x] `pytest tests/unit/mcpgateway/services/test_server_service.py tests/unit/mcpgateway/test_schemas.py` — 267 passed
  - [x] `pytest tests/unit/mcpgateway/test_auth.py -k BuildServerResourceUrl` — existing coverage for the reused helper still passes
  - [x] Module doctest (`convert_server_to_read`) passes
  - [x] `ruff check` on changed files — no new issues