### PR TITLE
refactor(auth): key session team resolution on canonical user_id

### DIFF
--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -253,7 +253,8 @@ def _get_user_team_ids_sync(email: str) -> List[str]:
     Matches the behavior of user.get_teams() which returns all active memberships.
 
     Args:
-        email: User email address
+        email: Canonical user_id for the membership query. Phase-1 value =
+            e-mail, so the ``EmailTeamMember.user_email`` query is unchanged.
 
     Returns:
         List of team ID strings
@@ -594,7 +595,9 @@ async def _resolve_teams_from_db(email: str, user_info) -> Optional[List[str]]:
     For non-admin users, returns the full list of team IDs from DB/cache.
 
     Args:
-        email: User email address
+        email: Canonical user_id for the DB/cache lookup. Phase-1 value =
+            e-mail, so the ``EmailTeamMember.user_email`` queries are
+            unchanged.
         user_info: User dict or EmailUser instance
 
     Returns:
@@ -684,11 +687,27 @@ async def resolve_session_teams(
             from a batched query), pass them here to skip the DB call.
             Pass ``None`` to indicate admin bypass was already determined.
 
+    The identity passed to the DB layer comes from ``get_user_id(payload)``
+    (canonical user_id; phase-1 value = e-mail). A UUID session subject is
+    an opaque reference, not an identity: like a missing identity, it falls
+    back to the *email* argument.
+
     Returns:
         None (admin bypass), [] (public-only), or list of team ID strings.
     """
     if not email:
         return []  # No identity — public-only; never admin bypass
+
+    # Canonical identity for team resolution (phase-1 value = e-mail).
+    identity = get_user_id(payload)
+    try:
+        uuid.UUID(identity)
+        identity = "unknown"  # UUID session subject — take the identity from the email argument
+    except ValueError:
+        pass  # Non-UUID identity
+    identity_from_email = identity == "unknown"
+    if identity_from_email:
+        identity = email
 
     # If sub is a UUID (new token format), resolve to email for DB lookups
     try:
@@ -696,13 +715,15 @@ async def resolve_session_teams(
         resolved = await asyncio.to_thread(_get_email_by_id_sync, email)
         if resolved:
             email = resolved
+            if identity_from_email:
+                identity = resolved
     except ValueError:
         pass  # Already an email string
 
     if preresolved_db_teams is not _UNSET:
         db_teams: Optional[List[str]] = preresolved_db_teams
     else:
-        db_teams = await _resolve_teams_from_db(email, user_info)
+        db_teams = await _resolve_teams_from_db(identity, user_info)
 
     return _narrow_by_jwt_teams(payload, db_teams)
 

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -1217,7 +1217,9 @@ class TeamManagementService:
 
         Args:
             team_id: ID of the team
-            user_email: Email of the user to add
+            user_email: Canonical user_id of the user to add. Phase-1 value =
+                e-mail, so the ``EmailTeamMember.user_email`` queries are
+                unchanged.
             role: Role to assign (owner, member)
             invited_by: Email of user who added this member
             grant_source: Origin of grant (e.g., 'sso', 'manual', 'bootstrap', 'auto')
@@ -1300,7 +1302,9 @@ class TeamManagementService:
 
         Args:
             team_id: ID of the team
-            user_email: Email of the user to remove
+            user_email: Canonical user_id of the user to remove. Phase-1
+                value = e-mail, so the ``EmailTeamMember.user_email`` query
+                is unchanged.
             removed_by: Email of user performing the removal
 
         Returns:
@@ -1486,7 +1490,9 @@ class TeamManagementService:
 
         Args:
             team_id: ID of the team
-            user_email: Email of the user
+            user_email: Canonical user_id of the user. Phase-1 value =
+                e-mail, so the ``EmailTeamMember.user_email`` query is
+                unchanged.
 
         Returns:
             EmailTeamMember if found and active, None otherwise

--- a/tests/unit/mcpgateway/middleware/test_token_scoping.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping.py
@@ -2615,3 +2615,64 @@ class TestUnifiedSearchPathScoping:
 
         assert client.get("/v1/search", headers=headers).status_code == 200  # middleware lets it through
         assert client.get("/v1/other", headers=headers).status_code == 403  # control: default-deny still enforced
+
+
+class TestUserIdKeyedTeamResolution:
+    """Team resolution keys on the canonical user_id (#5890).
+
+    Duplicates the session-token truth-table cases with user_id-keyed
+    payloads: the identity passed to the DB layer comes from
+    ``get_user_id(payload)``, with the e-mail argument as fallback.
+    """
+
+    @pytest.mark.asyncio
+    async def test_resolve_session_teams_uses_canonical_user_id(self):
+        """An explicit user_id claim wins over sub/e-mail for DB team resolution."""
+        # First-Party
+        from mcpgateway.auth import resolve_session_teams  # pylint: disable=import-outside-toplevel
+
+        payload = {"user_id": "u-1", "sub": "e@x.test", "token_use": "session"}
+        with patch("mcpgateway.auth._resolve_teams_from_db", new=AsyncMock(return_value=["t1"])) as spy:
+            result = await resolve_session_teams(payload, "e@x.test", {"is_admin": False})
+
+        spy.assert_awaited_once_with("u-1", {"is_admin": False})
+        assert result == ["t1"]
+
+    @pytest.mark.asyncio
+    async def test_revoked_membership_fails_closed(self):
+        """Revoked membership (empty DB teams) yields public-only, never admin bypass."""
+        # First-Party
+        from mcpgateway.auth import resolve_session_teams  # pylint: disable=import-outside-toplevel
+
+        payload = {"user_id": "u-1", "sub": "e@x.test", "token_use": "session"}
+        with patch("mcpgateway.auth._resolve_teams_from_db", new=AsyncMock(return_value=[])) as spy:
+            result = await resolve_session_teams(payload, "e@x.test", {"is_admin": False})
+
+        spy.assert_awaited_once_with("u-1", {"is_admin": False})
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_jwt_teams_intersect(self):
+        """A JWT teams claim narrows the user_id-keyed DB teams to the intersection."""
+        # First-Party
+        from mcpgateway.auth import resolve_session_teams  # pylint: disable=import-outside-toplevel
+
+        payload = {"user_id": "u-1", "sub": "e@x.test", "token_use": "session", "teams": ["t1"]}
+        with patch("mcpgateway.auth._resolve_teams_from_db", new=AsyncMock(return_value=["t1", "t2"])) as spy:
+            result = await resolve_session_teams(payload, "e@x.test", {"is_admin": False})
+
+        spy.assert_awaited_once_with("u-1", {"is_admin": False})
+        assert result == ["t1"]
+
+    @pytest.mark.asyncio
+    async def test_missing_identity_falls_back_to_email_param(self):
+        """A payload without user_id/email/sub uses the e-mail argument (unchanged behavior)."""
+        # First-Party
+        from mcpgateway.auth import resolve_session_teams  # pylint: disable=import-outside-toplevel
+
+        payload = {"token_use": "session"}
+        with patch("mcpgateway.auth._resolve_teams_from_db", new=AsyncMock(return_value=["t1"])) as spy:
+            result = await resolve_session_teams(payload, "e@x.test", {"is_admin": False})
+
+        spy.assert_awaited_once_with("e@x.test", {"is_admin": False})
+        assert result == ["t1"]


### PR DESCRIPTION
This PR keys session team resolution on the canonical user_id. `resolve_session_teams` derives the identity with `get_user_id(payload)` and passes it to `_resolve_teams_from_db`, `_get_user_team_ids_sync`, and the team-cache keys. A UUID session subject is an opaque reference, not an identity: it falls back to the e-mail argument, exactly like a missing identity. Phase-1 values are e-mail strings, so the `EmailTeamMember.user_email` queries, the DB-authority contract, and `normalize_token_teams()` are unchanged. `_narrow_by_jwt_teams` uses no identity and is unchanged. Docstrings state the new parameter meaning in `auth.py` and `team_management_service.py`.

Tested with:
- `uv run pytest tests/unit/mcpgateway/middleware/test_token_scoping.py::TestUserIdKeyedTeamResolution -q` — failed first with the expected mode (spy received `'e@x.test'` instead of `'u-1'`), then 4 passed
- `uv run pytest tests -k "team or scoping" -q` — 2475 passed, 73 skipped
- `uv run pytest tests/unit/mcpgateway/transports/test_streamablehttp_transport.py -q` — 601 passed (call sites verified unchanged)
- `make ruff` — all checks passed

Acceptance criteria of #5890 are met. Risk to existing users: none; phase-1 values are identical, including UUID-subject session tokens.

Stack: A.5 of epic #5884 (base: #6731).

Closes #5890