### PR TITLE
fix: skip forced password-change flag when custom PLATFORM_ADMIN_PASS…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,6 +122,10 @@ CSRF_TRUSTED_ORIGINS=["http://localhost:4444","http://localhost:8080"]
 PLATFORM_ADMIN_EMAIL=admin@example.com
 PLATFORM_ADMIN_PASSWORD=__REPLACE_ME__run_init-secrets_before_starting
 DEFAULT_USER_PASSWORD=__REPLACE_ME__run_init-secrets_before_starting
+# Headless/CI deployments: when PLATFORM_ADMIN_PASSWORD differs from DEFAULT_USER_PASSWORD,
+# the forced password-change flag is skipped automatically. Set the flag below to false
+# only if you need to suppress it even when the default password is in use.
+#ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP=true
 # Set to false in development to enable the platform admin bootstrap path.
 # Production default is true (requires admin user seeded in the database).
 # Uncomment in development if you rely on the platform-admin email match
@@ -1299,7 +1303,7 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # Password Change Enforcement
 # Master switch for all password change enforcement checks
 # PASSWORD_CHANGE_ENFORCEMENT_ENABLED=true
-# Force admin to change password after bootstrap
+# Force admin to change password after bootstrap (only applies when PLATFORM_ADMIN_PASSWORD equals DEFAULT_USER_PASSWORD)
 # ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP=true
 
 # Rate Limiting (for local dev/testing, disable to prevent account lockouts)

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-10T13:37:04Z",
+  "generated_at": "2026-09-10T14:52:26Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -92,7 +92,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 803,
+        "line_number": 807,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -100,7 +100,7 @@
         "hashed_secret": "15ab6d87c10ed359ba98e6a578764fa53954fdfc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1275,
+        "line_number": 1279,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -108,7 +108,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1381,
+        "line_number": 1385,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -116,7 +116,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1416,
+        "line_number": 1420,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1569,
+        "line_number": 1573,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1574,
+        "line_number": 1578,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1579,
+        "line_number": 1583,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1586,
+        "line_number": 1590,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1598,
+        "line_number": 1602,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1616,
+        "line_number": 1620,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1677,
+        "line_number": 1681,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -879,7 +879,7 @@ mcpContextForge:
     PASSWORD_REQUIRE_NUMBERS: "false"      # require numbers in passwords
     PASSWORD_REQUIRE_SPECIAL: "true"       # require special characters in passwords
     PASSWORD_CHANGE_ENFORCEMENT_ENABLED: "true" # enable password change enforcement checks
-    ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP: "true" # force admin to change password after bootstrap
+    ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP: "true" # force admin to change password after bootstrap (only applies when PLATFORM_ADMIN_PASSWORD equals DEFAULT_USER_PASSWORD)
     DETECT_DEFAULT_PASSWORD_ON_LOGIN: "true" # detect default passwords on login
     REQUIRE_PASSWORD_CHANGE_FOR_DEFAULT_PASSWORD: "true" # require change for default password
     PASSWORD_POLICY_ENABLED: "true"         # enable password policy enforcement

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -332,9 +332,7 @@ async def bootstrap_admin_user(conn: Connection) -> None:
                     # the login-time default-password detector on a rotated password).
                     password_service = Argon2PasswordService()
                     stored_hash = getattr(admin_user, "password_hash", None)
-                    _stored_is_default = stored_hash is not None and await password_service.verify_password_async(
-                        settings.default_user_password.get_secret_value(), stored_hash
-                    )
+                    _stored_is_default = stored_hash is not None and await password_service.verify_password_async(settings.default_user_password.get_secret_value(), stored_hash)
                     if _stored_is_default:
                         admin_user.password_change_required = False
                         logger.info("Custom PLATFORM_ADMIN_PASSWORD detected and stored hash is default; cleared bootstrap-set flag.")

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -290,14 +290,20 @@ async def bootstrap_admin_user(conn: Connection) -> None:
                 full_name=settings.platform_admin_full_name,
             )
 
-            # Mark admin user as email verified and require password change on first login
+            # Mark admin user as email verified
             # First-Party
             from mcpgateway.db import utc_now  # pylint: disable=import-outside-toplevel
 
             admin_user.email_verified_at = utc_now()
-            # Respect configuration: only require password change on bootstrap when enabled
-            if getattr(settings, "password_change_enforcement_enabled", True) and getattr(settings, "admin_require_password_change_on_bootstrap", True):
-                admin_user.password_change_required = True  # Force admin to change default password
+            _enforcement_on = getattr(settings, "password_change_enforcement_enabled", True)
+            _bootstrap_flag = getattr(settings, "admin_require_password_change_on_bootstrap", True)
+            if _enforcement_on and _bootstrap_flag:
+                _using_default_pwd = settings.platform_admin_password.get_secret_value() == settings.default_user_password.get_secret_value()
+                if _using_default_pwd:
+                    admin_user.password_change_required = True
+                    logger.warning("Admin bootstrapped with the default password; password change required on first login.")
+                else:
+                    logger.info("Custom PLATFORM_ADMIN_PASSWORD detected; skipping forced password-change flag.")
             try:
                 admin_user.password_changed_at = utc_now()
             except Exception as exc:

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -310,26 +310,15 @@ async def bootstrap_admin_user(conn: Connection) -> None:
             _enforcement_on = getattr(settings, "password_change_enforcement_enabled", True)
             _bootstrap_flag = getattr(settings, "admin_require_password_change_on_bootstrap", True)
 
-            if not _enforcement_on or not _bootstrap_flag:
-                # Master switch or bootstrap flag disabled — never touch the flag.
-                pass
-            else:
-                # Compare PLATFORM_ADMIN_PASSWORD against the compiled-in default using
-                # constant-time bytes comparison.  Both sides are encoded to UTF-8 so that
-                # non-ASCII passwords don't raise a TypeError inside compare_digest.
+            if _enforcement_on and _bootstrap_flag:
                 _admin_pwd_bytes = settings.platform_admin_password.get_secret_value().encode("utf-8")
                 _default_pwd_bytes = settings.default_user_password.get_secret_value().encode("utf-8")
                 _env_is_default = hmac.compare_digest(_admin_pwd_bytes, _default_pwd_bytes)
 
                 if _env_is_default:
