### PR TITLE
feat(auth): add external group mappings table, resolver, and admin CRUD

### DIFF
--- a/mcpgateway/alembic/versions/b7c8d9e0f1a2_add_external_group_mappings_null_tenant_index.py
+++ b/mcpgateway/alembic/versions/b7c8d9e0f1a2_add_external_group_mappings_null_tenant_index.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/alembic/versions/b7c8d9e0f1a2_add_external_group_mappings_null_tenant_index.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+add_external_group_mappings_null_tenant_index
+
+Revision ID: b7c8d9e0f1a2
+Revises: e5f6a7b8c9d0
+Create Date: 2026-09-12 09:00:00.000000
+"""
+
+# Standard
+from typing import Sequence, Union
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "b7c8d9e0f1a2"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "e5f6a7b8c9d0"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# The plain unique constraint on (issuer, tenant, external_group_id) treats
+# NULL tenants as distinct on both SQLite and PostgreSQL, so duplicate
+# (issuer, external_group_id) rows could coexist when tenant IS NULL,
+# weakening the one-group-to-one-team rule. This partial unique index closes
+# the hole for the NULL-tenant case; the existing constraint keeps covering
+# non-null tenants.
+TABLE_NAME = "external_group_mappings"
+INDEX_NAME = "uq_external_group_mappings_null_tenant"
+
+
+def upgrade() -> None:
+    """Create the partial unique index on (issuer, external_group_id) WHERE tenant IS NULL (idempotent)."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # Skip if the table does not exist (fresh DB uses db.py models directly,
+    # which already declare this index on ExternalGroupMapping.__table_args__).
+    if TABLE_NAME not in inspector.get_table_names():
+        return
+
+    indexes = {ix["name"] for ix in inspector.get_indexes(TABLE_NAME)}
+    if INDEX_NAME not in indexes:
+        op.create_index(
+            INDEX_NAME,
+            TABLE_NAME,
+            ["issuer", "external_group_id"],
+            unique=True,
+            sqlite_where=sa.text("tenant IS NULL"),
+            postgresql_where=sa.text("tenant IS NULL"),
+        )
+
+
+def downgrade() -> None:
+    """Drop the partial unique index if present."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if TABLE_NAME not in inspector.get_table_names():
+        return
+
+    indexes = {ix["name"] for ix in inspector.get_indexes(TABLE_NAME)}
+    if INDEX_NAME in indexes:
+        op.drop_index(INDEX_NAME, table_name=TABLE_NAME)

--- a/mcpgateway/alembic/versions/e5f6a7b8c9d0_add_external_group_mappings.py
+++ b/mcpgateway/alembic/versions/e5f6a7b8c9d0_add_external_group_mappings.py
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 add_external_group_mappings
 
 Revision ID: e5f6a7b8c9d0
-Revises: bf2998718ea1
+Revises: a824749abd27
 Create Date: 2026-09-10 09:00:00.000000
 """
 
@@ -19,7 +19,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "e5f6a7b8c9d0"  # pragma: allowlist secret
-down_revision: Union[str, Sequence[str], None] = "bf2998718ea1"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "a824749abd27"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/alembic/versions/e5f6a7b8c9d0_add_external_group_mappings.py
+++ b/mcpgateway/alembic/versions/e5f6a7b8c9d0_add_external_group_mappings.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/alembic/versions/e5f6a7b8c9d0_add_external_group_mappings.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+add_external_group_mappings
+
+Revision ID: e5f6a7b8c9d0
+Revises: bf2998718ea1
+Create Date: 2026-09-10 09:00:00.000000
+"""
+
+# Standard
+from typing import Sequence, Union
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "e5f6a7b8c9d0"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "bf2998718ea1"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# One group maps to exactly one CF team and one role. The unique constraint on
+# (issuer, tenant, external_group_id) enforces this. The co-location of cf_role
+# in the same row is intentional: a single Entra group can grant both team
+# membership and invocation role in one admin operation. If future requirements
+# need one group to grant membership in multiple teams, relax the unique
+# constraint or add a separate cf_role_overrides table.
+TABLE_NAME = "external_group_mappings"
+UNIQUE_CONSTRAINT = "uq_external_group_mappings_identity"
+
+_COLUMNS = (
+    sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+    sa.Column("issuer", sa.String(length=512), nullable=False),
+    sa.Column("tenant", sa.String(length=512), nullable=True),
+    sa.Column("external_group_id", sa.String(length=512), nullable=False),
+    sa.Column("cf_team_id", sa.String(length=255), nullable=False),
+    # cf_role is a plain String with no foreign key: roles.name has only a
+    # partial unique index, so name alone cannot be an FK target. Existence is
+    # validated at the application level against the roles table.
+    sa.Column("cf_role", sa.String(length=255), nullable=True),
+    sa.Column("validation_status", sa.String(length=50), server_default="valid", nullable=False),
+    sa.Column("last_validated_at", sa.DateTime(timezone=True), nullable=True),
+    sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+)
+
+
+def upgrade() -> None:
+    """Create the external_group_mappings table (idempotent)."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = inspector.get_table_names()
+
+    # Skip if the teams table does not exist (fresh DB uses db.py models directly)
+    if "email_teams" not in tables:
+        return
+
+    if TABLE_NAME not in tables:
+        op.create_table(
+            TABLE_NAME,
+            *_COLUMNS,
+            sa.ForeignKeyConstraint(["cf_team_id"], ["email_teams.id"]),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("issuer", "tenant", "external_group_id", name=UNIQUE_CONSTRAINT),
+        )
+        return
+
+    # Partial-apply recovery: add any missing columns to an existing table
+    columns = [col["name"] for col in inspector.get_columns(TABLE_NAME)]
+    missing = [col for col in _COLUMNS if col.name not in columns]
+    if missing:
+        with op.batch_alter_table(TABLE_NAME, schema=None) as batch_op:
+            for col in missing:
+                batch_op.add_column(col)
+
+    constraints = [con["name"] for con in inspector.get_unique_constraints(TABLE_NAME)]
+    if UNIQUE_CONSTRAINT not in constraints:
+        with op.batch_alter_table(TABLE_NAME, schema=None) as batch_op:
+            batch_op.create_unique_constraint(UNIQUE_CONSTRAINT, ["issuer", "tenant", "external_group_id"])
+
+
+def downgrade() -> None:
+    """Drop the external_group_mappings table."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if TABLE_NAME not in inspector.get_table_names():
+        return
+
+    op.drop_table(TABLE_NAME)

--- a/mcpgateway/api/v1/__init__.py
+++ b/mcpgateway/api/v1/__init__.py
@@ -299,6 +299,14 @@ def _assemble_routers(  # noqa: C901 — deliberate single-function assembly, co
             # mount and this dependency is the only CSRF control these PATCH routes get.
             target_router.include_router(runtime_admin_router, prefix="/admin/runtime", tags=["Runtime Admin"], dependencies=[Depends(enforce_admin_csrf)])
 
+            # First-Party
+            from mcpgateway.routers.admin_external_group_mappings import admin_external_group_mappings_router  # pylint: disable=import-outside-toplevel
+
+            # Same enforce_admin_csrf rationale as runtime_admin_router above:
+            # /admin is in settings.csrf_exempt_paths, so this dependency is the
+            # only CSRF control these routes get.
+            target_router.include_router(admin_external_group_mappings_router, prefix="/admin/external-group-mappings", tags=["External Group Mappings"], dependencies=[Depends(enforce_admin_csrf)])
+
             # Only the /admin/well-known status endpoint belongs in the versioned
             # router.  The full well_known router (which owns /.well-known/* paths)
             # is mounted on app directly in main.py so those paths stay at server

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -5173,6 +5173,42 @@ class ServerTaskMapping(Base):
         return f"<ServerTaskMapping(id='{self.id}', server_task_id='{self.server_task_id}', agent_task_id='{self.agent_task_id}')>"
 
 
+class ExternalGroupMapping(Base):
+    """Maps an external IdP group to one ContextForge team and, optionally, one role.
+
+    External IdP tokens carry group memberships (for example Entra group object
+    IDs) that never match ContextForge team IDs. This table is the translation
+    layer: the trust-mode resolver reads it to compute token_teams (Layer 1)
+    and role names (Layer 2) from the groups claim. One group maps to exactly
+    one CF team and one role; the unique constraint on
+    (issuer, tenant, external_group_id) enforces this. Unmapped groups
+    contribute nothing (fail-closed).
+
+    cf_role is a plain String with no foreign key: roles.name has only a
+    partial unique index, so name alone cannot be an FK target. Existence is
+    validated at the application level against the roles table.
+    """
+
+    __tablename__ = "external_group_mappings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    issuer: Mapped[str] = mapped_column(String(512), nullable=False)
+    tenant: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
+    external_group_id: Mapped[str] = mapped_column(String(512), nullable=False)
+    cf_team_id: Mapped[str] = mapped_column(String(255), ForeignKey("email_teams.id"), nullable=False)
+    cf_role: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    validation_status: Mapped[str] = mapped_column(String(50), nullable=False, default="valid", server_default="valid")
+    last_validated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, server_default=func.now(), nullable=False)
+
+    __table_args__ = (UniqueConstraint("issuer", "tenant", "external_group_id", name="uq_external_group_mappings_identity"),)
+
+    def __repr__(self) -> str:
+        """Return a string representation of the ExternalGroupMapping instance."""
+        return f"<ExternalGroupMapping(id={self.id}, issuer='{self.issuer}', external_group_id='{self.external_group_id}', cf_team_id='{self.cf_team_id}')>"
+
+
 class ServerInterface(Base):
     """Protocol-specific interface configuration per virtual server."""
 

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -5202,7 +5202,13 @@ class ExternalGroupMapping(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, server_default=func.now(), nullable=False)
 
-    __table_args__ = (UniqueConstraint("issuer", "tenant", "external_group_id", name="uq_external_group_mappings_identity"),)
+    __table_args__ = (
+        UniqueConstraint("issuer", "tenant", "external_group_id", name="uq_external_group_mappings_identity"),
+        # Plain unique constraints treat NULL tenants as distinct on both SQLite
+        # and PostgreSQL, so the (issuer, external_group_id) pair gets its own
+        # partial unique index for the tenant-IS-NULL case.
+        Index("uq_external_group_mappings_null_tenant", "issuer", "external_group_id", unique=True, postgresql_where=text("tenant IS NULL"), sqlite_where=text("tenant IS NULL")),
+    )
 
     def __repr__(self) -> str:
         """Return a string representation of the ExternalGroupMapping instance."""

--- a/mcpgateway/routers/admin_external_group_mappings.py
+++ b/mcpgateway/routers/admin_external_group_mappings.py
@@ -42,6 +42,7 @@ from mcpgateway.db import EmailTeam, ExternalGroupMapping, Role
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, get_db, require_permission
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.security_logger import get_security_logger
+from mcpgateway.utils.verify_credentials import invalidate_external_identity_cache
 
 logging_service = LoggingService()
 logger = logging_service.get_logger(__name__)
@@ -140,6 +141,35 @@ def _validate_role_exists(db: Session, cf_role: Optional[str]) -> None:
         raise HTTPException(status_code=400, detail=f"Role not found: {cf_role}")
 
 
+def _check_null_tenant_duplicate(db: Session, issuer: str, external_group_id: str, exclude_id: Optional[int] = None) -> None:
+    """Raise 409 when a NULL-tenant mapping already exists for (issuer, external_group_id).
+
+    The plain unique constraint on (issuer, tenant, external_group_id) treats
+    NULL tenants as distinct on SQLite and PostgreSQL, so the tenant-IS-NULL
+    case is pre-checked here at the application level (and backstopped by the
+    uq_external_group_mappings_null_tenant partial unique index).
+
+    Args:
+        db: Database session.
+        issuer: Token issuer of the mapping being written.
+        external_group_id: External group ID of the mapping being written.
+        exclude_id: Mapping primary key to exclude (the row being updated).
+
+    Raises:
+        HTTPException: 409 when another NULL-tenant row already maps this
+            (issuer, external_group_id) pair.
+    """
+    query = db.query(ExternalGroupMapping).filter(
+        ExternalGroupMapping.issuer == issuer,
+        ExternalGroupMapping.tenant.is_(None),
+        ExternalGroupMapping.external_group_id == external_group_id,
+    )
+    if exclude_id is not None:
+        query = query.filter(ExternalGroupMapping.id != exclude_id)
+    if query.first() is not None:
+        raise HTTPException(status_code=409, detail="Mapping already exists for (issuer, tenant, external_group_id)")
+
+
 def _run_group_validation(mapping: ExternalGroupMapping, user, db: Session) -> None:
     """Run the group-existence validator and record the outcome on the row.
 
