### PR TITLE
ci: run PR checks on pull requests targeting chore/mcp-sdk-v2

### DIFF
--- a/.github/workflows/alembic-upgrade-validation.yml
+++ b/.github/workflows/alembic-upgrade-validation.yml
@@ -26,7 +26,7 @@ name: Alembic Upgrade Validation
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: ["main"]
+    branches: ["main", "chore/mcp-sdk-v2"]
     paths:
       - "mcpgateway/alembic/**"
       - "scripts/ci/run_upgrade_validation.sh"

--- a/.github/workflows/compose-prod-smoke-required.yml
+++ b/.github/workflows/compose-prod-smoke-required.yml
@@ -20,7 +20,7 @@ name: Compose Production Smoke Skip Reporter
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: ["main"]
+    branches: ["main", "chore/mcp-sdk-v2"]
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,7 +26,7 @@ name: Dependency Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: ["main"]
+    branches: ["main", "chore/mcp-sdk-v2"]
     paths:
       - "pyproject.toml"
       - "Cargo.lock"

--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -41,7 +41,7 @@ on:
       - '.github/workflows/docker-multiplatform.yml'
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: ["main"]
+    branches: ["main", "chore/mcp-sdk-v2"]
     paths:
       - '.dockerignore'
       - 'Containerfile'

--- a/.github/workflows/docker-required.yml
+++ b/.github/workflows/docker-required.yml
@@ -19,7 +19,7 @@ name: Docker Build Skip Reporter
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: ["main"]
+    branches: ["main", "chore/mcp-sdk-v2"]
     paths-ignore:
       - '.dockerignore'
       - 'Containerfile'

--- a/.github/workflows/docker-scan-required.yml
+++ b/.github/workflows/docker-scan-required.yml
@@ -19,7 +19,7 @@ name: Docker Scan Skip Reporter
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: ["main"]
+    branches: ["main", "chore/mcp-sdk-v2"]
     paths-ignore:
       - 'Containerfile'
       - 'infra/nginx/**'

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -28,7 +28,7 @@ name: Docker Security Scan
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: ["main"]
+    branches: ["main", "chore/mcp-sdk-v2"]
     paths:
       - 'Containerfile'
       - 'infra/nginx/**'

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -23,7 +23,7 @@ on:
       - ".github/workflows/helm-publish.yml"
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: ["main"]
+    branches: ["main", "chore/mcp-sdk-v2"]
     paths:
       - "charts/mcp-stack/**"
       - ".github/workflows/helm-publish.yml"

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -3,7 +3,7 @@ name: License Check
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: ["main"]
+    branches: ["main", "chore/mcp-sdk-v2"]
     paths:
       - "pyproject.toml"
       - "Cargo.toml"

--- a/.github/workflows/lint-web.yml
+++ b/.github/workflows/lint-web.yml
@@ -14,7 +14,7 @@ name: Web Lint & Static Analysis
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: ["main"]
+    branches: ["main", "chore/mcp-sdk-v2"]
     paths:
       - "mcpgateway/static/**"
       - "mcpgateway/templates/**"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ name: Lint & Static Analysis
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: ["main"]
+    branches: ["main", "chore/mcp-sdk-v2"]
     paths:
       - "mcpgateway/**"
       - "plugins/**"

--- a/.github/workflows/linting-required.yml
+++ b/.github/workflows/linting-required.yml
@@ -19,7 +19,7 @@ name: Linting Skip Reporter
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: ["main"]
+    branches: ["main", "chore/mcp-sdk-v2"]
 
 permissions:
   contents: read

--- a/.github/workflows/mcp-url-to-markdown-tests.yml
+++ b/.github/workflows/mcp-url-to-markdown-tests.yml
@@ -15,7 +15,7 @@ name: URL-to-Markdown MCP Server Tests
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: ["main"]
+    branches: ["main", "chore/mcp-sdk-v2"]
     paths:
       - "mcp-servers/python/url_to_markdown_server/**"
       - ".github/workflows/mcp-url-to-markdown-tests.yml"

--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -3,7 +3,7 @@ name: Playwright Smoke
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: ["main"]
+    branches: ["main", "chore/mcp-sdk-v2"]
     paths:
       - "mcpgateway/**"
       - "tests/playwright/**"

--- a/.github/workflows/plugin-integration-required.yml
+++ b/.github/workflows/plugin-integration-required.yml
@@ -24,7 +24,7 @@ name: Plugin Integration Skip Reporter
 on:
     pull_request:
         types: [opened, synchronize, ready_for_review]
-        branches: ["main"]
+        branches: ["main", "chore/mcp-sdk-v2"]
         paths-ignore:
             - "pyproject.toml"
             - "uv.lock"

--- a/.github/workflows/plugin-integration.yml
+++ b/.github/workflows/plugin-integration.yml
@@ -28,7 +28,7 @@ name: Plugin Integration E2E
 on:
     merge_group:
     pull_request:
