### PR TITLE
feat(auth): align token catalog and secondary auth choke points with trust mode

### DIFF
--- a/mcpgateway/api/v1/__init__.py
+++ b/mcpgateway/api/v1/__init__.py
@@ -307,6 +307,14 @@ def _assemble_routers(  # noqa: C901 — deliberate single-function assembly, co
             # only CSRF control these routes get.
             target_router.include_router(admin_external_group_mappings_router, prefix="/admin/external-group-mappings", tags=["External Group Mappings"], dependencies=[Depends(enforce_admin_csrf)])
 
+            # First-Party
+            from mcpgateway.routers.tokens import admin_tokens_router  # pylint: disable=import-outside-toplevel
+
+            # Same enforce_admin_csrf rationale as runtime_admin_router above:
+            # /admin is in settings.csrf_exempt_paths, so this dependency is the
+            # only CSRF control these routes get.
+            target_router.include_router(admin_tokens_router, prefix="/admin/tokens", tags=["JWT Token Catalog"], dependencies=[Depends(enforce_admin_csrf)])
+
             # Only the /admin/well-known status endpoint belongs in the versioned
             # router.  The full well_known router (which owns /.well-known/* paths)
             # is mounted on app directly in main.py so those paths stay at server

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -1385,19 +1385,29 @@ class TokenValidationError(Exception):
         self.original = original
 
 
-async def validate_token_user(request: Request, token: str) -> EmailUser:
+async def validate_token_user(request: Request, token: str) -> Any:
     """Validate a bearer token through the full get_current_user() stack.
 
     This is the single shared validation path for all admin-token checks.
     Both /admin/login (redirect-to-dashboard) and /admin (dashboard itself)
     should call this so they agree on whether a token is acceptable.
 
+    Trust-mode return type (#5904): when ``jwt_trust_mode="jwt-trust"`` and
+    the token is trust-eligible (``token_use == "trusted"``), the return
+    value is the trust-mode principal (a ``VirtualPrincipal``) instead of an
+    ``EmailUser`` row. The principal is EmailUser-compatible for the
+    attributes callers read (``email``, ``is_admin``, ``full_name``) and is
+    returned directly — trust-mode principals have no local user record by
+    design.
+
     Args:
         request: FastAPI request object (for request-level caching and state).
         token: Raw JWT token string (from cookie or header).
 
     Returns:
-        EmailUser: The fully validated, authenticated user.
+        The fully validated, authenticated user: an ``EmailUser`` in default
+        mode, or a trust-mode principal (``VirtualPrincipal``) when trust
+        mode resolved the token.
 
     Raises:
         TokenValidationError: If the token is missing, invalid, expired,
@@ -1687,7 +1697,14 @@ async def get_current_user(
         # Get plugin manager singleton
         plugin_manager = await get_plugin_manager()
 
-        if plugin_manager and plugin_manager.has_hooks_for(HttpHookType.HTTP_AUTH_RESOLVE_USER):
+        hooks_registered = bool(plugin_manager and plugin_manager.has_hooks_for(HttpHookType.HTTP_AUTH_RESOLVE_USER))
+        if hooks_registered and settings.jwt_trust_mode == "jwt-trust":
+            # Fail-closed default (#5904): in trust mode the signed token alone
+            # proves identity, roles, and teams; a plugin hook could re-introduce
+            # caller-supplied identity. The hook is skipped and the trust-mode
+            # path handles authentication directly.
+            logger.info("HTTP_AUTH_RESOLVE_USER hook disabled in trust mode")
+        elif hooks_registered:
             # Extract client information
             client_host = None
             client_port = None

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -1321,6 +1321,21 @@ class TokenScopingMiddleware:
 
             # Resolve teams based on token_use claim
             token_use = payload.get("token_use")
+            # Trusted tokens in jwt-trust mode: the teams claim was derived
+            # from the external group-mapping resolver at authentication time
+            # (auth.py trust branch / TokenCatalogService.mint_trust_token),
+            # so the resolver mapping IS the server-side membership authority
+            # — per the AGENTS.md security invariant, authorization derives
+            # from authenticated identity and server-side state, and
+            # trust-only principals have no email_team_members rows to check.
+            # Everything else stays enforced for trusted tokens: revocation
+            # (keyed by the configured jwt_trust_revocation_claim, checked by
+            # the auth layer on every request), expiry/signature (token
+            # verification above), resource team ownership, server/IP/time/
+            # permission restrictions, and usage limits (all below).
+            skip_team_membership_check = token_use == "session" or (  # nosec B105 - Not a password; token_use is a JWT claim type
+                token_use == "trusted" and settings.jwt_trust_mode == "jwt-trust"  # nosec B105 - Not a password; token_use is a JWT claim type
+            )
             if token_use == "session":  # nosec B105 - Not a password; token_use is a JWT claim type
                 user_email = await self._resolve_user_email_from_payload(payload)
                 # Session token: resolve teams from DB/cache directly
@@ -1354,9 +1369,11 @@ class TokenScopingMiddleware:
                     # the DB; re-checking the raw JWT claim here would conflict with
                     # the intersection semantics (stale JWT teams would cause a 403
                     # even though the user has valid DB teams).
+                    # Trusted tokens skip it because the resolver mapping is the
+                    # membership authority (see skip_team_membership_check above).
                     # NOTE: session-token membership staleness is bounded by the
                     # auth_cache TTL (see _resolve_teams_from_db).
-                    if token_use != "session" and not self._check_team_membership(payload, db=db):  # nosec B105 - Not a password; token_use is a JWT claim type
+                    if not skip_team_membership_check and not self._check_team_membership(payload, db=db):
                         logger.warning("Token rejected: User no longer member of associated team(s)")
                         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Token is invalid: User is no longer a member of the associated team")
 
@@ -1377,9 +1394,10 @@ class TokenScopingMiddleware:
             else:
                 # Public-only token (or session token with empty intersection):
                 # skip _check_team_membership for session tokens — the empty
-                # intersection already means no team-scoped access.
+                # intersection already means no team-scoped access; trusted
+                # tokens skip it per the resolver-mapping authority above.
                 # Membership staleness bounded by auth_cache TTL.
-                if token_use != "session" and not self._check_team_membership(payload):  # nosec B105 - Not a password; token_use is a JWT claim type
+                if not skip_team_membership_check and not self._check_team_membership(payload):
                     logger.warning("Token rejected: User no longer member of associated team(s)")
                     raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Token is invalid: User is no longer a member of the associated team")
 

--- a/mcpgateway/routers/tokens.py
+++ b/mcpgateway/routers/tokens.py
@@ -13,22 +13,30 @@ from typing import List, Optional
 
 # Third-Party
 from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.auth_context import get_user_email
 from mcpgateway.common.validators import SecurityValidator
-from mcpgateway.db import get_db
+from mcpgateway.config import settings
+from mcpgateway.db import EmailUser, get_db, Role, UserRole, utc_now
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
 from mcpgateway.schemas import TokenCreateRequest, TokenCreateResponse, TokenListResponse, TokenResponse, TokenRevokeRequest, TokenUpdateRequest, TokenUsageStatsResponse
 from mcpgateway.services.permission_service import PermissionService
 from mcpgateway.services.token_catalog_service import TokenCatalogService, TokenScope
 from mcpgateway.utils.error_formatter import PublicValidationError, safe_error_detail, should_expose_error_details
+from mcpgateway.utils.trusted_claims import VirtualPrincipal
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/tokens", tags=["tokens"])
+
+#: Admin router for the trust-token mint endpoint. Mounted at
+#: ``/admin/tokens`` by the router assembly (mcpgateway/api/v1/__init__.py).
+admin_tokens_router = APIRouter()
 
 
 def _handle_token_integrity_error(err_str: str) -> None:
@@ -323,6 +331,128 @@ async def create_token(
         err_str = str(e.orig) if hasattr(e, "orig") and e.orig else str(e)
         logger.error("Token creation integrity error: %s", SecurityValidator.sanitize_log_message(err_str))
         _handle_token_integrity_error(err_str)
+
+
+class TrustTokenMintRequest(BaseModel):
+    """Request body for POST /admin/tokens/trust.
+
+    Only the target user identifier is honored. Extra fields are accepted
+    and ignored: every minted claim derives from server-side authority, and
+    an extra ``sub``/``user_id`` field that contradicts the target's
+    canonical user_id is rejected (no act-as).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    user_email: str = Field(min_length=3, max_length=255)
+
+
+class TrustTokenMintResponse(BaseModel):
+    """Response body for POST /admin/tokens/trust."""
+
+    access_token: str
+    token_use: str = "trusted"
+    user_email: str
+    user_id: str
+
+
+@admin_tokens_router.post("/trust", response_model=TrustTokenMintResponse)
+@require_permission("tokens.create")
+async def create_trust_token(
+    body: TrustTokenMintRequest,
+    current_user=Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+) -> TrustTokenMintResponse:
+    """Mint a gateway-signed trust token (``token_use="trusted"``) for a local user.
+
+    Admin-only operational mint path (#5904). All claims derive from
+    server-side authority: the DB admin flag, DB team memberships, and DB
+    role assignments. ``sub`` is the target's canonical user_id. Trust-only
+    targets (no ``email_users`` row) are rejected with 403 per the B.2
+    matrix. The token is ephemeral: no ``email_api_tokens`` row is written,
+    and revocation is via the jti-based blocklist only.
+
+    Args:
+        body: Target user identifier. Claim fields in the body are ignored.
+        current_user: Authenticated user context (must be platform admin).
+        db: Database session.
+
+    Returns:
+        TrustTokenMintResponse: The signed trust token and target identity.
+
+    Raises:
+        HTTPException: 403 when the caller is not a platform admin, when the
+            target has no local user record, or when the body names a subject
+            other than the target's canonical user_id.
+    """
+    _require_authenticated_session(current_user)
+
+    if not current_user.get("is_admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required to mint trust tokens",
+        )
+
+    user = db.execute(select(EmailUser).where(EmailUser.email == body.user_email)).scalar_one_or_none()
+    if not user:
+        # B.2 matrix: trust-only principals have no local user record, so no
+        # server-side authority exists to derive claims from. Fail closed.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Token minting is disabled for trust-only principals. Create a local user account first.",
+        )
+
+    # No act-as: a body that names a subject other than the target's
+    # canonical user_id is rejected. Other extra fields (claim attempts such
+    # as teams/roles/is_admin) are ignored — claims come from the DB only.
+    extras = body.model_extra or {}
+    for identity_field in ("sub", "user_id"):
+        named_subject = extras.get(identity_field)
+        if named_subject is not None and str(named_subject) != str(user.id):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Minting a trust token for a subject other than the target user's canonical user_id is not allowed",
+            )
+
+    service = TokenCatalogService(db)
+    team_ids = await service.get_user_team_ids(user.email)
+    role_names = list(
+        db.execute(
+            select(Role.name)
+            .join(UserRole, UserRole.role_id == Role.id)
+            .where(
+                UserRole.user_email == user.email,
+                UserRole.is_active.is_(True),
+                Role.is_active.is_(True),
+                or_(UserRole.expires_at.is_(None), UserRole.expires_at > utc_now()),
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    is_admin = bool(user.is_admin)
+    # Atomic admin mapping (#5902): the DB admin flag feeds both admin tracks.
+    if is_admin and "platform_admin" not in role_names:
+        role_names.append("platform_admin")
+
+    principal = VirtualPrincipal(
+        user_id=str(user.id),
+        email=user.email,
+        full_name=user.full_name,
+        teams=team_ids,
+        roles=role_names,
+        is_admin=is_admin,
+        auth_provider="trust",
+    )
+    raw_token = await service.mint_trust_token(principal, settings)
+
+    logger.info(
+        "Admin %s minted a trust token for user %s",
+        SecurityValidator.sanitize_log_message(get_user_email(current_user)),
+        SecurityValidator.sanitize_log_message(user.email),
+    )
+    return TrustTokenMintResponse(access_token=raw_token, user_email=user.email, user_id=str(user.id))
 
 
 @router.get("", response_model=TokenListResponse)

--- a/mcpgateway/services/token_catalog_service.py
+++ b/mcpgateway/services/token_catalog_service.py
@@ -18,7 +18,7 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 import hashlib
 import math
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, TYPE_CHECKING
 import uuid
 
 # Third-Party
@@ -31,6 +31,10 @@ from mcpgateway.config import settings
 from mcpgateway.db import EmailApiToken, EmailTeam, EmailUser, Permissions, TokenRevocation, TokenUsageLog, utc_now
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.utils.create_jwt_token import create_jwt_token
+
+if TYPE_CHECKING:
+    # First-Party
+    from mcpgateway.utils.trusted_claims import VirtualPrincipal
 
 # Initialize logging
 logging_service = LoggingService()
@@ -309,6 +313,61 @@ class TokenCatalogService:
             scopes=scopes_dict,
         )
 
+    async def mint_trust_token(self, principal: "VirtualPrincipal", trust_settings: Optional[object] = None, expires_in_minutes: Optional[int] = None) -> str:
+        """Mint a gateway-signed trust token (``token_use="trusted"``) for a verified principal.
+
+        The token satisfies the B.1 dispatch rule's eligibility check for
+        gateway-signed tokens: it carries the ``token_use="trusted"`` marker,
+        the mapped user_id claim (``jwt_claim_user_id``), and the configured
+        revocation claim (``jwt_trust_revocation_claim``, default ``jti``).
+        Every claim derives from the verified principal — server-side
+        authority only — and ``sub`` always equals ``principal.user_id``
+        (no act-as).
+
+        Trust tokens are ephemeral: this method never inserts into
+        ``email_api_tokens``. Revocation is via the jti-based blocklist only;
+        the catalog revoke endpoint does not apply to them.
+
+        Args:
+            principal: Verified principal (from ``extract_trusted_principal``
+                or built from a local ``EmailUser`` row by the admin mint
+                endpoint).
+            trust_settings: Settings object carrying the ``jwt_claim_*``
+                mappings. Defaults to the process settings.
+            expires_in_minutes: Token lifetime in minutes. ``None`` selects
+                the ``create_jwt_token`` default.
+
+        Returns:
+            str: Signed JWT token string with ``token_use="trusted"``.
+        """
+        trust_settings = trust_settings or settings
+        data = {
+            "sub": principal.user_id,
+            "jti": str(uuid.uuid4()),
+            "token_use": "trusted",  # nosec B105 - token type marker, not a password
+            trust_settings.jwt_claim_user_id: principal.user_id,
+            trust_settings.jwt_claim_teams: list(principal.teams),
+            trust_settings.jwt_claim_roles: list(principal.roles),
+            trust_settings.jwt_claim_admin: bool(principal.is_admin),
+        }
+        if principal.email:
+            data[trust_settings.jwt_claim_email] = principal.email
+
+        create_kwargs: Dict[str, object] = {}
+        if expires_in_minutes is not None:
+            create_kwargs["expires_in_minutes"] = expires_in_minutes
+        return await create_jwt_token(
+            data=data,
+            user_data={
+                "email": principal.email,
+                "full_name": principal.full_name,
+                "is_admin": bool(principal.is_admin),
+                "auth_provider": "trust",
+            },
+            teams=list(principal.teams),
+            **create_kwargs,
+        )
+
     def _hash_token(self, token: str) -> str:
         """Create secure hash of token for storage.
 
@@ -457,7 +516,19 @@ class TokenCatalogService:
         user = self.db.execute(select(EmailUser).where(EmailUser.email == user_email)).scalar_one_or_none()
 
         if not user:
+            # B.2 matrix (fail-closed default): trust-only principals have no
+            # local user record, so the catalog cannot derive claims from
+            # server-side authority. Disabled with an explicit error.
+            if settings.jwt_trust_mode == "jwt-trust":
+                raise ValueError("Token minting is disabled for trust-only principals. Create a local user account first.")
             raise ValueError(f"User not found: {user_email}")
+
+        # No act-as in trust mode (#5904): the minted sub is the target row's
+        # canonical user_id, so minting for another user delegates identity.
+        # Non-admin delegation is rejected; platform admins keep the existing
+        # delegation path (team membership is still enforced below).
+        if settings.jwt_trust_mode == "jwt-trust" and caller_email and caller_email.lower() != user_email.lower() and not is_admin:
+            raise ValueError("Token minting for another user requires platform admin privileges in trust mode.")
 
         # Validate scope containment (fail-secure if no caller_permissions)
         if scope and scope.permissions:

--- a/tests/live_gateway/test_trust_mode_external_ingress_e2e.py
+++ b/tests/live_gateway/test_trust_mode_external_ingress_e2e.py
@@ -16,12 +16,12 @@ external-issuer bearers to the trusted-OIDC-issuer (JWKS) verifier when
     missing_revocation_claim     -> 401  (no jti -> unrevocable -> reject, fail-closed)
     nonexistent_agent_with_role  -> 404  (authn + RBAC ok, agent lookup terminates at 404)
 
-Branch note (PR #6750): rows 1 and 5 are marked ``xfail(strict=False)``.
-On this branch the TokenScopingMiddleware still validates claim-derived
-teams against local ``email_team_members`` and 403s trust-only principals
-("User is no longer a member of the associated team") before RBAC/agent
-lookup. The trusted-team exemption is Task 10 (#5904, PR #6751); both rows
-flip to their pinned status there (XPASS), and rows 2-4 are green here.
+Branch note (PR #6750): rows 1 and 5 were marked ``xfail(strict=False)``
+because TokenScopingMiddleware validated claim-derived teams against local
+``email_team_members`` and 403'd trust-only principals ("User is no longer
+a member of the associated team") before RBAC/agent lookup. Task 10 (#5904,
+PR #6751) landed the trusted-team exemption: both rows XPASS'd and the
+markers were removed; the full matrix is green on this branch.
 
 Gateway startup (operator-provided; run from the repo root). This exact
 env was verified against a live run: the secret-strength validator rejects
@@ -107,32 +107,16 @@ NONEXISTENT_AGENT = "Agent-A-that-does-not-exist"
 
 MATRIX = [
     # (scenario, expected status)
-    pytest.param(
-        "mapped_user_invokes_agent",
-        200,  # #6272 acceptance row
-        marks=pytest.mark.xfail(
-            reason=(
-                "TokenScopingMiddleware validates mapped teams against local email_team_members; "
-                "trust-only principals have none -> 403 'User is no longer a member'. "
-                "The trusted-team exemption is Task 10 (#5904, PR #6751); this row flips to 200 there."
-            ),
-            strict=False,
-        ),
-    ),
+    # #6272 acceptance row. Previously xfail(strict=False): the TokenScopingMiddleware
+    # membership check 403'd trust-only principals; Task 10 (#5904, PR #6751)
+    # exempted resolver-derived trusted teams and this row went green (XPASS).
+    ("mapped_user_invokes_agent", 200),
     ("unmapped_user_invoke", 403),  # authn ok, RBAC deny (deny without disclosure)
     ("wrong_audience_token", 401),  # trust-root token, definitive failure -> fail-closed
     ("missing_revocation_claim", 401),  # no jti -> unrevocable -> reject
-    pytest.param(
-        "nonexistent_agent_with_role",
-        404,  # authenticated + authorized -> agent lookup 404
-        marks=pytest.mark.xfail(
-            reason=(
-                "Blocked upstream of agent lookup by the same TokenScopingMiddleware membership check; "
-                "Task 10 (#5904, PR #6751) exempts resolver-derived trusted teams and this row flips to 404."
-            ),
-            strict=False,
-        ),
-    ),
+    # Previously xfail(strict=False): blocked upstream of agent lookup by the same
+    # membership check; Task 10 (#5904, PR #6751) closed it (XPASS at 404).
+    ("nonexistent_agent_with_role", 404),  # authenticated + authorized -> agent lookup 404
 ]
 
 

--- a/tests/unit/mcpgateway/middleware/test_token_scoping_trusted.py
+++ b/tests/unit/mcpgateway/middleware/test_token_scoping_trusted.py
@@ -1,0 +1,216 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/middleware/test_token_scoping_trusted.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Trust-aware TokenScopingMiddleware regression tests (#5904, finding F3).
+
+A ``token_use="trusted"`` token carries teams derived at authentication
+time by the external group-mapping resolver (``auth.py`` trust branch /
+``TokenCatalogService.mint_trust_token``). Trust-only principals have no
+local ``email_team_members`` rows, so the Layer-1 membership re-check —
+designed for API/legacy tokens whose embedded teams claim may be stale —
+denied every team-scoped trusted token with
+``403 'User is no longer a member of the associated team'``.
+
+These tests pin the fixed contract:
+
+  * trusted token + trust mode ON -> the resolver-derived teams survive
+    Layer-1 scoping without an ``email_team_members`` lookup,
+  * a revoked trusted token is still denied (revocation is enforced by
+    the auth layer on every request and is NOT weakened by the skip),
+  * trusted token + trust mode OFF -> the membership check still applies
+    (feature-disabled boundary; the auth layer rejects it with 401),
+  * API/legacy tokens still validate membership against the local rows
+    (behavior unchanged).
+"""
+
+# Standard
+import contextlib
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+from fastapi import HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.auth import get_current_user
+from mcpgateway.config import settings
+from mcpgateway.db import Base, TokenRevocation
+from mcpgateway.middleware.token_scoping import ResourceOwnershipResult, TokenScopingMiddleware
+
+TRUSTED_SUBJECT = "entra-sub-123"
+TRUSTED_JTI = "trusted-jti-0001"
+MAPPED_TEAM = "agent-a-team"
+
+
+def _exp(hours: int = 1) -> float:
+    """Expiry timestamp for mocked JWT payloads."""
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).timestamp()
+
+
+def _trusted_payload() -> dict:
+    """Trusted-token payload as verified by ``verify_jwt_token_cached``."""
+    return {
+        "sub": TRUSTED_SUBJECT,
+        "token_use": "trusted",  # nosec B105 - JWT claim type, not a password
+        "teams": [MAPPED_TEAM],
+        "roles": ["developer"],
+        "jti": TRUSTED_JTI,
+        "exp": _exp(),
+        "scopes": {"permissions": ["*"]},
+    }
+
+
+@pytest.fixture
+def middleware():
+    """Create middleware instance."""
+    return TokenScopingMiddleware()
+
+
+@pytest.fixture
+def mock_request():
+    """Create mock request object (harness mirrors test_token_scoping.py)."""
+    request = MagicMock(spec=Request)
+    request.url.path = "/servers"
+    request.method = "GET"
+    request.headers = {"Authorization": "Bearer trusted-token"}  # pragma: allowlist secret
+    request.cookies = {}
+    request.scope = {"path": "/servers", "root_path": ""}
+    request.client = MagicMock()
+    request.client.host = "127.0.0.1"
+    request.state = MagicMock()
+    request.state._token_scoping_done = False
+    return request
+
+
+async def _run_scoping(middleware, mock_request, monkeypatch, payload):
+    """Drive the full middleware with a DB session whose membership lookup fails.
+
+    ``validate_token_team_membership`` returns False, simulating ZERO
+    ``email_team_members`` rows for the principal — the trust-only shape.
+    Returns (response_or_result, call_next, membership_validator_mock).
+    """
+    db = MagicMock()
+    monkeypatch.setattr("mcpgateway.db.get_db", lambda: iter([db]))
+    with (
+        patch.object(middleware, "_extract_token_scopes", new=AsyncMock(return_value=payload)),
+        patch("mcpgateway.middleware.token_scoping.validate_token_team_membership", return_value=False) as validator,
+        patch.object(middleware, "_check_resource_team_ownership", return_value=ResourceOwnershipResult.ALLOWED),
+    ):
+        call_next = AsyncMock(return_value="success")
+        result = await middleware(mock_request, call_next)
+    return result, call_next, validator
+
+
+class TestTrustedTokenTeamScoping:
+    """Trusted tokens skip the local email_team_members re-check."""
+
+    @pytest.mark.asyncio
+    async def test_trusted_token_teams_skip_local_membership_check(self, middleware, mock_request, monkeypatch):
+        """Resolver-derived teams survive Layer-1 scoping with zero membership rows."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+
+        result, call_next, validator = await _run_scoping(middleware, mock_request, monkeypatch, _trusted_payload())
+
+        assert result == "success"
+        call_next.assert_called_once()
+        # The local membership lookup must not run for trusted tokens: the
+        # group-mapping resolver already verified the mapped teams at
+        # authentication time.
+        validator.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_trusted_token_with_trust_mode_off_still_checks_membership(self, middleware, mock_request, monkeypatch):
+        """Feature-disabled boundary: trust mode OFF keeps the membership check."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "db")
+
+        result, call_next, validator = await _run_scoping(middleware, mock_request, monkeypatch, _trusted_payload())
+
+        assert result.status_code == status.HTTP_403_FORBIDDEN
+        call_next.assert_not_called()
+        validator.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("token_use", ["api", None])
+    async def test_api_and_legacy_tokens_without_membership_still_denied(self, middleware, mock_request, monkeypatch, token_use):
+        """API/legacy tokens with teams but no membership rows are still denied."""
+        payload = _trusted_payload()
+        if token_use is None:
+            del payload["token_use"]
+        else:
+            payload["token_use"] = token_use  # nosec B105 - JWT claim type, not a password
+
+        result, call_next, validator = await _run_scoping(middleware, mock_request, monkeypatch, payload)
+
+        assert result.status_code == status.HTTP_403_FORBIDDEN
+        call_next.assert_not_called()
+        validator.assert_called_once()
+
+
+class TestTrustedTokenRevocation:
+    """Revocation stays active for trusted tokens (auth layer, real DB)."""
+
+    @pytest.fixture
+    def db(self):
+        """In-memory SQLite session with the full schema and no user rows."""
+        engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+        Base.metadata.create_all(bind=engine)
+        session = sessionmaker(bind=engine)()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    def _patch_sessions(self, monkeypatch: pytest.MonkeyPatch, db) -> None:
+        """Re-point funnel sessions at the test database."""
+        session_test = sessionmaker(bind=db.get_bind())
+        monkeypatch.setattr("mcpgateway.auth.SessionLocal", session_test)
+
+        @contextlib.contextmanager
+        def _fresh_db_session():
+            session = session_test()
+            try:
+                yield session
+            finally:
+                session.close()
+
+        monkeypatch.setattr("mcpgateway.auth.fresh_db_session", _fresh_db_session)
+
+    @pytest.mark.asyncio
+    async def test_trusted_token_with_revoked_jti_still_denied(self, middleware, mock_request, monkeypatch, db):
+        """A trusted token whose jti is revoked is denied regardless of team handling.
+
+        The revocation check lives in the auth layer (``get_current_user``
+        trust branch), keyed by the configured revocation claim; the
+        middleware skip must not weaken it. ``_check_token_revoked_sync``
+        is deliberately NOT patched — the real check must find the row.
+        """
+        db.add(
+            TokenRevocation(
+                jti=TRUSTED_JTI,
+                revoked_by="system:test",
+                reason="security",
+                token_expiry=datetime.now(timezone.utc) + timedelta(hours=1),
+            )
+        )
+        db.commit()
+
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+        self._patch_sessions(monkeypatch, db)
+
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="trusted_jwt_token")  # pragma: allowlist secret
+        request = SimpleNamespace(state=SimpleNamespace())
+
+        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=_trusted_payload())):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(credentials=credentials, request=request)
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/unit/mcpgateway/services/test_token_catalog_trust_mode.py
+++ b/tests/unit/mcpgateway/services/test_token_catalog_trust_mode.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_token_catalog_trust_mode.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Mint-path decisions for the API-token catalog in JWT trust mode (#5904).
+
+The B.2 feature-mode matrix (docs/docs/architecture/auth-feature-mode-matrix.md)
+pins the API-token catalog row: DB-backed principals mint normally; trust-only
+principals (no email_users row) get an explicit documented error, never a
+500/IntegrityError. Claims in minted tokens derive from server-side authority
+only, and minted ``sub`` always equals the target row's canonical user_id.
+"""
+
+# Standard
+from datetime import datetime, timezone
+import uuid
+
+# Third-Party
+import jwt
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.config import settings
+from mcpgateway.db import Base, EmailTeam, EmailTeamMember, EmailUser
+from mcpgateway.services.token_catalog_service import TokenCatalogService
+
+CALLER_EMAIL = "caller@example.com"
+TARGET_EMAIL = "target@example.com"
+GHOST_EMAIL = "ghost@example.com"
+
+TRUST_ONLY_MESSAGE = "Token minting is disabled for trust-only principals. Create a local user account first."
+
+
+@pytest.fixture
+def db():
+    """In-memory SQLite session with the full schema and no rows."""
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def service(db):
+    """Token catalog service bound to the test database."""
+    return TokenCatalogService(db)
+
+
+def _add_user(db, email: str, *, is_admin: bool = False) -> EmailUser:
+    """Insert an EmailUser row and return it (with the generated id)."""
+    now = datetime.now(timezone.utc)
+    user = EmailUser(
+        email=email,
+        password_hash="hash",  # pragma: allowlist secret
+        full_name="Test User",
+        is_admin=is_admin,
+        is_active=True,
+        email_verified_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _add_team_with_member(db, team_id: str, user_email: str) -> EmailTeam:
+    """Insert a non-personal team plus an active membership for the user."""
+    team = EmailTeam(id=team_id, name=f"Team {team_id}", slug=f"team-{team_id}", created_by=user_email, is_personal=False, visibility="private")
+    db.add(team)
+    now = datetime.now(timezone.utc)
+    db.add(EmailTeamMember(id=str(uuid.uuid4()), team_id=team_id, user_email=user_email, role="member", is_active=True, joined_at=now))
+    db.commit()
+    return team
+
+
+def _decode(raw_token: str) -> dict:
+    """Verify and decode a gateway-signed JWT with the configured key."""
+    secret = settings.jwt_secret_key
+    if hasattr(secret, "get_secret_value"):
+        secret = secret.get_secret_value()
+    return jwt.decode(raw_token, secret, algorithms=[settings.jwt_algorithm], audience=settings.jwt_audience, issuer=settings.jwt_issuer)
+
+
+class TestTrustOnlyPrincipalMinting:
+    """Test A: a trust-only principal (no email_users row) cannot mint."""
+
+    @pytest.mark.asyncio
+    async def test_create_token_trust_only_principal_gets_documented_error(self, monkeypatch, service):
+        """Trust mode ON + no EmailUser row -> documented error, never 500/IntegrityError."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+
+        with pytest.raises(ValueError, match="Token minting is disabled for trust-only principals") as exc_info:
+            await service.create_token(user_email=GHOST_EMAIL, name="ghost-token", caller_email=GHOST_EMAIL)
+
+        assert str(exc_info.value) == TRUST_ONLY_MESSAGE
+
+    @pytest.mark.asyncio
+    async def test_create_token_unknown_user_default_mode_keeps_legacy_error(self, monkeypatch, service):
+        """Default mode is unchanged: unknown user -> the legacy not-found error."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "db")
+
+        with pytest.raises(ValueError, match="User not found"):
+            await service.create_token(user_email=GHOST_EMAIL, name="ghost-token")
+
+
+class TestDbBackedPrincipalMinting:
+    """Test B: a DB-backed principal mints API tokens with server-derived claims."""
+
+    @pytest.mark.asyncio
+    async def test_create_token_mints_api_token_with_db_derived_claims(self, monkeypatch, service, db):
+        """Minted JWT: token_use "api", is_admin from the DB row, sub == user.id."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        user = _add_user(db, CALLER_EMAIL, is_admin=True)
+
+        _, raw_token = await service.create_token(
+            user_email=CALLER_EMAIL,
+            name="self-token",
+            expires_in_days=30,
+            is_admin=False,  # Caller flag must not override the DB row.
+            caller_email=CALLER_EMAIL,
+        )
+
+        payload = _decode(raw_token)
+        assert payload["token_use"] == "api"
+        assert payload["sub"] == str(user.id)
+        assert payload["user"]["is_admin"] is True  # From the DB row, not the caller flag.
+
+
+class TestNoActAs:
+    """Test C: a mint request naming a different sub than the caller is rejected."""
+
+    @pytest.mark.asyncio
+    async def test_create_token_for_other_user_rejected_in_trust_mode(self, monkeypatch, service, db):
+        """Trust mode ON: non-admin caller minting for another user -> clear error."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        _add_user(db, CALLER_EMAIL)
+        target = _add_user(db, TARGET_EMAIL)
+
+        with pytest.raises(ValueError, match="requires platform admin"):
+            await service.create_token(
+                user_email=TARGET_EMAIL,
+                name="act-as-token",
+                caller_email=CALLER_EMAIL,
+                is_admin=False,
+                caller_permissions=["tokens.create"],
+            )
+
+        # The target row's canonical id must never reach a token minted this way.
+        assert target.id  # Control: the target has a distinct canonical user_id.
+
+    @pytest.mark.asyncio
+    async def test_default_mode_service_delegation_behavior_unchanged(self, monkeypatch, service, db):
+        """Default mode: the service-layer delegation path is not gated by the trust guard."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "db")
+        _add_user(db, CALLER_EMAIL)
+        _add_user(db, TARGET_EMAIL)
+
+        _, raw_token = await service.create_token(
+            user_email=TARGET_EMAIL,
+            name="delegated-token",
+            expires_in_days=30,
+            caller_email=CALLER_EMAIL,
+            is_admin=False,
+            caller_permissions=["tokens.create"],
+        )
+
+        assert _decode(raw_token)["token_use"] == "api"
+
+
+class TestCallerSuppliedClaimsIgnored:
+    """Test D: caller-supplied teams/is_admin values never enter minted claims."""
+
+    @pytest.mark.asyncio
+    async def test_create_token_claims_derive_from_server_authority_only(self, monkeypatch, service, db):
+        """Minted claims come from the DB row and team_id param, not caller values."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        user = _add_user(db, CALLER_EMAIL, is_admin=False)
+        _add_team_with_member(db, "team-a", CALLER_EMAIL)
+
+        _, raw_token = await service.create_token(
+            user_email=CALLER_EMAIL,
+            name="scoped-token",
+            expires_in_days=30,
+            team_id="team-a",
+            is_admin=True,  # Caller-supplied admin flag: must not leak into claims.
+            caller_permissions=["*"],
+            caller_token_teams=["team-evil"],  # Caller narrowing: must not leak.
+            caller_token_teams_provided=True,
+            caller_email=CALLER_EMAIL,
+        )
+
+        payload = _decode(raw_token)
+        assert payload["user"]["is_admin"] is False  # DB row wins over the caller flag.
+        assert payload["teams"] == ["team-a"]  # team_id param wins over caller teams.
+        assert payload["sub"] == str(user.id)

--- a/tests/unit/mcpgateway/services/test_trust_token_minting.py
+++ b/tests/unit/mcpgateway/services/test_trust_token_minting.py
@@ -1,0 +1,283 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_trust_token_minting.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Trust-token minting (#5904): the gateway-signed ``token_use="trusted"`` mint
+path and the operational ``POST /admin/tokens/trust`` endpoint.
+
+The minted token must satisfy the B.1 dispatch rule's eligibility check for
+gateway-signed tokens (``token_use=="trusted"``, mapped user_id claim present,
+configured revocation claim present). All claims derive from server-side
+authority; ``sub`` always equals the verified principal's user_id (no act-as).
+Trust tokens are ephemeral: no ``email_api_tokens`` row is written.
+"""
+
+# Standard
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+import uuid
+
+# Third-Party
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+import jwt
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.auth import get_current_user
+from mcpgateway.config import settings
+from mcpgateway.db import Base, EmailApiToken, EmailTeam, EmailTeamMember, EmailUser, Role, UserRole
+from mcpgateway.routers.tokens import create_trust_token, TrustTokenMintRequest
+from mcpgateway.services.token_catalog_service import TokenCatalogService
+from mcpgateway.utils.trusted_claims import VirtualPrincipal
+
+# Local
+from tests.utils.rbac_mocks import patch_rbac_decorators, restore_rbac_decorators
+
+CALLER_ID = "trust-subject-0042"
+CALLER_EMAIL = "trust.mint@example.com"
+TARGET_EMAIL = "mint.target@example.com"
+ADMIN_EMAIL = "mint.admin@example.com"
+
+
+@pytest.fixture(autouse=True)
+def setup_rbac_mocks():
+    """Bypass the RBAC decorator layer; the endpoint's own gates are under test."""
+    originals = patch_rbac_decorators()
+    yield
+    restore_rbac_decorators(originals)
+
+
+@pytest.fixture
+def db():
+    """In-memory SQLite session with the full schema and no rows."""
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def service(db):
+    """Token catalog service bound to the test database."""
+    return TokenCatalogService(db)
+
+
+def _add_user(db, email: str, *, is_admin: bool = False) -> EmailUser:
+    """Insert an EmailUser row and return it (with the generated id)."""
+    now = datetime.now(timezone.utc)
+    user = EmailUser(
+        email=email,
+        password_hash="hash",  # pragma: allowlist secret
+        full_name="Mint Target",
+        is_admin=is_admin,
+        is_active=True,
+        email_verified_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _add_team_with_member(db, team_id: str, user_email: str) -> EmailTeam:
+    """Insert a non-personal team plus an active membership for the user."""
+    team = EmailTeam(id=team_id, name=f"Team {team_id}", slug=f"team-{team_id}", created_by=user_email, is_personal=False, visibility="private")
+    db.add(team)
+    db.add(EmailTeamMember(id=str(uuid.uuid4()), team_id=team_id, user_email=user_email, role="member", is_active=True, joined_at=datetime.now(timezone.utc)))
+    db.commit()
+    return team
+
+
+def _assign_role(db, email: str, role_name: str) -> Role:
+    """Create a global role and assign it to the user."""
+    role = Role(name=role_name, description="test role", scope="global", permissions=["tools.read"], created_by=email, is_active=True)
+    db.add(role)
+    db.commit()
+    db.refresh(role)
+    db.add(UserRole(user_email=email, role_id=role.id, scope="global", granted_by=email, is_active=True))
+    db.commit()
+    return role
+
+
+def _decode(raw_token: str) -> dict:
+    """Verify and decode a gateway-signed JWT with the configured key."""
+    secret = settings.jwt_secret_key
+    if hasattr(secret, "get_secret_value"):
+        secret = secret.get_secret_value()
+    return jwt.decode(raw_token, secret, algorithms=[settings.jwt_algorithm], audience=settings.jwt_audience, issuer=settings.jwt_issuer)
+
+
+def _principal(**overrides) -> VirtualPrincipal:
+    """Verified trust principal as produced by extract_trusted_principal."""
+    values = {
+        "user_id": CALLER_ID,
+        "email": CALLER_EMAIL,
+        "full_name": "Trust Mint",
+        "teams": ["team-a"],
+        "roles": ["developer"],
+        "is_admin": False,
+    }
+    values.update(overrides)
+    return VirtualPrincipal(**values)
+
+
+class TestMintTrustToken:
+    """The mint_trust_token service method stamps server-authority claims."""
+
+    @pytest.mark.asyncio
+    async def test_stamps_trusted_marker_and_mapped_claims(self, monkeypatch, service):
+        """Minted token: token_use "trusted", mapped claims, jti present."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        principal = _principal(is_admin=True)
+
+        raw_token = await service.mint_trust_token(principal, settings)
+
+        payload = _decode(raw_token)
+        assert payload["token_use"] == "trusted"
+        assert payload[settings.jwt_claim_user_id] == CALLER_ID
+        assert payload[settings.jwt_claim_teams] == ["team-a"]
+        assert payload[settings.jwt_claim_roles] == ["developer"]
+        assert payload[settings.jwt_claim_admin] is True
+        assert payload[settings.jwt_claim_email] == CALLER_EMAIL
+        assert payload["jti"]  # Configured revocation claim present.
+
+    @pytest.mark.asyncio
+    async def test_minted_token_passes_dispatch_eligibility(self, monkeypatch, service, db):
+        """The minted token authenticates through the B.1 trust dispatch branch."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+
+        import contextlib  # pylint: disable=import-outside-toplevel
+
+        session_test = sessionmaker(bind=db.get_bind())
+        monkeypatch.setattr("mcpgateway.auth.SessionLocal", session_test)
+
+        @contextlib.contextmanager
+        def _fresh_db_session():
+            session = session_test()
+            try:
+                yield session
+            finally:
+                session.close()
+
+        monkeypatch.setattr("mcpgateway.auth.fresh_db_session", _fresh_db_session)
+
+        raw_token = await service.mint_trust_token(_principal(), settings)
+
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=raw_token)  # pragma: allowlist secret
+        request = SimpleNamespace(state=SimpleNamespace())
+        with patch("mcpgateway.auth._check_token_revoked_sync", return_value=False):
+            user = await get_current_user(credentials=credentials, request=request)
+
+        assert user.user_id == CALLER_ID
+        assert user.token_use == "trusted"
+        assert request.state.token_use == "trusted"
+
+    @pytest.mark.asyncio
+    async def test_sub_equals_inbound_user_id_no_act_as(self, monkeypatch, service):
+        """Minted sub equals the verified principal's user_id; identity cannot drift."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        principal = _principal(user_id="verified-user-1", email="someone.else@example.com")
+
+        raw_token = await service.mint_trust_token(principal, settings)
+
+        payload = _decode(raw_token)
+        assert payload["sub"] == "verified-user-1"
+        assert payload[settings.jwt_claim_user_id] == "verified-user-1"
+
+    @pytest.mark.asyncio
+    async def test_no_catalog_row_inserted(self, monkeypatch, service, db):
+        """Trust tokens are ephemeral: minting writes no email_api_tokens row."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+
+        await service.mint_trust_token(_principal(), settings)
+
+        assert db.query(EmailApiToken).count() == 0
+
+
+class TestTrustMintEndpoint:
+    """POST /admin/tokens/trust: admin-only mint with server-derived claims."""
+
+    def _admin_user(self):
+        return {
+            "email": ADMIN_EMAIL,
+            "is_admin": True,
+            "token_teams": None,
+            "permissions": ["*"],
+            "auth_method": "jwt",
+        }
+
+    @pytest.mark.asyncio
+    async def test_admin_mints_for_db_backed_user(self, monkeypatch, service, db):
+        """Admin mints for a DB-backed user: trusted token with server-derived claims."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        target = _add_user(db, TARGET_EMAIL, is_admin=False)
+        _add_team_with_member(db, "team-b", TARGET_EMAIL)
+        _assign_role(db, TARGET_EMAIL, "developer")
+
+        body = TrustTokenMintRequest.model_validate(
+            {
+                "user_email": TARGET_EMAIL,
+                # Caller-supplied claim fields: accepted but ignored.
+                "teams": ["team-evil"],
+                "roles": ["platform_admin"],
+                "is_admin": True,
+            }
+        )
+        response = await create_trust_token(body=body, current_user=self._admin_user(), db=db)
+
+        payload = _decode(response.access_token)
+        assert response.user_id == str(target.id)
+        assert payload["token_use"] == "trusted"
+        assert payload["sub"] == str(target.id)
+        assert payload[settings.jwt_claim_admin] is False  # DB row wins over body.
+        assert payload[settings.jwt_claim_teams] == ["team-b"]  # DB membership wins.
+        assert payload[settings.jwt_claim_roles] == ["developer"]  # DB roles win.
+
+    @pytest.mark.asyncio
+    async def test_non_admin_rejected(self, monkeypatch, service, db):
+        """A non-admin caller gets 403."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        _add_user(db, TARGET_EMAIL)
+        non_admin = {"email": CALLER_EMAIL, "is_admin": False, "permissions": ["tokens.create"], "auth_method": "jwt"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await create_trust_token(body=TrustTokenMintRequest(user_email=TARGET_EMAIL), current_user=non_admin, db=db)
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_trust_only_target_rejected(self, monkeypatch, service, db):
+        """A target with no email_users row gets 403 with the documented message."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await create_trust_token(body=TrustTokenMintRequest(user_email="ghost@example.com"), current_user=self._admin_user(), db=db)
+
+        assert exc_info.value.status_code == 403
+        assert "Token minting is disabled for trust-only principals" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_act_as_subject_rejected(self, monkeypatch, service, db):
+        """A body naming a sub other than the target's canonical user_id is rejected."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        target = _add_user(db, TARGET_EMAIL)
+
+        body = TrustTokenMintRequest.model_validate({"user_email": TARGET_EMAIL, "sub": "someone-else"})
+        with pytest.raises(HTTPException) as exc_info:
+            await create_trust_token(body=body, current_user=self._admin_user(), db=db)
+
+        assert exc_info.value.status_code == 403
+        assert target.id != "someone-else"  # Control: the named sub differs.

--- a/tests/unit/mcpgateway/test_auth_trust_choke_points.py
+++ b/tests/unit/mcpgateway/test_auth_trust_choke_points.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_auth_trust_choke_points.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Secondary auth choke points in JWT trust mode (#5904).
+
+- ``validate_token_user``: trust-mode tokens return the trust-mode principal
+  (``token_use="trusted"``) through the same shared validation path.
+- ``HTTP_AUTH_RESOLVE_USER`` plugin hook: fail-closed default — the hook is
+  disabled in trust mode with a clear log line; a registered hook is never
+  invoked. In default mode the hook is consulted as before.
+"""
+
+# Standard
+import contextlib
+from datetime import datetime, timedelta, timezone
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+from fastapi import HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.auth import get_current_user, TokenValidationError, validate_token_user
+from mcpgateway.config import settings
+from mcpgateway.db import Base
+
+CALLER_ID = "trust-subject-0007"
+CALLER_EMAIL = "choke.point@example.com"
+
+
+def _exp(hours: int = 1) -> float:
+    """Expiry timestamp for mocked JWT payloads."""
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).timestamp()
+
+
+@pytest.fixture
+def db():
+    """In-memory SQLite session with the full schema and no users."""
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _patch_funnel_sessions(monkeypatch: pytest.MonkeyPatch, db) -> None:
+    """Re-point the funnel's internal sessions at the test database."""
+    session_test = sessionmaker(bind=db.get_bind())
+    monkeypatch.setattr("mcpgateway.auth.SessionLocal", session_test)
+
+    @contextlib.contextmanager
+    def _fresh_db_session():
+        session = session_test()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("mcpgateway.auth.fresh_db_session", _fresh_db_session)
+
+
+def _trust_payload(**overrides):
+    """Gateway-signed trust-token payload with the mapped claim set."""
+    payload = {
+        "sub": CALLER_ID,
+        "token_use": "trusted",
+        "email": CALLER_EMAIL,
+        "teams": ["team-a"],
+        "roles": [],
+        "jti": "trusted_jti_choke",
+        "exp": _exp(),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _enable_trust_mode(monkeypatch: pytest.MonkeyPatch, db) -> None:
+    """Switch the funnel to trust mode against the test database."""
+    monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+    monkeypatch.setattr(settings, "auth_cache_enabled", False)
+    monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+    _patch_funnel_sessions(monkeypatch, db)
+
+
+class TestValidateTokenUserTrustMode:
+    """validate_token_user handles trust-mode principals (documented return)."""
+
+    @pytest.mark.asyncio
+    async def test_trust_mode_token_returns_trust_principal(self, monkeypatch, db):
+        """A trust-eligible token passes validate_token_user and returns the principal."""
+        _enable_trust_mode(monkeypatch, db)
+        request = SimpleNamespace(state=SimpleNamespace())
+
+        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=_trust_payload())):
+            with patch("mcpgateway.auth._check_token_revoked_sync", return_value=False):
+                user = await validate_token_user(request, "trusted_jwt_token")  # pragma: allowlist secret
+
+        assert user.user_id == CALLER_ID
+        assert user.email == CALLER_EMAIL
+        assert user.token_use == "trusted"
+
+    @pytest.mark.asyncio
+    async def test_trusted_marker_rejected_when_trust_mode_off(self, monkeypatch, db):
+        """token_use=trusted with trust mode OFF -> TokenValidationError 401."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "db")
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+        _patch_funnel_sessions(monkeypatch, db)
+        request = SimpleNamespace(state=SimpleNamespace())
+
+        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=_trust_payload())):
+            with pytest.raises(TokenValidationError) as exc_info:
+                await validate_token_user(request, "trusted_jwt_token")  # pragma: allowlist secret
+
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+class TestPluginHookTrustMode:
+    """HTTP_AUTH_RESOLVE_USER is disabled in trust mode (fail-closed default)."""
+
+    def _plugin_manager_mock(self):
+        """Plugin manager with a registered HTTP_AUTH_RESOLVE_USER hook."""
+        manager = MagicMock()
+        manager.has_hooks_for = MagicMock(return_value=True)
+        manager.invoke_hook = AsyncMock()
+        return manager
+
+    @pytest.mark.asyncio
+    async def test_hook_not_invoked_in_trust_mode(self, monkeypatch, db, caplog):
+        """Trust mode ON: registered hook is skipped; the clear log line is present."""
+        _enable_trust_mode(monkeypatch, db)
+        manager = self._plugin_manager_mock()
+        request = SimpleNamespace(state=SimpleNamespace())
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="trusted_jwt_token")  # pragma: allowlist secret
+
+        with patch("mcpgateway.auth.get_plugin_manager", AsyncMock(return_value=manager)):
+            with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=_trust_payload())):
+                with patch("mcpgateway.auth._check_token_revoked_sync", return_value=False):
+                    with caplog.at_level(logging.INFO, logger="mcpgateway.auth"):
+                        user = await get_current_user(credentials=credentials, request=request)
+
+        manager.invoke_hook.assert_not_called()
+        assert user.user_id == CALLER_ID
+        assert "HTTP_AUTH_RESOLVE_USER hook disabled in trust mode" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_hook_invoked_in_default_mode(self, monkeypatch, db):
+        """Default mode: the registered hook is consulted before standard auth."""
+        monkeypatch.setattr(settings, "jwt_trust_mode", "db")
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+        _patch_funnel_sessions(monkeypatch, db)
+
+        manager = self._plugin_manager_mock()
+        # Hook declines to authenticate: fall through to standard auth.
+        auth_result = MagicMock()
+        auth_result.modified_payload = None
+        auth_result.metadata = {}
+        manager.invoke_hook = AsyncMock(return_value=(auth_result, None))
+
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="default_jwt_token")  # pragma: allowlist secret
+        request = SimpleNamespace(state=SimpleNamespace())
+
+        with patch("mcpgateway.auth.get_plugin_manager", AsyncMock(return_value=manager)):
+            with patch(
+                "mcpgateway.auth.verify_jwt_token_cached",
+                AsyncMock(side_effect=HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")),
+            ):
+                with pytest.raises(HTTPException) as exc_info:
+                    await get_current_user(credentials=credentials, request=request)
+
+        manager.invoke_hook.assert_called_once()
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
Owns the trust-token mint path and aligns the secondary choke points with trust mode.

Minting: `create_token` gains a trust-only guard with the exact matrix message (`Token minting is disabled for trust-only principals. Create a local user account first.`) and a no-act-as guard in trust mode; default-mode delegation is unchanged (pinned by existing tests plus a new control). `mint_trust_token` (method on the catalog service, beside `_generate_token`) stamps `token_use="trusted"`, a fresh `jti`, `sub` = the verified principal's canonical user_id, and the mapped claims under the configured `jwt_claim_*` names — claims derive from server-side authority only, and no `email_api_tokens` row is written. The operational mint path is `POST /admin/tokens/trust` (admin router, CSRF-enforced): admin mints for a DB-backed user → 200; non-admin → 403; trust-only target → 403; body claim fields are accepted-but-ignored; a body naming another `sub`/`user_id` → 403 (no act-as). A minted token passes the B.1 dispatch branch end-to-end through `get_current_user`.

Choke points: `validate_token_user` returns trust principals directly (documented; mode-off marker → 401). The `HTTP_AUTH_RESOLVE_USER` plugin hook is disabled in trust mode with the log line `HTTP_AUTH_RESOLVE_USER hook disabled in trust mode` (fail-closed default; default mode still consults it — both tested).

Trust tokens are not tracked in the token catalog: revocation is via the jti-based blocklist only; the catalog revoke endpoint does not apply to them.

Tested with:
- `uv run pytest tests/unit/mcpgateway/services/test_token_catalog_trust_mode.py -q` — 6 passed (TDD red: Tests A and C failed with the exact expected modes)
- `uv run pytest tests/unit/mcpgateway/services/test_trust_token_minting.py -q` — 8 passed (mint + endpoint)
- `uv run pytest tests/unit/mcpgateway/test_auth_trust_choke_points.py -q` — 4 passed (hook NOT called in trust mode, log present; default-mode control)
- `uv run pytest tests -k "trust_token or token_catalog_trust or auth_trust_choke" -q` — 22 passed
- `make ruff` — all checks passed; `make test` — 23361 passed, 879 skipped, 2 xfailed

Every B.2 matrix row for these surfaces has an executable test matching the documented behavior; a trust-mode principal hitting a disabled surface gets the documented status and message, never a 500. Acceptance criteria of #5904 are met. Risk to existing users: none — default-mode paths unchanged.

Stack: B.12 of epic #5885 (base: #6750).

Closes #5904