### PR TITLE
fix: harden virtual-server scoped tool invocation

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -11412,6 +11412,7 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             return lowered_headers
 
         _trusted_internal_mcp_dispatch = get_internal_mcp_auth_context(request) is not None
+        _tools_call_permission_checked = False
         _internal_runtime_server_id = request_headers.get("x-contextforge-server-id") if request_headers.get("x-contextforge-mcp-runtime") == "rust" else None
 
         if not _trusted_internal_mcp_dispatch:
@@ -11456,6 +11457,19 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
                 )
         elif _token_server_id is not None:
             server_id = _token_server_id
+
+        # Public /rpc tools/call accepts an explicit virtual-server scope. Verify
+        # resource visibility before affinity forwarding or local invocation. The
+        # trusted internal transport path enforces its own server scope and must not
+        # pay for the full server graph hydration on every MCP tool call.
+        if method == "tools/call" and server_id and not _trusted_internal_mcp_dispatch:
+            await _ensure_rpc_permission(user, db, "tools.execute", method, request=request)
+            _tools_call_permission_checked = True
+            auth_user_email, auth_token_teams = get_scoped_resource_access_context(request, user)
+            try:
+                await server_service.get_server(db, server_id, user_email=auth_user_email, token_teams=auth_token_teams)
+            except ServerNotFoundError as exc:
+                raise JSONRPCError(-32002, f"Server not found: {server_id}", {"server_id": server_id}) from exc
 
         forwarded_response = await _maybe_forward_affinitized_rpc_request(
             request,
@@ -11666,7 +11680,8 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             # Per the MCP spec, a ping returns an empty result.
             result = {}
         elif method == "tools/call":  # pylint: disable=too-many-nested-blocks
-            await _ensure_rpc_permission(user, db, "tools.execute", method, request=request)
+            if not _tools_call_permission_checked:
+                await _ensure_rpc_permission(user, db, "tools.execute", method, request=request)
             # Note: Multi-worker session affinity forwarding is handled earlier
             # (before method routing) to apply to ALL methods, not just tools/call
             try:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -4300,6 +4300,9 @@ class ToolService(BaseService):
             tool_lookup_cache = _get_tool_lookup_cache()
             cached_payload = await tool_lookup_cache.get(name) if tool_lookup_cache.enabled else None
 
+            if server_id and cached_payload and (cached_payload.get("tool") or {}).get("name") != name:
+                cached_payload = None
+
             if cached_payload:
                 status = cached_payload.get("status", "active")
                 if status == "missing":
@@ -4312,47 +4315,28 @@ class ToolService(BaseService):
                 gateway_payload = cached_payload.get("gateway")
 
         if not tool_payload:
-            tools = self._load_invocable_tools(db, name, server_id=server_id)
+            tool, multiple_found = await self._select_invocable_tool(
+                db,
+                name,
+                user_email=user_email,
+                token_teams=token_teams,
+                server_id=server_id,
+            )
             tool_selected_from_server_scope = bool(server_id)
-
-            if not tools:
-                raise ToolNotFoundError(f"Tool not found: {name}")
-
-            multiple_found = len(tools) > 1
-            if not multiple_found:
-                tool = tools[0]
-            else:
-                visibility_priority = {"team": 0, "private": 1, "public": 2}
-                accessible_tools: list[tuple[int, int, Any]] = []
-                for candidate in tools:
-                    tool_dict = {"visibility": candidate.visibility, "team_id": candidate.team_id, "owner_email": candidate.owner_email}
-                    if await self._check_tool_access(db, tool_dict, user_email, token_teams):
-                        name_priority = 0 if getattr(candidate, "name", None) == name else 1
-                        priority = visibility_priority.get(candidate.visibility, 99)
-                        accessible_tools.append((name_priority, priority, candidate))
-
-                if not accessible_tools:
-                    raise ToolNotFoundError(f"Tool not found: {name}")
-
-                accessible_tools.sort(key=lambda item: (item[0], item[1]))
-                best_name_priority, best_visibility_priority = accessible_tools[0][0], accessible_tools[0][1]
-                best_tools = [candidate for name_priority, priority, candidate in accessible_tools if name_priority == best_name_priority and priority == best_visibility_priority]
-                if len(best_tools) > 1:
-                    raise ToolInvocationError(f"Multiple tools found with name '{name}' at same priority level. Tool name is ambiguous.")
-                tool = best_tools[0]
 
             if not tool.enabled:
                 raise ToolNotFoundError(f"Tool '{name}' exists but is inactive")
 
             if not tool.reachable:
-                await tool_lookup_cache.set_negative(name, "offline")
+                if tool.name == name:
+                    await tool_lookup_cache.set_negative(name, "offline")
                 raise ToolNotFoundError(f"Tool '{name}' exists but is currently offline. Please verify if it is running.")
 
             gateway = tool.gateway
             cache_payload = self._build_tool_cache_payload(tool, gateway)
             tool_payload = cache_payload.get("tool") or {}
             gateway_payload = cache_payload.get("gateway")
-            if not multiple_found:
+            if not multiple_found and tool_payload.get("name") == name:
                 await tool_lookup_cache.set(name, cache_payload, gateway_id=tool_payload.get("gateway_id"))
 
         if tool_payload.get("enabled") is False:
@@ -4836,24 +4820,95 @@ class ToolService(BaseService):
             False,
         )
 
