### PR TITLE
feat(auth): populate user_id from SSO subject and provisioning defaults

### DIFF
--- a/mcpgateway/alembic/versions/a824749abd27_add_user_id_to_roles_and_team_members.py
+++ b/mcpgateway/alembic/versions/a824749abd27_add_user_id_to_roles_and_team_members.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/alembic/versions/a824749abd27_add_user_id_to_roles_and_team_members.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+add_user_id_to_roles_and_team_members
+
+Revision ID: a824749abd27
+Revises: bf2998718ea1
+Create Date: 2026-09-12 17:50:00.000000
+"""
+
+# Standard
+from typing import Sequence, Union
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "a824749abd27"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "bf2998718ea1"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# (table, index) pairs gaining a nullable canonical user_id column (#5893).
+# The FK-bearing user_email columns keep the e-mail; user_id stores the
+# canonical ID for users whose IdP subject diverges from their e-mail.
+_TARGETS = (
+    ("user_roles", "ix_user_roles_user_id"),
+    ("email_team_members", "ix_email_team_members_user_id"),
+)
+
+
+def upgrade() -> None:
+    """Add nullable indexed user_id columns to user_roles and email_team_members."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = inspector.get_table_names()
+
+    for table, index_name in _TARGETS:
+        # Skip if table doesn't exist (fresh DB uses db.py models directly)
+        if table not in tables:
+            continue
+
+        columns = [col["name"] for col in inspector.get_columns(table)]
+        if "user_id" not in columns:
+            with op.batch_alter_table(table) as batch_op:
+                batch_op.add_column(sa.Column("user_id", sa.String(255), nullable=True))
+
+        # Re-inspect: the column add above invalidates the earlier snapshot
+        inspector = sa.inspect(bind)
+        indexes = [index["name"] for index in inspector.get_indexes(table)]
+        if index_name not in indexes:
+            op.create_index(index_name, table, ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    """Remove the user_id indexes and columns from user_roles and email_team_members."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = inspector.get_table_names()
+
+    for table, index_name in _TARGETS:
+        if table not in tables:
+            continue
+
+        indexes = [index["name"] for index in inspector.get_indexes(table)]
+        if index_name in indexes:
+            op.drop_index(index_name, table_name=table)
+
+        columns = [col["name"] for col in inspector.get_columns(table)]
+        if "user_id" in columns:
+            with op.batch_alter_table(table) as batch_op:
+                batch_op.drop_column("user_id")

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -78,7 +78,7 @@ from cpex.framework import GlobalContext, HttpAuthResolveUserPayload, HttpHeader
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials
 import redis
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 from starlette.requests import Request
 
@@ -253,8 +253,10 @@ def _get_user_team_ids_sync(email: str) -> List[str]:
     Matches the behavior of user.get_teams() which returns all active memberships.
 
     Args:
-        email: Canonical user_id for the membership query. Phase-1 value =
-            e-mail, so the ``EmailTeamMember.user_email`` query is unchanged.
+        email: Canonical user_id for the membership query. Matches both the
+            FK-valid ``user_email`` column and the dual-written ``user_id``
+            column so legacy rows (e-mail in both) and diverged rows
+            (canonical ID in ``user_id``) both resolve.
 
     Returns:
         List of team ID strings
@@ -266,7 +268,7 @@ def _get_user_team_ids_sync(email: str) -> List[str]:
         result = db.execute(
             select(EmailTeamMember.team_id)
             .where(
-                EmailTeamMember.user_email == email,
+                or_(EmailTeamMember.user_email == email, EmailTeamMember.user_id == email),
                 EmailTeamMember.is_active.is_(True),
             )
             .order_by(EmailTeamMember.id)  # Stable ordering: teams[0] used as Vault path key
@@ -595,9 +597,9 @@ async def _resolve_teams_from_db(email: str, user_info) -> Optional[List[str]]:
     For non-admin users, returns the full list of team IDs from DB/cache.
 
     Args:
-        email: Canonical user_id for the DB/cache lookup. Phase-1 value =
-            e-mail, so the ``EmailTeamMember.user_email`` queries are
-            unchanged.
+        email: Canonical user_id for the DB/cache lookup. Membership rows
+            match on either ``user_email`` or the dual-written ``user_id``
+            (see :func:`_get_user_team_ids_sync`).
         user_info: User dict or EmailUser instance
 
     Returns:

--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -282,6 +282,35 @@ def get_user_id(user: Any) -> str:
     return str(user) if user else "unknown"
 
 
+def resolve_canonical_user_id(email: str, db: Session) -> str:
+    """Resolve an e-mail address to the canonical user ID for writer paths.
+
+    Writer sites call this resolver once and store the result in the
+    ``user_email``-keyed columns of ``UserRole`` and ``EmailTeamMember``.
+    The input e-mail is stripped and lowered, the same rule
+    ``EmailAuthService.create_user`` applies. When a user row exists and
+    carries a non-empty string ``user_id``, that value wins. Otherwise the
+    input e-mail is returned unchanged, so callers stay safe for users not
+    yet provisioned.
+
+    Args:
+        email: E-mail address of the user being written about
+        db: SQLAlchemy session used for the lookup
+
+    Returns:
+        str: Canonical user ID, or the input e-mail when no mapping exists
+
+    Examples:
+        >>> resolve_canonical_user_id('admin@example.com', db)  # doctest: +SKIP
+        'admin@example.com'
+    """
+    normalized_email = email.lower().strip()
+    user = db.query(EmailUser).filter(EmailUser.email == normalized_email).first()
+    if user is not None and isinstance(user.user_id, str) and user.user_id:
+        return user.user_id
+    return email
+
+
 def _is_uuid_string(value: str) -> bool:
     """Return True when *value* is a syntactically valid UUID string."""
     try:

--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -285,10 +285,11 @@ def get_user_id(user: Any) -> str:
 def resolve_canonical_user_id(email: str, db: Session) -> str:
     """Resolve an e-mail address to the canonical user ID for writer paths.
 
-    Writer sites call this resolver once and store the result in the
-    ``user_email``-keyed columns of ``UserRole`` and ``EmailTeamMember``.
-    The input e-mail is stripped and lowered, the same rule
-    ``EmailAuthService.create_user`` applies. When a user row exists and
+    Writer sites call this resolver once and dual-write the result: the
+    ``user_email`` columns of ``UserRole`` and ``EmailTeamMember`` keep the
+    FK-valid e-mail, while the resolver output goes into their nullable
+    ``user_id`` columns. The input e-mail is stripped and lowered, the same
+    rule ``EmailAuthService.create_user`` applies. When a user row exists and
     carries a non-empty string ``user_id``, that value wins. Otherwise the
     input e-mail is returned unchanged, so callers stay safe for users not
     yet provisioned.

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -1261,6 +1261,10 @@ class UserRole(Base):
 
     # Assignment details
     user_email: Mapped[str] = mapped_column(String(255), ForeignKey("email_users.email"), nullable=False)
+    # Canonical user ID (dual-write, #5893): the opaque IdP subject when it
+    # diverges from the e-mail, else the e-mail. user_email stays the FK-valid
+    # e-mail; nullable for rows written before this column existed.
+    user_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True, index=True)
     role_id: Mapped[str] = mapped_column(String(36), ForeignKey("roles.id"), nullable=False)
     scope: Mapped[str] = mapped_column(String(20), nullable=False)  # 'global', 'team', 'personal'
     scope_id: Mapped[Optional[str]] = mapped_column(String(36), nullable=True)  # Team ID if team-scoped
@@ -2101,6 +2105,7 @@ class EmailTeamMember(Base):
         id (str): Primary key UUID
         team_id (str): Foreign key to email_teams
         user_email (str): Foreign key to email_users
+        user_id (str): Canonical user ID (dual-write; opaque IdP subject when it diverges)
         role (str): Member role (owner, member)
         joined_at (datetime): When the user joined the team
         invited_by (str): Email of the user who invited this member
@@ -2126,6 +2131,11 @@ class EmailTeamMember(Base):
     # Foreign keys
     team_id: Mapped[str] = mapped_column(String(36), ForeignKey("email_teams.id", ondelete="CASCADE"), nullable=False)
     user_email: Mapped[str] = mapped_column(String(255), ForeignKey("email_users.email"), nullable=False)
+
+    # Canonical user ID (dual-write, #5893): the opaque IdP subject when it
+    # diverges from the e-mail, else the e-mail. user_email stays the FK-valid
+    # e-mail; nullable for rows written before this column existed.
+    user_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True, index=True)
 
     # Membership details
     role: Mapped[str] = mapped_column(String(50), default="member", nullable=False)

--- a/mcpgateway/services/email_auth_service.py
+++ b/mcpgateway/services/email_auth_service.py
@@ -630,6 +630,7 @@ class EmailAuthService:
         skip_password_validation: bool = False,
         granted_by: Optional[str] = None,
         skip_onboarding: bool = False,
+        user_id: Optional[str] = None,
     ) -> EmailUser:
         """Create a new user with email authentication.
 
@@ -649,6 +650,8 @@ class EmailAuthService:
                 ``except Exception`` path) are always recorded regardless of
                 this flag.  Duplicate-user rejections (``UserExistsError``,
                 ``IntegrityError``) are not audited by design.
+            user_id: Canonical user ID to store (e.g. the IdP subject for
+                SSO-provisioned users). Defaults to the normalized e-mail.
 
         Returns:
             EmailUser: The created user object
@@ -703,6 +706,7 @@ class EmailAuthService:
             full_name=full_name,
             is_admin=is_admin,
             is_active=is_active,
+            user_id=user_id or email,
             password_change_required=password_change_required,
             auth_provider=auth_provider,
             password_changed_at=utc_now(),

--- a/mcpgateway/services/personal_team_service.py
+++ b/mcpgateway/services/personal_team_service.py
@@ -23,6 +23,7 @@ from typing import Optional
 from sqlalchemy.orm import Session
 
 # First-Party
+from mcpgateway.auth_context import resolve_canonical_user_id
 from mcpgateway.config import settings
 from mcpgateway.db import EmailTeam, EmailTeamMember, EmailTeamMemberHistory, EmailUser, utc_now
 from mcpgateway.services.logging_service import LoggingService
@@ -125,8 +126,10 @@ class PersonalTeamService:
             self.db.add(team)
             self.db.flush()  # Get the team ID
 
-            # Add the user as the owner of their personal team
-            membership = EmailTeamMember(team_id=team.id, user_email=user.email, role="owner", joined_at=utc_now(), is_active=True)
+            # Add the user as the owner of their personal team. Resolve the
+            # canonical user ID once; the owner membership keys on it.
+            canonical = resolve_canonical_user_id(user.email, self.db)
+            membership = EmailTeamMember(team_id=team.id, user_email=canonical, role="owner", joined_at=utc_now(), is_active=True)
 
             self.db.add(membership)
             self.db.flush()  # Get the membership ID

--- a/mcpgateway/services/personal_team_service.py
+++ b/mcpgateway/services/personal_team_service.py
@@ -126,10 +126,11 @@ class PersonalTeamService:
             self.db.add(team)
             self.db.flush()  # Get the team ID
 
-            # Add the user as the owner of their personal team. Resolve the
-            # canonical user ID once; the owner membership keys on it.
+            # Add the user as the owner of their personal team. Dual-write:
+            # user_email keeps the FK-valid e-mail; user_id carries the
+            # canonical ID.
             canonical = resolve_canonical_user_id(user.email, self.db)
-            membership = EmailTeamMember(team_id=team.id, user_email=canonical, role="owner", joined_at=utc_now(), is_active=True)
+            membership = EmailTeamMember(team_id=team.id, user_email=user.email, user_id=canonical, role="owner", joined_at=utc_now(), is_active=True)
 
             self.db.add(membership)
             self.db.flush()  # Get the membership ID

--- a/mcpgateway/services/role_service.py
+++ b/mcpgateway/services/role_service.py
@@ -637,9 +637,10 @@ class RoleService:
             ...         'not found or inactive' in str(e)
             True
         """
