### PR TITLE
fix(tools): give federated transport errors a non-empty message

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -7026,7 +7026,15 @@ class ToolService(BaseService):
                 if isinstance(e, BaseExceptionGroup):
                     while isinstance(root_cause, BaseExceptionGroup) and root_cause.exceptions:
                         root_cause = root_cause.exceptions[0]
-                error_message = str(root_cause)
+                # The anyio/httpx transport family (ClosedResourceError, EndOfStream,
+                # BrokenResourceError, ReadTimeout) stringifies to '', which would leave
+                # the caller with a bare "Tool invocation failed: ". Fall back to the
+                # qualified class name so the caller can still tell the failures apart.
+                error_message = str(root_cause) or f"{type(root_cause).__module__}.{type(root_cause).__qualname__}"
+                # A timeout raised inside the MCP SDK's TaskGroup arrives group-wrapped and
+                # misses the typed timeout lanes above, so restate it in their vocabulary.
+                if isinstance(root_cause, (asyncio.TimeoutError, httpx.TimeoutException)):
+                    error_message = f"Tool invocation timed out after {effective_timeout}s ({type(root_cause).__module__}.{type(root_cause).__qualname__})"
                 # Set span error status
                 if span:
                     set_span_error(span, error_message)

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -4369,6 +4369,138 @@ class TestToolService:
             assert "Connection refused by upstream MCP server" in call_kwargs["error_message"]
 
     @pytest.mark.asyncio
