### PR TITLE
feat(compose): add 'ui' profile for contextforge-web-ui and document release verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4117,12 +4117,14 @@ LEGACY_API_ENABLED=true
 LEGACY_API_SUNSET_DATE=Sat, 26 Sep 2026 00:00:00 GMT
 
 # =============================================================================
-# ContextForge Web UI (docker-compose --profile testing or --profile experimental)
+# ContextForge Web UI (docker-compose --profile ui or --profile testing)
 # =============================================================================
 # BFF-style frontend for the gateway API - see docker-compose.yml (web_ui, web_ui_redis)
 
-# Image to pull for the web_ui service
-# WEB_UI_IMAGE=ghcr.io/contextforge-org/contextforge-web-ui:latest
+# Image to pull for the web_ui service - pin to a specific released version rather
+# than `latest`; bump this (and verify) as part of each release, see
+# docs/docs/development/release-management.md
+# WEB_UI_IMAGE=ghcr.io/contextforge-org/contextforge-web-ui:0.2.1
 
 # Host port the UI listens on (also used as the container port - see docker-compose.yml)
 # WEB_UI_PORT=3001

--- a/.env.example
+++ b/.env.example
@@ -4121,10 +4121,11 @@ LEGACY_API_SUNSET_DATE=Sat, 26 Sep 2026 00:00:00 GMT
 # =============================================================================
 # BFF-style frontend for the gateway API - see docker-compose.yml (web_ui, web_ui_redis)
 
-# Image to pull for the web_ui service - pin to a specific released version rather
-# than `latest`; bump this (and verify) as part of each release, see
-# docs/docs/development/release-management.md
-# WEB_UI_IMAGE=ghcr.io/contextforge-org/contextforge-web-ui:0.2.1
+# Image to pull for the web_ui service - pin to a specific released version AND
+# its digest rather than `latest` (this service holds user sessions/auth, so a
+# retargeted tag would silently swap deployed code); bump both (and verify) as
+# part of each release, see docs/docs/development/release-management.md
+# WEB_UI_IMAGE=ghcr.io/contextforge-org/contextforge-web-ui:0.2.1@sha256:e2063ab012e7fe78815c5f840d517e1cc1fd484ed25c7b8e37cd78210cc3ab98
 
 # Host port the UI listens on (also used as the container port - see docker-compose.yml)
 # WEB_UI_PORT=3001

--- a/.github/workflows/compose-ui-config-check.yml
+++ b/.github/workflows/compose-ui-config-check.yml
@@ -1,0 +1,50 @@
+# ===============================================================
+# Compose UI Config Check
+# ===============================================================
+#
+# Config-only smoke test for the supported 'ui' profile
+# (contextforge-web-ui BFF + web_ui_redis). Runs
+# `docker compose --profile ui config --quiet` to catch profile,
+# variable-interpolation, and Compose-schema regressions without
+# building images or starting containers — fast enough to run on
+# every PR that touches the compose file or its env defaults.
+#
+# See docs/docs/development/release-management.md #6.4.
+#
+# ===============================================================
+
+name: Compose UI Config Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: ["main", "chore/mcp-sdk-v2"]
+    paths:
+      - "docker-compose.yml"
+      - ".env.example"
+      - ".github/workflows/compose-ui-config-check.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  compose-ui-config-check:
+    name: compose-ui-config-check
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Prepare .env
+        run: cp .env.example .env
+
+      - name: Validate 'ui' profile compose config
+        run: make compose-ui-config-check

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-09T13:58:48Z",
+  "generated_at": "2026-09-09T15:37:51Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1286,7 +1286,7 @@
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 235,
+        "line_number": 238,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -1294,7 +1294,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 268,
+        "line_number": 271,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-10T10:35:34Z",
+  "generated_at": "2026-09-10T11:07:23Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -812,7 +812,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1237,
+        "line_number": 1242,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -820,7 +820,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1272,
+        "line_number": 1277,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -828,7 +828,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1822,
+        "line_number": 1827,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -836,7 +836,7 @@
         "hashed_secret": "afba9d98073dfb79fba7b21516c4d4d676c72935",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2252,