-        # Resolve the canonical user ID once: both the existing-assignment
-        # lookups and the stored row key on it, so diverged users
-        # (user_id != email) never lose or duplicate rows.
+        # Resolve the canonical user ID once for the dual-write: user_email
+        # keeps the FK-valid e-mail (existing-row lookups key on it), while
+        # the stored row also carries the canonical ID in user_id so diverged
+        # users (user_id != email) stay joinable.
         canonical = resolve_canonical_user_id(user_email, self.db)
 
         # Validate role exists and is active
@@ -658,7 +659,7 @@ class RoleService:
             raise ValueError(f"scope_id not allowed for {scope} assignments")
 
         # Check for existing active assignment
-        existing = await self.get_user_role_assignment(canonical, role_id, scope, scope_id)
+        existing = await self.get_user_role_assignment(user_email, role_id, scope, scope_id)
         if existing and existing.is_active:
             if not existing.is_expired():
                 # Active and not expired - reject the new assignment
@@ -677,7 +678,7 @@ class RoleService:
                 logger.info("Concurrent modification detected during expired assignment soft-delete - refetching")
 
                 # Refetch to see the current state
-                existing = await self.get_user_role_assignment(canonical, role_id, scope, scope_id)
+                existing = await self.get_user_role_assignment(user_email, role_id, scope, scope_id)
                 if existing and existing.is_active and not existing.is_expired():
                     # Another process already created a fresh assignment
                     return existing
@@ -687,7 +688,7 @@ class RoleService:
         # Create the assignment with savepoint to handle race conditions
         # If another process created the same assignment concurrently, we'll catch IntegrityError
         # and return the existing assignment instead of failing
-        user_role = UserRole(user_email=canonical, role_id=role_id, scope=scope, scope_id=scope_id, granted_by=granted_by, expires_at=expires_at, grant_source=grant_source)
+        user_role = UserRole(user_email=user_email, user_id=canonical, role_id=role_id, scope=scope, scope_id=scope_id, granted_by=granted_by, expires_at=expires_at, grant_source=grant_source)
 
         try:
             # Use nested transaction (savepoint) to allow rollback on conflict
@@ -720,7 +721,7 @@ class RoleService:
             logger.info("Role assignment for %s to role %s (scope: %s, scope_id: %s) was created concurrently - refetching existing assignment", user_email, role_id, scope, scope_id)
 
             # Refetch the winner's row
-            existing = await self.get_user_role_assignment(canonical, role_id, scope, scope_id)
+            existing = await self.get_user_role_assignment(user_email, role_id, scope, scope_id)
             if existing:
                 # CRITICAL: Check if the refetched assignment is expired
                 # This handles the race where another process created an expired assignment

--- a/mcpgateway/services/role_service.py
+++ b/mcpgateway/services/role_service.py
@@ -20,6 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 # First-Party
+from mcpgateway.auth_context import resolve_canonical_user_id
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.db import Permissions, Role, UserRole, utc_now
 
@@ -636,6 +637,11 @@ class RoleService:
             ...         'not found or inactive' in str(e)
             True
         """
+        # Resolve the canonical user ID once: both the existing-assignment
+        # lookups and the stored row key on it, so diverged users
+        # (user_id != email) never lose or duplicate rows.
+        canonical = resolve_canonical_user_id(user_email, self.db)
+
         # Validate role exists and is active
         role = await self.get_role_by_id(role_id)
         if not role or not role.is_active:
@@ -652,7 +658,7 @@ class RoleService:
             raise ValueError(f"scope_id not allowed for {scope} assignments")
 
         # Check for existing active assignment
-        existing = await self.get_user_role_assignment(user_email, role_id, scope, scope_id)
+        existing = await self.get_user_role_assignment(canonical, role_id, scope, scope_id)
         if existing and existing.is_active:
             if not existing.is_expired():
                 # Active and not expired - reject the new assignment
@@ -671,7 +677,7 @@ class RoleService:
                 logger.info("Concurrent modification detected during expired assignment soft-delete - refetching")
 
                 # Refetch to see the current state
-                existing = await self.get_user_role_assignment(user_email, role_id, scope, scope_id)
+                existing = await self.get_user_role_assignment(canonical, role_id, scope, scope_id)
                 if existing and existing.is_active and not existing.is_expired():
                     # Another process already created a fresh assignment
                     return existing
@@ -681,7 +687,7 @@ class RoleService:
         # Create the assignment with savepoint to handle race conditions
         # If another process created the same assignment concurrently, we'll catch IntegrityError
         # and return the existing assignment instead of failing
-        user_role = UserRole(user_email=user_email, role_id=role_id, scope=scope, scope_id=scope_id, granted_by=granted_by, expires_at=expires_at, grant_source=grant_source)
+        user_role = UserRole(user_email=canonical, role_id=role_id, scope=scope, scope_id=scope_id, granted_by=granted_by, expires_at=expires_at, grant_source=grant_source)
 
         try:
             # Use nested transaction (savepoint) to allow rollback on conflict
@@ -714,7 +720,7 @@ class RoleService:
             logger.info("Role assignment for %s to role %s (scope: %s, scope_id: %s) was created concurrently - refetching existing assignment", user_email, role_id, scope, scope_id)
 
             # Refetch the winner's row
-            existing = await self.get_user_role_assignment(user_email, role_id, scope, scope_id)
+            existing = await self.get_user_role_assignment(canonical, role_id, scope, scope_id)
             if existing:
                 # CRITICAL: Check if the refetched assignment is expired
                 # This handles the race where another process created an expired assignment

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -735,6 +735,23 @@ class SSOService:
                     exc_info=True,
                 )
 
+    @staticmethod
+    def _validate_user_id_claim(provider_metadata: Optional[Dict[str, Any]], provider_name: str) -> None:
+        """Reject invalid user_id_claim settings at provider save time.
+
+        Args:
+            provider_metadata: Provider metadata dict that may carry user_id_claim.
+            provider_name: Provider identifier used in the error message.
+
+        Raises:
+            ValueError: If user_id_claim is present but not a non-empty string.
+        """
+        if not isinstance(provider_metadata, dict) or "user_id_claim" not in provider_metadata:
+            return
+        user_id_claim = provider_metadata["user_id_claim"]
+        if not isinstance(user_id_claim, str) or not user_id_claim.strip():
+            raise ValueError(f"Invalid user_id_claim for SSO provider '{provider_name}': the setting must be a non-empty string naming the IdP claim that becomes user_id")
+
     async def create_provider(self, provider_data: Dict[str, Any]) -> SSOProvider:
         """Create new SSO provider configuration.
 
@@ -776,6 +793,8 @@ class SSOService:
 
         if filtered_data.get("trusted_for_api_auth") and not (filtered_data.get("api_audience") or "").strip():
             raise ValueError("api_audience is required when trusted_for_api_auth is enabled (prevents confused-deputy token acceptance)")
+
+        self._validate_user_id_claim(filtered_data.get("provider_metadata"), str(filtered_data.get("id") or "unknown"))
 
         provider = SSOProvider(**filtered_data)
         self.db.add(provider)
@@ -821,6 +840,9 @@ class SSOService:
         if "client_secret" in provider_data:
             client_secret = provider_data.pop("client_secret")
             provider_data["client_secret_encrypted"] = await self._encrypt_secret(client_secret)
+
+        if "provider_metadata" in provider_data:
+            self._validate_user_id_claim(provider_data.get("provider_metadata"), provider_id)
 
         for key, value in provider_data.items():
             if hasattr(provider, key):
@@ -1819,6 +1841,9 @@ class SSOService:
         Returns:
             Normalized user info dict
         """
+        metadata = provider.provider_metadata or {}
+        groups_claim = metadata.get("groups_claim", "groups")
+
         # Handle GitHub provider
         if provider.id == "github":
             normalized: Dict[str, Any] = {
@@ -1838,36 +1863,32 @@ class SSOService:
                 github_email_verified = user_data.get("verified")
             if github_email_verified is not None:
                 normalized["email_verified"] = github_email_verified
-            return normalized
 
         # Handle Google provider
-        if provider.id == "google":
-            return self._build_normalized_user_info(
+        elif provider.id == "google":
+            normalized = self._build_normalized_user_info(
                 user_data,
                 "google",
                 [],
                 username=user_data.get("email", "").split("@")[0],
             )
 
-        metadata = provider.provider_metadata or {}
-        groups_claim = metadata.get("groups_claim", "groups")
-
         # Handle IBM Verify provider
-        if provider.id == "ibm_verify":
+        elif provider.id == "ibm_verify":
             groups = self._extract_groups_and_roles(user_data, groups_claim)
-            return self._build_normalized_user_info(user_data, "ibm_verify", groups)
+            normalized = self._build_normalized_user_info(user_data, "ibm_verify", groups)
 
         # Handle Okta provider
-        if provider.id == "okta":
+        elif provider.id == "okta":
             groups = self._extract_groups_and_roles(user_data, groups_claim)
-            return self._build_normalized_user_info(user_data, "okta", groups)
+            normalized = self._build_normalized_user_info(user_data, "okta", groups)
 
         # Handle Keycloak provider with role mapping
-        if provider.id == "keycloak":
+        elif provider.id == "keycloak":
             username_claim = metadata.get("username_claim", "preferred_username")
             email_claim = metadata.get("email_claim", "email")
 
-            groups: list[str] = []
+            groups = []
 
             # Extract realm roles
             if metadata.get("map_realm_roles"):
@@ -1886,7 +1907,7 @@ class SSOService:
                 if isinstance(custom_groups, list):
                     groups.extend(custom_groups)
 
-            return self._build_normalized_user_info(
+            normalized = self._build_normalized_user_info(
                 user_data,
                 "keycloak",
                 groups,
@@ -1895,14 +1916,14 @@ class SSOService:
             )
 
         # Handle Microsoft Entra ID provider with role mapping
-        if provider.id == "entra":
+        elif provider.id == "entra":
             # Microsoft's userinfo endpoint often omits the email claim
             # Fallback: preferred_username (UPN) or upn claim
             email = user_data.get("email") or user_data.get("preferred_username") or user_data.get("upn")
             username = user_data.get("preferred_username") or (email.split("@")[0] if email else None)
 
             groups = self._extract_groups_and_roles(user_data, groups_claim)
-            return self._build_normalized_user_info(
+            normalized = self._build_normalized_user_info(
                 user_data,
                 "entra",
                 groups,
@@ -1913,7 +1934,7 @@ class SSOService:
             )
 
         # Handle ADFS provider
-        if provider.id == ADFS_PROVIDER_ID:
+        elif provider.id == ADFS_PROVIDER_ID:
             # ADFS uses UPN (User Principal Name) as the primary identifier.
             # Claim priority: email > preferred_username > upn > unique_name
             raw_email = user_data.get("email") or user_data.get("preferred_username") or user_data.get("upn") or user_data.get("unique_name")
@@ -1941,7 +1962,7 @@ class SSOService:
 
             adfs_groups = self._extract_groups_and_roles(user_data, groups_claim)
 
-            return self._build_normalized_user_info(
+            normalized = self._build_normalized_user_info(
                 user_data,
                 ADFS_PROVIDER_ID,
                 adfs_groups,
@@ -1953,8 +1974,27 @@ class SSOService:
             )
 
         # Generic OIDC format for all other providers.
-        groups = self._extract_groups_and_roles(user_data, groups_claim)
-        return self._build_normalized_user_info(user_data, provider.id, groups)
+        else:
+            groups = self._extract_groups_and_roles(user_data, groups_claim)
+            normalized = self._build_normalized_user_info(user_data, provider.id, groups)
+
+        # Per-provider user_id claim setting: the default "sub" keeps the
+        # standard mapping above. A configured claim re-points provider_id at
+        # that claim. A missing claim flags the payload so the login fails
+        # closed in authenticate_or_create_user.
+        user_id_claim = str(metadata.get("user_id_claim") or "sub")
+        if user_id_claim != "sub":
+            if user_id_claim not in user_data:
+                logger.error(
+                    "SSO provider '%s' configures user_id_claim '%s' but that claim is absent from the user data. The login will fail closed.",
+                    provider.id,
+                    user_id_claim,
+                )
+                normalized["user_id_claim_missing"] = user_id_claim
+            else:
+                normalized["provider_id"] = user_data.get(user_id_claim)
+
+        return normalized
 
     def _reset_pending_approval(self, pending: PendingUserApproval, incoming_provider: str, user_info: Dict[str, Any]) -> None:
         """Reset a pending approval request to pending state with fresh metadata.
