### PR TITLE
Release/v1.0.10

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,9 +5,9 @@ tag = False
 sign-tags = True
 tag_name = v{new_version} # tag format (only used if you flip tag=True later)
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>BETA|RC)-(?P<build>\d+))?
-serialize = 
-	{major}.{minor}.{patch}-{release}-{build}
-	{major}.{minor}.{patch}
+serialize =
+    {major}.{minor}.{patch}-{release}-{build}
+    {major}.{minor}.{patch}
 
 [bumpversion:file:mcpgateway/__init__.py]
 search = __version__ = "{current_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,13 +1,13 @@
 [bumpversion]
-current_version = 1.0.9
+current_version = 1.0.10
 commit = False
 tag = False
 sign-tags = True
 tag_name = v{new_version} # tag format (only used if you flip tag=True later)
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>BETA|RC)-(?P<build>\d+))?
-serialize =
-    {major}.{minor}.{patch}-{release}-{build}
-    {major}.{minor}.{patch}
+serialize = 
+	{major}.{minor}.{patch}-{release}-{build}
+	{major}.{minor}.{patch}
 
 [bumpversion:file:mcpgateway/__init__.py]
 search = __version__ = "{current_version}"

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -81,6 +81,8 @@ jobs:
                   SSRF_PROTECTION_ENABLED: false
                   JWT_SECRET_KEY: ${{ env.DYNAMIC_JWT_SECRET }}
                   AUTH_ENCRYPTION_SECRET: ${{ env.DYNAMIC_ENC_SECRET }}
+                  PLATFORM_ADMIN_PASSWORD: "ci-test-admin-P@ssw0rd-DO-NOT-USE-IN-PRODUCTION"  # pragma: allowlist secret
+                  DEFAULT_USER_PASSWORD: "ci-test-user-P@ssw0rd-DO-NOT-USE-IN-PRODUCTION"  # pragma: allowlist secret
                   ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP: false
                   PASSWORD_CHANGE_ENFORCEMENT_ENABLED: false
               run: |

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -22,6 +22,8 @@ concurrency:
 env:
     CARGO_TERM_COLOR: always
     RUST_BACKTRACE: 1
+    PLATFORM_ADMIN_PASSWORD: "ci-test-admin-P@ssw0rd-DO-NOT-USE-IN-PRODUCTION"  # pragma: allowlist secret
+    DEFAULT_USER_PASSWORD: "ci-test-user-P@ssw0rd-DO-NOT-USE-IN-PRODUCTION"  # pragma: allowlist secret
 
 jobs:
     wrapper-e2e:
@@ -81,8 +83,6 @@ jobs:
                   SSRF_PROTECTION_ENABLED: false
                   JWT_SECRET_KEY: ${{ env.DYNAMIC_JWT_SECRET }}
                   AUTH_ENCRYPTION_SECRET: ${{ env.DYNAMIC_ENC_SECRET }}
