### PR TITLE
feat(auth): add app-only Graph client for Entra group overage in trust mode

### DIFF
--- a/mcpgateway/utils/entra_graph_client.py
+++ b/mcpgateway/utils/entra_graph_client.py
@@ -1,0 +1,259 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/utils/entra_graph_client.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+App-only Microsoft Graph client for Entra group-overage resolution (issue #5977).
+
+Beyond the Entra group-claim limit a token carries overage markers instead
+of a groups array. Under ``jwt_trust_overage_policy = "graph_lookup"`` this
+client resolves the user's security groups with an app-only
+client-credentials token. The token is acquired from the SSO provider
+record's token endpoint with the stored encrypted client secret, decrypted
+at call time. The inbound bearer token is never used: it is audience-bound
+to ContextForge and Graph would reject it. The delegated ``/me`` flow of
+the SSO browser path is not used either.
+
+Group resolution results are cached in Redis keyed by the user's ``oid``
+through the shared ``AuthCache._get_redis_key`` helper (key type ``graph``),
+so keys carry the auth-cache version segment. The TTL is bounded by the
+presenting token's ``exp``. A Redis read error degrades to a cache miss and
+a live Graph lookup; a Redis write error is logged and skipped.
+"""
+
+# Standard
+import logging
+import time
+from typing import Any, List, Optional
+
+# Third-Party
+import orjson
+
+# First-Party
+from mcpgateway.cache.auth_cache import AuthCache
+from mcpgateway.config import settings
+
+logger = logging.getLogger(__name__)
+
+#: Microsoft Graph v1.0 base URL.
+GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0"
+
+#: App-only scope for the client-credentials token request.
+GRAPH_SCOPE = "https://graph.microsoft.com/.default"
+
+#: Cache TTL fallback in seconds when the presenting token carries no exp.
+DEFAULT_CACHE_TTL = 300
+
+
+class EntraGraphError(Exception):
+    """Raised when app-only Graph group resolution fails."""
+
+
+class EntraGraphClient:
+    """App-only Microsoft Graph client for trust-mode overage resolution.
+
+    Uses the OAuth2 client-credentials grant with the SSO provider record's
+    stored encrypted client secret. Results are cached per ``oid`` in Redis
+    when Redis is available.
+
+    Attributes:
+        _auth_cache: Shared auth cache used for the Redis handle and the
+            versioned key helper.
+    """
+
+    def __init__(self, auth_cache: Optional[AuthCache] = None) -> None:
+        """Initialize the client.
+
+        Args:
+            auth_cache: Optional shared AuthCache override (tests). Defaults
+                to a new AuthCache, which supplies the Redis client and the
+                versioned key helper.
+        """
+        self._auth_cache = auth_cache or AuthCache()
+
+    async def get_member_groups(self, provider: Any, oid: str, token_exp: Optional[int] = None) -> List[str]:
+        """Resolve the security-group object IDs for a user's ``oid``.
+
+        Reads the oid-keyed Redis cache first. A cache hit returns the stored
+        group list. A Redis read error is a cache miss and falls through to a
+        live Graph call. A successful live call is written back with a TTL
+        bounded by the presenting token's ``exp``.
+
+        Args:
+            provider: SSO provider record supplying the token endpoint and
+                the encrypted client credentials.
+            oid: Entra object ID of the user (``oid`` claim).
+            token_exp: Expiry (epoch seconds) of the presenting token. Bounds
+                the cache TTL.
+
+        Returns:
+            List of security-group object IDs, de-duplicated and bounded by
+            ``sso_entra_graph_api_max_groups``.
+
+        Raises:
+            EntraGraphError: When token acquisition or the Graph call fails.
+        """
+        redis = await self._auth_cache._get_redis_client()
+        cache_key = self._auth_cache._get_redis_key("graph", oid)
+
+        if redis is not None:
+            try:
+                cached = await redis.get(cache_key)
+            except Exception as exc:  # noqa: BLE001 — cache read errors degrade to a live Graph lookup
+                logger.warning("Graph group cache read failed for oid %s: %s; falling back to live Graph lookup", oid, exc)
+                cached = None
+            if cached:
+                try:
+                    groups = orjson.loads(cached)
+                except ValueError:
+                    logger.warning("Graph group cache entry for oid %s is not valid JSON; falling back to live Graph lookup", oid)
+                else:
+                    if isinstance(groups, list):
+                        return [str(group) for group in groups]
+                    logger.warning("Graph group cache entry for oid %s is not a list; falling back to live Graph lookup", oid)
+
+        groups = await self._fetch_member_groups(provider, oid)
+
+        if redis is not None:
+            try:
+                await redis.setex(cache_key, self._cache_ttl(token_exp), orjson.dumps(groups))
+            except Exception as exc:  # noqa: BLE001 — a cache write failure never fails the request
+                logger.warning("Graph group cache write failed for oid %s: %s", oid, exc)
+
+        return groups
+
+    @staticmethod
+    def _cache_ttl(token_exp: Optional[int]) -> int:
+        """Compute the cache TTL, bounded by the presenting token's exp.
+
+        Args:
+            token_exp: Expiry (epoch seconds) of the presenting token.
+
+        Returns:
+            TTL in seconds. With an ``exp`` the TTL never exceeds the token's
+            remaining lifetime; without one the default applies.
+        """
+        if token_exp:
+            return max(1, int(token_exp - time.time()))
+        return DEFAULT_CACHE_TTL
+
+    async def _acquire_app_token(self, provider: Any) -> str:
+        """Acquire an app-only Graph token via the client-credentials grant.
+
+        Decrypts the SSO provider record's stored client secret at call time
+        and posts the grant to the provider's token endpoint. The inbound
+        bearer token is never used.
+
+        Args:
+            provider: SSO provider record with ``token_url``, ``client_id``,
+                and ``client_secret_encrypted``.
+
+        Returns:
+            The app-only access token.
+
+        Raises:
+            EntraGraphError: When the secret is missing or undecryptable, or
+                the token endpoint fails.
+        """
+        encrypted_secret = getattr(provider, "client_secret_encrypted", None)
+        provider_id = getattr(provider, "id", "unknown")
+        if not encrypted_secret:
+            raise EntraGraphError(f"SSO provider {provider_id!r} has no stored client secret; cannot acquire an app-only Graph token.")
+
+        # First-Party
+        from mcpgateway.services.encryption_service import get_encryption_service  # pylint: disable=import-outside-toplevel
+
+        client_secret = await get_encryption_service(settings.auth_encryption_secret).decrypt_secret_async(encrypted_secret)
+        if not client_secret:
+            raise EntraGraphError(f"Failed to decrypt the stored client secret of SSO provider {provider_id!r}.")
+
+        # First-Party
+        from mcpgateway.services.http_client_service import get_http_client  # pylint: disable=import-outside-toplevel
+
+        client = await get_http_client()
+        try:
+            response = await client.post(
+                provider.token_url,
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": provider.client_id,
+                    "client_secret": client_secret,
+                    "scope": GRAPH_SCOPE,
+                },
+                headers={"Accept": "application/json"},
+                timeout=settings.sso_entra_graph_api_timeout,
+            )
+        except Exception as exc:
+            raise EntraGraphError(f"App-only token request for SSO provider {provider_id!r} failed: {exc}") from exc
+        if response.status_code != 200:
+            raise EntraGraphError(f"App-only token request for SSO provider {provider_id!r} returned HTTP {response.status_code}.")
+
+        access_token = response.json().get("access_token")
+        if not access_token:
+            raise EntraGraphError(f"App-only token response for SSO provider {provider_id!r} carried no access_token.")
+        return access_token
+
+    async def _fetch_member_groups(self, provider: Any, oid: str) -> List[str]:
+        """Call Graph getMemberObjects for the user's ``oid``.
+
+        Posts ``{"securityEnabledOnly": true}`` to
+        ``/users/{oid}/getMemberObjects`` with the app-only token. Requests
+        are bounded by ``sso_entra_graph_api_timeout`` and results by
+        ``sso_entra_graph_api_max_groups``.
+
+        Args:
+            provider: SSO provider record (credential source).
+            oid: Entra object ID of the user.
+
+        Returns:
+            De-duplicated list of security-group object IDs.
+
+        Raises:
+            EntraGraphError: When the Graph call fails or the payload shape
+                is unexpected (fail-closed).
+        """
+        app_token = await self._acquire_app_token(provider)
+
+        # First-Party
+        from mcpgateway.services.http_client_service import get_http_client  # pylint: disable=import-outside-toplevel
+
+        client = await get_http_client()
+        try:
+            response = await client.post(
+                f"{GRAPH_BASE_URL}/users/{oid}/getMemberObjects",
+                headers={"Authorization": f"Bearer {app_token}"},
+                json={"securityEnabledOnly": True},
+                timeout=settings.sso_entra_graph_api_timeout,
+            )
+        except Exception as exc:
+            raise EntraGraphError(f"Graph getMemberObjects request for oid {oid} failed: {exc}") from exc
+        if response.status_code != 200:
+            raise EntraGraphError(f"Graph getMemberObjects for oid {oid} returned HTTP {response.status_code}.")
+
+        group_values = response.json().get("value", [])
+        if not isinstance(group_values, list):
+            raise EntraGraphError(f"Graph getMemberObjects for oid {oid} returned an unexpected payload: 'value' is not a list.")
+
+        deduped_groups: List[str] = []
+        seen_groups: set = set()
+        for group_id in group_values:
+            if not isinstance(group_id, str):
+                continue
+            normalized_group_id = group_id.strip()
+            if not normalized_group_id or normalized_group_id in seen_groups:
+                continue
+            seen_groups.add(normalized_group_id)
+            deduped_groups.append(normalized_group_id)
+
+        max_groups = settings.sso_entra_graph_api_max_groups
+        if max_groups > 0 and len(deduped_groups) > max_groups:
+            logger.warning(
+                "Graph returned %d groups for oid %s; applying configured cap (%d)",
+                len(deduped_groups),
+                oid,
+                max_groups,
+            )
+            deduped_groups = deduped_groups[:max_groups]
+
+        logger.info("Resolved %d groups from Graph for oid %s", len(deduped_groups), oid)
+        return deduped_groups

--- a/mcpgateway/utils/trusted_claims.py
+++ b/mcpgateway/utils/trusted_claims.py
@@ -6,8 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 Trusted claims extraction and group-to-team resolution (issues #5899, #5976).
 
 This module maps a verified external-IdP JWT payload to a virtual principal
-per the pinned trust-mode contract. It also hosts the group-mapping resolver
-and the group-overage marker detector shared with the SSO enrichment path.
+per the pinned trust-mode contract. It also hosts the group-mapping resolver,
+the group-overage marker detector shared with the SSO enrichment path, and
+the overage policy dispatch (:func:`resolve_overage_groups`, issue #5977).
 
 Claim readers support dotted paths one or more levels deep (for example the
 Keycloak ``realm_access.roles`` shape). Each path segment must name a JSON
@@ -69,8 +70,9 @@ from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
 # First-Party
-from mcpgateway.db import ExternalGroupMapping
+from mcpgateway.db import ExternalGroupMapping, Role, SSOProvider
 from mcpgateway.services.role_resolution import resolve_mapping_role
+from mcpgateway.utils.entra_graph_client import EntraGraphClient, EntraGraphError
 
 logger = logging.getLogger(__name__)
 
@@ -447,3 +449,78 @@ def extract_trusted_principal(payload: Dict[str, Any], settings: Any, db: Sessio
         auth_provider=issuer,
         token_use="trusted",
     )
+
+
+async def resolve_overage_groups(payload: Dict[str, Any], settings: Any, db: Session, graph_client: Optional[Any] = None) -> List[str]:
+    """Apply ``jwt_trust_overage_policy`` to an overage-marked trusted token.
+
+    Dispatches on the configured policy:
+
+    - ``fail_closed`` (default): reject with 401 and an actionable detail.
+    - ``graph_lookup``: resolve the user's security groups through the
+      app-only Microsoft Graph client (oid-keyed cache). The SSO provider
+      record matching the token issuer supplies the encrypted client
+      credentials; the inbound bearer token is never used. Any acquisition
+      failure rejects with 401.
+    - ``proceed_without_groups``: continue with an empty group list and emit
+      a WARNING log carrying the user's oid on every overage-triggered
+      request.
+
+    Args:
+        payload: Verified JWT payload carrying an overage marker (see
+            :func:`detect_overage_marker`).
+        settings: Settings object carrying ``jwt_trust_overage_policy`` and
+            ``jwt_claim_user_id``.
+        db: Database session for the SSO provider lookup.
+        graph_client: Optional EntraGraphClient override (tests).
+
+    Returns:
+        List of external group object IDs. Empty under
+        ``proceed_without_groups``.
+
+    Raises:
+        HTTPException: 401 under ``fail_closed``, or under ``graph_lookup``
+            when the oid claim, the provider record, or the Graph resolution
+            fails.
+    """
+    policy = getattr(settings, "jwt_trust_overage_policy", "fail_closed")
+    oid = payload.get("oid")
+    log_id = oid if isinstance(oid, str) and oid else _get_claim(payload, settings.jwt_claim_user_id)
+
+    if policy == "fail_closed":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token carries an Entra group-overage marker (groups claim omitted) and jwt_trust_overage_policy is 'fail_closed'. "
+            "Set jwt_trust_overage_policy to 'graph_lookup' or 'proceed_without_groups' to admit overage tokens.",
+        )
+
+    if policy == "proceed_without_groups":
+        logger.warning(
+            "Entra group overage for oid %s: group resolution skipped; proceeding without groups (jwt_trust_overage_policy=proceed_without_groups).",
+            log_id,
+        )
+        return []
+
+    # graph_lookup
+    if not isinstance(oid, str) or not oid:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="jwt_trust_overage_policy 'graph_lookup' requires the token 'oid' claim for the Graph user lookup.",
+        )
+
+    issuer = payload.get("iss")
+    provider = db.query(SSOProvider).filter(SSOProvider.issuer == issuer, SSOProvider.is_enabled.is_(True)).first()
+    if provider is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"No enabled SSO provider matches token issuer {issuer!r}; cannot resolve the group overage via Microsoft Graph.",
+        )
+
+    client = graph_client or EntraGraphClient()
+    try:
+        return await client.get_member_groups(provider, oid, token_exp=payload.get("exp"))
+    except EntraGraphError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Group overage resolution via Microsoft Graph failed for oid {oid}: {exc}",
+        ) from exc

--- a/tests/unit/mcpgateway/test_entra_graph_client.py
+++ b/tests/unit/mcpgateway/test_entra_graph_client.py
@@ -1,0 +1,245 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_entra_graph_client.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for the app-only Entra Graph overage client (issue #5977).
+
+Beyond the Entra group-claim limit a trusted token carries overage markers
+instead of a groups array. ``resolve_overage_groups`` in trusted_claims.py
+applies ``jwt_trust_overage_policy``: ``fail_closed`` rejects with 401,
+``graph_lookup`` resolves security groups through the app-only Graph client
+(oid-keyed Redis cache), and ``proceed_without_groups`` continues with an
+empty group list plus a WARNING log carrying the user's oid. The client
+acquires a client-credentials token with the SSO provider record's stored
+encrypted client secret; the inbound bearer token is never used.
+"""
+
+# Standard
+import logging
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+# Third-Party
+from fastapi import HTTPException
+import pytest
+
+# First-Party
+from mcpgateway.cache.auth_cache import AuthCache
+from mcpgateway.utils.entra_graph_client import EntraGraphClient
+from mcpgateway.utils.trusted_claims import resolve_overage_groups
+
+ISSUER = "https://login.microsoftonline.com/tenant-1/v2.0"
+OID = "oid-9f8e7d6c"
+TOKEN_URL = "https://login.microsoftonline.com/tenant-1/oauth2/v2.0/token"
+APP_ONLY_TOKEN = "app-only-graph-token"  # noqa: S105 — test fixture, not a real secret
+
+
+def _overage_payload(**overrides):
+    """Trust-eligible Entra payload with the overage marker shapes set."""
+    payload = {
+        "sub": OID,
+        "oid": OID,
+        "iss": ISSUER,
+        "tid": "tenant-1",
+        "jti": "trusted-jti-1",
+        "exp": int(time.time()) + 600,
+        "hasgroups": True,
+        "_claim_names": {"groups": "src1"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _settings(policy):
+    """Minimal settings stand-in carrying the overage policy and claim map."""
+    return SimpleNamespace(
+        jwt_trust_overage_policy=policy,
+        jwt_claim_user_id="sub",
+    )
+
+
+def _provider():
+    """SSO provider record double: encrypted secret, never a plain secret."""
+    return SimpleNamespace(
+        id="entra",
+        name="entra",
+        issuer=ISSUER,
+        is_enabled=True,
+        client_id="app-client-id",
+        client_secret_encrypted="ENC(plain-secret)",
+        token_url=TOKEN_URL,
+    )
+
+
+def _db_returning(provider):
+    """Session double whose SSO provider lookup returns ``provider``."""
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = provider
+    return db
+
+
+class _FakeRedis:
+    """Dict-backed async Redis double that records keys and TTLs."""
+
+    def __init__(self):
+        self.store = {}
+        self.ttls = {}
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def setex(self, key, ttl, value):
+        self.store[key] = value
+        self.ttls[key] = ttl
+
+
+class _BrokenRedis:
+    """Redis double whose reads and writes raise ConnectionError."""
+
+    async def get(self, key):
+        raise ConnectionError("redis down")
+
+    async def setex(self, key, ttl, value):
+        raise ConnectionError("redis down")
+
+
+def _graph_http_client(graph_calls, graph_status=200, graph_payload=None, token_status=200):
+    """HTTP client double: client-credentials token POST plus getMemberObjects."""
+    if graph_payload is None:
+        graph_payload = {"value": ["group-1", "group-2"]}
+
+    async def _post(url, **kwargs):
+        if url == TOKEN_URL:
+            return SimpleNamespace(status_code=token_status, json=lambda: {"access_token": APP_ONLY_TOKEN}, text="")
+        if url.endswith("/getMemberObjects"):
+            graph_calls.append(kwargs)
+            return SimpleNamespace(status_code=graph_status, json=lambda: graph_payload, text="")
+        raise AssertionError(f"unexpected URL {url}")
+
+    return SimpleNamespace(post=_post)
+
+
+def _patch_http_and_encryption(monkeypatch, http_client):
+    """Point the lazy http/encryption lookups at test doubles."""
+    monkeypatch.setattr("mcpgateway.services.http_client_service.get_http_client", AsyncMock(return_value=http_client))
+    encryption = SimpleNamespace(decrypt_secret_async=AsyncMock(return_value="plain-secret"))
+    monkeypatch.setattr("mcpgateway.services.encryption_service.get_encryption_service", lambda _secret: encryption)
+
+
+def _client_with_redis(redis):
+    """EntraGraphClient on a real AuthCache whose Redis handle is a double."""
+    auth_cache = AuthCache()
+
+    async def _redis():
+        return redis
+
+    auth_cache._get_redis_client = _redis  # pyright: ignore[reportPrivateUsage]
+    return EntraGraphClient(auth_cache=auth_cache), auth_cache
+
+
+class TestOveragePolicyMatrix:
+    """Three-policy dispatch matrix of jwt_trust_overage_policy."""
+
+    async def test_fail_closed_rejects_with_401(self):
+        """fail_closed (default): overage token is rejected, error is actionable."""
+        with pytest.raises(HTTPException) as exc_info:
+            await resolve_overage_groups(_overage_payload(), _settings("fail_closed"), MagicMock())
+        assert exc_info.value.status_code == 401
+        assert "jwt_trust_overage_policy" in exc_info.value.detail
+
+    async def test_graph_lookup_resolves_groups_via_app_only_token(self, monkeypatch):
+        """graph_lookup: groups resolve; Graph is called with the app-only token."""
+        graph_calls = []
+        _patch_http_and_encryption(monkeypatch, _graph_http_client(graph_calls))
+        graph_client, _ = _client_with_redis(None)
+
+        groups = await resolve_overage_groups(_overage_payload(), _settings("graph_lookup"), _db_returning(_provider()), graph_client=graph_client)
+
+        assert groups == ["group-1", "group-2"]
+        assert len(graph_calls) == 1
+        # The Graph call carries the client-credentials token, never the inbound bearer token.
+        assert graph_calls[0]["headers"]["Authorization"] == f"Bearer {APP_ONLY_TOKEN}"
+        assert graph_calls[0]["json"] == {"securityEnabledOnly": True}
+
+    async def test_proceed_without_groups_returns_empty_and_warns_with_oid(self, caplog):
+        """proceed_without_groups: empty groups plus WARNING log carrying the oid (AC-extra-2)."""
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.trusted_claims"):
+            groups = await resolve_overage_groups(_overage_payload(), _settings("proceed_without_groups"), MagicMock())
+        assert groups == []
+        warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+        assert any(OID in record.getMessage() for record in warnings)
+
+
+class TestResolutionCache:
+    """oid-keyed Redis cache over the shared AuthCache key helper."""
+
+    async def test_second_identical_request_served_from_cache(self, monkeypatch):
+        """Two identical requests hit Graph once; the second is a cache hit."""
+        redis = _FakeRedis()
+        graph_client, auth_cache = _client_with_redis(redis)
+        graph_calls = []
+        _patch_http_and_encryption(monkeypatch, _graph_http_client(graph_calls))
+        db = _db_returning(_provider())
+        payload = _overage_payload()
+
+        before = int(time.time())
+        first = await resolve_overage_groups(payload, _settings("graph_lookup"), db, graph_client=graph_client)
+        second = await resolve_overage_groups(payload, _settings("graph_lookup"), db, graph_client=graph_client)
+
+        assert first == ["group-1", "group-2"]
+        assert second == first
+        assert len(graph_calls) == 1
+        # The cache key comes from the shared AuthCache helper (version segment).
+        key = auth_cache._get_redis_key("graph", OID)  # pyright: ignore[reportPrivateUsage]
+        assert key in redis.store
+        # TTL is bounded by the presenting token's exp.
+        assert 0 < redis.ttls[key] <= payload["exp"] - before
+
+
+class TestCacheErrorFallback:
+    """AC-extra-1: Redis read errors degrade to cache miss, never to 401."""
+
+    async def test_redis_error_with_graph_success_authorizes(self, monkeypatch):
+        """Redis raises ConnectionError on lookup and Graph succeeds -> authorized."""
+        graph_client, _ = _client_with_redis(_BrokenRedis())
+        _patch_http_and_encryption(monkeypatch, _graph_http_client([]))
+
+        groups = await resolve_overage_groups(_overage_payload(), _settings("graph_lookup"), _db_returning(_provider()), graph_client=graph_client)
+
+        assert groups == ["group-1", "group-2"]
+
+    async def test_redis_error_with_graph_failure_yields_401(self, monkeypatch):
+        """Redis raises ConnectionError on lookup and Graph fails -> 401."""
+        graph_client, _ = _client_with_redis(_BrokenRedis())
+        _patch_http_and_encryption(monkeypatch, _graph_http_client([], graph_status=500))
+
+        with pytest.raises(HTTPException) as exc_info:
+            await resolve_overage_groups(_overage_payload(), _settings("graph_lookup"), _db_returning(_provider()), graph_client=graph_client)
+
+        assert exc_info.value.status_code == 401
+
+
+class TestGraphLookupFailure:
+    """graph_lookup is fail-closed on Graph acquisition failure."""
+
+    async def test_graph_failure_under_graph_lookup_yields_401(self, monkeypatch):
+        """Healthy cache, Graph returns HTTP 500 -> 401."""
+        graph_client, _ = _client_with_redis(_FakeRedis())
+        _patch_http_and_encryption(monkeypatch, _graph_http_client([], graph_status=500))
+
+        with pytest.raises(HTTPException) as exc_info:
+            await resolve_overage_groups(_overage_payload(), _settings("graph_lookup"), _db_returning(_provider()), graph_client=graph_client)
+
+        assert exc_info.value.status_code == 401
+
+    async def test_token_endpoint_failure_under_graph_lookup_yields_401(self, monkeypatch):
+        """Client-credentials token acquisition fails -> 401."""
+        graph_client, _ = _client_with_redis(_FakeRedis())
+        _patch_http_and_encryption(monkeypatch, _graph_http_client([], token_status=400))
+
+        with pytest.raises(HTTPException) as exc_info:
+            await resolve_overage_groups(_overage_payload(), _settings("graph_lookup"), _db_returning(_provider()), graph_client=graph_client)
+
+        assert exc_info.value.status_code == 401


### PR DESCRIPTION
Adds `mcpgateway/utils/entra_graph_client.py`: an app-only client-credentials Microsoft Graph client for trust-mode overage resolution. Token acquisition posts `grant_type=client_credentials` to the SSO provider record's `token_url` using the stored encrypted client secret (decrypted at call time); the Graph call is `POST /users/{oid}/getMemberObjects` with `securityEnabledOnly: true`, bounded by `sso_entra_graph_api_timeout` and `sso_entra_graph_api_max_groups`. The inbound bearer token is never used (no inbound-token parameter exists; tests assert the `Bearer app-only-graph-token` header), and the delegated `/me` flow from the SSO browser path was not copied.

Group resolution is oid-keyed and cached through the shared `AuthCache._get_redis_key("graph", oid)` key (version-namespaced), TTL bounded by the presenting token's `exp`. A Redis read error is treated as a cache miss with a live Graph attempt. Policy dispatch in `trusted_claims.py`: `fail_closed` (default) returns 401 with an actionable error naming the setting; `graph_lookup` resolves via the client (cached — two identical requests make one Graph call); `proceed_without_groups` continues with empty groups and a WARNING log carrying the oid.

Tested with:
- `uv run pytest tests/unit/mcpgateway/test_entra_graph_client.py -q` — 8 passed (TDD: ModuleNotFoundError first). Covers the three-policy matrix, cache-hit single-call, AC-extra-1 (Redis ConnectionError + Graph 200 → authorized; Redis error + Graph failure → 401), and AC-extra-2 (WARNING with oid).
- `uv run pytest tests -k "overage or graph" -q` — 1455 tests, 0 failures
- `uv run pytest tests -k "sso" -q` — 644 tests, 0 failures, zero SSO test files modified
- `make ruff` — all checks passed
- `make test` — 23302 passed, 879 skipped, 13 xfailed

Acceptance criteria of #5977 are met. Risk to existing users: none — new module and policy dispatch; default-mode and SSO browser-flow behavior unchanged.

Stack: B.7 of epic #5885 (base: #6744).

Closes #5977