### PR TITLE
feat: publish built-in plugin configuration to dataplane

### DIFF
--- a/.github/workflows/plugin-integration.yml
+++ b/.github/workflows/plugin-integration.yml
@@ -322,7 +322,7 @@ jobs:
         name: Plugin Integration Complete
         runs-on: ubuntu-latest
         needs: [plugin-e2e]
-        if: always()
+        if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft)
         steps:
             - name: Verify all plugin E2E legs succeeded
               run: |

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-08T13:25:07Z",
+  "generated_at": "2026-09-08T15:11:02Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1956,7 +1956,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 493,
+        "line_number": 496,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1964,7 +1964,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 936,
+        "line_number": 939,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1972,7 +1972,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1413,
+        "line_number": 1416,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1980,7 +1980,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1445,
+        "line_number": 1448,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -1988,7 +1988,7 @@
         "hashed_secret": "424ca52f87120d5dd4475b0b4aaed10adc379fb9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1449,
+        "line_number": 1452,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -262,12 +262,15 @@ For detailed guidance on embedding and section customization, see [Admin UI Cust
 
 | Setting                                  | Description                                           | Default | Options |
 | ---------------------------------------- | ----------------------------------------------------- | ------- | ------- |
-| `DATAPLANE_PUBLISHER`                    | Publish gateway configuration for the Rust dataplane  | `false` | bool    |
+| `DATAPLANE_PUBLISHER`                    | Publish routing and resolved plugin configuration for the Rust dataplane | `false` | bool    |
 | `DATAPLANE_PUBLISHER_INTERVAL_SECONDS`   | Interval between configuration snapshots, in seconds | `60`    | int ≥ 1 |
 
 User configuration keys expire after twice the configured snapshot interval plus 10 seconds. Shorter intervals can reduce
 convergence time in test environments; production deployments should retain the default unless their Redis and database
 capacity has been sized for more frequent snapshots.
+
+Published plugin configuration can include API keys and other credentials. Restrict access to the publisher's Redis
+instance to trusted gateway and dataplane components.
 
 ### Direct Proxy Mode
 

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -27,6 +27,7 @@ from typing import Any, Callable, Optional
 # Third-Party
 from cpex.framework import ConfigLoader, HookPayloadPolicy, ObservabilityProvider, OnError, PluginMode, TenantPluginManager
 from cpex.framework.models import Config
+from cpex.framework.settings import settings as plugin_settings
 from pydantic import BaseModel, ValidationError
 from sqlalchemy.orm import Session
 
@@ -126,6 +127,28 @@ class TenantPluginManagerFactory:
             return []
         return [plugin.name for plugin in self._base_config.plugins]
 
+    @property
+    def runtime_settings(self) -> dict[str, Any]:
+        """Return the execution settings used by this factory's managers."""
+        return {
+            "plugin_timeout": self._timeout,
+            "fail_on_plugin_error": plugin_settings.fail_on_plugin_error,
+            "execution_pool": plugin_settings.execution_pool,
+            "default_hook_policy": plugin_settings.default_hook_policy,
+            "hook_policies": {hook: {"writable_fields": sorted(policy.writable_fields)} for hook, policy in (self._hook_policies or {}).items()},
+        }
+
+    async def get_config(self, context_id: str = "__global__") -> Config:
+        """Resolve current overrides without constructing or executing plugins.
+
+        Both manager construction and dataplane publication use this resolver.
+        The base YAML stays loaded until factory reinitialization, while DB and
+        runtime mode overrides are reread on each resolution.
+        """
+        overrides = await self.get_config_from_db(context_id)
+        config = self._merge_tenant_config(overrides)
+        return await self._apply_redis_mode_overrides(config)
+
     async def get_manager(self, context_id: Optional[str] = None) -> TenantPluginManager:
         """Get or create a TenantPluginManager for the given context."""
         context_id = context_id or "__global__"
@@ -167,9 +190,7 @@ class TenantPluginManagerFactory:
         """Create, initialise, and cache a new manager for *context_id*."""
         manager = None
         try:
-            new_config = await self.get_config_from_db(context_id)
-            config = self._merge_tenant_config(new_config)
-            config = await self._apply_redis_mode_overrides(config)
+            config = await self.get_config(context_id)
 
             manager = TenantPluginManager(
                 config=config,
@@ -236,7 +257,7 @@ class TenantPluginManagerFactory:
 
         return self._base_config.model_copy(update={"plugins": merged_plugins}, deep=True)
 
-    async def _apply_redis_mode_overrides(self, config: Any) -> Any:
+    async def _apply_redis_mode_overrides(self, config: Config) -> Config:
         """Apply per-plugin mode overrides. Redis is authoritative; the in-process map is the fallback."""
         if not config.plugins:
             return config

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -27,7 +27,6 @@ from typing import Any, Callable, Optional
 # Third-Party
 from cpex.framework import ConfigLoader, HookPayloadPolicy, ObservabilityProvider, OnError, PluginMode, TenantPluginManager
 from cpex.framework.models import Config
-from cpex.framework.settings import settings as plugin_settings
 from pydantic import BaseModel, ValidationError
 from sqlalchemy.orm import Session
 
@@ -127,28 +126,6 @@ class TenantPluginManagerFactory:
             return []
         return [plugin.name for plugin in self._base_config.plugins]
 
-    @property
-    def runtime_settings(self) -> dict[str, Any]:
-        """Return the execution settings used by this factory's managers."""
-        return {
-            "plugin_timeout": self._timeout,
-            "fail_on_plugin_error": plugin_settings.fail_on_plugin_error,
-            "execution_pool": plugin_settings.execution_pool,
-            "default_hook_policy": plugin_settings.default_hook_policy,
-            "hook_policies": {hook: {"writable_fields": sorted(policy.writable_fields)} for hook, policy in (self._hook_policies or {}).items()},
-        }
-
-    async def get_config(self, context_id: str = "__global__") -> Config:
-        """Resolve current overrides without constructing or executing plugins.
-
-        Both manager construction and dataplane publication use this resolver.
-        The base YAML stays loaded until factory reinitialization, while DB and
-        runtime mode overrides are reread on each resolution.
-        """
-        overrides = await self.get_config_from_db(context_id)
-        config = self._merge_tenant_config(overrides)
-        return await self._apply_redis_mode_overrides(config)
-
     async def get_manager(self, context_id: Optional[str] = None) -> TenantPluginManager:
         """Get or create a TenantPluginManager for the given context."""
         context_id = context_id or "__global__"
@@ -190,7 +167,9 @@ class TenantPluginManagerFactory:
         """Create, initialise, and cache a new manager for *context_id*."""
         manager = None
         try:
-            config = await self.get_config(context_id)
+            new_config = await self.get_config_from_db(context_id)
+            config = self._merge_tenant_config(new_config)
+            config = await self._apply_redis_mode_overrides(config)
 
             manager = TenantPluginManager(
                 config=config,
@@ -257,7 +236,7 @@ class TenantPluginManagerFactory:
 
         return self._base_config.model_copy(update={"plugins": merged_plugins}, deep=True)
 
-    async def _apply_redis_mode_overrides(self, config: Config) -> Config:
+    async def _apply_redis_mode_overrides(self, config: Any) -> Any:
         """Apply per-plugin mode overrides. Redis is authoritative; the in-process map is the fallback."""
         if not config.plugins:
             return config

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -19,6 +19,7 @@ from typing import Any, TypedDict
 
 # Third-Party
 from cpex.framework.models import Config
+from cpex.framework.settings import settings as plugin_settings
 import msgpack
 from sqlalchemy import select
 
@@ -63,12 +64,14 @@ def get_publisher_ttl(publisher_interval: int | None = None) -> int:
     return publisher_interval * 2 + 10
 
 
-def _serialize_plugin_config(config: Config) -> dict[str, Any]:
+def _serialize_plugin_config(config: Config | None) -> dict[str, Any]:
     """Serialize the native contract with stable ordering for condition sets.
 
     The runtime fingerprints config bytes. Worker-specific set iteration order
     must not trigger a reload when the effective policy has not changed.
     """
+    if config is None:
+        raise ValueError("Cannot publish a plugin manager without configuration")
     document = config.model_dump(mode="json")
     for plugin, serialized in zip(config.plugins or [], document["plugins"] or []):
         for condition, serialized_condition in zip(plugin.conditions, serialized["conditions"]):
@@ -219,12 +222,18 @@ class DataplanePublisherService:
         if factory is None:
             raise RuntimeError("Cannot publish enabled plugins without an initialized plugin manager factory")
 
+        manager = await factory.get_manager()
+        executor = manager.executor
         document["settings"] = {
-            **factory.runtime_settings,
+            "plugin_timeout": executor.timeout,
+            "fail_on_plugin_error": plugin_settings.fail_on_plugin_error,
+            "execution_pool": plugin_settings.execution_pool,
+            "default_hook_policy": executor.default_hook_policy.value,
+            "hook_policies": {hook: {"writable_fields": sorted(policy.writable_fields)} for hook, policy in executor.hook_policies.items()},
             "plugins_can_override_rbac": settings.plugins_can_override_rbac,
             "plugins_can_override_auth_headers": settings.plugins_can_override_auth_headers,
         }
-        document["global"] = _serialize_plugin_config(await factory.get_config())
+        document["global"] = _serialize_plugin_config(manager.config)
         context_ids = {
             context["context_id"]
             for config in payload.values()
@@ -235,7 +244,7 @@ class DataplanePublisherService:
         if "" in context_ids:
             raise ValueError("Published tool is missing its plugin policy context")
         for context_id in sorted(context_ids):
-            document["contexts"][context_id] = _serialize_plugin_config(await factory.get_config(context_id))
+            document["contexts"][context_id] = _serialize_plugin_config((await factory.get_manager(context_id)).config)
         return document
 
     async def publish_to_redis(self) -> None:

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -125,7 +125,6 @@ class UserConfig(TypedDict):
     """User-specific configuration mapping virtual host IDs to their configs."""
 
     virtual_hosts: dict[str, VirtualHostConfig]
-    user_email: str
 
 
 class BackendItems(TypedDict):
@@ -395,7 +394,7 @@ class DataplanePublisherService:
 
                 virtual_hosts[server["id"]] = {"backends": backends}
 
-            result[subject_key] = {"virtual_hosts": virtual_hosts, "user_email": user_data["user_email"]}
+            result[subject_key] = {"virtual_hosts": virtual_hosts}
 
         return result
 
@@ -501,7 +500,6 @@ class DataplanePublisherService:
             }
 
         return {
-            "user_email": user_email,
             "servers": [
                 {
                     "id": server.id,

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -444,6 +444,7 @@ class DataplanePublisherService:
                         DbResource.uri_template.is_(None),
                     )
                 ).all()
+                # DbTool.name emits the same SQL, but mypy treats the hybrid property as an overloaded function.
                 tool_rows = db.execute(
                     select(DbTool.id, DbTool.__table__.c.name, DbTool.original_name, DbTool.input_schema, DbTool.owner_email, DbTool.team_id, DbTool.visibility).where(DbTool.enabled.is_(True))
                 ).all()

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -18,6 +18,7 @@ import socket
 from typing import Any, TypedDict
 
 # Third-Party
+from cpex.framework.models import Config
 import msgpack
 from sqlalchemy import select
 
@@ -38,12 +39,19 @@ from mcpgateway.db import Prompt as DbPrompt
 from mcpgateway.db import Resource as DbResource
 from mcpgateway.db import Server as DbServer
 from mcpgateway.db import Tool as DbTool
+from mcpgateway.plugins import are_plugins_enabled_shared, get_plugin_manager_factory
+from mcpgateway.plugins.gateway_plugin_manager import make_context_id
 from mcpgateway.utils.redis_client import get_redis_client
 
 logger = logging.getLogger(__name__)
 
 USER_CONFIG_KEY = "UserConfig"
 PUBLISHER_LOCK_KEY = "mcpgw:dataplane_publisher:lock"
+# Reuse the external dataplane's runtime-config key. Version 2 carries the
+# built-in contract: version 1 readers must reject it rather than ignore scope,
+# conditions, capabilities or gateway execution settings they cannot enforce.
+RUNTIME_PLUGIN_CONFIG_KEY = "ContextForgeGatewayRuntimePluginConfig"
+RUNTIME_PLUGIN_CONFIG_VERSION = 2
 
 
 def get_publisher_interval() -> int:
@@ -58,6 +66,30 @@ def get_publisher_ttl(publisher_interval: int | None = None) -> int:
     return publisher_interval * 2 + 10
 
 
+def _serialize_plugin_config(config: Config) -> dict[str, Any]:
+    """Serialize the native contract with stable ordering for condition sets.
+
+    The runtime fingerprints config bytes. Worker-specific set iteration order
+    must not trigger a reload when the effective policy has not changed.
+    """
+    document = config.model_dump(mode="json")
+    for plugin, serialized in zip(config.plugins or [], document["plugins"] or []):
+        for condition, serialized_condition in zip(plugin.conditions, serialized["conditions"]):
+            for key, value in condition:
+                if isinstance(value, set) and value:
+                    serialized_condition[key] = sorted(value)
+    return document
+
+
+class ToolPolicyContext(TypedDict):
+    """Canonical tool identity and the built-in policy lookup context."""
+
+    id: str
+    name: str
+    team_id: str | None
+    context_id: str
+
+
 class BackendConfig(TypedDict):
     """Backend gateway configuration for dataplane routing."""
 
@@ -69,6 +101,7 @@ class BackendConfig(TypedDict):
     capabilities: dict[str, Any]
     allowed_tool_names: list[str]
     tool_schemas: dict[str, dict[str, Any]]
+    tool_policy_contexts: dict[str, ToolPolicyContext]
     allowed_resource_names: list[str]
     allowed_resource_uris: list[str]
     allowed_prompt_names: list[str]
@@ -95,6 +128,7 @@ class UserConfig(TypedDict):
     """User-specific configuration mapping virtual host IDs to their configs."""
 
     virtual_hosts: dict[str, VirtualHostConfig]
+    user_email: str
 
 
 class BackendItems(TypedDict):
@@ -109,6 +143,7 @@ class PublishedBackendItems(BackendItems):
     """User-filtered backend items enriched with tool input schemas."""
 
     tool_schemas: dict[str, dict[str, Any]]
+    tool_policy_contexts: dict[str, ToolPolicyContext]
 
 
 class ToolMetadata(TypedDict):
@@ -116,6 +151,7 @@ class ToolMetadata(TypedDict):
 
     name: str
     input_schema: dict[str, Any]
+    policy_context: ToolPolicyContext
 
 
 BackendItemsByServer = dict[str, dict[str, BackendItems]]
@@ -169,6 +205,43 @@ class DataplanePublisherService:
             return None
         return self.create_payload(user_data)
 
+    async def fetch_plugin_config(self, payload: dict[str, UserConfig]) -> dict[str, Any]:
+        """Resolve built-in policy for every published target, failing the cycle on errors.
+
+        Prompt, resource and HTTP hooks use the global configuration. Tools
+        with a team use the same team/name context as ToolService; unscoped
+        tools use their virtual server. Only published contexts are exported.
+        Disabled plugins remain in the config, preserving override removal and
+        later re-enabling. Credentials retain the framework's serialization.
+        """
+        enabled = await are_plugins_enabled_shared()
+        document: dict[str, Any] = {"version": RUNTIME_PLUGIN_CONFIG_VERSION, "enabled": enabled, "global": None, "contexts": {}}
+        if not enabled:
+            return document
+
+        factory = get_plugin_manager_factory()
+        if factory is None:
+            raise RuntimeError("Cannot publish enabled plugins without an initialized plugin manager factory")
+
+        document["settings"] = {
+            **factory.runtime_settings,
+            "plugins_can_override_rbac": settings.plugins_can_override_rbac,
+            "plugins_can_override_auth_headers": settings.plugins_can_override_auth_headers,
+        }
+        document["global"] = _serialize_plugin_config(await factory.get_config())
+        context_ids = {
+            context["context_id"]
+            for config in payload.values()
+            for virtual_host in config["virtual_hosts"].values()
+            for backend in virtual_host["backends"].values()
+            for context in backend["tool_policy_contexts"].values()
+        }
+        if "" in context_ids:
+            raise ValueError("Published tool is missing its plugin policy context")
+        for context_id in sorted(context_ids):
+            document["contexts"][context_id] = _serialize_plugin_config(await factory.get_config(context_id))
+        return document
+
     async def publish_to_redis(self) -> None:
         """Continuously publish user configuration payloads to Redis."""
         while not self._shutdown_event.is_set():
@@ -204,7 +277,11 @@ class DataplanePublisherService:
                 if payload is None:
                     logger.warning("Skipping publish cycle due to data fetch failure - keeping existing Redis data")
                 else:
+                    # Resolve everything before queuing writes: a failed policy
+                    # lookup must not refresh routing with missing protection.
+                    plugin_config = await self.fetch_plugin_config(payload)
                     pipe = redis.pipeline()
+                    pipe.set(RUNTIME_PLUGIN_CONFIG_KEY, msgpack.dumps(plugin_config, use_bin_type=True), ex=publisher_ttl)
                     for key, config in payload.items():
                         key = msgpack.dumps((USER_CONFIG_KEY, key), use_bin_type=True)
                         pipe.set(
@@ -293,6 +370,10 @@ class DataplanePublisherService:
                     if not backend_items["tools"] and not allowed_resource_names and not allowed_prompt_names:
                         continue
 
+                    tool_contexts = {name: context.copy() for name, context in backend_items["tool_policy_contexts"].items()}
+                    for context in tool_contexts.values():
+                        context["context_id"] = context["context_id"] or server["id"]
+
                     backends[gateway_id] = {
                         "name": gateway_config["name"],
                         "url": gateway_config["url"],
@@ -302,6 +383,7 @@ class DataplanePublisherService:
                         "capabilities": gateway_config["capabilities"],
                         "allowed_tool_names": backend_items["tools"],
                         "tool_schemas": backend_items["tool_schemas"],
+                        "tool_policy_contexts": tool_contexts,
                         "allowed_resource_names": allowed_resource_names,
                         "allowed_resource_uris": allowed_resource_uris,
                         "allowed_prompt_names": allowed_prompt_names,
@@ -316,7 +398,7 @@ class DataplanePublisherService:
 
                 virtual_hosts[server["id"]] = {"backends": backends}
 
-            result[subject_key] = {"virtual_hosts": virtual_hosts}
+            result[subject_key] = {"virtual_hosts": virtual_hosts, "user_email": user_data["user_email"]}
 
         return result
 
@@ -365,7 +447,9 @@ class DataplanePublisherService:
                         DbResource.uri_template.is_(None),
                     )
                 ).all()
-                tool_rows = db.execute(select(DbTool.id, DbTool.original_name, DbTool.input_schema, DbTool.owner_email, DbTool.team_id, DbTool.visibility).where(DbTool.enabled.is_(True))).all()
+                tool_rows = db.execute(
+                    select(DbTool.id, DbTool.__table__.c.name, DbTool.original_name, DbTool.input_schema, DbTool.owner_email, DbTool.team_id, DbTool.visibility).where(DbTool.enabled.is_(True))
+                ).all()
                 backend_items_by_server = self._get_backend_items_by_server(db)
 
                 return {
@@ -410,9 +494,16 @@ class DataplanePublisherService:
             tool_by_id[tool.id] = {
                 "name": tool.original_name,
                 "input_schema": tool.input_schema,
+                "policy_context": {
+                    "id": tool.id,
+                    "name": tool.name,
+                    "team_id": tool.team_id,
+                    "context_id": make_context_id(str(tool.team_id), tool.name) if tool.team_id else "",
+                },
             }
 
         return {
+            "user_email": user_email,
             "servers": [
                 {
                     "id": server.id,
@@ -458,6 +549,7 @@ class DataplanePublisherService:
             gateway_id: {
                 "tools": [tool_by_id[tool_id]["name"] for tool_id in backend_items["tools"] if tool_id in tool_by_id],
                 "tool_schemas": {tool_by_id[tool_id]["name"]: tool_by_id[tool_id]["input_schema"] for tool_id in backend_items["tools"] if tool_id in tool_by_id},
+                "tool_policy_contexts": {tool_by_id[tool_id]["name"]: tool_by_id[tool_id]["policy_context"] for tool_id in backend_items["tools"] if tool_id in tool_by_id},
                 "resources": list(backend_items["resources"]),
                 "prompts": list(backend_items["prompts"]),
             }

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -47,11 +47,8 @@ logger = logging.getLogger(__name__)
 
 USER_CONFIG_KEY = "UserConfig"
 PUBLISHER_LOCK_KEY = "mcpgw:dataplane_publisher:lock"
-# Reuse the external dataplane's runtime-config key. Version 2 carries the
-# built-in contract: version 1 readers must reject it rather than ignore scope,
-# conditions, capabilities or gateway execution settings they cannot enforce.
+# Reuse the external dataplane's runtime-config key.
 RUNTIME_PLUGIN_CONFIG_KEY = "ContextForgeGatewayRuntimePluginConfig"
-RUNTIME_PLUGIN_CONFIG_VERSION = 2
 
 
 def get_publisher_interval() -> int:
@@ -215,7 +212,7 @@ class DataplanePublisherService:
         later re-enabling. Credentials retain the framework's serialization.
         """
         enabled = await are_plugins_enabled_shared()
-        document: dict[str, Any] = {"version": RUNTIME_PLUGIN_CONFIG_VERSION, "enabled": enabled, "global": None, "contexts": {}}
+        document: dict[str, Any] = {"enabled": enabled, "global": None, "contexts": {}}
         if not enabled:
             return document
 

--- a/tests/live_gateway/plugins/test_dataplane_plugin_publication.py
+++ b/tests/live_gateway/plugins/test_dataplane_plugin_publication.py
@@ -54,7 +54,6 @@ def test_binding_changes_reach_dataplane_redis(admin_client, fast_time_server):
     context_id = f"{fast_time_server['team_id']}::{fast_time_server['echo_tool']}"
     with Redis.from_url(REDIS_URL) as redis:
         initial = _wait_for_document(redis, lambda doc: _plugin(doc, context_id) is not None)
-        assert initial["version"] == 2
         assert initial["enabled"] is True
         original = _plugin(initial, context_id)
         assert original is not None

--- a/tests/live_gateway/plugins/test_dataplane_plugin_publication.py
+++ b/tests/live_gateway/plugins/test_dataplane_plugin_publication.py
@@ -61,7 +61,11 @@ def test_binding_changes_reach_dataplane_redis(admin_client, fast_time_server):
 
         # The routed upstream name must retain its owning team and canonical
         # gateway name, so direct and aliased routes can select the same policy.
-        user_configs = [msgpack.unpackb(redis.get(key), raw=False) for key in redis.scan_iter() if key != PLUGIN_KEY.encode() and key.startswith(b"\x92\xaaUserConfig")]
+        user_configs = []
+        for key in redis.scan_iter(match=b"\x92\xaaUserConfig*"):
+            raw = redis.get(key)
+            if raw is not None:  # A snapshot can expire between SCAN and GET.
+                user_configs.append(msgpack.unpackb(raw, raw=False))
         contexts = [
             context
             for config in user_configs
@@ -76,12 +80,13 @@ def test_binding_changes_reach_dataplane_redis(admin_client, fast_time_server):
         binding_id = None
         try:
             for mode, expected_mode, priority in [("enforce_ignore_error", "sequential", 7), ("permissive", "transform", 8), ("disabled", "disabled", 9)]:
+                override_config = {**(original["config"] or {}), "publisher_test_revision": priority}
                 binding = _helpers.create_tool_plugin_binding(
                     admin_client,
                     team_id=fast_time_server["team_id"],
                     tool_name=fast_time_server["echo_tool"],
                     plugin_id=PLUGIN_NAME,
-                    config=original["config"] or {},
+                    config=override_config,
                     mode=mode,
                     priority=priority,
                 )
@@ -90,6 +95,7 @@ def test_binding_changes_reach_dataplane_redis(admin_client, fast_time_server):
                 effective = _plugin(document, context_id)
                 assert effective is not None
                 assert effective["mode"] == expected_mode
+                assert effective["config"] == override_config
                 if mode == "enforce_ignore_error":
                     assert effective["on_error"] == "ignore"
                 assert document["global"]["plugins"] == initial["global"]["plugins"]

--- a/tests/live_gateway/plugins/test_dataplane_plugin_publication.py
+++ b/tests/live_gateway/plugins/test_dataplane_plugin_publication.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/live_gateway/plugins/test_dataplane_plugin_publication.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Black-box control-plane HTTP mutations to published Redis plugin configuration.
+
+Run against a dedicated gateway with DATAPLANE_PUBLISHER=true, a short publish
+interval, and PLUGINS_ENABLED=true. Set DATAPLANE_PLUGIN_E2E_REDIS_URL to its
+Redis URL and DATAPLANE_PLUGIN_E2E_NAME to a configured plugin name. The shared
+fixtures require fast-time-server at FAST_TIME_SERVER_URL. MCP_CLI_BASE_URL and
+JWT_SECRET_KEY must match the gateway. No gateway internals are imported.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Callable
+
+import msgpack
+import pytest
+from redis import Redis
+
+from tests.live_gateway.plugins import _helpers
+
+REDIS_URL = os.getenv("DATAPLANE_PLUGIN_E2E_REDIS_URL")
+PLUGIN_NAME = os.getenv("DATAPLANE_PLUGIN_E2E_NAME", "PublisherGuard")
+PLUGIN_KEY = "ContextForgeGatewayRuntimePluginConfig"
+pytestmark = [pytest.mark.e2e, pytest.mark.skipif(not REDIS_URL, reason="requires a dedicated dataplane publisher stack")]
+
+
+def _wait_for_document(redis: Redis, predicate: Callable[[dict[str, Any]], bool]) -> dict[str, Any]:
+    """Wait for a complete publisher cycle to expose the expected policy."""
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        raw = redis.get(PLUGIN_KEY)
+        if raw is not None:
+            document: dict[str, Any] = msgpack.unpackb(raw, raw=False)
+            if predicate(document):
+                return document
+        time.sleep(0.2)
+    pytest.fail("Dataplane policy did not reflect the HTTP mutation within 30 seconds")
+
+
+def _plugin(document: dict[str, Any], context_id: str) -> dict[str, Any] | None:
+    """Find the configured plugin in a published scoped policy."""
+    return next((plugin for plugin in document["contexts"].get(context_id, {}).get("plugins", []) if plugin["name"] == PLUGIN_NAME), None)
+
+
+def test_binding_changes_reach_dataplane_redis(admin_client, fast_time_server):
+    """Add, update, disable and remove a binding through the live gateway API."""
+    assert REDIS_URL is not None
+    context_id = f"{fast_time_server['team_id']}::{fast_time_server['echo_tool']}"
+    with Redis.from_url(REDIS_URL) as redis:
+        initial = _wait_for_document(redis, lambda doc: _plugin(doc, context_id) is not None)
+        assert initial["version"] == 2
+        assert initial["enabled"] is True
+        original = _plugin(initial, context_id)
+        assert original is not None
+
+        # The routed upstream name must retain its owning team and canonical
+        # gateway name, so direct and aliased routes can select the same policy.
+        user_configs = [msgpack.unpackb(redis.get(key), raw=False) for key in redis.scan_iter() if key != PLUGIN_KEY.encode() and key.startswith(b"\x92\xaaUserConfig")]
+        contexts = [
+            context
+            for config in user_configs
+            for virtual_host in config["virtual_hosts"].values()
+            for backend in virtual_host["backends"].values()
+            for context in backend["tool_policy_contexts"].values()
+            if context["context_id"] == context_id
+        ]
+        assert contexts
+        assert all(context["team_id"] == fast_time_server["team_id"] and context["name"] == fast_time_server["echo_tool"] for context in contexts)
+
+        binding_id = None
+        try:
+            for mode, expected_mode, priority in [("enforce_ignore_error", "sequential", 7), ("permissive", "transform", 8), ("disabled", "disabled", 9)]:
+                binding = _helpers.create_tool_plugin_binding(
+                    admin_client,
+                    team_id=fast_time_server["team_id"],
+                    tool_name=fast_time_server["echo_tool"],
+                    plugin_id=PLUGIN_NAME,
+                    config=original["config"] or {},
+                    mode=mode,
+                    priority=priority,
+                )
+                binding_id = binding["id"]
+                document = _wait_for_document(redis, lambda doc: (_plugin(doc, context_id) or {}).get("priority") == priority)
+                effective = _plugin(document, context_id)
+                assert effective is not None
+                assert effective["mode"] == expected_mode
+                if mode == "enforce_ignore_error":
+                    assert effective["on_error"] == "ignore"
+                assert document["global"]["plugins"] == initial["global"]["plugins"]
+        finally:
+            if binding_id is not None:
+                response = admin_client.delete(f"/v1/tools/plugin_bindings/{binding_id}")
+                assert response.status_code == 200, response.text
+
+        _wait_for_document(redis, lambda doc: _plugin(doc, context_id) == original)
+        assert redis.ttl(PLUGIN_KEY) > 0

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -140,9 +140,12 @@ async def test_plugin_publication_tracks_override_lifecycle_and_specificity(plug
 
     exact.mode = "disabled"
     exact.on_error = "disable"
+    exact.config = {"nested": {"updated": True}}
     db.commit()
     document = await service.fetch_plugin_config(payload)
     assert document["contexts"]["team-a::gateway-echo"]["plugins"][0]["mode"] == "disabled"
+    assert document["contexts"]["team-a::gateway-echo"]["plugins"][0]["on_error"] == "disable"
+    assert document["contexts"]["team-a::gateway-echo"]["plugins"][0]["config"] == {"words": [], "retained": "base", "nested": {"updated": True}}
 
     # Runtime mode overrides win over DB overrides, including legacy error policy.
     await redis.set("plugin:Guard:mode", "enforce_ignore_error")
@@ -199,6 +202,14 @@ def test_plugin_condition_serialization_is_stable_without_reordering_hooks():
     assert serialized["plugins"][0]["conditions"][0]["tenant_ids"] is None
     assert serialized["plugins"][0]["hooks"] == ["tool_pre_invoke", "resource_pre_fetch"]
     assert config.plugins[0].conditions[0].tools == {"z", "a"}
+
+
+@pytest.mark.asyncio
+async def test_plugin_publication_rejects_missing_tool_context(plugin_publication):
+    """A routed tool without its policy scope cannot silently use global policy."""
+    service, _factory, _db, _redis = plugin_publication
+    with pytest.raises(ValueError, match="missing its plugin policy context"):
+        await service.fetch_plugin_config(_policy_payload(""))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -99,7 +99,6 @@ async def test_plugin_publication_preserves_builtin_config_and_settings(plugin_p
         manager.assert_not_called()
 
     assert msgpack.unpackb(msgpack.packb(document), raw=False) == document
-    assert document["version"] == 2
     assert document["enabled"] is True
     assert document["global"] == (await factory.get_config()).model_dump(mode="json")
     assert document["contexts"]["server"] == document["global"]
@@ -222,7 +221,7 @@ async def test_plugin_publication_distinguishes_disabled_from_missing_factory(pl
     with pytest.raises(RuntimeError, match="initialized plugin manager"):
         await service.fetch_plugin_config({})
     monkeypatch.setattr(dataplane_publisher, "are_plugins_enabled_shared", AsyncMock(return_value=False))
-    assert await service.fetch_plugin_config({}) == {"version": 2, "enabled": False, "global": None, "contexts": {}}
+    assert await service.fetch_plugin_config({}) == {"enabled": False, "global": None, "contexts": {}}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -82,7 +82,6 @@ def _policy_payload(*context_ids):
     """Make routing data whose targets point to the requested policy contexts."""
     return {
         USER1_ID: {
-            "user_email": "user1@example.com",
             "virtual_hosts": {"server": {"backends": {"gateway": {"tool_policy_contexts": {str(i): {"context_id": context_id} for i, context_id in enumerate(context_ids)}}}}},
         }
     }
@@ -612,7 +611,7 @@ async def test_full_payload_generation_with_mock_db():
         assert user3_backend["tool_schemas"] == {"public_tool": tool1.input_schema}
         assert list(user3_backend["tool_policy_contexts"]) == ["public_tool"]
         assert user3_backend["tool_policy_contexts"]["public_tool"]["context_id"] == "team1::gw1-public_tool"
-        assert payload[USER3_ID]["user_email"] == "user3@example.com"
+        assert "user_email" not in payload[USER3_ID]
 
 
 def test_build_user_data_excludes_non_object_tool_schema(caplog):
@@ -714,7 +713,6 @@ def test_create_payload_filters_empty_backends():
     service = DataplanePublisherService()
     data = {
         USER1_ID: {
-            "user_email": "user1@example.com",
             "servers": [
                 {
                     "id": "server1",
@@ -744,7 +742,6 @@ def test_create_payload_excludes_non_streamable_gateways(transport: str):
     service = DataplanePublisherService()
     data = {
         USER1_ID: {
-            "user_email": "user1@example.com",
             "servers": [
                 {
                     "id": "server1",
@@ -778,7 +775,6 @@ def test_create_payload_normalizes_null_passthrough_headers():
     service = DataplanePublisherService()
     data = {
         USER1_ID: {
-            "user_email": "user1@example.com",
             "servers": [
                 {
                     "id": "server1",
@@ -811,7 +807,6 @@ def test_create_payload_handles_missing_references():
     service = DataplanePublisherService()
     data = {
         USER1_ID: {
-            "user_email": "user1@example.com",
             "servers": [
                 {
                     "id": "server1",

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -16,6 +16,254 @@ USER2_ID = "22222222-2222-2222-2222-222222222222"
 USER3_ID = "33333333-3333-3333-3333-333333333333"
 
 
+@pytest.fixture(autouse=True)
+def plugins_disabled_by_default(monkeypatch):
+    """Isolate publisher tests from process-global toggles in other modules."""
+    monkeypatch.setattr("mcpgateway.services.dataplane_publisher.are_plugins_enabled_shared", AsyncMock(return_value=False))
+
+
+@pytest.fixture
+def plugin_publication(tmp_path, monkeypatch):
+    """Use the real config loader, binding resolver and Redis mode handling."""
+    import fakeredis.aioredis
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from mcpgateway.db import Base
+    from mcpgateway.plugins.gateway_plugin_manager import TenantPluginManagerFactory
+    from mcpgateway.plugins.policy import HOOK_PAYLOAD_POLICIES
+    from mcpgateway.services import dataplane_publisher
+
+    config_path = tmp_path / "plugins.yaml"
+    config_path.write_text(
+        """plugins:
+  - name: Guard
+    kind: plugins.regex_filter.search_replace.SearchReplacePlugin
+    hooks: [tool_pre_invoke, tool_post_invoke, prompt_pre_fetch, prompt_post_fetch,
+            resource_pre_fetch, resource_post_fetch, http_pre_request, http_post_request]
+    mode: sequential
+    on_error: fail
+    priority: 31
+    capabilities: [read_headers]
+    conditions:
+      - tools: [gateway-echo]
+        tenant_ids: [team-a]
+        server_ids: [gateway]
+        user_patterns: ['.*@example.com']
+    config:
+      words: []
+      retained: base
+      nested: {base: true}
+  - name: Disabled
+    kind: unavailable.Plugin
+    hooks: [tool_post_invoke]
+    mode: disabled
+""",
+        encoding="utf-8",
+    )
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine)
+    redis = fakeredis.aioredis.FakeRedis()
+    monkeypatch.setattr("mcpgateway.plugins.gateway_plugin_manager._redis", AsyncMock(return_value=redis))
+    monkeypatch.setattr("mcpgateway.plugins.gateway_plugin_manager.active_local_mode_overrides", lambda _now: {})
+    factory = TenantPluginManagerFactory(str(config_path), timeout=17, db_factory=session_factory, hook_policies=HOOK_PAYLOAD_POLICIES)
+    monkeypatch.setattr(dataplane_publisher, "are_plugins_enabled_shared", AsyncMock(return_value=True))
+    monkeypatch.setattr(dataplane_publisher, "get_plugin_manager_factory", lambda: factory)
+    session = session_factory()
+    try:
+        yield dataplane_publisher.DataplanePublisherService(), factory, session, redis
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def _policy_payload(*context_ids):
+    """Make routing data whose targets point to the requested policy contexts."""
+    return {
+        USER1_ID: {
+            "user_email": "user1@example.com",
+            "virtual_hosts": {"server": {"backends": {"gateway": {"tool_policy_contexts": {str(i): {"context_id": context_id} for i, context_id in enumerate(context_ids)}}}}},
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_plugin_publication_preserves_builtin_config_and_settings(plugin_publication):
+    """The wire document preserves all configured hooks and execution settings."""
+    import msgpack
+
+    service, factory, _db, _redis = plugin_publication
+    with patch("mcpgateway.plugins.gateway_plugin_manager.TenantPluginManager") as manager:
+        document = await service.fetch_plugin_config(_policy_payload("team-a::gateway-echo", "server"))
+        manager.assert_not_called()
+
+    assert msgpack.unpackb(msgpack.packb(document), raw=False) == document
+    assert document["version"] == 2
+    assert document["enabled"] is True
+    assert document["global"] == (await factory.get_config()).model_dump(mode="json")
+    assert document["contexts"]["server"] == document["global"]
+    plugin = document["global"]["plugins"][0]
+    assert plugin["name"] == "Guard"
+    assert plugin["kind"] == "plugins.regex_filter.search_replace.SearchReplacePlugin"
+    assert len(plugin["hooks"]) == 8
+    assert plugin["capabilities"] == ["read_headers"]
+    assert plugin["conditions"][0]["tools"] == ["gateway-echo"]
+    assert plugin["on_error"] == "fail"
+    assert plugin["priority"] == 31
+    assert document["global"]["plugins"][1]["mode"] == "disabled"
+    assert document["settings"]["plugin_timeout"] == 17
+    assert document["settings"]["hook_policies"]["resource_pre_fetch"] == {"writable_fields": ["metadata", "uri"]}
+    assert document["settings"]["plugins_can_override_rbac"] is False
+
+
+@pytest.mark.asyncio
+async def test_plugin_publication_tracks_override_lifecycle_and_specificity(plugin_publication):
+    """Exact overrides replace wildcard rows; removing them restores the fallback."""
+    from mcpgateway.db import ToolPluginBinding
+
+    service, factory, db, redis = plugin_publication
+    payload = _policy_payload("team-a::gateway-echo", "team-b::gateway-echo")
+    wildcard = ToolPluginBinding(team_id="team-a", tool_name="*", plugin_id="Guard", created_by="admin@example.com", updated_by="admin@example.com", mode="permissive", config={"nested": {"wildcard": True}}, priority=12)
+    exact = ToolPluginBinding(team_id="team-a", tool_name="gateway-echo", plugin_id="Guard", created_by="admin@example.com", updated_by="admin@example.com", mode="enforce_ignore_error", config={"nested": {"exact": True}}, priority=0)
+    db.add_all([exact, wildcard])
+    db.commit()
+
+    document = await service.fetch_plugin_config(payload)
+    scoped = document["contexts"]["team-a::gateway-echo"]
+    assert scoped == (await factory.get_config("team-a::gateway-echo")).model_dump(mode="json")
+    assert scoped["plugins"][0]["config"] == {"words": [], "retained": "base", "nested": {"exact": True}}
+    assert scoped["plugins"][0]["mode"] == "sequential"
+    assert scoped["plugins"][0]["on_error"] == "ignore"
+    assert scoped["plugins"][0]["priority"] == 0
+    assert document["contexts"]["team-b::gateway-echo"] == document["global"]
+
+    exact.mode = "disabled"
+    exact.on_error = "disable"
+    db.commit()
+    document = await service.fetch_plugin_config(payload)
+    assert document["contexts"]["team-a::gateway-echo"]["plugins"][0]["mode"] == "disabled"
+
+    # Runtime mode overrides win over DB overrides, including legacy error policy.
+    await redis.set("plugin:Guard:mode", "enforce_ignore_error")
+    document = await service.fetch_plugin_config(payload)
+    assert document["contexts"]["team-a::gateway-echo"]["plugins"][0]["on_error"] == "ignore"
+    await redis.delete("plugin:Guard:mode")
+    db.delete(exact)
+    db.commit()
+    document = await service.fetch_plugin_config(payload)
+    assert document["contexts"]["team-a::gateway-echo"]["plugins"][0]["mode"] == "transform"
+    assert document["contexts"]["team-a::gateway-echo"]["plugins"][0]["config"]["nested"] == {"wildcard": True}
+    db.delete(wildcard)
+    db.commit()
+    document = await service.fetch_plugin_config(payload)
+    assert document["contexts"]["team-a::gateway-echo"] == document["global"]
+
+
+@pytest.mark.asyncio
+async def test_plugin_publication_uses_loaded_yaml_and_only_published_contexts(plugin_publication):
+    """Publication neither rereads YAML nor leaks cached, unpublished scopes."""
+    service, factory, _db, _redis = plugin_publication
+    with patch.object(factory, "get_config", wraps=factory.get_config) as resolve, patch("cpex.framework.ConfigLoader.load_config", side_effect=AssertionError("YAML reread")):
+        document = await service.fetch_plugin_config(_policy_payload("team-a::gateway-echo", "team-a::gateway-echo"))
+    assert list(document["contexts"]) == ["team-a::gateway-echo"]
+    assert resolve.await_count == 2  # global plus one unique context
+    assert (await service.fetch_plugin_config({}))["contexts"] == {}
+
+
+@pytest.mark.asyncio
+async def test_invalid_binding_config_fails_like_builtin_resolution(plugin_publication):
+    """Malformed DB config cannot silently replace a required scoped override."""
+    from pydantic import ValidationError
+
+    from mcpgateway.db import ToolPluginBinding
+
+    service, factory, db, _redis = plugin_publication
+    db.add(ToolPluginBinding(team_id="team-a", tool_name="*", plugin_id="Guard", config=["invalid"], created_by="admin@example.com", updated_by="admin@example.com"))
+    db.commit()
+    with pytest.raises(ValidationError, match="valid dictionary"):
+        await factory.get_config("team-a::gateway-echo")
+    with pytest.raises(ValidationError, match="valid dictionary"):
+        await service.fetch_plugin_config(_policy_payload("team-a::gateway-echo"))
+
+
+def test_plugin_condition_serialization_is_stable_without_reordering_hooks():
+    """Sort unordered selection sets while preserving ordered hooks and plugins."""
+    from cpex.framework.models import Config, PluginConfig, PluginCondition
+
+    from mcpgateway.services.dataplane_publisher import _serialize_plugin_config
+
+    config = Config(plugins=[PluginConfig(name="Guard", kind="test.Plugin", hooks=["tool_pre_invoke", "resource_pre_fetch"], conditions=[PluginCondition(tools={"z", "a"}, tenant_ids=set())])])
+    serialized = _serialize_plugin_config(config)
+    assert serialized["plugins"][0]["conditions"][0]["tools"] == ["a", "z"]
+    assert serialized["plugins"][0]["conditions"][0]["tenant_ids"] is None
+    assert serialized["plugins"][0]["hooks"] == ["tool_pre_invoke", "resource_pre_fetch"]
+    assert config.plugins[0].conditions[0].tools == {"z", "a"}
+
+
+@pytest.mark.asyncio
+async def test_plugin_publication_distinguishes_disabled_from_missing_factory(plugin_publication, monkeypatch):
+    """An unavailable enabled factory cannot become an empty policy document."""
+    from mcpgateway.services import dataplane_publisher
+
+    service, _factory, _db, _redis = plugin_publication
+    monkeypatch.setattr(dataplane_publisher, "get_plugin_manager_factory", lambda: None)
+    with pytest.raises(RuntimeError, match="initialized plugin manager"):
+        await service.fetch_plugin_config({})
+    monkeypatch.setattr(dataplane_publisher, "are_plugins_enabled_shared", AsyncMock(return_value=False))
+    assert await service.fetch_plugin_config({}) == {"version": 2, "enabled": False, "global": None, "contexts": {}}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [RuntimeError("DB unavailable"), TypeError("invalid binding config")])
+async def test_policy_failure_does_not_publish_or_refresh_routing(plugin_publication, monkeypatch, failure):
+    """A failed resolution leaves both existing keys untouched and releases the lock."""
+    import msgpack
+
+    from mcpgateway.services import dataplane_publisher
+
+    service, factory, _db, redis = plugin_publication
+    routing_key = msgpack.packb((dataplane_publisher.USER_CONFIG_KEY, USER1_ID))
+    await redis.set(routing_key, b"old-routing", ex=100)
+    await redis.set(dataplane_publisher.RUNTIME_PLUGIN_CONFIG_KEY, b"old-policy", ex=100)
+    monkeypatch.setattr(dataplane_publisher, "get_redis_client", AsyncMock(return_value=redis))
+    monkeypatch.setattr(service, "fetch_payload", AsyncMock(return_value=_policy_payload("team-a::gateway-echo")))
+
+    async def fail_resolution(_context_id):
+        service._shutdown_event.set()
+        raise failure
+
+    monkeypatch.setattr(factory, "get_config_from_db", fail_resolution)
+    await service.publish_to_redis()
+    assert await redis.get(routing_key) == b"old-routing"
+    assert await redis.get(dataplane_publisher.RUNTIME_PLUGIN_CONFIG_KEY) == b"old-policy"
+    assert await redis.get(dataplane_publisher.PUBLISHER_LOCK_KEY) is None
+
+
+@pytest.mark.asyncio
+async def test_plugin_and_routing_documents_share_publish_cycle_and_ttl(plugin_publication, monkeypatch):
+    """Real MessagePack bytes reach Redis together with the existing routing payload."""
+    import msgpack
+
+    from mcpgateway.services import dataplane_publisher
+
+    service, _factory, _db, redis = plugin_publication
+    payload = _policy_payload("team-a::gateway-echo")
+    monkeypatch.setattr(dataplane_publisher, "get_redis_client", AsyncMock(return_value=redis))
+
+    async def fetch_once():
+        service._shutdown_event.set()
+        return payload
+
+    monkeypatch.setattr(service, "fetch_payload", fetch_once)
+    await service.publish_to_redis()
+    routing_key = msgpack.packb((dataplane_publisher.USER_CONFIG_KEY, USER1_ID))
+    assert msgpack.unpackb(await redis.get(routing_key), raw=False) == payload[USER1_ID]
+    document = msgpack.unpackb(await redis.get(dataplane_publisher.RUNTIME_PLUGIN_CONFIG_KEY), raw=False)
+    assert document == await service.fetch_plugin_config(payload)
+    assert await redis.ttl(routing_key) == await redis.ttl(dataplane_publisher.RUNTIME_PLUGIN_CONFIG_KEY)
+
+
 async def _wait_forever():
     """Block until cancelled by the test cleanup."""
     await asyncio.Event().wait()
@@ -304,6 +552,10 @@ async def test_full_payload_generation_with_mock_db():
             "remove_headers": ["Cookie"],
             "capabilities": {"resources": {"subscribe": True}},
             "allowed_tool_names": ["public_tool", "private_tool"],
+            "tool_policy_contexts": {
+                "public_tool": {"id": "t1", "name": "gw1-public_tool", "team_id": "team1", "context_id": "team1::gw1-public_tool"},
+                "private_tool": {"id": "t2", "name": "gw1-private_tool", "team_id": "team1", "context_id": "team1::gw1-private_tool"},
+            },
             "tool_schemas": {
                 "public_tool": tool1.input_schema,
                 "private_tool": {},
@@ -348,6 +600,9 @@ async def test_full_payload_generation_with_mock_db():
         user3_backend = user3_config["virtual_hosts"]["s1"]["backends"]["g1"]
         assert user3_backend["allowed_tool_names"] == ["public_tool"]
         assert user3_backend["tool_schemas"] == {"public_tool": tool1.input_schema}
+        assert list(user3_backend["tool_policy_contexts"]) == ["public_tool"]
+        assert user3_backend["tool_policy_contexts"]["public_tool"]["context_id"] == "team1::gw1-public_tool"
+        assert payload[USER3_ID]["user_email"] == "user3@example.com"
 
 
 def test_build_user_data_excludes_non_object_tool_schema(caplog):
@@ -357,7 +612,8 @@ def test_build_user_data_excludes_non_object_tool_schema(caplog):
     from mcpgateway.services.dataplane_publisher import BackendItemsByServer, DataplanePublisherService
 
     bad_tool = Mock(id="bad-tool", original_name="bad", input_schema=None, visibility="public")
-    good_tool = Mock(id="good-tool", original_name="good", input_schema={"type": "object"}, visibility="public")
+    good_tool = Mock(id="good-tool", original_name="good", input_schema={"type": "object"}, visibility="public", team_id=None)
+    good_tool.name = "gw-good"
     server = Mock(id="server", visibility="public")
     backend_items_by_server: BackendItemsByServer = {
         "server": {
@@ -448,11 +704,12 @@ def test_create_payload_filters_empty_backends():
     service = DataplanePublisherService()
     data = {
         USER1_ID: {
+            "user_email": "user1@example.com",
             "servers": [
                 {
                     "id": "server1",
                     "backend_items": {
-                        "gateway1": {"tools": [], "tool_schemas": {}, "resources": [], "prompts": []},
+                        "gateway1": {"tools": [], "tool_schemas": {}, "tool_policy_contexts": {}, "resources": [], "prompts": []},
                     },
                 }
             ],
@@ -477,6 +734,7 @@ def test_create_payload_excludes_non_streamable_gateways(transport: str):
     service = DataplanePublisherService()
     data = {
         USER1_ID: {
+            "user_email": "user1@example.com",
             "servers": [
                 {
                     "id": "server1",
@@ -484,6 +742,7 @@ def test_create_payload_excludes_non_streamable_gateways(transport: str):
                         "gateway_non_streamable": {
                             "tools": ["tool1"],
                             "tool_schemas": {},
+                            "tool_policy_contexts": {},
                             "resources": [],
                             "prompts": [],
                         },
@@ -509,11 +768,12 @@ def test_create_payload_normalizes_null_passthrough_headers():
     service = DataplanePublisherService()
     data = {
         USER1_ID: {
+            "user_email": "user1@example.com",
             "servers": [
                 {
                     "id": "server1",
                     "backend_items": {
-                        "gateway1": {"tools": ["tool1"], "tool_schemas": {}, "resources": [], "prompts": []},
+                        "gateway1": {"tools": ["tool1"], "tool_schemas": {}, "tool_policy_contexts": {"tool1": {"id": "t1", "name": "gateway-tool1", "team_id": None, "context_id": ""}}, "resources": [], "prompts": []},
                     },
                 }
             ],
@@ -530,6 +790,8 @@ def test_create_payload_normalizes_null_passthrough_headers():
     assert backend["add_headers"] == {}
     assert backend["remove_headers"] == []
     assert backend["capabilities"] == {}
+    assert backend["tool_policy_contexts"]["tool1"] == {"id": "t1", "name": "gateway-tool1", "team_id": None, "context_id": "server1"}
+    assert data[USER1_ID]["servers"][0]["backend_items"]["gateway1"]["tool_policy_contexts"]["tool1"]["context_id"] == ""
 
 
 def test_create_payload_handles_missing_references():
@@ -539,6 +801,7 @@ def test_create_payload_handles_missing_references():
     service = DataplanePublisherService()
     data = {
         USER1_ID: {
+            "user_email": "user1@example.com",
             "servers": [
                 {
                     "id": "server1",
@@ -546,6 +809,7 @@ def test_create_payload_handles_missing_references():
                         "missing_gateway": {
                             "tools": ["tool1"],
                             "tool_schemas": {},
+                            "tool_policy_contexts": {},
                             "resources": ["missing_res"],
                             "prompts": ["missing_prompt"],
                         },
@@ -708,7 +972,7 @@ async def test_publish_writes_payload_releases_lock_and_exits_when_shutdown_wait
 
         await service.publish_to_redis()
 
-    pipe.set.assert_called_once()
+    assert pipe.set.call_count == 2
     key_arg, value_arg = pipe.set.call_args.args
     assert msgpack.unpackb(key_arg, raw=False) == [USER_CONFIG_KEY, USER1_ID]
     assert msgpack.unpackb(value_arg, raw=False) == payload[USER1_ID]
@@ -779,7 +1043,7 @@ async def test_publish_releases_lock_when_pipeline_execute_fails():
 
         await service.publish_to_redis()
 
-    pipe.set.assert_called_once()
+    assert pipe.set.call_count == 2
     pipe.execute.assert_awaited_once()
     mock_redis.eval.assert_awaited_once()
 

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -23,7 +23,7 @@ def plugins_disabled_by_default(monkeypatch):
 
 
 @pytest.fixture
-def plugin_publication(tmp_path, monkeypatch):
+async def plugin_publication(tmp_path, monkeypatch):
     """Use the real config loader, binding resolver and Redis mode handling."""
     import fakeredis.aioredis
     from sqlalchemy import create_engine
@@ -74,6 +74,8 @@ def plugin_publication(tmp_path, monkeypatch):
     try:
         yield dataplane_publisher.DataplanePublisherService(), factory, session, redis
     finally:
+        await factory.shutdown()
+        await redis.aclose()
         session.close()
         engine.dispose()
 
@@ -93,13 +95,11 @@ async def test_plugin_publication_preserves_builtin_config_and_settings(plugin_p
     import msgpack
 
     service, factory, _db, _redis = plugin_publication
-    with patch("mcpgateway.plugins.gateway_plugin_manager.TenantPluginManager") as manager:
-        document = await service.fetch_plugin_config(_policy_payload("team-a::gateway-echo", "server"))
-        manager.assert_not_called()
+    document = await service.fetch_plugin_config(_policy_payload("team-a::gateway-echo", "server"))
 
     assert msgpack.unpackb(msgpack.packb(document), raw=False) == document
     assert document["enabled"] is True
-    assert document["global"] == (await factory.get_config()).model_dump(mode="json")
+    assert document["global"] == (await factory.get_manager()).config.model_dump(mode="json")
     assert document["contexts"]["server"] == document["global"]
     plugin = document["global"]["plugins"][0]
     assert plugin["name"] == "Guard"
@@ -126,10 +126,11 @@ async def test_plugin_publication_tracks_override_lifecycle_and_specificity(plug
     exact = ToolPluginBinding(team_id="team-a", tool_name="gateway-echo", plugin_id="Guard", created_by="admin@example.com", updated_by="admin@example.com", mode="enforce_ignore_error", config={"nested": {"exact": True}}, priority=0)
     db.add_all([exact, wildcard])
     db.commit()
+    await factory.invalidate_all()
 
     document = await service.fetch_plugin_config(payload)
     scoped = document["contexts"]["team-a::gateway-echo"]
-    assert scoped == (await factory.get_config("team-a::gateway-echo")).model_dump(mode="json")
+    assert scoped == (await factory.get_manager("team-a::gateway-echo")).config.model_dump(mode="json")
     assert scoped["plugins"][0]["config"] == {"words": [], "retained": "base", "nested": {"exact": True}}
     assert scoped["plugins"][0]["mode"] == "sequential"
     assert scoped["plugins"][0]["on_error"] == "ignore"
@@ -140,6 +141,7 @@ async def test_plugin_publication_tracks_override_lifecycle_and_specificity(plug
     exact.on_error = "disable"
     exact.config = {"nested": {"updated": True}}
     db.commit()
+    await factory.invalidate_all()
     document = await service.fetch_plugin_config(payload)
     assert document["contexts"]["team-a::gateway-echo"]["plugins"][0]["mode"] == "disabled"
     assert document["contexts"]["team-a::gateway-echo"]["plugins"][0]["on_error"] == "disable"
@@ -147,16 +149,19 @@ async def test_plugin_publication_tracks_override_lifecycle_and_specificity(plug
 
     # Runtime mode overrides win over DB overrides, including legacy error policy.
     await redis.set("plugin:Guard:mode", "enforce_ignore_error")
+    await factory.invalidate_all()
     document = await service.fetch_plugin_config(payload)
     assert document["contexts"]["team-a::gateway-echo"]["plugins"][0]["on_error"] == "ignore"
     await redis.delete("plugin:Guard:mode")
     db.delete(exact)
     db.commit()
+    await factory.invalidate_all()
     document = await service.fetch_plugin_config(payload)
     assert document["contexts"]["team-a::gateway-echo"]["plugins"][0]["mode"] == "transform"
     assert document["contexts"]["team-a::gateway-echo"]["plugins"][0]["config"]["nested"] == {"wildcard": True}
     db.delete(wildcard)
     db.commit()
+    await factory.invalidate_all()
     document = await service.fetch_plugin_config(payload)
     assert document["contexts"]["team-a::gateway-echo"] == document["global"]
 
@@ -165,7 +170,7 @@ async def test_plugin_publication_tracks_override_lifecycle_and_specificity(plug
 async def test_plugin_publication_uses_loaded_yaml_and_only_published_contexts(plugin_publication):
     """Publication neither rereads YAML nor leaks cached, unpublished scopes."""
     service, factory, _db, _redis = plugin_publication
-    with patch.object(factory, "get_config", wraps=factory.get_config) as resolve, patch("cpex.framework.ConfigLoader.load_config", side_effect=AssertionError("YAML reread")):
+    with patch.object(factory, "get_manager", wraps=factory.get_manager) as resolve, patch("cpex.framework.ConfigLoader.load_config", side_effect=AssertionError("YAML reread")):
         document = await service.fetch_plugin_config(_policy_payload("team-a::gateway-echo", "team-a::gateway-echo"))
     assert list(document["contexts"]) == ["team-a::gateway-echo"]
     assert resolve.await_count == 2  # global plus one unique context
@@ -183,7 +188,7 @@ async def test_invalid_binding_config_fails_like_builtin_resolution(plugin_publi
     db.add(ToolPluginBinding(team_id="team-a", tool_name="*", plugin_id="Guard", config=["invalid"], created_by="admin@example.com", updated_by="admin@example.com"))
     db.commit()
     with pytest.raises(ValidationError, match="valid dictionary"):
-        await factory.get_config("team-a::gateway-echo")
+        await factory.get_manager("team-a::gateway-echo")
     with pytest.raises(ValidationError, match="valid dictionary"):
         await service.fetch_plugin_config(_policy_payload("team-a::gateway-echo"))
 


### PR DESCRIPTION
The dataplane currently receives routing settings but no plugin configuration. This PR sends the same plugin settings and team/tool overrides used by the gateway through the existing Redis publisher. If a policy cannot be loaded, the publisher leaves the previous data untouched.

It also fixes CI reporting a failure when plugin tests are intentionally skipped on draft PRs.

Validated with 947 passing tests and a live gateway test. Full repository validation is still outstanding.

Closes #6252. Rust support for reading and applying this configuration remains in #6253 and is required before deployment.
