### PR TITLE
fix: unpack list_servers tuple in import conflict preview

### DIFF
--- a/mcpgateway/services/import_service.py
+++ b/mcpgateway/services/import_service.py
@@ -1663,7 +1663,7 @@ class ImportService:
                 existing, _ = await self.gateway_service.list_gateways(db)
                 item_info["conflicts_with"] = any(g.name == item_name for g in existing)
             elif entity_type == "servers":
-                existing = await self.server_service.list_servers(db)
+                existing, _ = await self.server_service.list_servers(db)
                 item_info["conflicts_with"] = any(s.name == item_name for s in existing)
             elif entity_type == "prompts":
                 existing, _ = await self.prompt_service.list_prompts(db)


### PR DESCRIPTION
### Summary

`ImportService._build_item_info()` iterated the `(List[ServerRead], Optional[str])` tuple returned by `list_servers()` instead of the list itself. Each `s` was therefore the list or `None`, so `s.name` raised `AttributeError`, which the surrounding `except Exception` swallowed — leaving `conflicts_with` permanently `False` for servers.

The effect: the import preview never warns that a server of the same name already exists, so users importing into a populated instance are surprised by the actual `UPDATE`/`SKIP` behaviour at submit time.

### Change

One line in `mcpgateway/services/import_service.py`, bringing the `servers` branch in line with the `tools`, `gateways`, `prompts` and `resources` branches immediately around it:

```python
-existing = await self.server_service.list_servers(db)
+existing, _ = await self.server_service.list_servers(db)
```

### Context

This is the last outstanding defect from #5500; the other four items reported there were confirmed already fixed during triage on the issue.

Closes #5500

### Validation

Not yet run on this branch — happy to add the lint/test/coverage results, or a regression test covering the server conflict-preview path, if maintainers would like that before merge.