### PR TITLE
feat(config): add JWT-trust mode and claim-mapping settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,6 +148,33 @@ REQUIRE_JTI=true
 # Tokens without expiration never expire and pose a security risk
 REQUIRE_TOKEN_EXPIRATION=true
 
+# -----------------------------------------------------------------------------
+# JWT Trust Mode (trust claims from external identity providers)
+# -----------------------------------------------------------------------------
+# Trust mode toggle. "db" (default) performs the existing database-backed
+# user lookup for every request. "jwt-trust" accepts claims from tokens
+# issued by trusted external identity providers without a per-request
+# database lookup. Default preserves current behavior.
+#JWT_TRUST_MODE=db
+
+# Claim-name mapping for trust mode. Each names the JWT claim that carries
+# the value. None of these may be empty when JWT_TRUST_MODE=jwt-trust.
+#JWT_CLAIM_USER_ID=sub      # user identifier claim (default: sub)
+#JWT_CLAIM_EMAIL=email      # email claim (default: email)
+#JWT_CLAIM_TEAMS=teams      # team memberships claim (default: teams)
+#JWT_CLAIM_ROLES=roles      # role names claim (default: roles)
+#JWT_CLAIM_ADMIN=is_admin   # admin flag claim (default: is_admin)
+
+# Policy when a trust-mode token exceeds the group-claim overage limit:
+# fail_closed (reject, default), graph_lookup (resolve via Microsoft Graph),
+# proceed_without_groups (continue without group claims).
+#JWT_TRUST_OVERAGE_POLICY=fail_closed
+
+# JWT claim used as the revocation identifier for trust-eligible tokens.
+# Default "jti"; use "uti" for Entra roots. A trust-eligible token missing
+# this claim is rejected with 401.
+#JWT_TRUST_REVOCATION_CLAIM=jti
+
 # Disable public user self-registration (admin must create accounts)
 PUBLIC_REGISTRATION_ENABLED=false
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-12T09:37:45Z",
+  "generated_at": "2026-09-12T09:39:39Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -190,7 +190,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 305,
+        "line_number": 307,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -198,7 +198,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 307,
+        "line_number": 309,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -206,7 +206,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 408,
+        "line_number": 410,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -214,7 +214,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 409,
+        "line_number": 411,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -1076,7 +1076,7 @@
         "hashed_secret": "e204d28a2874f6123747650d3e4003d4357d75eb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 884,
+        "line_number": 886,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1084,7 +1084,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1179,
+        "line_number": 1181,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2330,7 +2330,7 @@
         "hashed_secret": "1513802ada0ec04c2446206e16baa7256ebff74b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 666,
+        "line_number": 668,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-12T09:39:39Z",
+  "generated_at": "2026-09-12T17:24:57Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -762,7 +762,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 450,
+        "line_number": 458,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -770,7 +770,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 974,
+        "line_number": 982,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -778,7 +778,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1077,
+        "line_number": 1085,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -786,7 +786,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1247,
+        "line_number": 1255,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -794,7 +794,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1282,
+        "line_number": 1290,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -802,7 +802,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1863,
+        "line_number": 1871,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -810,7 +810,7 @@
         "hashed_secret": "afba9d98073dfb79fba7b21516c4d4d676c72935",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2306,
+        "line_number": 2314,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -818,7 +818,7 @@
         "hashed_secret": "db521f60ff25f37ce29401ad93cb12cf4dc9f814",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2309,
+        "line_number": 2317,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -826,7 +826,7 @@
         "hashed_secret": "b7aa580d298f50cfece35543607ccd68177c6413",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2310,
+        "line_number": 2318,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -834,7 +834,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2410,
+        "line_number": 2418,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -842,7 +842,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2410,
+        "line_number": 2418,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -850,7 +850,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2423,
+        "line_number": 2431,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -858,7 +858,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2573,
+        "line_number": 2581,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -866,7 +866,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2594,
+        "line_number": 2602,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -874,7 +874,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2602,
+        "line_number": 2610,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -882,7 +882,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2607,
+        "line_number": 2615,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docker-compose.sso.yml
+++ b/docker-compose.sso.yml
@@ -37,3 +37,10 @@ services:
       # Keep existing local admin login alongside SSO
       - SSO_AUTO_CREATE_USERS=true
       - SSO_PRESERVE_ADMIN_AUTH=true