-    def _load_invocable_tools(self, db: Session, name: str, server_id: Optional[str] = None) -> List[DbTool]:
-        """Load candidate tools for invocation, narrowing to a virtual server when possible.
+    def _load_invocable_tools(self, db: Session, name: str, server_id: Optional[str] = None, *, match_original_name: bool = False) -> List[DbTool]:
+        """Load exact-name or original-name candidates for invocation.
 
         Args:
             db: Active database session.
             name: Tool name to resolve.
             server_id: Optional virtual server identifier used to constrain results.
+            match_original_name: Match ``DbTool.original_name`` instead of
+                ``DbTool.name``. Used only for server-scoped fallback resolution.
 
         Returns:
             A list of candidate tool ORM rows matching the request.
         """
-        name_filter = DbTool.name == name  # pylint: disable=comparison-with-callable
-        if server_id:
-            name_filter = or_(name_filter, DbTool.original_name == name)
+        name_filter = DbTool.original_name == name if match_original_name else DbTool.name == name  # pylint: disable=comparison-with-callable
         query = select(DbTool).options(joinedload(DbTool.gateway)).where(name_filter)
         if server_id:
             query = query.join(server_tool_association, DbTool.id == server_tool_association.c.tool_id).where(server_tool_association.c.server_id == server_id)
-        return db.execute(query).scalars().all()
+        return list(db.execute(query).scalars().all())
+
+    async def _select_invocable_tool(
+        self,
+        db: Session,
+        name: str,
+        *,
+        user_email: Optional[str],
+        token_teams: Optional[List[str]],
+        server_id: Optional[str],
+    ) -> Tuple[DbTool, bool]:
+        """Select an accessible invocation target using exact then scoped fallback lookup.
+
+        Exact-name candidates retain the existing visibility-priority behavior. A
+        server-scoped ``original_name`` fallback is valid only when exactly one
+        accessible attached tool matches, because visibility cannot disambiguate
+        tools exposed by different gateways under the same upstream name.
+
+        Args:
+            db: Active database session.
+            name: Tool name requested by the caller.
+            user_email: Effective requester email for visibility checks.
+            token_teams: Team scope from the caller token.
+            server_id: Optional virtual server identifier restricting candidates.
+
+        Returns:
+            The selected tool and whether its lookup contained multiple raw candidates.
+
+        Raises:
+            ToolNotFoundError: If no accessible candidate exists.
+            ToolInvocationError: If the highest-priority exact match or the scoped
+                original-name fallback is ambiguous.
+        """
+
+        async def accessible_tools(candidates: List[DbTool]) -> List[DbTool]:
+            accessible: List[DbTool] = []
+            for candidate in candidates:
+                tool_dict = {
+                    "visibility": candidate.visibility,
+                    "team_id": candidate.team_id,
+                    "owner_email": candidate.owner_email,
+                }
+                if await self._check_tool_access(db, tool_dict, user_email, token_teams):
+                    accessible.append(candidate)
+            return accessible
+
+        exact_candidates = self._load_invocable_tools(db, name, server_id=server_id)
+        if not server_id and len(exact_candidates) == 1:
+            # Preserve direct invocation's existing state-check and access-check
+            # ordering. The access-first behavior below is required specifically
+            # to decide whether scoped original-name fallback may run.
+            return exact_candidates[0], False
+
+        accessible_exact = await accessible_tools(exact_candidates)
+        if accessible_exact:
+            multiple_found = len(exact_candidates) > 1
+            visibility_priority = {"team": 0, "private": 1, "public": 2}
+            best_priority = min(visibility_priority.get(candidate.visibility, 99) for candidate in accessible_exact)
+            best_tools = [candidate for candidate in accessible_exact if visibility_priority.get(candidate.visibility, 99) == best_priority]
+            if len(best_tools) > 1:
+                raise ToolInvocationError(f"Multiple tools found with name '{name}' at same priority level. Tool name is ambiguous.")
+            return best_tools[0], multiple_found
+
+        if server_id:
+            fallback_candidates = self._load_invocable_tools(db, name, server_id=server_id, match_original_name=True)
+            accessible_fallback = await accessible_tools(fallback_candidates)
+            if len(accessible_fallback) > 1:
+                raise ToolInvocationError(f"Multiple tools found with name '{name}' at same priority level. Tool name is ambiguous.")
+            if accessible_fallback:
+                return accessible_fallback[0], len(fallback_candidates) > 1
+
+        raise ToolNotFoundError(f"Tool not found: {name}")
 
     # ------------------------------------------------------------------
     # Retry helpers (used by invoke_tool)
@@ -5088,6 +5143,9 @@ class ToolService(BaseService):
             tool_lookup_cache = _get_tool_lookup_cache()
             cached_payload = await tool_lookup_cache.get(name) if tool_lookup_cache.enabled else None
 
+            if server_id and cached_payload and (cached_payload.get("tool") or {}).get("name") != name:
+                cached_payload = None
+
             if cached_payload:
                 status = cached_payload.get("status", "active")
                 if status == "missing":
@@ -5100,50 +5158,22 @@ class ToolService(BaseService):
                 gateway_payload = cached_payload.get("gateway")
 
         if not tool_payload:
-            # Eager load tool WITH gateway in single query to prevent lazy load N+1
-            # Use a single query to avoid a race between separate enabled/inactive lookups.
-            # Use scalars().all() instead of scalar_one_or_none() to handle duplicate
-            # tool names across teams without crashing on MultipleResultsFound.
-            tools = self._load_invocable_tools(db, name, server_id=server_id)
-
-            if not tools:
-                raise ToolNotFoundError(f"Tool not found: {name}")
-
-            multiple_found = len(tools) > 1
-            if not multiple_found:
-                tool = tools[0]
-            else:
-                # Multiple tools found with same name — filter by access using
-                # _check_tool_access (same rules as list_tools) and prioritize.
-                # Priority (lower is better): team (0) > private (1) > public (2)
-                visibility_priority = {"team": 0, "private": 1, "public": 2}
-                accessible_tools: list[tuple[int, int, Any]] = []
-                for t in tools:
-                    tool_dict = {"visibility": t.visibility, "team_id": t.team_id, "owner_email": t.owner_email}
-                    if await self._check_tool_access(db, tool_dict, user_email, token_teams):
-                        name_priority = 0 if getattr(t, "name", None) == name else 1
-                        priority = visibility_priority.get(t.visibility, 99)
-                        accessible_tools.append((name_priority, priority, t))
-
-                if not accessible_tools:
-                    raise ToolNotFoundError(f"Tool not found: {name}")
-
-                accessible_tools.sort(key=lambda x: (x[0], x[1]))
-
-                # Check for ambiguity at the highest priority level
-                best_name_priority, best_visibility_priority = accessible_tools[0][0], accessible_tools[0][1]
-                best_tools = [t for name_priority, p, t in accessible_tools if name_priority == best_name_priority and p == best_visibility_priority]
-
-                if len(best_tools) > 1:
-                    raise ToolInvocationError(f"Multiple tools found with name '{name}' at same priority level. Tool name is ambiguous.")
-
-                tool = best_tools[0]
+            # Each resolution stage eager-loads the gateway and uses scalars().all()
+            # so duplicate names across teams remain deterministic.
+            tool, multiple_found = await self._select_invocable_tool(
+                db,
+                name,
+                user_email=user_email,
+                token_teams=token_teams,
+                server_id=server_id,
+            )
 
             if not tool.enabled:
                 raise ToolNotFoundError(f"Tool '{name}' exists but is inactive")
 
             if not tool.reachable:
-                await tool_lookup_cache.set_negative(name, "offline")
+                if tool.name == name:
+                    await tool_lookup_cache.set_negative(name, "offline")
                 raise ToolNotFoundError(f"Tool '{name}' exists but is currently offline. Please verify if it is running.")
 
             gateway = tool.gateway
@@ -5152,7 +5182,7 @@ class ToolService(BaseService):
             gateway_payload = cache_payload.get("gateway")
             # Skip caching when multiple tools share a name — resolution is
             # user-dependent, so a cached result could be wrong for other users.
-            if not multiple_found:
+            if not multiple_found and tool_payload.get("name") == name:
                 await tool_lookup_cache.set(name, cache_payload, gateway_id=tool_payload.get("gateway_id"))
 
         if tool_payload.get("enabled") is False:
@@ -5172,7 +5202,8 @@ class ToolService(BaseService):
             # Check deprecated status after RBAC to avoid leaking tool existence
             if tool_payload.get("deprecated") is True:
                 # Cache the deprecated status to avoid repeated DB queries
-                await tool_lookup_cache.set_negative(name, "deprecated")
+                if tool_payload.get("name") == name:
+                    await tool_lookup_cache.set_negative(name, "deprecated")
                 raise ToolInvocationError(f"Tool '{name}' is deprecated and cannot be executed. Please update your agent to use an alternative tool.")
 
             # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -9437,6 +9437,292 @@ class TestInvokeToolDirectProxyViaHeader:
                 )
 
 
+class TestScopedToolResolution:
+    """Tests for exact-name and virtual-server original-name resolution."""
+
+    @staticmethod
+    def _candidate(name, original_name, visibility="public", team_id=None, owner_email=None):
+        return SimpleNamespace(
+            id=f"{name}-{visibility}",
+            name=name,
+            original_name=original_name,
+            visibility=visibility,
+            team_id=team_id,
+            owner_email=owner_email,
+        )
+
+    @staticmethod
+    def _cache_payload(name, original_name, *, deprecated=False):
+        return {
+            "status": "active",
+            "tool": {
+                "id": "tool-1",
+                "name": name,
+                "original_name": original_name,
+                "enabled": True,
+                "reachable": True,
+                "deprecated": deprecated,
+                "visibility": "public",
+                "team_id": None,
+                "owner_email": None,
+                "gateway_id": "gateway-1",
+            },
+            "gateway": {"id": "gateway-1"},
+        }
+
+    @staticmethod
+    def _cache_mock(payload=None):
+        cache = AsyncMock()
+        cache.enabled = True
+        cache.get = AsyncMock(return_value=payload)
+        cache.set = AsyncMock()
+        cache.set_negative = AsyncMock()
+        return cache
+
+    @pytest.mark.asyncio
+    async def test_exact_name_keeps_visibility_priority(self, tool_service):
+        """Exact-name collisions should retain team/private/public priority behavior."""
+        public_tool = self._candidate("qualified-tool", "remote-tool", visibility="public")
+        team_tool = self._candidate("qualified-tool", "remote-tool", visibility="team", team_id="team-a")
+
+        with (
+            patch.object(tool_service, "_load_invocable_tools", return_value=[public_tool, team_tool]),
+            patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+        ):
+            selected, multiple_found = await tool_service._select_invocable_tool(
+                MagicMock(),
+                "qualified-tool",
+                user_email="user@example.com",
+                token_teams=["team-a"],
+                server_id="server-1",
+            )
+
+        assert selected is team_tool
+        assert multiple_found is True
+
+    @pytest.mark.asyncio
+    async def test_exact_name_same_priority_remains_ambiguous(self, tool_service):
+        """Exact-name candidates tied at the best visibility priority remain ambiguous."""
+        first = self._candidate("qualified-tool", "remote-tool", visibility="team", team_id="team-a")
+        second = self._candidate("qualified-tool", "remote-tool", visibility="team", team_id="team-b")
+
+        with (
+            patch.object(tool_service, "_load_invocable_tools", return_value=[first, second]),
+            patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+        ):
+            with pytest.raises(ToolInvocationError, match="ambiguous"):
+                await tool_service._select_invocable_tool(
+                    MagicMock(),
+                    "qualified-tool",
+                    user_email="user@example.com",
+                    token_teams=["team-a", "team-b"],
+                    server_id="server-1",
+                )
+
+    @pytest.mark.asyncio
+    async def test_original_name_fallback_runs_after_inaccessible_exact_match(self, tool_service):
+        """An inaccessible exact match should not block an accessible scoped fallback."""
+        inaccessible_exact = self._candidate("search", "remote-search", visibility="team", team_id="other-team")
+        fallback = self._candidate("gateway-search", "search", visibility="public")
+        load_tools = MagicMock(side_effect=[[inaccessible_exact], [fallback]])
+        db = MagicMock()
+
+        with (
+            patch.object(tool_service, "_load_invocable_tools", load_tools),
+            patch.object(tool_service, "_check_tool_access", AsyncMock(side_effect=[False, True])),
+        ):
+            selected, multiple_found = await tool_service._select_invocable_tool(
+                db,
+                "search",
+                user_email="user@example.com",
+                token_teams=["team-a"],
+                server_id="server-1",
+            )
+
+        assert selected is fallback
+        assert multiple_found is False
+        assert load_tools.call_args_list == [
+            call(db, "search", server_id="server-1"),
+            call(db, "search", server_id="server-1", match_original_name=True),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_original_name_fallback_does_not_use_visibility_priority(self, tool_service):
+        """Multiple accessible fallback matches are ambiguous across gateways."""
+        team_tool = self._candidate("gateway-a-search", "search", visibility="team", team_id="team-a")
+        public_tool = self._candidate("gateway-b-search", "search", visibility="public")
+
+        with (
+            patch.object(tool_service, "_load_invocable_tools", side_effect=[[], [team_tool, public_tool]]),
+            patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+        ):
+            with pytest.raises(ToolInvocationError, match="ambiguous"):
+                await tool_service._select_invocable_tool(
+                    MagicMock(),
+                    "search",
+                    user_email="user@example.com",
+                    token_teams=["team-a"],
+                    server_id="server-1",
+                )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "cached_payload",
+        [
+            {"status": "offline"},
+            {"status": "active", "tool": {"name": "other-qualified-tool"}},
+        ],
+        ids=["negative", "nonmatching-positive"],
+    )
+    async def test_python_scoped_resolution_ignores_unsafe_cache_entries(self, tool_service, cached_payload):
+        """Python scoped lookup should fall through unsafe global cache entries."""
+        cache = self._cache_mock(cached_payload)
+        select_tool = AsyncMock(side_effect=ToolNotFoundError("scoped database lookup"))
+
+        with (
+            patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
+            patch.object(tool_service, "_select_invocable_tool", select_tool),
+        ):
+            with pytest.raises(ToolNotFoundError, match="scoped database lookup"):
+                await tool_service._resolve_tool_for_invocation(
+                    MagicMock(),
+                    "qualified-search",
+                    request_headers=None,
+                    server_id="server-1",
+                    user_email="user@example.com",
+                    token_teams=["team-a"],
+                    require_app_visible=False,
+                    require_model_visible=False,
+                )
+
+        select_tool.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_scoped_exact_name_populates_cache(self, tool_service):
+        """A deterministic scoped exact-name resolution should warm the global cache."""
+        cache = self._cache_mock()
+        tool = self._candidate("qualified-search", "search")
+        tool.enabled = True
+        tool.reachable = True
+        tool.gateway = SimpleNamespace(id="gateway-1")
+        payload = self._cache_payload("qualified-search", "search")
+        db = MagicMock()
+        db.execute.return_value.first.return_value = ("tool-1",)
+
+        with (
+            patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
+            patch.object(tool_service, "_select_invocable_tool", AsyncMock(return_value=(tool, False))),
+            patch.object(tool_service, "_build_tool_cache_payload", return_value=payload),
+            patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+        ):
+            await tool_service._resolve_tool_for_invocation(
+                db,
+                "qualified-search",
+                request_headers=None,
+                server_id="server-1",
+                user_email="user@example.com",
+                token_teams=["team-a"],
+                require_app_visible=False,
+                require_model_visible=False,
+            )
+
+        cache.set.assert_awaited_once_with("qualified-search", payload, gateway_id="gateway-1")
+
+    @pytest.mark.asyncio
+    async def test_visibility_resolved_exact_name_does_not_populate_cache(self, tool_service):
+        """User-dependent exact-name selection should retain cache-write suppression."""
+        cache = self._cache_mock()
+        tool = self._candidate("qualified-search", "search", visibility="team", team_id="team-a")
+        tool.enabled = True
+        tool.reachable = True
+        tool.gateway = SimpleNamespace(id="gateway-1")
+        payload = self._cache_payload("qualified-search", "search")
+        db = MagicMock()
+        db.execute.return_value.first.return_value = ("tool-1",)
+
+        with (
+            patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
+            patch.object(tool_service, "_select_invocable_tool", AsyncMock(return_value=(tool, True))),
+            patch.object(tool_service, "_build_tool_cache_payload", return_value=payload),
+            patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+        ):
+            await tool_service._resolve_tool_for_invocation(
+                db,
+                "qualified-search",
+                request_headers=None,
+                server_id="server-1",
+                user_email="user@example.com",
+                token_teams=["team-a"],
+                require_app_visible=False,
+                require_model_visible=False,
+            )
+
+        cache.set.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_scoped_original_name_fallback_does_not_write_cache(self, tool_service):
+        """A fallback result must not publish a payload under its unqualified request key."""
+        cache = self._cache_mock()
+        tool = self._candidate("gateway-search", "search")
+        tool.enabled = True
+        tool.reachable = True
+        tool.gateway = SimpleNamespace(id="gateway-1")
+        payload = self._cache_payload("gateway-search", "search")
+        db = MagicMock()
+        db.execute.return_value.first.return_value = ("tool-1",)
+
+        with (
+            patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
+            patch.object(tool_service, "_select_invocable_tool", AsyncMock(return_value=(tool, False))),
+            patch.object(tool_service, "_build_tool_cache_payload", return_value=payload),
+            patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+        ):
+            await tool_service._resolve_tool_for_invocation(
+                db,
+                "search",
+                request_headers=None,
+                server_id="server-1",
+                user_email="user@example.com",
+                token_teams=["team-a"],
+                require_app_visible=False,
+                require_model_visible=False,
+            )
+
+        cache.set.assert_not_awaited()
+        cache.set_negative.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("reachable", "deprecated", "error_type"), [(False, False, ToolNotFoundError), (True, True, ToolInvocationError)])
+    async def test_scoped_original_name_failure_does_not_write_negative_cache(self, tool_service, reachable, deprecated, error_type):
+        """Offline and deprecated fallback results must not poison the bare-name key."""
+        cache = self._cache_mock()
+        tool = self._candidate("gateway-search", "search")
+        tool.enabled = True
+        tool.reachable = reachable
+        tool.gateway = SimpleNamespace(id="gateway-1")
+        payload = self._cache_payload("gateway-search", "search", deprecated=deprecated)
+
+        with (
+            patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
+            patch.object(tool_service, "_select_invocable_tool", AsyncMock(return_value=(tool, False))),
+            patch.object(tool_service, "_build_tool_cache_payload", return_value=payload),
+            patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+        ):
+            with pytest.raises(error_type):
+                await tool_service._resolve_tool_for_invocation(
+                    MagicMock(),
+                    "search",
+                    request_headers=None,
+                    server_id="server-1",
+                    user_email="user@example.com",
+                    token_teams=["team-a"],
+                    require_app_visible=False,
+                    require_model_visible=False,
+                )
+
+        cache.set_negative.assert_not_awaited()
+
+
 class TestRustMcpExecutionPlan:
     """Tests for ToolService.prepare_rust_mcp_tool_execution()."""
 
@@ -9569,7 +9855,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service.create_span", MagicMock(return_value=MagicMock(__enter__=MagicMock(return_value=MagicMock()), __exit__=MagicMock(return_value=False)))),
             patch("mcpgateway.services.tool_service.create_child_span", MagicMock(return_value=MagicMock(__enter__=MagicMock(return_value=MagicMock()), __exit__=MagicMock(return_value=False)))),
             patch("mcpgateway.services.tool_service.metrics_buffer", MagicMock()),
-            patch.object(tool_service, "_load_invocable_tools", return_value=[original_name_match, exact_name_tool]),
+            patch.object(tool_service, "_load_invocable_tools", side_effect=[[exact_name_tool], [original_name_match]]),
             patch.object(tool_service, "_check_tool_access", AsyncMock(side_effect=[True, True, True])),
             patch.object(tool_service, "_build_tool_cache_payload", return_value=exact_payload) as build_payload,
             patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
@@ -9884,6 +10170,81 @@ class TestRustMcpExecutionPlan:
                 await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one")
 
     @pytest.mark.asyncio
+    async def test_prepare_rust_mcp_tool_execution_ignores_scoped_negative_cache_entry(self, tool_service):
+        """Scoped lookup should ignore a global negative entry and query its server."""
+        cache = self._cache_mock({"status": "offline"})
+        select_tool = AsyncMock(side_effect=ToolNotFoundError("scoped database lookup"))
+
+        with (
+            patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
+            patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
+            patch.object(tool_service, "_select_invocable_tool", select_tool),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
+        ):
+            with pytest.raises(ToolNotFoundError, match="scoped database lookup"):
+                await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one", server_id="server-1")
+
+        select_tool.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_prepare_rust_mcp_tool_execution_ignores_scoped_nonmatching_cache_entry(self, tool_service):
+        """Scoped lookup should ignore a positive entry stored under the wrong name."""
+        cache = self._cache_mock(self._cache_payload(name="other-qualified-tool"))
+        select_tool = AsyncMock(side_effect=ToolNotFoundError("scoped database lookup"))
+
+        with (
+            patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
+            patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
+            patch.object(tool_service, "_select_invocable_tool", select_tool),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
+        ):
+            with pytest.raises(ToolNotFoundError, match="scoped database lookup"):
+                await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one", server_id="server-1")
+
+        select_tool.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_prepare_rust_mcp_tool_execution_does_not_cache_scoped_fallback(self, tool_service):
+        """Rust preparation should not publish an original-name fallback under a bare key."""
+        cache = self._cache_mock(None)
+        gateway = SimpleNamespace(id="gw-1", auth_value=None, auth_query_params=None, oauth_config=None)
+        tool = SimpleNamespace(
+            id="tool-1",
+            name="gateway-tool-one",
+            original_name="tool-one",
+            enabled=True,
+            deprecated=False,
+            reachable=True,
+            visibility="public",
+            team_id=None,
+            owner_email=None,
+            gateway=gateway,
+        )
+        payload = self._cache_payload(name="gateway-tool-one", original_name="tool-one")
+
+        with (
+            patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
+            patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
+            patch("mcpgateway.services.tool_service.global_config_cache.get_passthrough_headers", return_value=[]),
+            patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", side_effect=lambda request_headers, headers, *_args, **_kwargs: headers),
+            patch.object(tool_service, "_select_invocable_tool", AsyncMock(return_value=(tool, False))),
+            patch.object(tool_service, "_build_tool_cache_payload", return_value=payload),
+            patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
+        ):
+            plan = await tool_service.prepare_rust_mcp_tool_execution(
+                MagicMock(),
+                "tool-one",
+                server_id="server-1",
+                user_email="user@example.com",
+                token_teams=["team-a"],
+            )
+
+        assert plan["eligible"] is True
+        cache.set.assert_not_awaited()
+        cache.set_negative.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_prepare_rust_mcp_tool_execution_direct_proxy_fallback(self, tool_service):
         """Direct-proxy gateways should fall back to the Python execution path."""
         gateway = SimpleNamespace(
@@ -10103,7 +10464,7 @@ class TestRustMcpExecutionPlan:
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
             patch("mcpgateway.services.tool_service.global_config_cache.get_passthrough_headers", return_value=[]),
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", side_effect=lambda request_headers, headers, *_args, **_kwargs: headers),
-            patch.object(tool_service, "_load_invocable_tools", return_value=[original_name_match, exact_name_tool]),
+            patch.object(tool_service, "_load_invocable_tools", side_effect=[[exact_name_tool], [original_name_match]]),
             patch.object(tool_service, "_check_tool_access", AsyncMock(side_effect=[True, True, True])),
             patch.object(tool_service, "_build_tool_cache_payload", return_value=self._cache_payload(id="exact-tool", gateway_id="gw-1")),
             patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
@@ -10138,9 +10499,11 @@ class TestRustMcpExecutionPlan:
 
     @pytest.mark.asyncio
     async def test_prepare_rust_mcp_tool_execution_rejects_inactive_db_tool(self, tool_service):
-        """Inactive DB-loaded tools should fail before plan generation."""
+        """An inactive exact match should fail without trying original-name fallback."""
         cache = self._cache_mock(None)
         tool = SimpleNamespace(
+            name="tool-one",
+            original_name="remote-tool-one",
             enabled=False,
             reachable=True,
             visibility="public",
@@ -10148,21 +10511,35 @@ class TestRustMcpExecutionPlan:
             owner_email=None,
             gateway=SimpleNamespace(),
         )
+        fallback = SimpleNamespace(
+            name="gateway-tool-one",
+            original_name="tool-one",
+            enabled=True,
+            reachable=True,
+            visibility="public",
+            team_id=None,
+            owner_email=None,
+            gateway=SimpleNamespace(),
+        )
+        load_tools = MagicMock(side_effect=[[tool], [fallback]])
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),
             patch("mcpgateway.services.tool_service.current_trace_id", MagicMock(get=MagicMock(return_value=None))),
-            patch.object(tool_service, "_load_invocable_tools", return_value=[tool]),
+            patch.object(tool_service, "_load_invocable_tools", load_tools),
             patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             with pytest.raises(ToolNotFoundError, match="inactive"):
-                await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one")
+                await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one", server_id="server-1")
+
+        assert load_tools.call_count == 1
 
     @pytest.mark.asyncio
     async def test_prepare_rust_mcp_tool_execution_marks_unreachable_tools_offline_and_caches_negative_result(self, tool_service):
-        """Unreachable DB-loaded tools should set a negative cache entry before failing."""
+        """A scoped exact-name offline tool should retain negative-cache behavior."""
         cache = self._cache_mock(None)
         tool = SimpleNamespace(
+            name="tool-one",
             enabled=True,
             reachable=False,
             visibility="public",
@@ -10178,7 +10555,7 @@ class TestRustMcpExecutionPlan:
             patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=None)),
         ):
             with pytest.raises(ToolNotFoundError, match="currently offline"):
-                await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one")
+                await tool_service.prepare_rust_mcp_tool_execution(MagicMock(), "tool-one", server_id="server-1")
 
         cache.set_negative.assert_awaited_once_with("tool-one", "offline")
 

--- a/tests/unit/mcpgateway/test_rpc_tool_invocation.py
+++ b/tests/unit/mcpgateway/test_rpc_tool_invocation.py
@@ -7,7 +7,7 @@ Test RPC tool invocation after PR #746 changes.
 """
 
 # Standard
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 # Third-Party
 from fastapi.testclient import TestClient
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 # First-Party
 from mcpgateway.main import app
 from mcpgateway.common.models import Tool