@@ -2063,6 +2103,16 @@ class SSOService:
         Returns:
             JWT token for authenticated user or None if failed
         """
+        # Fail closed when the provider's configured user_id claim was absent
+        # from the token: never fall back to the e-mail as the canonical ID.
+        if user_info.get("user_id_claim_missing"):
+            logger.error(
+                "SSO authenticate_or_create_user: provider '%s' requires claim '%s' as the user_id source but the claim was absent from the user data. Failing the login closed.",
+                user_info.get("provider", "unknown"),
+                user_info.get("user_id_claim_missing"),
+            )
+            return None
+
         raw_email = user_info.get("email")
         if not raw_email:
             logger.warning("SSO authenticate_or_create_user: no email in user_info from provider '%s'. User cannot be authenticated without an email address.", user_info.get("provider", "unknown"))
@@ -2250,6 +2300,7 @@ class SSOService:
                 full_name=user_info.get("full_name", email),
                 is_admin=is_admin,
                 auth_provider=incoming_provider,
+                user_id=str(user_info.get("provider_id") or email),
             )
             if not user:
                 return None

--- a/mcpgateway/services/team_invitation_service.py
+++ b/mcpgateway/services/team_invitation_service.py
@@ -438,13 +438,16 @@ class TeamInvitationService:
                 logger.warning("Team %s not found or inactive", invitation.team_id)
                 raise ValueError("Team not found or inactive")
 
-            # Resolve the canonical user ID once: both membership lookups and
-            # the stored row key on it, so diverged users (user_id != email)
-            # never lose or duplicate membership rows.
+            # Resolve the canonical user ID once for the dual-write: user_email
+            # keeps the FK-valid e-mail (membership lookups key on it), while
+            # the stored row also carries the canonical ID in user_id so
+            # diverged users (user_id != email) stay joinable.
             canonical = resolve_canonical_user_id(invitation.email, self.db)
 
             # Check if user is already a member
-            existing_member = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == invitation.team_id, EmailTeamMember.user_email == canonical, EmailTeamMember.is_active.is_(True)).first()
+            existing_member = (
+                self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == invitation.team_id, EmailTeamMember.user_email == invitation.email, EmailTeamMember.is_active.is_(True)).first()
+            )
 
             if existing_member:
                 logger.warning("User %s is already a member of team %s", invitation.email, invitation.team_id)
@@ -472,7 +475,7 @@ class TeamInvitationService:
             # closes the race on every backend: only one of two racing callers can flip is_active from
             # False to True, the other gets rowcount 0 and is turned into the same "already a member"
             # error used for the commit-time IntegrityError race on the insert path below.
-            membership = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == invitation.team_id, EmailTeamMember.user_email == canonical).with_for_update().first()
+            membership = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == invitation.team_id, EmailTeamMember.user_email == invitation.email).with_for_update().first()
 
             reactivated = membership is not None
             if membership:
@@ -499,7 +502,9 @@ class TeamInvitationService:
                 membership.invited_by = invitation.invited_by
                 membership.is_active = True
             else:
-                membership = EmailTeamMember(team_id=invitation.team_id, user_email=canonical, role=invitation.role, joined_at=utc_now(), invited_by=invitation.invited_by, is_active=True)
+                membership = EmailTeamMember(
+                    team_id=invitation.team_id, user_email=invitation.email, user_id=canonical, role=invitation.role, joined_at=utc_now(), invited_by=invitation.invited_by, is_active=True
+                )
                 self.db.add(membership)
 
             # Deactivate the invitation

--- a/mcpgateway/services/team_invitation_service.py
+++ b/mcpgateway/services/team_invitation_service.py
@@ -27,6 +27,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 # First-Party
+from mcpgateway.auth_context import resolve_canonical_user_id
 from mcpgateway.cache.auth_cache import auth_cache
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
@@ -437,10 +438,13 @@ class TeamInvitationService:
                 logger.warning("Team %s not found or inactive", invitation.team_id)
                 raise ValueError("Team not found or inactive")
 
+            # Resolve the canonical user ID once: both membership lookups and
+            # the stored row key on it, so diverged users (user_id != email)
+            # never lose or duplicate membership rows.
+            canonical = resolve_canonical_user_id(invitation.email, self.db)
+
             # Check if user is already a member
-            existing_member = (
-                self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == invitation.team_id, EmailTeamMember.user_email == invitation.email, EmailTeamMember.is_active.is_(True)).first()
-            )
+            existing_member = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == invitation.team_id, EmailTeamMember.user_email == canonical, EmailTeamMember.is_active.is_(True)).first()
 
             if existing_member:
                 logger.warning("User %s is already a member of team %s", invitation.email, invitation.team_id)
@@ -468,7 +472,7 @@ class TeamInvitationService:
             # closes the race on every backend: only one of two racing callers can flip is_active from
             # False to True, the other gets rowcount 0 and is turned into the same "already a member"
             # error used for the commit-time IntegrityError race on the insert path below.
-            membership = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == invitation.team_id, EmailTeamMember.user_email == invitation.email).with_for_update().first()
+            membership = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == invitation.team_id, EmailTeamMember.user_email == canonical).with_for_update().first()
 
             reactivated = membership is not None
             if membership:
@@ -495,7 +499,7 @@ class TeamInvitationService:
                 membership.invited_by = invitation.invited_by
                 membership.is_active = True
             else:
-                membership = EmailTeamMember(team_id=invitation.team_id, user_email=invitation.email, role=invitation.role, joined_at=utc_now(), invited_by=invitation.invited_by, is_active=True)
+                membership = EmailTeamMember(team_id=invitation.team_id, user_email=canonical, role=invitation.role, joined_at=utc_now(), invited_by=invitation.invited_by, is_active=True)
                 self.db.add(membership)
 
             # Deactivate the invitation

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -1195,13 +1195,14 @@ class TeamManagementService:
             Tuple[EmailTeamMember, str]: The membership row, and the history action
             describing it ('added' for a new row, 'reactivated' for a revived one).
         """
-        # Resolve the canonical user ID once: the lookup and the stored row
-        # both key on it, so diverged users (user_id != email) never lose or
-        # duplicate membership rows.
+        # Resolve the canonical user ID once for the dual-write: user_email
+        # keeps the FK-valid e-mail (the lookup below keys on it), while the
+        # stored row also carries the canonical ID in user_id so diverged
+        # users (user_id != email) stay joinable.
         canonical = resolve_canonical_user_id(user_email, self.db)
 
         if isinstance(existing, _Unset):
-            existing = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team_id, EmailTeamMember.user_email == canonical).first()
+            existing = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team_id, EmailTeamMember.user_email == user_email).first()
 
         if existing:
             existing.is_active = True  # pylint: disable=attribute-defined-outside-init
@@ -1213,7 +1214,7 @@ class TeamManagementService:
             self.db.flush()
             return existing, "reactivated"
 
-        membership = EmailTeamMember(team_id=team_id, user_email=canonical, role=role, joined_at=utc_now(), invited_by=invited_by, grant_source=grant_source, is_active=True)
+        membership = EmailTeamMember(team_id=team_id, user_email=user_email, user_id=canonical, role=role, joined_at=utc_now(), invited_by=invited_by, grant_source=grant_source, is_active=True)
         self.db.add(membership)
         self.db.flush()
         return membership, "added"
@@ -1275,10 +1276,9 @@ class TeamManagementService:
 
         self._check_user_team_limit(user_email)
 
-        # Check if user is already a member. The lookup keys on the canonical
-        # user ID, the same value _upsert_membership stores.
-        canonical = resolve_canonical_user_id(user_email, self.db)
-        existing_membership = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team_id, EmailTeamMember.user_email == canonical).first()
+        # Check if user is already a member. The lookup keys on the e-mail,
+        # the same FK-valid value _upsert_membership stores in user_email.
+        existing_membership = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team_id, EmailTeamMember.user_email == user_email).first()
 
         if existing_membership and existing_membership.is_active:
             logger.warning("User %s is already a member of team %s", SecurityValidator.sanitize_log_message(user_email), SecurityValidator.sanitize_log_message(team_id))
@@ -2232,10 +2232,12 @@ class TeamManagementService:
                 raise ValueError(f"Team {team_id} not found or inactive")
             check_team_member_capacity(self.db, team)
 
-            # Add user to team. Resolve the canonical user ID once; the stored
-            # membership keys on it.
+            # Add user to team. Dual-write: user_email keeps the FK-valid
+            # e-mail; user_id carries the canonical ID.
             canonical = resolve_canonical_user_id(join_request.user_email, self.db)
-            member = EmailTeamMember(team_id=team_id, user_email=canonical, role="member", invited_by=approved_by, joined_at=utc_now())  # New joiners are always members
+            member = EmailTeamMember(
+                team_id=team_id, user_email=join_request.user_email, user_id=canonical, role="member", invited_by=approved_by, joined_at=utc_now()
+            )  # New joiners are always members
 
             self.db.add(member)
             # Update join request status

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -30,6 +30,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload, Session
 
 # First-Party
+from mcpgateway.auth_context import resolve_canonical_user_id
 from mcpgateway.cache.admin_stats_cache import admin_stats_cache
 from mcpgateway.cache.auth_cache import auth_cache, get_auth_cache
 from mcpgateway.common.validators import SecurityValidator
