### PR TITLE
chore: bump CPEX plugin versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,13 +267,13 @@ templating = [
 # External plugin packages (optional)
 # Install with: pip install mcp-contextforge-gateway[plugins]
 plugins = [
-    "cpex-encoded-exfil-detection>=0.3.6", # 0.3.6 is the first release that emits result.metadata
-    "cpex-pii-filter>=0.3.6", # 0.3.6 is the first release that emits result.metadata on tool_post_invoke
-    "cpex-rate-limiter>=0.1.7", # 0.1.7 is the first release that emits result.metadata
-    "cpex-retry-with-backoff>=0.3.7", # 0.3.7 fixes a retry-detection regression against the gateway's CopyOnWriteDict payload isolation (IBM/cpex-plugins#124); 0.3.6 added the result.metadata emission but never actually retried in the gateway. Prior <0.3.2 CI pin (from #5332) is superseded.
-    "cpex-secrets-detection>=0.3.10", # 0.3.10 preserves secret field names during redaction; 0.3.9 adds field filters; 0.3.7 first emits result.metadata
-    "cpex-sql-sanitizer>=0.1.0", # Rust-backed SQL sanitizer; 0.1.0 is the only release
-    "cpex-url-reputation>=0.3.5", # 0.3.5 is the first release that emits result.metadata
+    "cpex-encoded-exfil-detection>=0.3.8", # 0.3.6 is the first release that emits result.metadata
+    "cpex-pii-filter>=0.3.8", # 0.3.6 is the first release that emits result.metadata on tool_post_invoke
+    "cpex-rate-limiter>=0.1.9", # 0.1.7 is the first release that emits result.metadata
+    "cpex-retry-with-backoff>=0.3.9", # 0.3.7 fixes a retry-detection regression against the gateway's CopyOnWriteDict payload isolation (IBM/cpex-plugins#124); 0.3.6 added the result.metadata emission but never actually retried in the gateway. Prior <0.3.2 CI pin (from #5332) is superseded.
+    "cpex-secrets-detection>=0.3.12", # 0.3.10 preserves secret field names during redaction; 0.3.9 adds field filters; 0.3.7 first emits result.metadata
+    "cpex-sql-sanitizer>=0.1.2", # Rust-backed SQL sanitizer
+    "cpex-url-reputation>=0.3.7", # 0.3.5 is the first release that emits result.metadata
 ]
 
 # gRPC Support (EXPERIMENTAL - optional, disabled by default)


### PR DESCRIPTION
## Summary

- bump the optional CPEX plugin dependencies to the versions released from IBM/cpex-plugins#177
- target the existing dependency refresh branch from #6658

## Dependency

The PyPI registry is still propagating the new Rust-backed plugin releases. Regenerate `uv.lock` with the targeted `uv lock --upgrade-package` command once all seven versions are visible.