### PR TITLE
refactor(rbac): resolve identity via canonical user_id in permission path

### DIFF
--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -779,6 +779,7 @@ async def check_permission_inline(
     """
     if not user_context or not isinstance(user_context, dict) or "email" not in user_context:
         return False
+    identity = get_user_id(user_context)
 
     # SECURITY: Check API token scopes BEFORE plugin hooks and RBAC (Layer 1).
     # A scoped API token must carry the required permission; this is independent of
@@ -822,7 +823,7 @@ async def check_permission_inline(
         result, _ = await plugin_manager.invoke_hook(
             HttpHookType.HTTP_AUTH_CHECK_PERMISSION,
             payload=HttpAuthCheckPermissionPayload(
-                user_email=user_context["email"],
+                user_email=identity,
                 permission=permission,
                 resource_type=resource_type,
                 team_id=team_id,
@@ -891,7 +892,7 @@ async def check_permission_inline(
     if db:
         permission_service = PermissionService(db)
         granted = await permission_service.check_permission(
-            user_email=user_context["email"],
+            user_email=identity,
             permission=permission,
             resource_type=resource_type,
             team_id=team_id,
@@ -906,7 +907,7 @@ async def check_permission_inline(
         with fresh_db_session() as fresh_db:
             permission_service = PermissionService(fresh_db)
             granted = await permission_service.check_permission(
-                user_email=user_context["email"],
+                user_email=identity,
                 permission=permission,
                 resource_type=resource_type,
                 team_id=team_id,
@@ -1078,6 +1079,7 @@ def require_admin_permission():
             user_context = kwargs.get("user") or kwargs.get("_user") or kwargs.get("current_user") or kwargs.get("current_user_ctx")
             if not user_context or not isinstance(user_context, dict) or "email" not in user_context:
                 raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User authentication required")
+            identity = get_user_id(user_context)
 
             # Get db session: prefer endpoint's db param, then user_context["db"], then create fresh
             db_session = kwargs.get("db") or user_context.get("db")
@@ -1085,12 +1087,12 @@ def require_admin_permission():
             if db_session:
                 # Use existing session from endpoint or user_context
                 permission_service = PermissionService(db_session)
-                has_admin_permission = await permission_service.check_admin_permission(user_context["email"], token_teams=token_teams)
+                has_admin_permission = await permission_service.check_admin_permission(identity, token_teams=token_teams)
             else:
                 # Create fresh db session for permission check
                 with fresh_db_session() as db:
                     permission_service = PermissionService(db)
-                    has_admin_permission = await permission_service.check_admin_permission(user_context["email"], token_teams=token_teams)
+                    has_admin_permission = await permission_service.check_admin_permission(identity, token_teams=token_teams)
 
             if not has_admin_permission:
                 logger.warning(f"Admin permission denied: user={user_context['email']}")
@@ -1165,6 +1167,7 @@ def require_any_permission(permissions: List[str], resource_type: Optional[str] 
             user_context = kwargs.get("user") or kwargs.get("_user") or kwargs.get("current_user") or kwargs.get("current_user_ctx")
             if not user_context or not isinstance(user_context, dict) or "email" not in user_context:
                 raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User authentication required")
+            identity = get_user_id(user_context)
 
             # SECURITY: Check API token scopes BEFORE RBAC (Layer 1)
             # A scoped API token must carry at least ONE of the required permissions; this is
@@ -1187,7 +1190,7 @@ def require_any_permission(permissions: List[str], resource_type: Optional[str] 
                 granted = False
                 for permission in permissions:
                     if await permission_service.check_permission(
-                        user_email=user_context["email"],
+                        user_email=identity,
                         permission=permission,
                         resource_type=resource_type,
                         team_id=team_id,
@@ -1207,7 +1210,7 @@ def require_any_permission(permissions: List[str], resource_type: Optional[str] 
                     granted = False
                     for permission in permissions:
                         if await permission_service.check_permission(
-                            user_email=user_context["email"],
+                            user_email=identity,
                             permission=permission,
                             resource_type=resource_type,
                             team_id=team_id,
@@ -1252,6 +1255,7 @@ class PermissionChecker:
         """
         self.user_context = user_context
         self.db_session = user_context.get("db")
+        self.identity = get_user_id(user_context)
 
     async def has_permission(self, permission: str, resource_type: Optional[str] = None, resource_id: Optional[str] = None, team_id: Optional[str] = None, check_any_team: bool = False) -> bool:
         """Check if user has specific permission.
@@ -1270,7 +1274,7 @@ class PermissionChecker:
             # Use existing session
             permission_service = PermissionService(self.db_session)
             return await permission_service.check_permission(
-                user_email=self.user_context["email"],
+                user_email=self.identity,
                 permission=permission,
                 resource_type=resource_type,
                 resource_id=resource_id,
@@ -1284,7 +1288,7 @@ class PermissionChecker:
         with fresh_db_session() as db:
             permission_service = PermissionService(db)
             return await permission_service.check_permission(
-                user_email=self.user_context["email"],
+                user_email=self.identity,
                 permission=permission,
                 resource_type=resource_type,
                 resource_id=resource_id,
@@ -1305,11 +1309,11 @@ class PermissionChecker:
         if self.db_session:
             # Use existing session
             permission_service = PermissionService(self.db_session)
-            return await permission_service.check_admin_permission(self.user_context["email"], token_teams=token_teams)
+            return await permission_service.check_admin_permission(self.identity, token_teams=token_teams)
         # Create fresh db session
         with fresh_db_session() as db:
             permission_service = PermissionService(db)
-            return await permission_service.check_admin_permission(self.user_context["email"], token_teams=token_teams)
+            return await permission_service.check_admin_permission(self.identity, token_teams=token_teams)
 
     async def has_any_permission(self, permissions: List[str], resource_type: Optional[str] = None, team_id: Optional[str] = None) -> bool:
         """Check if user has any of the specified permissions.
@@ -1327,7 +1331,7 @@ class PermissionChecker:
             permission_service = PermissionService(self.db_session)
             for permission in permissions:
                 if await permission_service.check_permission(
-                    user_email=self.user_context["email"],
+                    user_email=self.identity,
                     permission=permission,
                     resource_type=resource_type,
                     team_id=team_id,
@@ -1342,7 +1346,7 @@ class PermissionChecker:
             permission_service = PermissionService(db)
             for permission in permissions:
                 if await permission_service.check_permission(
-                    user_email=self.user_context["email"],
+                    user_email=self.identity,
                     permission=permission,
                     resource_type=resource_type,
                     team_id=team_id,

--- a/mcpgateway/services/permission_service.py
+++ b/mcpgateway/services/permission_service.py
@@ -85,7 +85,8 @@ class PermissionService:
         and returns True if any role grants the required permission.
 
         Args:
-            user_email: Email of the user to check
+            user_email: Canonical user_id of the user to check. The phase-1
+                       value is the e-mail. The role queries are unchanged.
             permission: Permission to check (e.g., 'tools.create')
             resource_type: Type of resource being accessed
             resource_id: Specific resource ID if applicable
@@ -229,7 +230,8 @@ class PermissionService:
         Includes role inheritance and handles permission caching.
 
         Args:
-            user_email: Email of the user
+            user_email: Canonical user_id of the user. The phase-1 value is
+                       the e-mail. The role queries are unchanged.
             team_id: Optional team context
             include_all_teams: If True, include ALL team-scoped roles (for list/read endpoints)
             token_teams: Optional list of team IDs from token narrowing. When include_all_teams=True
@@ -522,7 +524,8 @@ class PermissionService:
           with scope_id=NULL (roles that apply to all teams, e.g. during login)
 
         Args:
-            user_email: Email address of the user
+            user_email: Canonical user_id of the user. The phase-1 value is
+                       the e-mail. The UserRole.user_email query is unchanged.
             team_id: Optional team ID to filter to a specific team's roles
             include_all_teams: If True, include ALL team-scoped roles (for list/read with session tokens)
             token_teams: Optional list of team IDs from token narrowing. When include_all_teams=True

--- a/mcpgateway/utils/admin_check.py
+++ b/mcpgateway/utils/admin_check.py
@@ -58,7 +58,8 @@ def is_user_admin(db: Optional[Session], user_email: Optional[str]) -> bool:
         db: Active SQLAlchemy session.  ``None`` returns ``False`` after
             the platform-admin fast-path — the DB check cannot run without
             a session (fail-closed).
-        user_email: Email to test.  ``None`` or empty returns ``False``
+        user_email: Canonical user_id to test. The phase-1 value is the
+            e-mail. ``None`` or empty returns ``False``
             immediately (no identity → no admin).
 
     Returns:

--- a/tests/unit/mcpgateway/middleware/test_rbac.py
+++ b/tests/unit/mcpgateway/middleware/test_rbac.py
@@ -3292,3 +3292,62 @@ class TestCheckPermissionInline:
         result = await decorated(user={"email": "user@test.com", "db": MagicMock()})
 
         assert result == "reached"
+
+
+class TestUserIdKeyedPermissionChecks:
+    """Permission checks resolve the caller identity via the canonical user_id.
+
+    Principals carry ``user_id == email`` in phase 1. These tests use diverged
+    values on purpose to prove the permission path passes the canonical
+    user_id to PermissionService.
+    """
+
+    class _SpyPS:
+        """DummyPS-style spy: records the kwargs of the last check_permission call."""
+
+        last_check_kwargs = None
+
+        def __init__(self, db):
+            pass
+
+        async def check_permission(self, **kwargs):
+            TestUserIdKeyedPermissionChecks._SpyPS.last_check_kwargs = kwargs
+            return True
+
+    @pytest.mark.asyncio
+    async def test_check_permission_inline_uses_canonical_user_id(self, monkeypatch):
+        """check_permission_inline passes the canonical user_id as user_email."""
+        user_context = {"user_id": "u-1", "email": "e@x.test", "db": object()}
+        monkeypatch.setattr(rbac, "PermissionService", self._SpyPS)
+
+        with patch("mcpgateway.plugins.get_plugin_manager", AsyncMock(return_value=None)):
+            granted = await rbac.check_permission_inline(user_context, "tools.read", db=user_context["db"])
+
+        assert granted is True
+        assert self._SpyPS.last_check_kwargs["user_email"] == "u-1"
+
+    @pytest.mark.asyncio
+    async def test_require_permission_denies_without_identity(self):
+        """A user context without email and without user_id still raises 401."""
+
+        async def dummy_func(user=None):
+            return "should-not-reach"
+
+        decorated = rbac.require_permission("tools.read")(dummy_func)
+        with pytest.raises(HTTPException) as exc:
+            await decorated(user={"db": MagicMock()})
+
+        assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.asyncio
+    async def test_permission_checker_class_uses_canonical_user_id(self, monkeypatch):
+        """PermissionChecker passes the canonical user_id as user_email."""
+        mock_db = MagicMock()
+        user_context = {"user_id": "u-1", "email": "e@x.test", "db": mock_db}
+        monkeypatch.setattr(rbac, "PermissionService", self._SpyPS)
+
+        checker = rbac.PermissionChecker(user_context)
+        granted = await checker.has_permission("tools.read")
+
+        assert granted is True
+        assert self._SpyPS.last_check_kwargs["user_email"] == "u-1"


### PR DESCRIPTION
This PR resolves the caller identity through `get_user_id()` in the RBAC middleware. `check_permission_inline`, the `require_permission`/`require_admin_permission`/`require_any_permission` wrapper paths, and the permission-checker class now pass the canonical user_id to `PermissionService`. Of the 22 `user_context["email"]` occurrences in `rbac.py`, 13 identity uses were replaced; 9 logging uses keep the e-mail attribute. The 401 guard and the `team_id`/`check_any_team` logic are unchanged. Docstrings in `permission_service.py` and `admin_check.py` state the new parameter meaning. Phase-1 values are e-mail strings, so role queries and admin-bypass semantics are unchanged.

Tested with:
- `uv run pytest tests/unit/mcpgateway/middleware/test_rbac.py -k TestUserIdKeyedPermissionChecks -q` — failed first with the expected mode (`assert 'e@x.test' == 'u-1'`), then passed
- `uv run pytest tests -k "permission or rbac" -q` — 1412 passed, 37 skipped
- `uv run pytest tests/unit/mcpgateway/middleware/test_rbac_admin_bypass.py -q` — 9 passed, file unmodified (deny paths intact)
- `make ruff` — all checks passed

Acceptance criteria of #5889 are met. Risk to existing users: none; values are identical in phase 1.

Stack: A.4 of epic #5884 (base: #6730).

Closes #5889