+      # JWT trust mode (default OFF - high-risk; enable only with a configured
+      # trust root). SSO_API_TOKEN_AUTH_ENABLED accepts external SSO access
+      # tokens as API Bearer tokens.
+      # Docs: docs/docs/manage/configuration.md (JWT Trust Mode),
+      #       docs/docs/architecture/auth-token-dispatch.md
+      # - JWT_TRUST_MODE=db
+      # - SSO_API_TOKEN_AUTH_ENABLED=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -401,6 +401,14 @@ services:
       - SSO_KEYCLOAK_RESOLVE_TEAM_SCOPE_TO_PERSONAL_TEAM=${SSO_KEYCLOAK_RESOLVE_TEAM_SCOPE_TO_PERSONAL_TEAM:-false}
       - SSO_AUTO_CREATE_USERS=${SSO_AUTO_CREATE_USERS:-true}
       - SSO_PRESERVE_ADMIN_AUTH=${SSO_PRESERVE_ADMIN_AUTH:-true}
+      # JWT trust mode (default OFF - high-risk; enable only with a configured
+      # trust root). Trust mode accepts claims from trusted external IdP tokens
+      # without a per-request DB lookup; SSO_API_TOKEN_AUTH_ENABLED accepts
+      # external SSO access tokens as API Bearer tokens.
+      # Docs: docs/docs/manage/configuration.md (JWT Trust Mode),
+      #       docs/docs/architecture/auth-token-dispatch.md
+      # - JWT_TRUST_MODE=db
+      # - SSO_API_TOKEN_AUTH_ENABLED=false
       # Security defaults (tokens require expiration and JTI for revocation)
       - REQUIRE_TOKEN_EXPIRATION=${REQUIRE_TOKEN_EXPIRATION:-true}
       - REQUIRE_JTI=${REQUIRE_JTI:-true}

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -199,6 +199,28 @@ appropriate secure-cookie, SameSite, credential, and CSRF configuration.
     export MCPGATEWAY_BEARER_TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 10080 --secret my-test-key-but-now-longer-than-32-bytes)
     ```
 
+### JWT Trust Mode
+
+JWT trust mode controls how the gateway resolves the caller's identity. The default `db` mode performs the existing database-backed user lookup for every request. `jwt-trust` mode accepts claims from tokens issued by trusted external identity providers without a per-request database lookup.
+
+| Setting                      | Description                                                                                  | Default       | Options                                          |
+|------------------------------|----------------------------------------------------------------------------------------------|---------------|--------------------------------------------------|
+| `JWT_TRUST_MODE`             | JWT trust mode toggle                                                                        | `db`          | `db`, `jwt-trust`                                |
+| `JWT_CLAIM_USER_ID`          | JWT claim carrying the user identifier in trust mode                                         | `sub`         | non-empty string                                 |
+| `JWT_CLAIM_EMAIL`            | JWT claim carrying the user email in trust mode                                              | `email`       | non-empty string                                 |
+| `JWT_CLAIM_TEAMS`            | JWT claim carrying team memberships in trust mode                                            | `teams`       | non-empty string                                 |
+| `JWT_CLAIM_ROLES`            | JWT claim carrying role names in trust mode                                                  | `roles`       | non-empty string                                 |
+| `JWT_CLAIM_ADMIN`            | JWT claim carrying the admin flag in trust mode                                              | `is_admin`    | non-empty string                                 |
+| `JWT_TRUST_OVERAGE_POLICY`   | Policy when a token exceeds the group-claim overage limit                                    | `fail_closed` | `fail_closed`, `graph_lookup`, `proceed_without_groups` |
+| `JWT_TRUST_REVOCATION_CLAIM` | JWT claim used as the revocation identifier for trust-eligible tokens (`uti` for Entra roots) | `jti`         | non-empty string                                 |
+
+Startup validation rules:
+
+- When `JWT_TRUST_MODE=jwt-trust`, every claim-mapping setting and `JWT_TRUST_REVOCATION_CLAIM` must be a non-empty string. The gateway refuses to start with an error naming the offending setting.
+- A trust-eligible token that lacks the configured revocation claim is rejected with `401`. The revocation claim is mandatory because trust mode relies on it for token revocation.
+
+All defaults preserve the current behavior: trust mode defaults to `db` and the new settings are inert until `jwt-trust` is enabled.
+
 ### UI Features
 
 For detailed guidance on embedding and section customization, see [Admin UI Customization](admin-ui-customization.md).

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1738,7 +1738,9 @@ class Settings(BaseSettings):
 
         Raises:
             SecurityConfigurationError: If a secret or feature-gated password
-                fails its strength checks.
+                fails its strength checks, or if trust mode aliases
+                ``jwt_claim_teams`` onto the ``sso_entra_groups_claim`` claim
+                consumed by the external group-mapping resolver.
         """
         weak_secrets = {v.lower() for v in self.WEAK_VALUES}
         effective_min = max(self.min_secret_length, _MIN_SECRET_LENGTH)
@@ -1861,6 +1863,26 @@ class Settings(BaseSettings):
                 "Please set ENABLE_HEADER_PASSTHROUGH=true in your environment or disable ENABLE_SENSITIVE_HEADER_PASSTHROUGH. "
                 "See .env.example for configuration examples."
             )
+
+        # Claim-collision guard (trust mode only). In trust mode the external
+        # group-mapping resolver consumes the claim named by
+        # ``sso_entra_groups_claim`` for external group IDs. If
+        # ``jwt_claim_teams`` names the same claim, raw external group IDs
+        # land in native ContextForge team memberships before mapping.
+        # Outside trust mode ``jwt_claim_teams`` is not consumed, so an
+        # aliased value is dead config and does not fail startup.
+        if self.jwt_trust_mode == "jwt-trust":
+            teams_claim = self.jwt_claim_teams.strip()
+            groups_claim = self.sso_entra_groups_claim.strip()
+            if teams_claim and teams_claim == groups_claim:
+                raise SecurityConfigurationError(
+                    f"JWT_CLAIM_TEAMS and SSO_ENTRA_GROUPS_CLAIM both name the {teams_claim!r} claim. "
+                    "In trust mode the external group-mapping resolver consumes SSO_ENTRA_GROUPS_CLAIM for "
+                    "external group IDs; aliasing it with JWT_CLAIM_TEAMS places raw external group IDs into "
+                    "native ContextForge team memberships before mapping. "
+                    "Remediation: point JWT_CLAIM_TEAMS at a distinct claim (default 'teams') while "
+                    "SSO_ENTRA_GROUPS_CLAIM keeps naming the provider's groups claim (default 'groups')."
+                )
 
         return self
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -400,6 +400,28 @@ class Settings(BaseSettings):
         default=True,
         description="Require all authenticated users to exist in the database. When true, disables the platform admin bootstrap mechanism. Set REQUIRE_USER_IN_DB=false in .env for development environments that use the bootstrap admin path.",
     )
+    # JWT Trust Mode Configuration
+    # Trust mode "jwt-trust" accepts claims from tokens issued by trusted
+    # external identity providers without a per-request database lookup.
+    # Default "db" preserves the existing database-backed behavior.
+    jwt_trust_mode: Literal["db", "jwt-trust"] = Field(
+        default="db",
+        description="JWT trust mode: 'db' (database-backed user lookup, default) or 'jwt-trust' (trust claims from tokens of trusted external identity providers)",
+    )
+    jwt_claim_user_id: str = Field(default="sub", description="JWT claim name carrying the user identifier in trust mode")
+    jwt_claim_email: str = Field(default="email", description="JWT claim name carrying the user email in trust mode")
+    jwt_claim_teams: str = Field(default="teams", description="JWT claim name carrying team memberships in trust mode")
+    jwt_claim_roles: str = Field(default="roles", description="JWT claim name carrying role names in trust mode")
+    jwt_claim_admin: str = Field(default="is_admin", description="JWT claim name carrying the admin flag in trust mode")
+    jwt_trust_overage_policy: Literal["fail_closed", "graph_lookup", "proceed_without_groups"] = Field(
+        default="fail_closed",
+        description="Policy when a trust-mode token exceeds the group-claim overage limit: 'fail_closed' (reject), 'graph_lookup' (resolve via Microsoft Graph), 'proceed_without_groups' (continue without group claims)",
+    )
+    jwt_trust_revocation_claim: str = Field(
+        default="jti",
+        description="JWT claim used as the revocation identifier for trust-eligible tokens (default 'jti'; use 'uti' for Entra roots). A trust-eligible token missing this claim is rejected with 401.",
+    )
+
     embed_environment_in_tokens: bool = Field(default=True, description="Embed environment claim in gateway-issued JWTs for environment isolation")
     validate_token_environment: bool = Field(default=True, description="Reject tokens with mismatched environment claim (tokens without env claim are allowed)")
     derive_key_per_environment: bool = Field(
@@ -1840,6 +1862,29 @@ class Settings(BaseSettings):
                 "See .env.example for configuration examples."
             )
 
+        return self
+
+    @model_validator(mode="after")
+    def validate_jwt_trust_config(self) -> Self:
+        """Reject JWT-trust misconfiguration at startup.
+
+        Trust mode requires a non-empty revocation claim and non-empty claim
+        mappings. A trust-eligible token that lacks the configured revocation
+        claim is rejected with 401 at request time; that enforcement lands in
+        #5900. This validator only covers the startup contract.
+        """
+        if self.jwt_trust_mode == "jwt-trust":
+            claim_settings = [
+                "jwt_claim_user_id",
+                "jwt_claim_email",
+                "jwt_claim_teams",
+                "jwt_claim_roles",
+                "jwt_claim_admin",
+                "jwt_trust_revocation_claim",
+            ]
+            for name in claim_settings:
+                if not getattr(self, name).strip():
+                    raise ValueError(f"Setting {name} must not be empty when jwt_trust_mode is enabled.")
         return self
 
     def get_security_warnings(self) -> List[str]:

--- a/tests/unit/mcpgateway/test_jwt_trust_config.py
+++ b/tests/unit/mcpgateway/test_jwt_trust_config.py
@@ -11,12 +11,15 @@ validators must reject empty claim names and a trust mode without a
 revocation claim.
 """
 
+# Standard
+from pathlib import Path
+
 # Third-Party
 import pytest
 from pydantic import ValidationError
 
 # First-Party
-from mcpgateway.config import Settings
+from mcpgateway.config import SecurityConfigurationError, Settings
 
 
 def _settings(**overrides) -> Settings:
@@ -73,3 +76,55 @@ class TestJwtTrustRevocationRequirement:
         message = str(exc_info.value)
         assert "jwt_trust_revocation_claim" in message
         assert "must not be empty" in message
+
+
+class TestClaimTeamsGroupClaimCollision:
+    """JWT_CLAIM_TEAMS must not alias the claim the external group-mapping resolver consumes.
+
+    In trust mode the resolver reads ``sso_entra_groups_claim`` for external
+    group IDs and maps them to ContextForge teams. If ``jwt_claim_teams``
+    names the same claim, raw external group IDs land in native ContextForge
+    team memberships before mapping (finding F9). Startup validation must
+    reject the collision with ``SecurityConfigurationError``.
+    """
+
+    def test_claim_teams_cannot_alias_group_mapping_source(self):
+        with pytest.raises(SecurityConfigurationError) as exc_info:
+            _settings(jwt_trust_mode="jwt-trust", jwt_claim_teams="groups", sso_entra_groups_claim="groups")
+        message = str(exc_info.value)
+        assert "JWT_CLAIM_TEAMS" in message
+        assert "SSO_ENTRA_GROUPS_CLAIM" in message
+
+    def test_distinct_team_and_group_claims_accepted(self):
+        s = _settings(jwt_trust_mode="jwt-trust", jwt_claim_teams="teams", sso_entra_groups_claim="groups")
+        assert s.jwt_claim_teams == "teams"
+        assert s.sso_entra_groups_claim == "groups"
+
+    def test_collision_inert_when_trust_mode_disabled(self):
+        # Outside trust mode jwt_claim_teams is not consumed, so an aliased
+        # value is dead config and must not fail startup.
+        s = _settings(jwt_trust_mode="db", jwt_claim_teams="groups", sso_entra_groups_claim="groups")
+        assert s.jwt_trust_mode == "db"
+
+
+class TestComposeDeclaresTrustFlags:
+    """The supported Compose stacks declare the trust flags, commented and default-off."""
+
+    @staticmethod
+    def _repo_root() -> Path:
+        return Path(__file__).resolve().parents[3]
+
+    def test_compose_declares_trust_flags(self):
+        text = (self._repo_root() / "docker-compose.yml").read_text(encoding="utf-8")
+        assert "JWT_TRUST_MODE" in text
+        assert "SSO_API_TOKEN_AUTH_ENABLED" in text
+
+    def test_compose_trust_flags_default_off(self):
+        text = (self._repo_root() / "docker-compose.yml").read_text(encoding="utf-8")
+        assert "# - JWT_TRUST_MODE=db" in text
+        assert "# - SSO_API_TOKEN_AUTH_ENABLED=false" in text
+
+    def test_sso_compose_declares_trust_flags(self):
+        text = (self._repo_root() / "docker-compose.sso.yml").read_text(encoding="utf-8")
+        assert "# - JWT_TRUST_MODE=db" in text
+        assert "# - SSO_API_TOKEN_AUTH_ENABLED=false" in text

--- a/tests/unit/mcpgateway/test_jwt_trust_config.py
+++ b/tests/unit/mcpgateway/test_jwt_trust_config.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_jwt_trust_config.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for JWT-trust mode configuration surface.
+
+Covers the settings added for issue #5898: trust mode toggle, claim
+mapping, overage policy, and the revocation-claim contract. The startup
+validators must reject empty claim names and a trust mode without a
+revocation claim.
+"""
+
+# Third-Party
+import pytest
+from pydantic import ValidationError
+
+# First-Party
+from mcpgateway.config import Settings
+
+
+def _settings(**overrides) -> Settings:
+    """Build Settings isolated from the process environment."""
+    return Settings(environment="development", _env_file=None, **overrides)
+
+
+class TestJwtTrustDefaults:
+    """Default values preserve current behavior."""
+
+    def test_defaults(self):
+        s = _settings()
+        assert s.jwt_trust_mode == "db"
+        assert s.jwt_claim_user_id == "sub"
+        assert s.jwt_claim_email == "email"
+        assert s.jwt_claim_teams == "teams"
+        assert s.jwt_claim_roles == "roles"
+        assert s.jwt_claim_admin == "is_admin"
+        assert s.jwt_trust_overage_policy == "fail_closed"
+        assert s.jwt_trust_revocation_claim == "jti"
+
+
+class TestJwtTrustModeBoot:
+    """Trust mode with valid config boots cleanly."""
+
+    def test_trust_mode_valid_config_boots(self):
+        s = _settings(jwt_trust_mode="jwt-trust", jwt_trust_revocation_claim="jti")
+        assert s.jwt_trust_mode == "jwt-trust"
+        assert s.jwt_trust_revocation_claim == "jti"
+
+
+class TestJwtTrustClaimValidation:
+    """Empty claim names are rejected at startup."""
+
+    def test_empty_jwt_claim_user_id_rejected(self):
+        with pytest.raises(ValidationError) as exc_info:
+            _settings(jwt_trust_mode="jwt-trust", jwt_claim_user_id="")
+        assert "jwt_claim_user_id" in str(exc_info.value)
+        assert "must not be empty" in str(exc_info.value)
+
+    def test_unknown_claim_name_rejected_with_setting_name(self):
+        with pytest.raises(ValidationError) as exc_info:
+            _settings(jwt_trust_mode="jwt-trust", jwt_claim_teams="")
+        assert "jwt_claim_teams" in str(exc_info.value)
+        assert "must not be empty" in str(exc_info.value)
+
+
+class TestJwtTrustRevocationRequirement:
+    """Trust mode without a revocation claim is rejected at startup."""
+
+    def test_trust_mode_without_revocation_claim_rejected(self):
+        with pytest.raises(ValidationError) as exc_info:
+            _settings(jwt_trust_mode="jwt-trust", jwt_trust_revocation_claim="")
+        message = str(exc_info.value)
+        assert "jwt_trust_revocation_claim" in message
+        assert "must not be empty" in message


### PR DESCRIPTION
Adds the trust-mode config surface: `jwt_trust_mode` (Literal `db`/`jwt-trust`, default `db`), the five claim-mapping settings (`jwt_claim_user_id` default `sub`, `jwt_claim_email` `email`, `jwt_claim_teams` `teams`, `jwt_claim_roles` `roles`, `jwt_claim_admin` `is_admin`), `jwt_trust_overage_policy` (default `fail_closed`), and `jwt_trust_revocation_claim` (default `jti`; `uti` supported for Entra roots). A startup validator rejects trust mode without a revocation claim and rejects empty claim-name settings with an actionable message naming the setting. The 401 contract for trust-eligible tokens missing the configured revocation claim is documented at the setting (enforcement lands in #5900). `.env.example` documents every variable; `docs/docs/manage/configuration.md` gains a JWT Trust Mode section.

No funnel wiring; no existing setting's default changed. The `.secrets.baseline` change is a mechanical hook line-number refresh.

Tested with:
- `uv run pytest tests/unit/mcpgateway/test_jwt_trust_config.py -q` — 5 passed (TDD: 5 failed first with the expected AttributeErrors and missing ValidationErrors)
- `uv run pytest tests/unit/mcpgateway/ -k "config or settings" -q` — green
- `make ruff` — all checks passed
- `make test` — 23238 passed, 879 skipped, 5 xfailed

Acceptance criteria of #5898 are met. Risk to existing users: none — all defaults preserve current behavior; trust mode defaults to `db`.

Stack: B.3 of epic #5885 (base: #6739).

Closes #5898