+from mcpgateway.services.server_service import ServerNotFoundError
 from mcpgateway.services.tool_service import ToolNotFoundError
 from mcpgateway.services.tool_service import ToolService
 
@@ -262,6 +263,71 @@ class TestRPCServerIdScoping:
         assert body["jsonrpc"] == "2.0"
         assert "result" in body
         assert "tools" in body["result"]
+
+    def test_rpc_tools_call_preflights_accessible_server(self, client):
+        """Scoped tools/call should validate server visibility before invocation."""
+        with (
+            patch("mcpgateway.config.settings.auth_required", False),
+            patch("mcpgateway.main.validate_server_access", return_value=True),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", ["team-a"])),
+            patch("mcpgateway.main.server_service.get_server", new_callable=AsyncMock, return_value=MagicMock()) as get_server,
+            patch("mcpgateway.main._execute_rpc_tools_call", new_callable=AsyncMock, return_value={"content": []}) as execute_call,
+        ):
+            response = client.post(
+                "/rpc",
+                json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "qualified-tool", "server_id": "server-1", "arguments": {}}, "id": 4},
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {"jsonrpc": "2.0", "result": {"content": []}, "id": 4}
+        get_server.assert_awaited_once_with(ANY, "server-1", user_email="user@example.com", token_teams=["team-a"])
+        execute_call.assert_awaited_once()
+
+    def test_rpc_tools_call_maps_hidden_server_to_generic_not_found(self, client):
+        """ServerNotFoundError should preserve get_server's non-disclosure contract."""
+        get_server = AsyncMock(side_effect=ServerNotFoundError("Server not found: server-1"))
+        execute_call = AsyncMock()
+
+        with (
+            patch("mcpgateway.config.settings.auth_required", False),
+            patch("mcpgateway.main.validate_server_access", return_value=True),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", ["team-a"])),
+            patch("mcpgateway.main.server_service.get_server", get_server),
+            patch("mcpgateway.main._execute_rpc_tools_call", execute_call),
+        ):
+            response = client.post(
+                "/rpc",
+                json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "qualified-tool", "server_id": "server-1", "arguments": {}}, "id": 5},
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "jsonrpc": "2.0",
+            "error": {"code": -32002, "message": "Server not found: server-1", "data": {"server_id": "server-1"}},
+            "id": 5,
+        }
+        get_server.assert_awaited_once()
+        execute_call.assert_not_awaited()
+
+    def test_internal_tools_call_skips_public_rpc_server_preflight(self, client):
+        """Trusted MCP transport dispatch should retain its existing lightweight path."""
+        get_server = AsyncMock()
+
+        with (
+            patch("mcpgateway.config.settings.auth_required", False),
+            patch("mcpgateway.main.get_internal_mcp_auth_context", return_value={"scoped_server_id": "server-1"}),
+            patch("mcpgateway.main.validate_server_access", return_value=True),
+            patch("mcpgateway.main.server_service.get_server", get_server),
+            patch("mcpgateway.main._execute_rpc_tools_call", new_callable=AsyncMock, return_value={"content": []}) as execute_call,
+        ):
+            response = client.post(
+                "/rpc",
+                json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "qualified-tool", "server_id": "server-1", "arguments": {}}, "id": 6},
+            )
+
+        assert response.status_code == 200
+        get_server.assert_not_awaited()
+        execute_call.assert_awaited_once()
 
     def test_rpc_skips_validation_for_unscoped_token_without_server_id(self, client, mock_db):
         """Global token (no scopes.server_id) without server_id in params → proceeds to global list."""