-                    # The env var still holds the default — force a change on login.
                     admin_user.password_change_required = True
                     logger.warning("Admin bootstrapped with the default password; password change required on first login.")
                 elif admin_user.password_change_required:
-                    # A custom PLATFORM_ADMIN_PASSWORD is now in env and the flag is set.
-                    # Only clear it if the admin's *stored* hash is still the default password
-                    # (i.e. the flag was set by bootstrap, not by a deliberate admin action or
-                    # the login-time default-password detector on a rotated password).
                     password_service = Argon2PasswordService()
                     stored_hash = getattr(admin_user, "password_hash", None)
                     _stored_is_default = stored_hash is not None and await password_service.verify_password_async(settings.default_user_password.get_secret_value(), stored_hash)

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -28,6 +28,7 @@ Examples:
 # Standard
 import asyncio
 from contextlib import contextmanager
+import hmac
 from importlib.resources import files
 import json
 import os
@@ -276,42 +277,52 @@ async def bootstrap_admin_user(conn: Connection) -> None:
         with Session(bind=conn) as db:
             auth_service = EmailAuthService(db)
 
-            # Check if admin user already exists
-            existing_user = await auth_service.get_user_by_email(settings.platform_admin_email)
-            if existing_user:
-                logger.info(f"Admin user {SecurityValidator.sanitize_log_message(settings.platform_admin_email)} already exists - skipping creation")
-                return
+            is_new_user = not await auth_service.get_user_by_email(settings.platform_admin_email)
+            if is_new_user:
+                logger.info(f"Creating platform admin user: {SecurityValidator.sanitize_log_message(settings.platform_admin_email)}")
+            else:
+                logger.info(f"Admin user {SecurityValidator.sanitize_log_message(settings.platform_admin_email)} exists; re-evaluating bootstrap flags")
 
-            # Create admin user
-            logger.info(f"Creating platform admin user: {SecurityValidator.sanitize_log_message(settings.platform_admin_email)}")
             admin_user = await auth_service.create_platform_admin(
                 email=settings.platform_admin_email,
                 password=settings.platform_admin_password.get_secret_value(),
                 full_name=settings.platform_admin_full_name,
             )
 
-            # Mark admin user as email verified
             # First-Party
             from mcpgateway.db import utc_now  # pylint: disable=import-outside-toplevel
 
-            admin_user.email_verified_at = utc_now()
+            if is_new_user:
+                admin_user.email_verified_at = utc_now()
+
+            # Evaluate forced-change flag for both new and existing admins so that:
+            # - operators who set PLATFORM_ADMIN_PASSWORD after being locked out are unblocked on restart
+            # - the Helm "Method 1" recovery (update values.yaml + helm upgrade) works as documented
             _enforcement_on = getattr(settings, "password_change_enforcement_enabled", True)
             _bootstrap_flag = getattr(settings, "admin_require_password_change_on_bootstrap", True)
-            if _enforcement_on and _bootstrap_flag:
-                _using_default_pwd = settings.platform_admin_password.get_secret_value() == settings.default_user_password.get_secret_value()
-                if _using_default_pwd:
-                    admin_user.password_change_required = True
-                    logger.warning("Admin bootstrapped with the default password; password change required on first login.")
-                else:
-                    logger.info("Custom PLATFORM_ADMIN_PASSWORD detected; skipping forced password-change flag.")
-            try:
-                admin_user.password_changed_at = utc_now()
-            except Exception as exc:
-                logger.debug("Failed to set admin password_changed_at: %s", exc)
+            _admin_pwd = settings.platform_admin_password.get_secret_value()
+            _default_pwd = settings.default_user_password.get_secret_value()
+            _using_default_pwd = hmac.compare_digest(_admin_pwd, _default_pwd)
+
+            if _enforcement_on and _bootstrap_flag and _using_default_pwd:
+                admin_user.password_change_required = True
+                logger.warning("Admin bootstrapped with the default password; password change required on first login.")
+            elif admin_user.password_change_required:
+                # Custom password supplied — clear any stale flag from a previous default-password boot
+                admin_user.password_change_required = False
+                logger.info("Custom PLATFORM_ADMIN_PASSWORD detected; cleared stale password-change flag.")
+            else:
+                logger.info("Custom PLATFORM_ADMIN_PASSWORD detected; skipping forced password-change flag.")
+
+            if is_new_user:
+                try:
+                    admin_user.password_changed_at = utc_now()
+                except Exception as exc:
+                    logger.debug("Failed to set admin password_changed_at: %s", exc)
+
             db.commit()
 
-            # Personal team is automatically created during user creation if enabled
-            if settings.auto_create_personal_teams:
+            if is_new_user and settings.auto_create_personal_teams:
                 logger.info("Personal team automatically created for admin user")
 
             db.commit()

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -255,11 +255,13 @@ def advisory_lock(conn: Connection):
 
 
 async def bootstrap_admin_user(conn: Connection) -> None:
-    """
-    Bootstrap the platform admin user from environment variables.
+    """Bootstrap the platform admin user from environment variables.
 
-    Creates the admin user if email authentication is enabled and the user doesn't exist.
-    Also creates a personal team for the admin user if auto-creation is enabled.
+    Creates the admin user on first boot.  On subsequent boots the user is
+    fetched (not re-created) so that any password the admin rotated via the UI
+    is never overwritten.  The ``password_change_required`` flag is re-evaluated
+    on every boot so an operator can recover a locked-out account by setting
+    ``PLATFORM_ADMIN_PASSWORD`` to a custom value and restarting.
 
     Args:
         conn: Active SQLAlchemy connection
