### PR TITLE
feat: add passwordless SSO user provisioning service

### DIFF
--- a/mcpgateway/services/email_auth_service.py
+++ b/mcpgateway/services/email_auth_service.py
@@ -39,7 +39,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 # First-Party
-from mcpgateway.auth_user_helpers import DISABLED_PASSWORD_HASH, is_passwordless_user
+from mcpgateway.auth_user_helpers import DISABLED_PASSWORD_HASH, is_passwordless_user, PASSWORDLESS_HASH_TYPE
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.db import (
@@ -55,6 +55,7 @@ from mcpgateway.db import (
     PendingUserApproval,
     Role,
     SSOAuthSession,
+    SSOProvider,
     TokenRevocation,
     UserRole,
     utc_now,
@@ -64,6 +65,7 @@ from mcpgateway.services.argon2_service import Argon2PasswordService
 from mcpgateway.services.email_notification_service import AuthEmailNotificationService, build_frontend_url
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.metrics import password_reset_completions_counter, password_reset_requests_counter
+from mcpgateway.sso_provider_ids import canonicalize_sso_provider_id, SSOProviderValidationError
 from mcpgateway.utils.pagination import unified_paginate
 
 # Initialize logging
@@ -630,6 +632,9 @@ class EmailAuthService:
         skip_password_validation: bool = False,
         granted_by: Optional[str] = None,
         skip_onboarding: bool = False,
+        passwordless: bool = False,
+        email_verified: Optional[bool] = None,
+        admin_origin_source: Optional[str] = None,
     ) -> EmailUser:
         """Create a new user with email authentication.
 
@@ -649,11 +654,16 @@ class EmailAuthService:
                 ``except Exception`` path) are always recorded regardless of
                 this flag.  Duplicate-user rejections (``UserExistsError``,
                 ``IntegrityError``) are not audited by design.
+            passwordless: Create a passwordless user with no local password hash.
+            email_verified: Explicit email verification state. ``None`` keeps the
+                existing granted_by-derived behavior.
+            admin_origin_source: Source to record when creating an administrator.
 
         Returns:
             EmailUser: The created user object
 
         Raises:
+            ValueError: If passwordless creation is requested with local-password-only fields
             EmailValidationError: If email format is invalid
             PasswordValidationError: If password doesn't meet policy
             UserExistsError: If user already exists
@@ -670,12 +680,17 @@ class EmailAuthService:
             # user.full_name      # Returns: 'New User'
             # user.is_active      # Returns: True
         """
+        if passwordless and password:
+            raise ValueError("Password is not allowed for passwordless users")
+        if passwordless and password_change_required:
+            raise ValueError("Password change cannot be required for passwordless users")
+
         # Normalize email to lowercase
         email = email.lower().strip()
 
         # Validate inputs
         self.validate_email(email)
-        if not skip_password_validation:
+        if not skip_password_validation and not passwordless:
             # Determine if this is a privileged account
             is_privileged_account = is_admin or auth_provider != "local"
             self.validate_password(password, email, is_privileged_account)
@@ -686,10 +701,18 @@ class EmailAuthService:
         # ensure_user_exists for service accounts) get a non-loginable sentinel;
         # all other callers go through hash_password_async which raises
         # ValueError on empty input.
-        if not password and skip_password_validation:
+        if passwordless:
+            password_hash = None
+            password_hash_type = PASSWORDLESS_HASH_TYPE
+            password_changed_at = None
+        elif not password and skip_password_validation:
             password_hash = DISABLED_PASSWORD_HASH  # nosec B105 — not a valid Argon2 hash, verify_password always rejects
+            password_hash_type = "argon2id"
+            password_changed_at = utc_now()
         else:
             password_hash = await self.password_service.hash_password_async(password)
+            password_hash_type = "argon2id"
+            password_changed_at = utc_now()
 
         # Check if user already exists
         existing_user = await self.get_user_by_email(email)
@@ -705,16 +728,22 @@ class EmailAuthService:
             is_active=is_active,
             password_change_required=password_change_required,
             auth_provider=auth_provider,
-            password_changed_at=utc_now(),
-            admin_origin="api" if is_admin else None,
+            password_hash_type=password_hash_type,
+            password_changed_at=password_changed_at,
+            admin_origin=(admin_origin_source or "api") if is_admin else None,
         )
 
