### PR TITLE
feat(auth): add configurable claims extraction and virtual principal contract

### DIFF
--- a/mcpgateway/routers/admin_external_group_mappings.py
+++ b/mcpgateway/routers/admin_external_group_mappings.py
@@ -41,9 +41,10 @@ from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.auth_context import get_user_email
-from mcpgateway.db import EmailTeam, ExternalGroupMapping, Role
+from mcpgateway.db import EmailTeam, ExternalGroupMapping
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, get_db, require_permission
 from mcpgateway.services.logging_service import LoggingService
+from mcpgateway.services.role_resolution import resolve_mapping_role
 from mcpgateway.services.security_logger import get_security_logger
 from mcpgateway.utils.verify_credentials import invalidate_external_identity_cache
 
@@ -127,53 +128,10 @@ def _validate_team_exists(db: Session, cf_team_id: str) -> None:
         raise HTTPException(status_code=400, detail=f"Team not found: {cf_team_id}")
 
 
-#: Scope preference for cf_role resolution: a mapping's context is a team,
-#: so a team-scoped role wins over a global-scoped role of the same name.
-_MAPPING_ROLE_SCOPE_PREFERENCE = ("team", "global")
-
-
-def _resolve_mapping_role(db: Session, cf_role: str, cf_team_id: Optional[str] = None) -> Optional[Role]:
-    """Resolve a mapping's cf_role to exactly one active Role row.
-
-    roles.name is unique only per (name, scope) among active rows (partial
-    unique index uq_roles_name_scope_active), so a name-only lookup can
-    match several active rows across scopes and union more permissions
-    than intended (or pick arbitrarily). Resolution is scope-exact and
-    deterministic:
-
-    1. The active team-scoped row wins: the mapping's context is a team
-       (cf_team_id).
-    2. Otherwise the active global-scoped row.
-    3. Otherwise the lowest-id active row of any other scope.
-
-    Duplicate active rows within one scope are impossible via the unique
-    index; defended anyway by taking the lowest role id. Rows are never
-    unioned. Inactive rows never resolve.
-
-    Args:
-        db: Database session.
-        cf_role: Role name to resolve.
-        cf_team_id: Team context of the mapping (recorded for the scope
-            preference; Role.scope is a scope type, not a per-team id).
-
-    Returns:
-        Optional[Role]: The single resolved row, or None when no active
-            row matches the name.
-    """
-    rows = db.query(Role).filter(Role.name == cf_role, Role.is_active.is_(True)).all()
-    if not rows:
-        return None
-    for scope in _MAPPING_ROLE_SCOPE_PREFERENCE:
-        scoped = [row for row in rows if row.scope == scope]
-        if scoped:
-            return min(scoped, key=lambda row: row.id)
-    return min(rows, key=lambda row: row.id)
-
-
 def _validate_role_exists(db: Session, cf_role: Optional[str], cf_team_id: Optional[str] = None) -> None:
     """Raise 400 when cf_role is set but resolves to no active Role row.
 
-    Resolution is scope-exact via _resolve_mapping_role: exactly one
+    Resolution is scope-exact via resolve_mapping_role: exactly one
     active row, team scope preferred over global, never a union of rows.
     An inactive role does not pass validation.
 
@@ -187,7 +145,7 @@ def _validate_role_exists(db: Session, cf_role: Optional[str], cf_team_id: Optio
     """
     if cf_role is None:
         return
-    if _resolve_mapping_role(db, cf_role, cf_team_id) is None:
+    if resolve_mapping_role(db, cf_role, cf_team_id) is None:
         raise HTTPException(status_code=400, detail=f"Role not found: {cf_role}")
 
 

