### PR TITLE
fix(auth): relax revoked_by FK and persist revocations for trust-mode principals

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -5009,7 +5009,8 @@ async def _admin_logout(request: Request) -> Response:
 
                 payload = await verify_jwt_token_cached(token, request)
                 jti = payload.get("jti")
-                user_id = payload.get("sub") or payload.get("email", "admin")
+                # Canonical user_id from the token; sentinel when no identity resolves.
+                user_id = payload.get("sub") or payload.get("email") or "system:admin-logout"
 
                 if jti:
                     blocklist_service = get_token_blocklist_service()

--- a/mcpgateway/alembic/versions/f7a8b9c0d1e2_relax_revoked_by_fk.py
+++ b/mcpgateway/alembic/versions/f7a8b9c0d1e2_relax_revoked_by_fk.py
@@ -30,7 +30,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "f7a8b9c0d1e2"  # pragma: allowlist secret
-down_revision: Union[str, Sequence[str], None] = "e5f6a7b8c9d0"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "b7c8d9e0f1a2"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/alembic/versions/f7a8b9c0d1e2_relax_revoked_by_fk.py
+++ b/mcpgateway/alembic/versions/f7a8b9c0d1e2_relax_revoked_by_fk.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/alembic/versions/f7a8b9c0d1e2_relax_revoked_by_fk.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+relax_revoked_by_fk
+
+Revision ID: f7a8b9c0d1e2
+Revises: e5f6a7b8c9d0
+Create Date: 2026-09-10 10:00:00.000000
+
+Make ``token_revocations.revoked_by`` nullable and drop the foreign key
+to ``email_users.email``. Trust-mode principals have no local user row,
+so the old FK rejected every revocation they wrote; the idle-timeout
+path then swallowed the error and the revocation never landed. The
+column now stores the canonical user_id or a system sentinel string
+(``system:idle-timeout``, ``system:logout``, ``system:admin-logout``).
+
+SQLite has no ALTER COLUMN / DROP CONSTRAINT, so both changes run inside
+``batch_alter_table`` (table rebuild). All operations are guarded by
+inspector checks so the migration is idempotent and safe to re-run.
+"""
+
+# Standard
+from typing import Sequence, Union
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "f7a8b9c0d1e2"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "e5f6a7b8c9d0"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE_NAME = "token_revocations"
+COLUMN_NAME = "revoked_by"
+FK_NAME = "token_revocations_revoked_by_fkey"
+
+
+def _revoked_by_fk_names(inspector: sa.engine.reflection.Inspector) -> list:
+    """Return the names of every FK that constrains token_revocations.revoked_by.
+
+    The name depends on how the schema was created: alembic-managed
+    databases predate the FK (none exists), ``create_all`` databases use
+    the model naming convention, and PostgreSQL default naming produces
+    ``token_revocations_revoked_by_fkey``. Read the real names from the
+    inspector instead of assuming one.
+    """
+    names = []
+    for fk in inspector.get_foreign_keys(TABLE_NAME):
+        if fk.get("constrained_columns") == [COLUMN_NAME] and fk.get("name"):
+            names.append(fk["name"])
+    return names
+
+
+def upgrade() -> None:
+    """Drop the revoked_by FK and make the column nullable (idempotent)."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if TABLE_NAME not in inspector.get_table_names():
+        return
+
+    fk_names = _revoked_by_fk_names(inspector)
+    columns = {column["name"]: column for column in inspector.get_columns(TABLE_NAME)}
+    needs_nullable = COLUMN_NAME in columns and not columns[COLUMN_NAME]["nullable"]
+
+    if not fk_names and not needs_nullable:
+        return
+
+    # batch_alter_table rebuilds the table on SQLite; op.drop_constraint
+    # outside batch mode fails there. Both changes share one rebuild.
+    with op.batch_alter_table(TABLE_NAME, schema=None) as batch_op:
+        for fk_name in fk_names:
+            batch_op.drop_constraint(fk_name, type_="foreignkey")
+        if needs_nullable:
+            batch_op.alter_column(COLUMN_NAME, existing_type=sa.String(255), nullable=True)
+
+
+def downgrade() -> None:
+    """Restore the revoked_by FK and the NOT NULL constraint (idempotent).
+
+    Rows that the relaxed schema allows (NULL or non-email revoked_by)
+    block the restore; delete or re-key them before downgrading.
+    """
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if TABLE_NAME not in inspector.get_table_names():
+        return
+
+    fk_names = _revoked_by_fk_names(inspector)
+    columns = {column["name"]: column for column in inspector.get_columns(TABLE_NAME)}
+    needs_not_null = COLUMN_NAME in columns and columns[COLUMN_NAME]["nullable"]
+
+    if fk_names and not needs_not_null:
+        return
+
+    with op.batch_alter_table(TABLE_NAME, schema=None) as batch_op:
+        if needs_not_null:
+            batch_op.alter_column(COLUMN_NAME, existing_type=sa.String(255), nullable=False)
+        if not fk_names:
+            batch_op.create_foreign_key(FK_NAME, "email_users", [COLUMN_NAME], ["email"])

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -2149,14 +2149,32 @@ async def get_current_user(
                         max_idle = timedelta(minutes=settings.token_idle_timeout)
 
                         if idle_duration > max_idle:
-                            # Revoke token due to idle timeout
-                            try:
-                                exp_ts = payload.get("exp")
-                                token_expiry = datetime.fromtimestamp(exp_ts, tz=timezone.utc) if exp_ts else None
+                            # Revoke token due to idle timeout. revoked_by stores
+                            # the canonical user_id, or the system sentinel when
+                            # the request has no resolvable identity.
+                            exp_ts = payload.get("exp")
+                            token_expiry = datetime.fromtimestamp(exp_ts, tz=timezone.utc) if exp_ts else None
 
-                                blocklist_service.revoke_token(jti=jti, revoked_by=email, reason="idle_timeout", token_expiry=token_expiry, last_activity=last_activity)
+                            # Revocation persistence is best-effort: a failure is
+                            # logged at ERROR with the jti and the error detail,
+                            # and the request continues. Never re-raise, never
+                            # swallow silently (#5901).
+                            try:
+                                persisted = blocklist_service.revoke_token(
+                                    jti=jti, revoked_by=email or "system:idle-timeout", reason="idle_timeout", token_expiry=token_expiry, last_activity=last_activity
+                                )
                             except Exception as revoke_error:
-                                logger.warning(f"Failed to revoke idle token: {revoke_error}")
+                                logger.error(
+                                    "Idle-timeout revocation insert failed: jti=%s, error=%s",
+                                    SecurityValidator.sanitize_log_message(jti),
+                                    SecurityValidator.sanitize_log_message(str(revoke_error)),
+                                )
+                            else:
+                                if not persisted:
+                                    logger.error(
+                                        "Idle-timeout revocation was not persisted: jti=%s",
+                                        SecurityValidator.sanitize_log_message(jti),
+                                    )
 
                             logger.warning(
                                 f"Token exceeded idle timeout: jti={jti}, idle_minutes={idle_duration.total_seconds() / 60:.1f}",

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -5724,7 +5724,7 @@ class TokenRevocation(Base):
     Attributes:
         jti (str): JWT ID (primary key)
         revoked_at (datetime): Revocation timestamp
-        revoked_by (str): Email of user who revoked the token
+        revoked_by (str): Canonical user_id of the revoker, or a system sentinel string
         reason (str): Optional reason for revocation (logout, idle_timeout, security, token_refresh, etc.)
         token_expiry (datetime): Original token expiry for cleanup scheduling
         last_activity (datetime): Last activity timestamp for idle timeout tracking
@@ -5745,15 +5745,13 @@ class TokenRevocation(Base):
 
     # Revocation details
     revoked_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, nullable=False, index=True)
-    revoked_by: Mapped[str] = mapped_column(String(255), ForeignKey("email_users.email"), nullable=False)
+    # Canonical user_id or system sentinel; no FK: trust-mode principals have no user row
+    revoked_by: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     reason: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
 
     # Token lifecycle tracking
     token_expiry: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True, index=True)
     last_activity: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