+        "line_number": 2257,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -844,7 +844,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2352,
+        "line_number": 2357,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -852,7 +852,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2352,
+        "line_number": 2357,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -860,7 +860,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2365,
+        "line_number": 2370,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -868,7 +868,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2513,
+        "line_number": 2518,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -876,7 +876,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2534,
+        "line_number": 2539,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -884,7 +884,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2542,
+        "line_number": 2547,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -892,7 +892,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2547,
+        "line_number": 2552,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-09T14:19:15Z",
+  "generated_at": "2026-09-09T13:58:48Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -756,7 +756,7 @@
         "hashed_secret": "b6f3674b78a02881de33177e6f6fb8b851e0101c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 250,
+        "line_number": 249,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -764,7 +764,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 345,
+        "line_number": 344,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -772,7 +772,7 @@
         "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 395,
+        "line_number": 394,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -780,7 +780,7 @@
         "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 403,
+        "line_number": 402,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -788,7 +788,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 450,
+        "line_number": 449,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -796,7 +796,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 968,
+        "line_number": 967,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -804,7 +804,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1071,
+        "line_number": 1070,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -812,7 +812,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1238,
+        "line_number": 1237,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -820,7 +820,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1273,
+        "line_number": 1272,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -828,7 +828,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1823,
+        "line_number": 1822,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -836,7 +836,7 @@
         "hashed_secret": "afba9d98073dfb79fba7b21516c4d4d676c72935",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2253,
+        "line_number": 2252,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -844,7 +844,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2353,
+        "line_number": 2352,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -852,7 +852,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2353,
+        "line_number": 2352,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -860,7 +860,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2366,
+        "line_number": 2365,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -868,7 +868,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2514,
+        "line_number": 2513,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -876,7 +876,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2535,
+        "line_number": 2534,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -884,7 +884,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2543,
+        "line_number": 2542,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -892,7 +892,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2548,
+        "line_number": 2547,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1286,7 +1286,7 @@
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 223,
+        "line_number": 235,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -1294,7 +1294,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 256,
+        "line_number": 268,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-09T15:37:51Z",
+  "generated_at": "2026-09-10T10:35:34Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6115,
+        "line_number": 6132,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6612,
+        "line_number": 6629,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6624,
+        "line_number": 6641,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6696,
+        "line_number": 6713,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "bb589d0621e5472f470fa3425a234c74b1e202e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7112,
+        "line_number": 7129,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7802,
+        "line_number": 7819,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,7 +360,7 @@ Configuration (see the commented `WEB_UI_*` block in `.env.example`):
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `WEB_UI_IMAGE` | `ghcr.io/contextforge-org/contextforge-web-ui:0.2.1` | Image to pull — pinned to a specific released version, never `latest`; bumped as part of the release checklist (`docs/docs/development/release-management.md`) |
+| `WEB_UI_IMAGE` | see `docker-compose.yml` | Image to pull — pinned to a specific released version *and* digest, never `latest`; bumped as part of the release checklist (`docs/docs/development/release-management.md`). Kept in one place (`docker-compose.yml`) rather than duplicated here so it can't drift out of sync. |
 | `WEB_UI_PORT` | `3001` | Host **and** container port (the image reads `PORT` at startup, so both sides of the mapping stay in sync) |
 | `WEB_UI_HOST` | `0.0.0.0` | Bind address inside the container — must stay `0.0.0.0` in Docker |
 | `WEB_UI_CONTEXTFORGE_URL` | `http://gateway:4444` | Gateway API base URL the UI talks to (internal compose network) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,17 +340,17 @@ python -m mcpgateway.translate --stdio "uvx mcp-server-git" --port 9000
 3. Create virtual server: `POST /servers`
 4. Access via SSE/WebSocket endpoints
 
