### PR TITLE
refactor(auth): re-key auth caches by canonical user_id with mode namespace

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2491,6 +2491,10 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # Streamable HTTP MCP auth uses this too before falling back to per-query checks
 # AUTH_CACHE_BATCH_QUERIES=true
 
+# Redis key version prefix for auth cache namespace isolation (default: v1)
+# Bump this when the auth identity mode changes so old cached keys become unreachable
+# AUTH_CACHE_KEY_VERSION=v1
+
 # Registry Cache Configuration
 # =============================================================================
 # Caches registry list endpoints (tools, prompts, resources, agents, servers, gateways)

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -1749,13 +1749,27 @@ async def get_current_user(
         # Extract JTI for revocation check
         jti = payload.get("jti")
 
+        # Canonical identity for auth cache keys (phase-1 value = e-mail).
+        # The JWT "user" metadata may carry no identity keys, and a UUID
+        # session subject is an opaque reference, not an identity: both
+        # cases fall back to the resolved e-mail so phase-1 keys keep
+        # today's value.
+        user_id = get_user_id(payload.get("user") or {"email": email})
+        try:
+            uuid.UUID(user_id)
+            user_id = "unknown"  # UUID subject — take the identity from the resolved e-mail
+        except ValueError:
+            pass  # Non-UUID identity
+        if user_id == "unknown":
+            user_id = email
+
         # === AUTH CACHING: Check cache before DB queries ===
         if settings.auth_cache_enabled:
             try:
                 # First-Party
                 from mcpgateway.cache.auth_cache import auth_cache, CachedAuthContext  # pylint: disable=import-outside-toplevel
 
-                cached_ctx = await auth_cache.get_auth_context(email, jti)
+                cached_ctx = await auth_cache.get_auth_context(user_id, jti)
                 if cached_ctx:
                     logger.debug(f"Auth cache hit for {email}")
 
@@ -1882,7 +1896,7 @@ async def get_current_user(
                         from mcpgateway.cache.auth_cache import auth_cache, CachedAuthContext  # noqa: F811 pylint: disable=import-outside-toplevel
 
                         await auth_cache.set_auth_context(
-                            email,
+                            user_id,
                             jti,
                             CachedAuthContext(
                                 user=auth_ctx.get("user"),
@@ -1896,7 +1910,7 @@ async def get_current_user(
                         # intersection (teams), so that other sessions for the same
                         # user see the full membership and can narrow independently.
                         if token_use == "session" and batch_teams is not None:  # nosec B105
-                            await auth_cache.set_user_teams(f"{email}:True", batch_teams)
+                            await auth_cache.set_user_teams(f"{user_id}:True", batch_teams)
                     except Exception as cache_set_error:
                         logger.debug(f"Failed to cache auth context: {cache_set_error}")
 

--- a/mcpgateway/cache/auth_cache.py
+++ b/mcpgateway/cache/auth_cache.py
@@ -156,6 +156,7 @@ class AuthCache:
             self._teams_list_enabled = getattr(settings, "auth_cache_teams_enabled", True)
             self._enabled = enabled if enabled is not None else getattr(settings, "auth_cache_enabled", True)
             self._cache_prefix = getattr(settings, "cache_prefix", "mcpgw:")
+            self._key_version = getattr(settings, "auth_cache_key_version", "v1")
         except ImportError:
             self._user_ttl = user_ttl or 60
             self._revocation_ttl = revocation_ttl or 30
@@ -165,6 +166,7 @@ class AuthCache:
             self._teams_list_enabled = True
             self._enabled = enabled if enabled is not None else True
             self._cache_prefix = "mcpgw:"
+            self._key_version = "v1"
 
         # In-memory cache (fallback when Redis unavailable)
         self._user_cache: Dict[str, CacheEntry] = {}
@@ -199,21 +201,25 @@ class AuthCache:
         )
 
     def _get_redis_key(self, key_type: str, identifier: str) -> str:
-        """Generate Redis key with proper prefix.
+        """Generate Redis key with prefix and namespace version.
+
+        The version segment isolates keys across auth modes: bumping
+        ``auth_cache_key_version`` makes every key written under the old
+        version unreachable (cold start) without flushing Redis.
 
         Args:
             key_type: Type of cache entry (user, team, revoke, ctx)
-            identifier: Unique identifier (email, jti, etc.)
+            identifier: Unique identifier (canonical user_id, jti, etc.)
 
         Returns:
-            Full Redis key with prefix
+            Full Redis key with prefix and version
 
         Examples:
             >>> cache = AuthCache()
             >>> cache._get_redis_key("user", "test@example.com")
-            'mcpgw:auth:user:test@example.com'
+            'mcpgw:auth:v1:user:test@example.com'
         """
-        return f"{self._cache_prefix}auth:{key_type}:{identifier}"
+        return f"{self._cache_prefix}auth:{self._key_version}:{key_type}:{identifier}"
 
     async def _get_redis_client(self):
         """Get Redis client if available.
@@ -249,7 +255,8 @@ class AuthCache:
         Returns None on cache miss.
 
         Args:
-            email: User email address
+            email: Canonical user_id of the user (phase-1 value = e-mail).
+                The Redis key carries the ``_key_version`` namespace prefix.
             jti: JWT ID for revocation check (optional)
 
         Returns:
@@ -341,7 +348,8 @@ class AuthCache:
         Stores in both Redis (if available) and in-memory cache.
 
         Args:
-            email: User email address
+            email: Canonical user_id of the user (phase-1 value = e-mail).
+                The Redis key carries the ``_key_version`` namespace prefix.
             jti: JWT ID (optional)
             context: Authentication context to cache
 
@@ -387,10 +395,11 @@ class AuthCache:
             )
 
     async def get_user(self, email: str) -> Optional[Dict[str, Any]]:
-        """Get cached user dict for a given email (L1 → L2 lookup).
+        """Get cached user dict for a given identity (L1 → L2 lookup).
 
         Args:
-            email: Normalised user email address.
+            email: Canonical user_id of the user (phase-1 value = e-mail).
+                The Redis key carries the ``_key_version`` namespace prefix.
 
         Returns:
             Cached user dict or None on cache miss.
@@ -440,7 +449,8 @@ class AuthCache:
         """Store user dict in cache (L2 then L1).
 
         Args:
-            email: Normalised user email address.
+            email: Canonical user_id of the user (phase-1 value = e-mail).
+                The Redis key carries the ``_key_version`` namespace prefix.
             user_dict: Serialisable user data dict.
 
         Examples:
@@ -827,8 +837,12 @@ class AuthCache:
     async def set_user_teams(self, cache_key: str, team_ids: List[str]) -> None:
         """Store team IDs for a user in cache.
 
+        The identifier inside the cache key is the canonical user_id
+        (phase-1 value = e-mail); the Redis key also carries the
+        ``_key_version`` namespace prefix.
+
         Args:
-            cache_key: Cache key in format "email:include_personal"
+            cache_key: Cache key in format "user_id:include_personal"
             team_ids: List of team IDs the user belongs to
 
         Examples:

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -2436,6 +2436,7 @@ class Settings(BaseSettings):
     auth_cache_teams_enabled: bool = Field(default=True, description="Enable caching for get_user_teams() (default: true)")
     auth_cache_teams_ttl: int = Field(default=60, ge=10, le=300, description="TTL in seconds for user teams list cache")
     auth_cache_batch_queries: bool = Field(default=True, description="Batch auth DB queries into single call (reduces 3 queries to 1)")
+    auth_cache_key_version: str = Field(default="v1", description="Redis key version prefix for auth cache namespace isolation")
 
     # Registry Cache Configuration (reduces DB queries for list endpoints)
     registry_cache_enabled: bool = Field(default=True, description="Enable caching for registry list endpoints (tools, prompts, resources, etc.)")

--- a/tests/unit/mcpgateway/cache/test_auth_cache_l1_l2.py
+++ b/tests/unit/mcpgateway/cache/test_auth_cache_l1_l2.py
@@ -44,6 +44,50 @@ def mock_redis():
     return redis
 
 
+class TestCacheKeyNamespace:
+    """Auth cache Redis keys carry a version segment for namespace isolation (issue #5891)."""
+
+    def test_redis_key_contains_version_segment(self):
+        """_get_redis_key inserts the configured key version after the auth prefix."""
+        assert AuthCache()._get_redis_key("user", "test@example.com").startswith("mcpgw:auth:v1:user:")
+
+    @pytest.mark.asyncio
+    async def test_version_bump_makes_old_keys_unreachable(self):
+        """A version bump cold-starts the cache: keys written under v1 are invisible to v2."""
+        store = {}
+
+        async def fake_get(key):
+            return store.get(key)
+
+        async def fake_setex(key, _ttl, value):
+            store[key] = value
+
+        shared_redis = AsyncMock()
+        shared_redis.get = AsyncMock(side_effect=fake_get)
+        shared_redis.setex = AsyncMock(side_effect=fake_setex)
+        shared_redis.exists = AsyncMock(return_value=False)
+
+        cache_a = AuthCache(enabled=True)
+        cache_b = AuthCache(enabled=True)
+        cache_b._key_version = "v2"  # synthetic namespace bump
+
+        identity = "test@example.com"
+        jti = "jti-ns-1"
+        ctx = CachedAuthContext(
+            user={"email": identity, "is_admin": False},
+            personal_team_id="team-1",
+            is_token_revoked=False,
+        )
+
+        with patch.object(cache_a, "_get_redis_client", return_value=shared_redis):
+            await cache_a.set_auth_context(identity, jti, ctx)
+
+        with patch.object(cache_b, "_get_redis_client", return_value=shared_redis):
+            result = await cache_b.get_auth_context(identity, jti)
+
+        assert result is None  # cold start: the v1 key is unreachable under v2
+
+
 class TestGetAuthContextL1L2:
     """Test get_auth_context L1/L2 behavior."""
 

--- a/tests/unit/mcpgateway/cache/test_auth_cache_user.py
+++ b/tests/unit/mcpgateway/cache/test_auth_cache_user.py
@@ -165,3 +165,55 @@ class TestGetUser:
         stats = cache.stats()
         assert "user_cache_size" in stats
         assert stats["user_cache_size"] == 1
+
+
+@pytest.mark.asyncio
+async def test_auth_context_key_uses_user_id_identity(monkeypatch):
+    """get_current_user keys the auth-context cache by canonical user_id, not raw e-mail (issue #5891)."""
+    # Standard
+    from datetime import datetime, timedelta, timezone
+    from types import SimpleNamespace
+
+    # Third-Party
+    from fastapi.security import HTTPAuthorizationCredentials
+
+    # First-Party
+    from mcpgateway.auth import get_current_user
+    from mcpgateway.config import settings
+    from mcpgateway.db import EmailUser
+
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="valid_jwt_token")  # pragma: allowlist secret
+    jwt_payload = {
+        "sub": "e@x.test",
+        "exp": (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp(),
+        "user": {"user_id": "u-1", "email": "e@x.test", "is_admin": False, "auth_provider": "local"},
+    }
+
+    mock_user = EmailUser(
+        email="e@x.test",
+        password_hash="hash",  # pragma: allowlist secret
+        full_name="Test User",
+        is_admin=False,
+        is_active=True,
+        email_verified_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+    get_auth_context_spy = AsyncMock(return_value=None)  # cache miss: fall through to the DB path
+
+    monkeypatch.setattr(settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+
+    request = SimpleNamespace(state=SimpleNamespace())
+    with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", get_auth_context_spy):
+            with patch("mcpgateway.auth._check_token_revoked_sync", return_value=False):
+                with patch("mcpgateway.auth._is_api_token_jti_sync", return_value=True):
+                    with patch("mcpgateway.auth._update_api_token_last_used_sync", return_value=None):
+                        with patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user):
+                            with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
+                                await get_current_user(credentials=credentials, request=request)
+
+    get_auth_context_spy.assert_awaited_once()
+    assert get_auth_context_spy.await_args.args[0] == "u-1"


### PR DESCRIPTION
This PR re-keys the auth caches by canonical user_id. Redis keys gain a version segment through `_get_redis_key` (`mcpgw:auth:{version}:{key_type}:{identifier}`), so a future auth-mode change cannot serve stale cross-mode context. The version comes from the new `auth_cache_key_version` setting (default `v1`), documented in `.env.example`. Cache call sites in `get_current_user` derive the identity via `get_user_id()` with the e-mail fallback; a raw UUID `sub` and an `unknown` identity both fall back to the resolved e-mail, so phase-1 keys are byte-identical to today. TTLs, backends, and eviction are unchanged. A synthetic version-bump test proves old keys turn cold.

The 30-second negative-revocation cache also cold-starts: revocation checks fall through to the DB/blocklist for the first request per identity after deploy. No security gap — the check still runs.

Tested with:
- `uv run pytest tests/unit/mcpgateway/cache/test_auth_cache_l1_l2.py tests/unit/mcpgateway/cache/test_auth_cache_user.py -q` — 99 passed (3 new tests failed first with the expected modes)
- `make doctest` — 1228 passed, 56 skipped
- `make ruff` — all checks passed
- `make test` — 23184 passed, 879 skipped, 2 xfailed

Acceptance criteria of #5891 are met. Risk to existing users: one cold cache start after deploy; no other effect.

Stack: A.6 of epic #5884 (base: #6732). Completes Epic 1 Phase A.

Closes #5891