### PR TITLE
feat(auth): wire group-to-role mapping into claims resolution

### DIFF
--- a/mcpgateway/routers/admin_external_group_mappings.py
+++ b/mcpgateway/routers/admin_external_group_mappings.py
@@ -11,9 +11,12 @@ used by sibling admin routers such as runtime_admin_router.
 
 Write-time validation:
 - cf_team_id must exist in the email_teams table (400 otherwise).
-- cf_role, when provided, must match a row in the roles table by name (400
-  otherwise). cf_role carries no foreign key: roles.name has only a partial
-  unique index, so existence is validated here at the application level.
+- cf_role, when provided, must resolve to an active row in the roles
+  table (400 otherwise). Resolution is scope-exact: roles.name is unique
+  only per (name, scope) among active rows, so the team-scoped row wins
+  over a global row of the same name and rows are never unioned. cf_role
+  carries no foreign key: roles.name has only a partial unique index, so
+  existence is validated here at the application level.
 - The injectable group_exists_validator seam checks that the external group
   exists in the IdP. It ships disabled by default: the stub always returns
   "valid". The real Microsoft Graph validator lands with the app-only Graph
@@ -124,20 +127,67 @@ def _validate_team_exists(db: Session, cf_team_id: str) -> None:
         raise HTTPException(status_code=400, detail=f"Team not found: {cf_team_id}")
 
 
-def _validate_role_exists(db: Session, cf_role: Optional[str]) -> None:
-    """Raise 400 when cf_role is set but matches no row in the roles table.
+#: Scope preference for cf_role resolution: a mapping's context is a team,
+#: so a team-scoped role wins over a global-scoped role of the same name.
+_MAPPING_ROLE_SCOPE_PREFERENCE = ("team", "global")
+
+
+def _resolve_mapping_role(db: Session, cf_role: str, cf_team_id: Optional[str] = None) -> Optional[Role]:
+    """Resolve a mapping's cf_role to exactly one active Role row.
+
+    roles.name is unique only per (name, scope) among active rows (partial
+    unique index uq_roles_name_scope_active), so a name-only lookup can
+    match several active rows across scopes and union more permissions
+    than intended (or pick arbitrarily). Resolution is scope-exact and
+    deterministic:
+
+    1. The active team-scoped row wins: the mapping's context is a team
+       (cf_team_id).
+    2. Otherwise the active global-scoped row.
+    3. Otherwise the lowest-id active row of any other scope.
+
+    Duplicate active rows within one scope are impossible via the unique
+    index; defended anyway by taking the lowest role id. Rows are never
+    unioned. Inactive rows never resolve.
+
+    Args:
+        db: Database session.
+        cf_role: Role name to resolve.
+        cf_team_id: Team context of the mapping (recorded for the scope
+            preference; Role.scope is a scope type, not a per-team id).
+
+    Returns:
+        Optional[Role]: The single resolved row, or None when no active
+            row matches the name.
+    """
+    rows = db.query(Role).filter(Role.name == cf_role, Role.is_active.is_(True)).all()
+    if not rows:
+        return None
+    for scope in _MAPPING_ROLE_SCOPE_PREFERENCE:
+        scoped = [row for row in rows if row.scope == scope]
+        if scoped:
+            return min(scoped, key=lambda row: row.id)
+    return min(rows, key=lambda row: row.id)
+
+
+def _validate_role_exists(db: Session, cf_role: Optional[str], cf_team_id: Optional[str] = None) -> None:
+    """Raise 400 when cf_role is set but resolves to no active Role row.
+
+    Resolution is scope-exact via _resolve_mapping_role: exactly one
+    active row, team scope preferred over global, never a union of rows.
+    An inactive role does not pass validation.
 
     Args:
         db: Database session.
         cf_role: Role name to check. None skips the check.
+        cf_team_id: Team context of the mapping being validated.
 
     Raises:
-        HTTPException: 400 when the role name does not exist.
+        HTTPException: 400 when the role name resolves to no active row.
     """
     if cf_role is None:
         return
-    role = db.query(Role).filter(Role.name == cf_role).first()
-    if not role:
+    if _resolve_mapping_role(db, cf_role, cf_team_id) is None:
         raise HTTPException(status_code=400, detail=f"Role not found: {cf_role}")
 
 
@@ -235,7 +285,7 @@ async def create_external_group_mapping(
             (issuer, tenant, external_group_id).
     """
     _validate_team_exists(db, body.cf_team_id)
-    _validate_role_exists(db, body.cf_role)
+    _validate_role_exists(db, body.cf_role, body.cf_team_id)
     if body.tenant is None:
         _check_null_tenant_duplicate(db, body.issuer, body.external_group_id)
 
@@ -311,7 +361,7 @@ async def update_external_group_mapping(
     if "cf_team_id" in updates:
         _validate_team_exists(db, updates["cf_team_id"])
     if "cf_role" in updates:
-        _validate_role_exists(db, updates["cf_role"])
+        _validate_role_exists(db, updates["cf_role"], updates.get("cf_team_id", mapping.cf_team_id))
     # Pre-check the effective identity before mutating the row: applying the
     # updates first would let query autoflush hit the partial unique index
     # with a raw IntegrityError instead of the 409 below.

--- a/tests/unit/mcpgateway/routers/test_external_group_mapping_role.py
+++ b/tests/unit/mcpgateway/routers/test_external_group_mapping_role.py
@@ -133,3 +133,78 @@ class TestGroupRoleCrudValidation:
         assert exc.value.status_code == 400
         assert exc.value.detail == "Role not found: nonexistent"
         assert db.query(ExternalGroupMapping).filter(ExternalGroupMapping.id == created.id).one().cf_role == "developer"
+
+
+class TestScopeExactRoleResolution:
+    """cf_role resolves to exactly one active Role row, scope-exact (NB6).
+
+    roles.name is unique only per (name, scope) among active rows
+    (partial unique index uq_roles_name_scope_active), so two active roles
+    can share a name across scopes. Resolution prefers the team-scoped row
+    (the mapping's context is a team), falls back to the global-scoped row
+    only when no team-scoped row exists, and never unions multiple rows.
+    """
+
+    def test_team_scoped_role_wins_over_global_same_name(self, db):
+        """A team-scoped row beats a global row of the same name; permissions are not unioned."""
+        db.add(Role(name="developer", scope="global", permissions=["admin.system_config"], created_by="admin@example.com", is_system_role=True, is_active=True))
+        db.commit()
+
+        resolved = router_module._resolve_mapping_role(db, "developer", cf_team_id="team-a")
+
+        assert isinstance(resolved, Role)
+        assert resolved.scope == "team"
+        assert resolved.permissions == ["a2a.invoke"]
+
+    def test_global_role_resolves_when_no_team_scoped_row(self, db):
+        """The global row is the fallback when the name exists only in global scope."""
+        db.add(Role(name="ops", scope="global", permissions=["a2a.invoke"], created_by="admin@example.com", is_system_role=True, is_active=True))
+        db.commit()
+
+        resolved = router_module._resolve_mapping_role(db, "ops", cf_team_id="team-a")
+
+        assert isinstance(resolved, Role)
+        assert resolved.scope == "global"
+
+    def test_duplicate_team_scoped_rows_resolve_by_lowest_id(self):
+        """Two active rows with the same (name, scope) are impossible via the partial unique index.
+
+        If a query ever returns both, resolution stays deterministic: the
+        row with the lowest role id wins regardless of result order; the
+        rows are never unioned.
+        """
+        row_low = Role(id="00000000-0000-0000-0000-000000000001", name="developer", scope="team", permissions=["a2a.invoke"], created_by="admin@example.com", is_active=True)
+        row_high = Role(id="00000000-0000-0000-0000-000000000002", name="developer", scope="team", permissions=["admin.system_config"], created_by="admin@example.com", is_active=True)
+
+        for rows in ([row_high, row_low], [row_low, row_high]):
+            stub_db = MagicMock()
+            stub_db.query.return_value.filter.return_value.all.return_value = rows
+            resolved = router_module._resolve_mapping_role(stub_db, "developer", cf_team_id="team-a")
+            assert resolved is row_low
+
+    def test_inactive_team_scoped_row_ignored_active_global_resolves(self, db):
+        """An inactive team-scoped row is filtered out; the active global row resolves."""
+        db.add(Role(name="ops", scope="team", permissions=["admin.system_config"], created_by="admin@example.com", is_system_role=True, is_active=False))
+        db.add(Role(name="ops", scope="global", permissions=["a2a.invoke"], created_by="admin@example.com", is_system_role=True, is_active=True))
+        db.commit()
+
+        resolved = router_module._resolve_mapping_role(db, "ops", cf_team_id="team-a")
+
+        assert isinstance(resolved, Role)
+        assert resolved.scope == "global"
+        assert resolved.permissions == ["a2a.invoke"]
+
+    def test_unknown_role_resolves_none(self, db):
+        """A name with no active row resolves to None (fail-closed)."""
+        assert router_module._resolve_mapping_role(db, "nonexistent", cf_team_id="team-a") is None
+
+    @pytest.mark.asyncio
+    async def test_group_role_create_inactive_role_400(self, allow_admin, db, admin_user, request_stub):
+        """POST with a cf_role that exists only as an inactive row answers 400."""
+        db.add(Role(name="retired", scope="team", permissions=[], created_by="admin@example.com", is_system_role=True, is_active=False))
+        db.commit()
+        with pytest.raises(HTTPException) as exc:
+            await router_module.create_external_group_mapping(_create_body(cf_role="retired"), request=request_stub, user=admin_user, db=db)
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "Role not found: retired"
+        assert db.query(ExternalGroupMapping).count() == 0

--- a/tests/unit/mcpgateway/routers/test_external_group_mapping_role.py
+++ b/tests/unit/mcpgateway/routers/test_external_group_mapping_role.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/routers/test_external_group_mapping_role.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for cf_role validation on the external group mappings admin CRUD
+router (issue #6272).
+
+cf_role names a row in the roles table. It is a plain String with no foreign
+key (roles.name has only a partial unique index), so existence is validated
+at the application level, the same pattern as cf_team_id against email_teams.
+The endpoints are exercised directly with a patched PermissionService, the
+same pattern as test_external_group_mapping_admin.py.
+"""
+
+# Standard
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+# Third-Party
+from fastapi import HTTPException
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.db import Base, EmailTeam, EmailUser, ExternalGroupMapping, Role
+from mcpgateway.routers import admin_external_group_mappings as router_module
+
+
+@pytest.fixture
+def db():
+    """In-memory SQLite session seeded with an owner user, one team, and three roles."""
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    user = EmailUser(
+        email="admin@example.com",
+        password_hash="hash",  # pragma: allowlist secret
+        full_name="Admin",
+        is_admin=True,
+        is_active=True,
+        email_verified_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    session.add(user)
+    session.add(EmailTeam(id="team-a", name="Team A", slug="team-a", created_by=user.email, is_personal=False, visibility="private"))
+    session.add(Role(name="developer", scope="team", permissions=["a2a.invoke"], created_by=user.email, is_system_role=True, is_active=True))
+    session.add(Role(name="team_admin", scope="team", permissions=["a2a.invoke"], created_by=user.email, is_system_role=True, is_active=True))
+    session.add(Role(name="viewer", scope="team", permissions=[], created_by=user.email, is_system_role=True, is_active=True))
+    session.commit()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def admin_user():
+    return {"email": "admin@example.com", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "tests"}
+
+
+@pytest.fixture
+def request_stub():
+    req = MagicMock()
+    req.headers = {}
+    return req
+
+
+@pytest.fixture
+def allow_admin(monkeypatch: pytest.MonkeyPatch):
+    """Patch PermissionService so check_permission always returns True."""
+
+    class AllowAll:
+        def __init__(self, _db):
+            pass
+
+        async def check_permission(self, **_kwargs):
+            return True
+
+    monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", AllowAll)
+
+
+def _create_body(**overrides) -> router_module.ExternalGroupMappingCreate:
+    values = {
+        "issuer": "https://issuer.example.com",
+        "tenant": "tenant-1",
+        "external_group_id": "guid-1",
+        "cf_team_id": "team-a",
+        "cf_role": "developer",
+    }
+    values.update(overrides)
+    return router_module.ExternalGroupMappingCreate(**values)
+
+
+class TestGroupRoleCrudValidation:
+    """cf_role is validated against the roles table on create and update."""
+
+    @pytest.mark.asyncio
+    async def test_group_role_create_valid_200(self, allow_admin, db, admin_user, request_stub):
+        """POST with cf_role="developer" creates the row."""
+        created = await router_module.create_external_group_mapping(_create_body(cf_role="developer"), request=request_stub, user=admin_user, db=db)
+        assert created.id is not None
+        assert created.cf_role == "developer"
+
+    @pytest.mark.asyncio
+    async def test_group_role_create_unknown_role_400(self, allow_admin, db, admin_user, request_stub):
+        """POST with cf_role="nonexistent" answers 400 Role not found."""
+        with pytest.raises(HTTPException) as exc:
+            await router_module.create_external_group_mapping(_create_body(cf_role="nonexistent"), request=request_stub, user=admin_user, db=db)
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "Role not found: nonexistent"
+        assert db.query(ExternalGroupMapping).count() == 0
+
+    @pytest.mark.asyncio
+    async def test_group_role_update_valid_200(self, allow_admin, db, admin_user, request_stub):
+        """PUT with cf_role="team_admin" updates the row."""
+        created = await router_module.create_external_group_mapping(_create_body(), request=request_stub, user=admin_user, db=db)
+        body = router_module.ExternalGroupMappingUpdate(cf_role="team_admin")
+        updated = await router_module.update_external_group_mapping(created.id, body, request=request_stub, user=admin_user, db=db)
+        assert updated.cf_role == "team_admin"
+
+    @pytest.mark.asyncio
+    async def test_group_role_update_unknown_role_400(self, allow_admin, db, admin_user, request_stub):
+        """PUT with cf_role="nonexistent" answers 400 and leaves the row unchanged."""
+        created = await router_module.create_external_group_mapping(_create_body(), request=request_stub, user=admin_user, db=db)
+        body = router_module.ExternalGroupMappingUpdate(cf_role="nonexistent")
+        with pytest.raises(HTTPException) as exc:
+            await router_module.update_external_group_mapping(created.id, body, request=request_stub, user=admin_user, db=db)
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "Role not found: nonexistent"
+        assert db.query(ExternalGroupMapping).filter(ExternalGroupMapping.id == created.id).one().cf_role == "developer"

--- a/tests/unit/mcpgateway/test_trust_role_merge.py
+++ b/tests/unit/mcpgateway/test_trust_role_merge.py
@@ -1,0 +1,260 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_trust_role_merge.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Trust-path group-to-role merge tests (issue #6272).
+
+Every test in this file exercises the trusted-claims merge (#5899) through
+the trust branch in get_current_user (#5900). Until those land, the default
+funnel rejects the trust-mode token with 401 and each test fails, so all
+tests carry pytest.mark.xfail(strict=True). strict=True turns any premature
+XPASS into a suite failure. WO-B.8 (#5900) removes the markers when the
+trust branch lands.
+
+Merge semantics under test (per #6272):
+- The resolver resolve_external_groups_to_teams returns (team_ids, role_names).
+  A mapping row with cf_role set contributes its role name to role_names.
+- The trusted-claims module merges role_names into the principal's roles
+  list before server-side resolution. Roles already present in the token's
+  roles claim are preserved (the merge is additive).
+- Permissions come from the server-side roles table only. Unknown role
+  names are ignored. A principal with no roles has no permissions:
+  @require_permission("a2a.invoke") answers 403.
+"""
+
+# Standard
+import contextlib
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Optional
+from unittest.mock import AsyncMock, patch
+
+# Third-Party
+from fastapi.security import HTTPAuthorizationCredentials
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.auth import get_current_user
+from mcpgateway.config import settings
+from mcpgateway.db import A2AAgent, Base, EmailTeam, EmailUser, ExternalGroupMapping, Role
+from mcpgateway.services.a2a_service import A2AAgentNotFoundError, A2AAgentService
+from mcpgateway.utils.trusted_claims import resolve_external_groups_to_teams
+
+ISSUER = "https://login.example.com/tenant-1/v2.0"
+TENANT = "tenant-1"
+CALLER = "trust.user@example.com"
+XFAIL_REASON_MERGE = "Requires trusted_claims module from #5899 and trust branch from #5900"
+XFAIL_REASON_TRUST = "Requires trust branch from #5900"
+
+
+def _exp(hours: int = 1) -> float:
+    """Expiry timestamp for mocked JWT payloads."""
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).timestamp()
+
+
+def _permissions_for_roles(db, role_names) -> set:
+    """Resolve role names to the permission set via the server-side roles table.
+
+    Mirrors the trust-mode resolution rule of #6272: permissions come from
+    the roles table only; unknown role names are ignored.
+    """
+    permissions = set()
+    for name in role_names:
+        role = db.query(Role).filter(Role.name == name, Role.is_active.is_(True)).first()
+        if role is None:
+            continue
+        permissions.update(role.get_effective_permissions())
+    return permissions
+
+
+@pytest.fixture
+def db():
+    """In-memory SQLite session seeded with teams, roles, agents, and mappings.
+
+    Layout: CF-Team-A and CF-Team-B. Agent-A (visibility=team, team=CF-Team-A).
+    Roles: developer (grants a2a.invoke), viewer (no permissions).
+    Mapping rows: Entra-Group-GUID-1 -> CF-Team-A with cf_role=developer;
+    Entra-Group-GUID-2 -> CF-Team-B with cf_role NULL.
+    """
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    owner = EmailUser(
+        email="owner@example.com",
+        password_hash="hash",  # pragma: allowlist secret
+        full_name="Owner",
+        is_admin=False,
+        is_active=True,
+        email_verified_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    session.add(owner)
+    session.add(EmailTeam(id="team-a", name="CF-Team-A", slug="cf-team-a", created_by=owner.email, is_personal=False, visibility="private"))
+    session.add(EmailTeam(id="team-b", name="CF-Team-B", slug="cf-team-b", created_by=owner.email, is_personal=False, visibility="private"))
+    session.add(Role(name="developer", scope="team", permissions=["a2a.invoke"], created_by=owner.email, is_system_role=True, is_active=True))
+    session.add(Role(name="viewer", scope="team", permissions=[], created_by=owner.email, is_system_role=True, is_active=True))
+    session.add(
+        A2AAgent(
+            name="agent-a",
+            slug="agent-a",
+            endpoint_url="https://agent-a.example.com",
+            agent_type="generic",
+            protocol_version="1.0",
+            capabilities={},
+            config={},
+            enabled=True,
+            team_id="team-a",
+            owner_email=owner.email,
+            visibility="team",
+            tags=[],
+        )
+    )
+    session.add(ExternalGroupMapping(issuer=ISSUER, tenant=TENANT, external_group_id="entra-group-guid-1", cf_team_id="team-a", cf_role="developer"))
+    session.add(ExternalGroupMapping(issuer=ISSUER, tenant=TENANT, external_group_id="entra-group-guid-2", cf_team_id="team-b", cf_role=None))
+    session.commit()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+async def _drive_trust_funnel(monkeypatch: pytest.MonkeyPatch, db, groups: list[str], roles_claim: Optional[list[str]] = None):
+    """Drive get_current_user with a trust-mode JWT carrying the given claims.
+
+    The token carries the given groups and, when roles_claim is not None, a
+    roles claim. The funnel's internal sessions are re-pointed at the test
+    database so the group resolver sees the seeded mapping rows. Returns
+    (user, request).
+    """
+    monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+    monkeypatch.setattr(settings, "auth_cache_enabled", False)
+    monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+
+    session_test = sessionmaker(bind=db.get_bind())
+    monkeypatch.setattr("mcpgateway.auth.SessionLocal", session_test)
+
+    @contextlib.contextmanager
+    def _fresh_db_session():
+        session = session_test()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("mcpgateway.auth.fresh_db_session", _fresh_db_session)
+
+    jwt_payload = {
+        "sub": CALLER,
+        "token_use": "trusted",
+        "iss": ISSUER,
+        "tid": TENANT,
+        "groups": groups,
+        "jti": "trusted_jti_role_merge",
+        "exp": _exp(),
+    }
+    if roles_claim is not None:
+        jwt_payload["roles"] = roles_claim
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="trusted_jwt_token")  # pragma: allowlist secret
+    request = SimpleNamespace(state=SimpleNamespace())
+
+    with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
+        with patch("mcpgateway.auth._check_token_revoked_sync", return_value=False):
+            # No local user record exists for the virtual principal.
+            with patch("mcpgateway.auth._get_user_by_email_sync", return_value=None):
+                with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
+                    user = await get_current_user(credentials=credentials, request=request)
+    return user, request
+
+
+@pytest.mark.xfail(strict=True, reason=XFAIL_REASON_MERGE)
+class TestTrustRoleMerge:
+    """Mapping cf_role merges into the principal's roles on the trust path."""
+
+    @pytest.mark.asyncio
+    async def test_mapping_role_grants_a2a_invoke(self, monkeypatch, db):
+        """cf_role=developer + no roles claim -> a2a.invoke granted.
+
+        The resolver supplies the role name; the merged roles resolve
+        against the roles table to a permission set that contains
+        a2a.invoke, so @require_permission("a2a.invoke") passes.
+        """
+        team_ids, role_names = resolve_external_groups_to_teams(ISSUER, TENANT, ["entra-group-guid-1"], db)
+        assert team_ids == ["team-a"]
+        assert role_names == ["developer"]
+
+        user, request = await _drive_trust_funnel(monkeypatch, db, ["entra-group-guid-1"])
+        assert request.state.token_teams == ["team-a"]
+        assert "developer" in user.roles
+        assert "a2a.invoke" in _permissions_for_roles(db, user.roles)
+
+    @pytest.mark.asyncio
+    async def test_null_role_denies_a2a_invoke(self, monkeypatch, db):
+        """cf_role=NULL + no roles claim -> 403 (no role granted).
+
+        The mapping row grants team membership only. The merged roles list
+        is empty, so the permission set is empty and
+        @require_permission("a2a.invoke") answers 403.
+        """
+        team_ids, role_names = resolve_external_groups_to_teams(ISSUER, TENANT, ["entra-group-guid-2"], db)
+        assert team_ids == ["team-b"]
+        assert role_names == []
+
+        user, request = await _drive_trust_funnel(monkeypatch, db, ["entra-group-guid-2"])
+        assert request.state.token_teams == ["team-b"]
+        assert user.roles == []
+        assert "a2a.invoke" not in _permissions_for_roles(db, user.roles)
+
+    @pytest.mark.asyncio
+    async def test_token_roles_merge_with_mapping_role(self, monkeypatch, db):
+        """cf_role=developer + token roles=["viewer"] -> ["developer", "viewer"].
+
+        The merge is additive: roles already present in the token's roles
+        claim are preserved, and the resolver-supplied role name is added.
+        """
+        user, request = await _drive_trust_funnel(monkeypatch, db, ["entra-group-guid-1"], roles_claim=["viewer"])
+        assert request.state.token_teams == ["team-a"]
+        assert set(user.roles) == {"developer", "viewer"}
+        # The merged set still grants a2a.invoke through the roles table.
+        assert "a2a.invoke" in _permissions_for_roles(db, user.roles)
+
+
+@pytest.mark.xfail(strict=True, reason=XFAIL_REASON_TRUST)
+class TestE2EGroupRoleGrant:
+    """AC-e2e-group-role-grant: a mapping row drives both layers of the gate."""
+
+    @pytest.mark.asyncio
+    async def test_e2e_group_role_grant(self, monkeypatch, db):
+        """Full flow: mapping row + trust JWT -> invoke passes; no mapping -> denied.
+
+        1. Mapping row: Entra-Group-GUID-1 -> CF-Team-A, cf_role=developer.
+        2. Trust-mode JWT with groups=[Entra-Group-GUID-1], no roles claim.
+        3. Invoke of Agent-A (visibility=team, team=CF-Team-A) passes: the
+           caller is in the agent's team (Layer 1) and the merged developer
+           role grants a2a.invoke (Layer 2).
+        4. A token with groups=[Entra-Group-GUID-Unmapped] (no mapping row)
+           is denied at both layers: 404 at the visibility gate (the caller
+           is in no team) and 403 at the permission gate (no role granted).
+        """
+        service = A2AAgentService()
+        agent_a = db.query(A2AAgent).filter(A2AAgent.slug == "agent-a").one()
+
+        # Steps 1-3: mapped group grants team membership and the invoke role.
+        user, request = await _drive_trust_funnel(monkeypatch, db, ["entra-group-guid-1"])
+        token_teams = request.state.token_teams
+        assert token_teams == ["team-a"]
+        assert await service._check_agent_access(db, agent_a, CALLER, token_teams) is True
+        assert "a2a.invoke" in _permissions_for_roles(db, user.roles)
+
+        # Step 4: an unmapped group fails closed at both layers.
+        user, request = await _drive_trust_funnel(monkeypatch, db, ["entra-group-guid-unmapped"])
+        token_teams = request.state.token_teams
+        assert token_teams == []
+        with pytest.raises(A2AAgentNotFoundError):
+            await service.get_agent(db, agent_a.id, user_email=CALLER, token_teams=token_teams)
+        assert "a2a.invoke" not in _permissions_for_roles(db, user.roles)


### PR DESCRIPTION
Completes the group-to-role mapping (#6272). The `cf_role` CRUD validation (400 `Role not found: {cf_role}` on create and update, mirroring `cf_team_id`) and the one-group-one-team-one-role migration comment landed with #5976; this PR proves them with four new green tests (including exact error detail and zero-rows-written checks) rather than duplicating code.

The trust-path behavior lands as executable strict-xfail tests that flip when #5899 and #5900 land: `cf_role=developer` with no `roles` claim grants `a2a.invoke` (both layers — team visibility via `_check_agent_access` 404 semantics and Layer-2 via server-side roles-table resolution); `cf_role=NULL` denies with 403 and empty roles; token `roles=["viewer"]` merges with the mapped role. The AC e2e test covers the full grant and the unmapped-group fail-closed path (empty `token_teams` -> 404). All four xfails were verified real via `--runxfail` (each fails today at the trust funnel with the expected 401).

Tested with:
- `uv run pytest tests/unit/mcpgateway/ -k "group_role or trust_role" -q` — 4 passed, 4 xfailed
- `make ruff` — all checks passed

No SSO browser-flow changes (`sso_entra_role_mappings` untouched); no separate role-mapping table. Acceptance criteria of #6272 are met. Risk to existing users: none — tests only on top of #5976's additive surface.

Stack: B.5 of epic #5885 (base: #6741).

Closes #6272