-        branches: [main]
+        branches: [main, "chore/mcp-sdk-v2"]
         types: [opened, synchronize, reopened, ready_for_review]
         paths:
             - "pyproject.toml"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,7 @@ on:
     tags: ["*"]
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: ["main"]
+    branches: ["main", "chore/mcp-sdk-v2"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pytest-rust.yml
+++ b/.github/workflows/pytest-rust.yml
@@ -13,7 +13,7 @@ name: Tests & Coverage (Rust)
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: ["main"]
+    branches: ["main", "chore/mcp-sdk-v2"]
     paths:
       - "crates/**"
       - "Cargo.toml"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ name: Tests & Coverage
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: ["main"]
+    branches: ["main", "chore/mcp-sdk-v2"]
     paths:
       - "mcpgateway/**"
       - "tests/**"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,7 +6,7 @@ name: Build Python Package
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: [ "main" ]
+    branches: [ "main", "chore/mcp-sdk-v2" ]
     paths:
       - "mcpgateway/**"
       - "pyproject.toml"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,7 +5,7 @@ name: Rust CI
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: [main, develop]
+    branches: [main, "chore/mcp-sdk-v2", develop]
     paths:
       - "crates/**"
       - "Cargo.toml"

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -12,7 +12,7 @@ name: JavaScript Tests (Vitest)
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: ["main"]
+    branches: ["main", "chore/mcp-sdk-v2"]
     paths:
       - "mcpgateway/static/**"
       - "tests/**"

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -2,7 +2,7 @@ name: Wrapper E2E
 
 on:
     pull_request:
-        branches: [main]
+        branches: [main, "chore/mcp-sdk-v2"]
         types: [opened, synchronize, reopened]
         paths:
             - "crates/wrapper/**"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-28T12:29:08Z",
+  "generated_at": "2026-09-09T14:19:15Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -140,7 +140,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1417,
+        "line_number": 1420,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1567,
+        "line_number": 1570,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1572,
+        "line_number": 1575,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1577,
+        "line_number": 1580,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1583,
+        "line_number": 1586,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1595,
+        "line_number": 1598,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1613,
+        "line_number": 1616,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1674,
+        "line_number": 1677,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -730,7 +730,7 @@
         "hashed_secret": "cb58df830a45cc33df1a313e616ecad78cd796c5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 122,
+        "line_number": 119,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -738,7 +738,7 @@
         "hashed_secret": "2e0c522bfe4e7885492862df2e0b987c0ca02623",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 145,
+        "line_number": 142,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -746,7 +746,7 @@
         "hashed_secret": "d9d007c8de197b3f36a3a0ba4f13c0f7df175d5a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 309,
+        "line_number": 306,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -828,7 +828,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1821,
+        "line_number": 1823,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -836,7 +836,7 @@
         "hashed_secret": "afba9d98073dfb79fba7b21516c4d4d676c72935",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2251,
+        "line_number": 2253,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -844,7 +844,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2351,
+        "line_number": 2353,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -852,7 +852,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2351,
+        "line_number": 2353,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -860,7 +860,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2364,
+        "line_number": 2366,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -868,7 +868,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2512,
+        "line_number": 2514,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -876,7 +876,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2533,
+        "line_number": 2535,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -884,7 +884,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2541,
+        "line_number": 2543,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -892,7 +892,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2546,
+        "line_number": 2548,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1922,7 +1922,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 482,
+        "line_number": 497,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1930,7 +1930,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 925,
+        "line_number": 940,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1938,7 +1938,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1432,
+        "line_number": 1449,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -1946,7 +1946,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1436,
+        "line_number": 1453,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4782,7 +4782,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 398,
+        "line_number": 399,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/mcpgateway/services/modern_listener_service.py
+++ b/mcpgateway/services/modern_listener_service.py
@@ -13,7 +13,7 @@ Events are funneled into :class:`NotificationService`'s debounced refresh
 pipeline (``notify_list_changed``), so listener-driven refreshes share the
 same coalescing and rate limiting as session-delivered notifications.
 
-The scheduled auto-refresh (``AUTO_REFRESH_SERVERS``) covers legacy servers, 
+The scheduled auto-refresh (``AUTO_REFRESH_SERVERS``) covers legacy servers,
 modern-era servers that never announce, and any window
 where a listen stream is down.
 
@@ -204,7 +204,7 @@ class ModernListenerService:
                     UNSUPPORTED_REPROBE_SECONDS,
                 )
                 return