--- a/mcpgateway/services/role_resolution.py
+++ b/mcpgateway/services/role_resolution.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/services/role_resolution.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Scope-exact role-name resolution for external group mappings.
+
+Shared by the admin CRUD router (write-time validation) and the trust-mode
+claims module (read-time merge of mapping-supplied role names). It lives in
+a neutral module because the claims module cannot import the router without
+an import cycle (router -> verify_credentials -> sso_service ->
+trusted_claims).
+
+The rule (finding NB6): a mapping's cf_role resolves to exactly ONE active
+roles row — team scope preferred, global scope as fallback, lowest role id
+as tie-break, inactive rows never resolve, rows are never unioned.
+"""
+
+# Standard
+from typing import Optional
+
+# Third-Party
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.db import Role
+
+#: Scope preference for cf_role resolution: a mapping's context is a team,
+#: so a team-scoped role wins over a global-scoped role of the same name.
+MAPPING_ROLE_SCOPE_PREFERENCE = ("team", "global")
+
+
+def resolve_mapping_role(db: Session, cf_role: str, cf_team_id: Optional[str] = None) -> Optional[Role]:
+    """Resolve a mapping's cf_role to exactly one active Role row.
+
+    roles.name is unique only per (name, scope) among active rows (partial
+    unique index uq_roles_name_scope_active), so a name-only lookup can
+    match several active rows across scopes and union more permissions
+    than intended (or pick arbitrarily). Resolution is scope-exact and
+    deterministic:
+
+    1. The active team-scoped row wins: the mapping's context is a team
+       (cf_team_id).
+    2. Otherwise the active global-scoped row.
+    3. Otherwise the lowest-id active row of any other scope.
+
+    Duplicate active rows within one scope are impossible via the unique
+    index; defended anyway by taking the lowest role id. Rows are never
+    unioned. Inactive rows never resolve.
+
+    Args:
+        db: Database session.
+        cf_role: Role name to resolve.
+        cf_team_id: Team context of the mapping (recorded for the scope
+            preference; Role.scope is a scope type, not a per-team id).
+
+    Returns:
+        Optional[Role]: The single resolved row, or None when no active
+            row matches the name.
+    """
+    rows = db.query(Role).filter(Role.name == cf_role, Role.is_active.is_(True)).all()
+    if not rows:
+        return None
+    for scope in MAPPING_ROLE_SCOPE_PREFERENCE:
+        scoped = [row for row in rows if row.scope == scope]
+        if scoped:
+            return min(scoped, key=lambda row: row.id)
+    return min(rows, key=lambda row: row.id)

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -39,6 +39,7 @@ from mcpgateway.db import PendingUserApproval, SSOAuthSession, SSOProvider, utc_
 from mcpgateway.services.email_auth_service import EmailAuthService
 from mcpgateway.services.encryption_service import get_encryption_service
 from mcpgateway.utils.create_jwt_token import create_jwt_token
+from mcpgateway.utils.trusted_claims import detect_overage_marker
 
 # Logger
 logger = logging.getLogger(__name__)
@@ -1465,14 +1466,10 @@ class SSOService:
             entra_groups_from_graph: Optional[List[str]] = None
             # Detect group overage — when user has too many groups (>200), EntraID can return
             # overage markers (e.g. _claim_names/_claim_sources, hasgroups, groups:srcN)
-            # instead of an inline groups array.
+            # instead of an inline groups array. Detection is shared with the
+            # trust-mode claims module; behavior is unchanged.
             # See: https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference
-            claim_names = verified_id_token_claims.get("_claim_names", {})
-            has_groups_src_key = any(isinstance(key, str) and key.startswith("groups:src") for key in verified_id_token_claims)
-            groups_claim_value = verified_id_token_claims.get("groups")
-            has_group_overage = (
-                (isinstance(claim_names, dict) and "groups" in claim_names) or bool(verified_id_token_claims.get("hasgroups")) or has_groups_src_key or isinstance(groups_claim_value, str)
-            )
+            has_group_overage = detect_overage_marker(verified_id_token_claims)
             if has_group_overage:
                 user_email = user_data.get("email") or user_data.get("preferred_username") or "unknown"
                 logger.warning(

--- a/mcpgateway/utils/trusted_claims.py
+++ b/mcpgateway/utils/trusted_claims.py
@@ -36,11 +36,19 @@ PRINCIPAL CONTRACT (VirtualPrincipal):
   (public-only access; the principal still authenticates).
 - ``roles``: list of role names. The claim named by ``jwt_claim_roles``
   merges with role names returned by the group-mapping resolver before
-  resolution. Role names resolve to permission sets via the server-side
-  ``roles`` table only; permissions are never embedded in or read from the
-  token. Unknown role names are ignored with a WARNING log (fail-closed).
+  resolution. Each name resolves scope-exactly to exactly one active row
+  in the server-side ``roles`` table via
+  ``mcpgateway.services.role_resolution.resolve_mapping_role`` (team scope
+  preferred, global fallback, lowest id, rows never unioned); permissions
+  are never embedded in or read from the token. Names with no active row
+  are ignored with a WARNING log (fail-closed).
 - ``is_admin``: bool, default False. Read from the claim named by
-  ``jwt_claim_admin``.
+  ``jwt_claim_admin`` and parsed strictly: only ``True``, ``1``, and the
+  case-insensitive strings ``"true"``/``"1"``/``"yes"`` grant admin; every
+  other value (including the truthy-coercing strings ``"false"``/``"0"``/
+  ``"no"``) is non-admin. A present but non-canonical value logs one
+  structured warning naming the claim and its JSON type, never the value.
+  A missing claim is silently non-admin (fail-closed).
 - ``auth_provider``: the token issuer (``iss``) when present, else the
   string ``"jwt-trust"``.
 - ``token_use``: the constant string ``"trusted"``.
@@ -61,12 +69,99 @@ from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
 # First-Party
-from mcpgateway.db import ExternalGroupMapping, Role
+from mcpgateway.db import ExternalGroupMapping
+from mcpgateway.services.role_resolution import resolve_mapping_role
 
 logger = logging.getLogger(__name__)
 
 #: Sentinel written on the AuditTrail path when the token carries no email.
 AUDIT_UNKNOWN_SENTINEL = "unknown"
+
+#: Case-insensitive string values of the admin claim that mean True.
+_ADMIN_CLAIM_TRUE_STRINGS = frozenset({"true", "1", "yes"})
+
+#: Case-insensitive string values of the admin claim that are recognized
+#: explicit denials; they coerce False without a warning.
+_ADMIN_CLAIM_FALSE_STRINGS = frozenset({"false", "0", "no"})
+
+
+def _json_type_name(value: Any) -> str:
+    """Return the JSON type name for a claim value (for logs, never the value).
+
+    Args:
+        value: Claim value to classify.
+
+    Returns:
+        str: One of "boolean", "string", "number", "array", "object", or
+            the Python type name for exotica.
+
+    Examples:
+        >>> _json_type_name(True)
+        'boolean'
+        >>> _json_type_name([1])
+        'array'
+    """
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return type(value).__name__
+
+
+def _parse_admin_flag(value: Any, claim_name: str) -> bool:
+    """Strictly parse the admin claim to a boolean (finding NB1).
+
+    ``bool()`` coercion is unsafe here: the strings ``"false"``, ``"0"``,
+    and ``"no"`` are all truthy, so an issuer emitting string claims would
+    silently grant admin. The only values accepted as True are ``True``,
+    ``1``, and the case-insensitive strings ``"true"``/``"1"``/``"yes"``.
+    Every other present value — including ``False``, ``0``, the recognized
+    denial strings, empty strings, floats, arrays, and objects — coerces
+    False. A present value that is neither a boolean, nor integer 0/1, nor
+    a recognized string logs one structured warning naming the claim and
+    the observed JSON type (never the value). A missing claim (None) is
+    silently non-admin: fail-closed.
+
+    Args:
+        value: Raw claim value (None when the claim is absent).
+        claim_name: Configured claim name, used in the warning log.
+
+    Returns:
+        bool: True only for canonical true values; False otherwise.
+
+    Examples:
+        >>> _parse_admin_flag("true", "is_admin")
+        True
+        >>> _parse_admin_flag("false", "is_admin")
+        False
+        >>> _parse_admin_flag(None, "is_admin")
+        False
+    """
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        if value in (0, 1):
+            return value == 1
+    elif isinstance(value, str):
+        lowered = value.lower()
+        if lowered in _ADMIN_CLAIM_TRUE_STRINGS:
+            return True
+        if lowered in _ADMIN_CLAIM_FALSE_STRINGS:
+            return False
+    logger.warning(
+        "Admin claim %r is present with a non-canonical %s value; treating the principal as non-admin.",
+        claim_name,
+        _json_type_name(value),
+    )
+    return False
 
 
 def resolve_external_groups_to_teams(issuer: str, tenant: Optional[str], groups: List[str], db: Session) -> Tuple[List[str], List[str]]:
@@ -264,10 +359,14 @@ def extract_trusted_principal(payload: Dict[str, Any], settings: Any, db: Sessio
       directly. All groups unmapped and no teams claim yields ``[]``
       (public-only access; the principal still authenticates).
     - ``roles`` (list of strings): the ``jwt_claim_roles`` claim merged with
-      resolver-supplied role names, then validated against the server-side
-      ``roles`` table; unknown names are skipped with a WARNING log
-      (fail-closed). Permissions are never read from the token.
-    - ``is_admin`` (bool, default False): read from ``jwt_claim_admin``.
+      resolver-supplied role names, each name resolved scope-exactly to
+      exactly one active row in the server-side ``roles`` table (team scope
+      preferred, global fallback, never unioned); names with no active row
+      are skipped with a WARNING log (fail-closed). Permissions are never
+      read from the token.
+    - ``is_admin`` (bool, default False): read from ``jwt_claim_admin`` and
+      parsed strictly (``_parse_admin_flag``); a present but non-canonical
+      value coerces False with one structured warning.
     - ``auth_provider``: the token issuer (``iss``) when present, else
       ``"jwt-trust"``.
     - ``token_use``: the constant ``"trusted"``.
@@ -320,10 +419,15 @@ def extract_trusted_principal(payload: Dict[str, Any], settings: Any, db: Sessio
             if role_name not in role_names:
                 role_names.append(role_name)
 
-    known_roles = {row[0] for row in db.query(Role.name).filter(Role.is_active.is_(True)).all()}
+    # Names resolve scope-exactly to exactly one active Role row each via
+    # the shared mapping resolver (team scope preferred, global fallback,
+    # lowest id, never union). A name-only lookup could match several
+    # active rows across scopes and union more permissions than intended.
+    # cf_team_id is not threaded here: Role.scope is a scope type, not a
+    # per-team id, so the team context does not change the resolution.
     roles: List[str] = []
     for role_name in role_names:
-        if role_name in known_roles:
+        if resolve_mapping_role(db, role_name) is not None:
             if role_name not in roles:
                 roles.append(role_name)
         else:
@@ -339,7 +443,7 @@ def extract_trusted_principal(payload: Dict[str, Any], settings: Any, db: Sessio
         full_name=full_name if isinstance(full_name, str) else None,
         teams=teams,
         roles=roles,
-        is_admin=bool(_get_claim(payload, settings.jwt_claim_admin)),
+        is_admin=_parse_admin_flag(_get_claim(payload, settings.jwt_claim_admin), settings.jwt_claim_admin),
         auth_provider=issuer,
         token_use="trusted",
     )

--- a/mcpgateway/utils/trusted_claims.py
+++ b/mcpgateway/utils/trusted_claims.py
@@ -3,18 +3,70 @@
 Copyright contributors to the MCP-CONTEXT-FORGE project
 SPDX-License-Identifier: Apache-2.0
 
-Trusted claims extraction and group-to-team resolution. This module will also
-host extract_trusted_principal (added by #5899).
+Trusted claims extraction and group-to-team resolution (issues #5899, #5976).
+
+This module maps a verified external-IdP JWT payload to a virtual principal
+per the pinned trust-mode contract. It also hosts the group-mapping resolver
+and the group-overage marker detector shared with the SSO enrichment path.
+
+Claim readers support dotted paths one or more levels deep (for example the
+Keycloak ``realm_access.roles`` shape). Each path segment must name a JSON
+object member; traversal through arrays or scalar values is not supported and
+resolves to "claim absent". A missing optional claim yields the field
+default; a missing required claim is an extraction error.
+
+PRINCIPAL CONTRACT (VirtualPrincipal):
+
+- ``user_id``: required, opaque string. Read from the claim named by
+  ``jwt_claim_user_id``. No UUID heuristic applies in trust mode. A missing
+  mapped claim raises an extraction error with 401 semantics; the value never
+  defaults to the email claim.
+- ``email``: optional, None allowed. Read from the claim named by
+  ``jwt_claim_email``. Audit-path writes degrade to the ``"unknown"``
+  sentinel string (never None) because ``AuditTrail.user_id`` is
+  ``nullable=False``; ``ObservabilityTrace.user_email`` is nullable and
+  accepts None. See :attr:`VirtualPrincipal.audit_identity`.
+- ``full_name``: optional, default None. Read from the ``name`` claim.
+- ``teams``: normalized list of team ID strings. The claim named by
+  ``jwt_claim_teams`` accepts a list of strings or a list of ``{id, name}``
+  mappings, mirroring ``normalize_token_teams`` in ``auth_context.py``.
+  Mapped team IDs from the external-group resolver are appended. External
+  group IDs never enter ``teams`` directly. When every external group is
+  unmapped and the token carries no teams claim, ``teams`` is ``[]``
+  (public-only access; the principal still authenticates).
+- ``roles``: list of role names. The claim named by ``jwt_claim_roles``
+  merges with role names returned by the group-mapping resolver before
+  resolution. Role names resolve to permission sets via the server-side
+  ``roles`` table only; permissions are never embedded in or read from the
+  token. Unknown role names are ignored with a WARNING log (fail-closed).
+- ``is_admin``: bool, default False. Read from the claim named by
+  ``jwt_claim_admin``.
+- ``auth_provider``: the token issuer (``iss``) when present, else the
+  string ``"jwt-trust"``.
+- ``token_use``: the constant string ``"trusted"``.
+
+Revocation: the claim named by ``jwt_trust_revocation_claim`` (default
+``jti``; ``uti`` supported for Entra trust roots) is the revocation
+identifier. A trust-eligible token missing the configured claim is rejected
+with 401 semantics.
 """
 
 # Standard
