### PR TITLE
chore: remove dead external log sink settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2242,21 +2242,6 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # Number of days to retain logs in the database
 # LOG_RETENTION_DAYS=30
 
-# External Log Integration Configuration
-# Send logs to Elasticsearch
-# ELASTICSEARCH_ENABLED=false
-# ELASTICSEARCH_URL=
-# ELASTICSEARCH_INDEX_PREFIX=mcpgateway-logs
-
-# Send logs to syslog
-# SYSLOG_ENABLED=false
-# SYSLOG_HOST=
-# SYSLOG_PORT=514
-
-# Send logs to webhook endpoints
-# WEBHOOK_LOGGING_ENABLED=false
-# WEBHOOK_LOGGING_URLS=[]
-
 # SIEM Export Configuration (security/audit event export pipeline)
 # SIEM_EXPORT_ENABLED=false
 # SIEM_EXPORT_BATCH_SIZE=100

--- a/charts/mcp-stack/README.md
+++ b/charts/mcp-stack/README.md
@@ -732,14 +732,6 @@ For detailed guidance on resource limits and process management, see `docs/docs/
 | mcpContextForge.config.STRUCTURED_LOGGING_ENABLED | string | `"true"` |  |
 | mcpContextForge.config.STRUCTURED_LOGGING_EXTERNAL_ENABLED | string | `"false"` |  |
 | mcpContextForge.config.STRUCTURED_LOGGING_DATABASE_ENABLED | string | `"false"` |  |
-| mcpContextForge.config.SYSLOG_ENABLED | string | `"false"` |  |
-| mcpContextForge.config.SYSLOG_HOST | string | `""` |  |
-| mcpContextForge.config.SYSLOG_PORT | string | `"514"` |  |
-| mcpContextForge.config.ELASTICSEARCH_ENABLED | string | `"false"` |  |
-| mcpContextForge.config.ELASTICSEARCH_URL | string | `""` |  |
-| mcpContextForge.config.ELASTICSEARCH_INDEX_PREFIX | string | `"mcpgateway-logs"` |  |
-| mcpContextForge.config.WEBHOOK_LOGGING_ENABLED | string | `"false"` |  |
-| mcpContextForge.config.WEBHOOK_LOGGING_URLS | string | `"[]"` |  |
 | mcpContextForge.config.LOG_RETENTION_DAYS | string | `"30"` |  |
 | mcpContextForge.config.LOG_SEARCH_MAX_RESULTS | string | `"1000"` |  |
 | mcpContextForge.config.MASKED_AUTH_VALUE | string | `"*****"` |  |

--- a/charts/mcp-stack/values.schema.json
+++ b/charts/mcp-stack/values.schema.json
@@ -457,9 +457,6 @@
                 "false"
               ]
             },
-            "ELASTICSEARCH_ENABLED": {
-              "type": "string"
-            },
             "ENABLE_HEADER_PASSTHROUGH": {
               "type": "string"
             },
@@ -1240,9 +1237,6 @@
             "STRUCTURED_LOGGING_EXTERNAL_ENABLED": {
               "type": "string"
             },
-            "SYSLOG_ENABLED": {
-              "type": "string"
-            },
             "TEAM_MEMBER_COUNT_CACHE_ENABLED": {
               "type": "string"
             },
@@ -1326,9 +1320,6 @@
               "type": "string"
             },
             "VALIDATION_STRICT": {
-              "type": "string"
-            },
-            "WEBHOOK_LOGGING_ENABLED": {
               "type": "string"
             },
             "WELL_KNOWN_CACHE_MAX_AGE": {

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -817,18 +817,7 @@ mcpContextForge:
     # Structured logging
     STRUCTURED_LOGGING_ENABLED: "true" # enable structured logging
     STRUCTURED_LOGGING_DATABASE_ENABLED: "false" # persist structured logs to DB (impacts performance)
-
-    # External log sinks (all disabled by default)
-    STRUCTURED_LOGGING_EXTERNAL_ENABLED: "false"
-    SYSLOG_ENABLED: "false"
-    ELASTICSEARCH_ENABLED: "false"
-    WEBHOOK_LOGGING_ENABLED: "false"
-    # Uncomment and configure when enabling an external sink:
-    # SYSLOG_HOST: ""
-    # SYSLOG_PORT: "514"
-    # ELASTICSEARCH_URL: ""
-    # ELASTICSEARCH_INDEX_PREFIX: "mcpgateway-logs"
-    # WEBHOOK_LOGGING_URLS: "[]"
+    STRUCTURED_LOGGING_EXTERNAL_ENABLED: "false" # enable external structured logging
 
     # Log search
     LOG_RETENTION_DAYS: "30" # retention in days

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -2455,16 +2455,6 @@ class Settings(BaseSettings):
     log_search_max_results: int = Field(default=1000, description="Maximum results per log search query")
     log_retention_days: int = Field(default=30, description="Number of days to retain logs in database")
 
-    # External Log Integration Configuration
-    elasticsearch_enabled: bool = Field(default=False, description="Send logs to Elasticsearch")
-    elasticsearch_url: Optional[str] = Field(default=None, description="Elasticsearch cluster URL")
-    elasticsearch_index_prefix: str = Field(default="mcpgateway-logs", description="Elasticsearch index prefix")
-    syslog_enabled: bool = Field(default=False, description="Send logs to syslog")
-    syslog_host: Optional[str] = Field(default=None, description="Syslog server host")
-    syslog_port: int = Field(default=514, description="Syslog server port")
-    webhook_logging_enabled: bool = Field(default=False, description="Send logs to webhook endpoints")
-    webhook_logging_urls: List[str] = Field(default_factory=list, description="Webhook URLs for log delivery")
-
     @field_validator("siem_destinations", mode="before")
     @classmethod
     def parse_siem_destinations(cls, value: Any) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary

Removes the three dead external logging sink settings identified in #5848:

- `elasticsearch_enabled`
- `syslog_enabled`
- `webhook_logging_enabled`

Also removes their unused companion configuration values and corresponding Helm chart / `.env.example` documentation entries.

`STRUCTURED_LOGGING_EXTERNAL_ENABLED` remains in place as the active external structured logging toggle.

## Scope

This PR is intentionally limited to the three logging-sink flags discussed in #5848. The remaining five flags can be handled separately as needed.

## Verification

- Updated against current upstream `main` before applying the cleanup
- Confirmed the three removed flags no longer appear outside the generated `docs/docs/design/images/classes.svg`
- DCO sign-off included

Part of #5848.