-        # Admin-created users are implicitly email-verified (the admin vouched for them)
-        if granted_by:
+        # Admin-created users are implicitly email-verified unless callers explicitly override it.
+        if email_verified is not None:
+            user.email_verified_at = utc_now() if email_verified else None
+        elif granted_by:
             user.email_verified_at = utc_now()
 
         try:
             self.db.add(user)
+            if passwordless:
+                self.db.flush()
+                user.password_changed_at = None
             self.db.commit()
             self.db.refresh(user)
 
@@ -794,6 +823,82 @@ class EmailAuthService:
             self.db.commit()
 
             raise
+
+    def _validate_enabled_sso_provider_id(self, provider_id: str) -> str:
+        """Return the canonical ID for a configured, enabled SSO provider.
+
+        Args:
+            provider_id: Inbound provider ID or supported alias.
+
+        Returns:
+            Canonical provider ID stored on users.
+
+        Raises:
+            SSOProviderValidationError: If the provider ID is invalid, missing,
+                or configured but disabled.
+        """
+        canonical_provider_id = canonicalize_sso_provider_id(provider_id)
+        provider = self.db.execute(select(SSOProvider).where(SSOProvider.id == canonical_provider_id)).scalar_one_or_none()
+        if not provider:
+            raise SSOProviderValidationError(f"SSO provider '{canonical_provider_id}' is not configured")
+        if not provider.is_enabled:
+            raise SSOProviderValidationError(f"SSO provider '{canonical_provider_id}' is disabled")
+        return canonical_provider_id
+
+    async def create_sso_user(
+        self,
+        email: str,
+        auth_provider: str,
+        full_name: Optional[str] = None,
+        is_admin: bool = False,
+        is_active: bool = True,
+        granted_by: Optional[str] = None,
+    ) -> EmailUser:
+        """Create a passwordless SSO/federated user.
+
+        This service method is for explicit administrator-driven provisioning.
+        It intentionally does not enforce browser JIT policies such as
+        provider ``auto_create_users``, trusted-domain checks, or pending
+        approval flows.
+
+        Args:
+            email: User's email address.
+            auth_provider: SSO provider ID or supported alias.
+            full_name: Optional full name.
+            is_admin: Whether to create the user as an administrator.
+            is_active: Whether the user is active.
+            granted_by: Email of the administrator provisioning the user.
+
+        Returns:
+            EmailUser: The created user.
+
+        Raises:
+            EmailValidationError: If email format is invalid.
+            SSOProviderValidationError: If provider ID is invalid, missing, or disabled.
+            UserExistsError: If a user with the email already exists.
+        """
+        normalized_email = email.lower().strip()
+        self.validate_email(normalized_email)
+        canonical_provider_id = self._validate_enabled_sso_provider_id(auth_provider)
+
+        existing_user = await self.get_user_by_email(normalized_email)
+        if existing_user:
+            raise UserExistsError(f"User with email {normalized_email} already exists")
+
+        return await self.create_user(
+            email=normalized_email,
+            password="",
+            full_name=full_name,
+            is_admin=is_admin,
+            is_active=is_active,
+            password_change_required=False,
+            auth_provider=canonical_provider_id,
+            skip_password_validation=True,
+            granted_by=granted_by,
+            passwordless=True,
+            email_verified=False,
+            admin_origin_source="sso" if is_admin else None,
+        )
 
     async def ensure_user_exists(
         self,

--- a/mcpgateway/sso_provider_ids.py
+++ b/mcpgateway/sso_provider_ids.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/sso_provider_ids.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Helpers for SSO provider identifier canonicalization.
+"""
+
+MAX_SSO_PROVIDER_ID_LENGTH = 50
+
+_PROVIDER_ALIASES = {
+    "azure-ad": "entra",
+}
+
+
+class SSOProviderValidationError(Exception):
+    """Raised when an SSO provider ID is invalid or unavailable.
+
+    Examples:
+        >>> canonicalize_sso_provider_id("azure-ad")
+        'entra'
+        >>> canonicalize_sso_provider_id(" Entra ")
+        'entra'
+        >>> canonicalize_sso_provider_id("custom-oidc")
+        'custom-oidc'
+        >>> canonicalize_sso_provider_id("")
+        Traceback (most recent call last):
+        ...
+        mcpgateway.sso_provider_ids.SSOProviderValidationError: SSO provider ID is required
+    """
+
+
+def canonicalize_sso_provider_id(provider_id: str) -> str:
+    """Return the canonical provider ID for an inbound SSO provider value.
+
+    This helper is intentionally pure: it does not decide whether a provider
+    is configured or enabled. Callers validate the returned ID against
+    ``SSOProvider`` rows.
+
+    Args:
+        provider_id: Inbound provider ID.
+
+    Returns:
+        Canonical provider ID.
+
+    Raises:
+        SSOProviderValidationError: If the provider ID is empty or too long.
+
+    Examples:
+        >>> canonicalize_sso_provider_id("AZURE-AD")
+        'entra'
+        >>> canonicalize_sso_provider_id("okta")
+        'okta'
+        >>> canonicalize_sso_provider_id("custom-provider")
+        'custom-provider'
+        >>> canonicalize_sso_provider_id("x" * 51)
+        Traceback (most recent call last):
+        ...
+        mcpgateway.sso_provider_ids.SSOProviderValidationError: SSO provider ID exceeds 50 characters
+    """
+    if not isinstance(provider_id, str):
+        raise SSOProviderValidationError("SSO provider ID is required")
+
+    normalized = provider_id.strip().lower()
+    canonical = _PROVIDER_ALIASES.get(normalized, normalized)
+
+    if not canonical:
+        raise SSOProviderValidationError("SSO provider ID is required")
+    if len(canonical) > MAX_SSO_PROVIDER_ID_LENGTH:
+        raise SSOProviderValidationError(f"SSO provider ID exceeds {MAX_SSO_PROVIDER_ID_LENGTH} characters")
+
+    return canonical

--- a/tests/unit/mcpgateway/services/test_email_auth_basic.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_basic.py
@@ -526,8 +526,90 @@ class TestEmailAuthServiceUserManagement:
         )
 
         assert user.password_hash == DISABLED_PASSWORD_HASH
+        assert user.password_hash_type == "argon2id"
+        assert user.password_changed_at is not None
         mock_password_service.hash_password_async.assert_not_called()
         mock_db.add.assert_called_once_with(user)
+
+    @pytest.mark.asyncio
+    async def test_create_user_passwordless_rejects_non_empty_password(self, service, mock_db):
+        """Passwordless creation cannot silently discard a supplied password."""
+        with pytest.raises(ValueError, match="Password is not allowed"):
+            await service.create_user(email="passwordless@example.com", password="SecurePass4$x", passwordless=True)  # pragma: allowlist secret
+
+        mock_db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_user_passwordless_rejects_password_change_required(self, service, mock_db):
+        """Passwordless users cannot be created into a local password-change flow."""
+        with pytest.raises(ValueError, match="Password change cannot be required"):
+            await service.create_user(email="passwordless@example.com", password="", passwordless=True, password_change_required=True)
+
+        mock_db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_user_email_verified_default_preserves_self_registration(self, service, mock_db, mock_password_service):
+        """Without granted_by, create_user preserves the existing unverified default."""
+        service.password_service = mock_password_service
+        mock_db.execute.return_value.scalar_one_or_none.return_value = None
+
+        user = await service.create_user(
+            email="self-register@example.com",
+            password="SecurePass4$x",  # pragma: allowlist secret
+            skip_password_validation=True,
+            skip_onboarding=True,
+        )
+
+        assert user.email_verified_at is None
+
+    @pytest.mark.asyncio
+    async def test_create_user_granted_by_still_marks_email_verified(self, service, mock_db, mock_password_service):
+        """Admin-vouched users retain the existing verified behavior."""
+        service.password_service = mock_password_service
+        mock_db.execute.return_value.scalar_one_or_none.return_value = None
+
+        user = await service.create_user(
+            email="admin-created@example.com",
+            password="SecurePass4$x",  # pragma: allowlist secret
+            skip_password_validation=True,
+            skip_onboarding=True,
+            granted_by="admin@example.com",
+        )
+
+        assert user.email_verified_at is not None
+
+    @pytest.mark.asyncio
+    async def test_create_user_explicit_email_verified_false_wins_over_granted_by(self, service, mock_db, mock_password_service):
+        """Explicit email_verified=False overrides the granted_by-derived default."""
+        service.password_service = mock_password_service
+        mock_db.execute.return_value.scalar_one_or_none.return_value = None
+
+        user = await service.create_user(
+            email="explicit-unverified@example.com",
+            password="SecurePass4$x",  # pragma: allowlist secret
+            skip_password_validation=True,
+            skip_onboarding=True,
+            granted_by="admin@example.com",
+            email_verified=False,
+        )
+
+        assert user.email_verified_at is None
+
+    @pytest.mark.asyncio
+    async def test_create_user_admin_origin_defaults_to_api_for_admins(self, service, mock_db, mock_password_service):
+        """Existing admin creation callers keep admin_origin='api' by default."""
+        service.password_service = mock_password_service
+        mock_db.execute.return_value.scalar_one_or_none.return_value = None
+
+        user = await service.create_user(
+            email="admin-origin@example.com",
+            password="SecurePass4$x",  # pragma: allowlist secret
+            is_admin=True,
+            skip_password_validation=True,
+            skip_onboarding=True,
+        )
+
+        assert user.admin_origin == "api"
 
     @pytest.mark.skip(reason="PersonalTeamService import happens inside method, complex to mock")
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/services/test_email_auth_sso_provisioning.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_sso_provisioning.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_email_auth_sso_provisioning.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Tests for internal passwordless SSO user provisioning.
+"""
+
+# Standard
+from uuid import uuid4
+
+# Third-Party
+import pytest
+from sqlalchemy import select
+
+# First-Party
+from mcpgateway.auth_user_helpers import is_passwordless_user, PASSWORDLESS_HASH_TYPE
+from mcpgateway.db import EmailUser, SSOProvider, utc_now
+from mcpgateway.services.email_auth_service import EmailAuthService, SSOProviderValidationError, UserExistsError
+
+
+def _unique(prefix: str) -> str:
+    """Return a unique identifier for shared test DB fixtures."""
+    return f"{prefix}-{uuid4().hex}"
+
+
+def _add_provider(db, provider_id: str, *, name: str | None = None, is_enabled: bool = True, auto_create_users: bool = True) -> SSOProvider:
+    """Add an SSO provider row for provisioning tests."""
+    provider = SSOProvider(
+        id=provider_id,
+        name=name or provider_id,
+        display_name=f"{provider_id} provider",
+        provider_type="oidc",
+        is_enabled=is_enabled,
+        client_id=f"{provider_id}-client",
+        client_secret_encrypted="encrypted",
+        authorization_url=f"https://{provider_id}.example.com/authorize",
+        token_url=f"https://{provider_id}.example.com/token",
+        userinfo_url=f"https://{provider_id}.example.com/userinfo",
+        auto_create_users=auto_create_users,
+    )
+    db.add(provider)
+    db.commit()
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_create_sso_user_creates_passwordless_user(test_db, monkeypatch) -> None:
+    """Enabled providers can create explicit passwordless SSO users."""
+    monkeypatch.setattr("mcpgateway.services.email_auth_service.settings.auto_create_personal_teams", False)
+    _add_provider(test_db, "entra")
+    service = EmailAuthService(test_db)
+    email = f"{_unique('sso-user')}@example.com"
+
+    user = await service.create_sso_user(email=email, auth_provider="azure-ad", full_name="SSO User", granted_by="admin@example.com")
+
+    assert user.email == email
+    assert user.full_name == "SSO User"
+    assert user.password_hash is None
+    assert user.password_hash_type == PASSWORDLESS_HASH_TYPE
+    assert user.password_changed_at is None
+    assert user.auth_provider == "entra"
+    assert user.email_verified_at is None
+    assert user.password_change_required is False
+    assert is_passwordless_user(user) is True
+
+    stored = test_db.execute(select(EmailUser).where(EmailUser.email == email)).scalar_one()
+    assert stored.password_hash is None
+    assert stored.password_hash_type == PASSWORDLESS_HASH_TYPE
+
+
+@pytest.mark.asyncio
+async def test_create_sso_user_accepts_unknown_configured_provider(test_db, monkeypatch) -> None:
+    """Custom provider IDs pass canonicalization when configured and enabled."""
+    monkeypatch.setattr("mcpgateway.services.email_auth_service.settings.auto_create_personal_teams", False)
+    provider_id = _unique("custom-oidc")
+    _add_provider(test_db, provider_id)
+    service = EmailAuthService(test_db)
+
+    user = await service.create_sso_user(email=f"{_unique('custom-sso')}@example.com", auth_provider=provider_id.upper())
+
+    assert user.auth_provider == provider_id
+    assert user.password_hash is None
+    assert user.password_hash_type == PASSWORDLESS_HASH_TYPE
+
+
+@pytest.mark.asyncio
+async def test_create_sso_user_does_not_match_provider_name(test_db) -> None:
+    """Provider validation matches SSOProvider.id only, not the display name or name."""
+    provider_id = _unique("provider-id")
+    _add_provider(test_db, provider_id, name="name-only-provider")
+    service = EmailAuthService(test_db)
+
+    with pytest.raises(SSOProviderValidationError, match="not configured"):
+        await service.create_sso_user(email=f"{_unique('name-match')}@example.com", auth_provider="name-only-provider")
+
+
+@pytest.mark.asyncio
+async def test_create_sso_user_rejects_missing_disabled_and_overlength_provider(test_db) -> None:
+    """Provider failures use the typed provider validation error."""
+    disabled_provider_id = _unique("disabled")
+    _add_provider(test_db, disabled_provider_id, is_enabled=False)
+    service = EmailAuthService(test_db)
+
+    with pytest.raises(SSOProviderValidationError, match="not configured"):
+        await service.create_sso_user(email=f"{_unique('missing')}@example.com", auth_provider=_unique("missing-provider"))
+
+    with pytest.raises(SSOProviderValidationError, match="disabled"):
+        await service.create_sso_user(email=f"{_unique('disabled-user')}@example.com", auth_provider=disabled_provider_id)
+
+    with pytest.raises(SSOProviderValidationError, match="exceeds 50"):
+        await service.create_sso_user(email=f"{_unique('long-provider')}@example.com", auth_provider="x" * 51)
+
+
+@pytest.mark.asyncio
+async def test_create_sso_user_provider_error_precedes_duplicate(test_db) -> None:
+    """Provider validation happens before duplicate checks for actionable errors."""
+    email = f"{_unique('duplicate-provider-order')}@example.com"
+    existing = EmailUser(email=email, password_hash="hash", password_hash_type="argon2id", auth_provider="local")
+    test_db.add(existing)
+    test_db.commit()
+    service = EmailAuthService(test_db)
+
+    with pytest.raises(SSOProviderValidationError, match="not configured"):
+        await service.create_sso_user(email=email, auth_provider=_unique("missing-provider"))
+
+    stored = test_db.execute(select(EmailUser).where(EmailUser.email == email)).scalar_one()
+    assert stored.password_hash == "hash"
+    assert stored.password_hash_type == "argon2id"
+    assert stored.auth_provider == "local"
+
+
+@pytest.mark.asyncio
+async def test_create_sso_user_duplicate_leaves_existing_user_unchanged(test_db) -> None:
+    """Duplicate email raises UserExistsError and does not mutate the existing row."""
+    provider_id = _unique("dup-provider")
+    _add_provider(test_db, provider_id)
+    email = f"{_unique('duplicate-sso')}@example.com"
+    changed_at = utc_now()
+    existing = EmailUser(
+        email=email,
+        password_hash="existing-hash",
+        password_hash_type="argon2id",
+        full_name="Existing User",
+        auth_provider="local",
+        password_changed_at=changed_at,
+    )
+    test_db.add(existing)
+    test_db.commit()
+    service = EmailAuthService(test_db)
+
+    with pytest.raises(UserExistsError, match="already exists"):
+        await service.create_sso_user(email=email, auth_provider=provider_id, full_name="Changed User")
+
+    stored = test_db.execute(select(EmailUser).where(EmailUser.email == email)).scalar_one()
+    assert stored.full_name == "Existing User"
+    assert stored.password_hash == "existing-hash"
+    assert stored.password_hash_type == "argon2id"
+    assert stored.auth_provider == "local"
+    assert stored.password_changed_at is not None
+    assert stored.password_changed_at.replace(tzinfo=changed_at.tzinfo) == changed_at
+
+
+@pytest.mark.asyncio
+async def test_create_sso_user_ignores_auto_create_users_policy(test_db, monkeypatch) -> None:
+    """Admin/service provisioning intentionally bypasses browser JIT auto-create policy."""
+    monkeypatch.setattr("mcpgateway.services.email_auth_service.settings.auto_create_personal_teams", False)
+    provider_id = _unique("manual-provider")
+    _add_provider(test_db, provider_id, auto_create_users=False)
+    service = EmailAuthService(test_db)
+
+    user = await service.create_sso_user(email=f"{_unique('manual-provisioned')}@example.com", auth_provider=provider_id)
+
+    assert user.auth_provider == provider_id
+    assert user.password_hash is None
+    assert user.password_hash_type == PASSWORDLESS_HASH_TYPE
+
+
+@pytest.mark.asyncio
+async def test_create_sso_user_admin_origin_is_sso(test_db, monkeypatch) -> None:
+    """SSO-provisioned admins are marked as SSO-origin admins."""
+    monkeypatch.setattr("mcpgateway.services.email_auth_service.settings.auto_create_personal_teams", False)
+    provider_id = _unique("admin-provider")
+    _add_provider(test_db, provider_id)
+    service = EmailAuthService(test_db)
+
+    user = await service.create_sso_user(email=f"{_unique('sso-admin')}@example.com", auth_provider=provider_id, is_admin=True)
+
+    assert user.is_admin is True
+    assert user.admin_origin == "sso"

--- a/tests/unit/mcpgateway/test_sso_provider_ids.py
+++ b/tests/unit/mcpgateway/test_sso_provider_ids.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_sso_provider_ids.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Tests for SSO provider ID canonicalization.
+"""
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.sso_provider_ids import canonicalize_sso_provider_id, SSOProviderValidationError
+
+
+@pytest.mark.parametrize(
+    ("provider_id", "expected"),
+    [
+        ("azure-ad", "entra"),
+        ("AZURE-AD", "entra"),
+        (" Entra ", "entra"),
+        ("okta", "okta"),
+        (" Custom-OIDC ", "custom-oidc"),
+    ],
+)
+def test_canonicalize_sso_provider_id(provider_id: str, expected: str) -> None:
+    """Provider IDs are normalized without becoming a hard-coded allowlist."""
+    assert canonicalize_sso_provider_id(provider_id) == expected
+
+
+@pytest.mark.parametrize("provider_id", ["", "   ", None])
+def test_canonicalize_sso_provider_id_rejects_missing(provider_id: object) -> None:
+    """Missing provider IDs raise the typed provider validation error."""
+    with pytest.raises(SSOProviderValidationError, match="required"):
+        canonicalize_sso_provider_id(provider_id)
+
+
+def test_canonicalize_sso_provider_id_checks_length_after_aliasing() -> None:
+    """Length is checked after normalization and alias resolution."""
+    assert canonicalize_sso_provider_id(" " + ("x" * 50) + " ") == "x" * 50
+    with pytest.raises(SSOProviderValidationError, match="exceeds 50"):
+        canonicalize_sso_provider_id("x" * 51)


### PR DESCRIPTION
## Summary

Adds the internal service-layer path for administrator-driven passwordless SSO user provisioning.

## Details

- Adds pure SSO provider ID canonicalization with azure-ad accepted as an inbound alias for entra.
- Validates SSO providers against configured, enabled SSOProvider rows by provider id.
- Adds EmailAuthService.create_sso_user(...) for passwordless federated users.
- Extends create_user(...) with internal passwordless, email verification, and admin-origin controls while preserving existing defaults.
- Keeps browser SSO/JIT behavior unchanged.

## Notes

This service intentionally bypasses browser JIT policies such as auto_create_users, trusted-domain checks, and pending-approval flow. Those policies remain owned by runtime SSO login paths.

No live-gateway endpoint is exposed in this PR.

Closes #6581