-from typing import List, Optional, Tuple
+from dataclasses import dataclass, field
+import logging
+from typing import Any, Dict, List, Optional, Tuple
 
 # Third-Party
+from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
 # First-Party
-from mcpgateway.db import ExternalGroupMapping
+from mcpgateway.db import ExternalGroupMapping, Role
+
+logger = logging.getLogger(__name__)
+
+#: Sentinel written on the AuditTrail path when the token carries no email.
+AUDIT_UNKNOWN_SENTINEL = "unknown"
 
 
 def resolve_external_groups_to_teams(issuer: str, tenant: Optional[str], groups: List[str], db: Session) -> Tuple[List[str], List[str]]:
@@ -60,3 +112,234 @@ def resolve_external_groups_to_teams(issuer: str, tenant: Optional[str], groups:
         if row.cf_role and row.cf_role not in role_names:
             role_names.append(row.cf_role)
     return team_ids, role_names
+
+
+@dataclass
+class VirtualPrincipal:
+    """Virtual principal extracted from a trusted external-IdP token.
+
+    Exposes the attributes downstream consumers read (``.email``,
+    ``.is_admin``, ``.full_name``) per the pinned contract in the module
+    docstring. Instances are synthetic: they are never persisted and never
+    cached as ORM rows.
+    """
+
+    user_id: str
+    email: Optional[str] = None
+    full_name: Optional[str] = None
+    teams: List[str] = field(default_factory=list)
+    roles: List[str] = field(default_factory=list)
+    is_admin: bool = False
+    auth_provider: str = "jwt-trust"
+    token_use: str = "trusted"
+
+    @property
+    def audit_identity(self) -> str:
+        """Identity string for the AuditTrail path.
+
+        ``AuditTrail.user_id`` is ``nullable=False``, so an absent email
+        degrades to the ``"unknown"`` sentinel string; a None write never
+        occurs on this path.
+
+        Returns:
+            The principal email, or the ``"unknown"`` sentinel.
+        """
+        return self.email or AUDIT_UNKNOWN_SENTINEL
+
+
+def _get_claim(payload: Dict[str, Any], claim_path: str) -> Any:
+    """Read a claim by dotted path.
+
+    Each segment must name a JSON object member. Traversal through arrays or
+    scalar values is not supported and resolves to None (claim absent).
+
+    Args:
+        payload: Verified JWT payload.
+        claim_path: Claim name, optionally dotted (``realm_access.roles``).
+
+    Returns:
+        The claim value, or None when the path does not resolve.
+    """
+    node: Any = payload
+    for segment in claim_path.split("."):
+        if not isinstance(node, dict) or segment not in node:
+            return None
+        node = node[segment]
+    return node
+
+
+def _normalize_teams_claim(value: Any) -> List[str]:
+    """Normalize a teams claim to a list of team ID strings.
+
+    Mirrors ``normalize_token_teams`` in ``auth_context.py``: a list of
+    strings passes through; a list of ``{id, name}`` mappings contributes
+    each ``id``; other entries are dropped.
+
+    Args:
+        value: Raw teams claim value.
+
+    Returns:
+        List of team ID strings.
+    """
+    if not isinstance(value, list):
+        return []
+    normalized: List[str] = []
+    for team in value:
+        if isinstance(team, dict):
+            team_id = team.get("id")
+            if team_id:
+                normalized.append(str(team_id))
+        elif isinstance(team, str):
+            normalized.append(team)
+    return normalized
+
+
+def detect_overage_marker(payload: Dict[str, Any]) -> bool:
+    """Detect the Entra group-overage marker shapes in a token payload.
+
+    When a user exceeds the group-claim limit, Entra emits overage markers
+    instead of an inline groups array: ``_claim_names`` containing
+    ``groups``, a ``hasgroups`` key, a ``groups:srcN`` key, or a string-typed
+    ``groups`` claim. Shared with the SSO enrichment path; detection only —
+    resolution behavior follows ``jwt_trust_overage_policy``.
+
+    Args:
+        payload: Token claims dict.
+
+    Returns:
+        True when any overage marker is present.
+    """
+    claim_names = payload.get("_claim_names", {})
+    if isinstance(claim_names, dict) and "groups" in claim_names:
+        return True
+    if payload.get("hasgroups"):
+        return True
+    if any(isinstance(key, str) and key.startswith("groups:src") for key in payload):
+        return True
+    return isinstance(payload.get("groups"), str)
+
+
+def extract_revocation_id(payload: Dict[str, Any], settings: Any) -> str:
+    """Extract the revocation identifier honoring the configured claim.
+
+    The claim named by ``jwt_trust_revocation_claim`` (default ``jti``;
+    ``uti`` supported for Entra trust roots) carries the revocation
+    identifier. A trust-eligible token missing the configured claim is
+    rejected with 401 semantics.
+
+    Args:
+        payload: Verified JWT payload.
+        settings: Settings object carrying ``jwt_trust_revocation_claim``.
+
+    Returns:
+        The revocation identifier string.
+
+    Raises:
+        HTTPException: 401 when the configured claim is absent or empty.
+    """
+    claim = settings.jwt_trust_revocation_claim
+    value = _get_claim(payload, claim)
+    if not value or not isinstance(value, str):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Trust-eligible token is missing the revocation claim {claim!r}.",
+        )
+    return value
+
+
+def extract_trusted_principal(payload: Dict[str, Any], settings: Any, db: Session) -> VirtualPrincipal:
+    """Extract a virtual principal from a verified trusted-IdP JWT payload.
+
+    Implements the pinned contract documented in the module docstring:
+
+    - ``user_id`` (required, opaque): read from the claim named by
+      ``jwt_claim_user_id``; a missing mapped claim raises 401 and never
+      defaults to email.
+    - ``email`` (optional, None allowed): read from ``jwt_claim_email``.
+    - ``full_name`` (optional, default None): read from the ``name`` claim.
+    - ``teams`` (list of strings): the ``jwt_claim_teams`` claim normalized
+      (list of strings or list of ``{id, name}``, mirroring
+      ``normalize_token_teams``), plus team IDs returned by the
+      external-group resolver. External group IDs never enter ``teams``
+      directly. All groups unmapped and no teams claim yields ``[]``
+      (public-only access; the principal still authenticates).
+    - ``roles`` (list of strings): the ``jwt_claim_roles`` claim merged with
+      resolver-supplied role names, then validated against the server-side
+      ``roles`` table; unknown names are skipped with a WARNING log
+      (fail-closed). Permissions are never read from the token.
+    - ``is_admin`` (bool, default False): read from ``jwt_claim_admin``.
+    - ``auth_provider``: the token issuer (``iss``) when present, else
+      ``"jwt-trust"``.
+    - ``token_use``: the constant ``"trusted"``.
+
+    The token must carry the revocation claim named by
+    ``jwt_trust_revocation_claim``; a missing claim raises 401.
+
+    Args:
+        payload: Verified JWT payload from a trusted external IdP.
+        settings: Settings object carrying the ``jwt_claim_*`` and
+            ``jwt_trust_revocation_claim`` mappings.
+        db: Database session for the group-mapping resolver and the
+            server-side roles table.
+
+    Returns:
+        VirtualPrincipal matching the pinned contract.
+
+    Raises:
+        HTTPException: 401 when the mapped user_id claim or the configured
+            revocation claim is absent.
+    """
+    extract_revocation_id(payload, settings)
+
+    user_id = _get_claim(payload, settings.jwt_claim_user_id)
+    if not user_id or not isinstance(user_id, str):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Trust-eligible token is missing the user_id claim {settings.jwt_claim_user_id!r}.",
+        )
+
+    issuer = payload.get("iss") or "jwt-trust"
+    tenant = payload.get("tid")
+
+    teams = _normalize_teams_claim(_get_claim(payload, settings.jwt_claim_teams))
+    role_names: List[str] = []
+    raw_roles = _get_claim(payload, settings.jwt_claim_roles)
+    if isinstance(raw_roles, list):
+        role_names.extend(str(role) for role in raw_roles)
+
+    # External groups are NOT teams: group-claim values are external group
+    # IDs that feed the mapping resolver. Resolver team IDs and role names
+    # merge here, before server-side roles-table resolution.
+    external_groups = payload.get("groups")
+    if isinstance(external_groups, list) and external_groups:
+        mapped_team_ids, mapped_role_names = resolve_external_groups_to_teams(issuer, tenant, [str(group) for group in external_groups], db)
+        for team_id in mapped_team_ids:
+            if team_id not in teams:
+                teams.append(team_id)
+        for role_name in mapped_role_names:
+            if role_name not in role_names:
+                role_names.append(role_name)
+
+    known_roles = {row[0] for row in db.query(Role.name).filter(Role.is_active.is_(True)).all()}
+    roles: List[str] = []
+    for role_name in role_names:
+        if role_name in known_roles:
+            if role_name not in roles:
+                roles.append(role_name)
+        else:
+            logger.warning("Ignoring unknown role name %r from trusted token for user %s (fail-closed).", role_name, user_id)
+
+    full_name = payload.get("name")
+
+    email = _get_claim(payload, settings.jwt_claim_email)
+
+    return VirtualPrincipal(
+        user_id=user_id,
+        email=email if isinstance(email, str) else None,
+        full_name=full_name if isinstance(full_name, str) else None,
+        teams=teams,
+        roles=roles,
+        is_admin=bool(_get_claim(payload, settings.jwt_claim_admin)),
+        auth_provider=issuer,
+        token_use="trusted",
+    )

