### PR TITLE
feat(auth): add canonical get_user_id helper and identifier-domain mapping doc

### DIFF
--- a/docs/docs/architecture/identity-domains.md
+++ b/docs/docs/architecture/identity-domains.md
@@ -1,0 +1,22 @@
+# Identifier Domains
+
+ContextForge issues and accepts more than one token type. Each token type
+puts a different value in the `sub` claim. This page maps each token type
+to the layer that resolves the value and to the canonical user ID.
+
+## Token-type mapping
+
+| Token type | `sub` content | Resolution layer | Canonical user_id (phase 1) |
+|---|---|---|---|
+| Session token (`token_use="session"`) | UUID (`EmailUser.id`) | `_get_email_by_id_sync` and `get_user_email_from_token` in `mcpgateway/auth.py`, plus `resolve_jwt_user_email_from_payload` in `mcpgateway/auth_context.py` | e-mail |
+| API token | UUID; signed metadata carries the e-mail | `resolve_jwt_user_email_from_payload` in `mcpgateway/auth_context.py` | e-mail |
+| Legacy token (no `token_use`) | e-mail | none (direct) | e-mail |
+| Future trust token | opaque | trusted-claims module (not built yet, epic #5885) | to be defined by Stack B |
+
+## Accessors
+
+`get_user_email()` is the e-mail-attribute accessor. `get_user_id()` is the
+identity accessor. Phase 1 populates both with the same value.
+
+The old assumption "the e-mail is the identity" (see the comment in
+`mcpgateway/middleware/auth_middleware.py`) is abolished by later stories.

--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -215,6 +215,67 @@ def get_user_email(user: Any) -> str:
     return str(user) if user else "unknown"
 
 
+def get_user_id(user: Any) -> str:
+    """Extract the canonical user ID from a user object.
+
+    The canonical user ID is the stable identity of a user. The explicit
+    ``user_id`` value wins when it is present. The e-mail value is the
+    fallback. Phase 1 populates ``user_id`` with the e-mail value, so the
+    two stay identical until later stories separate them.
+
+    Args:
+        user: User object, can be either a dict (new RBAC format), an object
+            with attributes (ORM model), or a string (legacy format)
+
+    Returns:
+        str: Canonical user ID extracted from the user object
+
+    Examples:
+        >>> get_user_id({'user_id': 'u-1', 'email': 'admin@example.com'})
+        'u-1'
+        >>> get_user_id({'email': 'admin@example.com'})
+        'admin@example.com'
+        >>> get_user_id({'sub': 'user@example.com'})
+        'user@example.com'
+        >>> get_user_id({})
+        'unknown'
+        >>> get_user_id(None)
+        'unknown'
+        >>> get_user_id('')
+        'unknown'
+        >>> import types
+        >>> get_user_id(types.SimpleNamespace(user_id='u-1', email='admin@example.com'))
+        'u-1'
+        >>> get_user_id(types.SimpleNamespace(user_id=None, email='admin@example.com'))
+        'admin@example.com'
+        >>> get_user_id('legacy_user')
+        'legacy_user'
+    """
+    if user is None:
+        return "unknown"
+    # Handle dict-like objects
+    if isinstance(user, dict):
+        user_id = user.get("user_id")
+        if isinstance(user_id, str) and user_id:
+            return user_id
+        email = user.get("email")
+        if isinstance(email, str) and email:
+            return email
+        sub = user.get("sub")
+        if isinstance(sub, str) and sub:
+            return sub
+        return "unknown"
+    # Handle objects with attributes (e.g., ORM models, dataclasses)
+    user_id = getattr(user, "user_id", None)
+    if isinstance(user_id, str) and user_id:
+        return user_id
+    email = getattr(user, "email", None)
+    if isinstance(email, str) and email:
+        return email
+    # Fallback to string conversion for other types
+    return str(user) if user else "unknown"
+
+
 def _is_uuid_string(value: str) -> bool:
     """Return True when *value* is a syntactically valid UUID string."""
     try:

--- a/tests/unit/mcpgateway/test_auth_context.py
+++ b/tests/unit/mcpgateway/test_auth_context.py
@@ -26,7 +26,7 @@ import pytest
 
 # First-Party
 from mcpgateway import auth_context
-from mcpgateway.auth_context import get_request_identity, get_rpc_filter_context, get_scoped_resource_access_context
+from mcpgateway.auth_context import get_request_identity, get_rpc_filter_context, get_scoped_resource_access_context, get_user_id
 
 
 def _request(*, jwt_payload=None, token_teams=None, token_use=None):
@@ -223,3 +223,40 @@ class TestRequestScopedMemoization:
         assert len(calls) == 2
         assert real_caller[0] == "caller@example.com"
         assert forwarded[0] == "forwarded@example.com"
+
+
+class TestGetUserId:
+    """Canonical user-ID extraction: explicit ``user_id`` first, e-mail next."""
+
+    def test_dict_with_user_id_and_email_prefers_user_id(self):
+        assert get_user_id({"user_id": "u-1", "email": "e@x"}) == "u-1"
+
+    def test_dict_with_email_only_returns_email(self):
+        assert get_user_id({"email": "e@x"}) == "e@x"
+
+    def test_dict_with_sub_only_returns_sub(self):
+        assert get_user_id({"sub": "e@x"}) == "e@x"
+
+    def test_empty_dict_returns_unknown(self):
+        assert get_user_id({}) == "unknown"
+
+    def test_none_returns_unknown(self):
+        assert get_user_id(None) == "unknown"
+
+    def test_object_with_user_id_and_email_prefers_user_id(self):
+        user = MagicMock()
+        user.user_id = "u-1"
+        user.email = "e@x"
+        assert get_user_id(user) == "u-1"
+
+    def test_object_with_email_only_returns_email(self):
+        user = MagicMock()
+        user.user_id = None
+        user.email = "e@x"
+        assert get_user_id(user) == "e@x"
+
+    def test_legacy_string_returns_itself(self):
+        assert get_user_id("legacy_user") == "legacy_user"
+
+    def test_empty_string_returns_unknown(self):
+        assert get_user_id("") == "unknown"


### PR DESCRIPTION
This PR adds `get_user_id()` to `mcpgateway/auth_context.py`. The helper reads an explicit `user_id` first, then the e-mail value, then falls back to `unknown`. This PR adds `docs/docs/architecture/identity-domains.md` with the token-type mapping table for all four token types. No call site, schema, or behavior changed.

Tested with:
- `uv run pytest tests/unit/mcpgateway/test_auth_context.py -q` — 23 passed (TDD: failed first with the expected ImportError, then passed)
- `uv run python -c "from mcpgateway.auth_context import get_user_id"` — exit 0
- `make doctest` — 1228 passed, 56 skipped
- `make ruff` — all checks passed
- `cd mcpgateway && alembic heads` — single head `12d4a0c7789c`, unchanged

Acceptance criteria of #5886 are met. Risk to existing users: none.

Part of stack A (epic #5884).

Closes #5886