### PR DESCRIPTION
## Summary

Refs #6416
Parent: #6400

Hardens virtual-server-scoped `tools/call` invocation for the frontend Try-it flow and other public `/rpc` clients.

This change:

- validates that the caller can access a supplied `server_id` before public `/rpc` dispatch
- preserves non-disclosure by returning the same generic JSON-RPC not-found response for unknown and inaccessible servers
- makes scoped tool resolution deterministic while preserving existing exact-name visibility behavior
- prevents `original_name` fallback lookups from polluting the global bare-name tool cache
- keeps exact qualified-name caching on the virtual-server MCP hot path

## Reproduction Steps

1. Attach tools from multiple gateways to a virtual server where the tools share an `original_name`.
2. Invoke that bare name through a scoped `tools/call` request.
3. Observe that visibility priority can silently choose one fallback candidate instead of reporting ambiguity.
4. Observe that a fallback result or negative status can be cached globally under the bare lookup name and affect later scoped or unscoped lookups.
5. Send a public `/rpc` `tools/call` with an arbitrary `server_id`; token scope is checked, but server visibility is not explicitly preflighted.

## Root Cause

Scoped lookup queried qualified names and `original_name` values together, then applied visibility priority to both. That priority is valid for exact qualified-name collisions but can hide ambiguity between fallback candidates from different gateways.