@@ -272,32 +274,45 @@ async def bootstrap_admin_user(conn: Connection) -> None:
         # Import services here to avoid circular imports
         # First-Party
         from mcpgateway.services.email_auth_service import EmailAuthService  # pylint: disable=import-outside-toplevel
+        from mcpgateway.db import utc_now  # pylint: disable=import-outside-toplevel
 
         # Use session bound to the locked connection
         with Session(bind=conn) as db:
             auth_service = EmailAuthService(db)
 
-            is_new_user = not await auth_service.get_user_by_email(settings.platform_admin_email)
-            if is_new_user:
+            existing_user = await auth_service.get_user_by_email(settings.platform_admin_email)
+
+            if existing_user is None:
+                # First boot — create the admin and mark email as verified.
                 logger.info(f"Creating platform admin user: {SecurityValidator.sanitize_log_message(settings.platform_admin_email)}")
-            else:
-                logger.info(f"Admin user {SecurityValidator.sanitize_log_message(settings.platform_admin_email)} exists; re-evaluating bootstrap flags")
-
-            admin_user = await auth_service.create_platform_admin(
-                email=settings.platform_admin_email,
-                password=settings.platform_admin_password.get_secret_value(),
-                full_name=settings.platform_admin_full_name,
-            )
-
-            # First-Party
-            from mcpgateway.db import utc_now  # pylint: disable=import-outside-toplevel
-
-            if is_new_user:
+                admin_user = await auth_service.create_platform_admin(
+                    email=settings.platform_admin_email,
+                    password=settings.platform_admin_password.get_secret_value(),
+                    full_name=settings.platform_admin_full_name,
+                )
                 admin_user.email_verified_at = utc_now()
+                try:
+                    admin_user.password_changed_at = utc_now()
+                except Exception as exc:
+                    logger.debug("Failed to set admin password_changed_at: %s", exc)
 
-            # Evaluate forced-change flag for both new and existing admins so that:
-            # - operators who set PLATFORM_ADMIN_PASSWORD after being locked out are unblocked on restart
-            # - the Helm "Method 1" recovery (update values.yaml + helm upgrade) works as documented
+                if settings.auto_create_personal_teams:
+                    logger.info("Personal team automatically created for admin user")
+            else:
+                # Subsequent boot — use the existing record as-is; do NOT call
+                # create_platform_admin() here because it overwrites the password hash
+                # whenever PLATFORM_ADMIN_PASSWORD != the stored hash, silently
+                # reverting any password the admin rotated via the UI.
+                logger.info(f"Admin user {SecurityValidator.sanitize_log_message(settings.platform_admin_email)} exists; re-evaluating bootstrap flag only")
+                admin_user = existing_user
+
+            # Re-evaluate the forced-change flag on every boot.
+            # This is the only mutation applied to existing admins, intentionally:
+            # - default password in env  → set flag (force change on login)
+            # - custom password in env + flag currently set by a previous default-password
+            #   boot (admin_require_password_change_on_bootstrap was True then) → clear it
+            # - flag set by login-time default-password detector (require_password_change_for_default_password)
+            #   is intentionally left untouched when _bootstrap_flag is False
             _enforcement_on = getattr(settings, "password_change_enforcement_enabled", True)
             _bootstrap_flag = getattr(settings, "admin_require_password_change_on_bootstrap", True)
             _admin_pwd = settings.platform_admin_password.get_secret_value()
@@ -307,26 +322,17 @@ async def bootstrap_admin_user(conn: Connection) -> None:
             if _enforcement_on and _bootstrap_flag and _using_default_pwd:
                 admin_user.password_change_required = True
                 logger.warning("Admin bootstrapped with the default password; password change required on first login.")
-            elif admin_user.password_change_required:
-                # Custom password supplied — clear any stale flag from a previous default-password boot
+            elif _enforcement_on and _bootstrap_flag and not _using_default_pwd and admin_user.password_change_required:
+                # Custom password is now in env and the bootstrap flag is on — clear the stale
+                # flag that was set by a previous default-password boot.  This is the intended
+                # "Helm recovery" path: operator sets PLATFORM_ADMIN_PASSWORD and restarts.
                 admin_user.password_change_required = False
-                logger.info("Custom PLATFORM_ADMIN_PASSWORD detected; cleared stale password-change flag.")
+                logger.info("Custom PLATFORM_ADMIN_PASSWORD detected; cleared bootstrap-set password-change flag.")
             else:
                 logger.info("Custom PLATFORM_ADMIN_PASSWORD detected; skipping forced password-change flag.")
 
-            if is_new_user:
-                try:
-                    admin_user.password_changed_at = utc_now()
-                except Exception as exc:
-                    logger.debug("Failed to set admin password_changed_at: %s", exc)
-
             db.commit()
-
-            if is_new_user and settings.auto_create_personal_teams:
-                logger.info("Personal team automatically created for admin user")
-
-            db.commit()
-            logger.info(f"Platform admin user created successfully: {SecurityValidator.sanitize_log_message(settings.platform_admin_email)}")
+            logger.info(f"Platform admin user bootstrapped successfully: {SecurityValidator.sanitize_log_message(settings.platform_admin_email)}")
 
     except Exception as e:
         logger.error(f"Failed to bootstrap admin user: {e}")

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -275,6 +275,7 @@ async def bootstrap_admin_user(conn: Connection) -> None:
         # First-Party
         from mcpgateway.services.email_auth_service import EmailAuthService  # pylint: disable=import-outside-toplevel
         from mcpgateway.db import utc_now  # pylint: disable=import-outside-toplevel
+        from mcpgateway.services.argon2_service import Argon2PasswordService  # pylint: disable=import-outside-toplevel
 
         # Use session bound to the locked connection
         with Session(bind=conn) as db:
@@ -306,30 +307,41 @@ async def bootstrap_admin_user(conn: Connection) -> None:
                 logger.info(f"Admin user {SecurityValidator.sanitize_log_message(settings.platform_admin_email)} exists; re-evaluating bootstrap flag only")
                 admin_user = existing_user
 
-            # Re-evaluate the forced-change flag on every boot.
-            # This is the only mutation applied to existing admins, intentionally:
-            # - default password in env  → set flag (force change on login)
-            # - custom password in env + flag currently set by a previous default-password
-            #   boot (admin_require_password_change_on_bootstrap was True then) → clear it
-            # - flag set by login-time default-password detector (require_password_change_for_default_password)
-            #   is intentionally left untouched when _bootstrap_flag is False
             _enforcement_on = getattr(settings, "password_change_enforcement_enabled", True)
             _bootstrap_flag = getattr(settings, "admin_require_password_change_on_bootstrap", True)
-            _admin_pwd = settings.platform_admin_password.get_secret_value()
-            _default_pwd = settings.default_user_password.get_secret_value()
-            _using_default_pwd = hmac.compare_digest(_admin_pwd, _default_pwd)
 
-            if _enforcement_on and _bootstrap_flag and _using_default_pwd:
-                admin_user.password_change_required = True
-                logger.warning("Admin bootstrapped with the default password; password change required on first login.")
-            elif _enforcement_on and _bootstrap_flag and not _using_default_pwd and admin_user.password_change_required:
-                # Custom password is now in env and the bootstrap flag is on — clear the stale
-                # flag that was set by a previous default-password boot.  This is the intended
-                # "Helm recovery" path: operator sets PLATFORM_ADMIN_PASSWORD and restarts.
-                admin_user.password_change_required = False
-                logger.info("Custom PLATFORM_ADMIN_PASSWORD detected; cleared bootstrap-set password-change flag.")
+            if not _enforcement_on or not _bootstrap_flag:
+                # Master switch or bootstrap flag disabled — never touch the flag.
+                pass
             else:
-                logger.info("Custom PLATFORM_ADMIN_PASSWORD detected; skipping forced password-change flag.")
+                # Compare PLATFORM_ADMIN_PASSWORD against the compiled-in default using
+                # constant-time bytes comparison.  Both sides are encoded to UTF-8 so that
+                # non-ASCII passwords don't raise a TypeError inside compare_digest.
+                _admin_pwd_bytes = settings.platform_admin_password.get_secret_value().encode("utf-8")
+                _default_pwd_bytes = settings.default_user_password.get_secret_value().encode("utf-8")
+                _env_is_default = hmac.compare_digest(_admin_pwd_bytes, _default_pwd_bytes)
+
+                if _env_is_default:
+                    # The env var still holds the default — force a change on login.
+                    admin_user.password_change_required = True
+                    logger.warning("Admin bootstrapped with the default password; password change required on first login.")
+                elif admin_user.password_change_required:
+                    # A custom PLATFORM_ADMIN_PASSWORD is now in env and the flag is set.
+                    # Only clear it if the admin's *stored* hash is still the default password
+                    # (i.e. the flag was set by bootstrap, not by a deliberate admin action or
+                    # the login-time default-password detector on a rotated password).
+                    password_service = Argon2PasswordService()
+                    stored_hash = getattr(admin_user, "password_hash", None)
+                    _stored_is_default = stored_hash is not None and await password_service.verify_password_async(
+                        settings.default_user_password.get_secret_value(), stored_hash
+                    )
+                    if _stored_is_default:
+                        admin_user.password_change_required = False
+                        logger.info("Custom PLATFORM_ADMIN_PASSWORD detected and stored hash is default; cleared bootstrap-set flag.")
+                    else:
+                        logger.info("password_change_required flag left intact (stored password is not the default).")
+                else:
+                    logger.info("Custom PLATFORM_ADMIN_PASSWORD detected; skipping forced password-change flag.")
 
             db.commit()
             logger.info(f"Platform admin user bootstrapped successfully: {SecurityValidator.sanitize_log_message(settings.platform_admin_email)}")