--- a/tests/unit/mcpgateway/routers/test_external_group_mapping_role.py
+++ b/tests/unit/mcpgateway/routers/test_external_group_mapping_role.py
@@ -27,6 +27,7 @@ from sqlalchemy.pool import StaticPool
 # First-Party
 from mcpgateway.db import Base, EmailTeam, EmailUser, ExternalGroupMapping, Role
 from mcpgateway.routers import admin_external_group_mappings as router_module
+from mcpgateway.services.role_resolution import resolve_mapping_role
 
 
 @pytest.fixture
@@ -150,7 +151,7 @@ class TestScopeExactRoleResolution:
         db.add(Role(name="developer", scope="global", permissions=["admin.system_config"], created_by="admin@example.com", is_system_role=True, is_active=True))
         db.commit()
 
-        resolved = router_module._resolve_mapping_role(db, "developer", cf_team_id="team-a")
+        resolved = resolve_mapping_role(db, "developer", cf_team_id="team-a")
 
         assert isinstance(resolved, Role)
         assert resolved.scope == "team"
@@ -161,7 +162,7 @@ class TestScopeExactRoleResolution:
         db.add(Role(name="ops", scope="global", permissions=["a2a.invoke"], created_by="admin@example.com", is_system_role=True, is_active=True))
         db.commit()
 