@@ -206,6 +236,8 @@ async def create_external_group_mapping(
     """
     _validate_team_exists(db, body.cf_team_id)
     _validate_role_exists(db, body.cf_role)
+    if body.tenant is None:
+        _check_null_tenant_duplicate(db, body.issuer, body.external_group_id)
 
     mapping = ExternalGroupMapping(
         issuer=body.issuer,
@@ -222,6 +254,7 @@ async def create_external_group_mapping(
         db.rollback()
         raise HTTPException(status_code=409, detail="Mapping already exists for (issuer, tenant, external_group_id)") from exc
     db.refresh(mapping)
+    await invalidate_external_identity_cache()
     return mapping
 
 
@@ -279,6 +312,11 @@ async def update_external_group_mapping(
         _validate_team_exists(db, updates["cf_team_id"])
     if "cf_role" in updates:
         _validate_role_exists(db, updates["cf_role"])
+    # Pre-check the effective identity before mutating the row: applying the
+    # updates first would let query autoflush hit the partial unique index
+    # with a raw IntegrityError instead of the 409 below.
+    if updates.get("tenant", mapping.tenant) is None:
+        _check_null_tenant_duplicate(db, updates.get("issuer", mapping.issuer), updates.get("external_group_id", mapping.external_group_id), exclude_id=mapping.id)
     for field, value in updates.items():
         setattr(mapping, field, value)
 
@@ -289,6 +327,7 @@ async def update_external_group_mapping(
         db.rollback()
         raise HTTPException(status_code=409, detail="Mapping already exists for (issuer, tenant, external_group_id)") from exc
     db.refresh(mapping)
+    await invalidate_external_identity_cache()
     return mapping
 
 
@@ -319,4 +358,5 @@ async def delete_external_group_mapping(
         raise HTTPException(status_code=404, detail=f"External group mapping not found: {mapping_id}")
     db.delete(mapping)
     db.commit()
+    await invalidate_external_identity_cache()
     return {"detail": "deleted", "id": mapping_id}

--- a/mcpgateway/routers/admin_external_group_mappings.py
+++ b/mcpgateway/routers/admin_external_group_mappings.py
@@ -1,0 +1,322 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/routers/admin_external_group_mappings.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Admin CRUD router for external group mappings (issue #5976).
+
+Exposes POST/PUT/GET/DELETE under /admin/external-group-mappings. Each
+endpoint requires the admin.system_config permission, the same permission
+used by sibling admin routers such as runtime_admin_router.
+
+Write-time validation:
+- cf_team_id must exist in the email_teams table (400 otherwise).
+- cf_role, when provided, must match a row in the roles table by name (400
+  otherwise). cf_role carries no foreign key: roles.name has only a partial
+  unique index, so existence is validated here at the application level.
+- The injectable group_exists_validator seam checks that the external group
+  exists in the IdP. It ships disabled by default: the stub always returns
+  "valid". The real Microsoft Graph validator lands with the app-only Graph
+  client (#5977). The semantics are WARN-AND-ALLOW: when Graph is unreachable
+  the validator returns "unknown", the mapping row is still stored, the row
+  is audit-logged, and a warning is emitted. A missing group never grants
+  access through this seam; the resolver fails closed at read time.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from datetime import datetime, timezone
+from typing import Callable, List, Optional
+
+# Third-Party
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.auth_context import get_user_email
+from mcpgateway.db import EmailTeam, ExternalGroupMapping, Role
+from mcpgateway.middleware.rbac import get_current_user_with_permissions, get_db, require_permission
+from mcpgateway.services.logging_service import LoggingService
+from mcpgateway.services.security_logger import get_security_logger
+
+logging_service = LoggingService()
+logger = logging_service.get_logger(__name__)
+
+admin_external_group_mappings_router = APIRouter()
+
+#: Injectable validator seam. Signature: (issuer, tenant, external_group_id)
+#: -> validation_status. Ships disabled: the stub always returns "valid".
+#: WO-B.7 (#5977) wires the real Microsoft Graph validator.
+GroupExistsValidator = Callable[[str, str, str], str]
+
+
+def _disabled_group_exists_validator(issuer: str, tenant: str, external_group_id: str) -> str:
+    """Default group-existence validator: disabled, always reports "valid".
+
+    Args:
+        issuer: Token issuer the mapping is scoped to.
+        tenant: Tenant the mapping is scoped to ("" when the row is tenant-less).
+        external_group_id: External IdP group ID to check.
+
+    Returns:
+        str: Always "valid"; no IdP call is made until #5977 lands.
+    """
+    return "valid"
+
+
+group_exists_validator: GroupExistsValidator = _disabled_group_exists_validator
+
+
+class ExternalGroupMappingCreate(BaseModel):
+    """Request body for POST /admin/external-group-mappings."""
+
+    issuer: str = Field(min_length=1, max_length=512)
+    tenant: Optional[str] = Field(default=None, max_length=512)
+    external_group_id: str = Field(min_length=1, max_length=512)
+    cf_team_id: str = Field(min_length=1, max_length=255)
+    cf_role: Optional[str] = Field(default=None, max_length=255)
+
+
+class ExternalGroupMappingUpdate(BaseModel):
+    """Request body for PUT /admin/external-group-mappings/{id}."""
+
+    issuer: Optional[str] = Field(default=None, min_length=1, max_length=512)
+    tenant: Optional[str] = Field(default=None, max_length=512)
+    external_group_id: Optional[str] = Field(default=None, min_length=1, max_length=512)
+    cf_team_id: Optional[str] = Field(default=None, min_length=1, max_length=255)
+    cf_role: Optional[str] = Field(default=None, max_length=255)
+
+
+class ExternalGroupMappingResponse(BaseModel):
+    """Response body for external group mapping endpoints."""
+
+    model_config = {"from_attributes": True}
+
+    id: int
+    issuer: str
+    tenant: Optional[str]
+    external_group_id: str
+    cf_team_id: str
+    cf_role: Optional[str]
+    validation_status: str
+    last_validated_at: Optional[datetime]
+    created_at: datetime
+    updated_at: datetime
+
+
+def _validate_team_exists(db: Session, cf_team_id: str) -> None:
+    """Raise 400 when cf_team_id does not exist in email_teams.
+
+    Args:
+        db: Database session.
+        cf_team_id: ContextForge team ID to check.
+
+    Raises:
+        HTTPException: 400 when the team does not exist.
+    """
+    team = db.query(EmailTeam).filter(EmailTeam.id == cf_team_id).first()
+    if not team:
+        raise HTTPException(status_code=400, detail=f"Team not found: {cf_team_id}")
+
+
+def _validate_role_exists(db: Session, cf_role: Optional[str]) -> None:
+    """Raise 400 when cf_role is set but matches no row in the roles table.
+
+    Args:
+        db: Database session.
+        cf_role: Role name to check. None skips the check.
+
+    Raises:
+        HTTPException: 400 when the role name does not exist.
+    """
+    if cf_role is None:
+        return
+    role = db.query(Role).filter(Role.name == cf_role).first()
+    if not role:
+        raise HTTPException(status_code=400, detail=f"Role not found: {cf_role}")
+
+
+def _run_group_validation(mapping: ExternalGroupMapping, user, db: Session) -> None:
+    """Run the group-existence validator and record the outcome on the row.
+
+    WARN-AND-ALLOW: a validation_status of "unknown" (Graph unreachable) does
+    not block the write. The outcome is audit-logged and a warning is emitted.
+
+    Args:
+        mapping: The mapping row to annotate.
+        user: Authenticated user context for the audit entry.
+        db: Database session for the audit entry.
+    """
+    status_value = group_exists_validator(mapping.issuer, mapping.tenant or "", mapping.external_group_id)
+    mapping.validation_status = status_value
+    mapping.last_validated_at = datetime.now(timezone.utc)
+    if status_value == "unknown":
+        logger.warning(
+            "External group existence could not be validated (IdP unreachable); storing mapping with validation_status=unknown: issuer=%s external_group_id=%s",
+            mapping.issuer,
+            mapping.external_group_id,
+        )
+        try:
+            get_security_logger().log_data_access(
+                action="create",
+                resource_type="external_group_mapping",
+                resource_id=mapping.external_group_id,
+                resource_name=mapping.external_group_id,
+                user_id=get_user_email(user),
+                user_email=get_user_email(user),
+                team_id=mapping.cf_team_id,
+                client_ip=user.get("ip_address") if isinstance(user, dict) else None,
+                user_agent=user.get("user_agent") if isinstance(user, dict) else None,
+                success=True,
+                old_values=None,
+                new_values={"validation_status": "unknown"},
+                additional_context={"reason": "idp_unreachable_warn_and_allow"},
+                db=db,
+            )
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.error("Audit write for unvalidated external group mapping failed (write still proceeded): %s", exc)
+
+
+@admin_external_group_mappings_router.post("", response_model=ExternalGroupMappingResponse)
+@require_permission("admin.system_config")
+async def create_external_group_mapping(
+    body: ExternalGroupMappingCreate,
+    request: Request,
+    user=Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+) -> ExternalGroupMapping:
+    """Create an external group mapping.
+
+    Args:
+        body: Mapping fields.
+        request: FastAPI request.
+        user: Authenticated user context (injected).
+        db: Database session (injected).
+
+    Returns:
+        ExternalGroupMapping: The stored mapping row.
+
+    Raises:
+        HTTPException: 400 on unknown team or role; 409 on duplicate
+            (issuer, tenant, external_group_id).
+    """
+    _validate_team_exists(db, body.cf_team_id)
+    _validate_role_exists(db, body.cf_role)
+
+    mapping = ExternalGroupMapping(
+        issuer=body.issuer,
+        tenant=body.tenant,
+        external_group_id=body.external_group_id,
+        cf_team_id=body.cf_team_id,
+        cf_role=body.cf_role,
+    )
+    _run_group_validation(mapping, user, db)
+    db.add(mapping)
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Mapping already exists for (issuer, tenant, external_group_id)") from exc
+    db.refresh(mapping)
+    return mapping
+
+
+@admin_external_group_mappings_router.get("", response_model=List[ExternalGroupMappingResponse])
+@require_permission("admin.system_config")
+async def list_external_group_mappings(
+    request: Request,
+    user=Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+) -> List[ExternalGroupMapping]:
+    """List all external group mappings.
+
+    Args:
+        request: FastAPI request.
+        user: Authenticated user context (injected).
+        db: Database session (injected).
+
+    Returns:
+        List[ExternalGroupMapping]: All mapping rows, oldest first.
+    """
+    return db.query(ExternalGroupMapping).order_by(ExternalGroupMapping.id).all()
+
+
+@admin_external_group_mappings_router.put("/{mapping_id}", response_model=ExternalGroupMappingResponse)
+@require_permission("admin.system_config")
+async def update_external_group_mapping(
+    mapping_id: int,
+    body: ExternalGroupMappingUpdate,
+    request: Request,
+    user=Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+) -> ExternalGroupMapping:
+    """Update an external group mapping.
+
+    Args:
+        mapping_id: Primary key of the mapping row.
+        body: Fields to change; unset fields stay unchanged.
+        request: FastAPI request.
+        user: Authenticated user context (injected).
+        db: Database session (injected).
+
+    Returns:
+        ExternalGroupMapping: The updated mapping row.
+
+    Raises:
+        HTTPException: 404 when the mapping does not exist; 400 on unknown
+            team or role; 409 when the change violates the unique constraint.
+    """
+    mapping = db.query(ExternalGroupMapping).filter(ExternalGroupMapping.id == mapping_id).first()
+    if not mapping:
+        raise HTTPException(status_code=404, detail=f"External group mapping not found: {mapping_id}")
+
+    updates = body.model_dump(exclude_unset=True)
+    if "cf_team_id" in updates:
+        _validate_team_exists(db, updates["cf_team_id"])
+    if "cf_role" in updates:
+        _validate_role_exists(db, updates["cf_role"])
+    for field, value in updates.items():
+        setattr(mapping, field, value)
+
+    _run_group_validation(mapping, user, db)
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Mapping already exists for (issuer, tenant, external_group_id)") from exc
+    db.refresh(mapping)
+    return mapping
+
+
+@admin_external_group_mappings_router.delete("/{mapping_id}")
+@require_permission("admin.system_config")
+async def delete_external_group_mapping(
+    mapping_id: int,
+    request: Request,
+    user=Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Delete an external group mapping.
+
+    Args:
+        mapping_id: Primary key of the mapping row.
+        request: FastAPI request.
+        user: Authenticated user context (injected).
+        db: Database session (injected).
+
+    Returns:
+        dict: Confirmation with the deleted mapping ID.
+
+    Raises:
+        HTTPException: 404 when the mapping does not exist.
+    """
+    mapping = db.query(ExternalGroupMapping).filter(ExternalGroupMapping.id == mapping_id).first()
+    if not mapping:
+        raise HTTPException(status_code=404, detail=f"External group mapping not found: {mapping_id}")
+    db.delete(mapping)
+    db.commit()
+    return {"detail": "deleted", "id": mapping_id}

--- a/mcpgateway/utils/trusted_claims.py
+++ b/mcpgateway/utils/trusted_claims.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/utils/trusted_claims.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Trusted claims extraction and group-to-team resolution. This module will also
+host extract_trusted_principal (added by #5899).
+"""
+
+# Standard
+from typing import List, Optional, Tuple
+
+# Third-Party
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.db import ExternalGroupMapping
+
+
+def resolve_external_groups_to_teams(issuer: str, tenant: Optional[str], groups: List[str], db: Session) -> Tuple[List[str], List[str]]:
+    """Resolve external IdP group IDs to ContextForge team IDs and role names.
+
+    Reads the external_group_mappings table for rows that match the token
+    issuer, tenant, and at least one of the supplied external group IDs.
+    Unmapped groups contribute nothing (fail-closed): a group with no mapping
+    row grants no team and no role. Raw external group IDs never reach
+    token_teams; only mapped cf_team_id values are returned.
+
+    Args:
+        issuer: Token issuer claim used to scope mapping rows.
+        tenant: Token tenant claim. None matches only tenant-less mapping rows.
+        groups: External group IDs from the token groups claim.
+        db: Database session.
+
+    Returns:
+        Tuple[List[str], List[str]]: (team_ids, role_names) in table order,
+        de-duplicated. A row with cf_role NULL contributes only its team.
+
+    Examples:
+        >>> resolve_external_groups_to_teams("iss", "tenant", [], None)
+        ([], [])
+    """
+    if not groups:
+        return [], []
+
+    query = db.query(ExternalGroupMapping).filter(
+        ExternalGroupMapping.issuer == issuer,
+        ExternalGroupMapping.external_group_id.in_(groups),
+    )
+    if tenant is None:
+        query = query.filter(ExternalGroupMapping.tenant.is_(None))
+    else:
+        query = query.filter(ExternalGroupMapping.tenant == tenant)
+
+    team_ids: List[str] = []
+    role_names: List[str] = []
+    for row in query.all():
+        if row.cf_team_id and row.cf_team_id not in team_ids:
+            team_ids.append(row.cf_team_id)
+        if row.cf_role and row.cf_role not in role_names:
+            role_names.append(row.cf_role)
+    return team_ids, role_names

--- a/tests/unit/mcpgateway/db/test_external_group_mapping_model.py
+++ b/tests/unit/mcpgateway/db/test_external_group_mapping_model.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/db/test_external_group_mapping_model.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for the ExternalGroupMapping ORM model (issue #5976).
+
+The model mirrors the external_group_mappings migration schema: one external
+group maps to exactly one CF team and, optionally, one role. cf_team_id is a
+foreign key to email_teams.id. cf_role is a plain String with no foreign key:
+roles.name has only a partial unique index, so role existence is validated at
+the application level.
+"""
+
+# Standard
+from datetime import datetime, timezone
+
+# Third-Party
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import event
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.db import Base, EmailTeam, EmailUser, ExternalGroupMapping
+
+
+def _make_session():
+    """Return a session on an in-memory SQLite DB with FK enforcement on."""
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+
+    @event.listens_for(engine, "connect")
+    def _enable_fk(dbapi_conn, _):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    Base.metadata.create_all(bind=engine)
+    return sessionmaker(bind=engine)()
+
+
+def _seed_user(db, email: str = "owner@example.com") -> EmailUser:
+    """Insert the owner user; return it."""
+    user = EmailUser(
+        email=email,
+        password_hash="hash",  # pragma: allowlist secret
+        full_name="Owner",
+        is_admin=False,
+        is_active=True,
+        email_verified_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    db.add(user)
+    db.commit()
+    return user
+
+
+def _seed_team(db, team_id: str, created_by: str = "owner@example.com") -> EmailTeam:
+    """Insert one team; return it."""
+    team = EmailTeam(id=team_id, name=f"Team {team_id}", slug=f"team-{team_id}", created_by=created_by, is_personal=False, visibility="private")
+    db.add(team)
+    db.commit()
+    return team
+
+
+def _seed_user_and_team(db, team_id: str = "team-a") -> EmailTeam:
+    """Insert the owner user and one team; return the team."""
+    _seed_user(db)
+    return _seed_team(db, team_id)
+
+
+def _mapping(**overrides) -> ExternalGroupMapping:
+    """Build a mapping row with sane defaults; override any field by name."""
+    values = {
+        "issuer": "https://issuer.example.com",
+        "tenant": "tenant-1",
+        "external_group_id": "guid-1",
+        "cf_team_id": "team-a",
+        "cf_role": "developer",
+    }
+    values.update(overrides)
+    return ExternalGroupMapping(**values)
+
+
+class TestExternalGroupMappingModel:
+    """Schema shape and constraint behavior of ExternalGroupMapping."""
+
+    def test_tablename(self):
+        assert ExternalGroupMapping.__tablename__ == "external_group_mappings"
+
+    def test_instantiation_fields(self):
+        mapping = _mapping()
+        assert mapping.issuer == "https://issuer.example.com"
+        assert mapping.tenant == "tenant-1"
+        assert mapping.external_group_id == "guid-1"
+        assert mapping.cf_team_id == "team-a"
+        assert mapping.cf_role == "developer"
+
+    def test_nullable_fields(self):
+        mapping = _mapping(tenant=None, cf_role=None)
+        assert mapping.tenant is None
+        assert mapping.cf_role is None
+
+    def test_server_defaults_on_insert(self):
+        db = _make_session()
+        try:
+            _seed_user_and_team(db)
+            mapping = _mapping()
+            db.add(mapping)
+            db.commit()
+            assert mapping.id is not None
+            assert mapping.validation_status == "valid"
+            assert mapping.created_at is not None
+            assert mapping.updated_at is not None
+            assert mapping.last_validated_at is None
+        finally:
+            db.close()
+
+    def test_unique_constraint_issuer_tenant_group(self):
+        db = _make_session()
+        try:
+            _seed_user(db)
+            _seed_team(db, "team-a")
+            _seed_team(db, "team-b")
+            db.add(_mapping(cf_team_id="team-a"))
+            db.commit()
+            db.add(_mapping(cf_team_id="team-b"))
+            with pytest.raises(IntegrityError):
+                db.commit()
+        finally:
+            db.close()
+
+    def test_cf_team_id_fk_target(self):
+        fks = ExternalGroupMapping.__table__.c.cf_team_id.foreign_keys
+        assert {fk.target_fullname for fk in fks} == {"email_teams.id"}
+
+    def test_cf_team_id_fk_enforced(self):
+        db = _make_session()
+        try:
+            db.add(_mapping(cf_team_id="missing-team"))
+            with pytest.raises(IntegrityError):
+                db.commit()
+        finally:
+            db.close()
+
+    def test_cf_role_has_no_fk(self):
+        # roles.name has only a partial unique index, so cf_role must stay a
+        # plain String. Existence is validated at the application level.
+        assert not ExternalGroupMapping.__table__.c.cf_role.foreign_keys

--- a/tests/unit/mcpgateway/routers/test_external_group_mapping_admin.py
+++ b/tests/unit/mcpgateway/routers/test_external_group_mapping_admin.py
@@ -1,0 +1,227 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/routers/test_external_group_mapping_admin.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for the external group mappings admin CRUD router (issue #5976).
+
+The endpoints are decorated with @require_permission("admin.system_config"),
+which calls PermissionService(db).check_permission(...). We patch the
+PermissionService class in mcpgateway.middleware.rbac to return the desired
+allow/deny outcome and exercise the endpoint functions directly, the same
+pattern used by test_runtime_admin_router.py.
+"""
+
+# Standard
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+# Third-Party
+from fastapi import HTTPException
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.db import Base, EmailTeam, EmailUser, ExternalGroupMapping, Role
+from mcpgateway.routers import admin_external_group_mappings as router_module
+
+
+@pytest.fixture
+def db():
+    """In-memory SQLite session seeded with an owner user, two teams, and two roles."""
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    user = EmailUser(
+        email="admin@example.com",
+        password_hash="hash",  # pragma: allowlist secret
+        full_name="Admin",
+        is_admin=True,
+        is_active=True,
+        email_verified_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    session.add(user)
+    session.add(EmailTeam(id="team-a", name="Team A", slug="team-a", created_by=user.email, is_personal=False, visibility="private"))
+    session.add(EmailTeam(id="team-b", name="Team B", slug="team-b", created_by=user.email, is_personal=False, visibility="private"))
+    session.add(Role(name="developer", scope="team", permissions=["a2a.invoke"], created_by=user.email, is_system_role=True, is_active=True))
+    session.add(Role(name="viewer", scope="team", permissions=[], created_by=user.email, is_system_role=True, is_active=True))
+    session.commit()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def admin_user():
+    return {"email": "admin@example.com", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "tests"}
+
+
+@pytest.fixture
+def non_admin_user():
+    return {"email": "user@example.com", "is_admin": False, "ip_address": "127.0.0.1", "user_agent": "tests"}
+
+
+@pytest.fixture
+def request_stub():
+    req = MagicMock()
+    req.headers = {}
+    return req
+
+
+@pytest.fixture
+def allow_admin(monkeypatch: pytest.MonkeyPatch):
+    """Patch PermissionService so check_permission always returns True."""
+
+    class AllowAll:
+        def __init__(self, _db):
+            pass
+
+        async def check_permission(self, **_kwargs):
+            return True
+
+    monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", AllowAll)
+
+
+@pytest.fixture
+def deny_all(monkeypatch: pytest.MonkeyPatch):
+    """Patch PermissionService so check_permission always returns False."""
+
+    class DenyAll:
+        def __init__(self, _db):
+            pass
+
+        async def check_permission(self, **_kwargs):
+            return False
+
+    monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", DenyAll)
+
+
+def _create_body(**overrides) -> router_module.ExternalGroupMappingCreate:
+    values = {
+        "issuer": "https://issuer.example.com",
+        "tenant": "tenant-1",
+        "external_group_id": "guid-1",
+        "cf_team_id": "team-a",
+        "cf_role": "developer",
+    }
+    values.update(overrides)
+    return router_module.ExternalGroupMappingCreate(**values)
+
+
+class TestDenyPaths:
+    """401 / 403 / 400 deny paths."""
+
+    @pytest.mark.asyncio
+    async def test_create_unauthenticated_401(self, db, request_stub):
+        with pytest.raises(HTTPException) as exc:
+            await router_module.create_external_group_mapping(_create_body(), request=request_stub, user=None, db=db)
+        assert exc.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_create_insufficient_permissions_403(self, deny_all, db, non_admin_user, request_stub):
+        with pytest.raises(HTTPException) as exc:
+            await router_module.create_external_group_mapping(_create_body(), request=request_stub, user=non_admin_user, db=db)
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_list_insufficient_permissions_403(self, deny_all, db, non_admin_user, request_stub):
+        with pytest.raises(HTTPException) as exc:
+            await router_module.list_external_group_mappings(request=request_stub, user=non_admin_user, db=db)
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_create_invalid_cf_team_id_400(self, allow_admin, db, admin_user, request_stub):
+        with pytest.raises(HTTPException) as exc:
+            await router_module.create_external_group_mapping(_create_body(cf_team_id="missing-team"), request=request_stub, user=admin_user, db=db)
+        assert exc.value.status_code == 400
+        assert "missing-team" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_create_invalid_cf_role_400(self, allow_admin, db, admin_user, request_stub):
+        with pytest.raises(HTTPException) as exc:
+            await router_module.create_external_group_mapping(_create_body(cf_role="no-such-role"), request=request_stub, user=admin_user, db=db)
+        assert exc.value.status_code == 400
+        assert "Role not found" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_update_invalid_cf_team_id_400(self, allow_admin, db, admin_user, request_stub):
+        created = await router_module.create_external_group_mapping(_create_body(), request=request_stub, user=admin_user, db=db)
+        body = router_module.ExternalGroupMappingUpdate(cf_team_id="missing-team")
+        with pytest.raises(HTTPException) as exc:
+            await router_module.update_external_group_mapping(created.id, body, request=request_stub, user=admin_user, db=db)
+        assert exc.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_404(self, allow_admin, db, admin_user, request_stub):
+        with pytest.raises(HTTPException) as exc:
+            await router_module.delete_external_group_mapping(9999, request=request_stub, user=admin_user, db=db)
+        assert exc.value.status_code == 404
+
+
+class TestCrudHappyPaths:
+    """Valid create, list, update, and delete flows."""
+
+    @pytest.mark.asyncio
+    async def test_create_valid_200(self, allow_admin, db, admin_user, request_stub):
+        created = await router_module.create_external_group_mapping(_create_body(), request=request_stub, user=admin_user, db=db)
+        assert created.id is not None
+        assert created.issuer == "https://issuer.example.com"
+        assert created.tenant == "tenant-1"
+        assert created.external_group_id == "guid-1"
+        assert created.cf_team_id == "team-a"
+        assert created.cf_role == "developer"
+        assert created.validation_status == "valid"
+
+    @pytest.mark.asyncio
+    async def test_list_200(self, allow_admin, db, admin_user, request_stub):
+        await router_module.create_external_group_mapping(_create_body(), request=request_stub, user=admin_user, db=db)
+        await router_module.create_external_group_mapping(_create_body(external_group_id="guid-2", cf_team_id="team-b", cf_role=None), request=request_stub, user=admin_user, db=db)
+        rows = await router_module.list_external_group_mappings(request=request_stub, user=admin_user, db=db)
+        assert len(rows) == 2
+        assert {row.external_group_id for row in rows} == {"guid-1", "guid-2"}
+
+    @pytest.mark.asyncio
+    async def test_update_valid_200(self, allow_admin, db, admin_user, request_stub):
+        created = await router_module.create_external_group_mapping(_create_body(), request=request_stub, user=admin_user, db=db)
+        body = router_module.ExternalGroupMappingUpdate(cf_team_id="team-b", cf_role="viewer")
+        updated = await router_module.update_external_group_mapping(created.id, body, request=request_stub, user=admin_user, db=db)
+        assert updated.cf_team_id == "team-b"
+        assert updated.cf_role == "viewer"
+
+    @pytest.mark.asyncio
+    async def test_delete_valid_200(self, allow_admin, db, admin_user, request_stub):
+        created = await router_module.create_external_group_mapping(_create_body(), request=request_stub, user=admin_user, db=db)
+        await router_module.delete_external_group_mapping(created.id, request=request_stub, user=admin_user, db=db)
+        assert db.query(ExternalGroupMapping).count() == 0
+
+    @pytest.mark.asyncio
+    async def test_create_duplicate_409(self, allow_admin, db, admin_user, request_stub):
+        await router_module.create_external_group_mapping(_create_body(), request=request_stub, user=admin_user, db=db)
+        with pytest.raises(HTTPException) as exc:
+            await router_module.create_external_group_mapping(_create_body(cf_team_id="team-b"), request=request_stub, user=admin_user, db=db)
+        assert exc.value.status_code == 409
+
+
+class TestGraphValidatorSeam:
+    """The injectable group-existence validator seam (Graph client lands in #5977)."""
+
+    @pytest.mark.asyncio
+    async def test_default_validator_returns_valid(self, allow_admin, db, admin_user, request_stub):
+        created = await router_module.create_external_group_mapping(_create_body(), request=request_stub, user=admin_user, db=db)
+        assert created.validation_status == "valid"
+
+    @pytest.mark.asyncio
+    async def test_unknown_status_warns_and_allows(self, allow_admin, db, admin_user, request_stub, monkeypatch: pytest.MonkeyPatch):
+        # Graph unreachable -> validation_status "unknown" -> row is still
+        # stored (warn-and-allow). The denial of a missing group never comes
+        # from this seam; fail-closed happens in the resolver at read time.
+        monkeypatch.setattr(router_module, "group_exists_validator", lambda issuer, tenant, group_id: "unknown")
+        created = await router_module.create_external_group_mapping(_create_body(), request=request_stub, user=admin_user, db=db)
+        assert created.validation_status == "unknown"
+        assert created.last_validated_at is not None

--- a/tests/unit/mcpgateway/services/test_external_group_mapping_resolver.py
+++ b/tests/unit/mcpgateway/services/test_external_group_mapping_resolver.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_external_group_mapping_resolver.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for resolve_external_groups_to_teams (issue #5976).
+
+The resolver translates external IdP group IDs into ContextForge team IDs and
+role names through the external_group_mappings table. Unmapped groups
+contribute nothing: the resolver fails closed.
+"""
+
+# Standard
+from datetime import datetime, timezone
+
+# Third-Party
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.db import Base, EmailTeam, EmailUser, ExternalGroupMapping
+from mcpgateway.utils.trusted_claims import resolve_external_groups_to_teams
+
+ISSUER = "https://issuer.example.com"
+TENANT = "tenant-1"
+
+
+@pytest.fixture
+def db():
+    """In-memory SQLite session seeded with teams and mapping rows."""
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    user = EmailUser(
+        email="owner@example.com",
+        password_hash="hash",  # pragma: allowlist secret
+        full_name="Owner",
+        is_admin=False,
+        is_active=True,
+        email_verified_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    session.add(user)
+    session.add(EmailTeam(id="team-a", name="Team A", slug="team-a", created_by=user.email, is_personal=False, visibility="private"))
+    session.add(EmailTeam(id="team-b", name="Team B", slug="team-b", created_by=user.email, is_personal=False, visibility="private"))
+    session.add(ExternalGroupMapping(issuer=ISSUER, tenant=TENANT, external_group_id="guid-1", cf_team_id="team-a", cf_role="developer"))
+    session.add(ExternalGroupMapping(issuer=ISSUER, tenant=TENANT, external_group_id="guid-2", cf_team_id="team-b", cf_role=None))
+    session.add(ExternalGroupMapping(issuer=ISSUER, tenant=None, external_group_id="guid-3", cf_team_id="team-b", cf_role="viewer"))
+    session.commit()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+class TestResolveExternalGroupsToTeams:
+    """Mapped, unmapped, and mixed group resolution."""
+
+    def test_mapped_groups_return_teams_and_roles(self, db):
+        team_ids, role_names = resolve_external_groups_to_teams(ISSUER, TENANT, ["guid-1", "guid-2"], db)
+        assert team_ids == ["team-a", "team-b"]
+        assert role_names == ["developer"]
+
+    def test_unmapped_groups_fail_closed(self, db):
+        team_ids, role_names = resolve_external_groups_to_teams(ISSUER, TENANT, ["guid-unknown"], db)
+        assert team_ids == []
+        assert role_names == []
+
+    def test_mixed_groups_only_mapped_contribute(self, db):
+        team_ids, role_names = resolve_external_groups_to_teams(ISSUER, TENANT, ["guid-1", "guid-unknown"], db)
+        assert team_ids == ["team-a"]
+        assert role_names == ["developer"]
+
+    def test_empty_groups_fail_closed(self, db):
+        team_ids, role_names = resolve_external_groups_to_teams(ISSUER, TENANT, [], db)
+        assert team_ids == []
+        assert role_names == []
+
+    def test_tenant_scoping_isolates_mappings(self, db):
+        # A mapping recorded for tenant-1 must not leak into another tenant.
+        team_ids, role_names = resolve_external_groups_to_teams(ISSUER, "other-tenant", ["guid-1"], db)
+        assert team_ids == []
+        assert role_names == []
+
+    def test_null_tenant_matches_only_tenantless_rows(self, db):
+        team_ids, role_names = resolve_external_groups_to_teams(ISSUER, None, ["guid-1", "guid-3"], db)
+        assert team_ids == ["team-b"]
+        assert role_names == ["viewer"]
+
+    def test_issuer_scoping_isolates_mappings(self, db):
+        team_ids, role_names = resolve_external_groups_to_teams("https://other-issuer.example.com", TENANT, ["guid-1"], db)
+        assert team_ids == []
+        assert role_names == []
+
+    def test_null_role_contributes_team_only(self, db):
+        team_ids, role_names = resolve_external_groups_to_teams(ISSUER, TENANT, ["guid-2"], db)
+        assert team_ids == ["team-b"]
+        assert role_names == []

--- a/tests/unit/mcpgateway/services/test_external_group_mapping_service.py
+++ b/tests/unit/mcpgateway/services/test_external_group_mapping_service.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_external_group_mapping_service.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Mapping uniqueness and external-identity cache invalidation tests (#5976).
+
+This branch has no separate service module: the mapping CRUD lives in
+mcpgateway/routers/admin_external_group_mappings.py, which is the mapping
+service layer exercised here.
+
+Defects under test:
+1. The unique constraint on (issuer, tenant, external_group_id) has a
+   nullable tenant; SQLite and PostgreSQL both permit duplicate rows when
+   tenant IS NULL. The service must reject a second create/update that
+   collides on (issuer, external_group_id) with tenant NULL, using the same
+   409 conflict error as the non-null-tenant duplicate path.
+2. _external_identity_cache in mcpgateway/utils/verify_credentials.py caches
+   synthesized external identities keyed by token hash. Every successful
+   mapping create/update/delete must call invalidate_external_identity_cache()
+   so a deleted mapping stops contributing teams to a cached token identity.
+"""
+
+# Standard
+from datetime import datetime, timezone
+from time import monotonic
+from unittest.mock import MagicMock
+
+# Third-Party
+from fastapi import HTTPException
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.db import Base, EmailTeam, EmailUser, ExternalGroupMapping, Role
+from mcpgateway.routers import admin_external_group_mappings as mapping_service
+from mcpgateway.utils import verify_credentials as vc
+
+
+@pytest.fixture
+def db():
+    """In-memory SQLite session seeded with an owner user, two teams, and two roles."""
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    user = EmailUser(
+        email="admin@example.com",
+        password_hash="hash",  # pragma: allowlist secret
+        full_name="Admin",
+        is_admin=True,
+        is_active=True,
+        email_verified_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    session.add(user)
+    session.add(EmailTeam(id="team-a", name="Team A", slug="team-a", created_by=user.email, is_personal=False, visibility="private"))
+    session.add(EmailTeam(id="team-b", name="Team B", slug="team-b", created_by=user.email, is_personal=False, visibility="private"))
+    session.add(Role(name="developer", scope="team", permissions=["a2a.invoke"], created_by=user.email, is_system_role=True, is_active=True))
+    session.add(Role(name="viewer", scope="team", permissions=[], created_by=user.email, is_system_role=True, is_active=True))
+    session.commit()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def admin_user():
+    return {"email": "admin@example.com", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "tests"}
+
+
+@pytest.fixture
+def request_stub():
+    req = MagicMock()
+    req.headers = {}
+    return req
+
+
+@pytest.fixture
+def allow_admin(monkeypatch: pytest.MonkeyPatch):
+    """Patch PermissionService so check_permission always returns True."""
+
+    class AllowAll:
+        def __init__(self, db):
+            pass
+
+        async def check_permission(self, *args, **kwargs):
+            return True
+
+    monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", AllowAll)
+
+
+@pytest.fixture
+def seeded_identity_cache():
+    """Seed the real external-identity cache with one token entry; always clean up."""
+    token_hash = vc._token_hash("raw-token")
+    vc._external_identity_cache[token_hash] = ({"token_teams": ["team-a"]}, monotonic() + 60)
+    try:
+        yield token_hash
+    finally:
+        vc._external_identity_cache.clear()
+
+
+def _create_body(**overrides) -> mapping_service.ExternalGroupMappingCreate:
+    values = {
+        "issuer": "https://issuer.example.com",
+        "tenant": None,
+        "external_group_id": "guid-1",
+        "cf_team_id": "team-a",
+        "cf_role": "developer",
+    }
+    values.update(overrides)
+    return mapping_service.ExternalGroupMappingCreate(**values)
+
+
+class TestNullTenantUniqueness:
+    """Duplicate (issuer, external_group_id) rows with tenant NULL must be rejected."""
+
+    @pytest.mark.asyncio
+    async def test_duplicate_null_tenant_create_rejected(self, allow_admin, db, admin_user, request_stub):
+        await mapping_service.create_external_group_mapping(_create_body(), request=request_stub, user=admin_user, db=db)
+        with pytest.raises(HTTPException) as exc:
+            await mapping_service.create_external_group_mapping(_create_body(cf_team_id="team-b", cf_role="viewer"), request=request_stub, user=admin_user, db=db)
+        assert exc.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_duplicate_non_null_tenant_create_still_rejected(self, allow_admin, db, admin_user, request_stub):
+        await mapping_service.create_external_group_mapping(_create_body(tenant="tenant-1"), request=request_stub, user=admin_user, db=db)
+        with pytest.raises(HTTPException) as exc:
+            await mapping_service.create_external_group_mapping(_create_body(tenant="tenant-1", cf_team_id="team-b"), request=request_stub, user=admin_user, db=db)
+        assert exc.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_same_group_different_tenants_allowed(self, allow_admin, db, admin_user, request_stub):
+        await mapping_service.create_external_group_mapping(_create_body(tenant=None), request=request_stub, user=admin_user, db=db)
+        created = await mapping_service.create_external_group_mapping(_create_body(tenant="tenant-1"), request=request_stub, user=admin_user, db=db)
+        assert created.id is not None
+
+    @pytest.mark.asyncio
+    async def test_update_colliding_null_tenant_rejected(self, allow_admin, db, admin_user, request_stub):
+        await mapping_service.create_external_group_mapping(_create_body(), request=request_stub, user=admin_user, db=db)
+        other = await mapping_service.create_external_group_mapping(_create_body(external_group_id="guid-2"), request=request_stub, user=admin_user, db=db)
+        body = mapping_service.ExternalGroupMappingUpdate(external_group_id="guid-1")
+        with pytest.raises(HTTPException) as exc:
+            await mapping_service.update_external_group_mapping(other.id, body, request=request_stub, user=admin_user, db=db)
+        assert exc.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_update_own_null_tenant_identity_allowed(self, allow_admin, db, admin_user, request_stub):
+        created = await mapping_service.create_external_group_mapping(_create_body(), request=request_stub, user=admin_user, db=db)
+        body = mapping_service.ExternalGroupMappingUpdate(cf_role="viewer")
+        updated = await mapping_service.update_external_group_mapping(created.id, body, request=request_stub, user=admin_user, db=db)
+        assert updated.cf_role == "viewer"
+
+
+class TestExternalIdentityCacheInvalidation:
+    """Every successful mapping mutation clears the external identity cache."""
+
+    @pytest.mark.asyncio
+    async def test_create_invalidates_cache(self, allow_admin, db, admin_user, request_stub, seeded_identity_cache):
+        await mapping_service.create_external_group_mapping(_create_body(), request=request_stub, user=admin_user, db=db)
+        assert vc._external_identity_cache == {}
+
+    @pytest.mark.asyncio
+    async def test_update_invalidates_cache(self, allow_admin, db, admin_user, request_stub, seeded_identity_cache):
+        created = await mapping_service.create_external_group_mapping(_create_body(), request=request_stub, user=admin_user, db=db)
+        vc._external_identity_cache[seeded_identity_cache] = ({"token_teams": ["team-a"]}, monotonic() + 60)
+        body = mapping_service.ExternalGroupMappingUpdate(cf_team_id="team-b")
+        await mapping_service.update_external_group_mapping(created.id, body, request=request_stub, user=admin_user, db=db)
+        assert vc._external_identity_cache == {}
+
+    @pytest.mark.asyncio
+    async def test_delete_invalidates_cache(self, allow_admin, db, admin_user, request_stub, seeded_identity_cache):
+        created = await mapping_service.create_external_group_mapping(_create_body(), request=request_stub, user=admin_user, db=db)
+        vc._external_identity_cache[seeded_identity_cache] = ({"token_teams": ["team-a"]}, monotonic() + 60)
+        await mapping_service.delete_external_group_mapping(created.id, request=request_stub, user=admin_user, db=db)
+        assert vc._external_identity_cache == {}
+        assert db.query(ExternalGroupMapping).count() == 0

--- a/tests/unit/mcpgateway/test_visibility_gate.py
+++ b/tests/unit/mcpgateway/test_visibility_gate.py
@@ -1,0 +1,278 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_visibility_gate.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Agent visibility-gate and end-to-end team-isolation tests for trust mode
+(issue #5976).
+
+Every test in this file exercises the trust branch in get_current_user, which
+lands with #5900. Until then the default funnel rejects the trust-mode token
+with 401 and each test fails, so all tests carry
+pytest.mark.xfail(strict=True, reason="Requires trust branch from #5900").
+strict=True turns a premature XPASS into a suite failure.
+
+Visibility semantics under test (per _check_agent_access in
+mcpgateway/services/a2a_service.py):
+- visibility="team": allowed only when the agent team_id is in token_teams.
+  A denied lookup raises A2AAgentNotFoundError: 404, not 403, so the gateway
+  never leaks the existence of another team's agent.
+- visibility="public": allowed for every authenticated caller, regardless of
+  token_teams. The Layer-1 gate does not apply to public agents.
+"""
+
+# Standard
+import contextlib
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+# Third-Party
+from fastapi.security import HTTPAuthorizationCredentials
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.auth import get_current_user
+from mcpgateway.config import settings
+from mcpgateway.db import A2AAgent, Base, EmailTeam, EmailUser, ExternalGroupMapping
+from mcpgateway.services.a2a_service import A2AAgentNotFoundError, A2AAgentService
+from mcpgateway.utils.trusted_claims import resolve_external_groups_to_teams
+
+ISSUER = "https://login.example.com/tenant-1/v2.0"
+TENANT = "tenant-1"
+CALLER = "trust.user@example.com"
+XFAIL_REASON = "Requires trust branch from #5900"
+
+
+def _exp(hours: int = 1) -> float:
+    """Expiry timestamp for mocked JWT payloads."""
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).timestamp()
+
+
+@pytest.fixture
+def db():
+    """In-memory SQLite session seeded with teams, agents, and one mapping row.
+
+    Layout: CF-Team-A and CF-Team-B. Agent-A (visibility=team, team=CF-Team-A),
+    Agent-B (visibility=team, team=CF-Team-B), Agent-Pub (visibility=public).
+    One mapping row: Entra-Group-GUID-1 -> CF-Team-A with cf_role=developer.
+    """
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    owner = EmailUser(
+        email="owner@example.com",
+        password_hash="hash",  # pragma: allowlist secret
+        full_name="Owner",
+        is_admin=False,
+        is_active=True,
+        email_verified_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    session.add(owner)
+    session.add(EmailTeam(id="team-a", name="CF-Team-A", slug="cf-team-a", created_by=owner.email, is_personal=False, visibility="private"))
+    session.add(EmailTeam(id="team-b", name="CF-Team-B", slug="cf-team-b", created_by=owner.email, is_personal=False, visibility="private"))
+    session.add(
+        A2AAgent(
+            name="agent-a",
+            slug="agent-a",
+            endpoint_url="https://agent-a.example.com",
+            agent_type="generic",
+            protocol_version="1.0",
+            capabilities={},
+            config={},
+            enabled=True,
+            team_id="team-a",
+            owner_email=owner.email,
+            visibility="team",
+            tags=[],
+        )
+    )
+    session.add(
+        A2AAgent(
+            name="agent-b",
+            slug="agent-b",
+            endpoint_url="https://agent-b.example.com",
+            agent_type="generic",
+            protocol_version="1.0",
+            capabilities={},
+            config={},
+            enabled=True,
+            team_id="team-b",
+            owner_email=owner.email,
+            visibility="team",
+            tags=[],
+        )
+    )
+    session.add(
+        A2AAgent(
+            name="agent-pub",
+            slug="agent-pub",
+            endpoint_url="https://agent-pub.example.com",
+            agent_type="generic",
+            protocol_version="1.0",
+            capabilities={},
+            config={},
+            enabled=True,
+            team_id=None,
+            owner_email=owner.email,
+            visibility="public",
+            tags=[],
+        )
+    )
+    session.add(ExternalGroupMapping(issuer=ISSUER, tenant=TENANT, external_group_id="entra-group-guid-1", cf_team_id="team-a", cf_role="developer"))
+    session.commit()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+async def _drive_trust_funnel(monkeypatch: pytest.MonkeyPatch, db, groups: list[str]):
+    """Drive get_current_user with a trust-mode JWT carrying the given groups.
+
+    The funnel's internal sessions are re-pointed at the test database so the
+    group resolver sees the seeded mapping rows. Returns (user, request).
+    """
+    monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+    monkeypatch.setattr(settings, "auth_cache_enabled", False)
+    monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+
+    session_test = sessionmaker(bind=db.get_bind())
+    monkeypatch.setattr("mcpgateway.auth.SessionLocal", session_test)
+
+    @contextlib.contextmanager
+    def _fresh_db_session():
+        session = session_test()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("mcpgateway.auth.fresh_db_session", _fresh_db_session)
+
+    jwt_payload = {
+        "sub": CALLER,
+        "token_use": "trusted",
+        "iss": ISSUER,
+        "tid": TENANT,
+        "groups": groups,
+        "jti": "trusted_jti_visibility_gate",
+        "exp": _exp(),
+    }
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="trusted_jwt_token")  # pragma: allowlist secret
+    request = SimpleNamespace(state=SimpleNamespace())
+
+    with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth._check_token_revoked_sync", return_value=False):
+            # No local user record exists for the virtual principal.
+            with patch("mcpgateway.auth._get_user_by_email_sync", return_value=None):
+                with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
+                    user = await get_current_user(credentials=credentials, request=request)
+    return user, request
+
+
+@pytest.mark.xfail(strict=True, reason=XFAIL_REASON)
+class TestVisibilityGate:
+    """AC-visibility-gate: team isolation and the public baseline."""
+
+    @pytest.mark.asyncio
+    async def test_team_visibility_isolation(self, monkeypatch, db):
+        """Caller maps to CF-Team-A only: Agent-A 200, Agent-B 404.
+
+        The denied lookup raises A2AAgentNotFoundError (404, not 403) per
+        _check_agent_access, so agent existence never leaks across teams.
+        """
+        _, request = await _drive_trust_funnel(monkeypatch, db, ["entra-group-guid-1"])
+        token_teams = request.state.token_teams
+        assert token_teams == ["team-a"]
+
+        service = A2AAgentService()
+        agent_a = db.query(A2AAgent).filter(A2AAgent.slug == "agent-a").one()
+        agent_b = db.query(A2AAgent).filter(A2AAgent.slug == "agent-b").one()
+
+        assert await service._check_agent_access(db, agent_a, CALLER, token_teams) is True
+        assert await service._check_agent_access(db, agent_b, CALLER, token_teams) is False
+        with pytest.raises(A2AAgentNotFoundError):
+            await service.get_agent(db, agent_b.id, user_email=CALLER, token_teams=token_teams)
+
+    @pytest.mark.asyncio
+    async def test_public_visibility_baseline(self, monkeypatch, db):
+        """Public agents stay accessible to every authenticated caller.
+
+        Documents the deliberate behavior that the Layer-1 team gate does
+        not apply to visibility="public" agents.
+        """
+        _, request = await _drive_trust_funnel(monkeypatch, db, ["entra-group-guid-1"])
+        token_teams = request.state.token_teams
+
+        service = A2AAgentService()
+        agent_pub = db.query(A2AAgent).filter(A2AAgent.slug == "agent-pub").one()
+        assert agent_pub.visibility == "public"
+        assert await service._check_agent_access(db, agent_pub, CALLER, token_teams) is True
+
+
+@pytest.mark.xfail(strict=True, reason=XFAIL_REASON)
+class TestE2ETeamIsolation:
+    """AC-e2e-team-isolation: mapping row + trust JWT drives the gate."""
+
+    @pytest.mark.asyncio
+    async def test_e2e_team_isolation(self, monkeypatch, db):
+        """Full flow: teams, agents, mapping row, trust JWT, invoke gate.
+
+        1. CF-Team-A and CF-Team-B exist; Agent-A (team=CF-Team-A) and
+           Agent-B (team=CF-Team-B) are registered with visibility=team.
+        2. Mapping row: Entra-Group-GUID-1 -> CF-Team-A, cf_role=developer.
+        3. Trust-mode JWT carries groups=[Entra-Group-GUID-1].
+        4. Agent-A is reachable; Agent-B answers 404 (A2AAgentNotFoundError).
+        """
+        # The resolver (landed in #5976) proves the mapping row translates
+        # the external group into exactly one team and one role.
+        team_ids, role_names = resolve_external_groups_to_teams(ISSUER, TENANT, ["entra-group-guid-1"], db)
+        assert team_ids == ["team-a"]
+        assert role_names == ["developer"]
+
+        _, request = await _drive_trust_funnel(monkeypatch, db, ["entra-group-guid-1"])
+        token_teams = request.state.token_teams
+        assert token_teams == ["team-a"]
+
+        service = A2AAgentService()
+        agent_a = db.query(A2AAgent).filter(A2AAgent.slug == "agent-a").one()
+        agent_b = db.query(A2AAgent).filter(A2AAgent.slug == "agent-b").one()
+
+        assert await service._check_agent_access(db, agent_a, CALLER, token_teams) is True
+        with pytest.raises(A2AAgentNotFoundError):
+            await service.get_agent(db, agent_b.id, user_email=CALLER, token_teams=token_teams)
+
+
+@pytest.mark.xfail(strict=True, reason=XFAIL_REASON)
+class TestE2ENoMapping:
+    """AC-e2e-no-mapping: an unmapped group fails closed."""
+
+    @pytest.mark.asyncio
+    async def test_e2e_no_mapping_fail_closed(self, monkeypatch, db):
+        """Trust JWT with an unmapped group: token_teams=[].
+
+        A visibility=team agent answers 404; a visibility=public agent
+        stays reachable.
+        """
+        team_ids, role_names = resolve_external_groups_to_teams(ISSUER, TENANT, ["entra-group-guid-unmapped"], db)
+        assert team_ids == []
+        assert role_names == []
+
+        _, request = await _drive_trust_funnel(monkeypatch, db, ["entra-group-guid-unmapped"])
+        token_teams = request.state.token_teams
+        assert token_teams == []
+
+        service = A2AAgentService()
+        agent_a = db.query(A2AAgent).filter(A2AAgent.slug == "agent-a").one()
+        agent_pub = db.query(A2AAgent).filter(A2AAgent.slug == "agent-pub").one()
+
+        with pytest.raises(A2AAgentNotFoundError):
+            await service.get_agent(db, agent_a.id, user_email=CALLER, token_teams=token_teams)
+        assert await service._check_agent_access(db, agent_pub, CALLER, token_teams) is True


### PR DESCRIPTION
Adds the `external_group_mappings` layer for trust-mode Layer-1 scoping. One idempotent migration (`e5f6a7b8c9d0`, parent `bf2998718ea1`) creates the table: `issuer`, `tenant` (nullable), `external_group_id`, `cf_team_id` (FK `email_teams.id`), `cf_role` (plain `String(255)` validated against the `roles` table at write time — NOT a foreign key, because `roles.name` carries only a partial unique index), `validation_status`, `last_validated_at`, timestamps, and the unique key `(issuer, tenant, external_group_id)` with the one-group-one-team-one-role decision documented in the migration comment. The `ExternalGroupMapping` ORM mirrors it.

The resolver `resolve_external_groups_to_teams(issuer, tenant, groups, db)` in the new `mcpgateway/utils/trusted_claims.py` returns `(team_ids, role_names)`; unmapped groups contribute nothing (fail-closed). Raw external group IDs never reach `token_teams`. Admin CRUD lives under `/admin/external-group-mappings` (RBAC-scoped, sibling convention), with deny paths tested: 401 unauthenticated, 403 insufficient permission, 400 unknown team or role, 409 duplicate, 404 missing. The Graph existence validator ships as an injectable seam, disabled by default (returns `valid`); WARN-AND-ALLOW semantics documented — the real client lands with #5977.

Visibility-gate and e2e team-isolation/no-mapping tests land as `xfail(strict=True, reason="Requires trust branch from #5900")` — 404-not-403 per `_check_agent_access`.

Tested with:
- `uv run pytest tests/unit/mcpgateway/ -k "group_mapping or external_group or visibility_gate" -q` — 34 passed, 4 xfailed (TDD: collection ImportErrors first)
- Migration up/down/up on SQLite: single head `e5f6a7b8c9d0`; columns verified in the migrated DB. Postgres runs in the Epic 2 gate's docker stacks (constructs used are portable).
- `make ruff` — all checks passed
- `make test` — 23268 passed, 879 skipped, 9 xfailed

Acceptance criteria of #5976 are met. Risk to existing users: none — a new table and new endpoints; no existing table or path changed.

Stack: B.4 of epic #5885 (base: #6740).

Closes #5976