### PR TITLE
fix(security): map plugin-binding routes in token scoping

### DIFF
--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -86,6 +86,10 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("GET", re.compile(r"^/tools(?:$|/)"), Permissions.TOOLS_READ),
     ("POST", re.compile(r"^/tools/?$"), Permissions.TOOLS_CREATE),  # Only exact /tools or /tools/
     ("POST", re.compile(r"^/tools/preview(?:$|/)"), Permissions.TOOLS_PREVIEW),  # Must precede the /tools/[^/]+/ catch-all below (#5629)
+    # Tool plugin bindings use tools.manage_plugins (see tool_plugin_bindings router),
+    # not tools.update / tools.delete from the catch-alls below (#6701).
+    ("POST", re.compile(r"^/tools/plugin_bindings(?:$|/)"), Permissions.TOOLS_MANAGE_PLUGINS),
+    ("DELETE", re.compile(r"^/tools/plugin_bindings(?:$|/)"), Permissions.TOOLS_MANAGE_PLUGINS),
     ("POST", re.compile(r"^/tools/[^/]+/"), Permissions.TOOLS_UPDATE),  # POST to sub-resources (state, toggle)
     ("PUT", re.compile(r"^/tools/[^/]+(?:$|/)"), Permissions.TOOLS_UPDATE),
     ("DELETE", re.compile(r"^/tools/[^/]+(?:$|/)"), Permissions.TOOLS_DELETE),
@@ -184,6 +188,12 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("POST", re.compile(r"^/a2a/[^/]+/(?:state|toggle)(?:$|/)"), Permissions.A2A_UPDATE),
     ("PUT", re.compile(r"^/a2a/[^/]+(?:$|/)"), Permissions.A2A_UPDATE),
     ("DELETE", re.compile(r"^/a2a/[^/]+(?:$|/)"), Permissions.A2A_DELETE),