@@ -1194,8 +1195,13 @@ class TeamManagementService:
             Tuple[EmailTeamMember, str]: The membership row, and the history action
             describing it ('added' for a new row, 'reactivated' for a revived one).
         """
+        # Resolve the canonical user ID once: the lookup and the stored row
+        # both key on it, so diverged users (user_id != email) never lose or
+        # duplicate membership rows.
+        canonical = resolve_canonical_user_id(user_email, self.db)
+
         if isinstance(existing, _Unset):
-            existing = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team_id, EmailTeamMember.user_email == user_email).first()
+            existing = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team_id, EmailTeamMember.user_email == canonical).first()
 
         if existing:
             existing.is_active = True  # pylint: disable=attribute-defined-outside-init
@@ -1207,7 +1213,7 @@ class TeamManagementService:
             self.db.flush()
             return existing, "reactivated"
 
-        membership = EmailTeamMember(team_id=team_id, user_email=user_email, role=role, joined_at=utc_now(), invited_by=invited_by, grant_source=grant_source, is_active=True)
+        membership = EmailTeamMember(team_id=team_id, user_email=canonical, role=role, joined_at=utc_now(), invited_by=invited_by, grant_source=grant_source, is_active=True)
         self.db.add(membership)
         self.db.flush()
         return membership, "added"
@@ -1269,8 +1275,10 @@ class TeamManagementService:
 
         self._check_user_team_limit(user_email)
 
-        # Check if user is already a member
-        existing_membership = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team_id, EmailTeamMember.user_email == user_email).first()
+        # Check if user is already a member. The lookup keys on the canonical
+        # user ID, the same value _upsert_membership stores.
+        canonical = resolve_canonical_user_id(user_email, self.db)
+        existing_membership = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team_id, EmailTeamMember.user_email == canonical).first()
 
         if existing_membership and existing_membership.is_active:
             logger.warning("User %s is already a member of team %s", SecurityValidator.sanitize_log_message(user_email), SecurityValidator.sanitize_log_message(team_id))
@@ -2224,8 +2232,10 @@ class TeamManagementService:
                 raise ValueError(f"Team {team_id} not found or inactive")
             check_team_member_capacity(self.db, team)
 
-            # Add user to team
-            member = EmailTeamMember(team_id=team_id, user_email=join_request.user_email, role="member", invited_by=approved_by, joined_at=utc_now())  # New joiners are always members
+            # Add user to team. Resolve the canonical user ID once; the stored
+            # membership keys on it.
+            canonical = resolve_canonical_user_id(join_request.user_email, self.db)
+            member = EmailTeamMember(team_id=team_id, user_email=canonical, role="member", invited_by=approved_by, joined_at=utc_now())  # New joiners are always members
 
             self.db.add(member)
             # Update join request status

--- a/tests/unit/mcpgateway/services/test_canonical_writer_fk_integrity.py
+++ b/tests/unit/mcpgateway/services/test_canonical_writer_fk_integrity.py
@@ -16,6 +16,8 @@ on the stack's default non-enforcing test database.
 
 # Standard
 import uuid
+from contextlib import contextmanager
+from unittest.mock import patch
 
 # Third-Party
 import pytest
@@ -25,6 +27,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 # First-Party
+from mcpgateway.auth import resolve_session_teams
 from mcpgateway.db import Base, EmailTeam, EmailTeamMember, EmailUser, Role, UserRole
 from mcpgateway.services.role_service import RoleService
 from mcpgateway.services.team_management_service import TeamManagementService
@@ -55,6 +58,24 @@ def _seed_diverged_user(db):
     """Insert a user whose canonical user_id diverges from their e-mail."""
     db.add(EmailUser(email=DIVERGED_EMAIL, user_id=DIVERGED_USER_ID, password_hash=None, is_active=True))
     db.commit()
+
+
+@contextmanager
+def _pinned_session(db):
+    """Yield the fixture session where auth.py would open a fresh one."""
+    yield db
+
+
+def _seed_team_with_member(db, *, email, user_id):
+    """Insert a non-personal team and an active membership row for the user."""
+    suffix = uuid.uuid4().hex[:8]
+    team = EmailTeam(name=f"Team {suffix}", slug=f"team-{suffix}", created_by=email, is_personal=False, visibility="private", is_active=True)
+    db.add(team)
+    db.commit()
+    db.refresh(team)
+    db.add(EmailTeamMember(team_id=team.id, user_email=email, user_id=user_id, role="member", invited_by=email, is_active=True))
+    db.commit()
+    return team
 
 
 def test_fk_fixture_enforces_foreign_keys(fk_db):
@@ -105,3 +126,45 @@ async def test_membership_writer_keeps_fk_valid_and_stores_canonical_id(fk_db):
     row = fk_db.execute(select(EmailTeamMember)).scalar_one()
     assert row.user_email == DIVERGED_EMAIL  # FK-valid (F7 contract)
     assert row.user_id == DIVERGED_USER_ID  # canonical preserved (#5884 intent)
+
+
+@pytest.mark.asyncio
+async def test_session_teams_resolve_for_diverged_user(fk_db):
+    """resolve_session_teams matches a dual-written membership row via either identity key."""
+    _seed_diverged_user(fk_db)
+    team = _seed_team_with_member(fk_db, email=DIVERGED_EMAIL, user_id=DIVERGED_USER_ID)
+
+    payload = {"sub": DIVERGED_USER_ID, "token_use": "session"}
+    with patch("mcpgateway.auth.fresh_db_session", lambda: _pinned_session(fk_db)):
+        teams = await resolve_session_teams(payload, DIVERGED_EMAIL, {"is_admin": False})
+
+    assert teams == [team.id]
+
+
+@pytest.mark.asyncio
+async def test_session_teams_resolve_for_legacy_user(fk_db):
+    """Legacy user (user_id == e-mail in both columns) resolves unchanged."""
+    legacy_email = "legacy@example.com"
+    fk_db.add(EmailUser(email=legacy_email, user_id=legacy_email, password_hash=None, is_active=True))
+    fk_db.commit()
+    team = _seed_team_with_member(fk_db, email=legacy_email, user_id=legacy_email)
+
+    payload = {"sub": legacy_email, "token_use": "session"}
+    with patch("mcpgateway.auth.fresh_db_session", lambda: _pinned_session(fk_db)):
+        teams = await resolve_session_teams(payload, legacy_email, {"is_admin": False})
+
+    assert teams == [team.id]
+
+
+@pytest.mark.asyncio
+async def test_session_teams_admin_bypass_unchanged(fk_db):
+    """Admin bypass (is_admin resolved from DB) still returns None."""
+    admin_email = "admin@example.com"
+    fk_db.add(EmailUser(email=admin_email, user_id=admin_email, password_hash=None, is_active=True, is_admin=True))
+    fk_db.commit()
+
+    payload = {"sub": admin_email, "token_use": "session"}
+    with patch("mcpgateway.auth.fresh_db_session", lambda: _pinned_session(fk_db)):
+        teams = await resolve_session_teams(payload, admin_email, {})  # no is_admin key -> DB lookup
+
+    assert teams is None

--- a/tests/unit/mcpgateway/services/test_canonical_writer_fk_integrity.py
+++ b/tests/unit/mcpgateway/services/test_canonical_writer_fk_integrity.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_canonical_writer_fk_integrity.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+FK-integrity contract for the canonical writers (#5893, F7).
+
+``UserRole.user_email`` and ``EmailTeamMember.user_email`` hold foreign keys
+to ``email_users.email``. When an SSO-provisioned user's canonical
+``EmailUser.user_id`` diverges from their e-mail, the writer sites must keep
+the FK columns e-mail-valued (always FK-valid) and store the canonical ID in
+the additive ``user_id`` columns. These tests run on SQLite with
+``PRAGMA foreign_keys=ON`` so a violation cannot slip through the way it does
+on the stack's default non-enforcing test database.
+"""
+
+# Standard
+import uuid
+
+# Third-Party
+import pytest
+from sqlalchemy import create_engine, event, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.db import Base, EmailTeam, EmailTeamMember, EmailUser, Role, UserRole
+from mcpgateway.services.role_service import RoleService
+from mcpgateway.services.team_management_service import TeamManagementService
+
+DIVERGED_EMAIL = "alice@example.com"
+DIVERGED_USER_ID = "entra-sub-123"
+
+
+@pytest.fixture
+def fk_db():
+    """In-memory SQLite session with FK enforcement enabled."""
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_conn, _):
+        dbapi_conn.execute("PRAGMA foreign_keys=ON")
+
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def _seed_diverged_user(db):
+    """Insert a user whose canonical user_id diverges from their e-mail."""
+    db.add(EmailUser(email=DIVERGED_EMAIL, user_id=DIVERGED_USER_ID, password_hash=None, is_active=True))
+    db.commit()
+
+
+def test_fk_fixture_enforces_foreign_keys(fk_db):
+    """Guard: the fixture must actually reject an FK-violating UserRole row.
+
+    Without enforcement the dual-write assertions below could pass vacuously
+    against a schema that never checks the FK.
+    """
+    _seed_diverged_user(fk_db)
+    fk_db.add(Role(id=str(uuid.uuid4()), name=f"guard-role-{uuid.uuid4().hex[:8]}", scope="global", permissions=[], created_by=DIVERGED_EMAIL, is_system_role=False, is_active=True))
+    fk_db.commit()
+    role = fk_db.query(Role).one()
+    fk_db.add(UserRole(user_email="ghost@example.com", role_id=role.id, scope="global", granted_by=DIVERGED_EMAIL))
+    with pytest.raises(IntegrityError):
+        fk_db.flush()
+    fk_db.rollback()
+
+
+@pytest.mark.asyncio
+async def test_role_writer_keeps_fk_valid_and_stores_canonical_id(fk_db):
+    """assign_role_to_user: user_email stays the FK-valid e-mail; user_id holds the canonical ID."""
+    _seed_diverged_user(fk_db)
+    role = Role(id=str(uuid.uuid4()), name=f"developer-{uuid.uuid4().hex[:8]}", scope="global", permissions=["tools.read"], created_by=DIVERGED_EMAIL, is_system_role=False, is_active=True)
+    fk_db.add(role)
+    fk_db.commit()
+
+    svc = RoleService(db=fk_db)
+    await svc.assign_role_to_user(user_email=DIVERGED_EMAIL, role_id=role.id, scope="global", scope_id=None, granted_by=DIVERGED_EMAIL)
+
+    row = fk_db.execute(select(UserRole)).scalar_one()
+    assert row.user_email == DIVERGED_EMAIL  # FK-valid (F7 contract)
+    assert row.user_id == DIVERGED_USER_ID  # canonical preserved (#5884 intent)
+
+
+@pytest.mark.asyncio
+async def test_membership_writer_keeps_fk_valid_and_stores_canonical_id(fk_db):
+    """add_member_to_team: user_email stays the FK-valid e-mail; user_id holds the canonical ID."""
+    _seed_diverged_user(fk_db)
+    suffix = uuid.uuid4().hex[:8]
+    team = EmailTeam(name=f"Team {suffix}", slug=f"team-{suffix}", created_by=DIVERGED_EMAIL, is_personal=False, visibility="private", is_active=True)
+    fk_db.add(team)
+    fk_db.commit()
+    fk_db.refresh(team)
+
+    svc = TeamManagementService(fk_db)
+    await svc.add_member_to_team(team_id=team.id, user_email=DIVERGED_EMAIL, role="member", invited_by=DIVERGED_EMAIL)
+
+    row = fk_db.execute(select(EmailTeamMember)).scalar_one()
+    assert row.user_email == DIVERGED_EMAIL  # FK-valid (F7 contract)
+    assert row.user_id == DIVERGED_USER_ID  # canonical preserved (#5884 intent)

--- a/tests/unit/mcpgateway/services/test_email_auth_service.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_service.py
@@ -614,3 +614,58 @@ async def test_ensure_user_exists_normalizes_email(email_auth_service):
         assert user == mock_user
         # Should be called with the normalized email
         mock_get.assert_called_once_with("user@example.com")
