### PR TITLE
refactor(auth): record canonical user_id in audit and observability identity fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,6 +239,8 @@ The derived triple is memoized on `request.state` per principal, so calling the 
 
 **Rationale**: The `email` field is the human-readable identifier used throughout AGENTS.md and user-facing documentation. Consistent precedence prevents forensic confusion where an incident review pivots on a logged email that differs from the principal actually evaluated by RBAC.
 
+**Two accessors**: `get_user_email()` in `mcpgateway/auth_context.py` is the e-mail-attribute accessor. `get_user_id()` in the same module is the identity accessor. Phase 1 populates both with the same value. Audit (`AuditTrail.user_id`) and observability (`ObservabilityTrace.user_email`) identity fields hold the canonical user_id from `get_user_id()`; the column names stay unchanged for compatibility.
+
 
 ## Observability Transaction Behavior
 

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -83,7 +83,7 @@ from sqlalchemy.orm import Session
 from starlette.requests import Request
 
 # First-Party
-from mcpgateway.auth_context import normalize_token_teams
+from mcpgateway.auth_context import get_user_id, normalize_token_teams
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.db import EmailTeam, EmailUser, fresh_db_session, SessionLocal
@@ -2235,7 +2235,7 @@ def _inject_userinfo_instate(request: Optional[object] = None, user: Optional[Em
         team_id = getattr(request.state, "team_id", None) if request and hasattr(request, "state") else None
 
         global_context.user_context = UserContext(
-            user_id=user.email,  # canonical user_id, phase-1 value = e-mail
+            user_id=get_user_id(user),  # canonical user_id, phase-1 value = e-mail
             email=user.email,
             full_name=user.full_name,
             is_admin=user.is_admin,

--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -150,6 +150,12 @@ _INTERNAL_MCP_RUNTIME_AUTH_CONTEXT = "contextforge-internal-mcp-runtime-v1"
 def get_user_email(user: Any) -> str:
     """Extract email from user object, handling both string and dict formats.
 
+    This function is the e-mail-attribute accessor: it answers "what is the
+    e-mail of this user". ``get_user_id`` is the identity accessor: it
+    answers "who is this user". The e-mail-over-sub order stays for the
+    ATTRIBUTE in phase 1; later stories separate the attribute from the
+    identity.
+
     Args:
         user: User object, can be either a dict (new RBAC format) or string (legacy format)
 

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -2912,7 +2912,7 @@ class ObservabilityTrace(Base):
     http_status_code: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
 
     # User context
-    user_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True, index=True)
+    user_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True, index=True)  # canonical user_id; phase-1 value = e-mail; name kept for compatibility
     user_agent: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     ip_address: Mapped[Optional[str]] = mapped_column(String(45), nullable=True)
 
@@ -6661,7 +6661,7 @@ class AuditTrail(Base):
     resource_name: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
 
     # User context
-    user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)  # canonical user_id; phase-1 value = e-mail; name kept for compatibility
     user_email: Mapped[Optional[str]] = mapped_column(String(255), index=True, nullable=True)
     team_id: Mapped[Optional[str]] = mapped_column(String(36), index=True, nullable=True)
 

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -81,6 +81,7 @@ except ImportError:
 
 # First-Party
 from mcpgateway import __version__
+from mcpgateway.auth_context import get_user_id
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.db import EmailTeam as DbEmailTeam
@@ -2080,7 +2081,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
             # Structured logging: Audit trail for gateway creation
             audit_trail.log_action(
-                user_id=created_by or "system",
+                user_id=get_user_id(created_by) if created_by else "system",
                 action="create_gateway",
                 resource_type="gateway",
                 resource_id=str(db_gateway.id),
@@ -3137,7 +3138,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     logger.info(f"Accepted gateway update for async initialization: {SecurityValidator.sanitize_log_message(gateway.name)}")
 
                     audit_trail.log_action(
-                        user_id=user_email or modified_by or "system",
+                        user_id=get_user_id(user_email or modified_by) if user_email or modified_by else "system",
                         action="update_gateway",
                         resource_type="gateway",
                         resource_id=str(gateway.id),
@@ -3338,7 +3339,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
                 # Structured logging: Audit trail for gateway update
                 audit_trail.log_action(
-                    user_id=user_email or modified_by or "system",
+                    user_id=get_user_id(user_email or modified_by) if user_email or modified_by else "system",
                     action="update_gateway",
                     resource_type="gateway",
                     resource_id=str(gateway.id),
@@ -3886,7 +3887,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
                 # Structured logging: Audit trail for gateway state change
                 audit_trail.log_action(
-                    user_id=user_email or "system",
+                    user_id=get_user_id(user_email) if user_email else "system",
                     action="set_gateway_state",
                     resource_type="gateway",
                     resource_id=str(gateway.id),
@@ -4065,7 +4066,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 logger.info(f"Accepted gateway deletion for async cleanup: {gateway_name}")
 
                 audit_trail.log_action(
-                    user_id=user_email or "system",
+                    user_id=get_user_id(user_email) if user_email else "system",
                     action="delete_gateway",
                     resource_type="gateway",
                     resource_id=str(gateway_info["id"]),
@@ -4210,7 +4211,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
         logger.info("Permanently deleted gateway: %s", gateway_name)
 
         audit_trail.log_action(
-            user_id=user_email or "system",
+            user_id=get_user_id(user_email) if user_email else "system",
             action="delete_gateway",
             resource_type="gateway",
             resource_id=str(gateway_info["id"]),

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -61,6 +61,7 @@ from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm import joinedload, selectinload, Session
 
 # First-Party
+from mcpgateway.auth_context import get_user_id
 from mcpgateway.cache.global_config_cache import global_config_cache
 from mcpgateway.common.models import Gateway as PydanticGateway
 from mcpgateway.common.models import TextContent
@@ -2258,7 +2259,7 @@ class ToolService(BaseService):
 
             # Structured logging: Audit trail for tool creation
             audit_trail.log_action(
-                user_id=created_by or "system",
+                user_id=get_user_id(created_by) if created_by else "system",
                 action="create_tool",
                 resource_type="tool",
                 resource_id=db_tool.id,
@@ -2578,7 +2579,7 @@ class ToolService(BaseService):
             # Log bulk audit trail entry
             if tools_to_add or tools_to_update:
                 audit_trail.log_action(
-                    user_id=created_by or "system",
+                    user_id=get_user_id(created_by) if created_by else "system",
                     action="bulk_create_tools" if tools_to_add else "bulk_update_tools",
                     resource_type="tool",
                     resource_id=None,
@@ -3577,7 +3578,7 @@ class ToolService(BaseService):
 
             # Structured logging: Audit trail for tool deletion
             audit_trail.log_action(
-                user_id=user_email or "system",
+                user_id=get_user_id(user_email) if user_email else "system",
                 action="delete_tool",
                 resource_type="tool",
                 resource_id=tool_info["id"],
@@ -3746,7 +3747,7 @@ class ToolService(BaseService):
 
                 # Structured logging: Audit trail for tool state change
                 audit_trail.log_action(
-                    user_id=user_email or "system",
+                    user_id=get_user_id(user_email) if user_email else "system",
                     action="set_tool_state",
                     resource_type="tool",
                     resource_id=tool.id,
@@ -7751,7 +7752,7 @@ class ToolService(BaseService):
                 changes.append("description updated")
 
             audit_trail.log_action(
-                user_id=user_email or modified_by or "system",
+                user_id=get_user_id(user_email or modified_by) if user_email or modified_by else "system",
                 action="update_tool",
                 resource_type="tool",
                 resource_id=tool.id,

--- a/tests/unit/mcpgateway/services/test_audit_trail_service.py
+++ b/tests/unit/mcpgateway/services/test_audit_trail_service.py
@@ -400,3 +400,65 @@ def test_log_action_user_identity_extraction_exception_logs_debug(monkeypatch, c
         assert record.error == "Identity extraction failed"
         assert hasattr(record, "correlation_id")
         assert record.correlation_id is not None  # correlation_id is auto-generated
+
+
+class TestAuditIdentity:
+    """Audit entries record the canonical user_id resolved through get_user_id (issue #5888)."""
+
+    @staticmethod
+    def _capture(monkeypatch):
+        """Enable the audit trail and capture the AuditTrail constructor kwargs."""
+        monkeypatch.setattr(svc.settings, "audit_trail_enabled", True)
+        dummy_session = DummySession()
+        monkeypatch.setattr(svc, "SessionLocal", lambda: dummy_session)
+        captured = {}
+
+        def _fake_audit(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr(svc, "AuditTrail", _fake_audit)
+        return captured
+
+    def test_principal_user_id_wins_over_email(self, monkeypatch):
+        """A principal with diverging user_id and e-mail records the user_id value."""
+        # First-Party
+        from mcpgateway.auth_context import get_user_id  # pylint: disable=import-outside-toplevel
+
+        captured = self._capture(monkeypatch)
+        principal = {"user_id": "u-1", "email": "e@x.test"}
+        assert get_user_id(principal) == "u-1"
+
+        service = svc.AuditTrailService()
+        service.log_action(
+            action="CREATE",
+            resource_type="tool",
+            resource_id="tool-1",
+            user_id=get_user_id(principal),
+            user_email=principal.get("email"),
+        )
+        assert captured["user_id"] == "u-1"
+
+    def test_fallbacks_when_email_absent(self, monkeypatch):
+        """A principal without e-mail still records user_id; an empty principal records 'unknown'."""
+        # First-Party
+        from mcpgateway.auth_context import get_user_id  # pylint: disable=import-outside-toplevel
+
+        captured = self._capture(monkeypatch)
+        service = svc.AuditTrailService()
+
+        service.log_action(
+            action="CREATE",
+            resource_type="tool",
+            resource_id="tool-1",
+            user_id=get_user_id({"user_id": "u-1"}),
+        )
+        assert captured["user_id"] == "u-1"
+
+        service.log_action(
+            action="CREATE",
+            resource_type="tool",
+            resource_id="tool-2",
+            user_id=get_user_id({}),
+        )
+        assert captured["user_id"] == "unknown"

--- a/tests/unit/mcpgateway/test_auth.py
+++ b/tests/unit/mcpgateway/test_auth.py
@@ -140,6 +140,40 @@ class TestGetCurrentUser:
                     assert user.full_name == mock_user.full_name
 
     @pytest.mark.asyncio
+    async def test_user_context_identity_uses_get_user_id(self, monkeypatch):
+        """UserContext identity comes from get_user_id(user): an explicit user_id wins over the e-mail (issue #5888)."""
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="valid_jwt_token")  # pragma: allowlist secret
+        jwt_payload = {"sub": "e@x.test", "exp": (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp()}
+
+        mock_user = EmailUser(
+            email="e@x.test",
+            password_hash="hash",
+            full_name="Test User",
+            is_admin=False,
+            is_active=True,
+            email_verified_at=datetime.now(timezone.utc),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        mock_user.user_id = "u-1"  # diverges from the e-mail on purpose
+
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+
+        request = SimpleNamespace(state=SimpleNamespace())
+        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+            with patch("mcpgateway.auth._check_token_revoked_sync", return_value=False):
+                with patch("mcpgateway.auth._is_api_token_jti_sync", return_value=True):
+                    with patch("mcpgateway.auth._update_api_token_last_used_sync", return_value=None):
+                        with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
+                            with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
+                                await get_current_user(credentials=credentials, request=request)
+
+        global_context = request.state.plugin_global_context
+        assert global_context.user_context.user_id == "u-1"
+        assert global_context.user_context.email == "e@x.test"
+
+    @pytest.mark.asyncio
     async def test_auth_method_set_on_cache_hit(self, monkeypatch):
         """Ensure auth_method is set when auth cache returns early."""
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="valid_jwt_token")  # pragma: allowlist secret


### PR DESCRIPTION
This PR routes audit and observability identity capture through `get_user_id()`. The `UserContext` identity now comes from `get_user_id(user)`. All eleven audit calls in the tool and gateway services use the exact guard `get_user_id(x) if x else "system"` — an empty identity keeps `"system"` and never becomes `"unknown"`. Column comments in `AuditTrail` and `ObservabilityTrace` state the new semantics. `get_user_email` keeps its behavior and gains a role statement. `AGENTS.md` documents the two-accessor rule in the same commit.

No column, schema, or `get_user_email()` behavior changed. The `.secrets.baseline` change is mechanical line-number drift from the pre-commit hook.

Tested with:
- `uv run pytest tests/unit/mcpgateway/test_auth.py tests/unit/mcpgateway/services/test_audit_trail_service.py -q` — 363 passed (TDD: the UserContext identity test failed first with `assert 'e@x.test' == 'u-1'`, then passed)
- `make doctest` — 1228 passed, 56 skipped (doctest outputs unchanged)
- `make ruff` — all checks passed
- `git diff --name-only` — no alembic files

Acceptance criteria of #5888 are met. Risk to existing users: none; phase-1 values are identical.

Stack: A.3 of epic #5884 (base: #6728).

Closes #5888