-        resolved = router_module._resolve_mapping_role(db, "ops", cf_team_id="team-a")
+        resolved = resolve_mapping_role(db, "ops", cf_team_id="team-a")
 
         assert isinstance(resolved, Role)
         assert resolved.scope == "global"
@@ -179,7 +180,7 @@ class TestScopeExactRoleResolution:
         for rows in ([row_high, row_low], [row_low, row_high]):
             stub_db = MagicMock()
             stub_db.query.return_value.filter.return_value.all.return_value = rows
-            resolved = router_module._resolve_mapping_role(stub_db, "developer", cf_team_id="team-a")
+            resolved = resolve_mapping_role(stub_db, "developer", cf_team_id="team-a")
             assert resolved is row_low
 
     def test_inactive_team_scoped_row_ignored_active_global_resolves(self, db):
@@ -188,7 +189,7 @@ class TestScopeExactRoleResolution:
         db.add(Role(name="ops", scope="global", permissions=["a2a.invoke"], created_by="admin@example.com", is_system_role=True, is_active=True))
         db.commit()
 
-        resolved = router_module._resolve_mapping_role(db, "ops", cf_team_id="team-a")
+        resolved = resolve_mapping_role(db, "ops", cf_team_id="team-a")
 
         assert isinstance(resolved, Role)
         assert resolved.scope == "global"
@@ -196,7 +197,7 @@ class TestScopeExactRoleResolution:
 
     def test_unknown_role_resolves_none(self, db):
         """A name with no active row resolves to None (fail-closed)."""
-        assert router_module._resolve_mapping_role(db, "nonexistent", cf_team_id="team-a") is None
+        assert resolve_mapping_role(db, "nonexistent", cf_team_id="team-a") is None
 
     @pytest.mark.asyncio
     async def test_group_role_create_inactive_role_400(self, allow_admin, db, admin_user, request_stub):

--- a/tests/unit/mcpgateway/test_trusted_claims.py
+++ b/tests/unit/mcpgateway/test_trusted_claims.py
@@ -28,6 +28,7 @@ from sqlalchemy.pool import StaticPool
 # First-Party
 from mcpgateway.config import settings
 from mcpgateway.db import AuditTrail, Base, EmailTeam, EmailUser, ExternalGroupMapping, ObservabilityTrace, Role
+from mcpgateway.services.role_resolution import resolve_mapping_role
 from mcpgateway.utils.trusted_claims import detect_overage_marker, extract_revocation_id, extract_trusted_principal
 
 ISSUER = "https://login.example.com/tenant-1/v2.0"
@@ -53,11 +54,13 @@ def _permissions_for_roles(db, role_names) -> set:
     """Resolve role names to the permission set via the server-side roles table.
 
     Mirrors the trust-mode resolution rule: permissions come from the roles
-    table only; unknown role names contribute nothing.
+    table only; each name resolves scope-exactly to exactly one active row
+    (team scope preferred, global fallback, never unioned); unknown role
+    names contribute nothing.
     """
     permissions = set()
     for name in role_names:
-        role = db.query(Role).filter(Role.name == name, Role.is_active.is_(True)).first()
+        role = resolve_mapping_role(db, name)
         if role is None:
             continue
         permissions.update(role.get_effective_permissions())