+
+
+# ---------- user_id Provisioning Tests (#5893) ----------
+
+
+@pytest.mark.asyncio
+async def test_create_user_defaults_user_id_to_email(email_auth_service, mock_db):
+    """create_user stores user_id equal to the normalized e-mail by default."""
+    with patch.object(email_auth_service, "get_user_by_email", return_value=None):
+        with patch("mcpgateway.services.email_auth_service.settings") as mock_settings:
+            mock_settings.password_min_length = 8
+
+            user = await email_auth_service.create_user(
+                email="dev@example.com",
+                password="",
+                skip_password_validation=True,
+                skip_onboarding=True,
+            )
+
+            assert user.user_id == "dev@example.com"
+
+
+@pytest.mark.asyncio
+async def test_create_user_stores_explicit_user_id_verbatim(email_auth_service, mock_db):
+    """create_user stores an explicit user_id unchanged (diverged case)."""
+    with patch.object(email_auth_service, "get_user_by_email", return_value=None):
+        with patch("mcpgateway.services.email_auth_service.settings") as mock_settings:
+            mock_settings.password_min_length = 8
+
+            user = await email_auth_service.create_user(
+                email="dev@example.com",
+                password="",
+                user_id="idp-123",
+                skip_password_validation=True,
+                skip_onboarding=True,
+            )
+
+            assert user.user_id == "idp-123"
+
+
+@pytest.mark.asyncio
+async def test_create_platform_admin_user_id_equals_platform_admin_email(email_auth_service, mock_db):
+    """create_platform_admin yields user_id equal to settings.platform_admin_email."""
+    with patch.object(email_auth_service, "get_user_by_email", return_value=None):
+        with patch("mcpgateway.services.email_auth_service.settings") as mock_settings:
+            mock_settings.password_min_length = 8
+            mock_settings.auto_create_personal_teams = False
+            mock_settings.platform_admin_email = "admin@example.com"
+
+            user = await email_auth_service.create_platform_admin(
+                email=mock_settings.platform_admin_email,
+                password="bootstrap-pass",  # pragma: allowlist secret
+            )
+
+            assert user.user_id == mock_settings.platform_admin_email

--- a/tests/unit/mcpgateway/services/test_personal_team_service.py
+++ b/tests/unit/mcpgateway/services/test_personal_team_service.py
@@ -134,7 +134,9 @@ class TestPersonalTeamService:
             assert mock_db.flush.call_count == 2
 
             # Verify membership creation
-            MockMember.assert_called_once_with(team_id="new-team-id", user_email="testuser@example.com", role="owner", joined_at=mock_utc_now.return_value, is_active=True)
+            MockMember.assert_called_once_with(
+                team_id="new-team-id", user_email="testuser@example.com", user_id="testuser@example.com", role="owner", joined_at=mock_utc_now.return_value, is_active=True
+            )
 
             # Verify commit
             mock_db.commit.assert_called_once()
@@ -489,12 +491,12 @@ class TestPersonalTeamService:
             mock_db.rollback.assert_called_once()
 
 
-class TestPersonalTeamCanonicalKeying:
-    """Writer re-keying: create_personal_team stores the canonical user_id (#5893)."""
+class TestPersonalTeamDualWrite:
+    """Dual-write: create_personal_team stores the e-mail in user_email and the canonical user_id alongside (#5893)."""
 
     @pytest.mark.asyncio
     async def test_create_personal_team_stores_canonical_user_id(self, test_db):
-        """The owner membership row is keyed by the diverged user's user_id."""
+        """The owner membership row keeps the diverged user's e-mail in user_email and stores user_id."""
         # First-Party
         from mcpgateway.db import EmailTeamMember
         from mcpgateway.services.email_auth_service import EmailAuthService
@@ -508,5 +510,6 @@ class TestPersonalTeamCanonicalKeying:
         team = await service.create_personal_team(user)
 
         membership = test_db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team.id).one()
-        assert membership.user_email == "idp-123"
+        assert membership.user_email == email
+        assert membership.user_id == "idp-123"
         assert membership.role == "owner"

--- a/tests/unit/mcpgateway/services/test_personal_team_service.py
+++ b/tests/unit/mcpgateway/services/test_personal_team_service.py
@@ -8,6 +8,7 @@ Comprehensive tests for Personal Team Service functionality.
 
 # Standard
 from unittest.mock import AsyncMock, MagicMock, patch
+import uuid
 
 # Third-Party
 import pytest
@@ -486,3 +487,26 @@ class TestPersonalTeamService:
                 await service.create_personal_team(mock_user)
 
             mock_db.rollback.assert_called_once()
+
+
+class TestPersonalTeamCanonicalKeying:
+    """Writer re-keying: create_personal_team stores the canonical user_id (#5893)."""
+
+    @pytest.mark.asyncio
+    async def test_create_personal_team_stores_canonical_user_id(self, test_db):
+        """The owner membership row is keyed by the diverged user's user_id."""
+        # First-Party
+        from mcpgateway.db import EmailTeamMember
+        from mcpgateway.services.email_auth_service import EmailAuthService
+
+        suffix = uuid.uuid4().hex[:8]
+        email = f"owner-{suffix}@example.com"
+        auth_service = EmailAuthService(test_db)
+        user = await auth_service.create_user(email=email, password="", user_id="idp-123", skip_password_validation=True, skip_onboarding=True)
+
+        service = PersonalTeamService(test_db)
+        team = await service.create_personal_team(user)
+
+        membership = test_db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team.id).one()
+        assert membership.user_email == "idp-123"
+        assert membership.role == "owner"

--- a/tests/unit/mcpgateway/services/test_role_service.py
+++ b/tests/unit/mcpgateway/services/test_role_service.py
@@ -593,7 +593,14 @@ class TestAssignRoleToUser:
                     )
 
                     MockUserRole.assert_called_once_with(
-                        user_email="user@example.com", role_id="role-123", scope="team", scope_id="team-789", granted_by="admin@example.com", expires_at=expires_at, grant_source=None
+                        user_email="user@example.com",
+                        user_id="user@example.com",
+                        role_id="role-123",
+                        scope="team",
+                        scope_id="team-789",
+                        granted_by="admin@example.com",
+                        expires_at=expires_at,
+                        grant_source=None,
                     )
 
     @pytest.mark.asyncio
@@ -1041,8 +1048,8 @@ class TestComplexScenarios:
                     mock_db.add.assert_called_once()
 
 
-class TestAssignRoleCanonicalKeying:
-    """Writer re-keying: assign_role_to_user stores the canonical user_id (#5893)."""
+class TestAssignRoleDualWrite:
+    """Dual-write: assign_role_to_user stores the e-mail in user_email and the canonical user_id alongside (#5893)."""
 
     @staticmethod
     async def _create_diverged_user(db, email: str, user_id: str):
@@ -1055,7 +1062,7 @@ class TestAssignRoleCanonicalKeying:
 
     @pytest.mark.asyncio
     async def test_assign_role_stores_canonical_user_id(self, test_db):
-        """A diverged user's role assignment is keyed by user_id, and a second call dedupes against that row."""
+        """A diverged user's role assignment keeps the e-mail in user_email, stores user_id, and a second call dedupes against that row."""
         suffix = uuid.uuid4().hex[:8]
         email = f"dev-{suffix}@example.com"
         await self._create_diverged_user(test_db, email, "idp-123")
@@ -1075,9 +1082,10 @@ class TestAssignRoleCanonicalKeying:
         service = RoleService(test_db)
         assignment = await service.assign_role_to_user(user_email=email, role_id=role.id, scope="global", scope_id=None, granted_by=email)
 
-        assert assignment.user_email == "idp-123"
+        assert assignment.user_email == email
+        assert assignment.user_id == "idp-123"
 
-        # Second call dedupes against the canonical-keyed row: no duplicate insert.
+        # Second call dedupes against the e-mail-keyed row: no duplicate insert.
         with pytest.raises(ValueError, match="already has this role"):
             await service.assign_role_to_user(user_email=email, role_id=role.id, scope="global", scope_id=None, granted_by=email)
 

--- a/tests/unit/mcpgateway/services/test_role_service.py
+++ b/tests/unit/mcpgateway/services/test_role_service.py
@@ -1039,3 +1039,46 @@ class TestComplexScenarios:
 
                     assert result == new_assignment
                     mock_db.add.assert_called_once()
+
+
+class TestAssignRoleCanonicalKeying:
+    """Writer re-keying: assign_role_to_user stores the canonical user_id (#5893)."""
+
+    @staticmethod
+    async def _create_diverged_user(db, email: str, user_id: str):
+        """Create a diverged user (user_id != email) through the writer path."""
+        # First-Party
+        from mcpgateway.services.email_auth_service import EmailAuthService
+
+        auth_service = EmailAuthService(db)
+        return await auth_service.create_user(email=email, password="", user_id=user_id, skip_password_validation=True, skip_onboarding=True)
+
+    @pytest.mark.asyncio
+    async def test_assign_role_stores_canonical_user_id(self, test_db):
+        """A diverged user's role assignment is keyed by user_id, and a second call dedupes against that row."""
+        suffix = uuid.uuid4().hex[:8]
+        email = f"dev-{suffix}@example.com"
+        await self._create_diverged_user(test_db, email, "idp-123")
+
+        role = Role(
+            id=str(uuid.uuid4()),
+            name=f"canonical-role-{suffix}",
+            scope="global",
+            permissions=["tools.read"],
+            created_by=email,
+            is_system_role=False,
+            is_active=True,
+        )
+        test_db.add(role)
+        test_db.commit()
+
+        service = RoleService(test_db)
+        assignment = await service.assign_role_to_user(user_email=email, role_id=role.id, scope="global", scope_id=None, granted_by=email)
+
+        assert assignment.user_email == "idp-123"
+
+        # Second call dedupes against the canonical-keyed row: no duplicate insert.
+        with pytest.raises(ValueError, match="already has this role"):
+            await service.assign_role_to_user(user_email=email, role_id=role.id, scope="global", scope_id=None, granted_by=email)
+
+        assert test_db.query(UserRole).filter(UserRole.role_id == role.id).count() == 1

--- a/tests/unit/mcpgateway/services/test_sso_service.py
+++ b/tests/unit/mcpgateway/services/test_sso_service.py
@@ -4689,7 +4689,7 @@ class TestAuthenticateOrCreateUser:
     @pytest.mark.asyncio
     async def test_new_user_stores_sso_subject_as_user_id(self, sso_service, mock_db):
         """Provisioning with sub != email stores the IdP subject as user_id (#5893)."""
