### PR TITLE
fix: distinguish upstream fetch failure from empty resource content

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -192,7 +192,7 @@ from mcpgateway.services.performance_service import get_performance_service
 from mcpgateway.services.permission_service import PermissionService
 from mcpgateway.services.plugin_service import get_plugin_service, sync_plugin_service_from_runtime
 from mcpgateway.services.prompt_service import PromptArgumentsJSONError, PromptNameConflictError, PromptNotFoundError, PromptService
-from mcpgateway.services.resource_service import ResourceNotFoundError, ResourceService, ResourceURIConflictError, ResourceValidationError
+from mcpgateway.services.resource_service import ResourceError, ResourceNotFoundError, ResourceService, ResourceURIConflictError, ResourceValidationError
 from mcpgateway.services.root_service import RootService, RootServiceError, RootServiceNotFoundError, RootServiceValidationError
 from mcpgateway.services.server_service import ServerError, ServerLockConflictError, ServerNameConflictError, ServerNotFoundError, ServerService
 from mcpgateway.services.structured_logger import get_structured_logger
@@ -13450,6 +13450,8 @@ async def admin_test_resource(resource_uri: str, db: Session = Depends(get_db), 
         return {"content": resource_content}
     except ResourceNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except ResourceError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         LOGGER.error(f"Error getting resource for {resource_uri}: {e}")
         raise e

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -6583,9 +6583,10 @@ async def read_resource(resource_id: str, request: Request, db: Session = Depend
         # Release transaction before response serialization
         db.commit()
         db.close()
-    except (ResourceNotFoundError, ResourceError) as exc:
-        # Translate to FastAPI HTTP error
+    except ResourceNotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ResourceError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
     # NOTE: Removed cache.set() - see cache removal comment above
     # Ensure a plain JSON-serializable structure

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -6526,6 +6526,8 @@ async def test_resource_by_uri(
         return {"content": resource_content}
     except ResourceNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except ResourceError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error("Error reading resource by URI %s: %s", resource_uri, e)
         raise

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -1877,11 +1877,11 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         existing.mime_type = mime_type
                         existing.uri_template = r.uri_template or None
                         existing.extension_metadata = r_extension_metadata
-                        existing.text_content = r.content if (mime_type.startswith("text/") or isinstance(r.content, str)) and isinstance(r.content, str) else None
-                        existing.binary_content = (
-                            r.content.encode() if (mime_type.startswith("text/") or isinstance(r.content, str)) and isinstance(r.content, str) else r.content if isinstance(r.content, bytes) else None
-                        )
-                        existing.size = len(r.content) if r.content else 0
+                        # MCP resources/list carries metadata only; ResourceCreate.content
+                        # is a schema placeholder here and real content is fetched on read.
+                        existing.text_content = None
+                        existing.binary_content = None
+                        existing.size = None
                         existing.title = getattr(r, "title", None)
                         existing.tags = getattr(r, "tags", []) or []
                         existing.federation_source = gateway.name
@@ -1904,15 +1904,11 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                                 mime_type=mime_type,
                                 uri_template=r.uri_template or None,
                                 extension_metadata=r_extension_metadata,
-                                text_content=r.content if (mime_type.startswith("text/") or isinstance(r.content, str)) and isinstance(r.content, str) else None,
-                                binary_content=(
-                                    r.content.encode()
-                                    if (mime_type.startswith("text/") or isinstance(r.content, str)) and isinstance(r.content, str)
-                                    else r.content
-                                    if isinstance(r.content, bytes)
-                                    else None
-                                ),
-                                size=len(r.content) if r.content else 0,
+                                # MCP resources/list carries metadata only; ResourceCreate.content
+                                # is a schema placeholder here and real content is fetched on read.
+                                text_content=None,
+                                binary_content=None,
+                                size=None,
                                 tags=getattr(r, "tags", []) or [],
                                 created_by=created_by or "system",
                                 created_from_ip=created_from_ip,

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -150,6 +150,7 @@ class ResourceError(Exception):
 
 
 UNRESOLVED_GATEWAY_RESOURCE_MESSAGE = "Gateway resource content could not be resolved"
+DIRECT_PROXY_RESOURCE_ERROR_MESSAGE = "Direct proxy resource read failed"
 
 
 def _has_authoritative_cached_content(resource: Optional[DbResource]) -> bool:
@@ -2599,8 +2600,9 @@ class ResourceService(BaseService):
                                     # Skip the rest of the DB lookup logic
 
                         except Exception as e:
-                            logger.exception("Error in direct_proxy mode for resource '%s': %s", uri, e)
-                            raise ResourceError(f"Direct proxy resource read failed: {str(e)}")
+                            sanitized_error = sanitize_exception_message(str(e))
+                            logger.exception("Error in direct_proxy mode for resource '%s': %s", uri, sanitized_error)
+                            raise ResourceError(DIRECT_PROXY_RESOURCE_ERROR_MESSAGE) from e
 
                     elif resource_db:
                         # Normal cache mode - resource found in DB

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -2753,6 +2753,15 @@ class ResourceService(BaseService):
                         # visibility scoping with user_email/token_teams before returning content.
                         gateway_fetch_allowed = True
                     if not gateway_fetch_allowed:
+                        if (
+                            resource_db is not None
+                            and getattr(resource_db, "uri_template", None)
+                            and content_id
+                            and template_value is not None
+                            and requested_uri is not None
+                            and str(template_value) == str(requested_uri)
+                        ):
+                            raise ResourceError(UNRESOLVED_GATEWAY_RESOURCE_MESSAGE)
                         return
                     try:
                         resource_response = await self.invoke_resource(

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -149,6 +149,24 @@ class ResourceError(Exception):
     """Base class for resource-related errors."""
 
 
+UNRESOLVED_GATEWAY_RESOURCE_MESSAGE = "Gateway resource content could not be resolved"
+
+
+def _has_authoritative_cached_content(resource: Optional[DbResource]) -> bool:
+    """Return whether persisted content is a trustworthy resource payload.
+
+    Gateway-backed rows with an empty text or binary column are legacy
+    federation placeholders from gateway_service.py resources/list
+    registration, not fetched content. Local resources can still have
+    genuinely empty content.
+    """
+    if resource is None:
+        return False
+    if resource.gateway_id is not None and (resource.text_content == "" or resource.binary_content == b""):
+        return False
+    return resource.text_content is not None or resource.binary_content is not None
+
+
 class ResourceNotFoundError(ResourceError):
     """Raised when a requested resource is not found."""
 
@@ -1705,10 +1723,11 @@ class ResourceService(BaseService):
                 the RFC 8693 subject_token from the caller's Authorization bearer.
 
         Returns:
-            Any: The text content returned by the remote resource, or ``None`` if the
-            gateway could not be contacted or an error occurred.
+            Any: The text content returned by the remote resource, or ``None`` when
+            no resource or gateway is available.
 
         Raises:
+            ResourceError: If the gateway transport/session/read fails.
             Exception: Any unhandled internal errors (e.g., DB issues).
 
         ---
@@ -2072,9 +2091,9 @@ class ResourceService(BaseService):
                             given URI, and returns the textual content from the first item in the
                             response's `contents` list.
 
-                            If any error occurs (network failure, unexpected response format, session
-                            initialization failure, etc.), the method logs the exception and returns
-                            ``None`` instead of raising.
+                            If any error occurs before content is received (network failure,
+                            unexpected response format, session initialization failure, etc.),
+                            the method logs sanitized detail and raises ``ResourceError``.
 
                             Note:
                                 MCP SDK 1.25.0 read_resource() does not support meta parameter.
@@ -2092,8 +2111,7 @@ class ResourceService(BaseService):
 
                             Returns:
                                 str | None:
-                                    The text content returned by the remote resource, or ``None`` if the
-                                    SSE connection fails or the response is invalid.
+                                    The text content returned by the remote resource.
 
                             Notes:
                                 - This function assumes the SSE client context manager yields:
@@ -2147,7 +2165,7 @@ class ResourceService(BaseService):
                                     logger.warning("Ignoring SSE teardown error after resource content was received: %s", sanitized_error)
                                     return resource_text
                                 logger.debug("Exception while connecting to sse gateway: %s", sanitized_error)
-                                return None
+                                raise ResourceError(UNRESOLVED_GATEWAY_RESOURCE_MESSAGE) from e
                             return resource_text
 
                         async def connect_to_streamablehttp_server(server_url: str, uri: str, authentication: Optional[Dict[str, str]] = None) -> str | None:
@@ -2159,9 +2177,9 @@ class ResourceService(BaseService):
                             given URI, and returns the textual content from the first element in the
                             response's `contents` list.
 
-                            If any exception occurs during connection, session initialization, or
-                            resource reading, the function logs the error and returns ``None`` instead
-                            of propagating the exception.
+                            If any exception occurs before content is received during connection,
+                            session initialization, or resource reading, the function logs sanitized
+                            detail and raises ``ResourceError``.
 
                             Note:
                                 MCP SDK 1.25.0 read_resource() does not support meta parameter.
@@ -2178,8 +2196,7 @@ class ResourceService(BaseService):
 
                             Returns:
                                 str | None:
-                                    The text content returned by the StreamableHTTP resource, or ``None``
-                                    if the connection fails or the response format is invalid.
+                                    The text content returned by the StreamableHTTP resource.
 
                             Notes:
                                 - The `streamablehttp_client` context manager must yield a tuple:
@@ -2232,7 +2249,7 @@ class ResourceService(BaseService):
                                     logger.warning("Ignoring StreamableHTTP teardown error after resource content was received: %s", sanitized_error)
                                     return resource_text
                                 logger.debug("Exception while connecting to streamablehttp gateway: %s", sanitized_error)
-                                return None
+                                raise ResourceError(UNRESOLVED_GATEWAY_RESOURCE_MESSAGE) from e
                             return resource_text
 
                         if span:
@@ -2361,6 +2378,21 @@ class ResourceService(BaseService):
         _validate_meta_data(meta_data)
         content = None
         uri = resource_uri or "unknown"
+        content_resolved = False
+        has_valid_cached_fallback = False
+
+        def _resource_has_gateway(resource: Optional[DbResource]) -> bool:
+            return resource_db_gateway is not None or (resource is not None and resource.gateway_id is not None)
+
+        def _resource_content_or_placeholder(resource: DbResource) -> ResourceContent:
+            nonlocal has_valid_cached_fallback
+            if _has_authoritative_cached_content(resource):
+                has_valid_cached_fallback = True
+                return resource.content
+            if _resource_has_gateway(resource):
+                return ResourceContent(type="resource", id=str(resource.id), uri=resource.uri, mime_type=resource.mime_type, text=None)
+            raise ResourceNotFoundError(f"Resource '{resource.id}' has no content")
+
         if resource_id:
             resource_db = db.get(DbResource, resource_id, options=[joinedload(DbResource.gateway)])
             if resource_db:
@@ -2369,7 +2401,7 @@ class ResourceService(BaseService):
                 # Check enabled status in Python (avoids redundant Q3/Q4 re-fetches)
                 if not include_inactive and not resource_db.enabled:
                     raise ResourceNotFoundError(f"Resource '{resource_id}' exists but is inactive")
-                content = resource_db.content
+                content = _resource_content_or_placeholder(resource_db)
             else:
                 uri = None
 
@@ -2558,7 +2590,7 @@ class ResourceService(BaseService):
                                     else:
                                         content = TextResourceContents(uri=uri, text="")
 
-                                    success = True
+                                    content_resolved = True
                                     logger.info(
                                         "[READ RESOURCE] Using direct_proxy mode for gateway %s (from X-Context-Forge-Gateway-Id header). Meta Attached: %s",
                                         SecurityValidator.sanitize_log_message(gateway.id),
@@ -2572,7 +2604,7 @@ class ResourceService(BaseService):
 
                     elif resource_db:
                         # Normal cache mode - resource found in DB
-                        content = resource_db.content
+                        content = _resource_content_or_placeholder(resource_db)
                     else:
                         # Check the inactivity first using the same server scope that
                         # governed the active lookup. Without this, duplicate URIs
@@ -2643,7 +2675,7 @@ class ResourceService(BaseService):
                     resource_db = db.execute(query).scalar_one_or_none()
                     if resource_db:
                         original_uri = resource_db.uri or None
-                        content = resource_db.content
+                        content = _resource_content_or_placeholder(resource_db)
                     else:
                         check_inactivity = db.execute(select(DbResource).where(DbResource.id == str(resource_id)).where(not_(DbResource.enabled))).scalar_one_or_none()
                         if check_inactivity:
@@ -2673,14 +2705,6 @@ class ResourceService(BaseService):
                             raise ResourceNotFoundError(f"Resource not found: {resource_uri or resource_id}")
                         server_scoped = True
 
-                # Set success attributes on span
-                if span:
-                    set_span_attribute(span, "success", True)
-                    set_span_attribute(span, "duration.ms", (time.monotonic() - start_time) * 1000)
-                    if content:
-                        set_span_attribute(span, "content.size", len(str(content)))
-
-                success = True
                 # Return standardized content without breaking callers that expect passthrough
                 # Prefer returning first-class content models or objects with content-like attributes.
                 # ResourceContent and TextContent already imported at top level
@@ -2697,9 +2721,13 @@ class ResourceService(BaseService):
                 # ResourceContent is the legacy model for backwards compatibility
 
                 def _set_gateway_content(content_obj: Any, attr_name: str, resource_response: Any) -> None:
-                    """Apply gateway content or reject unresolved template placeholders."""
+                    """Apply gateway content or keep a valid cached fallback."""
                     if resource_response is not None:
                         setattr(content_obj, attr_name, resource_response)
+                        return
+
+                    if has_valid_cached_fallback:
+                        logger.warning("Gateway resource read returned no content; serving cached content for resource '%s'", getattr(resource_db, "id", None))
                         return
 
                     template_uri = getattr(resource_db, "uri_template", None) if resource_db else None
@@ -2713,54 +2741,51 @@ class ResourceService(BaseService):
                             template_uri,
                             getattr(resource_db_gateway, "id", None) or getattr(resource_db, "gateway_id", None),
                         )
-                        raise ResourceError(f"Resource template '{template_uri}' did not resolve URI '{requested_uri}'")
+                    raise ResourceError(UNRESOLVED_GATEWAY_RESOURCE_MESSAGE)
 
-                if isinstance(content, (ResourceContent, ResourceContents, TextContent)):
+                async def _invoke_gateway_content(content_obj: Any, attr_name: str, template_value: Any) -> None:
+                    """Resolve gateway content, preserving only authoritative cached fallbacks."""
+                    content_id = getattr(content_obj, "id", None)
+                    gateway_fetch_allowed = _resource_has_gateway(resource_db)
+                    requested_uri = uri if uri is not None else original_uri
+                    if resource_db is None and content_id and template_value is not None and requested_uri is not None and str(template_value) == str(requested_uri):
+                        # Template fallback: _read_template_resource already applied Layer-1
+                        # visibility scoping with user_email/token_teams before returning content.
+                        gateway_fetch_allowed = True
+                    if not gateway_fetch_allowed:
+                        return
+                    try:
+                        resource_response = await self.invoke_resource(
+                            db,
+                            resource_id=content_id,
+                            resource_uri=getattr(content_obj, "uri") or None,
+                            resource_template_uri=template_value or None,
+                            user_identity=user,
+                            meta_data=meta_data,
+                            resource_obj=resource_db,
+                            gateway_obj=resource_db_gateway,
+                            server_id=server_id,
+                            request_headers=request_headers,
+                        )
+                    except ResourceError:
+                        if has_valid_cached_fallback:
+                            logger.warning("Gateway resource refresh failed; serving cached content for resource '%s'", getattr(resource_db, "id", None))
+                            return
+                        raise
+                    _set_gateway_content(content_obj, attr_name, resource_response)
+
+                if content_resolved:
+                    pass
+                elif isinstance(content, (ResourceContent, ResourceContents, TextContent)):
                     # Metrics are recorded in read_resource finally block for all resources
-                    resource_response = await self.invoke_resource(
-                        db,
-                        resource_id=getattr(content, "id"),
-                        resource_uri=getattr(content, "uri") or None,
-                        resource_template_uri=getattr(content, "text") or None,
-                        user_identity=user,
-                        meta_data=meta_data,
-                        resource_obj=resource_db,
-                        gateway_obj=resource_db_gateway,
-                        server_id=server_id,
-                        request_headers=request_headers,
-                    )
-                    _set_gateway_content(content, "text", resource_response)
+                    await _invoke_gateway_content(content, "text", getattr(content, "text", None))
                 # If content is any object that quacks like content
                 elif hasattr(content, "text") or hasattr(content, "blob"):
                     # Metrics are recorded in read_resource finally block for all resources
                     if hasattr(content, "blob"):
-                        resource_response = await self.invoke_resource(
-                            db,
-                            resource_id=getattr(content, "id"),
-                            resource_uri=getattr(content, "uri") or None,
-                            resource_template_uri=getattr(content, "blob") or None,
-                            user_identity=user,
-                            meta_data=meta_data,
-                            resource_obj=resource_db,
-                            gateway_obj=resource_db_gateway,
-                            server_id=server_id,
-                            request_headers=request_headers,
-                        )
-                        _set_gateway_content(content, "blob", resource_response)
+                        await _invoke_gateway_content(content, "blob", getattr(content, "blob", None))
                     elif hasattr(content, "text"):
-                        resource_response = await self.invoke_resource(
-                            db,
-                            resource_id=getattr(content, "id"),
-                            resource_uri=getattr(content, "uri") or None,
-                            resource_template_uri=getattr(content, "text") or None,
-                            user_identity=user,
-                            meta_data=meta_data,
-                            resource_obj=resource_db,
-                            gateway_obj=resource_db_gateway,
-                            server_id=server_id,
-                            request_headers=request_headers,
-                        )
-                        _set_gateway_content(content, "text", resource_response)
+                        await _invoke_gateway_content(content, "text", getattr(content, "text", None))
                 # Normalize primitive types to ResourceContent
                 elif isinstance(content, bytes):
                     content = ResourceContent(type="resource", id=str(resource_id), uri=original_uri, blob=content)
@@ -2791,6 +2816,15 @@ class ResourceService(BaseService):
                 if span and content is not None and is_output_capture_enabled("resource.read"):
                     set_span_attribute(span, "langfuse.observation.output", serialize_trace_payload(content))
 
+                # Set success attributes on span only after gateway resolution, hooks,
+                # metadata application, and output serialization have completed.
+                if span:
+                    set_span_attribute(span, "success", True)
+                    set_span_attribute(span, "duration.ms", (time.monotonic() - start_time) * 1000)
+                    if content is not None:
+                        set_span_attribute(span, "content.size", len(str(content)))
+
+                success = True
                 return content
             except Exception as e:
                 success = False

--- a/tests/e2e/test_gateway_async_lifecycle.py
+++ b/tests/e2e/test_gateway_async_lifecycle.py
@@ -25,7 +25,7 @@ from sqlalchemy.pool import StaticPool
 from mcpgateway.config import settings
 from mcpgateway.db import Base
 from mcpgateway.main import app, get_db
-from mcpgateway.schemas import ToolCreate
+from mcpgateway.schemas import ResourceCreate, ToolCreate
 from tests.helpers.auth import make_auth_headers, make_legacy_test_jwt
 from tests.utils.rbac_mocks import MockPermissionService, create_mock_email_user, create_mock_user_context
 
@@ -409,3 +409,79 @@ async def test_sqlite_async_gateway_lifecycle_retry_and_delete_stop_flow(lifecyc
 
     deleted_response = await client.get("/admin/gateways/retry-gateway", headers=TEST_ADMIN_AUTH_HEADER)
     assert deleted_response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_gateway_resource_cold_cache_failure_end_to_end(lifecycle_client, monkeypatch):
+    """A federated placeholder is resolved through the real gateway API and never served as empty content."""
+    client, live_gateway_service = lifecycle_client
+    monkeypatch.setattr(
+        live_gateway_service,
+        "_initialize_gateway",
+        AsyncMock(
+            return_value=(
+                {"resources": {"listChanged": False}},
+                [],
+                [
+                    ResourceCreate(
+                        uri="manual://resource",
+                        name="manual_resource",
+                        description="",
+                        mime_type="text/plain",
+                        content="",
+                    )
+                ],
+                [],
+                [],
+            )
+        ),
+    )
+    monkeypatch.setattr(settings, "gateway_async_lifecycle_enabled", True, raising=False)
+    from mcpgateway.services.resource_service import ResourceError
+    import mcpgateway.main as main_mod
+
+    gateway_id = None
+    try:
+        create_response = await client.post(
+            "/gateways",
+            json={
+                "name": "resource-cache-e2e",
+                "url": "http://example.com/mcp",
+                "transport": "STREAMABLEHTTP",
+                "visibility": "public",
+            },
+            headers=TEST_AUTH_HEADER,
+        )
+        assert create_response.status_code == 202
+        gateway_id = create_response.json()["id"]
+        await live_gateway_service._run_gateway_lifecycle_pass()
+
+        resources_response = await client.get("/resources?include_pagination=false", headers=TEST_AUTH_HEADER)
+        assert resources_response.status_code == 200
+        resource = next(item for item in resources_response.json() if item["uri"] == "manual://resource")
+        assert resource["size"] is None
+
+        with monkeypatch.context() as upstream_available:
+            upstream_available.setattr(main_mod.resource_service, "invoke_resource", AsyncMock(return_value="real upstream content"))
+            healthy_read = await client.post(
+                "/rpc",
+                json={"jsonrpc": "2.0", "id": 1, "method": "resources/read", "params": {"uri": "manual://resource"}},
+                headers=TEST_AUTH_HEADER,
+            )
+        assert healthy_read.status_code == 200
+        assert healthy_read.json()["result"]["contents"][0]["text"] == "real upstream content"
+
+        monkeypatch.setattr(main_mod.resource_service, "invoke_resource", AsyncMock(side_effect=ResourceError("Gateway resource content could not be resolved")))
+        failed_read = await client.post(
+            "/rpc",
+            json={"jsonrpc": "2.0", "id": 2, "method": "resources/read", "params": {"uri": "manual://resource"}},
+            headers=TEST_AUTH_HEADER,
+        )
+        failed_payload = failed_read.json()
+        assert failed_read.status_code == 200
+        assert failed_payload["error"]["code"] == -32000
+        assert "Gateway resource content could not be resolved" in failed_payload["error"]["message"]
+        assert "contents" not in failed_payload.get("result", {})
+    finally:
+        if gateway_id is not None:
+            await client.delete(f"/gateways/{gateway_id}", headers=TEST_AUTH_HEADER)

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -4485,6 +4485,9 @@ async def test_register_gateway_reassigns_orphaned_resource(gateway_service, mon
     added_gateway = db.add.call_args[0][0]
     assert existing in added_gateway.resources
     assert existing.title == "Resource Title"
+    assert existing.text_content is None
+    assert existing.binary_content is None
+    assert existing.size is None
     assert existing_prompt in added_gateway.prompts
     assert existing_prompt.title == "Prompt Title"
 
@@ -4953,6 +4956,9 @@ async def test_register_gateway_creates_new_resources_and_prompts(gateway_servic
     added_gateway = db.add.call_args[0][0]
     assert len(added_gateway.resources) == 1
     assert added_gateway.resources[0].title == "Resource Title"
+    assert added_gateway.resources[0].text_content is None
+    assert added_gateway.resources[0].binary_content is None
+    assert added_gateway.resources[0].size is None
     assert len(added_gateway.prompts) == 1
     assert added_gateway.prompts[0].title == "Prompt Title"
 

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -6045,6 +6045,41 @@ class TestReadResourceCoverageEdges:
                 await svc.read_resource(db, resource_uri="reference://users/7")
 
     @pytest.mark.asyncio
+    async def test_read_local_resource_template_placeholder_raises(self):
+        """Local template placeholders must not be returned as resolved content."""
+        # First-Party
+        from mcpgateway.common.models import ResourceContent
+        from mcpgateway.services.resource_service import ResourceError, ResourceService
+
+        svc = ResourceService()
+        db = MagicMock()
+        db.commit = MagicMock()
+
+        template_db = MagicMock()
+        template_db.id = "local-template"
+        template_db.uri = "greeting://{name}"
+        template_db.uri_template = "greeting://{name}"
+        template_db.enabled = True
+        template_db.visibility = "public"
+        template_db.owner_email = None
+        template_db.team_id = None
+        template_db.gateway_id = None
+
+        db.execute.return_value.scalar_one_or_none.side_effect = [None, None, template_db]
+        content = ResourceContent(type="resource", id="local-template", uri="greeting://{name}", text="greeting://Alice")
+
+        with (
+            patch.object(svc, "_read_template_resource", new_callable=AsyncMock, return_value=content),
+            patch.object(svc, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch.object(svc, "invoke_resource", new_callable=AsyncMock) as invoke_resource,
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service", return_value=MagicMock()),
+        ):
+            with pytest.raises(ResourceError, match="Gateway resource content could not be resolved"):
+                await svc.read_resource(db, resource_uri="greeting://Alice")
+
+        invoke_resource.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_read_resource_template_proxy_allows_empty_text_response(self):
         """Templated proxy reads preserve an intentionally empty text response."""
         # First-Party

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -3907,6 +3907,35 @@ class TestInvokeResourceCoverage:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_gateway_transport_failure_raises_sanitized_resource_error(self, resource_service):
+        """Gateway transport failures raise without exposing the upstream detail."""
+        # First-Party
+        from mcpgateway.services.resource_service import ResourceError
+
+        resource = self._make_resource()
+        gateway = self._make_gateway(transport="sse")
+        db = MagicMock()
+
+        with (
+            patch(
+                "mcpgateway.services.resource_service.settings",
+                MagicMock(
+                    enable_ed25519_signing=False,
+                    platform_admin_email="admin@test.com",
+                    httpx_max_connections=10,
+                    httpx_max_keepalive_connections=5,
+                    httpx_keepalive_expiry=30,
+                    mcp_session_pool_enabled=False,
+                ),
+            ),
+            patch("mcpgateway.services.resource_service.sse_client", side_effect=RuntimeError("secret upstream detail")),
+        ):
+            with pytest.raises(ResourceError, match="Gateway resource content could not be resolved") as exc_info:
+                await resource_service.invoke_resource(db, "res-1", "http://test.com", resource_obj=resource, gateway_obj=gateway)
+
+        assert "secret upstream detail" not in str(exc_info.value)
+
+    @pytest.mark.asyncio
     async def test_template_uri_overrides_resource_uri(self, resource_service, monkeypatch):
         """When resource_template_uri is provided, it should be used instead of resource_uri."""
         resource = self._make_resource()
@@ -6012,7 +6041,7 @@ class TestReadResourceCoverageEdges:
             patch.object(svc, "invoke_resource", new_callable=AsyncMock, return_value=None),
             patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service", return_value=MagicMock()),
         ):
-            with pytest.raises(ResourceError, match="did not resolve URI"):
+            with pytest.raises(ResourceError, match="Gateway resource content could not be resolved"):
                 await svc.read_resource(db, resource_uri="reference://users/7")
 
     @pytest.mark.asyncio
@@ -6082,7 +6111,7 @@ class TestReadResourceCoverageEdges:
             patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service", return_value=MagicMock()),
             caplog.at_level("WARNING", logger="mcpgateway.services.resource_service"),
         ):
-            with pytest.raises(ResourceError, match="did not resolve URI"):
+            with pytest.raises(ResourceError, match="Gateway resource content could not be resolved"):
                 await svc.read_resource(db, resource_uri="reference://users/7")
 
         assert "Resource template proxy read returned no content" in caplog.text
@@ -6122,6 +6151,211 @@ class TestReadResourceCoverageEdges:
             out = await svc.read_resource(db, resource_uri="reference://users/7")
 
         assert out.blob == b""
+
+    @pytest.mark.asyncio
+    async def test_gateway_empty_binary_placeholder_fetches_upstream(self):
+        """Gateway-backed empty binary placeholders are cold cache, not real content."""
+        # First-Party
+        from mcpgateway.db import Resource as DbResource
+        from mcpgateway.services.resource_service import ResourceService
+
+        svc = ResourceService()
+        db = MagicMock()
+        db.commit = MagicMock()
+
+        resource_db = DbResource(uri="reference://users/7", name="users")
+        resource_db.id = "res-1"
+        resource_db.enabled = True
+        resource_db.visibility = "public"
+        resource_db.owner_email = None
+        resource_db.team_id = None
+        resource_db.gateway_id = "gateway-1"
+        resource_db.gateway = None
+        resource_db.text_content = None
+        resource_db.binary_content = b""
+        resource_db.mime_type = "text/plain"
+
+        db.execute.return_value.scalar_one_or_none.return_value = resource_db
+
+        with (
+            patch.object(svc, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch.object(svc, "invoke_resource", new_callable=AsyncMock, return_value="real upstream content") as invoke_resource,
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service", return_value=MagicMock()),
+        ):
+            out = await svc.read_resource(db, resource_uri="reference://users/7")
+
+        invoke_resource.assert_awaited_once()
+        assert out.text == "real upstream content"
+
+    @pytest.mark.asyncio
+    async def test_gateway_empty_text_placeholder_failure_raises(self):
+        """Gateway-backed empty text placeholders are not served when refresh fails."""
+        # First-Party
+        from mcpgateway.db import Resource as DbResource
+        from mcpgateway.services.resource_service import ResourceError, ResourceService
+
+        svc = ResourceService()
+        db = MagicMock()
+        db.commit = MagicMock()
+
+        resource_db = DbResource(uri="reference://users/7", name="users")
+        resource_db.id = "res-1"
+        resource_db.enabled = True
+        resource_db.visibility = "public"
+        resource_db.owner_email = None
+        resource_db.team_id = None
+        resource_db.gateway_id = "gateway-1"
+        resource_db.gateway = None
+        resource_db.text_content = ""
+        resource_db.binary_content = b""
+        resource_db.mime_type = "text/plain"
+
+        db.execute.return_value.scalar_one_or_none.return_value = resource_db
+
+        with (
+            patch.object(svc, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch.object(svc, "invoke_resource", new_callable=AsyncMock, side_effect=ResourceError("refresh failed")),
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service", return_value=MagicMock()),
+        ):
+            with pytest.raises(ResourceError, match="refresh failed"):
+                await svc.read_resource(db, resource_uri="reference://users/7")
+
+    @pytest.mark.asyncio
+    async def test_cold_gateway_resource_fetches_upstream(self):
+        """Gateway-backed rows with no content columns fetch content on demand."""
+        # First-Party
+        from mcpgateway.db import Resource as DbResource
+        from mcpgateway.services.resource_service import ResourceService
+
+        svc = ResourceService()
+        db = MagicMock()
+        db.commit = MagicMock()
+
+        resource_db = DbResource(uri="reference://users/7", name="users")
+        resource_db.id = "res-1"
+        resource_db.enabled = True
+        resource_db.visibility = "public"
+        resource_db.owner_email = None
+        resource_db.team_id = None
+        resource_db.gateway_id = "gateway-1"
+        resource_db.gateway = None
+        resource_db.text_content = None
+        resource_db.binary_content = None
+        resource_db.mime_type = "text/plain"
+
+        db.execute.return_value.scalar_one_or_none.return_value = resource_db
+
+        with (
+            patch.object(svc, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch.object(svc, "invoke_resource", new_callable=AsyncMock, return_value="fetched"),
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service", return_value=MagicMock()),
+        ):
+            out = await svc.read_resource(db, resource_uri="reference://users/7")
+
+        assert out.text == "fetched"
+
+    @pytest.mark.asyncio
+    async def test_gateway_read_allows_empty_upstream_response(self):
+        """Gateway reads preserve intentionally empty upstream text."""
+        # First-Party
+        from mcpgateway.db import Resource as DbResource
+        from mcpgateway.services.resource_service import ResourceService
+
+        svc = ResourceService()
+        db = MagicMock()
+        db.commit = MagicMock()
+
+        resource_db = DbResource(uri="reference://users/7", name="users")
+        resource_db.id = "res-1"
+        resource_db.enabled = True
+        resource_db.visibility = "public"
+        resource_db.owner_email = None
+        resource_db.team_id = None
+        resource_db.gateway_id = "gateway-1"
+        resource_db.gateway = None
+        resource_db.text_content = None
+        resource_db.binary_content = None
+        resource_db.mime_type = "text/plain"
+
+        db.execute.return_value.scalar_one_or_none.return_value = resource_db
+
+        with (
+            patch.object(svc, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch.object(svc, "invoke_resource", new_callable=AsyncMock, return_value=""),
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service", return_value=MagicMock()),
+        ):
+            out = await svc.read_resource(db, resource_uri="reference://users/7")
+
+        assert out.text == ""
+
+    @pytest.mark.asyncio
+    async def test_gateway_authoritative_cache_survives_refresh_failure(self):
+        """Gateway-backed rows with real cached content retain stale-on-failure behavior."""
+        # First-Party
+        from mcpgateway.db import Resource as DbResource
+        from mcpgateway.services.resource_service import ResourceError, ResourceService
+
+        svc = ResourceService()
+        db = MagicMock()
+        db.commit = MagicMock()
+
+        resource_db = DbResource(uri="reference://users/7", name="users")
+        resource_db.id = "res-1"
+        resource_db.enabled = True
+        resource_db.visibility = "public"
+        resource_db.owner_email = None
+        resource_db.team_id = None
+        resource_db.gateway_id = "gateway-1"
+        resource_db.gateway = None
+        resource_db.text_content = "cached"
+        resource_db.binary_content = None
+        resource_db.mime_type = "text/plain"
+
+        db.execute.return_value.scalar_one_or_none.return_value = resource_db
+
+        with (
+            patch.object(svc, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch.object(svc, "invoke_resource", new_callable=AsyncMock, side_effect=ResourceError("refresh failed")),
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service", return_value=MagicMock()),
+        ):
+            out = await svc.read_resource(db, resource_uri="reference://users/7")
+
+        assert out.text == "cached"
+
+    @pytest.mark.asyncio
+    async def test_local_empty_text_resource_is_authoritative(self):
+        """Local resources may intentionally contain empty text."""
+        # First-Party
+        from mcpgateway.db import Resource as DbResource
+        from mcpgateway.services.resource_service import ResourceService
+
+        svc = ResourceService()
+        db = MagicMock()
+        db.commit = MagicMock()
+
+        resource_db = DbResource(uri="local://empty", name="empty")
+        resource_db.id = "res-1"
+        resource_db.enabled = True
+        resource_db.visibility = "public"
+        resource_db.owner_email = None
+        resource_db.team_id = None
+        resource_db.gateway_id = None
+        resource_db.gateway = None
+        resource_db.text_content = ""
+        resource_db.binary_content = None
+        resource_db.mime_type = "text/plain"
+
+        db.execute.return_value.scalar_one_or_none.return_value = resource_db
+
+        with (
+            patch.object(svc, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch.object(svc, "invoke_resource", new_callable=AsyncMock, return_value="should-not-fetch") as invoke_resource,
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service", return_value=MagicMock()),
+        ):
+            out = await svc.read_resource(db, resource_uri="local://empty")
+
+        invoke_resource.assert_not_awaited()
+        assert out.text == ""
 
     @pytest.mark.asyncio
     async def test_read_resource_resource_id_fallback_include_inactive_true_bytes_content_records_metric_failure(self):
@@ -7879,9 +8113,9 @@ class TestReadResourceDirectProxy:
                 patch("mcpgateway.common.models.TextResourceContents", _TextResourceContentsWithId),
                 patch("mcpgateway.common.models.BlobResourceContents", _BlobResourceContentsWithId),
                 patch.object(resource_service, "_check_resource_access", new_callable=AsyncMock, return_value=True),
-                patch.object(resource_service, "invoke_resource", new_callable=AsyncMock, return_value=None),
+                patch.object(resource_service, "invoke_resource", new_callable=AsyncMock, return_value=None) as invoke_resource,
             ):
-                yield
+                yield invoke_resource
 
         return _ctx()
 
@@ -7912,7 +8146,7 @@ class TestReadResourceDirectProxy:
             patch("mcpgateway.services.resource_service.build_gateway_auth_headers", return_value={"Authorization": "Bearer remote-token"}),
             patch("mcpgateway.services.resource_service.streamablehttp_client", mock_streamable_client),
             patch("mcpgateway.services.resource_service.ClientSession", return_value=client_session_cm),
-            self._common_patches(resource_service),
+            self._common_patches(resource_service) as invoke_resource,
         ):
             mock_settings.mcpgateway_direct_proxy_enabled = True
             mock_settings.mcpgateway_direct_proxy_timeout = 30
@@ -7928,6 +8162,7 @@ class TestReadResourceDirectProxy:
         assert isinstance(content, _TextBase)
         assert content.text == "hello from remote"
         assert content.uri == "http://example.com/dp-resource"
+        invoke_resource.assert_not_awaited()
         session_mock.read_resource.assert_awaited_once_with(uri="http://example.com/dp-resource")
 
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -6393,6 +6393,34 @@ class TestReadResourceCoverageEdges:
         assert out.text == ""
 
     @pytest.mark.asyncio
+    async def test_local_resource_without_content_is_not_found(self):
+        """Local resources without persisted content are not silently returned."""
+        # First-Party
+        from mcpgateway.db import Resource as DbResource
+        from mcpgateway.services.resource_service import ResourceNotFoundError, ResourceService
+
+        svc = ResourceService()
+        db = MagicMock()
+        db.commit = MagicMock()
+
+        resource_db = DbResource(uri="local://missing", name="missing")
+        resource_db.id = "res-1"
+        resource_db.enabled = True
+        resource_db.visibility = "public"
+        resource_db.owner_email = None
+        resource_db.team_id = None
+        resource_db.gateway_id = None
+        resource_db.gateway = None
+        resource_db.text_content = None
+        resource_db.binary_content = None
+        resource_db.mime_type = "text/plain"
+
+        db.execute.return_value.scalar_one_or_none.return_value = resource_db
+
+        with pytest.raises(ResourceNotFoundError, match="has no content"):
+            await svc.read_resource(db, resource_uri="local://missing")
+
+    @pytest.mark.asyncio
     async def test_read_resource_resource_id_fallback_include_inactive_true_bytes_content_records_metric_failure(self):
         """Cover resource_id fallback include_inactive query (2215), set original_uri/content (2218-2219), span content attrs (2250-2253),
         bytes normalization (2311), and metric-recording exception handler (2346-2347).
@@ -8372,13 +8400,59 @@ class TestReadResourceDirectProxy:
             mock_settings.mcpgateway_direct_proxy_timeout = 30
             mock_settings.experimental_validate_io = False
 
-            with pytest.raises(ResourceError, match="Direct proxy resource read failed"):
+            with pytest.raises(ResourceError, match="^Direct proxy resource read failed$") as exc_info:
                 await resource_service.read_resource(
                     db,
                     resource_uri="http://example.com/dp-resource",
                     user="user@example.com",
                     token_teams=["team-1"],
                 )
+
+        assert "Connection refused" not in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_read_resource_direct_proxy_real_content_model(self, resource_service, mock_direct_proxy_resource):
+        """Successful direct-proxy reads work with the SDK content model without an id field."""
+        # Standard
+        from contextlib import asynccontextmanager
+
+        # First-Party
+        from mcpgateway.common.models import TextResourceContents
+
+        db = self._make_mock_db(mock_direct_proxy_resource)
+        first_content = MagicMock()
+        first_content.text = "hello from remote"
+        first_content.mimeType = "text/plain"
+        result_mock = MagicMock(contents=[first_content])
+        client_session_cm, session_mock = self._make_session_mock(result_mock)
+
+        @asynccontextmanager
+        async def mock_streamable_client(*_args, **_kwargs):
+            yield ("read", "write", None)
+
+        with (
+            patch("mcpgateway.services.resource_service.settings") as mock_settings,
+            patch("mcpgateway.services.resource_service.check_gateway_access", new_callable=AsyncMock, return_value=True),
+            patch("mcpgateway.services.resource_service.build_gateway_auth_headers", return_value={}),
+            patch("mcpgateway.services.resource_service.streamablehttp_client", mock_streamable_client),
+            patch("mcpgateway.services.resource_service.ClientSession", return_value=client_session_cm),
+            patch.object(resource_service, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch.object(resource_service, "invoke_resource", new_callable=AsyncMock) as invoke_resource,
+        ):
+            mock_settings.mcpgateway_direct_proxy_enabled = True
+            mock_settings.mcpgateway_direct_proxy_timeout = 30
+            mock_settings.experimental_validate_io = False
+
+            content = await resource_service.read_resource(
+                db,
+                resource_uri="http://example.com/dp-resource",
+                user="user@example.com",
+                token_teams=["team-1"],
+            )
+
+        assert isinstance(content, TextResourceContents)
+        assert content.text == "hello from remote"
+        invoke_resource.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_read_resource_direct_proxy_with_meta(self, resource_service, mock_direct_proxy_resource):

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -1718,6 +1718,18 @@ class TestResourceEndpoints:
         assert body["uri"] == "test/resource" and body["text"] == "This is test content"
         mock_read_resource.assert_called_once()
 
+    @patch("mcpgateway.main.resource_service.read_resource")
+    def test_read_resource_endpoint_fetch_error_returns_bad_request(self, mock_read_resource, test_client, auth_headers):
+        """Upstream resource failures are not reported as missing resources."""
+        from mcpgateway.services.resource_service import ResourceError
+
+        mock_read_resource.side_effect = ResourceError("Gateway resource content could not be resolved")
+
+        response = test_client.get("/resources/1", headers=auth_headers)
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Gateway resource content could not be resolved"
+
     @patch("mcpgateway.main.resource_service.update_resource")
     def test_update_resource_endpoint(self, mock_update, test_client, auth_headers):
         """Test updating an existing resource."""


### PR DESCRIPTION
## Summary

- Treat federated empty text and binary placeholders as cold cache entries.
- Preserve intentionally empty upstream responses and local empty resources.
- Raise sanitized errors for gateway transport failures while retaining valid warm-cache fallback behavior.
- Prevent direct-proxy reads from being fetched twice.
- Add regression coverage for resource and federation cache paths.

Closes #6622

## Validation

- Full test suite, diff coverage, Ruff, interrogate, Pylint, verify, and pre-commit passed.
- Repository Bandit has unrelated pre-existing findings on files outside this change.

## Before vs After

<details>
<summary>Resource Cache Resolution</summary>

```text
BEFORE

Resource read
    |
    +-- Empty placeholder ------> Return empty/placeholder content
    |
    +-- Upstream failure -------> Silently keep fallback content
    |
    +-- Valid cached content ---> Return cached content


AFTER

Resource read
    |
    +-- Empty placeholder ------> Fetch upstream
    |                                |
    |                                +-- Content, including "" -> Return content
    |                                +-- Failure --------------> ResourceError (-32000)
    |
    +-- Valid cached content ---> Fetch upstream
                                     |
                                     +-- Success --------------> Return fresh content
                                     +-- Failure --------------> Return cached content
```

</details>

## Manual Verification

<details>
<summary>MCP Server Script Used</summary>

```python
from mcp.server.fastmcp import FastMCP

mcp = FastMCP(
    "manual-6622",
    host="127.0.0.1",
    port=8888,
    streamable_http_path="/mcp",
)


@mcp.resource("manual://resource")
def manual_resource() -> str:
    return "real upstream content"


if __name__ == "__main__":
    mcp.run(transport="streamable-http")
```

Started with:

```bash
./.venv/bin/python ./manual_6622_server.py
```

</details>

<details>
<summary>Steps Run</summary>

```text
1. Started the local ContextForge development server with SQLite:

   export SSRF_ALLOW_LOCALHOST=true
   export SSRF_DNS_FAIL_CLOSED=false
   make dev

2. Started the temporary Streamable HTTP MCP server on:
   http://127.0.0.1:8888/mcp

3. Verified the upstream directly with the MCP Streamable HTTP client:
   - Initialized an MCP session.
   - Listed resources.
   - Read manual://resource.

4. Generated a short-lived admin JWT and registered the upstream through:
   POST http://127.0.0.1:8000/gateways

5. Listed federated resources through:
   GET http://127.0.0.1:8000/resources?include_pagination=false

6. Read manual://resource while the upstream was available through:
   POST http://127.0.0.1:8000/rpc

7. Stopped the temporary upstream with Ctrl+C.

8. Read manual://resource again while the upstream was unavailable.

9. Deleted the temporary gateway after verification.
```

</details>

<details>
<summary>Observed Results</summary>

```text
Direct Streamable HTTP upstream validation:
  MCP initialization: Success
  resources/list: Returned manual://resource
  resources/read: Returned "real upstream content"

Gateway registration:
  HTTP 201
  status: active
  reachable: true
  transport: STREAMABLEHTTP

Federated resource discovery:
  Resource URI: manual://resource
  size: null

Healthy resource read:
  Returned text: "real upstream content"

Upstream unavailable resource read:
  JSON-RPC error response
  code: -32000
  message: "Resource read failed: Gateway resource content could not be resolved"
  Empty placeholder was not returned as successful content.

Cleanup:
  Gateway deletion: Success
```

</details>