-                  PLATFORM_ADMIN_PASSWORD: "ci-test-admin-P@ssw0rd-DO-NOT-USE-IN-PRODUCTION"  # pragma: allowlist secret
-                  DEFAULT_USER_PASSWORD: "ci-test-user-P@ssw0rd-DO-NOT-USE-IN-PRODUCTION"  # pragma: allowlist secret
                   ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP: false
                   PASSWORD_CHANGE_ENFORCEMENT_ENABLED: false
               run: |

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
+    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-07T12:25:21Z",
+  "generated_at": "2026-09-07T15:50:12Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -234,7 +234,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2228,
+        "line_number": 2276,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -242,7 +242,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2316,
+        "line_number": 2364,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -250,7 +250,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2666,
+        "line_number": 2714,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -258,28 +258,12 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4031,
+        "line_number": 4079,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
       {
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4122,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4165,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
         "line_number": 4170,
@@ -287,10 +271,26 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4213,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4218,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4175,
+        "line_number": 4223,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-04T17:17:01Z",
+  "generated_at": "2026-09-07T12:21:36Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -182,7 +182,7 @@
         "hashed_secret": "5546721ffdfc2e5b0e4c0da38f10774f9ad50b09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 246,
+        "line_number": 248,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-07T12:21:36Z",
+  "generated_at": "2026-09-07T12:25:21Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,57 @@
 
 ## [Unreleased]
 
+## [1.0.10] - 2026-09-07 - OAuth Security, Observability, Plugin Context, and Reliability
+
+### Overview
+
+Release 1.0.10 consolidates **10 PRs** focused on **OAuth security and reliability**, **observability and session-affinity performance**, **plugin context propagation**, **Vault support for A2A agents**, **team management reliability**, and **dependency security**:
+
+- **Security & Auth** - Rejects default passwords when authentication features are enabled, adds a strict post-OAuth redirect allowlist, and fixes cached team-membership checks during gateway OAuth authorization.
+- **Gateway & Plugins** - Preserves plugin context across MCP tool, prompt, and resource hooks; supports Vault token injection for A2A agents exposed as MCP tools; and uses the configured public application domain for Vault OAuth callbacks.
+- **Observability & Performance** - Adds affinity-path tracing, W3C trace propagation, optional Redis/HTTPX/SQLAlchemy instrumentation, and bounded concurrent affinity forwarding while preserving per-session ordering.
+- **Reliability & Tooling** - Returns clear client errors for duplicate active team names, centralizes interrogate configuration, and refreshes Python and Node.js dependencies with security updates.
+
+### Added
+
+#### **Security & OAuth**
+
+- **Post-OAuth redirect allowlist** ([#6411](https://github.com/IBM/mcp-context-forge/pull/6411)) - Added optional `redirect_uri_after_oauth` gateway configuration for returning users to an external application after Authorization Code OAuth. Redirects require an exact HTTPS origin configured by `OAUTH_REDIRECT_ALLOWED_ORIGIN` and are validated at configuration and callback time.
+
+#### **Observability & Performance**
+
+- **Affinity-path tracing and concurrent forwarding** ([#6164](https://github.com/IBM/mcp-context-forge/pull/6164)) - Added affinity-path spans, W3C trace propagation across affinity hops, optional Redis/HTTPX/SQLAlchemy auto-instrumentation, and bounded concurrent forwarding while preserving per-session FIFO ordering and timeout fallback.
+
+#### **Plugins**
+
+- **Vault support for A2A agents exposed as MCP tools** ([#6395](https://github.com/IBM/mcp-context-forge/pull/6395)) - Vault plugin now detects A2A-backed MCP tools, injects matching bearer tokens for tagged agents, and strips `X-Vault-Tokens` headers from forwarded requests.
+
 ### Breaking Changes
 
-- **Enabled authentication rejects default passwords** - When Basic Auth or email authentication is enabled, empty, placeholder, and known-weak password values now fail startup. Set `BASIC_AUTH_PASSWORD` for `API_ALLOW_BASIC_AUTH=true` or `DOCS_ALLOW_BASIC_AUTH=true`; set `PLATFORM_ADMIN_PASSWORD` and `DEFAULT_USER_PASSWORD` for `EMAIL_AUTH_ENABLED=true`. Existing deployments must run `make init-secrets-patch-env` or update their deployment Secret before restarting. See the [migration guide](docs/docs/operations/default-password-fail-closed-migration.md).
+- **Enabled authentication rejects default passwords** ([#6570](https://github.com/IBM/mcp-context-forge/pull/6570)) - When Basic Auth or email authentication is enabled, empty, placeholder, and known-weak password values now fail startup. Set `BASIC_AUTH_PASSWORD` for `API_ALLOW_BASIC_AUTH=true` or `DOCS_ALLOW_BASIC_AUTH=true`; set `PLATFORM_ADMIN_PASSWORD` and `DEFAULT_USER_PASSWORD` for `EMAIL_AUTH_ENABLED=true`. Existing deployments must run `make init-secrets-patch-env` or update their deployment Secret before restarting. See the [migration guide](../docs/docs/operations/default-password-fail-closed-migration.md).
+
+### Fixed
+
+#### **OAuth & Gateway Access**
+
+- **Team gateway OAuth access with cached users** ([#6589](https://github.com/IBM/mcp-context-forge/pull/6589)) - Gateway OAuth authorization now checks team membership through `TeamManagementService`, avoiding false `403` responses caused by detached cached user records.
+- **Vault OAuth callback origin behind reverse proxies** ([#6556](https://github.com/IBM/mcp-context-forge/pull/6556)) - Vault authorization now builds its callback URI from `APP_DOMAIN` instead of the internal request origin, preventing identity providers from rejecting redirects behind ingress proxies.
+
+#### **MCP Transport & Plugins**
+
+- **Plugin context propagation over `/mcp`** ([#6140](https://github.com/IBM/mcp-context-forge/pull/6140)) - Streamable HTTP tool calls, prompt fetches, and resource reads now receive context created by `HTTP_PRE_REQUEST`, preserving cross-hook plugin state on the MCP transport.
+
+#### **Teams & API Reliability**
+
+- **Active team name collision handling** ([#6558](https://github.com/IBM/mcp-context-forge/pull/6558)) - Duplicate active team names now return controlled client errors instead of an internal server error. Platform administrators receive a specific `400`; other callers receive a non-disclosing `409`, including during concurrent insert races.
+
+### Chores
+
+| PR | Description |
+|----|-------------|
+| [#6530](https://github.com/IBM/mcp-context-forge/pull/6530) | remove pre-commit interrogate arguments so checks use the shared `pyproject.toml` configuration |
+| [#6658](https://github.com/IBM/mcp-context-forge/pull/6658) | update Python and Node.js dependencies, rebuild the Admin UI bundle, and bump `fast-uri` to address four high-severity advisories |
+
 
 ## [1.0.9] - 2026-08-31 - mTLS, OAuth Quick Wins, Tool Preview, Catalog Actions, and Security Hardening
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "contextforge_mcp_runtime"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "async-stream",
  "axum",
@@ -1393,7 +1393,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp_stdio_wrapper"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "actson",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "1.0.9"
+version = "1.0.10"
 edition = "2024"
 rust-version = "1.85"
 authors = ["ContextForge Contributors"]

--- a/Containerfile
+++ b/Containerfile
@@ -373,7 +373,7 @@ LABEL maintainer="Mihai Criveti" \
     org.opencontainers.image.title="mcp/mcpgateway" \
     org.opencontainers.image.description="ContextForge: An enterprise-ready Model Context Protocol Gateway" \
     org.opencontainers.image.licenses="Apache-2.0" \
-    org.opencontainers.image.version="1.0.9"
+    org.opencontainers.image.version="1.0.10"
 
 # ----------------------------------------------------------------------------
 # Install minimal runtime dependencies

--- a/Containerfile
+++ b/Containerfile
@@ -45,9 +45,9 @@ ARG ENABLE_PROFILING=false
 #     --build-arg NODEJS_IMAGE=<internal-registry>/ubi9/nodejs-20:latest \
 #     --build-arg UBI_MINIMAL=<internal-registry>/ubi9/ubi-minimal:latest \
 #     .
-ARG UBI_BASE=registry.access.redhat.com/ubi10:10.2-1787684095
-ARG NODEJS_IMAGE=registry.access.redhat.com/ubi10/nodejs-24:10.2-1787666083
-ARG UBI_MINIMAL=registry.access.redhat.com/ubi10/ubi-minimal:10.2-1787688243
+ARG UBI_BASE=registry.access.redhat.com/ubi10:10.2-1788218897
+ARG NODEJS_IMAGE=registry.access.redhat.com/ubi10/nodejs-24:10.2-1788329637
+ARG UBI_MINIMAL=registry.access.redhat.com/ubi10/ubi-minimal:10.2-1788137716
 # Wheel closure stage — used only for s390x and ppc64le where PyPI manylinux
 # binary wheels are unavailable (tiktoken/psycopg/cryptography require native
 # compilation, and psycopg-binary has no s390x wheel at all).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # 🔐 Security Policy
 
-**Current Version: 1.0.9**
+**Current Version: 1.0.10**
 
 
 ### Admin UI is Development-Only

--- a/charts/mcp-stack/Chart.yaml
+++ b/charts/mcp-stack/Chart.yaml
@@ -22,8 +22,8 @@ type: application
 # * appVersion   - upstream application version; shown in UIs but not
 #                  used for upgrade logic.
 # --------------------------------------------------------------------
-version: 1.0.9
-appVersion: "1.0.9"
+version: 1.0.10
+appVersion: "1.0.10"
 
 # Icon shown by registries / dashboards (must be an http(s) URL).
 icon: https://ibm.github.io/mcp-context-forge/images/contextforge-icon_black.svg

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -85,7 +85,7 @@ mcpContextForge:
 
   image:
     repository: ghcr.io/ibm/mcp-context-forge
-    tag: "v1.0.9"                # PRODUCTION: pin a specific immutable tag (e.g. "v1.0.0")
+    tag: "v1.0.10"                # PRODUCTION: pin a specific immutable tag (e.g. "v1.0.0")
     pullPolicy: Always          # Always pull to ensure latest security patches
 
   # Service that fronts the gateway
@@ -1062,7 +1062,7 @@ migration:
   # Use same image as mcpgateway
   image:
     repository: ghcr.io/ibm/mcp-context-forge
-    tag: "v1.0.9"                            # Should match mcpContextForge.image.tag
+    tag: "v1.0.10"                            # Should match mcpContextForge.image.tag
     pullPolicy: Always                      # Always pull to ensure latest security patches
 
   # Resource limits for the migration job

--- a/infra/nginx/Dockerfile
+++ b/infra/nginx/Dockerfile
@@ -1,7 +1,7 @@
 # High-Performance Nginx Caching Proxy for ContextForge
 # Based on Red Hat UBI 10.1 Minimal for consistency with gateway container
 
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2-1784581369
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2-1788137716
 
 # Install nginx and curl (for healthchecks)
 RUN microdnf install -y \

--- a/infra/wheels/Containerfile
+++ b/infra/wheels/Containerfile
@@ -17,7 +17,7 @@
 #   docker buildx build --platform linux/ppc64le -t wheels:ppc64le -f infra/wheels/Containerfile .
 ###############################################################################
 
-ARG UBI_MINIMAL=registry.access.redhat.com/ubi10/ubi-minimal:10.2-1786928543
+ARG UBI_MINIMAL=registry.access.redhat.com/ubi10/ubi-minimal:10.2-1788137716
 FROM ${UBI_MINIMAL}
 
 ARG PYTHON_VERSION=3.12

--- a/mcpgateway/__init__.py
+++ b/mcpgateway/__init__.py
@@ -9,7 +9,7 @@ ContextForge - A flexible feature-rich FastAPI-based gateway for the Model Conte
 __author__ = "Mihai Criveti"
 __copyright__ = "Copyright 2025"
 __license__ = "Apache 2.0"
-__version__ = "1.0.9"
+__version__ = "1.0.10"
 __description__ = "IBM Consulting Assistants - Extensions API Library"
 __url__ = "https://ibm.github.io/mcp-context-forge/"
 __download_url__ = "https://github.com/IBM/mcp-context-forge"

--- a/plugins/external/cedar/pyproject.toml
+++ b/plugins/external/cedar/pyproject.toml
@@ -45,7 +45,7 @@ authors = [
 dependencies = [
     "cedarpy>=4.8.7",
     "mcp>=1.28.1,<2",
-    "mcp-contextforge-gateway>=1.0.9",
+    "mcp-contextforge-gateway>=1.0.10",
 ]
 
 # URLs

--- a/plugins/external/opa/pyproject.toml
+++ b/plugins/external/opa/pyproject.toml
@@ -45,7 +45,7 @@ authors = [
 dependencies = [
     "httpx>=0.28.1",
     "mcp>=1.28.1,<2",
-    "mcp-contextforge-gateway>=1.0.9",
+    "mcp-contextforge-gateway>=1.0.10",
 ]
 
 # URLs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ cpex-sql-sanitizer = "2026-09-07T23:59:59Z"
 # ----------------------------------------------------------------
 [project]
 name = "mcp-contextforge-gateway"
-version = "1.0.9"
+version = "1.0.10"
 description = "ContextForge AI Gateway — an AI gateway, registry, and proxy for MCP, A2A, and REST/gRPC APIs. Exposes a unified control plane with centralized governance, discovery, and observability. Optimizes agent and tool calling, and supports plugins."
 keywords = ["MCP","API","gateway","proxy","tools",
   "agents","agentic ai","model context protocol","multi-agent","fastapi",
@@ -287,11 +287,11 @@ grpc = [
 
 # Convenience meta-extras
 all = [
-    "mcp-contextforge-gateway[redis]>=1.0.9",
+    "mcp-contextforge-gateway[redis]>=1.0.10",
 ]
 
 dev-all = [
-    "mcp-contextforge-gateway[redis,dev,plugins]>=1.0.9",
+    "mcp-contextforge-gateway[redis,dev,plugins]>=1.0.10",
 ]
 
 # --------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -2574,7 +2574,7 @@ wheels = [
 
 [[package]]
 name = "mcp-contextforge-gateway"
-version = "1.0.9"
+version = "1.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -2808,8 +2808,8 @@ requires-dist = [
     { name = "langsmith", marker = "extra == 'llmchat'", specifier = ">=0.10.10" },
     { name = "mako", specifier = ">=1.4.1" },
     { name = "mcp", specifier = ">=1.28.1,<2" },
-    { name = "mcp-contextforge-gateway", extras = ["redis"], marker = "extra == 'all'", specifier = ">=1.0.9" },
-    { name = "mcp-contextforge-gateway", extras = ["redis", "dev", "plugins"], marker = "extra == 'dev-all'", specifier = ">=1.0.9" },
+    { name = "mcp-contextforge-gateway", extras = ["redis"], marker = "extra == 'all'", specifier = ">=1.0.10" },
+    { name = "mcp-contextforge-gateway", extras = ["redis", "dev", "plugins"], marker = "extra == 'dev-all'", specifier = ">=1.0.10" },
     { name = "memray", marker = "extra == 'profiling'", specifier = ">=1.19.3" },
     { name = "msgpack", specifier = ">=1.2.1" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.44.0" },


### PR DESCRIPTION
## [1.0.10] - 2026-09-07 - OAuth Security, Observability, Plugin Context, and Reliability

### Overview

Release 1.0.10 consolidates **10 PRs** focused on **OAuth security and reliability**, **observability and session-affinity performance**, **plugin context propagation**, **Vault support for A2A agents**, **team management reliability**, and **dependency security**:

- **Security & Auth** - Rejects default passwords when authentication features are enabled, adds a strict post-OAuth redirect allowlist, and fixes cached team-membership checks during gateway OAuth authorization.
- **Gateway & Plugins** - Preserves plugin context across MCP tool, prompt, and resource hooks; supports Vault token injection for A2A agents exposed as MCP tools; and uses the configured public application domain for Vault OAuth callbacks.
- **Observability & Performance** - Adds affinity-path tracing, W3C trace propagation, optional Redis/HTTPX/SQLAlchemy instrumentation, and bounded concurrent affinity forwarding while preserving per-session ordering.
- **Reliability & Tooling** - Returns clear client errors for duplicate active team names, centralizes interrogate configuration, and refreshes Python and Node.js dependencies with security updates.

### Added

#### **Security & OAuth**

- **Post-OAuth redirect allowlist** ([#6411](https://github.com/IBM/mcp-context-forge/pull/6411)) - Added optional `redirect_uri_after_oauth` gateway configuration for returning users to an external application after Authorization Code OAuth. Redirects require an exact HTTPS origin configured by `OAUTH_REDIRECT_ALLOWED_ORIGIN` and are validated at configuration and callback time.

#### **Observability & Performance**

- **Affinity-path tracing and concurrent forwarding** ([#6164](https://github.com/IBM/mcp-context-forge/pull/6164)) - Added affinity-path spans, W3C trace propagation across affinity hops, optional Redis/HTTPX/SQLAlchemy auto-instrumentation, and bounded concurrent forwarding while preserving per-session FIFO ordering and timeout fallback.

#### **Plugins**

- **Vault support for A2A agents exposed as MCP tools** ([#6395](https://github.com/IBM/mcp-context-forge/pull/6395)) - Vault plugin now detects A2A-backed MCP tools, injects matching bearer tokens for tagged agents, and strips `X-Vault-Tokens` headers from forwarded requests.

### Breaking Changes

- **Enabled authentication rejects default passwords** ([#6570](https://github.com/IBM/mcp-context-forge/pull/6570)) - When Basic Auth or email authentication is enabled, empty, placeholder, and known-weak password values now fail startup. Set `BASIC_AUTH_PASSWORD` for `API_ALLOW_BASIC_AUTH=true` or `DOCS_ALLOW_BASIC_AUTH=true`; set `PLATFORM_ADMIN_PASSWORD` and `DEFAULT_USER_PASSWORD` for `EMAIL_AUTH_ENABLED=true`. Existing deployments must run `make init-secrets-patch-env` or update their deployment Secret before restarting. See the [migration guide](../docs/docs/operations/default-password-fail-closed-migration.md).

### Fixed

#### **OAuth & Gateway Access**

- **Team gateway OAuth access with cached users** ([#6589](https://github.com/IBM/mcp-context-forge/pull/6589)) - Gateway OAuth authorization now checks team membership through `TeamManagementService`, avoiding false `403` responses caused by detached cached user records.
- **Vault OAuth callback origin behind reverse proxies** ([#6556](https://github.com/IBM/mcp-context-forge/pull/6556)) - Vault authorization now builds its callback URI from `APP_DOMAIN` instead of the internal request origin, preventing identity providers from rejecting redirects behind ingress proxies.

#### **MCP Transport & Plugins**

- **Plugin context propagation over `/mcp`** ([#6140](https://github.com/IBM/mcp-context-forge/pull/6140)) - Streamable HTTP tool calls, prompt fetches, and resource reads now receive context created by `HTTP_PRE_REQUEST`, preserving cross-hook plugin state on the MCP transport.

#### **Teams & API Reliability**

- **Active team name collision handling** ([#6558](https://github.com/IBM/mcp-context-forge/pull/6558)) - Duplicate active team names now return controlled client errors instead of an internal server error. Platform administrators receive a specific `400`; other callers receive a non-disclosing `409`, including during concurrent insert races.

### Chores

| PR | Description |
|----|-------------|
| [#6530](https://github.com/IBM/mcp-context-forge/pull/6530) | remove pre-commit interrogate arguments so checks use the shared `pyproject.toml` configuration |
| [#6658](https://github.com/IBM/mcp-context-forge/pull/6658) | update Python and Node.js dependencies, rebuild the Admin UI bundle, and bump `fast-uri` to address four high-severity advisories |