+    # A2A agent plugin bindings live under /a2a-agents/... (hyphen), which does not
+    # match ^/a2a(?:$|/) above. Decorators on a2a_agent_plugin_bindings require
+    # tools.read / tools.manage_plugins — same contract as tool plugin bindings (#6701).
+    ("GET", re.compile(r"^/a2a-agents/plugin-bindings(?:$|/)"), Permissions.TOOLS_READ),
+    ("POST", re.compile(r"^/a2a-agents/plugin-bindings(?:$|/)"), Permissions.TOOLS_MANAGE_PLUGINS),
+    ("DELETE", re.compile(r"^/a2a-agents/plugin-bindings(?:$|/)"), Permissions.TOOLS_MANAGE_PLUGINS),
 ]
 
 # Admin route permission map (granular by route group).

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -610,6 +610,44 @@ class TestTokenScopingMiddleware:
         assert middleware._check_permission_restrictions(path, method, [permission]) is False
 
     @pytest.mark.parametrize(
+        "method,path,permission",
+        [
+            ("GET", "/a2a-agents/plugin-bindings", Permissions.TOOLS_READ),
+            ("GET", "/a2a-agents/plugin-bindings/", Permissions.TOOLS_READ),
+            ("GET", "/a2a-agents/plugin-bindings/team-1", Permissions.TOOLS_READ),
+            ("GET", "/v1/a2a-agents/plugin-bindings", Permissions.TOOLS_READ),
+            ("POST", "/a2a-agents/plugin-bindings", Permissions.TOOLS_MANAGE_PLUGINS),
+            ("POST", "/a2a-agents/plugin-bindings/", Permissions.TOOLS_MANAGE_PLUGINS),
+            ("DELETE", "/a2a-agents/plugin-bindings", Permissions.TOOLS_MANAGE_PLUGINS),
+            ("DELETE", "/a2a-agents/plugin-bindings/abc", Permissions.TOOLS_MANAGE_PLUGINS),
+            ("GET", "/tools/plugin_bindings", Permissions.TOOLS_READ),
+            ("GET", "/v1/tools/plugin_bindings/team-1", Permissions.TOOLS_READ),
+            ("POST", "/tools/plugin_bindings", Permissions.TOOLS_MANAGE_PLUGINS),
+            ("POST", "/tools/plugin_bindings/", Permissions.TOOLS_MANAGE_PLUGINS),
+            ("DELETE", "/tools/plugin_bindings", Permissions.TOOLS_MANAGE_PLUGINS),
+            ("DELETE", "/tools/plugin_bindings/abc", Permissions.TOOLS_MANAGE_PLUGINS),
+        ],
+    )
+    def test_plugin_binding_routes_map_to_decorator_permissions(self, middleware, method, path, permission):
+        """Plugin-binding routers require tools.read / tools.manage_plugins (#6701)."""
+        assert middleware._check_permission_restrictions(path, method, [permission]) is True
+
+    @pytest.mark.parametrize(
+        "method,path,permission",
+        [
+            ("GET", "/a2a-agents/plugin-bindings", Permissions.A2A_READ),
+            ("POST", "/a2a-agents/plugin-bindings", Permissions.A2A_UPDATE),
+            ("DELETE", "/a2a-agents/plugin-bindings", Permissions.TOOLS_UPDATE),
+            ("POST", "/tools/plugin_bindings", Permissions.TOOLS_UPDATE),
+            ("DELETE", "/tools/plugin_bindings", Permissions.TOOLS_DELETE),
+            ("GET", "/a2a-agents/plugin-bindings", Permissions.TOOLS_MANAGE_PLUGINS),
+        ],
+    )
+    def test_plugin_binding_routes_reject_wrong_permission(self, middleware, method, path, permission):
+        """Wrong scopes are denied, including a2a.* guesses and tools update/delete catch-alls."""
+        assert middleware._check_permission_restrictions(path, method, [permission]) is False
+
+    @pytest.mark.parametrize(
         "token_scopes",
         [
             ["tools.execute"],


### PR DESCRIPTION
## 📌 Summary

Fixes #6701. Scoped API tokens received 403 on `/v1/a2a-agents/plugin-bindings` because token scoping had no pattern for that prefix (`^/a2a(?:$|/)` does not match `/a2a-agents/...`). The same gap meant tool plugin-binding write/delete paths were matched by the generic `tools.update` / `tools.delete` catch-alls instead of `tools.manage_plugins`.

## 🔁 Reproduction Steps

1. Issue a scoped token with `tools.read` / `tools.manage_plugins` (not full `*`).
2. `GET /v1/a2a-agents/plugin-bindings` → 403 before this change.
3. `POST` / `DELETE` on `/v1/tools/plugin_bindings` required `tools.update` / `tools.delete` at the middleware layer even though the router asks for `tools.manage_plugins`.

## 🐞 Root Cause

Unmapped paths are default-denied in `_check_permission_restrictions`. A2A agent plugin bindings are mounted at `/a2a-agents/plugin-bindings`, which is outside the existing `/a2a` map. Tool plugin bindings under `/tools/plugin_bindings` were only covered incidentally by broader `/tools` patterns that do not match the router decorators for mutating methods.

## 💡 Fix Description

- Map `GET/POST/DELETE /a2a-agents/plugin-bindings` to `tools.read` / `tools.manage_plugins` to match `a2a_agent_plugin_bindings` `@require_permission` decorators.
- Map `POST/DELETE /tools/plugin_bindings` to `tools.manage_plugins` ahead of the `/tools/[^/]+/` catch-alls (same pattern as `/tools/preview`).
- Note: the issue text suggested `a2a.read` / `a2a.update`; those scopes would still fail RBAC on the routers, so the middleware follows the decorator contract instead.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

| Check | Command | Status |
|-------|---------|--------|
| Focused + full token scoping unit tests | `uv run pytest tests/unit/mcpgateway/middleware/test_token_scoping.py --no-cov` | 377 passed |
| Ruff on changed middleware file | `uv run ruff check mcpgateway/middleware/token_scoping.py` | passed |

Full `make lint` / `make test` / `make coverage` / docker not run in this environment; change is confined to the permission map and unit tests for that map.

## ✅ Checklist

- [x] No secrets/credentials committed
- [x] DCO signed-off
- [x] Tests cover A2A and tool plugin-binding paths (allow + wrong-scope deny)