### PR TITLE
refactor(auth): carry user_id alongside email in all principal construction sites

### DIFF
--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -1202,6 +1202,7 @@ def _get_auth_context_batched_sync(email: str, jti: Optional[str] = None) -> Dic
         if user:
             # Detach user data as dict (session will close)
             result["user"] = {
+                "user_id": user.email,  # canonical user_id, phase-1 value = e-mail
                 "email": user.email,
                 "password_hash": user.password_hash,
                 "full_name": user.full_name,
@@ -1289,7 +1290,7 @@ def _user_from_cached_dict(user_dict: Dict[str, Any]) -> EmailUser:
     Returns:
         EmailUser instance (detached from any session)
     """
-    return EmailUser(
+    user = EmailUser(
         email=user_dict["email"],
         password_hash=user_dict.get("password_hash", ""),
         full_name=user_dict.get("full_name"),
@@ -1302,6 +1303,9 @@ def _user_from_cached_dict(user_dict: Dict[str, Any]) -> EmailUser:
         created_at=user_dict.get("created_at", datetime.now(timezone.utc)),
         updated_at=user_dict.get("updated_at", datetime.now(timezone.utc)),
     )
+    # Transient instance attribute (NOT a column): canonical user_id, phase-1 value = e-mail.
+    user.user_id = user_dict.get("user_id") or user_dict["email"]
+    return user
 
 
 class TokenValidationError(Exception):
@@ -1372,7 +1376,7 @@ def _bootstrap_platform_admin_user(email: str) -> "EmailUser":
     address, since session tokens no longer embed the is_admin claim.
     """
 
-    return EmailUser(
+    user = EmailUser(
         email=email,
         password_hash="",  # nosec B106 - not used for JWT authentication
         full_name=getattr(settings, "platform_admin_full_name", "Platform Administrator"),
@@ -1385,6 +1389,10 @@ def _bootstrap_platform_admin_user(email: str) -> "EmailUser":
         created_at=datetime.now(timezone.utc),
         updated_at=datetime.now(timezone.utc),
     )
+    # Transient instance attribute (NOT a column): canonical user_id, phase-1 value = e-mail.
+    # Not persisted and not surviving ORM serialization; the bootstrap user is synthetic and never cached.
+    user.user_id = email
+    return user
 
 
 async def get_current_user(
@@ -2227,7 +2235,7 @@ def _inject_userinfo_instate(request: Optional[object] = None, user: Optional[Em
         team_id = getattr(request.state, "team_id", None) if request and hasattr(request, "state") else None
 
         global_context.user_context = UserContext(
-            user_id=user.email,
+            user_id=user.email,  # canonical user_id, phase-1 value = e-mail
             email=user.email,
             full_name=user.full_name,
             is_admin=user.is_admin,

--- a/mcpgateway/middleware/auth_middleware.py
+++ b/mcpgateway/middleware/auth_middleware.py
@@ -179,11 +179,12 @@ class AuthContextMiddleware(BaseHTTPMiddleware):
             credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
             user = await get_current_user(credentials, request=request)
 
-            # Note: EmailUser.id is the primary key (UUID); .email is used here as the
-            # CSRF/logging identity, matching CSRFMiddleware's binding.
+            # Note: EmailUser.id is the primary key (UUID). The canonical identity comes
+            # from get_user_id(); the e-mail stays the e-mail attribute. In phase 1 both
+            # values are equal, matching CSRFMiddleware's binding.
             # User is already detached (created with fresh session that was closed)
             user_email = user.email
-            user_id = user_email  # CSRF/logging identity is the email, not EmailUser.id
+            user_id = user_email  # canonical user_id, phase-1 value = e-mail
 
             # Store user in request state for downstream use
             request.state.user = user

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -26,6 +26,7 @@ from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy.orm import Session
 
 # First-Party
+from mcpgateway.auth_context import get_user_id
 from mcpgateway.config import settings
 from mcpgateway.db import fresh_db_session, Permissions, SessionLocal
 from mcpgateway.plugins.utils import build_request_extensions, record_plugin_metrics
@@ -535,6 +536,7 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
         # Add request context for permission auditing
         return {
             "email": user.email,
+            "user_id": get_user_id(user),  # Canonical identity for RBAC checks
             "full_name": user.full_name,
             "is_admin": user.is_admin,
             "ip_address": request.client.host if request.client else None,

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2287,8 +2287,9 @@ async def _normalize_jwt_payload(payload: dict[str, Any]) -> dict[str, Any]:
     """Normalize a raw JWT payload to the canonical user context shape.
 
     Converts raw JWT fields (sub, token_use, nested user.is_admin) into the
-    canonical ``{email, teams, is_admin, is_authenticated, token_use}`` dict that MCP
-    handlers expect.  This mirrors the normalization performed by
+    canonical ``{email, user_id, teams, is_admin, is_authenticated, token_use}`` dict that MCP
+    handlers expect.  ``user_id`` is the canonical identity; its phase-1 value equals the e-mail.
+    This mirrors the normalization performed by
     ``streamable_http_auth`` so that the stateful-session fallback path in
     ``_get_request_context_or_default`` returns an identical shape.
 
@@ -2296,7 +2297,7 @@ async def _normalize_jwt_payload(payload: dict[str, Any]) -> dict[str, Any]:
         payload: Raw JWT payload dict from ``require_auth_header_first``.
 
     Returns:
-        Canonical user context dict with keys email, teams, is_admin, is_authenticated, token_use.
+        Canonical user context dict with keys email, user_id, teams, is_admin, is_authenticated, token_use.
     """
     email = await _resolve_jwt_user_email_for_streamable(payload)
     jwt_is_admin = payload.get("is_admin", False)
@@ -2411,6 +2412,7 @@ async def _normalize_jwt_payload(payload: dict[str, Any]) -> dict[str, Any]:
                                 user=(
                                     {
                                         "email": getattr(user_record, "email", email),
+                                        "user_id": getattr(user_record, "email", email),  # canonical user_id, phase-1 value = e-mail
                                         "password_hash": getattr(user_record, "password_hash", ""),
                                         "full_name": getattr(user_record, "full_name", None),
                                         "is_admin": bool(getattr(user_record, "is_admin", False)),
@@ -2460,6 +2462,7 @@ async def _normalize_jwt_payload(payload: dict[str, Any]) -> dict[str, Any]:
 
     user_ctx: dict[str, Any] = {
         "email": email,
+        "user_id": email,  # canonical user_id, phase-1 value = e-mail
         "teams": final_teams,
         "is_admin": effective_is_admin,
         "is_authenticated": True,
@@ -5462,6 +5465,7 @@ class _StreamableHttpAuthHandler:
                                     user=(
                                         {
                                             "email": user_record.email,
+                                            "user_id": user_record.email,  # canonical user_id, phase-1 value = e-mail
                                             "password_hash": user_record.password_hash,
                                             "full_name": user_record.full_name,
                                             "is_admin": bool(user_record.is_admin),

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -869,6 +869,7 @@ async def _authenticate_proxy_user(request: Request, proxy_user: str) -> dict:
                 "is_admin": user_info.is_admin,
                 "teams": token_teams,  # None for admin bypass, [] for public-only, or list of team IDs
                 "email": proxy_user,
+                "user_id": proxy_user,  # canonical user_id, phase-1 value = e-mail
                 # token_use: "session" signals DB-backed team resolution to downstream dispatchers
                 # (main.py:2870, streamablehttp_transport.py:1998) so they route via resolve_session_teams
                 # rather than treating the proxy payload as an API-token payload with embedded teams.
@@ -886,6 +887,7 @@ async def _authenticate_proxy_user(request: Request, proxy_user: str) -> dict:
                     "is_admin": True,
                     "teams": None,  # Admin bypass
                     "email": proxy_user,
+                    "user_id": proxy_user,  # canonical user_id, phase-1 value = e-mail
                     "token_use": "session",  # nosec B105 - Not a password; JWT claim type
                 }
             else:
@@ -2282,6 +2284,7 @@ async def build_external_identity(provider: SSOProvider, verified_claims: dict, 
     payload: dict = {
         "sub": email,
         "email": email,
+        "user_id": email,  # canonical user_id, phase-1 value = e-mail
         "token": token,
         "token_use": "session",  # nosec B105 - JWT claim type, not a password
         "source": "external_idp",  # audit/telemetry only -- never drives authz

--- a/tests/helpers/auth.py
+++ b/tests/helpers/auth.py
@@ -40,6 +40,8 @@ def make_test_jwt(
     include_email_claim: bool = False,
     user_data: dict[str, Any] | None = None,
     extra_payload: dict[str, Any] | None = None,
+    token_use: str | None = None,
+    user_id: str | None = None,
 ) -> str:
     """Create a standardized JWT for tests while preserving legacy helper semantics.
 
@@ -51,6 +53,10 @@ def make_test_jwt(
         payload["email"] = email
     if extra_payload:
         payload.update(extra_payload)
+    if token_use is not None:
+        payload["token_use"] = token_use
+    if user_id is not None:
+        payload["user_id"] = user_id
 
     # Auto-enable include_user_data when is_admin=True to ensure the claim is embedded
     if is_admin and not include_user_data and user_data is None:

--- a/tests/unit/mcpgateway/middleware/test_rbac_user_context.py
+++ b/tests/unit/mcpgateway/middleware/test_rbac_user_context.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/middleware/test_rbac_user_context.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Tests that the RBAC user context carries the canonical user_id.
+
+The authenticated context built by get_current_user_with_permissions must
+expose the canonical user_id (resolving user_id -> email -> sub -> "unknown"
+via mcpgateway.auth_context.get_user_id), not only the e-mail attribute, so
+live RBAC checks can key on the stable identity.
+"""
+
+# Standard
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.middleware.rbac import get_current_user_with_permissions
+
+
+def _mock_request():
+    """Build a minimal browser-style request for the JWT auth path."""
+
+    class MockState:
+        pass
+
+    mock_request = MagicMock()
+    mock_request.state = MockState()
+    mock_request.state.auth_method = "simple_token"
+    mock_request.state.request_id = "test-request-id"
+    mock_request.client = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.headers = {"user-agent": "TestAgent", "accept": "text/html"}  # Browser request allows cookie auth
+    mock_request.cookies = {"jwt_token": "test-token"}
+    return mock_request
+
+
+@pytest.mark.asyncio
+async def test_user_context_carries_canonical_user_id():
+    """The authenticated context must expose the canonical user_id, not only email."""
+    # Minimal principal whose user_id diverges from email — the F8 case.
+    principal = SimpleNamespace(
+        email="alice@example.com",
+        user_id="entra-sub-123",
+        full_name="Alice",
+        is_admin=False,
+        teams=[],
+    )
+
+    with patch("mcpgateway.auth.validate_token_user", new_callable=AsyncMock) as mock_validate:
+        mock_validate.return_value = principal
+
+        ctx = await get_current_user_with_permissions(
+            request=_mock_request(),
+            credentials=None,
+            jwt_token="test-token",
+        )
+
+    assert ctx["email"] == "alice@example.com"
+    assert ctx["user_id"] == "entra-sub-123"
+
+
+@pytest.mark.asyncio
+async def test_user_context_user_id_falls_back_to_email():
+    """A principal without an explicit user_id resolves user_id to its email."""
+    principal = SimpleNamespace(
+        email="bob@example.com",
+        full_name="Bob",
+        is_admin=False,
+    )
+
+    with patch("mcpgateway.auth.validate_token_user", new_callable=AsyncMock) as mock_validate:
+        mock_validate.return_value = principal
+
+        ctx = await get_current_user_with_permissions(
+            request=_mock_request(),
+            credentials=None,
+            jwt_token="test-token",
+        )
+
+    assert ctx["user_id"] == "bob@example.com"

--- a/tests/unit/mcpgateway/test_auth.py
+++ b/tests/unit/mcpgateway/test_auth.py
@@ -7236,3 +7236,80 @@ class TestUserFromCachedDictFullShape:
         # contract that writers must not rely on these defaults for existing fields.
         assert user.auth_provider == "local", "default masks real provider"
         assert user.password_change_required is False, "default skips forced change"
+
+
+class TestPrincipalCarriesUserId:
+    """Contract: every principal construction site emits user_id equal to the e-mail (issue #5887)."""
+
+    def test_bootstrap_platform_admin_user_carries_user_id(self):
+        """The synthesized platform-admin principal carries user_id equal to its e-mail."""
+        # First-Party
+        from mcpgateway.auth import _bootstrap_platform_admin_user  # pylint: disable=import-outside-toplevel
+
+        user = _bootstrap_platform_admin_user("admin@x.test")
+
+        assert user.email == "admin@x.test"
+        assert getattr(user, "user_id", None) == "admin@x.test"
+
+    def test_user_from_cached_dict_carries_user_id(self):
+        """The cache-rebuilt principal carries user_id, with e-mail fallback."""
+        # First-Party
+        from mcpgateway.auth import _user_from_cached_dict  # pylint: disable=import-outside-toplevel
+
+        user = _user_from_cached_dict({"email": "a@x.test", "user_id": "a@x.test", "is_admin": False, "is_active": True})
+        assert user.user_id == "a@x.test"
+
+        fallback_user = _user_from_cached_dict({"email": "a@x.test", "is_admin": False, "is_active": True})
+        assert fallback_user.user_id == "a@x.test"
+
+    def test_batched_auth_context_user_dict_carries_user_id(self, monkeypatch):
+        """The batched auth-context user dict carries user_id equal to its e-mail."""
+        # Standard
+        from contextlib import contextmanager
+
+        results = [
+            SimpleNamespace(  # user
+                email="user@example.com",
+                password_hash="h",
+                full_name="U",
+                is_admin=False,
+                is_active=True,
+                auth_provider="local",
+                password_change_required=False,
+                email_verified_at=None,
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            None,  # no personal team
+            [],  # no team memberships (query 4: team_ids)
+        ]
+
+        class DummyResult:
+            def __init__(self, val):
+                self._val = val
+
+            def scalar_one_or_none(self):
+                return self._val
+
+            def all(self):
+                return self._val if isinstance(self._val, list) else []
+
+        class DummySession:
+            def __init__(self):
+                self._idx = 0
+
+            def execute(self, _q):
+                val = results[self._idx] if self._idx < len(results) else None
+                self._idx += 1
+                return DummyResult(val)
+
+        @contextmanager
+        def _session_ctx():
+            yield DummySession()
+
+        monkeypatch.setattr("mcpgateway.auth.fresh_db_session", _session_ctx)
+        # First-Party
+        from mcpgateway.auth import _get_auth_context_batched_sync  # pylint: disable=import-outside-toplevel
+
+        result = _get_auth_context_batched_sync("user@example.com")
+        assert result["user"]["user_id"] == result["user"]["email"]

--- a/tests/unit/mcpgateway/test_auth.py
+++ b/tests/unit/mcpgateway/test_auth.py
@@ -7271,6 +7271,7 @@ class TestPrincipalCarriesUserId:
             SimpleNamespace(  # user
                 email="user@example.com",
                 password_hash="h",
+                password_hash_type="argon2id",
                 full_name="U",
                 is_admin=False,
                 is_active=True,

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -13822,7 +13822,27 @@ async def test_normalize_jwt_payload_api_token(monkeypatch):
 
     raw = {"sub": "user@example.com", "token_use": "api", "teams": ["team-a"], "exp": 1_800_000_000}
     result = await _normalize_jwt_payload(raw)
-    assert result == {"email": "user@example.com", "teams": ["team-a"], "is_admin": False, "is_authenticated": True, "token_use": "api", "exp": 1_800_000_000}
+    assert result == {"email": "user@example.com", "user_id": "user@example.com", "teams": ["team-a"], "is_admin": False, "is_authenticated": True, "token_use": "api", "exp": 1_800_000_000}
+
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_carries_user_id(monkeypatch):
+    """Contract: the normalized user context carries user_id equal to the e-mail (issue #5887)."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _normalize_jwt_payload
+
+    auth_cache = MagicMock()
+    auth_cache.get_auth_context = AsyncMock(return_value=None)
+    auth_cache.get_team_membership_valid_sync.return_value = True
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(tr.settings, "auth_cache_batch_queries", False)
+
+    monkeypatch.setattr("mcpgateway.auth.normalize_token_teams", lambda payload: ["team-a"])
+
+    raw = {"sub": "user@example.com", "token_use": "api", "teams": ["team-a"], "exp": 1_800_000_000}
+    user_ctx = await _normalize_jwt_payload(raw)
+    assert user_ctx["user_id"] == user_ctx["email"]
 
 
 @pytest.mark.asyncio
@@ -13834,7 +13854,7 @@ async def test_normalize_jwt_payload_session_token_admin():
     raw = {"sub": "admin@example.com", "token_use": "session", "is_admin": True}
     with patch("mcpgateway.auth.resolve_session_teams", new_callable=AsyncMock, return_value=None):
         result = await _normalize_jwt_payload(raw)
-    assert result == {"email": "admin@example.com", "teams": None, "is_admin": True, "is_authenticated": True, "token_use": "session"}
+    assert result == {"email": "admin@example.com", "user_id": "admin@example.com", "teams": None, "is_admin": True, "is_authenticated": True, "token_use": "session"}
 
 
 @pytest.mark.asyncio
@@ -13846,7 +13866,7 @@ async def test_normalize_jwt_payload_session_token_non_admin():
     raw = {"sub": "dev@example.com", "token_use": "session"}
     with patch("mcpgateway.auth.resolve_session_teams", new_callable=AsyncMock, return_value=["team-x"]):
         result = await _normalize_jwt_payload(raw)
-    assert result == {"email": "dev@example.com", "teams": ["team-x"], "is_admin": False, "is_authenticated": True, "token_use": "session"}
+    assert result == {"email": "dev@example.com", "user_id": "dev@example.com", "teams": ["team-x"], "is_admin": False, "is_authenticated": True, "token_use": "session"}
 
 
 @pytest.mark.asyncio
@@ -13884,7 +13904,7 @@ async def test_normalize_jwt_payload_session_no_email():
     # resolve_session_teams returns [] for no-email
     with patch("mcpgateway.auth.resolve_session_teams", new_callable=AsyncMock, return_value=[]):
         result = await _normalize_jwt_payload(raw)
-    assert result == {"email": None, "teams": [], "is_admin": False, "is_authenticated": True, "token_use": "session"}
+    assert result == {"email": None, "user_id": None, "teams": [], "is_admin": False, "is_authenticated": True, "token_use": "session"}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/utils/test_verify_credentials.py
+++ b/tests/unit/mcpgateway/utils/test_verify_credentials.py
@@ -1922,3 +1922,72 @@ async def test_require_admin_auth_non_admin_jwt_gets_403_not_basic_fallback(monk
     # Must be 403 Forbidden, NOT 200/success from basic auth fallback
     assert exc.value.status_code == status.HTTP_403_FORBIDDEN
     assert "Admin privileges required" in exc.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Principal user_id contract tests (issue #5887)
+# ---------------------------------------------------------------------------
+class TestPrincipalPayloadCarriesUserId:
+    """Contract: proxy and external-IdP payloads carry user_id equal to the e-mail."""
+
+    @pytest.mark.asyncio
+    async def test_proxy_payload_carries_user_id(self, monkeypatch):
+        """The proxy-authenticated payload carries user_id equal to its e-mail."""
+        mock_request = Mock(spec=Request)
+        mock_request.state = Mock()
+
+        mock_user = Mock()
+        mock_user.is_admin = False
+        mock_user.is_active = True
+        mock_user.email = "proxy-user@example.com"
+
+        with (
+            patch("mcpgateway.db.get_db") as mock_get_db,
+            patch("mcpgateway.services.email_auth_service.EmailAuthService") as mock_auth_service,
+            patch("mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock) as mock_resolve_teams,
+        ):
+            mock_get_db.return_value = iter([Mock()])
+            mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=mock_user)
+            mock_resolve_teams.return_value = ["team1"]
+
+            payload = await vc._authenticate_proxy_user(mock_request, "proxy-user@example.com")
+
+        assert payload["email"] == "proxy-user@example.com"
+        assert payload["user_id"] == payload["email"]
+
+    @pytest.mark.asyncio
+    async def test_external_identity_payload_carries_user_id(self, monkeypatch):
+        """The external-IdP identity payload carries user_id equal to its e-mail."""
+        prov = MagicMock()
+        prov.issuer = "https://kc/realms/m"
+        prov.is_enabled = True
+        prov.trusted_for_api_auth = True
+        prov.id = "keycloak"
+        claims = {"iss": "https://kc/realms/m", "sub": "agent", "email": "agent@corp.com"}
+
+        svc = MagicMock()
+        svc._normalize_user_info.return_value = {"email": "agent@corp.com", "is_admin": True}
+
+        async def fake_auth(user_info):
+            return "an-internal-jwt-token-string"
+
+        svc.authenticate_or_create_user = fake_auth
+
+        db_user = MagicMock()
+        db_user.is_admin = False
+
+        async def fake_get_user(email):
+            return db_user
+
+        svc.auth_service.get_user_by_email = fake_get_user
+        monkeypatch.setattr(vc, "_get_sso_service", lambda db: svc)
+
+        async def fake_resolve(payload, email, user_info, **kw):
+            return ["team-a"]
+
+        monkeypatch.setattr("mcpgateway.auth.resolve_session_teams", fake_resolve)
+
+        payload = await vc.build_external_identity(prov, claims, "rawtoken", MagicMock())
+
+        assert payload["email"] == "agent@corp.com"
+        assert payload["user_id"] == payload["email"]


### PR DESCRIPTION
This PR adds a `user_id` entry to every principal and user-dict construction site. The phase-1 value equals the e-mail. The sites are: `UserContext` in `get_current_user`, `_normalize_jwt_payload` (plus the mirrored literal in `streamable_http_auth`), `_bootstrap_platform_admin_user`, `_user_from_cached_dict` and its producer `_get_auth_context_batched_sync`, `_authenticate_proxy_user`, and `build_external_identity`. The stale identity comment in `auth_middleware.py` is corrected. Test fixtures in `tests/helpers/auth.py` gained optional `token_use` and `user_id` kwargs; default output is unchanged.

Four pre-existing `_normalize_jwt_payload` tests assert exact dict equality; each expected dict gained the new `user_id` key. No assertion was weakened. These four are the complete list of modified pre-existing tests.

Tested with:
- `uv run pytest tests/unit/mcpgateway/test_auth.py tests/unit/mcpgateway/transports/test_streamablehttp_transport.py tests/unit/mcpgateway/utils/test_verify_credentials.py -q` — pass (6 new tests failed first with the expected modes, then passed)
- `uv run pytest tests/unit/mcpgateway -k "principal or jwt_payload or user_context" -q` — pass
- `make ruff` — all checks passed
- `make test` — 23171 passed, 879 skipped, 2 xfailed

Acceptance criteria of #5887 are met. Risk to existing users: none; all values are unchanged in phase 1.

Stack: A.2 of epic #5884 (base: #6726).

Closes #5887