-## ContextForge Web UI (Experimental)
+## ContextForge Web UI
 
 A BFF-style frontend for the gateway API, separate from the built-in Admin UI (`MCPGATEWAY_UI_ENABLED`). Source and docs: https://github.com/contextforge-org/contextforge-web-ui
 
 - Runs as `web_ui` + a dedicated `web_ui_redis` session store in `docker-compose.yml`.
-- Enabled via `--profile experimental` (or `--profile testing`, which pulls it in too).
+- Enabled via `--profile ui` (or `--profile testing`, which pulls it in too).
 - `web_ui` depends on `gateway` and `web_ui_redis` being healthy before it starts.
 
 ```bash
 # Start the gateway plus the web UI
-docker compose --profile experimental up -d
+docker compose --profile ui up -d
 
 # Access
 open http://localhost:${WEB_UI_PORT:-3001}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,7 +360,7 @@ Configuration (see the commented `WEB_UI_*` block in `.env.example`):
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `WEB_UI_IMAGE` | `ghcr.io/contextforge-org/contextforge-web-ui:latest` | Image to pull |
+| `WEB_UI_IMAGE` | `ghcr.io/contextforge-org/contextforge-web-ui:0.2.1` | Image to pull — pinned to a specific released version, never `latest`; bumped as part of the release checklist (`docs/docs/development/release-management.md`) |
 | `WEB_UI_PORT` | `3001` | Host **and** container port (the image reads `PORT` at startup, so both sides of the mapping stay in sync) |
 | `WEB_UI_HOST` | `0.0.0.0` | Bind address inside the container — must stay `0.0.0.0` in Docker |
 | `WEB_UI_CONTEXTFORGE_URL` | `http://gateway:4444` | Gateway API base URL the UI talks to (internal compose network) |

--- a/Makefile
+++ b/Makefile
@@ -5670,7 +5670,8 @@ endef
 	compose-logs-service compose-restart-service compose-scale compose-up-safe \
 compose-siem-up compose-siem-down compose-siem-logs \
 	monitoring-lite-up monitoring-lite-down \
-	embedded-up embedded-down embedded-clean embedded-status embedded-logs
+	embedded-up embedded-down embedded-clean embedded-status embedded-logs \
+	compose-ui-config-check
 
 # Validate compose file
 # To auto-fix before validating, run: make setup && make compose-validate
@@ -5687,6 +5688,22 @@ compose-validate:
 	fi
 	$(COMPOSE) config --quiet
 	@echo "✅ Compose file is valid"
+
+# Config-only smoke test for the supported 'ui' profile (contextforge-web-ui BFF)
+# Catches profile, variable-interpolation, and Compose-schema regressions without
+# starting any containers. See docs/docs/development/release-management.md #6.4.
+compose-ui-config-check:
+	@echo "🔍 Validating 'ui' profile compose config..."
+	@if [ ! -f "$(COMPOSE_FILE)" ]; then \
+		echo "❌ Compose file not found: $(COMPOSE_FILE)"; \
+		exit 1; \
+	fi
+	@if [ ! -f .env ]; then \
+		echo "❌ .env not found. Run: make setup"; \
+		exit 1; \
+	fi
+	$(COMPOSE_CMD) -f $(COMPOSE_FILE) --profile ui config --quiet
+	@echo "✅ 'ui' profile compose config is valid"
 
 compose-upgrade-pg18: compose-validate
 	@echo "⚠️  This will upgrade Postgres 17 -> 18"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1194,7 +1194,7 @@ services:
   # Web UI - BFF-style frontend for the gateway API
   # ──────────────────────────────────────────────────────────────────────
   web_ui:
-    image: ${WEB_UI_IMAGE:-ghcr.io/contextforge-org/contextforge-web-ui:latest}
+    image: ${WEB_UI_IMAGE:-ghcr.io/contextforge-org/contextforge-web-ui:0.2.1}
     restart: unless-stopped
     ports:
       # Host and container port tied together on purpose - the image reads

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1194,7 +1194,12 @@ services:
   # Web UI - BFF-style frontend for the gateway API
   # ──────────────────────────────────────────────────────────────────────
   web_ui:
-    image: ${WEB_UI_IMAGE:-ghcr.io/contextforge-org/contextforge-web-ui:0.2.1}
+    # Pinned by tag AND digest: the digest makes the supported `ui` profile
+    # reproducible even if the tag is ever retargeted on the registry - this
+    # service holds user sessions/auth, so an unexpected code swap matters.
+    # Bump both together on release (see release-management.md #6.4); get the
+    # digest with: docker buildx imagetools inspect <image>:<tag>
+    image: ${WEB_UI_IMAGE:-ghcr.io/contextforge-org/contextforge-web-ui:0.2.1@sha256:e2063ab012e7fe78815c5f840d517e1cc1fd484ed25c7b8e37cd78210cc3ab98}
     restart: unless-stopped
     ports:
       # Host and container port tied together on purpose - the image reads

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,7 @@
 #  --profile benchmark:   Adds benchmark MCP servers for load testing
 #  --profile tls:         Enables HTTPS via nginx_tls (auto-generates certs)
 #  --profile inspector:   Adds MCP Inspector client (http://localhost:6274)
-#  --profile experimental: Adds the ContextForge web UI (web_ui) + its Redis session store
-#                          (web_ui is also included in --profile testing)
+#  --profile ui:          Adds the ContextForge web UI (web_ui) + its Redis session store
 #
 #  Compose overlays (separate files):
 #  docker-compose.with-phoenix.yml:   Phoenix observability (OTEL traces)
@@ -1167,8 +1166,8 @@ services:
           memory: 1G
 
 ###############################################################################
-#  CONTEXTFORGE WEB UI (enabled with --profile testing or --profile experimental)
-#  Usage: docker compose --profile experimental up -d
+#  CONTEXTFORGE WEB UI (enabled with --profile ui or --profile testing)
+#  Usage: docker compose --profile ui up -d
 #  Access: http://localhost:${WEB_UI_PORT:-3001}
 ###############################################################################
 
@@ -1189,7 +1188,7 @@ services:
       retries: 10
       start_period: 10s
     networks: [mcpnet]
-    profiles: ["testing", "experimental"]
+    profiles: ["testing", "ui"]
 
   # ──────────────────────────────────────────────────────────────────────
   # Web UI - BFF-style frontend for the gateway API
@@ -1215,7 +1214,7 @@ services:
         condition: service_healthy
       web_ui_redis:
         condition: service_healthy
-    profiles: ["testing", "experimental"]
+    profiles: ["testing", "ui"]
 
 ###############################################################################
 #  MONITORING STACK (enabled with --profile monitoring)

--- a/docs/docs/deployment/compose.md
+++ b/docs/docs/deployment/compose.md
@@ -151,6 +151,18 @@ Keycloak admin console:
 - URL: `http://localhost:8180`
 - Credentials: `admin` / `changeme`
 