The global lookup cache is keyed by the requested name. A scoped fallback can therefore resolve a qualified tool under a different bare requested name and publish a positive or negative entry under a key that does not identify the resolved tool.

The public `/rpc` handler validated token server scopes but did not perform the same server visibility lookup used by other server-facing entry points.

## Fix Description

- Public `/rpc` validates `server_id` with `server_service.get_server` before dispatching `tools/call`. Missing and inaccessible servers both return JSON-RPC error `-32002`. Token-scope rejection remains `-32003`.
- The preflight is limited to public `/rpc`; trusted internal `/servers/{id}/mcp` dispatch keeps its existing scope enforcement and does not hydrate the full server graph on every call.
- Scoped resolution now runs in two stages:
  1. Exact `DbTool.name` match: preserve access filtering, visibility priority, and same-priority ambiguity handling.
  2. `DbTool.original_name` fallback: after access filtering, require exactly one candidate and do not use visibility priority to choose between gateways.
- Enabled and reachable checks occur after exact-name selection and do not trigger fallback.
- Python and Rust preparation paths use the same selector and cache identity rules.
- A cached entry is accepted only when its stored qualified tool name equals the requested cache key. Negative entries and mismatched positive entries are ignored for scoped calls.
- Cache writes occur only when the resolved qualified name equals the requested key. Exact-name scoped calls still warm the cache; fallback calls do not publish positive, offline, or deprecated entries under a bare name.
- Existing suppression of visibility-dependent positive cache writes remains in place.