+    async def test_invoke_tool_error_empty_str_falls_back_to_class_name(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """Test that an exception whose str() is empty still yields a usable message.
+
+        The anyio/httpx transport family (ClosedResourceError, EndOfStream,
+        BrokenResourceError, ReadTimeout) stringifies to '', so building the
+        caller-facing message as str(root_cause) produced a bare
+        "Tool invocation failed: " with no detail at all. Fall back to the
+        qualified exception class name so a caller can tell a closed stream
+        from a broken resource.
+
+        See GitHub issue #6592.
+        """
+        # Configure tool
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.auth_value = None
+
+        # Mock DB to return the tool and GlobalConfig
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        # Standard library import
+        import anyio
+
+        # anyio transport errors carry no message: str(ClosedResourceError()) == ''
+        root_cause_error = anyio.ClosedResourceError()
+        assert str(root_cause_error) == ""
+
+        # Mock HTTP client to raise the empty-str error
+        tool_service._http_client.request.side_effect = root_cause_error
+
+        # Mock metrics buffer at module level and decode_auth
+        mock_metrics_buffer = Mock()
+        mock_metrics_buffer.record_tool_metric = Mock()
+        with (
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+        ):
+            # Should raise ToolInvocationError naming the exception class
+            with pytest.raises(ToolInvocationError) as exc_info:
+                await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
+
+            error_str = str(exc_info.value)
+            assert "ClosedResourceError" in error_str
+            assert error_str != "Tool invocation failed: "
+
+            # Verify metrics recorded with the same non-empty message
+            mock_metrics_buffer.record_tool_metric.assert_called_once()
+            call_kwargs = mock_metrics_buffer.record_tool_metric.call_args[1]
+            assert call_kwargs["success"] is False
+            assert "ClosedResourceError" in call_kwargs["error_message"]
+
+    @pytest.mark.asyncio
+    async def test_invoke_tool_group_wrapped_timeout_uses_timeout_vocabulary(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """Test that a timeout arriving inside an ExceptionGroup is still reported as a timeout.
+
+        A read timeout raised inside the MCP SDK's TaskGroup is wrapped in an
+        ExceptionGroup, so it misses the per-transport
+        `except (asyncio.TimeoutError, httpx.TimeoutException)` lanes that emit the
+        typed "Tool invocation timed out after {effective_timeout}s" message. It then
+        reaches the outer handler, where its empty str() used to produce a bare
+        "Tool invocation failed: ". Callers should see the same timeout vocabulary
+        regardless of whether the timeout arrived group-wrapped.
+
+        See GitHub issue #6592.
+        """
+        # Configure tool
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.auth_value = None
+
+        # Mock DB to return the tool and GlobalConfig
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        # Third-Party
+        import httpx
+
+        # A read timeout carries no message either: str(ReadTimeout("")) == ''
+        root_cause_error = httpx.ReadTimeout("")
+        assert str(root_cause_error) == ""
+
+        # Wrap it the way the MCP SDK's TaskGroup does
+        tool_service._http_client.request.side_effect = ExceptionGroup("unhandled errors in a TaskGroup (1 sub-exception)", [root_cause_error])
+
+        # Mock metrics buffer at module level and decode_auth
+        mock_metrics_buffer = Mock()
+        mock_metrics_buffer.record_tool_metric = Mock()
+        with (
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+        ):
+            with pytest.raises(ToolInvocationError) as exc_info:
+                await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
+
+            error_str = str(exc_info.value)
+            assert "Tool invocation timed out after" in error_str
+            assert "ReadTimeout" in error_str
+            assert error_str != "Tool invocation failed: "
+
+    @pytest.mark.asyncio
+    async def test_invoke_tool_error_non_empty_str_is_unchanged(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """Test that an exception with a real message is passed through untouched.
+
+        The empty-str fallback must not alter any exception that already
+        stringifies to something useful.
+
+        See GitHub issue #6592.
+        """
+        # Configure tool
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.auth_value = None
+
+        # Mock DB to return the tool and GlobalConfig
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        # Mock HTTP client to raise an error carrying a message
+        tool_service._http_client.request.side_effect = RuntimeError("upstream said no")
+
+        # Mock metrics buffer at module level and decode_auth
+        mock_metrics_buffer = Mock()
+        mock_metrics_buffer.record_tool_metric = Mock()
+        with (
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+        ):
+            with pytest.raises(ToolInvocationError) as exc_info:
+                await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
+
+            # Byte-identical to the pre-fix behaviour: no class name appended
+            assert str(exc_info.value) == "Tool invocation failed: upstream said no"
+
+    @pytest.mark.asyncio
     async def test_reset_metrics(self, tool_service, test_db):
         """Test resetting metrics."""
         # Mock DB operations


### PR DESCRIPTION
## Summary

Failures from the anyio/httpx transport family reached the caller as a bare
`Tool invocation failed: ` — an empty detail — so a caller could not tell a closed
stream from a read timeout from a broken resource.

Closes #6592

## Root cause

The outer `except BaseException` handler of `invoke_tool` builds the caller-facing
message as `error_message = str(root_cause)` (`mcpgateway/services/tool_service.py:7029`
on `main@5273986b3`). `str()` of that whole transport family is `''`:

```
anyio 4.14.0, httpx 0.28.1
ClosedResourceError   ''
EndOfStream           ''
BrokenResourceError   ''
httpx.ReadTimeout     ''
```

The exception class is logged server-side but never reaches the message. The empty
string flows to all three consumers of `error_message`: the error span, the
`ToolResult` handed to the post-invoke hooks, and the final `ToolInvocationError`.

A second, related gap: a read timeout raised inside the MCP SDK's `TaskGroup` arrives
wrapped in an `ExceptionGroup`, so it misses the per-transport
`except (asyncio.TimeoutError, httpx.TimeoutException)` lanes that emit the typed
`Tool invocation timed out after {effective_timeout}s` message, and lands in the same
outer handler — where it also stringifies to `''`.

## Fix

Two changes at the one construction site:

- `str(root_cause) or "<module>.<qualname>"` — byte-identical for every exception whose
  `str()` is already non-empty (e.g. `httpx.HTTPStatusError` for a 503), so nothing that
  works today changes.
- A group-wrapped timeout is restated in the vocabulary the per-transport lanes already
  emit, so callers key on one wording regardless of how the timeout arrived.

This is the shape proposed by the reporter in the issue.

## Tests

Three tests added to `tests/unit/mcpgateway/services/test_tool_service.py`, mirroring the
existing `test_invoke_tool_error_exception_group_unwrapping`:

- `test_invoke_tool_error_empty_str_falls_back_to_class_name` — `anyio.ClosedResourceError`
  now names its class instead of yielding an empty detail.
- `test_invoke_tool_group_wrapped_timeout_uses_timeout_vocabulary` — an `ExceptionGroup`-wrapped
  `httpx.ReadTimeout` is reported as a timeout.
- `test_invoke_tool_error_non_empty_str_is_unchanged` — regression guard: an exception carrying
  a real message still produces exactly `Tool invocation failed: upstream said no`.

**Before/after** (stash only the fix, keep the tests):

```
without the fix:  F F .
    assert 'ClosedResourceError' in 'Tool invocation failed: '
    assert 'Tool invocation timed out after' in 'Tool invocation failed: '
with the fix:     . . .
```

The regression test passes in both states, as it should.

## Verification

- `pytest tests/unit/mcpgateway/services/test_tool_service.py` — passes (exit 0)
- `pytest tests/unit/mcpgateway/services/test_tool_service_coverage.py` — passes (exit 0)
- `ruff check` — All checks passed
- `ruff format --diff` — 2 files already formatted

## Note on overlap

PR #6181 also touches `tool_service.py` error handling, but at a different level — it
changes the *envelope* (returning `CallToolResult(isError=True)` instead of raising),
while this changes the *content* of `error_message`. A textual merge conflict in that
region is possible; happy to rebase on whichever lands first.