+### Web UI Profile
+
+ContextForge provides a standalone BFF-style Web UI frontend (`web_ui` + `web_ui_redis` session store) via `--profile ui`:
+
+```bash
+docker compose --profile ui up -d
+```
+
+- **Web UI URL:** [http://localhost:3001](http://localhost:3001)
+- **Session Redis:** Dedicated Redis instance (`web_ui_redis`) on internal network
+- Configuration options: `WEB_UI_PORT`, `WEB_UI_IMAGE`, `WEB_UI_CONTEXTFORGE_URL`, `WEB_UI_COOKIE_SECURE`, `WEB_UI_REDIS_URL`
+
 ### Without Make
 
 | Make target       | Docker CLI                                    | Podman built-in                              | podman-compose                               |

--- a/docs/docs/deployment/compose.md
+++ b/docs/docs/deployment/compose.md
@@ -164,7 +164,7 @@ docker compose --profile ui up -d
 - **Web UI URL:** [http://localhost:3001](http://localhost:3001)
 - **Session Redis:** Dedicated Redis instance (`web_ui_redis`) on internal network
 - Configuration options: `WEB_UI_PORT`, `WEB_UI_IMAGE`, `WEB_UI_CONTEXTFORGE_URL`, `WEB_UI_COOKIE_SECURE`, `WEB_UI_REDIS_URL`
-- `WEB_UI_IMAGE` is pinned to a specific released version of `contextforge-web-ui` (never `latest`) — see [Release Management](../development/release-management.md#64-web-ui-verification) for the bump-and-verify step run on each release.
+- `WEB_UI_IMAGE` is pinned to a specific released version *and* image digest of `contextforge-web-ui` (never `latest`) — see [Release Management](../development/release-management.md#64-web-ui-verification) for the bump-and-verify step run on each release.
 
 ### Without Make
 

--- a/docs/docs/deployment/compose.md
+++ b/docs/docs/deployment/compose.md
@@ -153,7 +153,9 @@ Keycloak admin console:
 
 ### Web UI Profile
 
-ContextForge provides a standalone BFF-style Web UI frontend (`web_ui` + `web_ui_redis` session store) via `--profile ui`:
+ContextForge ships two UIs: a built-in UI (served by the gateway itself) and a backend for frontend (BFF) style frontend — [contextforge-web-ui](https://github.com/contextforge-org/contextforge-web-ui) (`web_ui` + `web_ui_redis` session store). Both are supported side by side for the time being.
+
+To activate the BFF-style Web UI, use the `ui` profile:
 
 ```bash
 docker compose --profile ui up -d
@@ -162,6 +164,7 @@ docker compose --profile ui up -d
 - **Web UI URL:** [http://localhost:3001](http://localhost:3001)
 - **Session Redis:** Dedicated Redis instance (`web_ui_redis`) on internal network
 - Configuration options: `WEB_UI_PORT`, `WEB_UI_IMAGE`, `WEB_UI_CONTEXTFORGE_URL`, `WEB_UI_COOKIE_SECURE`, `WEB_UI_REDIS_URL`
+- `WEB_UI_IMAGE` is pinned to a specific released version of `contextforge-web-ui` (never `latest`) — see [Release Management](../development/release-management.md#64-web-ui-verification) for the bump-and-verify step run on each release.
 
 ### Without Make
 

--- a/docs/docs/development/building.md
+++ b/docs/docs/development/building.md
@@ -132,6 +132,28 @@ For iterative development you can use watch mode:
 npx vite build --watch
 ```
 
+### Standalone ContextForge Web UI
+
+In addition to the built-in Admin UI, ContextForge provides a standalone BFF-style Web UI (source: [contextforge-web-ui](https://github.com/contextforge-org/contextforge-web-ui)).
+
+To run it locally with Docker Compose:
+
+```bash
+docker compose --profile ui up -d
+```
+
+Access the Web UI at [http://localhost:3001](http://localhost:3001).
+
+To test against a locally built image instead of the published `ghcr.io/contextforge-org/contextforge-web-ui` tag (for example, while iterating in a sibling `contextforge-web-ui` checkout), build it there and point compose at the resulting tag:
+
+```bash
+# In the contextforge-web-ui checkout
+docker build -t contextforge-web-ui:local .
+
+# Back in mcp-context-forge
+WEB_UI_IMAGE=contextforge-web-ui:local docker compose --profile ui up -d
+```
+
 ### Linting & Formatting
 
 ```bash

--- a/docs/docs/development/building.md
+++ b/docs/docs/development/building.md
@@ -134,7 +134,7 @@ npx vite build --watch
 
 ### Standalone ContextForge Web UI
 
-In addition to the built-in Admin UI, ContextForge provides a standalone BFF-style Web UI (source: [contextforge-web-ui](https://github.com/contextforge-org/contextforge-web-ui)).
+In addition to the built-in Admin UI, ContextForge provides a standalone BFF-style Web UI hosted in the [contextforge-web-ui](https://github.com/contextforge-org/contextforge-web-ui) repository.
 
 To run it locally with Docker Compose:
 

--- a/docs/docs/development/release-management.md
+++ b/docs/docs/development/release-management.md
@@ -471,7 +471,27 @@ Tear down when done:
 make embedded-down
 ```
 
-### 6.4 Python package build
+### 6.4 Web UI verification
+
+Verify the standalone ContextForge Web UI (`web_ui` + `web_ui_redis`) starts and communicates with the gateway under the `ui` profile:
+
+```bash
+docker compose --profile ui up -d
+```
+
+Verify:
+
+- `web_ui` and `web_ui_redis` services start cleanly
+- The web UI responds at `http://localhost:3001`
+- Gateway health endpoint responds at `http://localhost:8080/health`
+
+Tear down when done:
+
+```bash
+docker compose --profile ui down
+```
+
+### 6.5 Python package build
 
 ```bash
 make dist

--- a/docs/docs/development/release-management.md
+++ b/docs/docs/development/release-management.md
@@ -473,16 +473,26 @@ make embedded-down
 
 ### 6.4 Web UI verification
 
-The `web_ui` service is pinned to a specific released tag of
+The `web_ui` service is pinned to a specific released tag *and* image digest of
 [contextforge-web-ui](https://github.com/contextforge-org/contextforge-web-ui) via
 the `WEB_UI_IMAGE` default in `docker-compose.yml` (and the commented example in
-`.env.example`) — never `latest`. As part of each release:
+`.env.example`) — never `latest`. The digest makes the pin immutable: a tag alone
+can be retargeted on the registry, and this service handles user sessions/auth, so
+an unexpected code swap on deploy matters. As part of each release:
 
 1. Check the latest published release tag of `contextforge-web-ui` (GitHub releases
    or `ghcr.io/contextforge-org/contextforge-web-ui` tags).
-2. Update the `WEB_UI_IMAGE` default in `docker-compose.yml` and the example in
-   `.env.example` to that version.
-3. Verify the new pinned version starts and communicates with the gateway under the
+2. Resolve that tag's manifest digest:
+
+   ```bash
+   docker buildx imagetools inspect ghcr.io/contextforge-org/contextforge-web-ui:<tag>
+   ```
+
+   Use the top-level `Digest:` value (the multi-arch image index), not one of the
+   per-platform manifest digests underneath it.
+3. Update the `WEB_UI_IMAGE` default in `docker-compose.yml` and the example in
+   `.env.example` to `<tag>@<digest>`.
+4. Verify the new pinned version starts and communicates with the gateway under the
    `ui` profile:
 
 ```bash
@@ -500,6 +510,12 @@ Tear down when done:
 ```bash
 docker compose --profile ui down
 ```
+
+!!! tip "Config-only smoke test"
+    `make compose-ui-config-check` runs `docker compose --profile ui config --quiet`
+    to catch profile, variable-interpolation, and Compose-schema regressions without
+    starting containers. It also runs in CI on every PR that touches
+    `docker-compose.yml`.
 
 ### 6.5 Python package build
 

--- a/docs/docs/development/release-management.md
+++ b/docs/docs/development/release-management.md
@@ -473,7 +473,17 @@ make embedded-down
 
 ### 6.4 Web UI verification
 
-Verify the standalone ContextForge Web UI (`web_ui` + `web_ui_redis`) starts and communicates with the gateway under the `ui` profile:
+The `web_ui` service is pinned to a specific released tag of
+[contextforge-web-ui](https://github.com/contextforge-org/contextforge-web-ui) via
+the `WEB_UI_IMAGE` default in `docker-compose.yml` (and the commented example in
+`.env.example`) — never `latest`. As part of each release:
+
+1. Check the latest published release tag of `contextforge-web-ui` (GitHub releases
+   or `ghcr.io/contextforge-org/contextforge-web-ui` tags).
+2. Update the `WEB_UI_IMAGE` default in `docker-compose.yml` and the example in
+   `.env.example` to that version.
+3. Verify the new pinned version starts and communicates with the gateway under the
+   `ui` profile:
 
 ```bash
 docker compose --profile ui up -d

--- a/docs/docs/overview/ui.md
+++ b/docs/docs/overview/ui.md
@@ -124,3 +124,21 @@ MCPGATEWAY_UI_AIRGAPPED=true make dev
 All vendor JavaScript is installed via npm and bundled/chunked with Vite for local serving.
 
 ---
+
+## 🌐 Standalone ContextForge Web UI
+
+In addition to the built-in Admin UI, ContextForge provides a standalone BFF-style Web UI (source: [contextforge-web-ui](https://github.com/contextforge-org/contextforge-web-ui)).
+
+### Running with Docker Compose
+
+Enable the Web UI and its dedicated session store using the `ui` profile:
+
+```bash
+docker compose --profile ui up -d
+```
+
+- **Web UI URL:** [http://localhost:3001](http://localhost:3001)
+- **Session Redis:** Dedicated Redis instance (`web_ui_redis`)
+- **Gateway connection:** Connects to gateway over the internal network (`http://gateway:4444`)
+
+---

--- a/docs/docs/overview/ui.md
+++ b/docs/docs/overview/ui.md
@@ -127,7 +127,7 @@ All vendor JavaScript is installed via npm and bundled/chunked with Vite for loc
 
 ## 🌐 Standalone ContextForge Web UI
 
-In addition to the built-in Admin UI, ContextForge provides a standalone BFF-style Web UI (source: [contextforge-web-ui](https://github.com/contextforge-org/contextforge-web-ui)).
+In addition to the built-in Admin UI, ContextForge provides a standalone BFF-style Web UI — [contextforge-web-ui](https://github.com/contextforge-org/contextforge-web-ui).
 
 ### Running with Docker Compose
 


### PR DESCRIPTION
Closes https://github.ibm.com/contextforge-org/internal_issues/issues/606

 ## Overview
  Promote the `contextforge-web-ui` frontend service and its dedicated session store (`web_ui_redis`) from experimental status to a first-class, supported `ui` profile in Docker Compose (`docker-compose.yml`) for the ContextForge 1.5 release, and document its execution, build, local development, and release verification workflows across the documentation suite.

  ---

  ## Key Changes

  ### 1. Docker Compose Profiles (`docker-compose.yml`)
  - Configured `profiles: ["testing", "ui"]` on both `web_ui` and `web_ui_redis` services.
  - Removed deprecated `experimental` profile references.
  - Updated Docker Compose profile header comments and inline service annotations.

  ### 2. Documentation & Workflows (`docs/` and `AGENTS.md`)
  - **Building & Local Development (`docs/docs/development/building.md`)**:
    - Added standalone ContextForge Web UI section explaining how to run with `--profile ui`.
    - Added instructions for local developer iteration using a custom/sibling build via `WEB_UI_IMAGE=contextforge-web-ui:local docker compose --profile ui up -d`.
  - **Deployment Guide (`docs/docs/deployment/compose.md`)**:
    - Added **Web UI Profile** section covering launch commands (`docker compose --profile ui up -d`), port mapping (`:3001`), and key configuration environment variables (`WEB_UI_PORT`, `WEB_UI_IMAGE`, `WEB_UI_CONTEXTFORGE_URL`, `WEB_UI_COOKIE_SECURE`, `WEB_UI_REDIS_URL`).
  - **Release Management (`docs/docs/development/release-management.md`)**:
    - Added verification gate **6.4 Web UI verification** under Phase 6 (Build & Compose Verification) in the release checklist.
  - **Overview (`docs/docs/overview/ui.md`)**:
    - Added architectural overview distinguishing the built-in Admin UI from the standalone BFF-style Web UI.
  - **Agent Guidelines (`AGENTS.md`)**:
    - Updated guidance to reference the `--profile ui` launch workflow.

  ---
  ## Verification

  [x] Run `docker compose --profile ui up -d` and verify `gateway, web_ui, and web_ui_redis` start and become healthy.
  [x] Verify the Web UI is reachable at `http://localhost:3001`.
  [x] Verify the gateway health endpoint responds at `http://localhost:8080/health`.
  [x] Verify local image tag override works via `WEB_UI_IMAGE=<image-tag> docker compose --profile ui up -d`.
  [x] Tear down cleanly with `docker compose --profile ui down`.