## Reviewability

- [x] This PR has one clear purpose
- [x] Unrelated changes are deferred to separate follow-ups
- [x] Tests are included with the code they validate

Out of scope for this PR:

- changing authorization for `POST /cancellation/cancel`; scoped cancellation already uses `notifications/cancelled` through `/rpc`
- adding standardized resolved-gateway result metadata
- changing cache keys, invalidation indexes, transport routing, or session-registry behavior

## Verification

| Check | Command | Status |
|---|---|---|
| Focused unit tests | `uv run pytest tests/unit/mcpgateway/services/test_tool_service.py tests/unit/mcpgateway/test_rpc_tool_invocation.py tests/unit/mcpgateway/cache/test_tool_lookup_cache.py -q` | Passed |
| Ruff lint | `uv run ruff check mcpgateway/main.py mcpgateway/services/tool_service.py tests/unit/mcpgateway/services/test_tool_service.py tests/unit/mcpgateway/test_rpc_tool_invocation.py` | Passed |
| Ruff format | `uv run ruff format --check mcpgateway/main.py mcpgateway/services/tool_service.py tests/unit/mcpgateway/services/test_tool_service.py tests/unit/mcpgateway/test_rpc_tool_invocation.py` | Passed |
| Python compile | `.venv/bin/python -m py_compile mcpgateway/main.py mcpgateway/services/tool_service.py` | Passed |
| Diff whitespace | `git diff --check main...HEAD` | Passed |

Repository-wide `uv run ty check` still reports existing baseline diagnostics. The changed production line ranges introduce no new diagnostics.

## MCP Compliance

- [x] No breaking change to MCP clients
- [x] Existing qualified tool names remain preferred
- [x] Scoped `original_name` support remains available as a compatibility fallback

## Checklist

- [x] Focused code and tests are formatted
- [x] No secrets or credentials are included
- [x] Public error responses preserve server non-disclosure