--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -241,11 +241,13 @@ async def login(login_request: EmailLoginRequest, request: Request, db: Session 
 
         # Password change enforcement respects master switch and individual toggles
         needs_password_change = False
+        _change_cause: Optional[str] = None  # tracks why the change is required for hint text
 
         if settings.password_change_enforcement_enabled:
             # If flag is set on the user, always honor it (flag is cleared when password is changed)
             if getattr(user, "password_change_required", False):
                 needs_password_change = True
+                _change_cause = "flag"
                 logger.debug("User %s has password_change_required flag set", login_request.email)
 
             # Enforce expiry-based password change if configured and not already required
@@ -257,6 +259,7 @@ async def login(login_request: EmailLoginRequest, request: Request, db: Session 
                         max_age = getattr(settings, "password_max_age_days", 90)
                         if age_days >= max_age:
                             needs_password_change = True
+                            _change_cause = "expiry"
                             logger.debug("User %s password expired (%s days >= %s)", login_request.email, age_days, max_age)
                 except Exception as exc:
                     logger.debug("Failed to evaluate password age for %s: %s", login_request.email, exc)
@@ -275,6 +278,7 @@ async def login(login_request: EmailLoginRequest, request: Request, db: Session 
                     if getattr(settings, "require_password_change_for_default_password", True):
                         user.password_change_required = True
                         needs_password_change = True
+                        _change_cause = "default_password"
                         try:
                             db.commit()
                         except Exception as exc:  # log commit failures
@@ -284,11 +288,14 @@ async def login(login_request: EmailLoginRequest, request: Request, db: Session 
 
         if needs_password_change:
             logger.info(f"Login blocked for {SecurityValidator.sanitize_log_message(login_request.email)}: password change required")
+            _hint = "Use the Admin UI at /admin/change-password-required to set a new password."
+            if _change_cause == "flag":
+                _hint += " If this is a headless deployment locked out at bootstrap, set ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP=false and restart."
             return ORJSONResponse(
                 status_code=status.HTTP_403_FORBIDDEN,
                 content={
                     "detail": "Password change required. Please change your password before continuing.",
-                    "hint": "Use the Admin UI at /admin/change-password-required. For headless deployments locked out at bootstrap, set ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP=false and restart.",
+                    "hint": _hint,
                 },
                 headers={"X-Password-Change-Required": "true"},
             )

--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -288,7 +288,7 @@ async def login(login_request: EmailLoginRequest, request: Request, db: Session 
                 status_code=status.HTTP_403_FORBIDDEN,
                 content={
                     "detail": "Password change required. Please change your password before continuing.",
-                    "hint": "Use POST /auth/email/change-password with a Bearer token, or set ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP=false for headless deployments.",
+                    "hint": "Use the Admin UI at /admin/change-password-required, or set PASSWORD_CHANGE_ENFORCEMENT_ENABLED=false and restart to unblock headless deployments.",
                 },
                 headers={"X-Password-Change-Required": "true"},
             )

--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -288,7 +288,7 @@ async def login(login_request: EmailLoginRequest, request: Request, db: Session 
                 status_code=status.HTTP_403_FORBIDDEN,
                 content={
                     "detail": "Password change required. Please change your password before continuing.",
-                    "hint": "Use the Admin UI at /admin/change-password-required, or set PASSWORD_CHANGE_ENFORCEMENT_ENABLED=false and restart to unblock headless deployments.",
+                    "hint": "Use the Admin UI at /admin/change-password-required. For headless deployments locked out at bootstrap, set ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP=false and restart.",
                 },
                 headers={"X-Password-Change-Required": "true"},
             )

--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -286,7 +286,10 @@ async def login(login_request: EmailLoginRequest, request: Request, db: Session 
             logger.info(f"Login blocked for {SecurityValidator.sanitize_log_message(login_request.email)}: password change required")
             return ORJSONResponse(
                 status_code=status.HTTP_403_FORBIDDEN,
-                content={"detail": "Password change required. Please change your password before continuing."},
+                content={
+                    "detail": "Password change required. Please change your password before continuing.",
+                    "hint": "Use POST /auth/email/change-password with a Bearer token, or set ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP=false for headless deployments.",
+                },
                 headers={"X-Password-Change-Required": "true"},
             )
 

--- a/tests/unit/mcpgateway/test_bootstrap_db.py
+++ b/tests/unit/mcpgateway/test_bootstrap_db.py
@@ -134,12 +134,13 @@ class TestBootstrapAdminUser:
 
     @pytest.mark.asyncio
     async def test_bootstrap_admin_user_already_exists(self, mock_settings, mock_db_session, mock_email_auth_service, mock_admin_user, mock_conn):
-        """Existing admin must still have create_platform_admin called to re-evaluate the password-change flag."""
+        """Existing admin: create_platform_admin must NOT be called (prevents password overwrite)."""
         mock_settings.password_change_enforcement_enabled = True
         mock_settings.admin_require_password_change_on_bootstrap = True
         mock_settings.platform_admin_password = SecretStr("MyStr0ng$ecret!")
         mock_settings.default_user_password = SecretStr("changeme")
 
+        mock_admin_user.password_change_required = False
         mock_email_auth_service.get_user_by_email.return_value = mock_admin_user
         mock_email_auth_service.create_platform_admin = AsyncMock(return_value=mock_admin_user)
 
@@ -153,8 +154,8 @@ class TestBootstrapAdminUser:
             await bootstrap_admin_user(mock_conn)
 
             mock_email_auth_service.get_user_by_email.assert_called_once_with(mock_settings.platform_admin_email)
-            mock_email_auth_service.create_platform_admin.assert_called_once()
-            assert any("re-evaluating bootstrap flags" in str(c) for c in mock_logger.info.call_args_list)
+            mock_email_auth_service.create_platform_admin.assert_not_called()
+            assert any("re-evaluating bootstrap flag only" in str(c) for c in mock_logger.info.call_args_list)
 
     @pytest.mark.asyncio
     async def test_bootstrap_admin_user_success(self, mock_settings, mock_db_session, mock_email_auth_service, mock_admin_user, mock_conn):
@@ -278,16 +279,17 @@ class TestBootstrapAdminUser:
 
     @pytest.mark.asyncio
     async def test_bootstrap_admin_user_existing_with_stale_flag_cleared(self, mock_settings, mock_db_session, mock_email_auth_service, mock_conn):
-        """Existing admin with stale password_change_required and a custom password must have the flag cleared on restart."""
+        """Existing admin with stale password_change_required and a custom password: flag cleared, password NOT overwritten."""
         mock_settings.password_change_enforcement_enabled = True
         mock_settings.admin_require_password_change_on_bootstrap = True
         mock_settings.platform_admin_password = SecretStr("MyStr0ng$ecret!")
         mock_settings.default_user_password = SecretStr("changeme")
 
-        # Simulate an admin that was previously bootstrapped with the default password
         stale_admin = Mock()
         stale_admin.email = mock_settings.platform_admin_email
-        stale_admin.password_change_required = True  # stale flag from previous boot
+        stale_admin.password_change_required = True
+        original_hash = "original_rotated_hash"
+        stale_admin.password_hash = original_hash
 
         mock_email_auth_service.get_user_by_email.return_value = stale_admin
         mock_email_auth_service.create_platform_admin = AsyncMock(return_value=stale_admin)
@@ -301,6 +303,36 @@ class TestBootstrapAdminUser:
         ):
             await bootstrap_admin_user(mock_conn)
             assert stale_admin.password_change_required is False
+            # create_platform_admin must not be called — password must not be overwritten
+            mock_email_auth_service.create_platform_admin.assert_not_called()
+            assert stale_admin.password_hash == original_hash
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_admin_user_rotated_password_survives_restart(self, mock_settings, mock_db_session, mock_email_auth_service, mock_conn):
+        """A password rotated via the UI must never be overwritten on a subsequent restart."""
+        mock_settings.password_change_enforcement_enabled = True
+        mock_settings.admin_require_password_change_on_bootstrap = True
+        mock_settings.platform_admin_password = SecretStr("MyStr0ng$ecret!")
+        mock_settings.default_user_password = SecretStr("changeme")
+
+        existing_admin = Mock()
+        existing_admin.email = mock_settings.platform_admin_email
+        existing_admin.password_change_required = False
+        existing_admin.password_hash = "hash_of_ui_rotated_password"
+
+        mock_email_auth_service.get_user_by_email.return_value = existing_admin
+        mock_email_auth_service.create_platform_admin = AsyncMock(return_value=existing_admin)
+
+        with (
+            patch("mcpgateway.bootstrap_db.settings", mock_settings),
+            patch("mcpgateway.bootstrap_db.Session", return_value=mock_db_session),
+            patch("mcpgateway.services.email_auth_service.EmailAuthService", return_value=mock_email_auth_service),
+            patch("mcpgateway.db.utc_now", return_value="2024-01-01T00:00:00Z"),
+            patch("mcpgateway.bootstrap_db.logger"),
+        ):
+            await bootstrap_admin_user(mock_conn)
+            mock_email_auth_service.create_platform_admin.assert_not_called()
+            assert existing_admin.password_hash == "hash_of_ui_rotated_password"
 
     @pytest.mark.asyncio
     async def test_bootstrap_admin_user_exception(self, mock_settings, mock_db_session, mock_email_auth_service, mock_conn):

--- a/tests/unit/mcpgateway/test_bootstrap_db.py
+++ b/tests/unit/mcpgateway/test_bootstrap_db.py
@@ -279,7 +279,7 @@ class TestBootstrapAdminUser:
 
     @pytest.mark.asyncio
     async def test_bootstrap_admin_user_existing_with_stale_flag_cleared(self, mock_settings, mock_db_session, mock_email_auth_service, mock_conn):
-        """Existing admin with stale password_change_required and a custom password: flag cleared, password NOT overwritten."""
+        """Existing admin: custom env password + stored hash IS default → flag cleared (bootstrap recovery path)."""
         mock_settings.password_change_enforcement_enabled = True
         mock_settings.admin_require_password_change_on_bootstrap = True
         mock_settings.platform_admin_password = SecretStr("MyStr0ng$ecret!")
@@ -288,7 +288,7 @@ class TestBootstrapAdminUser:
         stale_admin = Mock()
         stale_admin.email = mock_settings.platform_admin_email
         stale_admin.password_change_required = True
-        original_hash = "original_rotated_hash"
+        original_hash = "argon2_hash_of_changeme"
         stale_admin.password_hash = original_hash
 
         mock_email_auth_service.get_user_by_email.return_value = stale_admin
@@ -300,12 +300,62 @@ class TestBootstrapAdminUser:
             patch("mcpgateway.services.email_auth_service.EmailAuthService", return_value=mock_email_auth_service),
             patch("mcpgateway.db.utc_now", return_value="2024-01-01T00:00:00Z"),
             patch("mcpgateway.bootstrap_db.logger"),
+            patch("mcpgateway.services.argon2_service.Argon2PasswordService.verify_password_async", new=AsyncMock(return_value=True)),
         ):
             await bootstrap_admin_user(mock_conn)
             assert stale_admin.password_change_required is False
-            # create_platform_admin must not be called — password must not be overwritten
             mock_email_auth_service.create_platform_admin.assert_not_called()
             assert stale_admin.password_hash == original_hash
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_admin_user_flag_set_for_non_bootstrap_reason_not_cleared(self, mock_settings, mock_db_session, mock_email_auth_service, mock_conn):
+        """Existing admin: flag set by admin action/login-detector (stored hash NOT default) must survive restart."""
+        mock_settings.password_change_enforcement_enabled = True
+        mock_settings.admin_require_password_change_on_bootstrap = True
+        mock_settings.platform_admin_password = SecretStr("MyStr0ng$ecret!")
+        mock_settings.default_user_password = SecretStr("changeme")
+
+        admin = Mock()
+        admin.email = mock_settings.platform_admin_email
+        admin.password_change_required = True  # set by admin action, not bootstrap
+        admin.password_hash = "hash_of_rotated_password_not_default"
+
+        mock_email_auth_service.get_user_by_email.return_value = admin
+        mock_email_auth_service.create_platform_admin = AsyncMock(return_value=admin)
+
+        with (
+            patch("mcpgateway.bootstrap_db.settings", mock_settings),
+            patch("mcpgateway.bootstrap_db.Session", return_value=mock_db_session),
+            patch("mcpgateway.services.email_auth_service.EmailAuthService", return_value=mock_email_auth_service),
+            patch("mcpgateway.db.utc_now", return_value="2024-01-01T00:00:00Z"),
+            patch("mcpgateway.bootstrap_db.logger"),
+            # stored hash does NOT match the default password
+            patch("mcpgateway.services.argon2_service.Argon2PasswordService.verify_password_async", new=AsyncMock(return_value=False)),
+        ):
+            await bootstrap_admin_user(mock_conn)
+            assert admin.password_change_required is True  # flag must be preserved
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_admin_user_non_ascii_password(self, mock_settings, mock_db_session, mock_email_auth_service, mock_admin_user, mock_conn):
+        """Non-ASCII PLATFORM_ADMIN_PASSWORD must not raise TypeError in hmac.compare_digest."""
+        mock_settings.password_change_enforcement_enabled = True
+        mock_settings.admin_require_password_change_on_bootstrap = True
+        mock_settings.platform_admin_password = SecretStr("P@ssw\u00f6rd\u4e2d\u6587!")
+        mock_settings.default_user_password = SecretStr("changeme")
+
+        mock_email_auth_service.get_user_by_email.return_value = None
+        mock_email_auth_service.create_platform_admin = AsyncMock(return_value=mock_admin_user)
+
+        with (
+            patch("mcpgateway.bootstrap_db.settings", mock_settings),
+            patch("mcpgateway.bootstrap_db.Session", return_value=mock_db_session),
+            patch("mcpgateway.services.email_auth_service.EmailAuthService", return_value=mock_email_auth_service),
+            patch("mcpgateway.db.utc_now", return_value="2024-01-01T00:00:00Z"),
+            patch("mcpgateway.bootstrap_db.logger"),
+        ):
+            # Must complete without raising TypeError; flag must not be set (custom password)
+            await bootstrap_admin_user(mock_conn)
+            assert mock_admin_user.password_change_required is not True
 
     @pytest.mark.asyncio
     async def test_bootstrap_admin_user_rotated_password_survives_restart(self, mock_settings, mock_db_session, mock_email_auth_service, mock_conn):

--- a/tests/unit/mcpgateway/test_bootstrap_db.py
+++ b/tests/unit/mcpgateway/test_bootstrap_db.py
@@ -224,6 +224,49 @@ class TestBootstrapAdminUser:
                             mock_email_auth_service.create_platform_admin.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_bootstrap_admin_user_custom_password_skips_password_change_flag(self, mock_settings, mock_db_session, mock_email_auth_service, mock_admin_user, mock_conn):
+        """Custom PLATFORM_ADMIN_PASSWORD must not set password_change_required (issue #6493)."""
+        mock_settings.password_change_enforcement_enabled = True
+        mock_settings.admin_require_password_change_on_bootstrap = True
+        mock_settings.platform_admin_password = SecretStr("MyStr0ng$ecret!")
+        mock_settings.default_user_password = SecretStr("changeme")
+
+        mock_email_auth_service.get_user_by_email.return_value = None
+        mock_email_auth_service.create_platform_admin = AsyncMock(return_value=mock_admin_user)
+
+        with (
+            patch("mcpgateway.bootstrap_db.settings", mock_settings),
+            patch("mcpgateway.bootstrap_db.Session", return_value=mock_db_session),
+            patch("mcpgateway.services.email_auth_service.EmailAuthService", return_value=mock_email_auth_service),
+            patch("mcpgateway.db.utc_now", return_value="2024-01-01T00:00:00Z"),
+            patch("mcpgateway.bootstrap_db.logger"),
+        ):
+            await bootstrap_admin_user(mock_conn)
+            # password_change_required must NOT have been set to True on the user object
+            assert mock_admin_user.password_change_required is not True
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_admin_user_default_password_sets_password_change_flag(self, mock_settings, mock_db_session, mock_email_auth_service, mock_admin_user, mock_conn):
+        """Default password bootstrap must set password_change_required to True."""
+        mock_settings.password_change_enforcement_enabled = True
+        mock_settings.admin_require_password_change_on_bootstrap = True
+        mock_settings.platform_admin_password = SecretStr("changeme")
+        mock_settings.default_user_password = SecretStr("changeme")
+
+        mock_email_auth_service.get_user_by_email.return_value = None
+        mock_email_auth_service.create_platform_admin = AsyncMock(return_value=mock_admin_user)
+
+        with (
+            patch("mcpgateway.bootstrap_db.settings", mock_settings),
+            patch("mcpgateway.bootstrap_db.Session", return_value=mock_db_session),
+            patch("mcpgateway.services.email_auth_service.EmailAuthService", return_value=mock_email_auth_service),
+            patch("mcpgateway.db.utc_now", return_value="2024-01-01T00:00:00Z"),
+            patch("mcpgateway.bootstrap_db.logger"),
+        ):
+            await bootstrap_admin_user(mock_conn)
+            assert mock_admin_user.password_change_required is True
+
+    @pytest.mark.asyncio
     async def test_bootstrap_admin_user_exception(self, mock_settings, mock_db_session, mock_email_auth_service, mock_conn):
         """Test exception handling during admin user creation."""
         mock_email_auth_service.get_user_by_email.side_effect = Exception("Database error")

--- a/tests/unit/mcpgateway/test_bootstrap_db.py
+++ b/tests/unit/mcpgateway/test_bootstrap_db.py
@@ -36,6 +36,7 @@ def mock_settings():
     settings.email_auth_enabled = True
     settings.platform_admin_email = "admin@example.com"
     settings.platform_admin_password = SecretStr("secure_password")
+    settings.default_user_password = SecretStr("changeme")
     settings.platform_admin_full_name = "Platform Admin"
     settings.auto_create_personal_teams = True
     settings.database_url = "sqlite:///:memory:"
@@ -133,18 +134,27 @@ class TestBootstrapAdminUser:
 
     @pytest.mark.asyncio
     async def test_bootstrap_admin_user_already_exists(self, mock_settings, mock_db_session, mock_email_auth_service, mock_admin_user, mock_conn):
-        """Test when admin user already exists."""
+        """Existing admin must still have create_platform_admin called to re-evaluate the password-change flag."""
+        mock_settings.password_change_enforcement_enabled = True
+        mock_settings.admin_require_password_change_on_bootstrap = True
+        mock_settings.platform_admin_password = SecretStr("MyStr0ng$ecret!")
+        mock_settings.default_user_password = SecretStr("changeme")
+
         mock_email_auth_service.get_user_by_email.return_value = mock_admin_user
+        mock_email_auth_service.create_platform_admin = AsyncMock(return_value=mock_admin_user)
 
-        with patch("mcpgateway.bootstrap_db.settings", mock_settings):
-            with patch("mcpgateway.bootstrap_db.Session", return_value=mock_db_session):
-                with patch("mcpgateway.services.email_auth_service.EmailAuthService", return_value=mock_email_auth_service):
-                    with patch("mcpgateway.bootstrap_db.logger") as mock_logger:
-                        await bootstrap_admin_user(mock_conn)
+        with (
+            patch("mcpgateway.bootstrap_db.settings", mock_settings),
+            patch("mcpgateway.bootstrap_db.Session", return_value=mock_db_session),
+            patch("mcpgateway.services.email_auth_service.EmailAuthService", return_value=mock_email_auth_service),
+            patch("mcpgateway.db.utc_now", return_value="2024-01-01T00:00:00Z"),
+            patch("mcpgateway.bootstrap_db.logger") as mock_logger,
+        ):
+            await bootstrap_admin_user(mock_conn)
 
-                        mock_email_auth_service.get_user_by_email.assert_called_once_with(mock_settings.platform_admin_email)
-                        mock_email_auth_service.create_user.assert_not_called()
-                        mock_logger.info.assert_called_with(f"Admin user {mock_settings.platform_admin_email} already exists - skipping creation")
+            mock_email_auth_service.get_user_by_email.assert_called_once_with(mock_settings.platform_admin_email)
+            mock_email_auth_service.create_platform_admin.assert_called_once()
+            assert any("re-evaluating bootstrap flags" in str(c) for c in mock_logger.info.call_args_list)
 
     @pytest.mark.asyncio
     async def test_bootstrap_admin_user_success(self, mock_settings, mock_db_session, mock_email_auth_service, mock_admin_user, mock_conn):
@@ -265,6 +275,32 @@ class TestBootstrapAdminUser:
         ):
             await bootstrap_admin_user(mock_conn)
             assert mock_admin_user.password_change_required is True
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_admin_user_existing_with_stale_flag_cleared(self, mock_settings, mock_db_session, mock_email_auth_service, mock_conn):
+        """Existing admin with stale password_change_required and a custom password must have the flag cleared on restart."""
+        mock_settings.password_change_enforcement_enabled = True
+        mock_settings.admin_require_password_change_on_bootstrap = True
+        mock_settings.platform_admin_password = SecretStr("MyStr0ng$ecret!")
+        mock_settings.default_user_password = SecretStr("changeme")
+
+        # Simulate an admin that was previously bootstrapped with the default password
+        stale_admin = Mock()
+        stale_admin.email = mock_settings.platform_admin_email
+        stale_admin.password_change_required = True  # stale flag from previous boot
+
+        mock_email_auth_service.get_user_by_email.return_value = stale_admin
+        mock_email_auth_service.create_platform_admin = AsyncMock(return_value=stale_admin)
+
+        with (
+            patch("mcpgateway.bootstrap_db.settings", mock_settings),
+            patch("mcpgateway.bootstrap_db.Session", return_value=mock_db_session),
+            patch("mcpgateway.services.email_auth_service.EmailAuthService", return_value=mock_email_auth_service),
+            patch("mcpgateway.db.utc_now", return_value="2024-01-01T00:00:00Z"),
+            patch("mcpgateway.bootstrap_db.logger"),
+        ):
+            await bootstrap_admin_user(mock_conn)
+            assert stale_admin.password_change_required is False
 
     @pytest.mark.asyncio
     async def test_bootstrap_admin_user_exception(self, mock_settings, mock_db_session, mock_email_auth_service, mock_conn):


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #6493

---

## 📝 Summary

Headless deployments (Helm/k8s, CI, docker-compose) that supply a strong `PLATFORM_ADMIN_PASSWORD` were locked out at bootstrap. `bootstrap_db.py` unconditionally set `password_change_required = True` whenever the enforcement and bootstrap flags were both on, regardless of whether the operator actually left the built-in default password in place. The subsequent login returns `403` with no access token, and `/auth/email/change-password` requires a bearer token to call — a closed loop with no API-only escape.

**Fix:** only set the forced-change flag when `PLATFORM_ADMIN_PASSWORD` equals `DEFAULT_USER_PASSWORD`. A custom secret already proves the operator chose a strong credential; skipping the flag makes headless provisioning work without any feature-flag workaround.

**Also:**
- `403` login response now includes a `hint` field naming the escape hatch (`ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP=false`) for operators already locked out.
- `.env.example` adds an inline note next to `PLATFORM_ADMIN_PASSWORD` explaining the auto-skip behaviour.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Lint suite | `make ruff` | ✅ |
| Unit tests (bootstrap + auth) | `.venv/bin/pytest tests/unit/mcpgateway/test_bootstrap_db.py tests/unit/mcpgateway/routers/test_email_auth_router.py tests/unit/mcpgateway/services/test_email_auth_service.py tests/unit/mcpgateway/services/test_email_auth_basic.py` | ✅ 370 passed, 0 failed |

**Manual reproduction (before fix):**
```bash
# Deploy with a strong custom password — login is blocked
PLATFORM_ADMIN_PASSWORD=MyStr0ng$ecret docker run ... 
POST /auth/email/login → 403 {"detail": "Password change required..."}
# No token issued; /auth/email/change-password unreachable
```
After fix:

```
# Same deployment — login succeeds immediately
POST /auth/email/login → 200 {"access_token": "..."}
```

Default-password behaviour unchanged: deploying without changing PLATFORM_ADMIN_PASSWORD still sets the flag and requires a change on first login.

✅ Checklist
---

## 📓 Notes

**Decision matrix for `password_change_required` at bootstrap:**

| `enforcement_enabled` | `bootstrap_flag` | password == default | Result |
|---|---|---|---|
| ✅ | ✅ | ✅ | Flag set — change required (original behaviour) |
| ✅ | ✅ | ❌ | Flag skipped — custom secret, headless-safe (new) |
| ✅ | ❌ | any | Flag skipped — opt-out respected |
| ❌ | any | any | Flag skipped — master switch off |

**Files changed:**
- `mcpgateway/bootstrap_db.py` — core logic fix
- `mcpgateway/routers/email_auth.py` — actionable `hint` in 403 body
- `.env.example` — inline guidance next to `PLATFORM_ADMIN_PASSWORD`
- `tests/unit/mcpgateway/test_bootstrap_db.py` — two new test cases covering both branches