### PR TITLE
docs(auth): define trust-mode token dispatch rule and cross-mode deny matrix

### DIFF
--- a/docs/docs/architecture/auth-token-dispatch.md
+++ b/docs/docs/architecture/auth-token-dispatch.md
@@ -1,0 +1,73 @@
+# Token Dispatch Rule
+
+This page pins the rule the verifier uses to route a bearer token when JWT
+trust mode (epic #5885) exists. Trust mode lets a signed JWT alone prove
+identity, roles, and teams. No local user record is read on the request path.
+
+The dispatch rule has three parts: the eligibility rule, the 401 rule for
+marked tokens when trust mode is OFF, and the default-funnel rule for all
+other tokens.
+
+## Eligibility rule (disjunctive)
+
+A token is trust-eligible when trust mode is ON AND one of these two trust
+roots applies:
+
+- **(a) Gateway-signed token.** `token_use == "trusted"` AND the required
+  mapped claim set (`sub`, `teams`, `roles` per #5899) AND a configured
+  revocation claim (default `jti`). The marker is an explicit positive
+  signal. It is not a claim-shape heuristic, so no future mint path can
+  become trust-eligible by accident.
+- **(b) External IdP token.** The issuer is a configured trust root
+  (`trusted_for_api_auth` + `api_audience` on `SSOProvider` in
+  `mcpgateway/db.py`) AND the required mapped claims AND a configured
+  revocation claim. External IdP tokens cannot carry the ContextForge
+  `token_use` marker, so the issuer is the trust root for this branch.
+
+## Marked tokens get HTTP 401 when trust mode is OFF
+
+A token that carries `token_use == "trusted"` gets HTTP 401 when trust mode
+is OFF. Such a token never enters the default funnel. Two default-funnel
+behaviors make this necessary:
+
+- The UUID heuristic (`resolve_uuid_subject` in `mcpgateway/auth.py`) could
+  silently re-attribute a UUID-shaped `sub` to a different local user.
+- `normalize_token_teams` in `mcpgateway/auth_context.py` would honor the
+  embedded `teams` claim under default semantics, without the trust-mode
+  claim mapping and revocation rules.
+
+## All other tokens use the default funnel
+
+Every token that is not trust-eligible routes through the default funnel,
+even when trust mode is ON. Default mode behavior does not change:
+
+- Session tokens (`token_use == "session"`) carry no `teams` or `is_admin`
+  claims (`create_access_token` in `mcpgateway/routers/email_auth.py`).
+  Teams come from server-side resolution.
+- API tokens (`token_use == "api"`) embed `user_data.is_admin` and `teams`
+  (`_generate_token` in `mcpgateway/services/token_catalog_service.py`).
+  The embedded teams are honored.
+- External IdP tokens follow the current provisioning behavior through
+  `verify_external_idp_token` in `mcpgateway/utils/verify_credentials.py`.
+
+## Mode x token combinations
+
+| Mode | Token type | Expected result |
+|------|-----------|-----------------|
+| Default | Session token | Default-semantics (server-side team resolution) |
+| Default | API token | Default-semantics (embedded teams honored) |
+| Trust | Default session token | Default-semantics (not trust-eligible; no `token_use=="trusted"` marker, issuer not a trust root) |
+| Trust | Default API token | Default-semantics (same reason) |
+| Trust | Gateway-signed trust token (`token_use=="trusted"`) | Trust-semantics (post-#5900); 401 before #5900 lands |
+| Trust | External IdP token (trusted issuer) | Trust-semantics via issuer branch (post-#5900); provisioning behavior pre-#5900 |
+
+The executable form of this table is
+`tests/unit/mcpgateway/test_token_dispatch_matrix.py`. Rows whose
+expectation holds today pass. Rows that need un-landed behavior carry
+`pytest.mark.xfail(strict=True, ...)` with a pointer to the story that
+flips them.
+
+## Operative fact
+
+No `token_use` value other than `session` or `api` exists in `mcpgateway/`
+today. The `trusted` marker is introduced by #5904.

--- a/tests/unit/mcpgateway/test_token_dispatch_matrix.py
+++ b/tests/unit/mcpgateway/test_token_dispatch_matrix.py
@@ -1,0 +1,285 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_token_dispatch_matrix.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Cross-mode token dispatch deny-test matrix (issue #5896).
+
+Executable form of the six mode-x-token combinations pinned in
+docs/docs/architecture/auth-token-dispatch.md:
+
+- Rows whose expectation holds today land green now. Trust mode does not
+  exist yet (config lands in #5898, the trust branch in #5900), so the
+  trust-mode rows for non-eligible tokens exercise the current code path:
+  the default funnel. That IS the documented behavior for these rows, and
+  it stays correct after trust mode lands.
+- Rows that need un-landed behavior carry pytest.mark.xfail(strict=True)
+  with a pointer to the story that flips them. strict=True turns any
+  premature XPASS into a suite failure.
+"""
+
+# Standard
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+from fastapi import HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
+import pytest
+
+# First-Party
+from mcpgateway.auth import get_current_user
+from mcpgateway.config import settings
+from mcpgateway.db import EmailUser
+
+
+def _exp(hours: int = 1) -> float:
+    """Expiry timestamp for mocked JWT payloads."""
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).timestamp()
+
+
+def _make_user(email: str) -> EmailUser:
+    """Active, non-admin local user for the default funnel."""
+    return EmailUser(
+        email=email,
+        password_hash="hash",
+        full_name="Matrix User",
+        is_admin=False,
+        is_active=True,
+        email_verified_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+
+def _fake_provider(issuer: str) -> MagicMock:
+    """SSO provider opted into API auth with a pinned audience."""
+    provider = MagicMock()
+    provider.issuer = issuer
+    provider.is_enabled = True
+    provider.trusted_for_api_auth = True
+    provider.api_audience = "api://my-app"
+    return provider
+
+
+class TestTokenDispatchMatrix:
+    """Six mode-x-token combinations of the token dispatch rule (#5896)."""
+
+    @pytest.mark.asyncio
+    async def test_external_idp_token_default_mode_provisioning(self, monkeypatch):
+        """Default mode + external IdP token -> current provisioning behavior.
+
+        A token from a trusted issuer verifies through
+        verify_external_idp_token and enters the default provisioning
+        funnel. This is the current code path and the expected result for
+        this combination.
+        """
+        # Third-Party
+        import jwt as pyjwt
+
+        # First-Party
+        from mcpgateway.utils import verify_credentials as vc
+
+        token = pyjwt.encode({"iss": "https://kc/realms/m", "sub": "agent"}, "k", algorithm="HS256")
+        provider = _fake_provider("https://kc/realms/m")
+        monkeypatch.setattr(vc, "resolve_trusted_provider_by_issuer", lambda iss, db: provider)
+
+        async def fake_verify(tok, authorization_servers, *, expected_audience=None):
+            return {"iss": "https://kc/realms/m", "sub": "agent"}
+
+        monkeypatch.setattr(vc, "verify_oauth_access_token", fake_verify)
+        claims, returned_provider = await vc.verify_external_idp_token(token, MagicMock())
+
+        assert claims["sub"] == "agent"
+        assert returned_provider is provider
+
+    @pytest.mark.asyncio
+    async def test_session_token_trust_mode_default_funnel(self, monkeypatch):
+        """Trust mode + default session token -> default-semantics.
+
+        A session token carries no trust marker and its issuer is not a
+        trust root, so it is not trust-eligible: teams are resolved
+        server-side and an embedded teams claim is narrowed against the
+        DB. Trust mode does not exist yet (#5898/#5900), so this exercises
+        the current path, which is the documented behavior for this row.
+        """
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="session_jwt_token")  # pragma: allowlist secret
+
+        # JWT claims one team; the DB reports a disjoint team. Default
+        # semantics intersect: the claim alone can never widen access.
+        jwt_payload = {
+            "sub": "test@example.com",
+            "token_use": "session",
+            "teams": ["team-from-claim"],
+            "exp": _exp(),
+            "jti": "session_jti_matrix",
+        }
+
+        cached_ctx = SimpleNamespace(
+            is_token_revoked=False,
+            user={"email": "test@example.com", "full_name": "Matrix User", "is_admin": False, "is_active": True},
+            personal_team_id="team_123",
+        )
+
+        request = SimpleNamespace(state=SimpleNamespace())
+        monkeypatch.setattr(settings, "auth_cache_enabled", True)
+        monkeypatch.setattr(settings, "require_user_in_db", False)
+
+        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+            with patch("mcpgateway.cache.auth_cache.auth_cache.get_auth_context", AsyncMock(return_value=cached_ctx)):
+                with patch("mcpgateway.auth._resolve_teams_from_db", return_value=["team-from-db"]) as mock_resolve_db:
+                    user = await get_current_user(credentials=credentials, request=request)
+
+                    assert user.email == "test@example.com"
+                    # Server-side resolution ran; the embedded claim was not honored.
+                    mock_resolve_db.assert_called_once()
+                    assert request.state.token_use == "session"
+                    assert request.state.token_teams == []
+
+    @pytest.mark.asyncio
+    async def test_api_token_trust_mode_default_funnel(self, monkeypatch):
+        """Trust mode + default API token -> default-semantics.
+
+        An API token carries token_use="api", not the trust marker, so it
+        is not trust-eligible: the embedded teams claim is honored and no
+        DB team resolution runs. Trust mode does not exist yet
+        (#5898/#5900), so this exercises the current path, which is the
+        documented behavior for this row.
+        """
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="api_jwt_token")  # pragma: allowlist secret
+
+        jwt_payload = {
+            "sub": "api@example.com",
+            "token_use": "api",
+            "teams": ["api-team-1"],
+            "exp": _exp(),
+            "user": {"auth_provider": "api_token"},
+        }
+
+        request = SimpleNamespace(state=SimpleNamespace())
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+
+        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+            with patch("mcpgateway.auth._get_user_by_email_sync", return_value=_make_user("api@example.com")):
+                with patch("mcpgateway.auth._resolve_teams_from_db") as mock_resolve_db:
+                    with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
+                        user = await get_current_user(credentials=credentials, request=request)
+
+                        assert user.email == "api@example.com"
+                        # Embedded teams honored; no server-side resolution.
+                        mock_resolve_db.assert_not_called()
+                        assert request.state.token_use == "api"
+                        assert request.state.token_teams == ["api-team-1"]
+
+    # Flipped by #5900 (trust branch in get_current_user)
+    @pytest.mark.xfail(strict=True, reason="Flipped by #5900")
+    @pytest.mark.asyncio
+    async def test_gateway_trust_token_trust_mode_trust_semantics(self, monkeypatch):
+        """Trust mode + gateway-signed trust token -> trust-semantics.
+
+        A token_use="trusted" token with the mapped claim set (sub, teams,
+        roles) and a jti authenticates from claims alone: no local user
+        record is read on the request path. Today no trust branch exists,
+        so the default funnel rejects the unknown user with 401.
+        """
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="trusted_jwt_token")  # pragma: allowlist secret
+
+        jwt_payload = {
+            "sub": "trust.user@example.com",
+            "token_use": "trusted",
+            "teams": ["trust-team-1"],
+            "roles": ["team_admin"],
+            "jti": "trusted_jti_matrix",
+            "exp": _exp(),
+        }
+
+        request = SimpleNamespace(state=SimpleNamespace())
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+
+        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+            with patch("mcpgateway.auth._check_token_revoked_sync", return_value=False):
+                # No EmailUser row exists for this principal.
+                with patch("mcpgateway.auth._get_user_by_email_sync", return_value=None):
+                    with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
+                        user = await get_current_user(credentials=credentials, request=request)
+
+                        # Trust-semantics: identity and teams come from the claims.
+                        assert user.email == "trust.user@example.com"
+                        assert request.state.token_use == "trusted"
+                        assert request.state.token_teams == ["trust-team-1"]
+
+    # Flipped by #5900 (trust branch in get_current_user)
+    @pytest.mark.xfail(strict=True, reason="Flipped by #5900")
+    @pytest.mark.asyncio
+    async def test_gateway_trust_token_default_mode_401(self, monkeypatch):
+        """Default mode + gateway-signed trust token -> HTTP 401.
+
+        Trust mode is OFF, so a token_use="trusted" token must be rejected
+        with 401. It must never enter the default funnel, whose UUID
+        heuristic and embedded-teams handling would re-attribute identity.
+        Today no such guard exists, so the default funnel authenticates
+        the token for the local user.
+        """
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="trusted_jwt_token")  # pragma: allowlist secret
+
+        jwt_payload = {
+            "sub": "existing@example.com",
+            "token_use": "trusted",
+            "teams": ["trust-team-1"],
+            "roles": ["team_admin"],
+            "jti": "trusted_jti_matrix_off",
+            "exp": _exp(),
+        }
+
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+
+        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+            with patch("mcpgateway.auth._check_token_revoked_sync", return_value=False):
+                with patch("mcpgateway.auth._get_user_by_email_sync", return_value=_make_user("existing@example.com")):
+                    with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
+                        with pytest.raises(HTTPException) as exc_info:
+                            await get_current_user(credentials=credentials)
+
+                        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+    # Flipped by #5903 (external IdP trust root)
+    @pytest.mark.xfail(strict=True, reason="Flipped by #5903")
+    @pytest.mark.asyncio
+    async def test_external_idp_token_trust_mode_trust_semantics(self, monkeypatch):
+        """Trust mode + external IdP token (trusted issuer) -> trust-semantics.
+
+        The issuer is a configured trust root, so the token is
+        trust-eligible via the issuer branch: the identity is built from
+        token claims alone and the provisioning path
+        (build_external_identity) is not invoked. Today the external-IdP
+        path always provisions, so the no-provisioning assertion fails.
+        """
+        # Third-Party
+        import jwt as pyjwt
+
+        # First-Party
+        from mcpgateway.utils import verify_credentials as vc
+
+        token = pyjwt.encode({"iss": "https://kc/realms/m", "sub": "agent", "exp": _exp()}, "k", algorithm="HS256")
+        provider = _fake_provider("https://kc/realms/m")
+
+        monkeypatch.setattr(vc.settings, "sso_api_token_auth_enabled", True)
+        monkeypatch.setattr(vc, "_has_trusted_providers", lambda db: True)
+
+        async def fake_verify_external(tok, db):
+            return {"iss": "https://kc/realms/m", "sub": "agent", "exp": _exp()}, provider
+
+        monkeypatch.setattr(vc, "verify_external_idp_token", fake_verify_external)
+        mock_build = AsyncMock(return_value={"sub": "agent", "token": token})
+        monkeypatch.setattr(vc, "build_external_identity", mock_build)
+
+        await vc.invalidate_external_identity_cache()
+        request = SimpleNamespace(state=SimpleNamespace(db=MagicMock()))
+        await vc._maybe_verify_external(token, request)
+
+        # Trust-semantics: claims-derived identity, no local provisioning.
+        mock_build.assert_not_called()


### PR DESCRIPTION
Architecture doc pins the disjunctive trust-eligibility rule: (a) gateway-signed tokens with `token_use=="trusted"` plus the required mapped claims and the configured revocation claim, or (b) external-IdP tokens from a configured trust root (`trusted_for_api_auth` + `api_audience`) with the same claim requirements. Tokens carrying the `trusted` marker get 401 when trust mode is OFF — they never enter the default funnel, whose UUID heuristic could re-attribute a UUID-shaped `sub`. All other tokens follow the default funnel in both modes. The doc states only the operative fact about `token_use` values (`session` and `api` exist today; the `trusted` marker arrives with #5904).

The executable deny-test matrix covers all six mode-x-token combinations. Expect-pass rows (current behavior) land green. Un-landed rows are `xfail(strict=True)` with split pointers: the two gateway-signed rows point at #5900, the external-IdP row points at #5903. Each xfail reason was verified real via `--runxfail`.

Tested with:
- `uv run pytest tests/unit/mcpgateway/test_token_dispatch_matrix.py -q` — 3 passed, 3 xfailed, 0 XPASS
- `make ruff` — all checks passed

No behavior change. Risk to existing users: none (doc + tests only).

Tested with `uv run pytest tests/unit/mcpgateway/test_token_dispatch_matrix.py -q` and `make ruff`. Acceptance criteria of #5896 are met.

Stack: B.1 of epic #5885 (base: #6737).

Closes #5896