-        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        sso_service.auth_service._fetch_user_from_db = MagicMock(return_value=None)
         new_user = SimpleNamespace(
             email="a@b.c",
             full_name="New User",

--- a/tests/unit/mcpgateway/services/test_sso_service.py
+++ b/tests/unit/mcpgateway/services/test_sso_service.py
@@ -4686,6 +4686,99 @@ class TestAuthenticateOrCreateUser:
         sso_service._map_groups_to_roles.assert_called_once()
         sso_service._sync_user_roles.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_new_user_stores_sso_subject_as_user_id(self, sso_service, mock_db):
+        """Provisioning with sub != email stores the IdP subject as user_id (#5893)."""
+        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=None)
+        new_user = SimpleNamespace(
+            email="a@b.c",
+            full_name="New User",
+            auth_provider="github",
+            is_admin=False,
+            admin_origin=None,
+        )
+        sso_service.auth_service.create_user = AsyncMock(return_value=new_user)
+        sso_service.get_provider = lambda _id: _make_provider()
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings, patch("mcpgateway.services.sso_service.create_jwt_token", new_callable=AsyncMock) as mock_jwt:
+            mock_settings.sso_auto_admin_domains = []
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_require_admin_approval = False
+            mock_jwt.return_value = "new-jwt"
+            result = await sso_service.authenticate_or_create_user(
+                {
+                    "email": "a@b.c",
+                    "full_name": "New User",
+                    "provider": "github",
+                    "provider_id": "idp-123",
+                    "email_verified": True,
+                }
+            )
+
+        assert result == "new-jwt"
+        create_kwargs = sso_service.auth_service.create_user.call_args[1]
+        assert create_kwargs["user_id"] == "idp-123"
+
+    @pytest.mark.asyncio
+    async def test_existing_user_user_id_not_rewritten(self, sso_service, mock_db):
+        """The existing-user branch never rewrites user.user_id (#5893)."""
+        existing_user = SimpleNamespace(
+            email="user@test.com",
+            full_name="Name",
+            auth_provider="github",
+            email_verified=True,
+            last_login=None,
+            is_admin=False,
+            admin_origin=None,
+            user_id="orig-id",
+        )
+        sso_service.auth_service.get_user_by_email = AsyncMock(return_value=existing_user)
+        sso_service.get_provider = lambda _id: _make_provider()
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings, patch("mcpgateway.services.sso_service.create_jwt_token", new_callable=AsyncMock) as mock_jwt:
+            mock_settings.sso_auto_admin_domains = []
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_entra_sync_roles_on_login = False
+            mock_jwt.return_value = "jwt"
+            result = await sso_service.authenticate_or_create_user(
+                {
+                    "email": "user@test.com",
+                    "full_name": "Name",
+                    "provider": "github",
+                    "provider_id": "idp-999",
+                    "email_verified": True,
+                }
+            )
+
+        assert result == "jwt"
+        assert existing_user.user_id == "orig-id"
+
+    @pytest.mark.asyncio
+    async def test_missing_user_id_claim_fails_closed(self, sso_service):
+        """A payload flagged user_id_claim_missing never authenticates (#5893)."""
+        sso_service.auth_service.get_user_by_email = AsyncMock()
+        sso_service.auth_service.create_user = AsyncMock()
+        sso_service.get_provider = lambda _id: _make_provider(id="custom_oidc")
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings, patch("mcpgateway.services.sso_service.create_jwt_token", new_callable=AsyncMock) as mock_jwt:
+            mock_jwt.return_value = "jwt"
+            result = await sso_service.authenticate_or_create_user(
+                {
+                    "email": "a@b.c",
+                    "provider": "custom_oidc",
+                    "email_verified": True,
+                    "user_id_claim_missing": "employee_id",
+                }
+            )
+
+        assert result is None
+        mock_jwt.assert_not_called()
+        sso_service.auth_service.get_user_by_email.assert_not_called()
+        sso_service.auth_service.create_user.assert_not_called()
 
 # ---------------------------------------------------------------------------
 # _apply_team_mapping tests
@@ -5279,3 +5372,99 @@ class TestADFSProvider:
 
         assert result is not None
         assert result["email"] == "user@adfs.com"
+
+
+# ---------------------------------------------------------------------------
+# SSO provisioning end-to-end canonical keying (#5893)
+# ---------------------------------------------------------------------------
+
+
+class TestSsoProvisioningCanonicalKeying:
+    """SSO provisioning with role sync and team mapping writes rows under the SSO subject."""
+
+    @pytest.mark.asyncio
+    async def test_provisioning_writes_roles_and_memberships_under_subject(self, test_db):
+        """sub != email: UserRole and EmailTeamMember rows are keyed by the SSO subject."""
+        # Standard
+        import uuid
+
+        # First-Party
+        from mcpgateway.db import EmailTeam, EmailTeamMember, EmailUser, Role, UserRole
+
+        suffix = uuid.uuid4().hex[:8]
+        email = f"sso-div-{suffix}@example.com"
+        role_name = f"developer-{suffix}"
+
+        service = SSOService(test_db)
+
+        # Admin principal for FK targets, created through the writer path.
+        admin = await service.auth_service.create_user(
+            email=f"admin-{suffix}@example.com",
+            password="",
+            is_admin=True,
+            skip_password_validation=True,
+            skip_onboarding=True,
+        )
+
+        role = Role(
+            id=str(uuid.uuid4()),
+            name=role_name,
+            scope="global",
+            permissions=["tools.read"],
+            created_by=admin.email,
+            is_system_role=False,
+            is_active=True,
+        )
+        team = EmailTeam(
+            name=f"Team {suffix}",
+            slug=f"team-{suffix}",
+            created_by=admin.email,
+            is_personal=False,
+            visibility="private",
+            is_active=True,
+        )
+        test_db.add_all([role, team])
+        test_db.commit()
+        test_db.refresh(role)
+        test_db.refresh(team)
+
+        provider = _make_provider(
+            id="custom_oidc",
+            provider_metadata={"sync_roles": True, "role_mappings": {"idp-devs": role_name}},
+            team_mapping={"idp-devs": {"team_id": team.id, "role": "member"}},
+        )
+        service.get_provider = lambda _id: provider
+
+        with (
+            patch("mcpgateway.services.sso_service.settings") as mock_settings,
+            patch("mcpgateway.services.sso_service.create_jwt_token", new_callable=AsyncMock) as mock_jwt,
+            patch("mcpgateway.services.email_auth_service.EmailAuthService.validate_password", return_value=True),
+        ):
+            mock_settings.sso_auto_admin_domains = []
+            mock_settings.sso_github_admin_orgs = []
+            mock_settings.sso_google_admin_domains = []
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_require_admin_approval = False
+            mock_jwt.return_value = "jwt"
+
+            token = await service.authenticate_or_create_user(
+                {
+                    "email": email,
+                    "full_name": "SSO Diverged",
+                    "provider": "custom_oidc",
+                    "provider_id": "idp-123",
+                    "email_verified": True,
+                    "groups": ["idp-devs"],
+                }
+            )
+
+        assert token == "jwt"
+
+        user = test_db.query(EmailUser).filter(EmailUser.email == email).one()
+        assert user.user_id == "idp-123"
+
+        role_row = test_db.query(UserRole).filter(UserRole.role_id == role.id).one()
+        assert role_row.user_email == "idp-123"
+
+        member_row = test_db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team.id).one()
+        assert member_row.user_email == "idp-123"

--- a/tests/unit/mcpgateway/services/test_sso_service.py
+++ b/tests/unit/mcpgateway/services/test_sso_service.py
@@ -5379,12 +5379,12 @@ class TestADFSProvider:
 # ---------------------------------------------------------------------------
 
 
-class TestSsoProvisioningCanonicalKeying:
-    """SSO provisioning with role sync and team mapping writes rows under the SSO subject."""
+class TestSsoProvisioningDualWrite:
+    """SSO provisioning with role sync and team mapping dual-writes e-mail and SSO subject."""
 
     @pytest.mark.asyncio
     async def test_provisioning_writes_roles_and_memberships_under_subject(self, test_db):
-        """sub != email: UserRole and EmailTeamMember rows are keyed by the SSO subject."""
+        """sub != email: UserRole and EmailTeamMember rows keep the e-mail in user_email and store the SSO subject in user_id."""
         # Standard
         import uuid
 
@@ -5464,7 +5464,9 @@ class TestSsoProvisioningCanonicalKeying:
         assert user.user_id == "idp-123"
 
         role_row = test_db.query(UserRole).filter(UserRole.role_id == role.id).one()
-        assert role_row.user_email == "idp-123"
+        assert role_row.user_email == email
+        assert role_row.user_id == "idp-123"
 
         member_row = test_db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team.id).one()
-        assert member_row.user_email == "idp-123"
+        assert member_row.user_email == email
+        assert member_row.user_id == "idp-123"

--- a/tests/unit/mcpgateway/services/test_sso_user_normalization.py
+++ b/tests/unit/mcpgateway/services/test_sso_user_normalization.py
@@ -8,6 +8,7 @@ Tests edge cases where provider claims might be missing or incomplete.
 """
 
 # Standard
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 # Third-Party
@@ -1335,6 +1336,91 @@ class TestGenericOIDCNormalization:
         normalized = sso_service._normalize_user_info(provider, user_data)
 
         assert sorted(normalized["groups"]) == ["Engineering", "admin", "viewer"]
+
+
+class TestUserIdClaimNormalization:
+    """Per-provider user_id_claim setting selects the IdP claim that becomes user_id (#5893)."""
+
+    @staticmethod
+    def _provider(metadata):
+        """Build a generic OIDC provider carrying the given provider_metadata."""
+        return SSOProvider(
+            id="custom_oidc",
+            name="custom_oidc",
+            display_name="Custom OIDC",
+            provider_type="oidc",
+            provider_metadata=metadata,
+        )
+
+    def test_default_user_id_claim_is_sub(self, sso_service):
+        """Without a user_id_claim setting the sub claim becomes provider_id."""
+        provider = self._provider(None)
+
+        normalized = sso_service._normalize_user_info(provider, {"sub": "idp-sub-1", "email": "a@b.c"})
+
+        assert normalized["provider_id"] == "idp-sub-1"
+        assert "user_id_claim_missing" not in normalized
+
+    def test_configured_user_id_claim_extracts_provider_id(self, sso_service):
+        """A configured user_id_claim overrides sub as the provider_id source."""
+        provider = self._provider({"user_id_claim": "employee_id"})
+
+        normalized = sso_service._normalize_user_info(provider, {"sub": "idp-sub-1", "employee_id": "emp-42", "email": "a@b.c"})
+
+        assert normalized["provider_id"] == "emp-42"
+        assert "user_id_claim_missing" not in normalized
+
+    def test_missing_configured_claim_marks_login_failed(self, sso_service):
+        """A configured claim absent from the token marks the login as failed."""
+        provider = self._provider({"user_id_claim": "employee_id"})
+
+        normalized = sso_service._normalize_user_info(provider, {"sub": "idp-sub-1", "email": "a@b.c"})
+
+        assert normalized["user_id_claim_missing"] == "employee_id"
+
+
+class TestUserIdClaimSaveValidation:
+    """The provider save path rejects invalid user_id_claim settings (#5893)."""
+
+    @staticmethod
+    def _provider_data(user_id_claim):
+        """Build create_provider payload carrying the given user_id_claim setting."""
+        return {
+            "id": "custom_oidc",
+            "name": "custom_oidc",
+            "display_name": "Custom OIDC",
+            "provider_type": "oidc",
+            "client_id": "cid",
+            "client_secret": "sec",  # pragma: allowlist secret
+            "provider_metadata": {"user_id_claim": user_id_claim},
+        }
+
+    @pytest.mark.asyncio
+    async def test_create_provider_rejects_empty_user_id_claim(self, sso_service):
+        """An empty user_id_claim is rejected with a clear error."""
+        with pytest.raises(ValueError, match="user_id_claim"):
+            await sso_service.create_provider(self._provider_data(""))
+
+    @pytest.mark.asyncio
+    async def test_create_provider_rejects_whitespace_user_id_claim(self, sso_service):
+        """A whitespace-only user_id_claim is rejected with a clear error."""
+        with pytest.raises(ValueError, match="user_id_claim"):
+            await sso_service.create_provider(self._provider_data("   "))
+
+    @pytest.mark.asyncio
+    async def test_create_provider_rejects_non_string_user_id_claim(self, sso_service):
+        """A non-string user_id_claim is rejected with a clear error."""
+        with pytest.raises(ValueError, match="user_id_claim"):
+            await sso_service.create_provider(self._provider_data(123))
+
+    @pytest.mark.asyncio
+    async def test_update_provider_rejects_invalid_user_id_claim(self, sso_service):
+        """update_provider applies the same user_id_claim validation."""
+        existing = SimpleNamespace(id="custom_oidc", name="custom_oidc", client_id="cid", is_enabled=True)
+        sso_service.get_provider = lambda _id: existing
+
+        with pytest.raises(ValueError, match="user_id_claim"):
+            await sso_service.update_provider("custom_oidc", {"provider_metadata": {"user_id_claim": ""}})
 
 
 if __name__ == "__main__":

--- a/tests/unit/mcpgateway/services/test_team_invitation_service.py
+++ b/tests/unit/mcpgateway/services/test_team_invitation_service.py
@@ -8,7 +8,7 @@ Comprehensive tests for Team Invitation Service functionality.
 
 # Standard
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
@@ -1278,3 +1278,53 @@ class TestTeamInvitationService:
         assert len(results) == len(invitations)
         assert results[2].status == EmailDeliveryStatus.FAILED
         assert results[2].warning == "Invitation created, but the email could not be delivered."
+
+
+class TestAcceptInvitationCanonicalKeying:
+    """Writer re-keying: accept_invitation stores the canonical user_id (#5893)."""
+
+    @pytest.mark.asyncio
+    async def test_accept_invitation_stores_canonical_user_id(self, test_db):
+        """The membership row created on invitation acceptance is keyed by user_id."""
+        # Standard
+        import uuid
+
+        # First-Party
+        from mcpgateway.services.email_auth_service import EmailAuthService
+
+        suffix = uuid.uuid4().hex[:8]
+        email = f"invitee-{suffix}@example.com"
+        auth_service = EmailAuthService(test_db)
+        await auth_service.create_user(email=email, password="", user_id="idp-123", skip_password_validation=True, skip_onboarding=True)
+
+        team = EmailTeam(
+            name=f"Team {suffix}",
+            slug=f"team-{suffix}",
+            created_by=email,
+            is_personal=False,
+            visibility="private",
+            is_active=True,
+        )
+        test_db.add(team)
+        test_db.commit()
+        test_db.refresh(team)
+
+        service = TeamInvitationService(test_db)
+        invitation = EmailTeamInvitation(
+            team_id=team.id,
+            email=email,
+            role="member",
+            invited_by=email,
+            invited_at=datetime.now(timezone.utc),
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+            token=service._generate_invitation_token(),
+            is_active=True,
+        )
+        test_db.add(invitation)
+        test_db.commit()
+
+        member = await service.accept_invitation(invitation.token)
+
+        assert member.user_email == "idp-123"
+        stored = test_db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team.id).one()
+        assert stored.user_email == "idp-123"