-            except asyncio.CancelledError:
+            except asyncio.CancelledError:  # pylint: disable=try-except-raise
                 raise
             except Exception as exc:  # pylint: disable=broad-except  # SubscriptionLost, MCPError, transport errors
                 logger.warning("Listen stream to server %s dropped (%s: %s); reconnecting in %.0fs", gw.name, type(exc).__name__, exc, backoff)

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -4978,6 +4978,10 @@ class ToolService(BaseService):
             require_app_visible: Whether the retried invocation must resolve an app-visible tool.
             require_model_visible: Whether the retried invocation must resolve a model-visible tool.
             path_label: Label for log messages (success/timeout/exception).
+            progress_callback: Optional callback forwarded to the retried invocation for progress notifications.
+            allow_input_required: Whether the retried invocation may return an InputRequiredResult (MRTR).
+            input_responses: Client responses to a prior InputRequiredResult, forwarded on retry.
+            request_state: Opaque server state echoed back with input_responses on retry.
 
         Returns:
             ToolResult from the retried invocation.
@@ -7162,10 +7166,10 @@ class ToolService(BaseService):
                         require_app_visible=require_app_visible,
                         require_model_visible=require_model_visible,
                         path_label="exception",
-                            progress_callback=progress_callback,
-                            allow_input_required=allow_input_required,
-                            input_responses=input_responses,
-                            request_state=request_state,
+                        progress_callback=progress_callback,
+                        allow_input_required=allow_input_required,
+                        input_responses=input_responses,
+                        request_state=request_state,
                     )
 
                 raise ToolInvocationError(f"Tool invocation failed: {error_message}")

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -44,6 +44,7 @@ from uuid import uuid4
 
 # Third-Party
 import anyio
+from cpex.framework import PluginViolationError
 from fastapi import HTTPException
 from fastapi.security.utils import get_authorization_scheme_param
 import httpx