@@ -252,3 +255,146 @@ class TestRevocationExtractor:
         with pytest.raises(HTTPException) as exc_info:
             extract_revocation_id({"sub": "oid-1"}, settings)
         assert exc_info.value.status_code == 401
+
+
+class TestAdminClaimStrictTyping:
+    """The admin claim is parsed strictly (NB1).
+
+    bool() coercion treats the strings "false", "0", and "no" as truthy,
+    which would grant admin to any principal whose issuer emits string
+    claims. Only True, 1, and the case-insensitive strings
+    "true"/"1"/"yes" are admin; every other present value coerces False.
+    A missing claim is silently non-admin (fail-closed).
+    """
+
+    @pytest.mark.parametrize(
+        "claim,expected",
+        [
+            (True, True),
+            ("true", True),
+            ("True", True),
+            ("1", True),
+            (1, True),
+            (False, False),
+            ("false", False),
+            ("0", False),
+            (0, False),
+            ("no", False),
+            ("", False),
+            (None, False),
+            ([], False),
+            ({"x": 1}, False),
+        ],
+    )
+    def test_admin_claim_strict_typing(self, db, claim, expected):
+        """Only canonical true values grant admin; malformed types are non-admin."""
+        payload = _base_payload(is_admin=claim)
+        principal = extract_trusted_principal(payload, settings, db)
+        assert principal.is_admin is expected
+
+    def test_noncanonical_admin_claim_logs_one_warning_without_value(self, db, caplog):
+        """A present-but-non-canonical admin claim logs one structured warning.
+
+        The warning names the claim and the observed JSON type, never the
+        claim value.
+        """
+        payload = _base_payload(is_admin="maybe")
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.trusted_claims"):
+            principal = extract_trusted_principal(payload, settings, db)
+        assert principal.is_admin is False
+        warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert settings.jwt_claim_admin in warnings[0].message
+        assert "string" in warnings[0].message
+        assert "maybe" not in warnings[0].message
+
+    def test_noncanonical_admin_claim_array_warns_with_json_type(self, db, caplog):
+        """A structured (array) admin claim coerces False and warns with its JSON type."""
+        payload = _base_payload(is_admin=["true"])
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.trusted_claims"):
+            principal = extract_trusted_principal(payload, settings, db)
+        assert principal.is_admin is False
+        warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "array" in warnings[0].message
+
+    def test_explicit_false_admin_claim_is_silent(self, db, caplog):
+        """Recognized explicit denials (False, 0, "false", "0", "no") do not warn."""
+        for claim in (False, 0, "false", "0", "no"):
+            caplog.clear()
+            payload = _base_payload(is_admin=claim)
+            with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.trusted_claims"):
+                principal = extract_trusted_principal(payload, settings, db)
+            assert principal.is_admin is False
+            assert [record for record in caplog.records if record.levelno == logging.WARNING] == []
+
+    def test_absent_admin_claim_is_silently_non_admin(self, db, caplog):
+        """A missing admin claim coerces False without any log (fail-closed)."""
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.trusted_claims"):
+            principal = extract_trusted_principal(_base_payload(), settings, db)
+        assert principal.is_admin is False
+        assert [record for record in caplog.records if record.levelno == logging.WARNING] == []
+
+
+class TestScopeExactRoleMerge:
+    """Mapping-supplied role names resolve scope-exactly at the merge (NB6).
+
+    roles.name is unique only per (name, scope) among active rows, so one
+    name can span a team-scoped and a global-scoped row. The merge
+    resolves each name to exactly ONE active row via the shared
+    resolve_mapping_role rule: team scope wins, global is the fallback,
+    rows are never unioned.
+    """
+
+    @pytest.fixture
+    def scoped_db(self):
+        """In-memory session with same-name roles in global and team scope.
+
+        The global row is inserted FIRST, so a name-only .first() lookup
+        picks it (the NB6 defect shape). Seeding order must not matter to
+        the scope-exact merge.
+        """
+        engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+        Base.metadata.create_all(bind=engine)
+        session = sessionmaker(bind=engine)()
+
+        owner = EmailUser(
+            email="owner@example.com",
+            password_hash="hash",  # pragma: allowlist secret
+            full_name="Owner",
+            is_admin=False,
+            is_active=True,
+            email_verified_at=datetime.now(timezone.utc),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        session.add(owner)
+        session.add(EmailTeam(id="team-a", name="Team A", slug="team-a", created_by=owner.email, is_personal=False, visibility="private"))
+        # Global row first: a name-only lookup would resolve it over the team row.
+        session.add(Role(name="developer", scope="global", permissions=["admin.system_config"], created_by=owner.email, is_system_role=True, is_active=True))
+        session.add(Role(name="developer", scope="team", permissions=["a2a.invoke"], created_by=owner.email, is_system_role=True, is_active=True))
+        session.add(ExternalGroupMapping(issuer=ISSUER, tenant=TENANT, external_group_id="entra-group-guid-1", cf_team_id="team-a", cf_role="developer"))
+        session.commit()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    def test_mapping_role_derives_from_team_row_only(self, scoped_db):
+        """A group mapping to a name spanning global+team scope derives from the team row only."""
+        payload = _base_payload(groups=["entra-group-guid-1"])
+        principal = extract_trusted_principal(payload, settings, scoped_db)
+        assert principal.roles == ["developer"]
+        permissions = _permissions_for_roles(scoped_db, principal.roles)
+        assert "a2a.invoke" in permissions
+        assert "admin.system_config" not in permissions  # global row never unioned
+
+    def test_global_fallback_when_no_team_scoped_row(self, scoped_db):
+        """A name that exists only in global scope resolves to the global row."""
+        scoped_db.add(Role(name="ops", scope="global", permissions=["a2a.invoke"], created_by="owner@example.com", is_system_role=True, is_active=True))
+        scoped_db.add(ExternalGroupMapping(issuer=ISSUER, tenant=TENANT, external_group_id="entra-group-guid-3", cf_team_id="team-a", cf_role="ops"))
+        scoped_db.commit()
+        payload = _base_payload(groups=["entra-group-guid-3"])
+        principal = extract_trusted_principal(payload, settings, scoped_db)
+        assert principal.roles == ["ops"]
+        assert _permissions_for_roles(scoped_db, principal.roles) == {"a2a.invoke"}

--- a/tests/unit/mcpgateway/test_trusted_claims.py
+++ b/tests/unit/mcpgateway/test_trusted_claims.py
@@ -1,0 +1,254 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_trusted_claims.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for the trust-mode claims extraction module (issue #5899).
+
+extract_trusted_principal maps a verified external-IdP JWT payload to a
+VirtualPrincipal per the pinned contract. user_id is required and opaque; a
+missing mapped claim is an extraction error and never defaults to email.
+email is optional: the AuditTrail path writes the "unknown" sentinel string
+(never None) while ObservabilityTrace.user_email accepts None. External group
+IDs feed the group-mapping resolver and never reach token_teams; resolver
+role names merge with claim roles before server-side roles-table resolution.
+"""
+
+# Standard
+import logging
+from datetime import datetime, timezone
+
+# Third-Party
+from fastapi import HTTPException
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.config import settings
+from mcpgateway.db import AuditTrail, Base, EmailTeam, EmailUser, ExternalGroupMapping, ObservabilityTrace, Role
+from mcpgateway.utils.trusted_claims import detect_overage_marker, extract_revocation_id, extract_trusted_principal
+
+ISSUER = "https://login.example.com/tenant-1/v2.0"
+TENANT = "tenant-1"
+CALLER_ID = "oid-9f8e7d6c"
+CALLER_EMAIL = "trust.user@example.com"
+
+
+def _base_payload(**overrides):
+    """Minimal trust-eligible payload: mapped user_id claim plus jti."""
+    payload = {
+        "sub": CALLER_ID,
+        "iss": ISSUER,
+        "tid": TENANT,
+        "jti": "trusted-jti-1",
+        "exp": 9999999999,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _permissions_for_roles(db, role_names) -> set:
+    """Resolve role names to the permission set via the server-side roles table.
+
+    Mirrors the trust-mode resolution rule: permissions come from the roles
+    table only; unknown role names contribute nothing.
+    """
+    permissions = set()
+    for name in role_names:
+        role = db.query(Role).filter(Role.name == name, Role.is_active.is_(True)).first()
+        if role is None:
+            continue
+        permissions.update(role.get_effective_permissions())
+    return permissions
+
+
+@pytest.fixture
+def db():
+    """In-memory SQLite session seeded with teams, roles, and mapping rows.
+
+    Roles: developer (grants a2a.invoke), viewer (no permissions).
+    Mapping rows: entra-group-guid-1 -> team-a with cf_role=developer;
+    entra-group-guid-2 -> team-b with cf_role NULL.
+    """
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    owner = EmailUser(
+        email="owner@example.com",
+        password_hash="hash",  # pragma: allowlist secret
+        full_name="Owner",
+        is_admin=False,
+        is_active=True,
+        email_verified_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    session.add(owner)
+    session.add(EmailTeam(id="team-a", name="Team A", slug="team-a", created_by=owner.email, is_personal=False, visibility="private"))
+    session.add(EmailTeam(id="team-b", name="Team B", slug="team-b", created_by=owner.email, is_personal=False, visibility="private"))
+    session.add(Role(name="developer", scope="team", permissions=["a2a.invoke"], created_by=owner.email, is_system_role=True, is_active=True))
+    session.add(Role(name="viewer", scope="team", permissions=[], created_by=owner.email, is_system_role=True, is_active=True))
+    session.add(ExternalGroupMapping(issuer=ISSUER, tenant=TENANT, external_group_id="entra-group-guid-1", cf_team_id="team-a", cf_role="developer"))
+    session.add(ExternalGroupMapping(issuer=ISSUER, tenant=TENANT, external_group_id="entra-group-guid-2", cf_team_id="team-b", cf_role=None))
+    session.commit()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+class TestExtractionContract:
+    """The pinned virtual-principal contract, field by field."""
+
+    def test_full_claim_token_yields_complete_principal(self, db):
+        """Happy path: every claim present yields a complete principal."""
+        payload = _base_payload(
+            email=CALLER_EMAIL,
+            name="Trust User",
+            teams=["team-x"],
+            roles=["viewer"],
+            is_admin=False,
+            groups=["entra-group-guid-1"],
+        )
+        principal = extract_trusted_principal(payload, settings, db)
+        assert principal.user_id == CALLER_ID
+        assert principal.email == CALLER_EMAIL
+        assert principal.full_name == "Trust User"
+        assert principal.teams == ["team-x", "team-a"]
+        assert principal.roles == ["viewer", "developer"]
+        assert principal.is_admin is False
+        assert principal.auth_provider == ISSUER
+        assert principal.token_use == "trusted"
+
+    def test_missing_user_id_claim_raises_never_defaults_to_email(self, db):
+        """A missing user_id-mapped claim is an extraction error (401)."""
+        payload = _base_payload(email=CALLER_EMAIL)
+        del payload["sub"]
+        with pytest.raises(HTTPException) as exc_info:
+            extract_trusted_principal(payload, settings, db)
+        assert exc_info.value.status_code == 401
+
+    def test_email_absent_yields_principal_with_email_none(self, db):
+        """A missing email claim yields email=None; identity stays intact."""
+        payload = _base_payload()
+        principal = extract_trusted_principal(payload, settings, db)
+        assert principal.user_id == CALLER_ID
+        assert principal.email is None
+
+    def test_audit_path_writes_unknown_sentinel_never_none(self, db):
+        """AuditTrail.user_id is nullable=False: the sentinel string lands there."""
+        assert AuditTrail.__table__.c.user_id.nullable is False
+        payload = _base_payload()
+        principal = extract_trusted_principal(payload, settings, db)
+        assert principal.email is None
+        assert principal.audit_identity == "unknown"
+        assert principal.audit_identity is not None
+        db.add(AuditTrail(action="read", resource_type="tool", user_id=principal.audit_identity, success=True))
+        db.commit()
+
+    def test_observability_trace_user_email_accepts_none(self, db):
+        """ObservabilityTrace.user_email is nullable and accepts None."""
+        assert ObservabilityTrace.__table__.c.user_email.nullable is True
+        payload = _base_payload()
+        principal = extract_trusted_principal(payload, settings, db)
+        db.add(ObservabilityTrace(name="GET /tools", start_time=datetime.now(timezone.utc), status="ok", user_email=principal.email))
+        db.commit()
+
+    def test_nested_dotted_path_roles_resolves(self, db, monkeypatch):
+        """Keycloak-style nested path realm_access.roles resolves."""
+        monkeypatch.setattr(settings, "jwt_claim_roles", "realm_access.roles")
+        payload = _base_payload(realm_access={"roles": ["developer"]})
+        principal = extract_trusted_principal(payload, settings, db)
+        assert principal.roles == ["developer"]
+
+    def test_teams_claim_normalizes_list_of_dicts(self, db):
+        """Teams claim accepts list of {id, name} mirroring normalize_token_teams."""
+        payload = _base_payload(teams=[{"id": "team-x", "name": "Team X"}, "team-y"])
+        principal = extract_trusted_principal(payload, settings, db)
+        assert principal.teams == ["team-x", "team-y"]
+
+    def test_unknown_role_name_ignored_with_warning(self, db, caplog):
+        """Unknown role names are skipped (fail-closed) with a WARNING log."""
+        payload = _base_payload(roles=["developer", "no-such-role"])
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.trusted_claims"):
+            principal = extract_trusted_principal(payload, settings, db)
+        assert principal.roles == ["developer"]
+        assert any("no-such-role" in record.message for record in caplog.records)
+
+    def test_resolver_cf_role_developer_without_roles_claim(self, db):
+        """No roles claim + mapping row cf_role=developer -> developer permission set."""
+        payload = _base_payload(groups=["entra-group-guid-1"])
+        principal = extract_trusted_principal(payload, settings, db)
+        assert principal.roles == ["developer"]
+        assert principal.teams == ["team-a"]
+        assert "a2a.invoke" in _permissions_for_roles(db, principal.roles)
+
+    def test_unmapped_groups_yield_empty_teams_public_only(self, db):
+        """All external groups unmapped -> teams is [] (public-only, authenticated)."""
+        payload = _base_payload(groups=["unmapped-group"])
+        principal = extract_trusted_principal(payload, settings, db)
+        assert principal.teams == []
+        assert principal.roles == []
+        assert principal.user_id == CALLER_ID
+
+    def test_revocation_claim_default_jti(self, db):
+        """Default revocation claim jti is accepted."""
+        principal = extract_trusted_principal(_base_payload(), settings, db)
+        assert principal.user_id == CALLER_ID
+
+    def test_revocation_claim_uti_supported(self, db, monkeypatch):
+        """An Entra trust root may configure uti as the revocation claim."""
+        monkeypatch.setattr(settings, "jwt_trust_revocation_claim", "uti")
+        payload = _base_payload(uti="entra-uti-1")
+        del payload["jti"]
+        principal = extract_trusted_principal(payload, settings, db)
+        assert principal.user_id == CALLER_ID
+
+    def test_missing_revocation_claim_rejected_401(self, db):
+        """A trust-eligible token without the configured revocation claim is rejected."""
+        payload = _base_payload()
+        del payload["jti"]
+        with pytest.raises(HTTPException) as exc_info:
+            extract_trusted_principal(payload, settings, db)
+        assert exc_info.value.status_code == 401
+
+
+class TestOverageMarker:
+    """detect_overage_marker flags the Entra group-overage token shapes."""
+
+    def test_claim_names_containing_groups(self):
+        assert detect_overage_marker({"_claim_names": {"groups": "src1"}}) is True
+
+    def test_hasgroups_key(self):
+        assert detect_overage_marker({"hasgroups": True}) is True
+
+    def test_groups_src_key(self):
+        assert detect_overage_marker({"groups:src1": "https://graph.example.com"}) is True
+
+    def test_string_typed_groups_claim(self):
+        assert detect_overage_marker({"groups": "src1"}) is True
+
+    def test_inline_groups_list_is_not_overage(self):
+        assert detect_overage_marker({"groups": ["guid-1", "guid-2"]}) is False
+
+    def test_no_groups_markers(self):
+        assert detect_overage_marker({"sub": "oid-1"}) is False
+
+
+class TestRevocationExtractor:
+    """extract_revocation_id honors the configured revocation claim."""
+
+    def test_default_jti(self):
+        assert extract_revocation_id({"jti": "tok-1"}, settings) == "tok-1"
+
+    def test_uti_configured(self, monkeypatch):
+        monkeypatch.setattr(settings, "jwt_trust_revocation_claim", "uti")
+        assert extract_revocation_id({"uti": "entra-uti-9"}, settings) == "entra-uti-9"
+
+    def test_missing_configured_claim_raises_401(self):
+        with pytest.raises(HTTPException) as exc_info:
+            extract_revocation_id({"sub": "oid-1"}, settings)
+        assert exc_info.value.status_code == 401


### PR DESCRIPTION
Extends `mcpgateway/utils/trusted_claims.py` with the trust-mode principal contract. `extract_trusted_principal(payload, settings, db)` returns a `VirtualPrincipal`: `user_id` (required, opaque — a missing mapped claim raises 401, never defaults to the e-mail), `email` (optional, `None` allowed), `full_name`, `teams` (normalized list-of-strings or list-of-`{id,name}`, mirroring `normalize_token_teams`), `roles`, `is_admin` (default `False`), `auth_provider`, `token_use="trusted"`. Claim readers support dotted paths (Keycloak `realm_access.roles`; support level documented). The revocation-claim extractor honors `jwt_trust_revocation_claim` (`jti` default, `uti` supported).

`detect_overage_marker` is shared with the SSO enrichment path — the inline Entra detection in `sso_service.py` now calls the shared helper, behavior-identical. External group IDs never enter `token_teams`: they feed `resolve_external_groups_to_teams`, whose `role_names` merge into `roles` before server-side resolution (unknown names skipped with a WARNING, fail-closed; asserted via caplog). All-unmapped groups yield `[]` (authenticated, public-only). The audit path writes the `"unknown"` sentinel string — never `None` — via the principal's `audit_identity` property (both nullability columns asserted by live inserts).

Tested with:
- `uv run pytest tests/unit/mcpgateway/test_trusted_claims.py -q` — 22 passed (TDD: collection ImportError first)
- `uv run pytest tests -k "trusted_claims or claims" -q` — 116 passed
- `uv run pytest tests -k "sso" -q` — 611 passed, zero SSO test files modified
- `make ruff` — all checks passed
- `make test` — 23294 passed, 879 skipped, 13 xfailed (two consecutive green runs; a first-run flake in two pre-existing audit tests was root-caused to a pre-existing correlation-id contextvar leak across xdist workers — parent-state baseline green, scheduling-order dependent, unmodified)

Acceptance criteria of #5899 are met. `get_current_user` untouched. Risk to existing users: none — new module plus a behavior-identical SSO refactor.

Stack: B.6 of epic #5885 (base: #6742).

Closes #5899