### PR TITLE
feat(auth): add JWT-trust verification path with claims-derived identity

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-12T17:24:57Z",
+  "generated_at": "2026-09-12T17:30:40Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1902,7 +1902,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 494,
+        "line_number": 516,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1910,7 +1910,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 937,
+        "line_number": 959,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1918,7 +1918,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1415,
+        "line_number": 1437,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1926,7 +1926,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1447,
+        "line_number": 1469,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -1934,7 +1934,7 @@
         "hashed_secret": "424ca52f87120d5dd4475b0b4aaed10adc379fb9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1451,
+        "line_number": 1473,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -221,6 +221,8 @@ Startup validation rules:
 
 All defaults preserve the current behavior: trust mode defaults to `db` and the new settings are inert until `jwt-trust` is enabled.
 
+Posture change in `jwt-trust` mode: the gateway does not read the local user record on the request path, so there is no per-user `is_active` kill-switch for trust-mode principals. To withdraw access, revoke the token through the configured revocation claim (`JWT_TRUST_REVOCATION_CLAIM`, default `jti`) or remove the external group mapping. A token that carries `token_use="trusted"` is rejected with `401` when trust mode is `db`: the marker never enters the default funnel. The auth-cache Redis key carries the mode as a namespace segment, so a mode flip cold-starts every auth cache automatically.
+
 ### UI Features
 
 For detailed guidance on embedding and section customization, see [Admin UI Customization](admin-ui-customization.md).

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -1760,6 +1760,105 @@ async def get_current_user(
 
         logger.debug("JWT token validated successfully")
 
+        # === TRUST DISPATCH: token_use="trusted" (#5896 dispatch rule) ===
+        # A token marked token_use="trusted" is trust-eligible only when trust
+        # mode is ON (jwt_trust_mode="jwt-trust"). With trust mode OFF the
+        # marker must never enter the default funnel: the UUID->email seam
+        # could silently re-attribute identity, and normalize_token_teams
+        # would honor the embedded teams claim without the trust-mode claim
+        # mapping and revocation rules. Reject with 401.
+        if payload.get("token_use") == "trusted" and settings.jwt_trust_mode != "jwt-trust":  # nosec B105 - Not a password; token_use is a JWT claim type
+            logger.warning(
+                "Rejected token with token_use=trusted: JWT trust mode is OFF",
+                extra={"security_event": "trust_token_rejected_mode_off"},
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Trusted tokens require JWT trust mode",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        if settings.jwt_trust_mode == "jwt-trust" and payload.get("token_use") == "trusted":  # nosec B105 - Not a password; token_use is a JWT claim type
+            # Trust-eligible branch for gateway-signed tokens (dispatch rule
+            # branch (a) in docs/docs/architecture/auth-token-dispatch.md).
+            # Identity, teams, and roles derive from the mapped claims via
+            # extract_trusted_principal (#5899); the external-group resolver
+            # (#5976/#6272) translates group claims into CF team IDs, and raw
+            # external group IDs never reach token_teams.
+            #
+            # SKIPPED on this path, by design: the local user-record lookup,
+            # the is_active check, the UUID->email seam, and DB team
+            # resolution. Accepted posture change: trust mode has no per-user
+            # is_active kill-switch. Access is withdrawn through token
+            # revocation (the configured revocation claim) or by removing the
+            # group mapping. See docs/docs/manage/configuration.md.
+            #
+            # The revocation check is RETAINED: the configured revocation
+            # claim (jwt_trust_revocation_claim, default jti) is checked
+            # against the revocation store on every request.
+            # First-Party
+            from mcpgateway.utils.trusted_claims import detect_overage_marker, extract_revocation_id, extract_trusted_principal, resolve_overage_groups  # pylint: disable=import-outside-toplevel
+
+            # Entra group-overage markers mean the groups claim was omitted.
+            # Dispatch on jwt_trust_overage_policy (#5977): fail_closed ->
+            # 401; graph_lookup -> app-only Graph resolution;
+            # proceed_without_groups -> continue with no groups. The resolved
+            # group IDs replace the marker in a payload copy; the inbound
+            # payload is never mutated.
+            if detect_overage_marker(payload):
+                with fresh_db_session() as overage_db:
+                    resolved_groups = await resolve_overage_groups(payload, settings, overage_db)
+                payload = {**payload, "groups": resolved_groups}
+
+            def _extract_principal_sync():
+                with fresh_db_session() as db:
+                    return extract_trusted_principal(payload, settings, db)
+
+            # extract_trusted_principal raises 401 when a required mapped
+            # claim or the configured revocation claim is absent (fail-closed).
+            principal = await asyncio.to_thread(_extract_principal_sync)
+
+            # The email claim is optional in trust mode. When absent, the
+            # token subject backs the email attribute (display and tracing);
+            # the canonical user_id stays the opaque mapped claim.
+            if principal.email is None:
+                subject = payload.get("sub")
+                principal.email = subject if isinstance(subject, str) else None
+
+            revocation_id = extract_revocation_id(payload, settings)
+            if await asyncio.to_thread(_check_token_revoked_sync, revocation_id):
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Token has been revoked",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+
+            token_teams = list(principal.teams)
+            if request:
+                request.state.token_teams = token_teams
+                # Same team-context rule as default mode: a single concrete
+                # team derives request.state.team_id.
+                request.state.team_id = await derive_token_team_id(token_teams, "trusted")
+                request.state.token_use = "trusted"
+                request.state.trace_team_name = await resolve_trace_team_name(payload, token_teams)
+                # Preserve the raw JWT teams claim for OAuth storage path selection.
+                request.state.jwt_teams_claim = payload.get("teams")
+                # Store the revocation identifier for middleware (token usage logging).
+                request.state.jti = revocation_id
+                # Trust tokens are JWT-authenticated; the API-token scope layer
+                # does not apply to them.
+                request.state.auth_method = "jwt"
+
+            _inject_userinfo_instate(request, principal)
+            _propagate_tenant_id(request)
+
+            _set_trace_for_user(
+                principal,
+                teams=token_teams if request else _UNSET,
+                team_name=getattr(request.state, "trace_team_name", None) if request else None,
+            )
+            return principal
+
         # Extract user identifier (support new UUID-sub and legacy email-sub formats).
         # Signed email metadata wins; only UUID-only tokens need DB resolution.
         from mcpgateway.auth_context import resolve_jwt_user_email_from_payload  # pylint: disable=import-outside-toplevel

--- a/mcpgateway/cache/auth_cache.py
+++ b/mcpgateway/cache/auth_cache.py
@@ -157,6 +157,9 @@ class AuthCache:
             self._enabled = enabled if enabled is not None else getattr(settings, "auth_cache_enabled", True)
             self._cache_prefix = getattr(settings, "cache_prefix", "mcpgw:")
             self._key_version = getattr(settings, "auth_cache_key_version", "v1")
+            # Auth mode is a key segment: a mode flip (db <-> jwt-trust)
+            # changes every key, cold-starting all auth caches automatically.
+            self._key_mode = getattr(settings, "jwt_trust_mode", "db")
         except ImportError:
             self._user_ttl = user_ttl or 60
             self._revocation_ttl = revocation_ttl or 30
@@ -167,6 +170,7 @@ class AuthCache:
             self._enabled = enabled if enabled is not None else True
             self._cache_prefix = "mcpgw:"
             self._key_version = "v1"
+            self._key_mode = "db"
 
         # In-memory cache (fallback when Redis unavailable)
         self._user_cache: Dict[str, CacheEntry] = {}
@@ -201,25 +205,28 @@ class AuthCache:
         )
 
     def _get_redis_key(self, key_type: str, identifier: str) -> str:
-        """Generate Redis key with prefix and namespace version.
+        """Generate Redis key with prefix, namespace version, and auth mode.
 
-        The version segment isolates keys across auth modes: bumping
+        The version segment isolates keys across key-shape changes: bumping
         ``auth_cache_key_version`` makes every key written under the old
-        version unreachable (cold start) without flushing Redis.
+        version unreachable (cold start) without flushing Redis. The mode
+        segment isolates keys across auth modes: flipping ``jwt_trust_mode``
+        (``db`` <-> ``jwt-trust``) cold-starts all auth caches automatically,
+        so no manual version bump is needed on a mode change.
 
         Args:
             key_type: Type of cache entry (user, team, revoke, ctx)
             identifier: Unique identifier (canonical user_id, jti, etc.)
 
         Returns:
-            Full Redis key with prefix and version
+            Full Redis key with prefix, version, and mode
 
         Examples:
             >>> cache = AuthCache()
             >>> cache._get_redis_key("user", "test@example.com")
-            'mcpgw:auth:v1:user:test@example.com'
+            'mcpgw:auth:v1:db:user:test@example.com'
         """
-        return f"{self._cache_prefix}auth:{self._key_version}:{key_type}:{identifier}"
+        return f"{self._cache_prefix}auth:{self._key_version}:{self._key_mode}:{key_type}:{identifier}"
 
     async def _get_redis_client(self):
         """Get Redis client if available.

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -404,6 +404,10 @@ class Settings(BaseSettings):
     # Trust mode "jwt-trust" accepts claims from tokens issued by trusted
     # external identity providers without a per-request database lookup.
     # Default "db" preserves the existing database-backed behavior.
+    # The auth-cache Redis key carries the mode as a namespace segment
+    # (mcpgw:auth:{version}:{mode}:...), so flipping this setting
+    # cold-starts every auth cache automatically; no manual bump of
+    # auth_cache_key_version is needed on a mode change.
     jwt_trust_mode: Literal["db", "jwt-trust"] = Field(
         default="db",
         description="JWT trust mode: 'db' (database-backed user lookup, default) or 'jwt-trust' (trust claims from tokens of trusted external identity providers)",
@@ -2504,6 +2508,10 @@ class Settings(BaseSettings):
     auth_cache_teams_ttl: int = Field(default=60, ge=10, le=300, description="TTL in seconds for user teams list cache")
     auth_cache_batch_queries: bool = Field(default=True, description="Batch auth DB queries into single call (reduces 3 queries to 1)")
     auth_cache_key_version: str = Field(default="v1", description="Redis key version prefix for auth cache namespace isolation")
+    # The Redis key format is mcpgw:auth:{version}:{mode}:{key_type}:{identifier}.
+    # The mode segment comes from jwt_trust_mode: a mode flip cold-starts all
+    # auth caches automatically, so this version needs a bump only for key-shape
+    # changes within a mode.
 
     # Registry Cache Configuration (reduces DB queries for list endpoints)
     registry_cache_enabled: bool = Field(default=True, description="Enable caching for registry list endpoints (tools, prompts, resources, etc.)")

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -575,6 +575,7 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
             "request_id": request_id,  # Include request_id from middleware
             "team_id": team_id,  # Include team_id from token
             "token_teams": token_teams,  # Include token teams for query-level scoping
+            "token_use": token_use,  # Include token_use for RBAC team derivation
             "roles": claims_roles,  # Claims-derived role names (trust path); [] for non-trust
             "token_is_admin": token_is_admin,  # Claims-derived admin flag (trust path); False for non-trust
             "token_scopes": token_scopes,  # Include token scopes for API token permission checking

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -347,6 +347,9 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
                     "auth_method": "proxy",
                     "request_id": getattr(request.state, "request_id", None),
                     "team_id": getattr(request.state, "team_id", None),
+                    "token_teams": None,  # Key presence only; None preserves the implicit .get() value (admin bypass)
+                    "roles": [],  # Neutral default; no claims identity on the proxy path
+                    "token_is_admin": False,  # Neutral default; no claims identity on the proxy path
                     "plugin_context_table": plugin_context_table,
                     "plugin_global_context": plugin_global_context,
                 }
@@ -380,6 +383,9 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
                 "auth_method": "anonymous",
                 "request_id": getattr(request.state, "request_id", None),
                 "team_id": getattr(request.state, "team_id", None),
+                "token_teams": [],  # Neutral default for key presence
+                "roles": [],  # Neutral default for key presence
+                "token_is_admin": False,  # Neutral default for key presence
                 "plugin_context_table": plugin_context_table,
                 "plugin_global_context": plugin_global_context,
             }