-
-    # Relationship
-    revoker: Mapped["EmailUser"] = relationship("EmailUser")
 
     # Indexes for efficient cleanup and queries
     __table_args__ = (

--- a/mcpgateway/routers/auth.py
+++ b/mcpgateway/routers/auth.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.auth import get_current_user, TokenValidationError, validate_token_user
+from mcpgateway.auth_context import get_user_id
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.db import EmailUser, SessionLocal
@@ -320,12 +321,17 @@ async def logout(request: Request, current_user: EmailUser = Depends(get_current
 
             # Revoke token using blocklist service
             blocklist_service = get_token_blocklist_service(db=db)
-            success = blocklist_service.revoke_token(jti=jti, revoked_by=user.email, reason="logout", token_expiry=token_expiry, last_activity=last_activity_dt)
+            # Store the canonical user_id; fall back to the system sentinel
+            # when the principal carries no resolvable identity.
+            revoked_by = get_user_id(user)
+            if revoked_by == "unknown":
+                revoked_by = "system:logout"
+            success = blocklist_service.revoke_token(jti=jti, revoked_by=revoked_by, reason="logout", token_expiry=token_expiry, last_activity=last_activity_dt)
 
             if not success:
                 raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to revoke token")
 
-            logger.info("User %s logged out successfully", SecurityValidator.sanitize_log_message(user.email), extra={"security_event": "logout", "user_email": user.email, "jti": jti})
+            logger.info("User %s logged out successfully", SecurityValidator.sanitize_log_message(revoked_by), extra={"security_event": "logout", "user_id": revoked_by, "jti": jti})
 
             return {"message": "Logged out successfully", "revoked_token": jti}
 

--- a/mcpgateway/services/token_blocklist_service.py
+++ b/mcpgateway/services/token_blocklist_service.py
@@ -86,7 +86,9 @@ class TokenBlocklistService:
 
         Args:
             jti: JWT ID to revoke
-            revoked_by: Email of user revoking the token
+            revoked_by: Canonical user_id of the revoking principal, or a system
+                sentinel string ("system:idle-timeout", "system:logout",
+                "system:admin-logout"). No foreign key is enforced (#5901).
             reason: Reason for revocation (logout, idle_timeout, security, token_refresh, etc.)
             token_expiry: Original token expiry for cleanup scheduling
             last_activity: Last activity timestamp for audit trail

--- a/mcpgateway/services/token_catalog_service.py
+++ b/mcpgateway/services/token_catalog_service.py
@@ -919,7 +919,8 @@ class TokenCatalogService:
         Args:
             token_id: Token ID to revoke
             user_email: Caller's email - must own the token or be a member of the token's team
-            revoked_by: Email of user performing revocation (for audit)
+            revoked_by: Canonical user_id of the revoking principal, or a system
+                sentinel string (for audit). No foreign key is enforced (#5901).
             reason: Optional reason for revocation
 
         Returns:
@@ -983,7 +984,8 @@ class TokenCatalogService:
 
         Args:
             token_id: Token ID to revoke
-            revoked_by: Admin email for audit
+            revoked_by: Canonical user_id of the admin principal, or a system
+                sentinel string (for audit). No foreign key is enforced (#5901).
             reason: Revocation reason
 
         Returns:

--- a/tests/helpers/auth.py
+++ b/tests/helpers/auth.py
@@ -147,7 +147,9 @@ def make_trusted_test_jwt(
         claims.update(extra_payload)
 
     if not secret:
-        secret = settings.jwt_secret_key.get_secret_value()
+        secret = settings.jwt_secret_key
+        if hasattr(secret, "get_secret_value"):
+            secret = secret.get_secret_value()
     if not algorithm:
         algorithm = settings.jwt_algorithm
     return jwt.encode(claims, secret, algorithm=algorithm)

--- a/tests/migration/test_revoked_by_nullable.py
+++ b/tests/migration/test_revoked_by_nullable.py
@@ -1,0 +1,270 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/migration/test_revoked_by_nullable.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Migration tests for the TokenRevocation.revoked_by FK relaxation
+(issue #5901).
+
+The migration makes ``token_revocations.revoked_by`` nullable and drops
+the foreign key to ``email_users.email`` so trust-mode principals (no
+local user row) can write revocation rows. SQLite coverage runs hermetic
+against an in-memory pre-migration schema. The PostgreSQL cycle runs when
+``MIGRATION_TEST_POSTGRES_URL`` points at a scratch database; it is
+skipped otherwise.
+"""
+
+# Standard
+import importlib
+import os
+
+# Third-Party
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.pool import StaticPool
+
+REVISION = "f7a8b9c0d1e2"  # pragma: allowlist secret
+DOWN_REVISION = "e5f6a7b8c9d0"  # pragma: allowlist secret
+MODULE_NAME = f"mcpgateway.alembic.versions.{REVISION}_relax_revoked_by_fk"
+TABLE_NAME = "token_revocations"
+FK_NAME = "token_revocations_revoked_by_fkey"
+
+POSTGRES_URL = os.environ.get("MIGRATION_TEST_POSTGRES_URL")
+
+
+def _make_sqlite_engine():
+    """Return an in-memory SQLite engine that reuses one connection."""
+    return sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+
+
+def _migration_context(conn):
+    """Create an Alembic migration context for a live connection."""
+    return MigrationContext.configure(conn, opts={"as_sql": False})
+
+
+def _run_upgrade(conn) -> None:
+    """Execute the migration upgrade on a connection."""
+    ctx = _migration_context(conn)
+    with Operations.context(ctx):
+        module = importlib.import_module(MODULE_NAME)
+        module.upgrade()
+
+
+def _run_downgrade(conn) -> None:
+    """Execute the migration downgrade on a connection."""
+    ctx = _migration_context(conn)
+    with Operations.context(ctx):
+        module = importlib.import_module(MODULE_NAME)
+        module.downgrade()
+
+
+def _create_pre_migration_schema(conn) -> None:
+    """Create the pre-migration schema: revoked_by NOT NULL with the FK."""
+    conn.execute(
+        sa.text(
+            """
+            CREATE TABLE email_users (
+                id VARCHAR(36) PRIMARY KEY,
+                email VARCHAR(255) NOT NULL UNIQUE,
+                password_hash VARCHAR(255) NOT NULL
+            )
+            """
+        )
+    )
+    conn.execute(
+        sa.text(
+            f"""
+            CREATE TABLE {TABLE_NAME} (
+                jti VARCHAR(36) PRIMARY KEY,
+                revoked_at DATETIME NOT NULL,
+                revoked_by VARCHAR(255) NOT NULL,
+                reason VARCHAR(255),
+                token_expiry DATETIME,
+                last_activity DATETIME,
+                CONSTRAINT {FK_NAME} FOREIGN KEY(revoked_by) REFERENCES email_users (email)
+            )
+            """
+        )
+    )
+    conn.execute(sa.text("INSERT INTO email_users (id, email, password_hash) VALUES ('u-1', 'admin@example.com', 'hash')"))
+    conn.execute(
+        sa.text(f"INSERT INTO {TABLE_NAME} (jti, revoked_at, revoked_by, reason) VALUES ('jti-existing', '2026-01-01 00:00:00', 'admin@example.com', 'logout')"),
+    )
+    conn.commit()
+
+
+def _fk_names(conn) -> list:
+    """Return foreign key names constraining token_revocations."""
+    return [fk.get("name") for fk in sa.inspect(conn).get_foreign_keys(TABLE_NAME)]
+
+
+def _revoked_by_column(conn) -> dict:
+    """Return the reflected revoked_by column description."""
+    columns = {column["name"]: column for column in sa.inspect(conn).get_columns(TABLE_NAME)}
+    return columns["revoked_by"]
+
+
+def _revoked_by_values(conn) -> list:
+    """Return all (jti, revoked_by) rows ordered by jti."""
+    return list(conn.execute(sa.text(f"SELECT jti, revoked_by FROM {TABLE_NAME} ORDER BY jti")))
+
+
+def _assert_relaxed(conn) -> None:
+    """Assert the post-upgrade shape: nullable column, no FK, rows intact."""
+    assert _revoked_by_column(conn)["nullable"] is True
+    assert FK_NAME not in _fk_names(conn)
+    assert ("jti-existing", "admin@example.com") in _revoked_by_values(conn)
+    # Trust-mode shape: no user row backs the revoker identity.
+    conn.execute(sa.text(f"INSERT INTO {TABLE_NAME} (jti, revoked_at, revoked_by, reason) VALUES ('jti-trust', '2026-01-02 00:00:00', 'trust-subject-0001', 'logout')"))
+    # Sentinel shape: a NULL revoked_by is now legal.
+    conn.execute(sa.text(f"INSERT INTO {TABLE_NAME} (jti, revoked_at, revoked_by, reason) VALUES ('jti-null', '2026-01-03 00:00:00', NULL, 'idle_timeout')"))
+    conn.commit()
+
+
+def _assert_restored(conn) -> None:
+    """Assert the post-downgrade shape: NOT NULL column, FK restored."""
+    assert _revoked_by_column(conn)["nullable"] is False
+    assert FK_NAME in _fk_names(conn)
+
+
+class TestRevokedByMigrationStructure:
+    """Verify migration metadata and importability."""
+
+    def test_migration_module_imports(self):
+        """Migration module imports successfully."""
+        assert importlib.import_module(MODULE_NAME) is not None
+
+    def test_migration_revision_id(self):
+        """Revision identifier matches expected value."""
+        module = importlib.import_module(MODULE_NAME)
+        assert module.revision == REVISION
+
+    def test_migration_down_revision(self):
+        """down_revision points to the recorded head."""
+        module = importlib.import_module(MODULE_NAME)
+        assert module.down_revision == DOWN_REVISION
+
+
+class TestRevokedByMigrationSqlite:
+    """Functional SQLite coverage: up/down/up cycle."""
+
+    def test_upgrade_relaxes_fk_and_nullable(self):
+        """upgrade() drops the FK and makes revoked_by nullable."""
+        engine = _make_sqlite_engine()
+        try:
+            with engine.connect() as conn:
+                _create_pre_migration_schema(conn)
+                assert _revoked_by_column(conn)["nullable"] is False
+                assert FK_NAME in _fk_names(conn)
+
+                _run_upgrade(conn)
+
+                _assert_relaxed(conn)
+        finally:
+            engine.dispose()
+
+    def test_downgrade_restores_fk_and_not_null(self):
+        """downgrade() restores the FK and the NOT NULL constraint."""
+        engine = _make_sqlite_engine()
+        try:
+            with engine.connect() as conn:
+                _create_pre_migration_schema(conn)
+                _run_upgrade(conn)
+
+                # Downgrade needs FK-valid, non-NULL rows: remove the rows
+                # that only the relaxed schema allows.
+                conn.execute(sa.text(f"DELETE FROM {TABLE_NAME} WHERE jti IN ('jti-trust', 'jti-null')"))
+                conn.commit()
+
+                _run_downgrade(conn)
+
+                _assert_restored(conn)
+                assert ("jti-existing", "admin@example.com") in _revoked_by_values(conn)
+        finally:
+            engine.dispose()
+
+    def test_up_down_up_cycle_is_clean(self):
+        """up -> down -> up completes without error and keeps data."""
+        engine = _make_sqlite_engine()
+        try:
+            with engine.connect() as conn:
+                _create_pre_migration_schema(conn)
+                _run_upgrade(conn)
+                conn.execute(sa.text(f"DELETE FROM {TABLE_NAME} WHERE jti IN ('jti-trust', 'jti-null')"))
+                conn.commit()
+                _run_downgrade(conn)
+                _assert_restored(conn)
+
+                _run_upgrade(conn)
+
+                _assert_relaxed(conn)
+        finally:
+            engine.dispose()
+
+    def test_upgrade_is_idempotent(self):
+        """A second upgrade run raises no error."""
+        engine = _make_sqlite_engine()
+        try:
+            with engine.connect() as conn:
+                _create_pre_migration_schema(conn)
+                _run_upgrade(conn)
+
+                _run_upgrade(conn)
+
+                _assert_relaxed(conn)
+        finally:
+            engine.dispose()
+
+    def test_upgrade_skips_when_table_missing(self):
+        """upgrade() exits cleanly when token_revocations does not exist."""
+        engine = _make_sqlite_engine()
+        try:
+            with engine.connect() as conn:
+                _run_upgrade(conn)
+                assert TABLE_NAME not in set(sa.inspect(conn).get_table_names())
+        finally:
+            engine.dispose()
+
+    def test_downgrade_skips_when_table_missing(self):
+        """downgrade() exits cleanly when token_revocations does not exist."""
+        engine = _make_sqlite_engine()
+        try:
+            with engine.connect() as conn:
+                _run_downgrade(conn)
+                assert TABLE_NAME not in set(sa.inspect(conn).get_table_names())
+        finally:
+            engine.dispose()
+
+
+@pytest.mark.skipif(not POSTGRES_URL, reason="MIGRATION_TEST_POSTGRES_URL not set; PostgreSQL cycle runs in CI or local compose")
+class TestRevokedByMigrationPostgres:
+    """Functional PostgreSQL coverage: up/down/up cycle."""
+
+    def test_up_down_up_cycle_is_clean(self):
+        """up -> down -> up completes against a scratch PostgreSQL database."""
+        engine = sa.create_engine(POSTGRES_URL)
+        try:
+            with engine.connect() as conn:
+                conn.execute(sa.text(f"DROP TABLE IF EXISTS {TABLE_NAME}"))
+                conn.execute(sa.text("DROP TABLE IF EXISTS email_users"))
+                conn.commit()
+
+                _create_pre_migration_schema(conn)
+                _run_upgrade(conn)
+                _assert_relaxed(conn)
+
+                conn.execute(sa.text(f"DELETE FROM {TABLE_NAME} WHERE jti IN ('jti-trust', 'jti-null')"))
+                conn.commit()
+                _run_downgrade(conn)
+                _assert_restored(conn)
+
+                _run_upgrade(conn)
+                _assert_relaxed(conn)
+        finally:
+            with engine.connect() as conn:
+                conn.execute(sa.text(f"DROP TABLE IF EXISTS {TABLE_NAME}"))
+                conn.execute(sa.text("DROP TABLE IF EXISTS email_users"))
+                conn.commit()
+            engine.dispose()

--- a/tests/unit/mcpgateway/test_revocation_trust.py
+++ b/tests/unit/mcpgateway/test_revocation_trust.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_revocation_trust.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Trust-mode revocation persistence tests (issue #5901).
+
+Trust-mode principals have no local user row, so the historical
+``TokenRevocation.revoked_by`` foreign key to ``email_users.email``
+(NOT NULL) made every trust-initiated revocation insert fail. The
+idle-timeout path then swallowed the error and the revocation silently
+never landed. These tests pin the fixed contract:
+
+  * trust-mode logout writes a revocation row keyed by the canonical
+    user_id of the virtual principal,
+  * the same revocation identifier is rejected with 401 on the next
+    request through the REAL revocation check (no mock),
+  * an idle-timeout revocation persists even when the identity is a
+    synthetic principal with no ``email_users`` row.
+"""
+
+# Standard
+import contextlib
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+# Third-Party
+from fastapi import HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.auth import get_current_user
+from mcpgateway.config import settings
+from mcpgateway.db import Base, TokenRevocation
+from mcpgateway.routers.auth import logout
+from mcpgateway.utils.trusted_claims import VirtualPrincipal
+
+CALLER_ID = "trust-subject-0001"
+LOGOUT_JTI = "trusted-logout-jti-0001"
+IDLE_JTI = "idle-revoke-jti-0001"
+
+
+def _exp(hours: int = 1) -> float:
+    """Expiry timestamp for mocked JWT payloads."""
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).timestamp()
+
+
+@pytest.fixture
+def db():
+    """In-memory SQLite session with the full schema and no user rows.
+
+    Trust-mode principals exist only in token claims; no ``email_users``
+    row backs them, which is exactly the shape that broke the old FK.
+    """
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+
+    # SQLite does not enforce foreign keys by default; PostgreSQL does.
+    # Enforce them so this fixture reproduces the production failure mode.
+    @sa.event.listens_for(engine, "connect")
+    def _enable_sqlite_fk(dbapi_connection, _connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _patch_sessions(monkeypatch: pytest.MonkeyPatch, db) -> None:
+    """Re-point funnel and blocklist-service sessions at the test database."""
+    session_test = sessionmaker(bind=db.get_bind())
+    monkeypatch.setattr("mcpgateway.auth.SessionLocal", session_test)
+
+    @contextlib.contextmanager
+    def _fresh_db_session():
+        session = session_test()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("mcpgateway.auth.fresh_db_session", _fresh_db_session)
+    monkeypatch.setattr("mcpgateway.services.token_blocklist_service.fresh_db_session", _fresh_db_session)
+
+
+def _revocation_row(db, jti: str):
+    """Return the TokenRevocation row for jti, or None."""
+    return db.execute(sa.select(TokenRevocation).where(TokenRevocation.jti == jti)).scalar_one_or_none()
+
+
+async def _trust_logout(db, jti: str = LOGOUT_JTI) -> dict:
+    """Drive the logout endpoint as a trust-mode principal with no email claim."""
+    # First-Party
+    from tests.helpers.auth import make_trusted_test_jwt
+
+    token = make_trusted_test_jwt(CALLER_ID, revocation_id=jti)
+    principal = VirtualPrincipal(user_id=CALLER_ID, email=None)
+    request = SimpleNamespace(headers={"authorization": f"Bearer {token}"})
+    return await logout(request=request, current_user=principal, db=db)
+
+
+class TestTrustModeLogoutRevocation:
+    """Trust-mode logout persists a revocation row despite no user record."""
+
+    @pytest.mark.asyncio
+    async def test_trust_mode_logout_writes_revocation_row(self, db):
+        """Logout stores the canonical user_id, not an email FK reference."""
+        result = await _trust_logout(db)
+
+        assert result["revoked_token"] == LOGOUT_JTI
+        row = _revocation_row(db, LOGOUT_JTI)
+        assert row is not None
+        assert row.revoked_by == CALLER_ID
+        assert row.reason == "logout"
+
+    @pytest.mark.asyncio
+    async def test_same_jti_rejected_after_trust_logout(self, monkeypatch, db):
+        """After logout, the same jti yields 401 via the real revocation check."""
+        await _trust_logout(db)
+        assert _revocation_row(db, LOGOUT_JTI) is not None
+
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+        _patch_sessions(monkeypatch, db)
+
+        payload = {
+            "sub": CALLER_ID,
+            "token_use": "trusted",
+            "teams": [],
+            "roles": [],
+            "jti": LOGOUT_JTI,
+            "exp": _exp(),
+        }
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="trusted_jwt_token")  # pragma: allowlist secret
+        request = SimpleNamespace(state=SimpleNamespace())
+
+        # NOTE: _check_token_revoked_sync is deliberately NOT patched — the
+        # real check must find the persisted row.
+        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(credentials=credentials, request=request)
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+class TestIdleTimeoutRevocation:
+    """Idle-timeout revoke persists; insert failures are never swallowed."""
+
+    @pytest.mark.asyncio
+    async def test_idle_timeout_revoke_persists(self, monkeypatch, db):
+        """Synthetic principal (platform admin, no DB row): revocation row lands."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "db")
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+        monkeypatch.setattr(settings, "token_idle_timeout", 5)
+        _patch_sessions(monkeypatch, db)
+
+        old_activity = (datetime.now(timezone.utc) - timedelta(hours=1)).timestamp()
+        payload = {
+            "sub": settings.platform_admin_email,
+            "jti": IDLE_JTI,
+            "last_activity": old_activity,
+            "exp": _exp(),
+        }
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="idle_session_token")  # pragma: allowlist secret
+
+        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(credentials=credentials, request=SimpleNamespace(state=SimpleNamespace()))
+
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+        row = _revocation_row(db, IDLE_JTI)
+        assert row is not None
+        assert row.revoked_by == settings.platform_admin_email
+        assert row.reason == "idle_timeout"


### PR DESCRIPTION
One idempotent migration (`f7a8b9c0d1e2`, parent `e5f6a7b8c9d0`) makes `TokenRevocation.revoked_by` nullable and drops the FK to `email_users.email` — trust-mode principals have no user row, and the old NOT-NULL FK broke every revocation insert for them (the idle path silently swallowed the failure). The `revoker` relationship that depended on the FK is removed.

All six revocation insert sites now store the canonical user_id or an exact system sentinel: `routers/auth.py` logout (`get_user_id(user)`, `"system:logout"` fallback), `admin.py` admin logout (`"system:admin-logout"`), `token_catalog_service.py` revoke and `admin_revoke_token` (caller-supplied canonical id, contract pinned in docstrings), `token_blocklist_service.py` (same contract), and the `auth.py` idle-revoke (`"system:idle-timeout"`). The idle handler's broad `except Exception` is narrowed to a dedicated try/except around the revocation insert only: on failure it logs ERROR with the sanitized jti and error detail and continues the request — failures are visible, never swallowed, never re-raised into the request.

Tested with:
- `uv run pytest tests/unit/mcpgateway/test_revocation_trust.py -q` — 3 passed (TDD red first: logout 500s, idle row absent). Trust logout writes a row (`revoked_by` = the trust subject); the same jti then yields a real 401; idle revoke persists.
- `uv run pytest tests/migration/test_revoked_by_nullable.py -q` — 9 passed, 1 skipped (Postgres cycle ships gated on `MIGRATION_TEST_POSTGRES_URL`; SQLite hermetic and real scratch up/down/up verified, resulting DDL shows `revoked_by` nullable with no FK)
- `cd mcpgateway && uv run alembic heads` — exactly one head: `f7a8b9c0d1e2`
- `make ruff` — all checks passed
- `make test` — 23324 passed, 879 skipped, 3 xfailed

Acceptance criteria of #5901 are met. Risk to existing users: existing default-mode revocation rows keep their values; the migration is relax-only. The `db.py` model edit beyond the order's file list was required — the issue names it, and the funnel tests build schema from the models.

Stack: B.9 of epic #5885 (base: #6746).

Closes #5901