### PR TITLE
docs(auth): document canonical user_id identity model and Epic 1 gate evidence

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-12T08:51:17Z",
+  "generated_at": "2026-09-12T09:37:45Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -190,7 +190,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 303,
+        "line_number": 305,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -198,7 +198,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 305,
+        "line_number": 307,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -206,7 +206,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 406,
+        "line_number": 408,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -214,7 +214,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 407,
+        "line_number": 409,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,14 +230,16 @@ The derived triple is memoized on `request.state` per principal, so calling the 
 - **OAuth token delegation**: `docs/docs/architecture/oauth-design.md`
 ### User Identity Extraction
 
-**Canonical Email Precedence**: All user-email extraction helpers use a consistent **email-over-sub** precedence order to ensure forensic accuracy across visibility checks and audit logs:
+**Canonical User Identity**: `get_user_id()` in `mcpgateway/auth_context.py` returns the canonical user identity. The e-mail address is a mutable attribute of the user account, not the identity. `get_user_email()` remains the e-mail-attribute accessor:
 
-- When a user dict contains both `email` and `sub` keys, `email` takes precedence
-- The canonical implementation is `get_user_email()` in `mcpgateway/auth_context.py`
-- All other helpers (including `admin.get_user_email`) re-export or delegate to this canonical implementation
+- `get_user_id()` resolves `user_id` first, then `email`, then `sub`, then `"unknown"`
+- `get_user_email()` resolves the e-mail attribute; when a user dict contains both `email` and `sub` keys, `email` takes precedence
+- All other helpers (including `admin.get_user_email`) re-export or delegate to these canonical implementations
 - This ensures that the identity used for RBAC evaluation matches the identity logged in audit trails
+- Phase 1 populates the canonical user_id with the e-mail value; later stories separate them
+- The token-type-to-identity mapping contract is `docs/docs/architecture/identity-domains.md`
 
-**Rationale**: The `email` field is the human-readable identifier used throughout AGENTS.md and user-facing documentation. Consistent precedence prevents forensic confusion where an incident review pivots on a logged email that differs from the principal actually evaluated by RBAC.
+**Rationale**: The e-mail field is the human-readable identifier used throughout AGENTS.md and user-facing documentation, but it is an attribute that can change. A single canonical identity accessor prevents forensic confusion where an incident review pivots on a logged e-mail that differs from the principal actually evaluated by RBAC.
 
 **Two accessors**: `get_user_email()` in `mcpgateway/auth_context.py` is the e-mail-attribute accessor. `get_user_id()` in the same module is the identity accessor. Phase 1 populates both with the same value. Audit (`AuditTrail.user_id`) and observability (`ObservabilityTrace.user_email`) identity fields hold the canonical user_id from `get_user_id()`; the column names stay unchanged for compatibility.
 

--- a/docs/docs/architecture/multitenancy.md
+++ b/docs/docs/architecture/multitenancy.md
@@ -219,6 +219,8 @@ Discoverable; membership by invite/request"]
 
 #### Team Membership Levels (Design)
 
+Team membership keys on the canonical `user_id`, returned by `get_user_id()` in `mcpgateway/auth_context.py`. The e-mail address is a mutable attribute of the user account, not the identity. Phase 1 populates the canonical `user_id` with the e-mail value, so the `user_email` foreign keys in the diagrams below hold the canonical identity. The token-type-to-identity mapping contract is in [Identifier Domains](identity-domains.md).
+
 **Note**: These are team membership levels, separate from RBAC roles. A user can have both a membership level and RBAC role assignments within the same team.
 
 - **Owner** (Team Membership Level):

--- a/docs/docs/manage/rbac.md
+++ b/docs/docs/manage/rbac.md
@@ -51,6 +51,8 @@ Users authenticated via:
 - SSO providers (OAuth 2.0/OIDC)
 - Basic authentication (development only)
 
+Permissions and role assignments key on the canonical `user_id`, returned by `get_user_id()` in `mcpgateway/auth_context.py`. The e-mail address is a mutable attribute of the user account, not the identity; `get_user_email()` remains the e-mail accessor. Phase 1 populates the canonical `user_id` with the e-mail value. The token-type-to-identity mapping contract is in [Identifier Domains](../architecture/identity-domains.md).
+
 ### Teams
 Logical groups that:
 


### PR DESCRIPTION
This PR runs the Epic 1 gate and completes the identity documentation sweep. `AGENTS.md` "User Identity Extraction" now states the canonical contract: `get_user_id` returns the identity; the e-mail is a mutable attribute; `get_user_email` remains the e-mail accessor; `docs/docs/architecture/identity-domains.md` is the mapping contract. `docs/docs/manage/rbac.md` and `docs/docs/architecture/multitenancy.md` state that permission assignments and team membership key on the canonical user_id. Stale "email-over-sub" claims were swept (the historical CHANGELOG entry for #4539 stays — it records a shipped release).

Gate evidence (all exit 0):
- `cd mcpgateway && uv run alembic heads` — exactly one head: `bf2998718ea1` (the #5892 revision; file verified)
- `make test` — 23230 passed, 879 skipped, 2 xfailed
- `make doctest` — 1228 passed, 57 skipped
- `make ruff interrogate pylint` — clean; pylint 10.00/10
- `make coverage diff-cover` — total 98%; diff coverage 99% (1 uncovered line: `mcpgateway/auth.py:1785`)

Behavior-identity note (target zero modified pre-existing tests): 3 test files added; 13 modified files are additive-only; 5 files changed pre-existing lines, each justified: four dict-equality assertions gained the `user_id` key (#5887, stricter not weaker); nine resolver mock-plumbing patches (#5893, no assertion changed); two import-line extensions (#5886, #5893). No test was weakened or deleted.

Risk to existing users: none — documentation and evidence only.

Stack: A.10 of epic #5884 (base: #6736). Completes Stack A.

Closes #5895