@@ -412,6 +418,9 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
             "auth_method": "anonymous",
             "request_id": getattr(request.state, "request_id", None),
             "team_id": getattr(request.state, "team_id", None),
+            "token_teams": [],  # Neutral default for key presence
+            "roles": [],  # Neutral default for key presence
+            "token_is_admin": False,  # Neutral default for key presence
             "plugin_context_table": plugin_context_table,
             "plugin_global_context": plugin_global_context,
         }
@@ -488,6 +497,9 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
                 "auth_method": "disabled",
                 "request_id": getattr(request.state, "request_id", None),
                 "team_id": getattr(request.state, "team_id", None),
+                "token_teams": None,  # Key presence only; None preserves the implicit .get() value (admin bypass)
+                "roles": [],  # Neutral default for key presence
+                "token_is_admin": False,  # Neutral default for key presence
             }
 
         if not settings.auth_required:
@@ -502,6 +514,9 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
                 "auth_method": "anonymous",
                 "request_id": getattr(request.state, "request_id", None),
                 "team_id": getattr(request.state, "team_id", None),
+                "token_teams": [],  # Neutral default for key presence
+                "roles": [],  # Neutral default for key presence
+                "token_is_admin": False,  # Neutral default for key presence
                 "plugin_context_table": getattr(request.state, "plugin_context_table", None),
                 "plugin_global_context": getattr(request.state, "plugin_global_context", None),
             }
