### PR TITLE
feat(auth): accept trusted IdP tokens without local provisioning in trust mode

### DIFF
--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -1450,6 +1450,75 @@ def _bootstrap_platform_admin_user(email: str) -> "EmailUser":
     return user
 
 
+async def _try_external_verification(token: str, request: Optional[Request]) -> Optional[dict]:
+    """Dispatch a bearer token to the external-IdP (trusted OIDC issuer) verifier.
+
+    Trust-mode ingress dispatch (#5903): reads the token's ``iss`` claim
+    UNVERIFIED (``verify_signature: False``) solely to choose the
+    verification path — no other claim from this peek is ever trusted —
+    then delegates to the existing external verification chain
+    (``_maybe_verify_external`` -> ``verify_external_idp_token`` ->
+    ``build_trusted_external_identity``).
+
+    Dispatch contract (mirrors docs/5896 and the AGENTS.md trust-mode rule):
+
+    - Issuer is a configured trust root and verification succeeds -> the
+      claims-derived identity payload (``token_use="trusted"``).
+    - Issuer is a configured trust root but verification fails definitively
+      (bad signature, wrong audience, expiry, missing revocation claim) ->
+      401 fail-closed; the internal JWT funnel is NEVER consulted for that
+      token.
+    - Issuer is NOT a configured trust root (or is the internal issuer) ->
+      None; the caller falls through to the internal verifier exactly as
+      before.
+
+    Args:
+        token: The raw bearer token string.
+        request: Optional request object; the external payload is cached on
+            ``request.state._jwt_verified_payload`` for downstream consumers,
+            mirroring ``verify_credentials_cached``.
+
+    Returns:
+        The verified external identity payload, or None when the token is
+        not external-issuer material.
+
+    Raises:
+        HTTPException: 401 when a trust-root token fails external
+            verification (fail-closed).
+    """
+    # Third-Party
+    import jwt  # pylint: disable=import-outside-toplevel
+
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc  # pylint: disable=import-outside-toplevel
+
+    try:
+        unverified = jwt.decode(token, options={"verify_signature": False})
+    except jwt.PyJWTError:
+        return None  # not even a JWT -> internal funnel handles the 401
+    iss = unverified.get("iss")
+    if not isinstance(iss, str) or not iss or iss.rstrip("/") == (settings.jwt_issuer or "").rstrip("/"):
+        return None  # internal issuer (or no iss) -> internal funnel, zero JWKS cost
+
+    try:
+        external_payload = await vc._maybe_verify_external(token, request, fail_closed=True)  # pylint: disable=protected-access
+    except vc.ExternalIssuerVerificationError as exc:
+        logger.warning(
+            "Rejected bearer from a configured trust root at ingress (fail-closed): %s",
+            SecurityValidator.sanitize_log_message(str(exc)),
+            extra={"security_event": "trust_root_token_rejected_ingress"},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
+
+    if external_payload is not None and request is not None and hasattr(request, "state"):
+        request.state._jwt_verified_payload = (token, external_payload)  # pylint: disable=protected-access
+    return external_payload
+
+
 async def get_current_user(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
     request: Request = None,  # type: ignore[assignment]
@@ -1754,9 +1823,19 @@ async def get_current_user(
     email = None
 
     try:
-        # Try JWT token first using the centralized verify_jwt_token_cached function
-        logger.debug("Attempting JWT token validation")
-        payload = await verify_jwt_token_cached(credentials.credentials, request)
+        # Trust-mode ingress dispatch (#5903): when JWT trust mode is ON,
+        # external-issuer bearers go to the JWKS verifier BEFORE the internal
+        # verifier. The helper returns None only for "not an external-issuer
+        # token" (fall through to the internal funnel exactly as today); a
+        # trust-root token that fails verification raises 401 fail-closed.
+        payload = None
+        if settings.jwt_trust_mode == "jwt-trust":
+            payload = await _try_external_verification(credentials.credentials, request)
+
+        if payload is None:
+            # Try JWT token first using the centralized verify_jwt_token_cached function
+            logger.debug("Attempting JWT token validation")
+            payload = await verify_jwt_token_cached(credentials.credentials, request)
 
         logger.debug("JWT token validated successfully")
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1869,24 +1869,35 @@ class Settings(BaseSettings):
             )
 
         # Claim-collision guard (trust mode only). In trust mode the external
-        # group-mapping resolver consumes the claim named by
-        # ``sso_entra_groups_claim`` for external group IDs. If
-        # ``jwt_claim_teams`` names the same claim, raw external group IDs
-        # land in native ContextForge team memberships before mapping.
-        # Outside trust mode ``jwt_claim_teams`` is not consumed, so an
-        # aliased value is dead config and does not fail startup.
+        # group-mapping resolver consumes the claims named by
+        # ``sso_entra_groups_claim`` / ``sso_keycloak_groups_claim`` /
+        # ``sso_generic_groups_claim`` for external group IDs. If
+        # ``jwt_claim_teams`` names the same claim as ANY of them, raw
+        # external group IDs land in native ContextForge team memberships
+        # before mapping. Non-Entra trust roots are live (#5903), so the
+        # guard covers every provider's groups claim. Claim names are
+        # compared case-insensitively: JWT claim lookup is case-sensitive
+        # per token, but an operator-casing difference must not bypass the
+        # guard. Outside trust mode ``jwt_claim_teams`` is not consumed, so
+        # an aliased value is dead config and does not fail startup.
         if self.jwt_trust_mode == "jwt-trust":
             teams_claim = self.jwt_claim_teams.strip()
-            groups_claim = self.sso_entra_groups_claim.strip()
-            if teams_claim and teams_claim == groups_claim:
-                raise SecurityConfigurationError(
-                    f"JWT_CLAIM_TEAMS and SSO_ENTRA_GROUPS_CLAIM both name the {teams_claim!r} claim. "
-                    "In trust mode the external group-mapping resolver consumes SSO_ENTRA_GROUPS_CLAIM for "
-                    "external group IDs; aliasing it with JWT_CLAIM_TEAMS places raw external group IDs into "
-                    "native ContextForge team memberships before mapping. "
-                    "Remediation: point JWT_CLAIM_TEAMS at a distinct claim (default 'teams') while "
-                    "SSO_ENTRA_GROUPS_CLAIM keeps naming the provider's groups claim (default 'groups')."
-                )
+            if teams_claim:
+                for env_name, groups_claim in (
+                    ("SSO_ENTRA_GROUPS_CLAIM", self.sso_entra_groups_claim),
+                    ("SSO_KEYCLOAK_GROUPS_CLAIM", self.sso_keycloak_groups_claim),
+                    ("SSO_GENERIC_GROUPS_CLAIM", self.sso_generic_groups_claim),
+                ):
+                    groups_claim = (groups_claim or "").strip()
+                    if groups_claim and teams_claim.casefold() == groups_claim.casefold():
+                        raise SecurityConfigurationError(
+                            f"JWT_CLAIM_TEAMS and {env_name} both name the {teams_claim!r} claim. "
+                            f"In trust mode the external group-mapping resolver consumes {env_name} for "
+                            "external group IDs; aliasing it with JWT_CLAIM_TEAMS places raw external group IDs into "
+                            "native ContextForge team memberships before mapping. "
+                            "Remediation: point JWT_CLAIM_TEAMS at a distinct claim (default 'teams') while "
+                            f"{env_name} keeps naming the provider's groups claim (default 'groups')."
+                        )
 
         return self
 

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -646,17 +646,44 @@ def _record_external_auth_metric(outcome: str, provider_id, reason: str = "") ->
         logger.debug("external-idp auth metric skipped: %s", exc)
 
 
-async def _maybe_verify_external(token: str, request: Optional[Request]) -> Optional[dict]:
+class ExternalIssuerVerificationError(Exception):
+    """Definitive verification failure for a token from a configured trust root.
+
+    Raised only on the fail-closed dispatch path
+    (``_maybe_verify_external(..., fail_closed=True)``) when the token's
+    issuer matched a configured trust root (``trusted_for_api_auth``) but
+    external verification failed definitively: bad signature, wrong audience,
+    expiry, missing revocation claim, or identity-build rejection. The caller
+    must map this to 401 and MUST NOT fall through to the internal JWT
+    funnel for that token.
+    """
+
+
+async def _maybe_verify_external(token: str, request: Optional[Request], *, fail_closed: bool = False) -> Optional[dict]:
     """Attempt external-IdP (trusted OIDC issuer) verification for a bearer token.
 
     Args:
         token: The raw bearer token string.
         request: Optional FastAPI/Starlette request, used for a request-scoped DB session.
+        fail_closed: Trust-mode ingress dispatch semantics (#5903). When True
+            and the token's issuer IS a configured trust root, every
+            definitive verification failure raises
+            :class:`ExternalIssuerVerificationError` instead of returning
+            None, so the caller can reject with 401 without falling through
+            to the internal JWT funnel. ``None`` is still returned when the
+            issuer is NOT a configured trust root (fall-through is correct).
+            Default False preserves the legacy fall-through-on-any-failure
+            behavior for all existing callers.
 
     Returns:
         A session-semantics identity payload (see build_external_identity) if the
         token's issuer matches a trusted external provider and verification succeeds,
         or None to fall through to internal JWT verification.
+
+    Raises:
+        ExternalIssuerVerificationError: Only with ``fail_closed=True``: the
+            issuer is a configured trust root but verification failed
+            definitively.
     """
     if not getattr(settings, "sso_api_token_auth_enabled", False):
         return None
@@ -691,9 +718,19 @@ async def _maybe_verify_external(token: str, request: Optional[Request]) -> Opti
     if own_session:
         db = SessionLocal()
         db.info["external_owned"] = True  # M1: signals build_external_identity to commit provisioning
+    trust_root = None
     try:
+        if fail_closed:
+            # Decide the dispatch contract up front: when the issuer is a
+            # configured trust root, every failure below is definitive and
+            # must raise (fail-closed); when it is not, None means
+            # "not ours" and the caller falls through to the internal funnel.
+            trust_root = resolve_trusted_provider_by_issuer(iss, db)
+
         claims, provider = await verify_external_idp_token(token, db)
         if claims is None:
+            if trust_root is not None:
+                raise ExternalIssuerVerificationError("token from a configured trust root failed external verification")
             return None  # untrusted issuer / invalid sig -> fall through -> internal path 401s
         if _external_trust_root_active(provider):
             # Trust mode (#5903): the identity derives from the verified
@@ -702,10 +739,17 @@ async def _maybe_verify_external(token: str, request: Optional[Request]) -> Opti
             payload = await build_trusted_external_identity(provider, claims, token, db)
         else:
             payload = await build_external_identity(provider, claims, token, db)
-        if payload is not None:
-            await _external_identity_cache_put(th, payload, claims.get("exp"))
+        if payload is None:
+            if trust_root is not None:
+                raise ExternalIssuerVerificationError("identity resolution rejected a token from a configured trust root")
+            return None
+        await _external_identity_cache_put(th, payload, claims.get("exp"))
         return payload
+    except ExternalIssuerVerificationError:
+        raise
     except Exception as exc:  # pylint: disable=broad-except
+        if trust_root is not None:
+            raise ExternalIssuerVerificationError(f"external verification error for a configured trust root: {sanitize_for_log(str(exc))}") from exc
         logger.warning("external-idp auth error, falling through to internal (401): %s", sanitize_for_log(str(exc)))
         return None
     finally:

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -695,7 +695,13 @@ async def _maybe_verify_external(token: str, request: Optional[Request]) -> Opti
         claims, provider = await verify_external_idp_token(token, db)
         if claims is None:
             return None  # untrusted issuer / invalid sig -> fall through -> internal path 401s
-        payload = await build_external_identity(provider, claims, token, db)
+        if _external_trust_root_active(provider):
+            # Trust mode (#5903): the identity derives from the verified
+            # claims; the provisioning path (build_external_identity) is
+            # never invoked for a configured trust root.
+            payload = await build_trusted_external_identity(provider, claims, token, db)
+        else:
+            payload = await build_external_identity(provider, claims, token, db)
         if payload is not None:
             await _external_identity_cache_put(th, payload, claims.get("exp"))
         return payload
@@ -2206,12 +2212,149 @@ def _get_sso_service(db: Session):
     return SSOService(db)
 
 
+def _external_trust_root_active(provider: SSOProvider) -> bool:
+    """Check whether the external-IdP trust branch applies to this provider.
+
+    The trust branch requires trust mode ON (``jwt_trust_mode == "jwt-trust"``)
+    and a provider that is a configured trust root: ``trusted_for_api_auth``
+    set plus a non-empty ``api_audience``. The audience requirement mirrors
+    the fail-closed backstop in :func:`verify_external_idp_token`.
+
+    Args:
+        provider: The matched SSOProvider (from resolve_trusted_provider_by_issuer).
+
+    Returns:
+        True when the identity must be built from token claims alone.
+    """
+    if settings.jwt_trust_mode != "jwt-trust":
+        return False
+    if not getattr(provider, "trusted_for_api_auth", False):
+        return False
+    return bool((getattr(provider, "api_audience", None) or "").strip())
+
+
+async def build_trusted_external_identity(provider: SSOProvider, verified_claims: dict, token: str, db: Session) -> Optional[dict[str, Any]]:
+    """Build a claims-derived identity payload for a trusted external-IdP token.
+
+    Trust-mode branch of :func:`build_external_identity` (issue #5903). The
+    identity comes from the verified token claims via
+    ``extract_trusted_principal``: no local user record is read or written.
+    ``authenticate_or_create_user`` and ``get_user_by_email`` are never
+    called, and ``is_admin`` comes from the mapped claim, not a DB row.
+
+    SECURITY:
+        * A token that lacks the configured revocation claim
+          (``jwt_trust_revocation_claim``, default ``jti``) is unrevocable;
+          it is rejected (None return; the caller maps this to 401).
+        * Group-overage markers dispatch on ``jwt_trust_overage_policy``:
+          ``fail_closed`` rejects, ``graph_lookup`` resolves through the
+          app-only Graph client, ``proceed_without_groups`` continues with
+          an empty group list and a WARNING log.
+        * ``token_use="trusted"`` so downstream dispatchers route via the
+          trust branch (claim authority), NOT the session funnel.
+
+    Args:
+        provider: The matched trust-root SSOProvider.
+        verified_claims: Signature-verified claims from verify_external_idp_token.
+        token: The raw external bearer token (carried through for downstream use).
+        db: Request-scoped SQLAlchemy session (group-mapping resolver and the
+            server-side roles table only; never email_users).
+
+    Returns:
+        The claims-derived trust-semantics identity payload, or None when the
+        token is missing a required claim or the overage policy rejects it.
+    """
+    # First-Party
+    from mcpgateway.utils.trusted_claims import detect_overage_marker, extract_revocation_id, extract_trusted_principal, resolve_overage_groups  # pylint: disable=import-outside-toplevel
+
+    provider_id = getattr(provider, "id", None)
+    revocation_claim = settings.jwt_trust_revocation_claim
+
+    # Revocation guarantee (fail-closed): the configured revocation claim must
+    # be present, or the token is unrevocable and must be rejected.
+    try:
+        extract_revocation_id(verified_claims, settings)
+    except HTTPException:
+        logger.warning(
+            "external-idp trust auth denied: token is missing the configured revocation claim %r (iss=%s, provider=%s)",
+            revocation_claim,
+            sanitize_for_log(verified_claims.get("iss")),
+            sanitize_for_log(provider_id),
+        )
+        _record_external_auth_metric("denied", provider_id, reason="missing_revocation_claim")
+        return None
+
+    claims = verified_claims
+    if detect_overage_marker(verified_claims):
+        try:
+            resolved_groups = await resolve_overage_groups(verified_claims, settings, db)
+        except HTTPException as exc:
+            logger.warning(
+                "external-idp trust auth denied: group overage unresolved (iss=%s, provider=%s): %s",
+                sanitize_for_log(verified_claims.get("iss")),
+                sanitize_for_log(provider_id),
+                sanitize_for_log(str(exc.detail)),
+            )
+            _record_external_auth_metric("denied", provider_id, reason="group_overage_unresolved")
+            return None
+        # The resolved group IDs replace the overage markers in a claims copy.
+        # The inbound dict is never mutated, and the synthesized payload stays
+        # free of markers so downstream re-extraction does not resolve twice.
+        claims = {key: value for key, value in verified_claims.items() if key not in ("_claim_names", "hasgroups") and not (isinstance(key, str) and key.startswith("groups:src"))}
+        claims["groups"] = resolved_groups
+
+    # extract_trusted_principal raises 401 when a required mapped claim is
+    # absent (fail-closed). Teams and roles come from the claims plus the
+    # external-group resolver; is_admin comes from the mapped admin claim.
+    try:
+        principal = extract_trusted_principal(claims, settings, db)
+    except HTTPException as exc:
+        logger.warning(
+            "external-idp trust auth denied: %s (iss=%s, provider=%s)",
+            sanitize_for_log(str(exc.detail)),
+            sanitize_for_log(verified_claims.get("iss")),
+            sanitize_for_log(provider_id),
+        )
+        _record_external_auth_metric("denied", provider_id, reason="missing_mapped_claim")
+        return None
+
+    # The email claim is optional in trust mode. When absent, the token
+    # subject backs the email attribute (display and tracing); the canonical
+    # user_id stays the opaque mapped claim.
+    email = principal.email
+    if email is None:
+        subject = verified_claims.get("sub")
+        email = subject if isinstance(subject, str) else None
+
+    payload: dict = {
+        **claims,
+        "sub": principal.user_id,
+        "email": email,
+        "user_id": principal.user_id,
+        "token": token,
+        "token_use": "trusted",  # nosec B105 - JWT claim type, not a password
+        "source": "external_idp",  # audit/telemetry only -- never drives authz
+        "iss": verified_claims.get("iss"),
+        "auth_provider": provider_id,
+        "teams": list(principal.teams),
+        "roles": list(principal.roles),
+        "is_admin": principal.is_admin,
+    }
+    _record_external_auth_metric("success", provider_id)
+    logger.info("external-idp trust auth: claims-derived identity (iss=%s, provider=%s)", sanitize_for_log(verified_claims.get("iss")), sanitize_for_log(provider_id))
+    return payload
+
+
 async def build_external_identity(provider: SSOProvider, verified_claims: dict, token: str, db: Session) -> Optional[dict[str, Any]]:
     """Map verified external-IdP claims to a ContextForge identity payload.
 
-    Reuses browser-SSO normalization + provisioning so role/group -> team mapping
-    is identical. Team scoping uses SESSION semantics (DB authority) because an
-    external access token carries no internal ``teams`` claim.
+    Trust dispatch (issue #5903): when trust mode is ON and the provider is a
+    configured trust root, the identity is built from token claims alone by
+    :func:`build_trusted_external_identity` and this provisioning path is
+    never entered. Default mode is unchanged: browser-SSO normalization +
+    provisioning so role/group -> team mapping is identical. Team scoping
+    uses SESSION semantics (DB authority) because an external access token
+    carries no internal ``teams`` claim.
 
     SECURITY:
         * ``token_use="session"`` so downstream dispatchers route via
@@ -2233,6 +2376,9 @@ async def build_external_identity(provider: SSOProvider, verified_claims: dict, 
         The enriched session-semantics identity payload, or None when the user
         cannot be provisioned/resolved.
     """
+    if _external_trust_root_active(provider):
+        return await build_trusted_external_identity(provider, verified_claims, token, db)
+
     # First-Party
     from mcpgateway.auth import resolve_session_teams  # pylint: disable=import-outside-toplevel
 

--- a/tests/live_gateway/helpers/local_oidc_issuer.py
+++ b/tests/live_gateway/helpers/local_oidc_issuer.py
@@ -1,0 +1,305 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/live_gateway/helpers/local_oidc_issuer.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Local Entra-compatible OIDC issuer for live-gateway trust-mode tests.
+
+The gateway's external-IdP verifier (``verify_oauth_access_token``)
+discovers keys via RFC 8414 / OIDC metadata and enforces that the
+``jwks_uri`` is HTTPS and same-origin with the issuer (SSRF defense).
+This harness therefore serves its discovery and JWKS endpoints over TLS
+with a self-signed certificate:
+
+- ``ensure_tls_material()`` writes a reusable self-signed cert/key pair to
+  ``LOCAL_OIDC_MATERIAL_DIR`` (default ``/tmp/cf-local-oidc-issuer``). The
+  gateway under test must be started with
+  ``SSL_CERT_FILE=<material dir>/issuer-tls-cert.pem`` so its outbound
+  httpx clients (httpx >= 0.28 honors ``SSL_CERT_FILE``) trust the issuer.
+  Materialize it once before starting the gateway:
+
+      uv run python -m tests.live_gateway.helpers.local_oidc_issuer ensure-material
+
+- The ``local_oidc_issuer`` session fixture starts the issuer on an
+  ephemeral port (uvicorn in a thread, TLS) plus a plain-HTTP stub A2A
+  agent endpoint on a second ephemeral port, and yields a namespace with
+  the issuer URL, a ``mint_token`` helper (RS256, generated in-memory key)
+  and the stub agent URL.
+
+Token material is never logged by this module.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from datetime import datetime, timedelta, timezone
+import ipaddress
+import os
+from pathlib import Path
+import socket
+import threading
+import time
+from typing import Any, Dict, Optional
+
+# Third-Party
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+import jwt
+import pytest
+
+MATERIAL_DIR = Path(os.getenv("LOCAL_OIDC_MATERIAL_DIR", "/tmp/cf-local-oidc-issuer"))
+TLS_CERT_FILE = MATERIAL_DIR / "issuer-tls-cert.pem"
+TLS_KEY_FILE = MATERIAL_DIR / "issuer-tls-key.pem"
+TOKEN_KID = "local-oidc-test-key-1"
+
+
+# ---------------------------------------------------------------------------
+# TLS material (issuer HTTPS requirement)
+# ---------------------------------------------------------------------------
+def ensure_tls_material() -> Path:
+    """Write (or reuse) the self-signed TLS cert/key for the local issuer.
+
+    The certificate is its own trust root (CA:TRUE, self-signed) with SANs
+    for ``localhost`` / ``127.0.0.1``; the gateway trusts it via
+    ``SSL_CERT_FILE``. Existing material is reused so a previously started
+    gateway keeps working across test runs.
+
+    Returns:
+        Path to the PEM certificate file (the ``SSL_CERT_FILE`` value).
+    """
+    if TLS_CERT_FILE.is_file() and TLS_KEY_FILE.is_file():
+        return TLS_CERT_FILE
+
+    MATERIAL_DIR.mkdir(parents=True, exist_ok=True)
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "cf-local-oidc-issuer")])
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=5))
+        .not_valid_after(now + timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .add_extension(
+            x509.SubjectAlternativeName(
+                [
+                    x509.DNSName("localhost"),
+                    x509.IPAddress(ipaddress.ip_address("127.0.0.1")),
+                ]
+            ),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    TLS_KEY_FILE.write_bytes(key.private_bytes(serialization.Encoding.PEM, serialization.PrivateFormat.TraditionalOpenSSL, serialization.NoEncryption()))
+    TLS_CERT_FILE.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    return TLS_CERT_FILE
+
+
+# ---------------------------------------------------------------------------
+# Token signing key + JWKS
+# ---------------------------------------------------------------------------
+def generate_signing_key():
+    """Generate the RSA private key used to sign test tokens (in-memory only)."""
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _b64url_uint(value: int) -> str:
+    """Base64url-encode an unsigned integer per JWK (RFC 7518 §6.3)."""
+    # Standard
+    import base64
+
+    raw = value.to_bytes((value.bit_length() + 7) // 8, "big")
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def public_jwk(signing_key, kid: str = TOKEN_KID) -> Dict[str, Any]:
+    """Build the public JWK for the signing key."""
+    numbers = signing_key.public_key().public_numbers()
+    return {
+        "kty": "RSA",
+        "use": "sig",
+        "alg": "RS256",
+        "kid": kid,
+        "n": _b64url_uint(numbers.n),
+        "e": _b64url_uint(numbers.e),
+    }
+
+
+def mint_token(claims: Dict[str, Any], signing_key, kid: str = TOKEN_KID) -> str:
+    """Mint an RS256 token from the local issuer.
+
+    Args:
+        claims: Claim set; callers supply iss/aud/sub/exp/jti per scenario.
+        signing_key: RSA private key from :func:`generate_signing_key`.
+        kid: Key id placed in the JWT header (must match the JWKS entry).
+
+    Returns:
+        The encoded JWT. NEVER log the return value.
+    """
+    return jwt.encode(claims, signing_key, algorithm="RS256", headers={"kid": kid})
+
+
+# ---------------------------------------------------------------------------
+# Issuer application (discovery + JWKS + stub A2A agent)
+# ---------------------------------------------------------------------------
+def build_issuer_app(issuer_url: str, jwk: Dict[str, Any]) -> FastAPI:
+    """Build the FastAPI app serving OIDC discovery, JWKS, and a stub A2A agent.
+
+    The gateway probes RFC 8414 (``/.well-known/oauth-authorization-server``)
+    first, then OIDC discovery; both are served. The stub agent endpoint
+    answers A2A JSON-RPC invocations with a completed task so a fully
+    authorized ``POST /a2a/<agent>/invoke`` on the gateway yields 200.
+    """
+    app = FastAPI(title="cf-local-oidc-issuer")
+    metadata = {
+        "issuer": issuer_url,
+        "jwks_uri": f"{issuer_url}/jwks",
+        "token_endpoint": f"{issuer_url}/token",
+        "authorization_endpoint": f"{issuer_url}/authorize",
+        "response_types_supported": ["code"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["RS256"],
+    }
+
+    @app.get("/.well-known/openid-configuration")
+    async def oidc_configuration() -> Dict[str, Any]:  # noqa: D103
+        return metadata
+
+    @app.get("/.well-known/oauth-authorization-server")
+    async def oauth_authorization_server() -> Dict[str, Any]:  # noqa: D103
+        return metadata
+
+    @app.get("/jwks")
+    async def jwks() -> Dict[str, Any]:  # noqa: D103
+        return {"keys": [jwk]}
+
+    @app.post("/stub-agent/invoke")
+    async def stub_agent_invoke(request: Request) -> JSONResponse:
+        """Stub A2A agent: complete every JSON-RPC invocation immediately."""
+        try:
+            body = await request.json()
+        except Exception:  # pylint: disable=broad-except
+            body = {}
+        request_id = body.get("id", 1) if isinstance(body, dict) else 1
+        result = {
+            "id": "task-local-oidc-1",
+            "contextId": "ctx-local-oidc-1",
+            "status": {"state": "completed"},
+            "artifacts": [],
+            "history": [],
+        }
+        return JSONResponse({"jsonrpc": "2.0", "id": request_id, "result": result})
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# uvicorn-in-a-thread helpers
+# ---------------------------------------------------------------------------
+def _free_port() -> int:
+    """Reserve an ephemeral loopback port (small reuse race, fine for tests)."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _start_server(app: FastAPI, port: int, *, tls: bool) -> tuple[Any, threading.Thread]:
+    """Start uvicorn serving ``app`` on 127.0.0.1:port in a daemon thread.
+
+    Returns ``(server, thread)`` once the server reports started. TLS servers
+    use the material from :func:`ensure_tls_material`.
+    """
+    uvicorn = pytest.importorskip("uvicorn", reason="uvicorn is required for the local OIDC issuer fixture")
+
+    config_kwargs: Dict[str, Any] = {}
+    if tls:
+        ensure_tls_material()
+        config_kwargs = {"ssl_certfile": str(TLS_CERT_FILE), "ssl_keyfile": str(TLS_KEY_FILE)}
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning", **config_kwargs)
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, name=f"local-oidc-issuer:{port}", daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 15
+    while not server.started:
+        if time.monotonic() > deadline:
+            raise RuntimeError(f"local OIDC issuer failed to start on port {port}")
+        time.sleep(0.05)
+    return server, thread
+
+
+def _stop_server(server: Any, thread: threading.Thread) -> None:
+    """Signal the uvicorn server to exit and join its thread."""
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Session fixture
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="session")
+def local_oidc_issuer():
+    """Start the local OIDC issuer (TLS) and stub A2A agent (plain HTTP).
+
+    Yields a namespace with:
+
+    - ``issuer``: the issuer URL (``https://127.0.0.1:<port>``) to seed as
+      the SSO provider's issuer and to place in token ``iss`` claims.
+    - ``tls_cert_file``: path the gateway must trust via ``SSL_CERT_FILE``.
+    - ``stub_agent_url``: plain-HTTP endpoint for the seeded A2A agent.
+    - ``mint_token(claims)``: RS256 token minter bound to this issuer's key.
+    """
+    pytest.importorskip("uvicorn", reason="uvicorn is required for the local OIDC issuer fixture")
+
+    # Standard
+    from types import SimpleNamespace
+
+    ensure_tls_material()
+    signing_key = generate_signing_key()
+    jwk = public_jwk(signing_key)
+
+    tls_port = _free_port()
+    issuer_url = f"https://127.0.0.1:{tls_port}"
+    app = build_issuer_app(issuer_url, jwk)
+
+    issuer_server, issuer_thread = _start_server(app, tls_port, tls=True)
+    agent_port = _free_port()
+    agent_server, agent_thread = _start_server(app, agent_port, tls=False)
+
+    namespace = SimpleNamespace(
+        issuer=issuer_url,
+        jwks_uri=f"{issuer_url}/jwks",
+        tls_cert_file=TLS_CERT_FILE,
+        stub_agent_url=f"http://127.0.0.1:{agent_port}/stub-agent/invoke",
+        kid=TOKEN_KID,
+        mint_token=lambda claims: mint_token(claims, signing_key),
+    )
+    try:
+        yield namespace
+    finally:
+        _stop_server(issuer_server, issuer_thread)
+        _stop_server(agent_server, agent_thread)
+
+
+# ---------------------------------------------------------------------------
+# CLI: materialize the TLS cert before starting the gateway under test
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # Standard
+    import sys
+
+    if len(sys.argv) == 2 and sys.argv[1] == "ensure-material":
+        cert_path = ensure_tls_material()
+        print(f"local OIDC issuer TLS material ready; start the gateway with SSL_CERT_FILE={cert_path}")
+    else:
+        print(__doc__)
+        raise SystemExit(2)

--- a/tests/live_gateway/test_trust_mode_entra_barrier.py
+++ b/tests/live_gateway/test_trust_mode_entra_barrier.py
@@ -3,8 +3,8 @@
 Copyright contributors to the MCP-CONTEXT-FORGE project
 SPDX-License-Identifier: Apache-2.0
 
-Live-gateway evidence for the external-token ingress barrier on the A2A
-invocation route (issues #5884 / #5885, acceptance intent of #5976 / #6272).
+Live-gateway evidence for the external-issuer A2A ingress contract (issues
+#5884 / #5885, acceptance intent of #5976 / #6272; ingress fix #5903).
 
 What this module pins:
 
@@ -12,17 +12,20 @@ What this module pins:
       -> POST /a2a/<deliberately-nonexistent-agent>/invoke
       -> 401 "Invalid authentication credentials"
 
-The agent name is intentionally nonexistent: with a correctly wired
-ingress, an authenticated and authorized caller reaches agent lookup and
-receives 404. The current stack instead rejects the request at
-authentication because the A2A dependency chain
-(``require_permission`` -> ``get_current_user_with_permissions`` ->
-``get_current_user``) calls ContextForge's internal verifier
-(``verify_jwt_token_cached``), which accepts gateway-signed JWTs only.
-The external issuer/JWKS path lives in
-``mcpgateway/utils/verify_credentials.py`` but is never dispatched to on
-this route, so a genuine Entra-signed token is indistinguishable from a
-forged one at this choke point.
+The barrier scenario seeds no SSO providers, so the Entra issuer is NOT a
+configured trust root. Under the post-fix dispatch semantics
+(``get_current_user()`` -> ``_try_external_verification``), an issuer that
+is not a configured trust root falls through to the internal JWT verifier
+exactly as before, and the internal verifier rejects the externally-signed
+token with 401. This 401 is now the correct, by-design fall-through — NOT
+the pre-fix wiring failure, where the external JWKS path was unreachable
+even for a seeded trust root.
+
+The seeded-trust-root denial paths are proven by the ingress matrix
+(tests/live_gateway/test_trust_mode_external_ingress_e2e.py):
+authenticated-without-mapping -> 403 (``unmapped_user_invoke``) and
+authenticated-with-role + deliberately nonexistent agent -> 404
+(``nonexistent_agent_with_role``).
 
 Both tests read the bearer material from untracked files and never log
 their contents:
@@ -34,10 +37,10 @@ Set ``ENTRA_BARRIER_TOKEN_DIR`` if the files live outside the repository
 root. Point ``MCP_CLI_BASE_URL`` at the gateway under test (default
 ``http://127.0.0.1:8080``).
 
-Expected result while the ingress is unfixed: both requests return 401.
-When the external-aware verifier is wired into the authentication choke
-points, the valid-token expectation flips to 404 (agent not found) and
-the fake-token expectation stays 401.
+Expected result: both requests return 401 — the fake token because it is
+forged, the valid token because its issuer is untrusted in this scenario
+(fall-through). A fresh (unexpired) valid token is not required for these
+assertions; expiry does not change the untrusted-issuer outcome.
 """
 
 # Future
@@ -104,21 +107,24 @@ def test_fake_entra_token_is_rejected() -> None:
 
 @skip_unless_trust_mode
 @skip_no_entra_tokens
-def test_valid_entra_user_token_is_blocked_before_external_verification() -> None:
-    """PINNED NON-COMPLIANCE: a genuine Entra user token gets 401 at ingress.
+def test_valid_entra_user_token_untrusted_issuer_falls_to_internal_verifier() -> None:
+    """Unseeded Entra issuer -> fall-through to the internal verifier -> 401.
 
-    With ``JWT_TRUST_MODE=jwt-trust`` and
-    ``SSO_API_TOKEN_AUTH_ENABLED=true`` on the gateway, a real Entra-signed
-    end-user access token still fails the internal verifier before the
-    trust-mode branch, group mapping, RBAC, visibility, or agent lookup can
-    run: the request is rejected exactly like the forged-token control.
+    Post-fix dispatch semantics (#5903): the ingress dispatch in
+    ``get_current_user()`` routes a bearer to the external JWKS verifier
+    only when its issuer IS a configured trust root. The barrier scenario
+    seeds no providers, so the Entra issuer is NOT a configured trust root
+    here and the token falls through to the internal verifier, which
+    rejects it with 401 — the correct, by-design outcome for an untrusted
+    issuer, NOT the pre-fix wiring failure (where even a seeded trust-root
+    token could not authenticate).
 
-    Flipping expectation: once ``get_current_user()`` dispatches external
-    issuers to the JWKS verifier (``verify_credentials_cached``), this
-    caller authenticates, ``a2a.invoke`` authorization proceeds, and the
-    deliberately nonexistent agent yields 404. Update this assertion to
-    404 as part of that change; the fake-token control above must stay 401.
+    The seeded-issuer paths are proven by the ingress matrix
+    (tests/live_gateway/test_trust_mode_external_ingress_e2e.py):
+    authenticated-without-mapping -> 403 (``unmapped_user_invoke``) and
+    authenticated-with-role + nonexistent agent -> 404
+    (``nonexistent_agent_with_role``).
     """
     response = _invoke_agent(_bearer(_VALID_TOKEN_FILE))
-    assert response.status_code == 401, f"Ingress no longer blocked: valid Entra token got {response.status_code} (expected 401 pre-fix, 404 post-fix) {response.text[:200]}"
+    assert response.status_code == 401, f"untrusted-issuer fall-through no longer yields 401: {response.status_code} {response.text[:200]}"
     assert "Invalid authentication credentials" in response.text

--- a/tests/live_gateway/test_trust_mode_external_ingress_e2e.py
+++ b/tests/live_gateway/test_trust_mode_external_ingress_e2e.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/live_gateway/test_trust_mode_external_ingress_e2e.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Black-box external-issuer ingress matrix (issues #5884/#5885, acceptance
+row of #6272; ingress fix #5903).
+
+Proves the authentication choke point (``get_current_user``) dispatches
+external-issuer bearers to the trusted-OIDC-issuer (JWKS) verifier when
+``JWT_TRUST_MODE=jwt-trust``:
+
+    mapped_user_invokes_agent    -> 200  (external authn + group mapping + RBAC + team visibility)
+    unmapped_user_invoke         -> 403  (authn ok, no role -> RBAC Layer-2 deny)
+    wrong_audience_token         -> 401  (trust-root token, definitive failure, fail-closed)
+    missing_revocation_claim     -> 401  (no jti -> unrevocable -> reject, fail-closed)
+    nonexistent_agent_with_role  -> 404  (authn + RBAC ok, agent lookup terminates at 404)
+
+Branch note (PR #6750): rows 1 and 5 are marked ``xfail(strict=False)``.
+On this branch the TokenScopingMiddleware still validates claim-derived
+teams against local ``email_team_members`` and 403s trust-only principals
+("User is no longer a member of the associated team") before RBAC/agent
+lookup. The trusted-team exemption is Task 10 (#5904, PR #6751); both rows
+flip to their pinned status there (XPASS), and rows 2-4 are green here.
+
+Gateway startup (operator-provided; run from the repo root). This exact
+env was verified against a live run: the secret-strength validator rejects
+the repo's conventional weak test secrets, so strong throwaway values are
+required; SSO_ENABLED mounts the provider admin API; the SSRF allowances
+permit the loopback stub-agent endpoint; SSL_CERT_FILE lets the gateway
+trust the issuer's self-signed TLS cert for JWKS:
+
+    mkdir -p /tmp/opencode
+    # one-time: materialize the TLS cert the gateway must trust for JWKS
+    uv run python -m tests.live_gateway.helpers.local_oidc_issuer ensure-material
+
+    AUTH_REQUIRED=true \\
+    MCPGATEWAY_A2A_ENABLED=true \\
+    MCPGATEWAY_ADMIN_API_ENABLED=true \\
+    SSO_ENABLED=true \\
+    JWT_TRUST_MODE=jwt-trust \\
+    SSO_API_TOKEN_AUTH_ENABLED=true \\
+    DATABASE_URL=sqlite:////tmp/opencode/t9-e2e.db \\
+    JWT_SECRET_KEY=t9-e2e-live-secret-3f9a1c7e5b24d68f0a2c4e6f8b1d3a5c7e9f0b2d \\  # pragma: allowlist secret
+    AUTH_ENCRYPTION_SECRET=t9-e2e-encryption-secret-8f4a2c6e0b1d3a5c7e9f2b4d6a8c0e1f \\  # pragma: allowlist secret
+    PLATFORM_ADMIN_PASSWORD='T9-e2e-AdminPass!x9Qw2Kp5' \\  # pragma: allowlist secret
+    DEFAULT_USER_PASSWORD='T9-e2e-DefaultUser!x9Qw2Kp5' \\  # pragma: allowlist secret
+    ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP=false \\
+    PASSWORD_CHANGE_ENFORCEMENT_ENABLED=false \\
+    SSL_CERT_FILE=/tmp/cf-local-oidc-issuer/issuer-tls-cert.pem \\
+    SSRF_ALLOW_LOCALHOST=true \\
+    SSRF_ALLOW_PRIVATE_NETWORKS=true \\
+    uv run uvicorn mcpgateway.main:app --host 127.0.0.1 --port 8013
+
+Then (``JWT_SECRET_KEY`` must match the gateway so the seeded admin token verifies):
+
+    MCP_CLI_BASE_URL=http://127.0.0.1:8013 JWT_TRUST_MODE=jwt-trust \\
+    JWT_SECRET_KEY=t9-e2e-live-secret-3f9a1c7e5b24d68f0a2c4e6f8b1d3a5c7e9f0b2d \\
+        uv run pytest tests/live_gateway/test_trust_mode_external_ingress_e2e.py -v
+
+Seeding happens through the admin API with a gateway-signed platform-admin
+JWT minted from the shared test secret (``JWT_SECRET_KEY`` above): an
+SSOProvider row for the local issuer (``trusted_for_api_auth=True``,
+``api_audience`` pinned), team ``agent-a-team``, A2A agent ``Agent-A``
+(``visibility=team``, endpoint = the harness's stub agent), and the
+external group mapping ``local-issuer-group-1 -> agent-a-team + developer``.
+
+Token material is NEVER logged: assertion messages carry the status code
+and a short body excerpt only (response bodies contain no secrets).
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from datetime import datetime, timedelta, timezone
+import os
+import uuid
+
+# Third-Party
+import httpx
+import pytest
+
+# Local
+from tests.helpers.auth import make_test_jwt
+from .helpers.local_oidc_issuer import local_oidc_issuer  # noqa: F401  # fixture re-export
+from .helpers.mcp_test_helpers import ADMIN_EMAIL, BASE_URL, JWT_SECRET, skip_no_gateway
+
+pytestmark = [pytest.mark.e2e, skip_no_gateway]
+
+# Expected gateway mode for this run; must match the stack configuration.
+EXPECTED_TRUST_MODE = os.getenv("JWT_TRUST_MODE", "db")
+
+skip_unless_trust_mode = pytest.mark.skipif(
+    EXPECTED_TRUST_MODE != "jwt-trust",
+    reason="requires the stack started with JWT_TRUST_MODE=jwt-trust",
+)
+pytestmark.append(skip_unless_trust_mode)
+
+TEAM_NAME = "agent-a-team"
+AGENT_NAME = "Agent-A"
+PROVIDER_ID = "local-oidc-test"
+API_AUDIENCE = "api://local-oidc-test-audience"
+MAPPED_GROUP = "local-issuer-group-1"
+UNMAPPED_GROUP = "local-issuer-group-unmapped"
+NONEXISTENT_AGENT = "Agent-A-that-does-not-exist"
+
+MATRIX = [
+    # (scenario, expected status)
+    pytest.param(
+        "mapped_user_invokes_agent",
+        200,  # #6272 acceptance row
+        marks=pytest.mark.xfail(
+            reason=(
+                "TokenScopingMiddleware validates mapped teams against local email_team_members; "
+                "trust-only principals have none -> 403 'User is no longer a member'. "
+                "The trusted-team exemption is Task 10 (#5904, PR #6751); this row flips to 200 there."
+            ),
+            strict=False,
+        ),
+    ),
+    ("unmapped_user_invoke", 403),  # authn ok, RBAC deny (deny without disclosure)
+    ("wrong_audience_token", 401),  # trust-root token, definitive failure -> fail-closed
+    ("missing_revocation_claim", 401),  # no jti -> unrevocable -> reject
+    pytest.param(
+        "nonexistent_agent_with_role",
+        404,  # authenticated + authorized -> agent lookup 404
+        marks=pytest.mark.xfail(
+            reason=(
+                "Blocked upstream of agent lookup by the same TokenScopingMiddleware membership check; "
+                "Task 10 (#5904, PR #6751) exempts resolver-derived trusted teams and this row flips to 404."
+            ),
+            strict=False,
+        ),
+    ),
+]
+
+
+def _admin_headers() -> dict[str, str]:
+    """Gateway-signed platform-admin headers for seeding (shared test secret).
+
+    token_use="session" gives DB-authoritative team resolution: the platform
+    admin resolves to the admin bypass (token_teams=None), whereas a
+    claim-less token would resolve token_teams=[] and the public-only
+    semantics would suppress admin bypass on the admin APIs.
+    """
+    token = make_test_jwt(ADMIN_EMAIL, is_admin=True, secret=JWT_SECRET, token_use="session")
+    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+
+def _base_claims(local_oidc_issuer, subject: str) -> dict:
+    """Standard claim set for a local-issuer end-user token."""
+    now = datetime.now(timezone.utc)
+    return {
+        "iss": local_oidc_issuer.issuer,
+        "sub": subject,
+        "aud": API_AUDIENCE,
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(minutes=30)).timestamp()),
+        "jti": uuid.uuid4().hex,
+    }
+
+
+def _mint_user_token(local_oidc_issuer, subject: str, *, groups: list[str]) -> str:
+    """Mint a mapped/unmapped end-user token (RS256, local issuer key)."""
+    claims = _base_claims(local_oidc_issuer, subject)
+    claims["email"] = f"{subject}@example.com"
+    claims["name"] = f"Live {subject}"
+    claims["groups"] = groups
+    return local_oidc_issuer.mint_token(claims)
+
+
+def _invoke_agent(agent_name: str, token: str) -> httpx.Response:
+    """POST the A2A invocation route with the given bearer token."""
+    return httpx.post(
+        f"{BASE_URL}/a2a/{agent_name}/invoke",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        json={"parameters": {}, "interaction_type": "query"},
+        timeout=20,
+    )
+
+
+def _seed_team(client: httpx.Client) -> str:
+    """Create (or reuse) team ``agent-a-team``; return its team ID."""
+    response = client.post(f"{BASE_URL}/teams/", json={"name": TEAM_NAME, "description": "T9 ingress matrix team"})
+    if response.status_code not in (200, 201):
+        # Re-run against a reused database: find the existing team by name.
+        listing = client.get(f"{BASE_URL}/teams/", params={"include_inactive": "false"})
+        assert listing.status_code == 200, f"team seed failed: {response.status_code} {response.text[:200]}; listing failed: {listing.status_code}"
+        body = listing.json()
+        teams = body.get("teams", body) if isinstance(body, dict) else body
+        for team in teams:
+            if isinstance(team, dict) and team.get("name") == TEAM_NAME:
+                return team["id"]
+        raise AssertionError(f"team seed failed: {response.status_code} {response.text[:200]}")
+    return response.json()["id"]
+
+
+def _seed_provider(client: httpx.Client, local_oidc_issuer) -> None:
+    """Create the SSOProvider trust root for the local issuer (idempotent)."""
+    # Delete-first keeps re-runs against a reused database deterministic.
+    client.delete(f"{BASE_URL}/auth/sso/admin/providers/{PROVIDER_ID}")
+    payload = {
+        "id": PROVIDER_ID,
+        "name": PROVIDER_ID,
+        "display_name": "Local OIDC Test Issuer",
+        "provider_type": "oidc",
+        "client_id": "local-oidc-test-client",
+        "client_secret": "local-oidc-test-secret",  # pragma: allowlist secret
+        "authorization_url": f"{local_oidc_issuer.issuer}/authorize",
+        "token_url": f"{local_oidc_issuer.issuer}/token",
+        "userinfo_url": f"{local_oidc_issuer.issuer}/userinfo",
+        "issuer": local_oidc_issuer.issuer,
+        "trusted_for_api_auth": True,
+        "api_audience": API_AUDIENCE,
+    }
+    response = client.post(f"{BASE_URL}/auth/sso/admin/providers", json=payload)
+    assert response.status_code in (200, 201), f"provider seed failed: {response.status_code} {response.text[:200]}"
+
+
+def _seed_agent(client: httpx.Client, team_id: str, local_oidc_issuer) -> None:
+    """Register Agent-A (team-visible, endpoint = harness stub agent)."""
+    payload = {
+        "agent": {
+            "name": AGENT_NAME,
+            "description": "T9 ingress matrix stub agent",
+            "endpoint_url": local_oidc_issuer.stub_agent_url,
+            "agent_type": "generic",
+        },
+        "team_id": team_id,
+        "visibility": "team",
+    }
+    response = client.post(f"{BASE_URL}/a2a/", json=payload)
+    assert response.status_code in (200, 201, 409), f"agent seed failed: {response.status_code} {response.text[:200]}"
+
+
+def _seed_mapping(client: httpx.Client, team_id: str, local_oidc_issuer) -> None:
+    """Map external group -> team + developer role (idempotent on re-run)."""
+    payload = {
+        "issuer": local_oidc_issuer.issuer,
+        "tenant": None,
+        "external_group_id": MAPPED_GROUP,
+        "cf_team_id": team_id,
+        "cf_role": "developer",
+    }
+    response = client.post(f"{BASE_URL}/admin/external-group-mappings", json=payload)
+    assert response.status_code in (200, 201, 409), f"mapping seed failed: {response.status_code} {response.text[:200]}"
+
+
+@pytest.fixture(scope="module")
+def seeded_gateway(local_oidc_issuer) -> dict[str, str]:
+    """Seed the trust root, team, agent, and mapping; mint scenario tokens.
+
+    Returns a scenario -> bearer-token mapping. Token material stays inside
+    the fixture; tests only forward it in the Authorization header.
+    """
+    with httpx.Client(headers=_admin_headers(), timeout=20) as client:
+        team_id = _seed_team(client)
+        _seed_provider(client, local_oidc_issuer)
+        _seed_agent(client, team_id, local_oidc_issuer)
+        _seed_mapping(client, team_id, local_oidc_issuer)
+
+    mapped_token = _mint_user_token(local_oidc_issuer, "oid-mapped-user-0001", groups=[MAPPED_GROUP])
+    unmapped_token = _mint_user_token(local_oidc_issuer, "oid-unmapped-user-0001", groups=[UNMAPPED_GROUP])
+
+    wrong_audience_claims = _base_claims(local_oidc_issuer, "oid-mapped-user-0001")
+    wrong_audience_claims["aud"] = "api://not-the-gateway"
+    wrong_audience_claims["groups"] = [MAPPED_GROUP]
+    wrong_audience_token = local_oidc_issuer.mint_token(wrong_audience_claims)
+
+    no_jti_claims = _base_claims(local_oidc_issuer, "oid-mapped-user-0001")
+    del no_jti_claims["jti"]
+    no_jti_claims["groups"] = [MAPPED_GROUP]
+    missing_jti_token = local_oidc_issuer.mint_token(no_jti_claims)
+
+    return {
+        "mapped": mapped_token,
+        "unmapped": unmapped_token,
+        "wrong_audience": wrong_audience_token,
+        "missing_jti": missing_jti_token,
+    }
+
+
+@pytest.mark.parametrize("scenario,expected", MATRIX)
+def test_ingress_matrix(scenario, expected, local_oidc_issuer, seeded_gateway):
+    """External-issuer ingress matrix against the live trust-mode gateway."""
+    if scenario == "mapped_user_invokes_agent":
+        response = _invoke_agent(AGENT_NAME, seeded_gateway["mapped"])
+    elif scenario == "unmapped_user_invoke":
+        response = _invoke_agent(AGENT_NAME, seeded_gateway["unmapped"])
+    elif scenario == "wrong_audience_token":
+        response = _invoke_agent(AGENT_NAME, seeded_gateway["wrong_audience"])
+    elif scenario == "missing_revocation_claim":
+        response = _invoke_agent(AGENT_NAME, seeded_gateway["missing_jti"])
+    elif scenario == "nonexistent_agent_with_role":
+        response = _invoke_agent(NONEXISTENT_AGENT, seeded_gateway["mapped"])
+    else:  # pragma: no cover - parametrization guard
+        raise AssertionError(f"unknown scenario {scenario}")
+
+    assert response.status_code == expected, f"{scenario}: expected {expected}, got {response.status_code} {response.text[:200]}"
+    if scenario == "unmapped_user_invoke":
+        # The deny must come from RBAC (Layer 2), not from the token-scoping
+        # membership check: the unmapped principal has NO mapped teams
+        # (public-only), so "no longer a member" here would mean claim
+        # extraction fabricated a team grant.
+        assert "no longer a member" not in response.text, f"{scenario}: deny came from the wrong layer: {response.text[:200]}"

--- a/tests/unit/mcpgateway/test_jwt_trust_config.py
+++ b/tests/unit/mcpgateway/test_jwt_trust_config.py
@@ -106,6 +106,33 @@ class TestClaimTeamsGroupClaimCollision:
         s = _settings(jwt_trust_mode="db", jwt_claim_teams="groups", sso_entra_groups_claim="groups")
         assert s.jwt_trust_mode == "db"
 
+    def test_claim_teams_cannot_alias_keycloak_group_mapping_source(self):
+        # Non-Entra trust roots are live (#5903): the Keycloak groups claim
+        # feeds the same resolver, so the collision guard must cover it.
+        with pytest.raises(SecurityConfigurationError) as exc_info:
+            _settings(jwt_trust_mode="jwt-trust", jwt_claim_teams="groups", sso_entra_groups_claim="entra-groups", sso_keycloak_groups_claim="groups")
+        message = str(exc_info.value)
+        assert "JWT_CLAIM_TEAMS" in message
+        assert "SSO_KEYCLOAK_GROUPS_CLAIM" in message
+
+    def test_claim_teams_cannot_alias_generic_group_mapping_source(self):
+        with pytest.raises(SecurityConfigurationError) as exc_info:
+            _settings(jwt_trust_mode="jwt-trust", jwt_claim_teams="groups", sso_entra_groups_claim="entra-groups", sso_keycloak_groups_claim="kc-groups", sso_generic_groups_claim="groups")
+        message = str(exc_info.value)
+        assert "JWT_CLAIM_TEAMS" in message
+        assert "SSO_GENERIC_GROUPS_CLAIM" in message
+
+    def test_collision_detection_is_case_insensitive(self):
+        with pytest.raises(SecurityConfigurationError) as exc_info:
+            _settings(jwt_trust_mode="jwt-trust", jwt_claim_teams="Groups", sso_entra_groups_claim="groups")
+        message = str(exc_info.value)
+        assert "JWT_CLAIM_TEAMS" in message
+        assert "SSO_ENTRA_GROUPS_CLAIM" in message
+
+    def test_case_insensitive_match_across_providers_rejected(self):
+        with pytest.raises(SecurityConfigurationError):
+            _settings(jwt_trust_mode="jwt-trust", jwt_claim_teams="GROUPS", sso_entra_groups_claim="entra-groups", sso_keycloak_groups_claim="groups")
+
 
 class TestComposeDeclaresTrustFlags:
     """The supported Compose stacks declare the trust flags, commented and default-off."""

--- a/tests/unit/mcpgateway/test_token_dispatch_matrix.py
+++ b/tests/unit/mcpgateway/test_token_dispatch_matrix.py
@@ -303,3 +303,190 @@ class TestTokenDispatchMatrix:
 
         # Trust-semantics: claims-derived identity, no local provisioning.
         mock_build.assert_not_called()
+
+
+def _external_payload() -> dict:
+    """Claims-derived identity payload as build_trusted_external_identity returns it.
+
+    Carries the original token claims (sub/email/groups/jti) plus the derived
+    trust markers, exactly the shape ``_maybe_verify_external`` yields on the
+    trust-root branch.
+    """
+    return {
+        "iss": "https://idp.example.test",
+        "sub": "ext-subject-0001",
+        "email": "ext.user@example.com",
+        "user_id": "ext-subject-0001",
+        "groups": ["external-group-1"],
+        "teams": [],
+        "roles": [],
+        "is_admin": False,
+        "jti": "ext-jti-ingress-1",
+        "exp": _exp(),
+        "token_use": "trusted",
+        "source": "external_idp",
+        "auth_provider": "local-oidc-test",
+    }
+
+
+class TestIngressExternalDispatch:
+    """get_current_user() trust-mode ingress dispatch (#5903 / Task 9).
+
+    Dispatch contract pinned here (mirrors docs/5896 and AGENTS.md):
+
+    - Trust mode ON + issuer is a configured trust root + verification
+      succeeds -> external principal (token_use="trusted" branch).
+    - Trust mode ON + issuer is a configured trust root + definitive
+      verification failure -> 401 fail-closed; the internal verifier is
+      NEVER consulted for that token.
+    - Trust mode ON + issuer NOT a trust root -> fall through to the
+      internal funnel exactly as before.
+    - Trust mode OFF (db) -> external path is never entered.
+    - No credentials -> 401 (pre-existing behavior, pinned).
+    """
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_invoke_401(self):
+        """No bearer credentials -> 401 (existing behavior, pinned)."""
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials=None, request=None)
+
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.asyncio
+    async def test_db_mode_external_token_stays_on_internal_funnel(self, monkeypatch):
+        """Trust mode OFF + external-issuer token -> 401 via the internal funnel.
+
+        The external dispatch must never run: with jwt_trust_mode="db" the
+        internal verifier alone decides, and it rejects externally-signed
+        tokens.
+        """
+        # Third-Party
+        import jwt as pyjwt
+
+        # First-Party
+        from mcpgateway.utils import verify_credentials as vc
+
+        token = pyjwt.encode({"iss": "https://idp.example.test", "sub": "ext", "exp": _exp()}, "k", algorithm="HS256")
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)  # pragma: allowlist secret
+
+        monkeypatch.setattr(settings, "jwt_trust_mode", "db")
+        external_dispatch = AsyncMock(side_effect=AssertionError("external path entered in db mode"))
+        monkeypatch.setattr(vc, "_maybe_verify_external", external_dispatch)
+
+        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(side_effect=HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid authentication credentials"))):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(credentials=credentials, request=None)
+
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+        external_dispatch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_trust_mode_external_token_authenticates_via_external_path(self, monkeypatch):
+        """Trust mode ON + trust-root token -> claims-derived principal.
+
+        The internal verifier would reject this RS256-style external token
+        (mocked to 401); the request still authenticates because the ingress
+        dispatch consults the external verifier FIRST and its payload flows
+        into the token_use="trusted" branch.
+        """
+        # Third-Party
+        import jwt as pyjwt
+
+        # First-Party
+        from mcpgateway.utils import verify_credentials as vc
+
+        token = pyjwt.encode({"iss": "https://idp.example.test", "sub": "ext-subject-0001", "exp": _exp()}, "k", algorithm="HS256")
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)  # pragma: allowlist secret
+
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+        _repoint_funnel_sessions(monkeypatch)
+
+        external_dispatch = AsyncMock(return_value=_external_payload())
+        monkeypatch.setattr(vc, "_maybe_verify_external", external_dispatch)
+        internal_verifier = AsyncMock(side_effect=HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid authentication credentials"))
+
+        request = SimpleNamespace(state=SimpleNamespace())
+        with patch("mcpgateway.auth.verify_jwt_token_cached", internal_verifier):
+            with patch("mcpgateway.auth._check_token_revoked_sync", return_value=False):
+                user = await get_current_user(credentials=credentials, request=request)
+
+        assert user.email == "ext.user@example.com"
+        assert request.state.token_use == "trusted"
+        external_dispatch.assert_awaited_once()
+        internal_verifier.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_trust_mode_trust_root_invalid_token_fails_closed(self, monkeypatch):
+        """Trust mode ON + trust-root token that fails verification -> 401.
+
+        Fail-closed: a definitive external-verification failure (bad
+        signature, wrong audience, expired, missing revocation claim) must
+        NOT fall through to the internal funnel for that token.
+        """
+        # Third-Party
+        import jwt as pyjwt
+
+        # First-Party
+        from mcpgateway.utils import verify_credentials as vc
+
+        token = pyjwt.encode({"iss": "https://idp.example.test", "sub": "ext", "exp": _exp()}, "k", algorithm="HS256")
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)  # pragma: allowlist secret
+
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        external_dispatch = AsyncMock(side_effect=vc.ExternalIssuerVerificationError("trust-root token failed verification"))
+        monkeypatch.setattr(vc, "_maybe_verify_external", external_dispatch)
+        internal_verifier = AsyncMock(return_value={"sub": "internal@example.com", "exp": _exp(), "jti": "internal-jti"})
+
+        with patch("mcpgateway.auth.verify_jwt_token_cached", internal_verifier):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(credentials=credentials, request=SimpleNamespace(state=SimpleNamespace()))
+
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+        external_dispatch.assert_awaited_once()
+        internal_verifier.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_trust_mode_non_trust_root_token_falls_through_to_internal(self, monkeypatch):
+        """Trust mode ON + issuer NOT a trust root -> internal funnel as today.
+
+        The external dispatch returns None (not external-issuer material) and
+        the internal verifier decides; a gateway-signed JWT still
+        authenticates with trust mode ON (no regression).
+        """
+        # Third-Party
+        import jwt as pyjwt
+
+        # First-Party
+        from mcpgateway.utils import verify_credentials as vc
+
+        token = pyjwt.encode({"iss": "mcpgateway", "sub": "api@example.com", "exp": _exp()}, "k", algorithm="HS256")
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)  # pragma: allowlist secret
+
+        jwt_payload = {
+            "sub": "api@example.com",
+            "token_use": "api",
+            "teams": ["api-team-1"],
+            "exp": _exp(),
+            "user": {"auth_provider": "api_token"},
+        }
+
+        request = SimpleNamespace(state=SimpleNamespace())
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+
+        external_dispatch = AsyncMock(return_value=None)
+        monkeypatch.setattr(vc, "_maybe_verify_external", external_dispatch)
+        internal_verifier = AsyncMock(return_value=jwt_payload)
+
+        with patch("mcpgateway.auth.verify_jwt_token_cached", internal_verifier):
+            with patch("mcpgateway.auth._get_user_by_email_sync", return_value=_make_user("api@example.com")):
+                with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
+                    user = await get_current_user(credentials=credentials, request=request)
+
+        assert user.email == "api@example.com"
+        assert request.state.token_use == "api"
+        internal_verifier.assert_awaited_once()

--- a/tests/unit/mcpgateway/test_token_dispatch_matrix.py
+++ b/tests/unit/mcpgateway/test_token_dispatch_matrix.py
@@ -12,9 +12,8 @@ docs/docs/architecture/auth-token-dispatch.md:
   That IS the documented behavior for these rows.
 - The gateway-signed branch-(a) rows are green since #5900 landed the
   trust branch in get_current_user.
-- The external-IdP branch-(b) row carries pytest.mark.xfail(strict=True)
-  with a pointer to #5903, which lands the external IdP trust root.
-  strict=True turns any premature XPASS into a suite failure.
+- The external-IdP branch-(b) row is green since #5903 landed the
+  external IdP trust root.
 """
 
 # Standard
@@ -268,8 +267,6 @@ class TestTokenDispatchMatrix:
 
                         assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
 
-    # Flipped by #5903 (external IdP trust root)
-    @pytest.mark.xfail(strict=True, reason="Flipped by #5903")
     @pytest.mark.asyncio
     async def test_external_idp_token_trust_mode_trust_semantics(self, monkeypatch):
         """Trust mode + external IdP token (trusted issuer) -> trust-semantics.
@@ -277,8 +274,8 @@ class TestTokenDispatchMatrix:
         The issuer is a configured trust root, so the token is
         trust-eligible via the issuer branch: the identity is built from
         token claims alone and the provisioning path
-        (build_external_identity) is not invoked. Today the external-IdP
-        path always provisions, so the no-provisioning assertion fails.
+        (build_external_identity) is not invoked. Green since #5903 landed
+        the external IdP trust root.
         """
         # Third-Party
         import jwt as pyjwt
@@ -290,6 +287,7 @@ class TestTokenDispatchMatrix:
         provider = _fake_provider("https://kc/realms/m")
 
         monkeypatch.setattr(vc.settings, "sso_api_token_auth_enabled", True)
+        monkeypatch.setattr(vc.settings, "jwt_trust_mode", "jwt-trust")
         monkeypatch.setattr(vc, "_has_trusted_providers", lambda db: True)
 
         async def fake_verify_external(tok, db):

--- a/tests/unit/mcpgateway/utils/test_external_idp_trust_mode.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_trust_mode.py
@@ -1,0 +1,320 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/utils/test_external_idp_trust_mode.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for the external-IdP trust root (issue #5903).
+
+When jwt_trust_mode is "jwt-trust" and the token issuer is a configured
+trust root (trusted_for_api_auth + api_audience), build_external_identity
+builds the identity from the verified token claims alone. No local user
+record is read or written: a SQL listener proves zero INSERTs and zero
+SELECTs against email_users. Teams and roles come from
+resolve_external_groups_to_teams; is_admin comes from the mapped claim.
+A token that lacks the configured revocation claim is rejected (the caller
+maps the None return to a 401). The three overage policies are executable:
+fail_closed, graph_lookup (WO-B.7 client mocked), proceed_without_groups.
+"""
+
+# Standard
+import logging
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+# Third-Party
+import jwt as pyjwt
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.config import settings
+from mcpgateway.db import Base, EmailTeam, EmailUser, ExternalGroupMapping, Role, SSOProvider
+from mcpgateway.utils import verify_credentials as vc
+
+ISSUER = "https://login.example.com/tenant-1/v2.0"
+TENANT = "tenant-1"
+API_AUDIENCE = "api://my-app"
+CALLER_ID = "oid-9f8e7d6c"
+CALLER_EMAIL = "trust.user@example.com"
+
+
+def _claims(**overrides):
+    """Minimal trust-eligible external-IdP claims: sub, iss, jti, exp."""
+    claims = {
+        "sub": CALLER_ID,
+        "oid": CALLER_ID,
+        "iss": ISSUER,
+        "tid": TENANT,
+        "aud": API_AUDIENCE,
+        "jti": "trusted-jti-1",
+        "exp": 9999999999,
+    }
+    claims.update(overrides)
+    return claims
+
+
+class SqlRecorder:
+    """Records every SQL statement emitted on an engine."""
+
+    def __init__(self):
+        """Initialize an empty statement log."""
+        self.statements: list[str] = []
+
+    def _record(self, _conn, _cursor, statement, _parameters, _context, _executemany):
+        self.statements.append(statement)
+
+    def attach(self, engine):
+        """Start recording statements on the engine."""
+        sa.event.listen(engine, "before_cursor_execute", self._record)
+
+    def detach(self, engine):
+        """Stop recording statements on the engine."""
+        sa.event.remove(engine, "before_cursor_execute", self._record)
+
+    def count(self, verb: str, table: str) -> int:
+        """Count recorded statements of the given verb that touch the table."""
+        return sum(1 for statement in self.statements if verb in statement.upper() and table in statement.upper())
+
+
+@pytest.fixture
+def db():
+    """In-memory SQLite session seeded with a trust root and mapping rows.
+
+    The SSO provider is a configured trust root (trusted_for_api_auth plus
+    api_audience). Mapping rows: entra-group-guid-1 -> team-a with
+    cf_role=developer; entra-group-guid-2 -> team-b with cf_role NULL. No
+    EmailUser row exists for the caller identity.
+    """
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    owner = EmailUser(
+        email="owner@example.com",
+        password_hash="hash",  # pragma: allowlist secret
+        full_name="Owner",
+        is_admin=False,
+        is_active=True,
+        email_verified_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    session.add(owner)
+    session.add(EmailTeam(id="team-a", name="Team A", slug="team-a", created_by=owner.email, is_personal=False, visibility="private"))
+    session.add(EmailTeam(id="team-b", name="Team B", slug="team-b", created_by=owner.email, is_personal=False, visibility="private"))
+    session.add(Role(name="developer", scope="team", permissions=["a2a.invoke"], created_by=owner.email, is_system_role=True, is_active=True))
+    session.add(Role(name="viewer", scope="team", permissions=[], created_by=owner.email, is_system_role=True, is_active=True))
+    session.add(ExternalGroupMapping(issuer=ISSUER, tenant=TENANT, external_group_id="entra-group-guid-1", cf_team_id="team-a", cf_role="developer"))
+    session.add(ExternalGroupMapping(issuer=ISSUER, tenant=TENANT, external_group_id="entra-group-guid-2", cf_team_id="team-b", cf_role=None))
+    session.add(
+        SSOProvider(
+            id="entra",
+            name="entra",
+            display_name="Entra",
+            provider_type="oidc",
+            is_enabled=True,
+            client_id="client-1",
+            client_secret_encrypted="encrypted",  # pragma: allowlist secret
+            authorization_url="https://login.example.com/authorize",
+            token_url="https://login.example.com/token",
+            userinfo_url="https://login.example.com/userinfo",
+            issuer=ISSUER,
+            trusted_for_api_auth=True,
+            api_audience=API_AUDIENCE,
+        )
+    )
+    session.commit()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _provider(db):
+    """Return the seeded trust-root provider row."""
+    return db.query(SSOProvider).filter(SSOProvider.id == "entra").one()
+
+
+async def _async_none():
+    """Async stand-in for get_redis_client: forces the in-memory cache."""
+    return None
+
+
+class TestTrustModeNoProvisioning:
+    """Trust mode + trust root: identity from claims, zero email_users access."""
+
+    @pytest.mark.asyncio
+    async def test_trust_root_token_builds_identity_without_email_users_access(self, db, monkeypatch):
+        """Claims-derived identity: zero INSERTs and zero SELECTs on email_users."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        provider = _provider(db)
+        claims = _claims(email=CALLER_EMAIL, name="Trust User", is_admin=True, groups=["entra-group-guid-1"])
+        token = pyjwt.encode(claims, "k", algorithm="HS256")
+
+        recorder = SqlRecorder()
+        recorder.attach(db.get_bind())
+        try:
+            payload = await vc.build_external_identity(provider, claims, token, db)
+        finally:
+            recorder.detach(db.get_bind())
+
+        assert recorder.count("INSERT", "EMAIL_USERS") == 0
+        assert recorder.count("SELECT", "EMAIL_USERS") == 0
+        assert payload is not None
+        assert payload["token_use"] == "trusted"
+        assert payload["sub"] == CALLER_ID
+        assert payload["user_id"] == CALLER_ID
+        assert payload["email"] == CALLER_EMAIL
+        # Teams and roles derive from resolve_external_groups_to_teams, not a DB user.
+        assert payload["teams"] == ["team-a"]
+        assert payload["roles"] == ["developer", "platform_admin"]
+        # is_admin derives from the mapped claim; no DB row exists for the caller.
+        assert payload["is_admin"] is True
+
+    @pytest.mark.asyncio
+    async def test_maybe_verify_external_trust_mode_end_to_end(self, db, monkeypatch):
+        """JWKS-mocked IdP: verification plus trust identity, zero provisioning."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        monkeypatch.setattr(settings, "sso_api_token_auth_enabled", True)
+        monkeypatch.setattr(vc, "_has_trusted_providers", lambda _db: True)
+        monkeypatch.setattr(vc, "get_redis_client", _async_none)
+        provider = _provider(db)
+        monkeypatch.setattr(vc, "resolve_trusted_provider_by_issuer", lambda _iss, _db: provider)
+
+        claims = _claims(email=CALLER_EMAIL, groups=["entra-group-guid-2"])
+        token = pyjwt.encode(claims, "k", algorithm="HS256")
+
+        async def fake_verify_oauth(_token, authorization_servers, *, expected_audience=None):
+            return claims
+
+        monkeypatch.setattr(vc, "verify_oauth_access_token", fake_verify_oauth)
+        await vc.invalidate_external_identity_cache()
+
+        recorder = SqlRecorder()
+        recorder.attach(db.get_bind())
+        try:
+            request = SimpleNamespace(state=SimpleNamespace(db=db))
+            payload = await vc._maybe_verify_external(token, request)
+        finally:
+            recorder.detach(db.get_bind())
+
+        assert recorder.count("INSERT", "EMAIL_USERS") == 0
+        assert recorder.count("SELECT", "EMAIL_USERS") == 0
+        assert payload is not None
+        assert payload["token_use"] == "trusted"
+        assert payload["teams"] == ["team-b"]
+
+
+class TestRevocationClaimGate:
+    """A trust-eligible token must carry the configured revocation claim."""
+
+    @pytest.mark.asyncio
+    async def test_missing_configured_jti_returns_none_with_log(self, db, monkeypatch, caplog):
+        """Revocation claim jti configured; token has no jti -> None + log naming jti."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        monkeypatch.setattr(settings, "jwt_trust_revocation_claim", "jti")
+        claims = _claims(email=CALLER_EMAIL)
+        del claims["jti"]
+
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.verify_credentials"):
+            payload = await vc.build_external_identity(_provider(db), claims, "rawtoken", db)
+
+        assert payload is None
+        assert "'jti'" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_uti_configured_uti_present_jti_absent_succeeds(self, db, monkeypatch):
+        """Revocation claim uti configured; token has uti and no jti -> success."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        monkeypatch.setattr(settings, "jwt_trust_revocation_claim", "uti")
+        claims = _claims(email=CALLER_EMAIL, uti="entra-uti-1")
+        del claims["jti"]
+
+        payload = await vc.build_external_identity(_provider(db), claims, "rawtoken", db)
+
+        assert payload is not None
+        assert payload["token_use"] == "trusted"
+
+    @pytest.mark.asyncio
+    async def test_uti_configured_neither_claim_present_rejected(self, db, monkeypatch, caplog):
+        """Revocation claim uti configured; token has neither uti nor jti -> rejected."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        monkeypatch.setattr(settings, "jwt_trust_revocation_claim", "uti")
+        claims = _claims(email=CALLER_EMAIL)
+        del claims["jti"]
+
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.verify_credentials"):
+            payload = await vc.build_external_identity(_provider(db), claims, "rawtoken", db)
+
+        assert payload is None
+        assert "'uti'" in caplog.text
+
+
+class TestOveragePolicies:
+    """The three jwt_trust_overage_policy behaviors are executable."""
+
+    @pytest.mark.asyncio
+    async def test_overage_fail_closed_rejects(self, db, monkeypatch):
+        """Overage markers + fail_closed -> 401 semantics (None return)."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        monkeypatch.setattr(settings, "jwt_trust_overage_policy", "fail_closed")
+        claims = _claims(email=CALLER_EMAIL, _claim_names={"groups": "src1"}, hasgroups=True)
+
+        payload = await vc.build_external_identity(_provider(db), claims, "rawtoken", db)
+
+        assert payload is None
+
+    @pytest.mark.asyncio
+    async def test_overage_graph_lookup_resolves_via_client(self, db, monkeypatch):
+        """Overage markers + graph_lookup -> groups resolve via the WO-B.7 client."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        monkeypatch.setattr(settings, "jwt_trust_overage_policy", "graph_lookup")
+        claims = _claims(email=CALLER_EMAIL, _claim_names={"groups": "src1"}, hasgroups=True)
+
+        client = MagicMock()
+        client.get_member_groups = AsyncMock(return_value=["entra-group-guid-1"])
+        monkeypatch.setattr("mcpgateway.utils.trusted_claims.EntraGraphClient", lambda: client)
+
+        payload = await vc.build_external_identity(_provider(db), claims, "rawtoken", db)
+
+        assert payload is not None
+        client.get_member_groups.assert_awaited_once()
+        assert client.get_member_groups.await_args.args[1] == CALLER_ID
+        # Resolved groups map through resolve_external_groups_to_teams.
+        assert payload["teams"] == ["team-a"]
+        assert payload["roles"] == ["developer"]
+
+    @pytest.mark.asyncio
+    async def test_overage_proceed_without_groups_degrades(self, db, monkeypatch, caplog):
+        """Overage markers + proceed_without_groups -> teams=[], WARNING with oid."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        monkeypatch.setattr(settings, "jwt_trust_overage_policy", "proceed_without_groups")
+        claims = _claims(email=CALLER_EMAIL, _claim_names={"groups": "src1"}, hasgroups=True)
+
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.trusted_claims"):
+            payload = await vc.build_external_identity(_provider(db), claims, "rawtoken", db)
+
+        assert payload is not None
+        assert payload["teams"] == []
+        assert payload["token_use"] == "trusted"
+        assert any(CALLER_ID in record.message for record in caplog.records)
+
+
+class TestTrustIdentityCache:
+    """invalidate_external_identity_cache covers the claims-derived path."""
+
+    @pytest.mark.asyncio
+    async def test_invalidate_clears_trust_mode_entry(self, monkeypatch):
+        """A trust-mode cache entry (token-hash key) is gone after invalidate."""
+        monkeypatch.setattr(vc, "get_redis_client", _async_none)
+        token_hash = vc._token_hash("trust-mode-raw-token")  # pylint: disable=protected-access
+
+        await vc._external_identity_cache_put(token_hash, {"sub": CALLER_ID, "token_use": "trusted"}, 9999999999)  # pylint: disable=protected-access
+        assert await vc._external_identity_cache_get(token_hash) is not None  # pylint: disable=protected-access
+
+        await vc.invalidate_external_identity_cache()
+
+        assert await vc._external_identity_cache_get(token_hash) is None  # pylint: disable=protected-access


### PR DESCRIPTION
`build_external_identity` and `_maybe_verify_external` now branch on trust mode: when `jwt_trust_mode="jwt-trust"` and the issuer is a configured trust root (`SSOProvider.trusted_for_api_auth` + `api_audience`), the identity builds from verified claims via `extract_trusted_principal` — `token_use="trusted"`, `authenticate_or_create_user` provisioning skipped, no `get_user_by_email`, no DB `is_admin`. JWKS validation and iss/aud checks are unchanged; default-mode provisioning is untouched. External group IDs map through `resolve_external_groups_to_teams`; overage tokens dispatch on `jwt_trust_overage_policy` (graph_lookup uses the #5977 app-only client). A trust-eligible token missing the configured revocation claim (`jti` default, `uti` supported) is rejected. `invalidate_external_identity_cache` covers the claims-derived path (token-hash key, tested).

The B.1 dispatch-matrix external-IdP row flips from strict-xfail to green in this commit — the matrix file now contains zero xfail markers. The flip required one added line (`jwt_trust_mode` monkeypatch) so the row exercises what its own contract states.

Tested with:
- `uv run pytest tests/unit/mcpgateway/utils/test_external_idp_trust_mode.py -q` — 9 passed (TDD: 8 failed first — the provisioning path ran). Includes the SQLAlchemy `before_cursor_execute` recorder proof: ZERO `INSERT` and ZERO `SELECT` against `email_users` on the trust path; teams/roles from seeded mapping rows with no user row; `is_admin` from the mapped claim.
- `uv run pytest tests -k "external_idp or sso_token" -q` — 86 tests, 0 failures
- `uv run pytest tests/unit/mcpgateway/test_token_dispatch_matrix.py -q` — 6 passed, zero xfail
- `make ruff` — all checks passed; `make test` — 23343 passed, 879 skipped, 2 xfailed (the two pre-existing plugin rows — the last trust xfails are gone)

Acceptance criteria of #5903 are met. Risk to existing users: none — default mode byte-identical.

Stack: B.11 of epic #5885 (base: #6749).

Closes #5903