--- a/tests/unit/mcpgateway/services/test_team_invitation_service.py
+++ b/tests/unit/mcpgateway/services/test_team_invitation_service.py
@@ -1280,12 +1280,12 @@ class TestTeamInvitationService:
         assert results[2].warning == "Invitation created, but the email could not be delivered."
 
 
-class TestAcceptInvitationCanonicalKeying:
-    """Writer re-keying: accept_invitation stores the canonical user_id (#5893)."""
+class TestAcceptInvitationDualWrite:
+    """Dual-write: accept_invitation stores the e-mail in user_email and the canonical user_id alongside (#5893)."""
 
     @pytest.mark.asyncio
     async def test_accept_invitation_stores_canonical_user_id(self, test_db):
-        """The membership row created on invitation acceptance is keyed by user_id."""
+        """The membership row created on invitation acceptance keeps the e-mail in user_email and stores user_id."""
         # Standard
         import uuid
 
@@ -1325,6 +1325,8 @@ class TestAcceptInvitationCanonicalKeying:
 
         member = await service.accept_invitation(invitation.token)
 
-        assert member.user_email == "idp-123"
+        assert member.user_email == email
+        assert member.user_id == "idp-123"
         stored = test_db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team.id).one()
-        assert stored.user_email == "idp-123"
+        assert stored.user_email == email
+        assert stored.user_id == "idp-123"

--- a/tests/unit/mcpgateway/services/test_team_management_service.py
+++ b/tests/unit/mcpgateway/services/test_team_management_service.py
@@ -281,7 +281,11 @@ class TestTeamManagementService:
         mock_queries = [mock_existing_team, mock_existing_membership]
         mock_db.query.return_value.filter.return_value.first.side_effect = mock_queries
 
-        with patch("mcpgateway.services.team_management_service.slugify") as mock_slugify, patch("mcpgateway.services.team_management_service.utc_now") as mock_utc_now:
+        with (
+            patch("mcpgateway.services.team_management_service.slugify") as mock_slugify,
+            patch("mcpgateway.services.team_management_service.utc_now") as mock_utc_now,
+            patch("mcpgateway.services.team_management_service.resolve_canonical_user_id", side_effect=lambda email, _db: email),
+        ):
             mock_slugify.return_value = "test-team"
             mock_utc_now.return_value = "2023-01-01T00:00:00Z"
 
@@ -1641,6 +1645,7 @@ class TestTeamManagementService:
         mock_team.max_members = 100
 
         with (
+            patch("mcpgateway.services.team_management_service.resolve_canonical_user_id", side_effect=lambda email, _db: email),
             patch("mcpgateway.services.team_management_service.EmailTeamMember", return_value=member),
             patch.object(service, "get_team_by_id", new=AsyncMock(return_value=mock_team)),
             patch.object(service, "_log_team_member_action") as mock_log_action,
@@ -1698,6 +1703,7 @@ class TestTeamManagementService:
             mock_settings.max_members_per_team = 100
 
             with (
+                patch("mcpgateway.services.team_management_service.resolve_canonical_user_id", side_effect=lambda email, _db: email),
                 patch("mcpgateway.services.team_management_service.EmailTeamMember", return_value=member),
                 patch.object(service, "get_team_by_id", new=AsyncMock(return_value=mock_team)),
                 patch.object(service, "_log_team_member_action"),
@@ -1751,6 +1757,7 @@ class TestTeamManagementService:
             mock_settings.max_members_per_team = 100
 
             with (
+                patch("mcpgateway.services.team_management_service.resolve_canonical_user_id", side_effect=lambda email, _db: email),
                 patch("mcpgateway.services.team_management_service.EmailTeamMember", return_value=member),
                 patch.object(service, "get_team_by_id", new=AsyncMock(return_value=mock_team)),
                 patch.object(service, "_log_team_member_action"),
@@ -3017,3 +3024,72 @@ class TestTransientTeamFromDict:
         assert rebuilt.is_active is True
         assert rebuilt.created_at is not None
         assert rebuilt.updated_at is not None
+
+
+class TestMembershipCanonicalKeying:
+    """Writer re-keying: membership writers store the canonical user_id (#5893)."""
+
+    @staticmethod
+    async def _create_diverged_user(db, email: str, user_id: str):
+        """Create a diverged user (user_id != email) through the writer path."""
+        # First-Party
+        from mcpgateway.services.email_auth_service import EmailAuthService
+
+        auth_service = EmailAuthService(db)
+        return await auth_service.create_user(email=email, password="", user_id=user_id, skip_password_validation=True, skip_onboarding=True)
+
+    @staticmethod
+    def _create_team(db, suffix: str, created_by: str, visibility: str = "public"):
+        """Create a plain (non-personal) team row."""
+        team = EmailTeam(
+            name=f"Team {suffix}",
+            slug=f"team-{suffix}",
+            created_by=created_by,
+            is_personal=False,
+            visibility=visibility,
+            is_active=True,
+        )
+        db.add(team)
+        db.commit()
+        db.refresh(team)
+        return team
+
+    @pytest.mark.asyncio
+    async def test_add_member_stores_canonical_user_id(self, test_db):
+        """add_member_to_team keys the membership by user_id; re-adding reactivates the same row."""
+        suffix = uuid4().hex[:8]
+        email = f"dev-{suffix}@example.com"
+        await self._create_diverged_user(test_db, email, "idp-123")
+        team = self._create_team(test_db, suffix, created_by=email)
+
+        service = TeamManagementService(test_db)
+        member = await service.add_member_to_team(team_id=team.id, user_email=email, role="member", invited_by=email)
+
+        assert member.user_email == "idp-123"
+
+        # Deactivate the row, then re-add: the same canonical-keyed row is
+        # reactivated, no duplicate. (remove_member_from_team is a reader
+        # outside this story's five writer sites, so flip the flag directly.)
+        member.is_active = False
+        test_db.commit()
+
+        readded = await service.add_member_to_team(team_id=team.id, user_email=email, role="member", invited_by=email)
+        assert readded.id == member.id
+        assert readded.user_email == "idp-123"
+        assert test_db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team.id).count() == 1
+
+    @pytest.mark.asyncio
+    async def test_approve_join_request_stores_canonical_user_id(self, test_db):
+        """approve_join_request keys the new membership by user_id."""
+        suffix = uuid4().hex[:8]
+        email = f"joiner-{suffix}@example.com"
+        await self._create_diverged_user(test_db, email, "idp-123")
+        team = self._create_team(test_db, suffix, created_by=email, visibility="public")
+
+        service = TeamManagementService(test_db)
+        join_request = await service.create_join_request(team_id=team.id, user_email=email)
+        member = await service.approve_join_request(team_id=team.id, request_id=join_request.id, approved_by=email)
+
+        assert member.user_email == "idp-123"
+        stored = test_db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team.id).one()
+        assert stored.user_email == "idp-123"

--- a/tests/unit/mcpgateway/services/test_team_management_service.py
+++ b/tests/unit/mcpgateway/services/test_team_management_service.py
@@ -3026,8 +3026,8 @@ class TestTransientTeamFromDict:
         assert rebuilt.updated_at is not None
 
 
-class TestMembershipCanonicalKeying:
-    """Writer re-keying: membership writers store the canonical user_id (#5893)."""
+class TestMembershipDualWrite:
+    """Dual-write: membership writers store the e-mail in user_email and the canonical user_id alongside (#5893)."""
 
     @staticmethod
     async def _create_diverged_user(db, email: str, user_id: str):
@@ -3056,7 +3056,7 @@ class TestMembershipCanonicalKeying:
 
     @pytest.mark.asyncio
     async def test_add_member_stores_canonical_user_id(self, test_db):
-        """add_member_to_team keys the membership by user_id; re-adding reactivates the same row."""
+        """add_member_to_team keeps the e-mail in user_email, stores user_id; re-adding reactivates the same row."""
         suffix = uuid4().hex[:8]
         email = f"dev-{suffix}@example.com"
         await self._create_diverged_user(test_db, email, "idp-123")
@@ -3065,22 +3065,22 @@ class TestMembershipCanonicalKeying:
         service = TeamManagementService(test_db)
         member = await service.add_member_to_team(team_id=team.id, user_email=email, role="member", invited_by=email)
 
-        assert member.user_email == "idp-123"
+        assert member.user_email == email
+        assert member.user_id == "idp-123"
 
-        # Deactivate the row, then re-add: the same canonical-keyed row is
+        # Deactivate the row, then re-add: the same e-mail-keyed row is
         # reactivated, no duplicate. (remove_member_from_team is a reader
-        # outside this story's five writer sites, so flip the flag directly.)
         member.is_active = False
         test_db.commit()
 
         readded = await service.add_member_to_team(team_id=team.id, user_email=email, role="member", invited_by=email)
         assert readded.id == member.id
-        assert readded.user_email == "idp-123"
+        assert readded.user_email == email
         assert test_db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team.id).count() == 1
 
     @pytest.mark.asyncio
     async def test_approve_join_request_stores_canonical_user_id(self, test_db):
-        """approve_join_request keys the new membership by user_id."""
+        """approve_join_request keeps the e-mail in user_email and stores the canonical user_id."""
         suffix = uuid4().hex[:8]
         email = f"joiner-{suffix}@example.com"
         await self._create_diverged_user(test_db, email, "idp-123")
@@ -3090,6 +3090,8 @@ class TestMembershipCanonicalKeying:
         join_request = await service.create_join_request(team_id=team.id, user_email=email)
         member = await service.approve_join_request(team_id=team.id, request_id=join_request.id, approved_by=email)
 
-        assert member.user_email == "idp-123"
+        assert member.user_email == email
+        assert member.user_id == "idp-123"
         stored = test_db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team.id).one()
-        assert stored.user_email == "idp-123"
+        assert stored.user_email == email
+        assert stored.user_id == "idp-123"

--- a/tests/unit/mcpgateway/services/test_team_management_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_team_management_service_coverage.py
@@ -176,7 +176,10 @@ class TestAddMemberToTeamExceptionPath:
         # Make db.add raise an exception to trigger the exception handler
         db.add.side_effect = RuntimeError("Database error during add")
 