@@ -533,6 +548,20 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
         # Get token_use from request.state (set by get_current_user)
         token_use = getattr(request.state, "token_use", None)
 
+        # Claims-derived identity (F2): a trust principal (VirtualPrincipal,
+        # token_use="trusted") carries mapped role names, the claims-derived
+        # admin flag, and mapped teams; carry them so the permission layer can
+        # consume claims identity. Non-trust principals (EmailUser) get neutral
+        # defaults so downstream consumers can rely on key presence.
+        if token_use == "trusted" or getattr(user, "token_use", None) == "trusted":
+            claims_roles = list(getattr(user, "roles", None) or [])
+            token_is_admin = bool(getattr(user, "is_admin", False))
+            if token_teams is None:
+                token_teams = list(getattr(user, "teams", None) or [])
+        else:
+            claims_roles = []
+            token_is_admin = False
+
         # Add request context for permission auditing
         return {
             "email": user.email,
@@ -546,7 +575,8 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
             "request_id": request_id,  # Include request_id from middleware
             "team_id": team_id,  # Include team_id from token
             "token_teams": token_teams,  # Include token teams for query-level scoping
-            "token_use": token_use,  # Include token_use for RBAC team derivation
+            "roles": claims_roles,  # Claims-derived role names (trust path); [] for non-trust
+            "token_is_admin": token_is_admin,  # Claims-derived admin flag (trust path); False for non-trust
             "token_scopes": token_scopes,  # Include token scopes for API token permission checking
             "jwt_teams_claim": jwt_teams_claim,  # Raw JWT claim for OAuth Vault path selection
             "plugin_context_table": plugin_context_table,  # Plugin contexts for cross-hook sharing

--- a/tests/helpers/auth.py
+++ b/tests/helpers/auth.py
@@ -87,6 +87,72 @@ def make_test_jwt(
     )
 
 
+def make_trusted_test_jwt(
+    user_id: str,
+    *,
+    email: str | None = None,
+    teams: list[str] | None = None,
+    roles: list[str] | None = None,
+    is_admin: bool = False,
+    issuer: str | None = None,
+    tenant: str | None = None,
+    groups: list[str] | None = None,
+    revocation_id: str | None = None,
+    expires_in_minutes: int = 180,
+    secret: str = "",
+    algorithm: str = "",
+    extra_payload: dict[str, Any] | None = None,
+) -> str:
+    """Create a trust-mode marker token (``token_use="trusted"``) for tests.
+
+    The mapped claims are written under the claim names configured in
+    ``settings.jwt_claim_*`` and ``settings.jwt_trust_revocation_claim`` so
+    the helper stays correct when a test re-maps a claim. ``user_id`` is the
+    opaque subject. When ``revocation_id`` is omitted, a fresh ``jti`` is
+    generated. The token is signed directly (not via ``_create_jwt_token``)
+    so the ``issuer`` parameter is honored.
+    """
+    # Standard
+    import uuid
+
+    # First-Party
+    from mcpgateway.config import settings
+
+    now = datetime.now(timezone.utc)
+    claims: dict[str, Any] = {
+        settings.jwt_claim_user_id: user_id,
+        "token_use": "trusted",
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(minutes=expires_in_minutes)).timestamp()),
+        "iss": issuer or settings.jwt_issuer,
+        "aud": settings.jwt_audience,
+    }
+    if email is not None:
+        claims[settings.jwt_claim_email] = email
+    if teams is not None:
+        claims[settings.jwt_claim_teams] = teams
+    if roles is not None:
+        claims[settings.jwt_claim_roles] = roles
+    if is_admin:
+        claims[settings.jwt_claim_admin] = True
+    if tenant is not None:
+        claims["tid"] = tenant
+    if groups is not None:
+        claims["groups"] = groups
+    if revocation_id is not None:
+        claims[settings.jwt_trust_revocation_claim] = revocation_id
+    if "jti" not in claims:
+        claims["jti"] = str(uuid.uuid4())
+    if extra_payload:
+        claims.update(extra_payload)
+
+    if not secret:
+        secret = settings.jwt_secret_key.get_secret_value()
+    if not algorithm:
+        algorithm = settings.jwt_algorithm
+    return jwt.encode(claims, secret, algorithm=algorithm)
+
+
 def make_legacy_test_jwt(
     email: str = "admin@example.com",
     *,

--- a/tests/live_gateway/test_trust_mode_entra_barrier.py
+++ b/tests/live_gateway/test_trust_mode_entra_barrier.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/live_gateway/test_trust_mode_entra_barrier.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Live-gateway evidence for the external-token ingress barrier on the A2A
+invocation route (issues #5884 / #5885, acceptance intent of #5976 / #6272).
+
+What this module pins:
+
+    Microsoft Entra end-user access token
+      -> POST /a2a/<deliberately-nonexistent-agent>/invoke
+      -> 401 "Invalid authentication credentials"
+
+The agent name is intentionally nonexistent: with a correctly wired
+ingress, an authenticated and authorized caller reaches agent lookup and
+receives 404. The current stack instead rejects the request at
+authentication because the A2A dependency chain
+(``require_permission`` -> ``get_current_user_with_permissions`` ->
+``get_current_user``) calls ContextForge's internal verifier
+(``verify_jwt_token_cached``), which accepts gateway-signed JWTs only.
+The external issuer/JWKS path lives in
+``mcpgateway/utils/verify_credentials.py`` but is never dispatched to on
+this route, so a genuine Entra-signed token is indistinguishable from a
+forged one at this choke point.
+
+Both tests read the bearer material from untracked files and never log
+their contents:
+
+    entra-token-valid.txt   real Entra user access token
+    entra-token-fake.txt    deliberately invalid token
+
+Set ``ENTRA_BARRIER_TOKEN_DIR`` if the files live outside the repository
+root. Point ``MCP_CLI_BASE_URL`` at the gateway under test (default
+``http://127.0.0.1:8080``).
+
+Expected result while the ingress is unfixed: both requests return 401.
+When the external-aware verifier is wired into the authentication choke
+points, the valid-token expectation flips to 404 (agent not found) and
+the fake-token expectation stays 401.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import os
+from pathlib import Path
+
+# Third-Party
+import httpx
+import pytest
+
+# Local
+from .helpers.mcp_test_helpers import BASE_URL, skip_no_gateway
+
+pytestmark = [pytest.mark.e2e, skip_no_gateway]
+
+# Expected gateway mode for this run; must match the stack configuration.
+EXPECTED_TRUST_MODE = os.getenv("JWT_TRUST_MODE", "db")
+
+skip_unless_trust_mode = pytest.mark.skipif(
+    EXPECTED_TRUST_MODE != "jwt-trust",
+    reason="requires the stack started with JWT_TRUST_MODE=jwt-trust",
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TOKEN_DIR = Path(os.getenv("ENTRA_BARRIER_TOKEN_DIR", str(_REPO_ROOT)))
+_VALID_TOKEN_FILE = _TOKEN_DIR / "entra-token-valid.txt"
+_FAKE_TOKEN_FILE = _TOKEN_DIR / "entra-token-fake.txt"
+
+skip_no_entra_tokens = pytest.mark.skipif(
+    not (_VALID_TOKEN_FILE.is_file() and _FAKE_TOKEN_FILE.is_file()),
+    reason=f"entra-token-valid.txt / entra-token-fake.txt not found in {_TOKEN_DIR} (set ENTRA_BARRIER_TOKEN_DIR)",
+)
+
+# Deliberately nonexistent: the fixed ingress must terminate at agent
+# lookup with 404, not 401.
+_NONEXISTENT_AGENT = "Agent-A-that-does-not-exist"
+
+
+def _bearer(path: Path) -> str:
+    """Read a bearer token from file without logging it."""
+    return path.read_text(encoding="utf-8").strip()
+
+
+def _invoke_agent(token: str) -> httpx.Response:
+    """POST the A2A invocation route with the given bearer token."""
+    return httpx.post(
+        f"{BASE_URL}/a2a/{_NONEXISTENT_AGENT}/invoke",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        json={"parameters": {}, "interaction_type": "query"},
+        timeout=15,
+    )
+
+
+@skip_no_entra_tokens
+def test_fake_entra_token_is_rejected() -> None:
+    """Control: a deliberately invalid bearer gets 401 regardless of trust mode."""
+    response = _invoke_agent(_bearer(_FAKE_TOKEN_FILE))
+    assert response.status_code == 401, f"fake token not rejected: {response.status_code} {response.text[:200]}"
+    assert "Invalid authentication credentials" in response.text
+
+
+@skip_unless_trust_mode
+@skip_no_entra_tokens
+def test_valid_entra_user_token_is_blocked_before_external_verification() -> None:
+    """PINNED NON-COMPLIANCE: a genuine Entra user token gets 401 at ingress.
+
+    With ``JWT_TRUST_MODE=jwt-trust`` and
+    ``SSO_API_TOKEN_AUTH_ENABLED=true`` on the gateway, a real Entra-signed
+    end-user access token still fails the internal verifier before the
+    trust-mode branch, group mapping, RBAC, visibility, or agent lookup can
+    run: the request is rejected exactly like the forged-token control.
+
+    Flipping expectation: once ``get_current_user()`` dispatches external
+    issuers to the JWKS verifier (``verify_credentials_cached``), this
+    caller authenticates, ``a2a.invoke`` authorization proceeds, and the
+    deliberately nonexistent agent yields 404. Update this assertion to
+    404 as part of that change; the fake-token control above must stay 401.
+    """
+    response = _invoke_agent(_bearer(_VALID_TOKEN_FILE))
+    assert response.status_code == 401, f"Ingress no longer blocked: valid Entra token got {response.status_code} (expected 401 pre-fix, 404 post-fix) {response.text[:200]}"
+    assert "Invalid authentication credentials" in response.text

--- a/tests/live_gateway/test_trust_mode_rbac.py
+++ b/tests/live_gateway/test_trust_mode_rbac.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/live_gateway/test_trust_mode_rbac.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Live-gateway RBAC checks for JWT trust mode (issue #5900).
+
+The expected mode comes from the ``JWT_TRUST_MODE`` environment variable of
+the test process; run the suite once with the gateway stack in default mode
+and once with the stack started with ``JWT_TRUST_MODE=jwt-trust``.
+
+- Trust mode OFF (``db``): a ``token_use="trusted"`` token is rejected with
+  401 and never enters the default funnel.
+- Trust mode ON (``jwt-trust``): the same token authenticates from its
+  claims alone; ``token_teams`` on the request comes from the claims and the
+  group-mapping resolver, and RBAC evaluation proceeds with the
+  claims-derived identity.
+
+Requirements:
+    - ContextForge running with docker-compose (default: http://localhost:8080)
+
+Usage:
+    make test-mcp-rbac            # gateway in default (db) mode
+    JWT_TRUST_MODE=jwt-trust ...  # gateway restarted in trust mode
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import os
+
+# Third-Party
+import httpx
+import pytest
+
+# Local
+from tests.helpers.auth import make_trusted_test_jwt
+from .helpers.mcp_test_helpers import (
+    BASE_URL,
+    JWT_SECRET,
+    skip_no_gateway,
+)
+
+pytestmark = [pytest.mark.e2e, skip_no_gateway]
+
+# Expected gateway mode for this run; must match the stack configuration.
+EXPECTED_TRUST_MODE = os.getenv("JWT_TRUST_MODE", "db")
+
+TRUST_USER_ID = "live-trust-subject-0001"
+TRUST_EMAIL = "live.trust.user@example.com"
+TRUST_TEAMS = ["live-trust-team"]
+
+
+def _trust_token() -> str:
+    """Mint a trust-marker token with the shared gateway secret."""
+    return make_trusted_test_jwt(
+        TRUST_USER_ID,
+        email=TRUST_EMAIL,
+        teams=TRUST_TEAMS,
+        roles=[],
+        secret=JWT_SECRET,
+    )
+
+
+def test_trust_token_dispatches_per_mode() -> None:
+    """A trust-marker token gets 401 in db mode and authenticates in jwt-trust mode."""
+    token = _trust_token()
+    response = httpx.get(f"{BASE_URL}/tools", headers={"Authorization": f"Bearer {token}"}, timeout=10)
+
+    if EXPECTED_TRUST_MODE == "jwt-trust":
+        # Claims-derived principal: the request is authenticated.
+        assert response.status_code == 200, f"trust token rejected in jwt-trust mode: {response.status_code} {response.text[:200]}"
+    else:
+        # The marker must never enter the default funnel.
+        assert response.status_code == 401, f"trust token not rejected in db mode: {response.status_code}"

--- a/tests/unit/mcpgateway/cache/test_auth_cache_l1_l2.py
+++ b/tests/unit/mcpgateway/cache/test_auth_cache_l1_l2.py
@@ -48,8 +48,8 @@ class TestCacheKeyNamespace:
     """Auth cache Redis keys carry a version segment for namespace isolation (issue #5891)."""
 
     def test_redis_key_contains_version_segment(self):
-        """_get_redis_key inserts the configured key version after the auth prefix."""
-        assert AuthCache()._get_redis_key("user", "test@example.com").startswith("mcpgw:auth:v1:user:")
+        """_get_redis_key inserts the configured key version and auth mode after the auth prefix."""
+        assert AuthCache()._get_redis_key("user", "test@example.com").startswith("mcpgw:auth:v1:db:user:")
 
     @pytest.mark.asyncio
     async def test_version_bump_makes_old_keys_unreachable(self):

--- a/tests/unit/mcpgateway/middleware/test_rbac_user_context.py
+++ b/tests/unit/mcpgateway/middleware/test_rbac_user_context.py
@@ -3,12 +3,17 @@
 Copyright contributors to the MCP-CONTEXT-FORGE project
 SPDX-License-Identifier: Apache-2.0
 
-Tests that the RBAC user context carries the canonical user_id.
+Tests that the RBAC user context carries the canonical user_id and the
+claims-derived identity.
 
 The authenticated context built by get_current_user_with_permissions must
 expose the canonical user_id (resolving user_id -> email -> sub -> "unknown"
 via mcpgateway.auth_context.get_user_id), not only the e-mail attribute, so
-live RBAC checks can key on the stable identity.
+live RBAC checks can key on the stable identity. On the JWT-trust path it
+must additionally carry the VirtualPrincipal's claims-derived roles, the
+claims-derived admin flag (token_is_admin), and the claims-derived teams;
+non-trust authenticated paths expose the same keys with neutral defaults so
+downstream consumers can rely on key presence.
 """
 
 # Standard
@@ -20,6 +25,7 @@ import pytest
 
 # First-Party
 from mcpgateway.middleware.rbac import get_current_user_with_permissions
+from mcpgateway.utils.trusted_claims import VirtualPrincipal
 
 
 def _mock_request():
@@ -83,3 +89,85 @@ async def test_user_context_user_id_falls_back_to_email():
         )
 
     assert ctx["user_id"] == "bob@example.com"
+
+
+@pytest.mark.asyncio
+async def test_trust_principal_claims_reach_user_context():
+    """The trust-path context must carry the principal's claims-derived identity."""
+    principal = VirtualPrincipal(
+        user_id="entra-sub-123",
+        email="alice@example.com",
+        full_name="Alice",
+        teams=["team-a"],
+        roles=["developer"],
+        is_admin=False,
+    )
+    request = _mock_request()
+    request.state.token_use = "trusted"  # Set by get_current_user on the trust branch
+
+    with patch("mcpgateway.auth.validate_token_user", new_callable=AsyncMock) as mock_validate:
+        mock_validate.return_value = principal
+
+        ctx = await get_current_user_with_permissions(
+            request=request,
+            credentials=None,
+            jwt_token="test-token",
+        )
+
+    assert ctx["user_id"] == "entra-sub-123"
+    assert ctx["roles"] == ["developer"]
+    assert ctx["token_is_admin"] is False
+    assert ctx["token_teams"] == ["team-a"]
+
+
+@pytest.mark.asyncio
+async def test_internal_jwt_context_has_neutral_claims_defaults():
+    """A non-trust authenticated context exposes the claims keys with neutral defaults."""
+    principal = SimpleNamespace(
+        email="carol@example.com",
+        user_id="carol-uuid-456",
+        full_name="Carol",
+        is_admin=True,  # DB-derived admin must NOT leak into token_is_admin
+        teams=["team-x"],
+    )
+
+    with patch("mcpgateway.auth.validate_token_user", new_callable=AsyncMock) as mock_validate:
+        mock_validate.return_value = principal
+
+        ctx = await get_current_user_with_permissions(
+            request=_mock_request(),
+            credentials=None,
+            jwt_token="test-token",
+        )
+
+    assert ctx["roles"] == []
+    assert ctx["token_is_admin"] is False
+    assert ctx["is_admin"] is True
+    assert "token_teams" in ctx
+
+
+@pytest.mark.asyncio
+async def test_trust_principal_admin_flag_reaches_user_context():
+    """A trust principal with the mapped admin claim sets token_is_admin True."""
+    principal = VirtualPrincipal(
+        user_id="entra-sub-admin",
+        email="root@example.com",
+        full_name="Root",
+        teams=[],
+        roles=["platform_admin"],
+        is_admin=True,
+    )
+    request = _mock_request()
+    request.state.token_use = "trusted"
+
+    with patch("mcpgateway.auth.validate_token_user", new_callable=AsyncMock) as mock_validate:
+        mock_validate.return_value = principal
+
+        ctx = await get_current_user_with_permissions(
+            request=request,
+            credentials=None,
+            jwt_token="test-token",
+        )
+
+    assert ctx["token_is_admin"] is True
+    assert ctx["roles"] == ["platform_admin"]

--- a/tests/unit/mcpgateway/middleware/test_rbac_user_context.py
+++ b/tests/unit/mcpgateway/middleware/test_rbac_user_context.py
@@ -24,7 +24,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 # First-Party
-from mcpgateway.middleware.rbac import get_current_user_with_permissions
+from mcpgateway.middleware.rbac import _resolve_team_and_check_mode, get_current_user_with_permissions
 from mcpgateway.utils.trusted_claims import VirtualPrincipal
 
 
@@ -171,3 +171,51 @@ async def test_trust_principal_admin_flag_reaches_user_context():
 
     assert ctx["token_is_admin"] is True
     assert ctx["roles"] == ["platform_admin"]
+
+
+@pytest.mark.asyncio
+async def test_session_context_carries_token_use_and_neutral_claims():
+    """A session-type authenticated context must keep token_use for RBAC team derivation."""
+    principal = SimpleNamespace(
+        email="dave@example.com",
+        user_id="dave-uuid-789",
+        full_name="Dave",
+        is_admin=False,
+        teams=["team-a"],
+    )
+    request = _mock_request()
+    request.state.token_use = "session"
+    request.state.token_teams = ["team-a"]
+
+    with patch("mcpgateway.auth.validate_token_user", new_callable=AsyncMock) as mock_validate:
+        mock_validate.return_value = principal
+
+        ctx = await get_current_user_with_permissions(
+            request=request,
+            credentials=None,
+            jwt_token="test-token",
+        )
+
+    assert ctx["token_use"] == "session"
+    assert ctx["roles"] == []
+    assert ctx["token_is_admin"] is False
+    assert ctx["token_teams"] == ["team-a"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_team_and_check_mode_relies_on_context_token_use():
+    """_resolve_team_and_check_mode derives the accessed resource's team only when the
+    context carries a session/api token_use; without it the check broadens to any-team."""
+    with patch("mcpgateway.middleware.rbac._derive_team_from_resource", return_value="team-b") as mock_derive:
+        team_id, check_any_team = await _resolve_team_and_check_mode({"token_use": "session"}, {"db": MagicMock()})
+
+    assert team_id == "team-b"
+    assert check_any_team is False
+    mock_derive.assert_called_once()
+
+    with patch("mcpgateway.middleware.rbac._derive_team_from_resource", return_value="team-b") as mock_derive:
+        team_id, check_any_team = await _resolve_team_and_check_mode({}, {"db": MagicMock()})
+
+    assert team_id is None
+    assert check_any_team is True
+    mock_derive.assert_not_called()

--- a/tests/unit/mcpgateway/test_auth_trust_mode.py
+++ b/tests/unit/mcpgateway/test_auth_trust_mode.py
@@ -1,0 +1,250 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_auth_trust_mode.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Trust-mode funnel branch tests (issue #5900).
+
+The trust-eligible branch in get_current_user authenticates a
+``token_use="trusted"`` token from its claims alone: the local user-record
+lookup, the ``is_active`` check, the UUID->email seam, and DB team
+resolution are skipped. The revocation check on the configured revocation
+claim (default ``jti``) is retained.
+
+The smoke-level SQL-listener test asserts that the trust path issues zero
+SELECTs against ``email_users``. The full no-user-table proof is the
+acceptance suite (#5905).
+"""
+
+# Standard
+import contextlib
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+# Third-Party
+from fastapi import HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.auth import get_current_user
+from mcpgateway.config import settings
+from mcpgateway.db import Base, EmailTeam, EmailUser
+
+CALLER_ID = "trust-subject-0001"
+CALLER_EMAIL = "trust.user@example.com"
+
+
+def _exp(hours: int = 1) -> float:
+    """Expiry timestamp for mocked JWT payloads."""
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).timestamp()
+
+
+@pytest.fixture
+def db():
+    """In-memory SQLite session with one non-personal team and no users.
+
+    The principal exists only in the token claims; the database must not be
+    consulted for a user record on the trust path.
+    """
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    owner = EmailUser(
+        email="owner@example.com",
+        password_hash="hash",  # pragma: allowlist secret
+        full_name="Owner",
+        is_admin=False,
+        is_active=True,
+        email_verified_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    session.add(owner)
+    session.add(EmailTeam(id="team-a", name="CF-Team-A", slug="cf-team-a", created_by=owner.email, is_personal=False, visibility="private"))
+    session.commit()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _patch_funnel_sessions(monkeypatch: pytest.MonkeyPatch, db) -> None:
+    """Re-point the funnel's internal sessions at the test database."""
+    session_test = sessionmaker(bind=db.get_bind())
+    monkeypatch.setattr("mcpgateway.auth.SessionLocal", session_test)
+
+    @contextlib.contextmanager
+    def _fresh_db_session():
+        session = session_test()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("mcpgateway.auth.fresh_db_session", _fresh_db_session)
+
+
+def _trust_payload(**overrides):
+    """Gateway-signed trust-token payload with the mapped claim set."""
+    payload = {
+        "sub": CALLER_ID,
+        "token_use": "trusted",
+        "email": CALLER_EMAIL,
+        "teams": ["team-a"],
+        "roles": [],
+        "jti": "trusted_jti_smoke",
+        "exp": _exp(),
+    }
+    payload.update(overrides)
+    return payload
+
+
+async def _drive_trust_funnel(monkeypatch: pytest.MonkeyPatch, db, payload, *, revoked: bool = False):
+    """Drive get_current_user with the given payload on the trust path.
+
+    Returns (user, request). Raises whatever the funnel raises.
+    """
+    monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+    monkeypatch.setattr(settings, "auth_cache_enabled", False)
+    monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+    _patch_funnel_sessions(monkeypatch, db)
+
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="trusted_jwt_token")  # pragma: allowlist secret
+    request = SimpleNamespace(state=SimpleNamespace())
+
+    with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)):
+        with patch("mcpgateway.auth._check_token_revoked_sync", return_value=revoked):
+            # Fail the test loudly if the trust path touches the user table
+            # through the default-funnel helpers.
+            with patch("mcpgateway.auth._get_user_by_email_sync", side_effect=AssertionError("user lookup on trust path")):
+                user = await get_current_user(credentials=credentials, request=request)
+    return user, request
+
+
+class TestTrustBranchSmoke:
+    """Happy-path and request.state shape for the trust branch."""
+
+    @pytest.mark.asyncio
+    async def test_trust_token_authenticates_from_claims(self, monkeypatch, db):
+        """Claims-derived principal: email, teams, roles; request.state set."""
+        user, request = await _drive_trust_funnel(monkeypatch, db, _trust_payload(roles=["developer"]))
+
+        assert user.user_id == CALLER_ID
+        assert user.email == CALLER_EMAIL
+        assert user.token_use == "trusted"
+        assert request.state.token_use == "trusted"
+        assert request.state.token_teams == ["team-a"]
+        assert request.state.auth_method == "jwt"
+        assert request.state.jti == "trusted_jti_smoke"
+
+    @pytest.mark.asyncio
+    async def test_trust_path_issues_zero_email_users_selects(self, monkeypatch, db):
+        """Smoke-level proof: no SELECT against email_users on the trust path.
+
+        A SQL listener on the test engine records every statement; the full
+        no-user-table proof is the acceptance suite (#5905).
+        """
+        statements: list[str] = []
+        engine = db.get_bind()
+
+        def _listener(_conn, _cursor, statement, _parameters, _context, _executemany):
+            statements.append(statement)
+
+        sa.event.listen(engine, "before_cursor_execute", _listener)
+        try:
+            await _drive_trust_funnel(monkeypatch, db, _trust_payload())
+        finally:
+            sa.event.remove(engine, "before_cursor_execute", _listener)
+
+        user_table_reads = [stmt for stmt in statements if "email_users" in stmt]
+        assert user_table_reads == []
+
+
+class TestTrustBranchDeny:
+    """Failure semantics: revocation and claim completeness fail closed."""
+
+    @pytest.mark.asyncio
+    async def test_revoked_trust_token_rejected(self, monkeypatch, db):
+        """Revoked revocation-claim identifier -> 401 even in trust mode."""
+        with pytest.raises(HTTPException) as exc_info:
+            await _drive_trust_funnel(monkeypatch, db, _trust_payload(), revoked=True)
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.asyncio
+    async def test_missing_revocation_claim_rejected(self, monkeypatch, db):
+        """A trust-eligible token without the configured revocation claim -> 401."""
+        payload = _trust_payload()
+        del payload["jti"]
+        with pytest.raises(HTTPException) as exc_info:
+            await _drive_trust_funnel(monkeypatch, db, payload)
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.asyncio
+    async def test_missing_user_id_claim_rejected(self, monkeypatch, db):
+        """A trust-eligible token without the mapped user_id claim -> 401 (not fail-open)."""
+        payload = _trust_payload()
+        del payload["sub"]
+        with pytest.raises(HTTPException) as exc_info:
+            await _drive_trust_funnel(monkeypatch, db, payload)
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.asyncio
+    async def test_trusted_marker_rejected_when_trust_mode_off(self, monkeypatch, db):
+        """token_use=trusted with trust mode OFF -> 401; the default funnel never sees it."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "db")
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+        _patch_funnel_sessions(monkeypatch, db)
+
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="trusted_jwt_token")  # pragma: allowlist secret
+        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=_trust_payload())):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(credentials=credentials)
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.asyncio
+    async def test_overage_marker_fail_closed_rejected(self, monkeypatch, db):
+        """Entra overage marker + default fail_closed policy -> 401."""
+        monkeypatch.setattr(settings, "jwt_trust_overage_policy", "fail_closed")
+        payload = _trust_payload(_claim_names={"groups": "src1"})
+        with pytest.raises(HTTPException) as exc_info:
+            await _drive_trust_funnel(monkeypatch, db, payload)
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.asyncio
+    async def test_overage_marker_proceed_without_groups(self, monkeypatch, db):
+        """Entra overage marker + proceed_without_groups -> authenticates, no group teams."""
+        monkeypatch.setattr(settings, "jwt_trust_overage_policy", "proceed_without_groups")
+        payload = _trust_payload(_claim_names={"groups": "src1"})
+        user, request = await _drive_trust_funnel(monkeypatch, db, payload)
+        assert user.user_id == CALLER_ID
+        # Claim teams still apply; no group-derived teams are added.
+        assert request.state.token_teams == ["team-a"]
+
+    @pytest.mark.asyncio
+    async def test_tampered_token_rejected_before_trust_branch(self, monkeypatch, db):
+        """A token with an invalid signature never reaches claims extraction.
+
+        The real verifier runs first; a token signed with the wrong secret is
+        rejected with 401 before the trust branch reads any claim.
+        """
+        # First-Party
+        from tests.helpers.auth import make_trusted_test_jwt
+
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+        _patch_funnel_sessions(monkeypatch, db)
+
+        forged = make_trusted_test_jwt(CALLER_ID, email=CALLER_EMAIL, teams=["team-a"], secret="wrong-secret-that-is-long-enough-32")  # pragma: allowlist secret
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=forged)  # pragma: allowlist secret
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials=credentials)
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/unit/mcpgateway/test_token_dispatch_matrix.py
+++ b/tests/unit/mcpgateway/test_token_dispatch_matrix.py
@@ -8,17 +8,17 @@ Cross-mode token dispatch deny-test matrix (issue #5896).
 Executable form of the six mode-x-token combinations pinned in
 docs/docs/architecture/auth-token-dispatch.md:
 
-- Rows whose expectation holds today land green now. Trust mode does not
-  exist yet (config lands in #5898, the trust branch in #5900), so the
-  trust-mode rows for non-eligible tokens exercise the current code path:
-  the default funnel. That IS the documented behavior for these rows, and
-  it stays correct after trust mode lands.
-- Rows that need un-landed behavior carry pytest.mark.xfail(strict=True)
-  with a pointer to the story that flips them. strict=True turns any
-  premature XPASS into a suite failure.
+- The trust-mode rows for non-eligible tokens exercise the default funnel.
+  That IS the documented behavior for these rows.
+- The gateway-signed branch-(a) rows are green since #5900 landed the
+  trust branch in get_current_user.
+- The external-IdP branch-(b) row carries pytest.mark.xfail(strict=True)
+  with a pointer to #5903, which lands the external IdP trust root.
+  strict=True turns any premature XPASS into a suite failure.
 """
 
 # Standard
+import contextlib
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -27,11 +27,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi import HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials
 import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 # First-Party
 from mcpgateway.auth import get_current_user
 from mcpgateway.config import settings
-from mcpgateway.db import EmailUser
+from mcpgateway.db import Base, EmailUser
 
 
 def _exp(hours: int = 1) -> float:
@@ -61,6 +64,30 @@ def _fake_provider(issuer: str) -> MagicMock:
     provider.trusted_for_api_auth = True
     provider.api_audience = "api://my-app"
     return provider
+
+
+def _repoint_funnel_sessions(monkeypatch) -> None:
+    """Re-point the funnel's internal sessions at a schema-complete test DB.
+
+    The trust branch validates role claims against the server-side roles
+    table through ``fresh_db_session``. The default in-memory engine gives
+    each connection a fresh empty database, so the trust-path tests re-point
+    the funnel sessions the same way the B.4/B.5 trust tests do.
+    """
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    session_test = sessionmaker(bind=engine)
+    monkeypatch.setattr("mcpgateway.auth.SessionLocal", session_test)
+
+    @contextlib.contextmanager
+    def _fresh_db_session():
+        session = session_test()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("mcpgateway.auth.fresh_db_session", _fresh_db_session)
 
 
 class TestTokenDispatchMatrix:
@@ -173,16 +200,13 @@ class TestTokenDispatchMatrix:
                         assert request.state.token_use == "api"
                         assert request.state.token_teams == ["api-team-1"]
 
-    # Flipped by #5900 (trust branch in get_current_user)
-    @pytest.mark.xfail(strict=True, reason="Flipped by #5900")
     @pytest.mark.asyncio
     async def test_gateway_trust_token_trust_mode_trust_semantics(self, monkeypatch):
         """Trust mode + gateway-signed trust token -> trust-semantics.
 
         A token_use="trusted" token with the mapped claim set (sub, teams,
         roles) and a jti authenticates from claims alone: no local user
-        record is read on the request path. Today no trust branch exists,
-        so the default funnel rejects the unknown user with 401.
+        record is read on the request path.
         """
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="trusted_jwt_token")  # pragma: allowlist secret
 
@@ -196,8 +220,10 @@ class TestTokenDispatchMatrix:
         }
 
         request = SimpleNamespace(state=SimpleNamespace())
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
         monkeypatch.setattr(settings, "auth_cache_enabled", False)
         monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+        _repoint_funnel_sessions(monkeypatch)
 
         with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
             with patch("mcpgateway.auth._check_token_revoked_sync", return_value=False):
@@ -211,8 +237,6 @@ class TestTokenDispatchMatrix:
                         assert request.state.token_use == "trusted"
                         assert request.state.token_teams == ["trust-team-1"]
 
-    # Flipped by #5900 (trust branch in get_current_user)
-    @pytest.mark.xfail(strict=True, reason="Flipped by #5900")
     @pytest.mark.asyncio
     async def test_gateway_trust_token_default_mode_401(self, monkeypatch):
         """Default mode + gateway-signed trust token -> HTTP 401.
@@ -220,8 +244,6 @@ class TestTokenDispatchMatrix:
         Trust mode is OFF, so a token_use="trusted" token must be rejected
         with 401. It must never enter the default funnel, whose UUID
         heuristic and embedded-teams handling would re-attribute identity.
-        Today no such guard exists, so the default funnel authenticates
-        the token for the local user.
         """
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="trusted_jwt_token")  # pragma: allowlist secret
 

--- a/tests/unit/mcpgateway/test_trust_role_merge.py
+++ b/tests/unit/mcpgateway/test_trust_role_merge.py
@@ -6,11 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 Trust-path group-to-role merge tests (issue #6272).
 
 Every test in this file exercises the trusted-claims merge (#5899) through
-the trust branch in get_current_user (#5900). Until those land, the default
-funnel rejects the trust-mode token with 401 and each test fails, so all
-tests carry pytest.mark.xfail(strict=True). strict=True turns any premature
-XPASS into a suite failure. WO-B.8 (#5900) removes the markers when the
-trust branch lands.
+the trust branch in get_current_user (#5900).
 
 Merge semantics under test (per #6272):
 - The resolver resolve_external_groups_to_teams returns (team_ids, role_names).
@@ -47,8 +43,6 @@ from mcpgateway.utils.trusted_claims import resolve_external_groups_to_teams
 ISSUER = "https://login.example.com/tenant-1/v2.0"
 TENANT = "tenant-1"
 CALLER = "trust.user@example.com"
-XFAIL_REASON_MERGE = "Requires trusted_claims module from #5899 and trust branch from #5900"
-XFAIL_REASON_TRUST = "Requires trust branch from #5900"
 
 
 def _exp(hours: int = 1) -> float:
@@ -172,7 +166,6 @@ async def _drive_trust_funnel(monkeypatch: pytest.MonkeyPatch, db, groups: list[
     return user, request
 
 
-@pytest.mark.xfail(strict=True, reason=XFAIL_REASON_MERGE)
 class TestTrustRoleMerge:
     """Mapping cf_role merges into the principal's roles on the trust path."""
 
@@ -224,7 +217,6 @@ class TestTrustRoleMerge:
         assert "a2a.invoke" in _permissions_for_roles(db, user.roles)
 
 
-@pytest.mark.xfail(strict=True, reason=XFAIL_REASON_TRUST)
 class TestE2EGroupRoleGrant:
     """AC-e2e-group-role-grant: a mapping row drives both layers of the gate."""
 

--- a/tests/unit/mcpgateway/test_visibility_gate.py
+++ b/tests/unit/mcpgateway/test_visibility_gate.py
@@ -6,11 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 Agent visibility-gate and end-to-end team-isolation tests for trust mode
 (issue #5976).
 
-Every test in this file exercises the trust branch in get_current_user, which
-lands with #5900. Until then the default funnel rejects the trust-mode token
-with 401 and each test fails, so all tests carry
-pytest.mark.xfail(strict=True, reason="Requires trust branch from #5900").
-strict=True turns a premature XPASS into a suite failure.
+Every test in this file exercises the trust branch in get_current_user,
+which landed with #5900.
 
 Visibility semantics under test (per _check_agent_access in
 mcpgateway/services/a2a_service.py):
@@ -44,7 +41,6 @@ from mcpgateway.utils.trusted_claims import resolve_external_groups_to_teams
 ISSUER = "https://login.example.com/tenant-1/v2.0"
 TENANT = "tenant-1"
 CALLER = "trust.user@example.com"
-XFAIL_REASON = "Requires trust branch from #5900"
 
 
 def _exp(hours: int = 1) -> float:
@@ -177,7 +173,6 @@ async def _drive_trust_funnel(monkeypatch: pytest.MonkeyPatch, db, groups: list[
     return user, request
 
 
-@pytest.mark.xfail(strict=True, reason=XFAIL_REASON)
 class TestVisibilityGate:
     """AC-visibility-gate: team isolation and the public baseline."""
 
@@ -217,7 +212,6 @@ class TestVisibilityGate:
         assert await service._check_agent_access(db, agent_pub, CALLER, token_teams) is True
 
 
-@pytest.mark.xfail(strict=True, reason=XFAIL_REASON)
 class TestE2ETeamIsolation:
     """AC-e2e-team-isolation: mapping row + trust JWT drives the gate."""
 
@@ -250,7 +244,6 @@ class TestE2ETeamIsolation:
             await service.get_agent(db, agent_b.id, user_email=CALLER, token_teams=token_teams)
 
 
-@pytest.mark.xfail(strict=True, reason=XFAIL_REASON)
 class TestE2ENoMapping:
     """AC-e2e-no-mapping: an unmapped group fails closed."""
 


### PR DESCRIPTION
Wires the trust-eligible branch into `get_current_user` per the #5896 dispatch rule. A token marked `token_use="trusted"` with trust mode OFF is rejected 401 before the default funnel — the UUID heuristic could otherwise re-attribute identity. With trust mode ON, gateway-signed trust tokens authenticate via `extract_trusted_principal`: identity, teams, and roles come from the mapped claims; the external-group resolver translates group claims to CF team IDs (raw group IDs never reach `token_teams`); the configured revocation claim (`jti` default, `uti` supported) is checked against the revocation store on every request. The local user lookup, `is_active`, the UUID seam, and DB team resolution are skipped by design. The accepted posture change (no per-user `is_active` kill-switch in trust mode) is documented in code and `configuration.md`. Overage-marked tokens dispatch on `jwt_trust_overage_policy`. `request.state` mirrors the default-mode shape (`token_teams`, derived `team_id`, `token_use="trusted"`, `jti`, `auth_method`).

Auth-cache Redis keys gain the mode segment (`mcpgw:auth:{version}:{mode}:{key_type}:{identifier}`) — a mode flip cold-starts all auth caches with no manual bump; the A.6 prefix test and doctest updated per plan.

All strict-xfail suites from #5896 (branch a), #5976, and #6272 flip green in this PR; exactly one xfail remains — the external-IdP branch (b) row pointing at #5903.

Tested with:
- `uv run pytest tests -k "trust" -q` — green; the only XFAIL is the #5903 row (grep accounting in the work order report)
- `uv run pytest tests/unit/mcpgateway/test_auth_trust_mode.py -q` — 9 passed, including the SQLAlchemy event-listener proof of ZERO `email_users` reads on the trust path
- `make test` — 23321 passed, 879 skipped, 3 xfailed (the #5903 row + 2 pre-existing plugin rows)
- `make ruff` — all checks passed
- Live-stack `make test-mcp-rbac`: implemented as `tests/live_gateway/test_trust_mode_rbac.py` (`e2e` + `skip_no_gateway`, verified skipping correctly — no live stack in this worktree); ON/OFF RBAC verified via the unit selection and the flipped matrix rows. The Epic 2 gate (#5906) runs the live stack in both modes.

Acceptance criteria of #5900 are met. Risk to existing users: none with trust mode off (default) — the branch is unreachable; default-mode paths byte-identical.

Stack: B.8 of epic #5885 (base: #6745).

Closes #5900