@@ -2135,6 +2136,9 @@ async def call_tool(
     except ToolInvocationError as e:
         # covers tool timeouts
         logger.warning("Tool invocation failed for '%s': %s", name, e)
+        return types.CallToolResult(content=[types.TextContent(type="text", text=str(e))], is_error=True)
+    except PluginViolationError as e:
+        logger.info("Tool invocation blocked by plugin for '%s': %s", name, e)
         return types.CallToolResult(content=[types.TextContent(type="text", text=str(e))], is_error=True)
     except Exception as e:
         logger.exception("Error calling tool '%s': %s", name, e)

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -1749,7 +1749,7 @@ async def call_tool(
     inbound_request_state = None
     # Extract _meta from request context if available
     try:
-        ctx = mcp_app.request_context
+        ctx = mcp_app.request_context  # pylint: disable=no-member
         if ctx and ctx.meta is not None:
             # MCP 2.0 RequestParamsMeta is a TypedDict (no model_dump); tolerate
             # legacy model-shaped meta for tests that inject a Pydantic object.
@@ -2201,7 +2201,7 @@ async def _get_request_context_or_default() -> Tuple[str, dict[str, Any], dict[s
     # 2. Try ASGI scope context injected by handle_streamable_http()
     ctx = None
     try:
-        ctx = mcp_app.request_context
+        ctx = mcp_app.request_context  # pylint: disable=no-member
         request = ctx.request
         if request:
             gw_ctx = getattr(request, "scope", {}).get(_MCPGATEWAY_CONTEXT_KEY)
@@ -2229,7 +2229,7 @@ async def _get_request_context_or_default() -> Tuple[str, dict[str, Any], dict[s
         # Reuse ctx from the scope-reading block above (step 2) to avoid
         # a redundant mcp_app.request_context lookup.
         if ctx is None:
-            ctx = mcp_app.request_context
+            ctx = mcp_app.request_context  # pylint: disable=no-member
         request = ctx.request
         if not request:
             logger.warning("No request object found in MCP context")
@@ -2570,7 +2570,7 @@ async def get_prompt(prompt_id: str, arguments: dict[str, str] | None = None) ->
     meta_data = None
     # Extract _meta from request context if available
     try:
-        ctx = mcp_app.request_context
+        ctx = mcp_app.request_context  # pylint: disable=no-member
         if ctx and ctx.meta is not None:
             # MCP 2.0 RequestParamsMeta is a TypedDict (no model_dump); tolerate
             # legacy model-shaped meta for tests that inject a Pydantic object.
@@ -2753,7 +2753,7 @@ async def read_resource(resource_uri: str) -> Union[str, bytes, List[Any]]:
     meta_data = None
     # Extract _meta from request context if available
     try:
-        ctx = mcp_app.request_context
+        ctx = mcp_app.request_context  # pylint: disable=no-member
         if ctx and ctx.meta is not None:
             # MCP 2.0 RequestParamsMeta is a TypedDict (no model_dump); tolerate
             # legacy model-shaped meta for tests that inject a Pydantic object.

--- a/tests/unit/mcpgateway/services/test_server_handshake.py
+++ b/tests/unit/mcpgateway/services/test_server_handshake.py
@@ -24,7 +24,7 @@ from mcpgateway.services.gateway_service import test_server_handshake as run_ser
 
 
 def _mock_sdk_session(init_side_effect=None):
-    """Build mocked streamablehttp_client / ClientSession context managers.
+    """Build mocked streamable_http_client / ClientSession context managers.
 
     Args:
         init_side_effect: Optional exception (or exception instance) for
@@ -34,9 +34,9 @@ def _mock_sdk_session(init_side_effect=None):
         Tuple of (transport context manager, session) mocks.
     """
     init_result = MagicMock()
-    init_result.protocolVersion = "2025-11-25"
-    init_result.serverInfo.name = "smoke-test-server"
-    init_result.serverInfo.version = "1.0"
+    init_result.protocol_version = "2025-11-25"
+    init_result.server_info.name = "smoke-test-server"
+    init_result.server_info.version = "1.0"
     init_result.capabilities.tools = MagicMock()
     init_result.capabilities.resources = None
     init_result.capabilities.prompts = None
@@ -45,7 +45,7 @@ def _mock_sdk_session(init_side_effect=None):
 
     tools_result = MagicMock()
     tools_result.tools = [MagicMock(), MagicMock()]
-    tools_result.nextCursor = None
+    tools_result.next_cursor = None
 
     session = MagicMock()
     session.initialize = AsyncMock(side_effect=init_side_effect, return_value=init_result) if init_side_effect else AsyncMock(return_value=init_result)
@@ -54,7 +54,7 @@ def _mock_sdk_session(init_side_effect=None):
     session.__aexit__ = AsyncMock(return_value=None)
 
     transport_cm = MagicMock()
-    transport_cm.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock(), MagicMock()))
+    transport_cm.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock()))
     transport_cm.__aexit__ = AsyncMock(return_value=None)
 
     return transport_cm, session
@@ -63,7 +63,7 @@ def _mock_sdk_session(init_side_effect=None):
 @pytest.mark.asyncio
 async def test_disabled_server_fails_without_attempting_a_handshake():
     """A disabled virtual server returns a graceful failure with no outbound dispatch."""
-    with patch("mcpgateway.services.gateway_service.streamablehttp_client") as mock_streamable:
+    with patch("mcpgateway.services.gateway_service.streamable_http_client") as mock_streamable:
         result = await run_server_handshake("srv-1", "my-server", False, ServerHandshakeRequest(), {})
 
     assert isinstance(result, GatewayHandshakeResponse)
@@ -79,7 +79,7 @@ async def test_successful_handshake_reuses_forwarded_session_credentials():
     transport_cm, session = _mock_sdk_session()
 
     with patch("mcpgateway.main.app", MagicMock()):
-        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
+        with patch("mcpgateway.services.gateway_service.streamable_http_client", return_value=transport_cm) as mock_streamable:
             with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
                 result = await run_server_handshake("srv-1", "my-server", True, ServerHandshakeRequest(), {"Authorization": "Bearer caller-token"})
 
@@ -93,7 +93,7 @@ async def test_successful_handshake_reuses_forwarded_session_credentials():
     # Target is derived from the server ID via a loopback URL, never from caller input.
     called_url = mock_streamable.call_args.kwargs["url"]
     assert called_url.endswith("/servers/srv-1/mcp")
-    called_headers = mock_streamable.call_args.kwargs["headers"]
+    called_headers = mock_streamable.call_args.kwargs["http_client"].headers
     assert called_headers["Authorization"] == "Bearer caller-token"
 
 
@@ -103,7 +103,7 @@ async def test_no_credentials_reports_none_source():
     transport_cm, session = _mock_sdk_session()
 
     with patch("mcpgateway.main.app", MagicMock()):
-        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm):
+        with patch("mcpgateway.services.gateway_service.streamable_http_client", return_value=transport_cm):
             with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
                 result = await run_server_handshake("srv-1", "my-server", True, ServerHandshakeRequest(), {})
 
@@ -117,7 +117,7 @@ async def test_body_header_override_wins_over_forwarded_credentials():
     transport_cm, session = _mock_sdk_session()
 
     with patch("mcpgateway.main.app", MagicMock()):
-        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
+        with patch("mcpgateway.services.gateway_service.streamable_http_client", return_value=transport_cm) as mock_streamable:
             with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
                 result = await run_server_handshake(
                     "srv-1",
@@ -129,7 +129,7 @@ async def test_body_header_override_wins_over_forwarded_credentials():
 
     assert result.success is True
     assert result.credential_source == "form"
-    called_headers = mock_streamable.call_args.kwargs["headers"]
+    called_headers = mock_streamable.call_args.kwargs["http_client"].headers
     assert called_headers["Authorization"] == "Bearer override-token"
 
 
@@ -139,7 +139,7 @@ async def test_body_header_override_ignores_host():
     transport_cm, session = _mock_sdk_session()
 
     with patch("mcpgateway.main.app", MagicMock()):
-        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
+        with patch("mcpgateway.services.gateway_service.streamable_http_client", return_value=transport_cm) as mock_streamable:
             with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
                 await run_server_handshake(
                     "srv-1",
@@ -149,7 +149,7 @@ async def test_body_header_override_ignores_host():
                     {},
                 )
 
-    called_headers = mock_streamable.call_args.kwargs["headers"]
+    called_headers = mock_streamable.call_args.kwargs["http_client"].headers
     assert "Host" not in called_headers
     assert "host" not in {k.lower() for k in called_headers}
 
@@ -175,7 +175,7 @@ async def test_body_header_override_drops_forbidden_headers(forbidden_header):
     transport_cm, session = _mock_sdk_session()
 
     with patch("mcpgateway.main.app", MagicMock()):
-        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
+        with patch("mcpgateway.services.gateway_service.streamable_http_client", return_value=transport_cm) as mock_streamable:
             with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
                 result = await run_server_handshake(
                     "srv-1",
@@ -185,8 +185,10 @@ async def test_body_header_override_drops_forbidden_headers(forbidden_header):
                     {},
                 )
 
-    called_headers = mock_streamable.call_args.kwargs["headers"]
-    assert forbidden_header.lower() not in {k.lower() for k in called_headers}
+    called_headers = mock_streamable.call_args.kwargs["http_client"].headers
+    # The client's header set includes httpx's own defaults (e.g. Connection), so the
+    # leak check is on the spoofed value rather than on the header name being absent.
+    assert called_headers.get(forbidden_header) != "spoofed-value"
     assert called_headers["Authorization"] == "Bearer caller-own-token"
     assert result.credential_source == "form"
 
@@ -200,7 +202,7 @@ async def test_forwarded_proxy_identity_header_is_not_overridable_by_body():
     transport_cm, session = _mock_sdk_session()
 
     with patch("mcpgateway.main.app", MagicMock()):
-        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
+        with patch("mcpgateway.services.gateway_service.streamable_http_client", return_value=transport_cm) as mock_streamable:
             with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
                 result = await run_server_handshake(
                     "srv-1",
@@ -210,7 +212,7 @@ async def test_forwarded_proxy_identity_header_is_not_overridable_by_body():
                     {"X-Authenticated-User": "caller@example.com"},
                 )
 
-    called_headers = {k.lower(): v for k, v in mock_streamable.call_args.kwargs["headers"].items()}
+    called_headers = {k.lower(): v for k, v in mock_streamable.call_args.kwargs["http_client"].headers.items()}
     assert called_headers.get("x-authenticated-user") == "caller@example.com"
     assert result.credential_source == "session"
 
@@ -228,7 +230,7 @@ async def test_body_header_override_honors_custom_auth_header_name(monkeypatch):
     transport_cm, session = _mock_sdk_session()
 
     with patch("mcpgateway.main.app", MagicMock()):
-        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
+        with patch("mcpgateway.services.gateway_service.streamable_http_client", return_value=transport_cm) as mock_streamable:
             with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
                 result = await run_server_handshake(
                     "srv-1",
@@ -238,7 +240,7 @@ async def test_body_header_override_honors_custom_auth_header_name(monkeypatch):
                     {},
                 )
 
-    called_headers = {k.lower(): v for k, v in mock_streamable.call_args.kwargs["headers"].items()}
+    called_headers = {k.lower(): v for k, v in mock_streamable.call_args.kwargs["http_client"].headers.items()}
     assert called_headers.get("x-mcp-gateway-auth") == "Bearer custom-header-token"
     assert result.credential_source == "form"
 
@@ -256,7 +258,7 @@ async def test_body_header_override_still_drops_spoofed_headers_with_custom_auth
     transport_cm, session = _mock_sdk_session()
 
     with patch("mcpgateway.main.app", MagicMock()):
-        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
+        with patch("mcpgateway.services.gateway_service.streamable_http_client", return_value=transport_cm) as mock_streamable:
             with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
                 await run_server_handshake(
                     "srv-1",
@@ -266,7 +268,7 @@ async def test_body_header_override_still_drops_spoofed_headers_with_custom_auth
                     {},
                 )
 
-    called_headers = {k.lower(): v for k, v in mock_streamable.call_args.kwargs["headers"].items()}
+    called_headers = {k.lower(): v for k, v in mock_streamable.call_args.kwargs["http_client"].headers.items()}
     assert called_headers.get("x-mcp-gateway-auth") == "Bearer custom-header-token"
     assert "x-authenticated-user" not in called_headers
 
@@ -278,7 +280,7 @@ async def test_connect_error_is_classified_as_transport_failure():
     import httpx
 
     with patch("mcpgateway.main.app", MagicMock()):
-        with patch("mcpgateway.services.gateway_service.streamablehttp_client", side_effect=httpx.ConnectError("boom")):
+        with patch("mcpgateway.services.gateway_service.streamable_http_client", side_effect=httpx.ConnectError("boom")):
             result = await run_server_handshake("srv-1", "my-server", True, ServerHandshakeRequest(), {})
 
     assert result.success is False
@@ -294,7 +296,7 @@ async def test_initialize_timeout_is_transport_failure():
     transport_cm, session = _mock_sdk_session(init_side_effect=TimeoutError())
 
     with patch("mcpgateway.main.app", MagicMock()):
-        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm):
+        with patch("mcpgateway.services.gateway_service.streamable_http_client", return_value=transport_cm):
             with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
                 result = await run_server_handshake("srv-1", "my-server", True, ServerHandshakeRequest(), {})
 
@@ -315,7 +317,7 @@ async def test_exception_group_unwraps_root_cause():
     transport_cm, session = _mock_sdk_session(init_side_effect=ExceptionGroup("handshake failed", [httpx.ConnectError("connection refused")]))
 
     with patch("mcpgateway.main.app", MagicMock()):
-        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm):
+        with patch("mcpgateway.services.gateway_service.streamable_http_client", return_value=transport_cm):
             with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
                 result = await run_server_handshake("srv-1", "my-server", True, ServerHandshakeRequest(), {})
 
@@ -326,22 +328,18 @@ async def test_exception_group_unwraps_root_cause():
 
 @pytest.mark.asyncio
 async def test_httpx_client_factory_builds_asgi_transport_client():
-    """The httpx_client_factory passed to the SDK builds a client wired to the ASGI transport."""
+    """The http_client handed to the SDK is wired to the in-process ASGI transport."""
     # Third-Party
-    import httpx
+    import httpx2
 
     transport_cm, session = _mock_sdk_session()
     fake_app = MagicMock()
 
     with patch("mcpgateway.main.app", fake_app):
-        with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
+        with patch("mcpgateway.services.gateway_service.streamable_http_client", return_value=transport_cm) as mock_streamable:
             with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
                 await run_server_handshake("srv-1", "my-server", True, ServerHandshakeRequest(), {})
 
-    factory = mock_streamable.call_args.kwargs["httpx_client_factory"]
-    client = factory()
-    try:
-        assert isinstance(client, httpx.AsyncClient)
-        assert isinstance(client._transport, httpx.ASGITransport)
-    finally:
-        await client.aclose()
+    client = mock_streamable.call_args.kwargs["http_client"]
+    assert isinstance(client, httpx2.AsyncClient)
+    assert isinstance(client._transport, httpx2.ASGITransport)

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -3198,7 +3198,7 @@ class TestToolService:
             result = await tool_service.invoke_tool(test_db, "dummy_tool", {"param": "value"}, request_headers=None)
 
         session_mock.initialize.assert_not_awaited()
-        session_mock.call_tool.assert_awaited_once_with("dummy_tool", {"param": "value"}, meta=None)
+        session_mock.call_tool.assert_awaited_once_with("dummy_tool", {"param": "value"}, meta=None, progress_callback=None, allow_input_required=True, input_responses=None, request_state=None)
 
         # Our ToolResult bubbled back out
         assert result.content[0].text == "MCP response"
@@ -3303,7 +3303,7 @@ class TestToolService:
         # The per-call streamablehttp client path still reached call_tool successfully.
         # Note: mcp_proxy_client does NOT call initialize() - the client auto-initializes internally.
         session_mock.initialize.assert_not_awaited()
-        session_mock.call_tool.assert_awaited_once_with("dummy_tool", {"p": "v"}, meta=None)
+        session_mock.call_tool.assert_awaited_once_with("dummy_tool", {"p": "v"}, meta=None, progress_callback=None, allow_input_required=True, input_responses=None, request_state=None)
         assert result.content[0].text == "fallback ok"
 
     @pytest.mark.asyncio
@@ -3396,6 +3396,10 @@ class TestToolService:
             "dummy_tool",
             {"p": "v"},
             meta={"traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-3333333333333333-01"},
+            progress_callback=None,
+            allow_input_required=True,
+            input_responses=None,
+            request_state=None,
         )
         assert result.content[0].text == "sse fallback ok"
 
@@ -4210,7 +4214,7 @@ class TestToolService:
 
         # mcp_proxy_client auto-initializes internally; no explicit initialize() call.
         session_mock.initialize.assert_not_awaited()
-        session_mock.call_tool.assert_awaited_once_with("test_tool", {"param": "value"}, meta=None)
+        session_mock.call_tool.assert_awaited_once_with("test_tool", {"param": "value"}, meta=None, progress_callback=None, allow_input_required=True, input_responses=None, request_state=None)
 
         client_session_cm.__aenter__.assert_awaited_once()
 
@@ -4291,7 +4295,7 @@ class TestToolService:
         ):
             await tool_service.invoke_tool(test_db, "test_tool", {}, request_headers=None, meta_data=meta_data)
 
-        session_mock.call_tool.assert_awaited_once_with("test_tool", {}, meta=meta_data)
+        session_mock.call_tool.assert_awaited_once_with("test_tool", {}, meta=meta_data, progress_callback=None, allow_input_required=True, input_responses=None, request_state=None)
 
     @pytest.mark.asyncio
     async def test_invoke_tool_error_exception_group_unwrapping(self, tool_service, mock_tool, mock_global_config_obj, test_db):

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -7005,7 +7005,7 @@ class TestInvokeToolRestSuccess:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(return_value=sdk_error_result)
-        mock_session.session = mock_session  # v2 code calls client.session.call_tool
+        mock_session.session = mock_session
 
         class _ClientCM:
             """Stand-in for mcp_proxy_client — yields mock_session as the MCP Client."""
@@ -9181,7 +9181,7 @@ class TestInvokeToolMcpSse:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(return_value=ToolResult(content=[TextContent(type="text", text="ok")], is_error=False))
-        mock_session.session = mock_session  # v2 code calls client.session.call_tool
+        mock_session.session = mock_session
 
         def fake_proxy_client(*, url=None, headers=None, httpx_client_factory=None, **_kw):
             if httpx_client_factory is not None:
@@ -9239,7 +9239,7 @@ class TestInvokeToolMcpSse:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(return_value=ToolResult(content=[TextContent(type="text", text="ok")], is_error=False))
-        mock_session.session = mock_session  # v2 code calls client.session.call_tool
+        mock_session.session = mock_session
 
         def fake_proxy_client(*, url=None, headers=None, httpx_client_factory=None, **_kw):
             if httpx_client_factory is not None:

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -7005,6 +7005,7 @@ class TestInvokeToolRestSuccess:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(return_value=sdk_error_result)
+        mock_session.session = mock_session  # v2 code calls client.session.call_tool
 
         class _ClientCM:
             """Stand-in for mcp_proxy_client — yields mock_session as the MCP Client."""
@@ -9180,6 +9181,7 @@ class TestInvokeToolMcpSse:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(return_value=ToolResult(content=[TextContent(type="text", text="ok")], is_error=False))
+        mock_session.session = mock_session  # v2 code calls client.session.call_tool
 
         def fake_proxy_client(*, url=None, headers=None, httpx_client_factory=None, **_kw):
             if httpx_client_factory is not None:
@@ -9237,6 +9239,7 @@ class TestInvokeToolMcpSse:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(return_value=ToolResult(content=[TextContent(type="text", text="ok")], is_error=False))
+        mock_session.session = mock_session  # v2 code calls client.session.call_tool
 
         def fake_proxy_client(*, url=None, headers=None, httpx_client_factory=None, **_kw):
             if httpx_client_factory is not None:
@@ -9335,6 +9338,7 @@ class TestInvokeToolMcpSse:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(return_value=ToolResult(content=[TextContent(type="text", text="ok")], is_error=False))
+        mock_session.session = mock_session
 
         def fake_proxy_client(*, url=None, headers=None, httpx_client_factory=None, **_kw):
             captured_headers.update(headers or {})
@@ -9420,6 +9424,7 @@ class TestInvokeToolMcpSse:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(return_value=ToolResult(content=[TextContent(type="text", text="ok")], is_error=False))
+        mock_session.session = mock_session
 
         with (
             _setup_cache_for_invoke(tp, gp),
@@ -9506,6 +9511,7 @@ class TestInvokeToolMcpSse:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(return_value=ToolResult(content=[TextContent(type="text", text="ok")], is_error=False))
+        mock_session.session = mock_session
 
         with (
             _setup_cache_for_invoke(tp, gp),
@@ -9560,6 +9566,7 @@ class TestInvokeToolMcpSse:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(return_value=ToolResult(content=[TextContent(type="text", text="ok")], is_error=False))
+        mock_session.session = mock_session
 
         with (
             _setup_cache_for_invoke(tp, gp),
@@ -9627,6 +9634,7 @@ class TestInvokeToolMcpSse:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(return_value=ToolResult(content=[TextContent(type="text", text="ok")], is_error=False))
+        mock_session.session = mock_session
 
         with (
             _setup_cache_for_invoke(tp, gp),
@@ -9685,6 +9693,7 @@ class TestInvokeToolMcpSse:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(return_value=ToolResult(content=[TextContent(type="text", text="ok")], is_error=False))
+        mock_session.session = mock_session
 
         with (
             _setup_cache_for_invoke(tp, gp),
@@ -9745,6 +9754,7 @@ class TestInvokeToolMcpSse:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(return_value=ToolResult(content=[TextContent(type="text", text="ok")], is_error=False))
+        mock_session.session = mock_session
 
         with (
             _setup_cache_for_invoke(tp, gp),
@@ -9805,6 +9815,7 @@ class TestInvokeToolMcpSse:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(return_value=ToolResult(content=[TextContent(type="text", text="ok")], is_error=False))
+        mock_session.session = mock_session
 
         with (
             _setup_cache_for_invoke(tp, gp),
@@ -9955,6 +9966,7 @@ class TestInvokeToolMcpSseTimeoutAndErrors:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(side_effect=asyncio.TimeoutError())
+        mock_session.session = mock_session
 
         with (
             _setup_cache_for_invoke(tp, gp),
@@ -10003,6 +10015,7 @@ class TestInvokeToolMcpSseTimeoutAndErrors:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(side_effect=ExceptionGroup("eg", [ValueError("root")]))
+        mock_session.session = mock_session
 
         with (
             _setup_cache_for_invoke(tp, gp),
@@ -10055,6 +10068,7 @@ class TestInvokeToolMcpStreamableHttpCoverage:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(return_value=ToolResult(content=[TextContent(type="text", text="ok")], is_error=False))
+        mock_session.session = mock_session
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=None)
 
@@ -10171,6 +10185,7 @@ class TestInvokeToolMcpStreamableHttpCoverage:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(side_effect=asyncio.TimeoutError())
+        mock_session.session = mock_session
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=None)
 
@@ -10210,6 +10225,7 @@ class TestInvokeToolMcpStreamableHttpCoverage:
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(side_effect=ExceptionGroup("eg", [ValueError("root")]))
+        mock_session.session = mock_session
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=None)
 

--- a/tests/unit/mcpgateway/test_identity_propagation.py
+++ b/tests/unit/mcpgateway/test_identity_propagation.py
@@ -2051,7 +2051,7 @@ class TestToolServiceIdentityPropagationCoverage:
         client_mock.__aenter__ = AsyncMock(return_value=client_mock)
         client_mock.__aexit__ = AsyncMock(return_value=None)
         client_mock.call_tool = AsyncMock(return_value=mock_result)
-        client_mock.session = client_mock  # v2 code calls client.session.call_tool
+        client_mock.session = client_mock
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),

--- a/tests/unit/mcpgateway/test_identity_propagation.py
+++ b/tests/unit/mcpgateway/test_identity_propagation.py
@@ -2051,6 +2051,7 @@ class TestToolServiceIdentityPropagationCoverage:
         client_mock.__aenter__ = AsyncMock(return_value=client_mock)
         client_mock.__aexit__ = AsyncMock(return_value=None)
         client_mock.call_tool = AsyncMock(return_value=mock_result)
+        client_mock.session = client_mock  # v2 code calls client.session.call_tool
 
         with (
             patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=cache),

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -29,6 +29,8 @@ from typing import List
 from unittest.mock import AsyncMock, MagicMock, Mock, patch, PropertyMock
 
 # Third-Party
+from cpex.framework import PluginViolationError
+from cpex.framework.models import PluginViolation
 from fastapi import HTTPException
 import httpx
 from mcp_types import PromptArgument
@@ -18235,6 +18237,19 @@ class TestUnknownEntityErrors:
         assert isinstance(result, types.CallToolResult)
         assert result.is_error is True
         assert result.content[0].text == "Tool invocation failed: upstream event too large"
+
+    @pytest.mark.asyncio
+    async def test_plugin_violation_returns_iserror_result(self, monkeypatch):
+        """PluginViolationError (a plugin denying the call) becomes an isError result carrying the plugin's message."""
+        self._fake_db(monkeypatch)
+        message = "tool_pre_invoke blocked by plugin RateLimiterPlugin: RATE_LIMIT - Rate limit exceeded (Rate limit exceeded)"
+        violation = PluginViolation(reason="Rate limit exceeded", description="Rate limit exceeded", code="RATE_LIMIT", details={})
+        monkeypatch.setattr(tool_service, "invoke_tool", AsyncMock(side_effect=PluginViolationError(message=message, violation=violation)))
+
+        result = await call_tool("rate_limited_tool", {})
+        assert isinstance(result, types.CallToolResult)
+        assert result.is_error is True
+        assert result.content[0].text == message
 
     @pytest.mark.asyncio
     async def test_unknown_prompt_raises_invalid_params(self, monkeypatch):


### PR DESCRIPTION
Closes #6714 
1. Adds CI to PRs against `chore/mcp-sdk-v2` branch
2. Fixed test mocks to match sdk 2.0
3. Plugin blocked(PluginViolationError) tool raises `isError `to match existing plugin error patter

NOTE: some changes may seem unrelated to CI but they are needed for the CI checks to pass.