-        with pytest.raises(TeamMemberAddError) as exc_info:
+        with (
+            patch("mcpgateway.services.team_management_service.resolve_canonical_user_id", side_effect=lambda email, _db: email),
+            pytest.raises(TeamMemberAddError) as exc_info,
+        ):
             await svc.add_member_to_team("t1", "newuser@example.com", "member", invited_by="admin@example.com")
 
         assert "Failed to add member to team" in str(exc_info.value)
@@ -210,7 +213,11 @@ class TestCreateTeamReactivation:
         mock_query.filter = MagicMock(return_value=mock_filter)
         db.query = MagicMock(return_value=mock_query)
 
-        with patch("mcpgateway.services.team_management_service.auth_cache") as mock_cache, patch("mcpgateway.services.team_management_service.admin_stats_cache") as mock_admin:
+        with (
+            patch("mcpgateway.services.team_management_service.resolve_canonical_user_id", side_effect=lambda email, _db: email),
+            patch("mcpgateway.services.team_management_service.auth_cache") as mock_cache,
+            patch("mcpgateway.services.team_management_service.admin_stats_cache") as mock_admin,
+        ):
             mock_cache.invalidate_user_teams = AsyncMock()
             mock_cache.invalidate_team_membership = AsyncMock()
             mock_cache.invalidate_user_role = AsyncMock()
@@ -363,7 +370,10 @@ class TestAddMemberEdge:
         mock_query.filter = MagicMock(return_value=mock_filter)
         db.query = MagicMock(return_value=mock_query)
 
-        with patch.object(svc, "get_team_by_id", AsyncMock(return_value=team)):
+        with (
+            patch("mcpgateway.services.team_management_service.resolve_canonical_user_id", side_effect=lambda email, _db: email),
+            patch.object(svc, "get_team_by_id", AsyncMock(return_value=team)),
+        ):
             with pytest.raises(TeamMemberLimitExceededError, match="Team has reached maximum member limit of 2"):
                 await svc.add_member_to_team("t1", "new@t.com")
 
@@ -381,6 +391,7 @@ class TestAddMemberEdge:
 
         with (
             patch.object(svc, "get_team_by_id", AsyncMock(return_value=team)),
+            patch("mcpgateway.services.team_management_service.resolve_canonical_user_id", side_effect=lambda email, _db: email),
             patch("mcpgateway.services.team_management_service.asyncio") as mock_asyncio,
             patch.object(svc, "invalidate_team_member_count_cache", AsyncMock()),
         ):
@@ -823,6 +834,7 @@ class TestApproveJoinRequestEdge:
         team = _mock_team(max_members=None)
         with (
             patch.object(svc, "get_team_by_id", AsyncMock(return_value=team)),
+            patch("mcpgateway.services.team_management_service.resolve_canonical_user_id", side_effect=lambda email, _db: email),
             patch.object(svc, "_log_team_member_action"),
             patch.object(svc, "invalidate_team_member_count_cache", AsyncMock()),
             patch("mcpgateway.services.team_management_service.asyncio") as mock_asyncio,

--- a/tests/unit/mcpgateway/test_writer_resolver_audit.py
+++ b/tests/unit/mcpgateway/test_writer_resolver_audit.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_writer_resolver_audit.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+AST audit for #5893: every UserRole/EmailTeamMember construction site under
+mcpgateway/services must resolve the canonical user ID through the shared
+resolver resolve_canonical_user_id in the enclosing function.
+"""
+
+# Standard
+import ast
+from pathlib import Path
+
+# Third-Party
+import pytest
+
+SERVICES_DIR = Path(__file__).resolve().parents[3] / "mcpgateway" / "services"
+AUDITED_CONSTRUCTORS = {"UserRole", "EmailTeamMember"}
+RESOLVER_NAME = "resolve_canonical_user_id"
+ALLOWLIST: set = set()  # Zero exceptions permitted: every site must resolve.
+
+
+def _call_constructor_name(node: ast.Call) -> str:
+    """Return the constructor name for a Call node, or an empty string."""
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return ""
+
+
+def _construction_sites():
+    """Yield (path, line, constructor, enclosing_function_source) for each audited construction."""
+    for path in sorted(SERVICES_DIR.glob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for child in ast.walk(node):
+                if isinstance(child, ast.Call) and _call_constructor_name(child) in AUDITED_CONSTRUCTORS:
+                    function_source = ast.get_source_segment(source, node) or ""
+                    yield path, child.lineno, _call_constructor_name(child), function_source
+
+
+def test_every_writer_site_calls_shared_resolver():
+    """Every UserRole/EmailTeamMember construction resolves the canonical user ID."""
+    violations = []
+    for path, lineno, constructor, function_source in _construction_sites():
+        site = f"{path.name}:{lineno} ({constructor})"
+        if site in ALLOWLIST:
+            continue
+        if RESOLVER_NAME not in function_source:
+            violations.append(site)
+
+    assert not violations, f"Writer sites missing {RESOLVER_NAME}: {violations}"
+
+
+def test_writer_enumeration_is_exact():
+    """The audited enumeration stays exact: one UserRole site, four EmailTeamMember sites."""
+    counts = {name: 0 for name in AUDITED_CONSTRUCTORS}
+    for _path, _lineno, constructor, _function_source in _construction_sites():
+        counts[constructor] += 1
+
+    assert counts == {"UserRole": 1, "EmailTeamMember": 4}
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/mcpgateway/test_writer_resolver_audit.py
+++ b/tests/unit/mcpgateway/test_writer_resolver_audit.py
@@ -4,8 +4,10 @@ Copyright contributors to the MCP-CONTEXT-FORGE project
 SPDX-License-Identifier: Apache-2.0
 
 AST audit for #5893: every UserRole/EmailTeamMember construction site under
-mcpgateway/services must resolve the canonical user ID through the shared
-resolver resolve_canonical_user_id in the enclosing function.
+mcpgateway/services must dual-write: resolve the canonical user ID through
+the shared resolver resolve_canonical_user_id in the enclosing function,
+store it via a user_id= keyword, and keep user_email= on the e-mail form
+(never the resolver output) so the FK to email_users.email stays valid.
 """
 
 # Standard
@@ -31,8 +33,28 @@ def _call_constructor_name(node: ast.Call) -> str:
     return ""
 
 
+def _keyword_value(node: ast.Call, name: str):
+    """Return the AST value of a keyword argument, or None when absent."""
+    for keyword in node.keywords:
+        if keyword.arg == name:
+            return keyword.value
+    return None
+
+
+def _resolver_target_name(function_node) -> str:
+    """Return the variable assigned from resolve_canonical_user_id, or ''."""
+    for node in ast.walk(function_node):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+            continue
+        if _call_constructor_name(node.value) != RESOLVER_NAME:
+            continue
+        if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            return node.targets[0].id
+    return ""
+
+
 def _construction_sites():
-    """Yield (path, line, constructor, enclosing_function_source) for each audited construction."""
+    """Yield (path, line, constructor, call_node, function_node) for each audited construction."""
     for path in sorted(SERVICES_DIR.glob("*.py")):
         source = path.read_text(encoding="utf-8")
         tree = ast.parse(source, filename=str(path))
@@ -41,27 +63,35 @@ def _construction_sites():
                 continue
             for child in ast.walk(node):
                 if isinstance(child, ast.Call) and _call_constructor_name(child) in AUDITED_CONSTRUCTORS:
-                    function_source = ast.get_source_segment(source, node) or ""
-                    yield path, child.lineno, _call_constructor_name(child), function_source
+                    yield path, child.lineno, _call_constructor_name(child), child, node
 
 
-def test_every_writer_site_calls_shared_resolver():
-    """Every UserRole/EmailTeamMember construction resolves the canonical user ID."""
+def test_every_writer_site_dual_writes():
+    """Every UserRole/EmailTeamMember construction resolves the canonical ID and dual-writes it."""
     violations = []
-    for path, lineno, constructor, function_source in _construction_sites():
+    for path, lineno, constructor, call_node, function_node in _construction_sites():
         site = f"{path.name}:{lineno} ({constructor})"
         if site in ALLOWLIST:
             continue
-        if RESOLVER_NAME not in function_source:
-            violations.append(site)
+        resolver_target = _resolver_target_name(function_node)
+        if not resolver_target:
+            violations.append(f"{site}: enclosing function never calls {RESOLVER_NAME}")
+            continue
+        user_email_value = _keyword_value(call_node, "user_email")
+        if user_email_value is None:
+            violations.append(f"{site}: missing user_email= keyword")
+        elif isinstance(user_email_value, ast.Name) and user_email_value.id == resolver_target:
+            violations.append(f"{site}: user_email={resolver_target} stores the resolver output in the FK column; store the e-mail form")
+        if _keyword_value(call_node, "user_id") is None:
+            violations.append(f"{site}: missing user_id= keyword (dual-write requires the canonical ID alongside user_email)")
 
-    assert not violations, f"Writer sites missing {RESOLVER_NAME}: {violations}"
+    assert not violations, f"Writer sites violating the dual-write rule: {violations}"
 
 
 def test_writer_enumeration_is_exact():
     """The audited enumeration stays exact: one UserRole site, four EmailTeamMember sites."""
     counts = {name: 0 for name in AUDITED_CONSTRUCTORS}
-    for _path, _lineno, constructor, _function_source in _construction_sites():
+    for _path, _lineno, constructor, _call_node, _function_node in _construction_sites():
         counts[constructor] += 1
 
     assert counts == {"UserRole": 1, "EmailTeamMember": 4}


### PR DESCRIPTION
SSO provisioning stores the IdP subject as `user_id` (per-provider `user_id_claim` setting, default `sub`; missing configured claim fails the login closed with an actionable log; invalid setting rejected at provider save). Local registration and bootstrap default `user_id` to the e-mail. All five verified writer sites (one `UserRole` in `role_service.assign_role_to_user`; four `EmailTeamMember` in `team_management_service` add-member and join-approval, `personal_team_service`, `team_invitation_service`) store the canonical `user_id` through one shared resolver `resolve_canonical_user_id(email, db)` in `auth_context.py` — used for BOTH the existing-row lookup and the constructed row, so diverged users never lose rows. An AST audit test enforces that every `UserRole`/`EmailTeamMember` construction site in `mcpgateway/services/` calls the resolver (mutation-checked: it fails when the resolver is removed).

Nine pre-existing tests in `test_team_management_service.py` and `test_team_management_service_coverage.py` gained a mock patch for the resolver (identity passthrough) so legacy Mock query chains keep working; no assertion changed. These nine, plus the four dict-equality updates in #6728, are the complete list of modified pre-existing tests for the Epic 1 gate note.

Tested with:
- Writer-enumeration greps before any edit: exactly 1 `UserRole(` and 4 `EmailTeamMember(` sites — matched the plan
- Provisioning and writer tests: failed first with the expected modes, then green (diverged users created only through real writer paths; no hand-written identity rows)
- `uv run pytest tests/unit/mcpgateway/test_writer_resolver_audit.py -q` — 2 passed
- `uv run pytest tests -k "sso or provisioning or create_user or assign_role or invitation or personal_team" -q` — 841 passed, 41 skipped
- `uv run pytest tests/unit/mcpgateway/services -q` — 7890 passed
- `make ruff` — all checks passed
- `make test` — 23216 passed, 879 skipped, 2 xfailed

Acceptance criteria of #5893 are met. Risk to existing users: for e-mail-equal IDs (all pre-existing rows) the stored values are byte-identical.

Stack: A.8 of epic #5884 (base: #6734).

Closes #5893