### PR TITLE
test(auth): add trust-mode acceptance suite (no-DB, multi-worker, config-flip)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-12T17:30:40Z",
+  "generated_at": "2026-09-12T17:33:18Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1902,7 +1902,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 516,
+        "line_number": 518,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1910,7 +1910,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 959,
+        "line_number": 961,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1918,7 +1918,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1437,
+        "line_number": 1439,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1926,7 +1926,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1469,
+        "line_number": 1471,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -1934,7 +1934,7 @@
         "hashed_secret": "424ca52f87120d5dd4475b0b4aaed10adc379fb9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1473,
+        "line_number": 1475,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/security/uaid-cross-gateway-auth.md
+++ b/docs/security/uaid-cross-gateway-auth.md
@@ -63,6 +63,27 @@ UAID_FORWARD_AUTH=false
 6. Response returns through Gateway A → forwarded to user
 ```
 
+### Layer 2 and JWT Trust Mode
+
+When both gateways run JWT trust mode (`JWT_TRUST_MODE=jwt-trust`), the same
+forwarding rules apply without change:
+
+- The forwarded bearer token is the caller's inbound JWT. A trust-mode token
+  (`token_use="trusted"`) forwards verbatim; the remote gateway receives the
+  original claims (`sub`, `groups`, `teams`, the revocation claim).
+- The remote gateway re-evaluates the token against its own
+  `external_group_mappings` table. Team membership that the calling gateway
+  derived from its own mappings does NOT transfer. An agent on a team the
+  token does not map to on the remote gateway returns 404.
+- Local opaque tokens (`cf_sess_*`, `cf_pat_*`) are never forwarded. The
+  remote gateway treats the call as unauthenticated.
+- `UAID_ALLOWED_DOMAINS` semantics are unchanged: the allowlist stays
+  fail-closed. An empty allowlist blocks all cross-gateway routing unless
+  `UAID_ALLOW_ALL_DOMAINS=true` (unsafe for production).
+
+See `docs/docs/architecture/auth-token-dispatch.md` for the token dispatch
+rule the remote gateway applies to the forwarded token.
+
 **Headers:**
 
 ```http

--- a/tests/live_gateway/test_trust_mode_multi_worker.py
+++ b/tests/live_gateway/test_trust_mode_multi_worker.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/live_gateway/test_trust_mode_multi_worker.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Multi-worker revocation propagation for JWT trust mode (issue #5905, suite b).
+
+Two gateway workers share one database and one Redis blocklist. A trust-mode
+token revoked on worker A must be rejected by worker B within the documented
+negative-cache window (``auth_cache_revocation_ttl``, default 30 s): the
+trust branch re-checks the configured revocation claim on every request.
+
+Requirements (same pattern as ``run_primary_worker_multiinstance.sh``):
+    - docker compose stack with the gateway scaled to 2 replicas, sharing one
+      Postgres database and one Redis instance, started with
+      ``JWT_TRUST_MODE=jwt-trust``
+    - ``JWT_SECRET_KEY`` identical on both workers (shared signing key)
+    - ``TRUST_MULTI_WORKER_URLS``: comma-separated base URL per worker, e.g.
+      ``http://127.0.0.1:8080,http://127.0.0.1:8081``
+
+Run:
+    JWT_TRUST_MODE=jwt-trust \
+    TRUST_MULTI_WORKER_URLS=http://127.0.0.1:8080,http://127.0.0.1:8081 \
+        uv run pytest tests/live_gateway/test_trust_mode_multi_worker.py
+
+The suite self-skips when no gateway is reachable, when fewer than two
+worker URLs are configured, or when the stack is not in trust mode.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import os
+
+# Third-Party
+import httpx
+import pytest
+
+# Local
+from tests.helpers.auth import make_auth_headers, make_trusted_test_jwt
+from .helpers.mcp_test_helpers import (
+    BASE_URL,
+    JWT_SECRET,
+    skip_no_gateway,
+)
+
+pytestmark = [pytest.mark.e2e, skip_no_gateway]
+
+# Expected gateway mode for this run; must match the stack configuration.
+EXPECTED_TRUST_MODE = os.getenv("JWT_TRUST_MODE", "db")
+
+# One base URL per worker. With the single-node default stack this list has
+# one entry and the multi-worker test skips; the standard live stack still
+# runs the single-worker revocation sanity check.
+WORKER_URLS = [url.strip() for url in os.getenv("TRUST_MULTI_WORKER_URLS", "").split(",") if url.strip()] or [BASE_URL]
+
+skip_unless_trust_mode = pytest.mark.skipif(EXPECTED_TRUST_MODE != "jwt-trust", reason="requires the stack started with JWT_TRUST_MODE=jwt-trust")
+skip_unless_multi_worker = pytest.mark.skipif(len(WORKER_URLS) < 2, reason="multi-worker stack not configured (set TRUST_MULTI_WORKER_URLS to one base URL per worker)")
+
+TRUST_USER_ID = "live-mw-trust-subject-0001"
+TRUST_EMAIL = "live.mw.trust.user@example.com"
+REVOKE_JTI = "live-mw-revoke-jti-0001"
+CONTROL_JTI = "live-mw-control-jti-0001"
+
+
+def _trust_token(jti: str) -> str:
+    """Mint a trust-marker token with a known revocation identifier."""
+    return make_trusted_test_jwt(
+        TRUST_USER_ID,
+        email=TRUST_EMAIL,
+        teams=[],
+        roles=[],
+        revocation_id=jti,
+        secret=JWT_SECRET,
+    )
+
+
+def _get_tools(worker_url: str, token: str) -> httpx.Response:
+    """Issue an authenticated read against one worker."""
+    return httpx.get(f"{worker_url}/tools", headers=make_auth_headers(token), timeout=10)
+
+
+def _logout(worker_url: str, token: str) -> httpx.Response:
+    """Revoke the token through the logout endpoint on one worker."""
+    return httpx.post(f"{worker_url}/auth/logout", headers=make_auth_headers(token), timeout=10)
+
+
+@skip_unless_trust_mode
+def test_revocation_visible_on_single_worker() -> None:
+    """Sanity: logout revokes a trust token on the standard single-worker stack."""
+    token = _trust_token(REVOKE_JTI)
+
+    response = _get_tools(WORKER_URLS[0], token)
+    assert response.status_code == 200, f"trust token rejected before revocation: {response.status_code} {response.text[:200]}"
+
+    logout_response = _logout(WORKER_URLS[0], token)
+    assert logout_response.status_code == 200, f"logout failed: {logout_response.status_code} {logout_response.text[:200]}"
+    assert logout_response.json().get("revoked_token") == REVOKE_JTI
+
+    response = _get_tools(WORKER_URLS[0], token)
+    assert response.status_code == 401, f"revoked trust token still accepted: {response.status_code}"
+
+
+@skip_unless_trust_mode
+@skip_unless_multi_worker
+def test_revocation_propagates_across_workers() -> None:
+    """Revoke on worker A; the same jti is rejected on worker B.
+
+    Revocation lands in the shared database (and the shared Redis blocklist),
+    so worker B rejects the token immediately — well within the documented
+    30 s negative-cache window.
+    """
+    worker_a, worker_b = WORKER_URLS[0], WORKER_URLS[1]
+    token = _trust_token(REVOKE_JTI)
+
+    # The token authenticates against both workers before revocation.
+    for url in (worker_a, worker_b):
+        response = _get_tools(url, token)
+        assert response.status_code == 200, f"trust token rejected by {url} before revocation: {response.status_code} {response.text[:200]}"
+
+    # Revoke on worker A via the logout endpoint (writes the blocklist row).
+    logout_response = _logout(worker_a, token)
+    assert logout_response.status_code == 200, f"logout on worker A failed: {logout_response.status_code} {logout_response.text[:200]}"
+    assert logout_response.json().get("revoked_token") == REVOKE_JTI
+
+    # Worker B must reject the same jti. The trust branch checks the
+    # revocation store on every request, so no cache wait is needed; the
+    # assertion runs well inside the 30 s negative-cache window.
+    response = _get_tools(worker_b, token)
+    assert response.status_code == 401, f"worker B accepted a token revoked on worker A: {response.status_code}"
+
+    # Control: a different, unrevoked jti still authenticates on both workers.
+    control = _trust_token(CONTROL_JTI)
+    for url in (worker_a, worker_b):
+        response = _get_tools(url, control)
+        assert response.status_code == 200, f"unrevoked control token rejected by {url}: {response.status_code} {response.text[:200]}"

--- a/tests/unit/mcpgateway/test_token_dispatch_matrix.py
+++ b/tests/unit/mcpgateway/test_token_dispatch_matrix.py
@@ -14,13 +14,23 @@ docs/docs/architecture/auth-token-dispatch.md:
   trust branch in get_current_user.
 - The external-IdP branch-(b) row is green since #5903 landed the
   external IdP trust root.
+
+Real-entry-point conversion (#6753 / F4): the external rows previously
+called ``_maybe_verify_external()`` directly with a mocked
+``verify_external_idp_token``. They now drive the real entry points
+(``get_current_user()`` for the ingress rows, ``verify_credentials_cached()``
+for the default-mode provisioning row) with externally-signed RS256 tokens
+minted from Task 9's local OIDC issuer key. ONLY the OIDC discovery/JWKS
+network fetch is mocked: the dispatch (``_maybe_verify_external`` /
+``verify_credentials_cached``), provider resolution, RSA
+signature/audience/expiry verification, and claim mapping all run for real.
 """
 
 # Standard
 import contextlib
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 # Third-Party
 from fastapi import HTTPException, status
@@ -33,12 +43,34 @@ from sqlalchemy.pool import StaticPool
 # First-Party
 from mcpgateway.auth import get_current_user
 from mcpgateway.config import settings
-from mcpgateway.db import Base, EmailUser
+from mcpgateway.db import Base, EmailUser, SSOProvider
+from mcpgateway.services import sso_service
+from mcpgateway.utils import verify_credentials as vc
+from tests.live_gateway.helpers.local_oidc_issuer import generate_signing_key, mint_token
+
+# The externally-signed fixtures' issuer/audience. The issuer is an https
+# origin so the JWKS-URI SSRF defense in verify_oauth_access_token accepts
+# the (mocked) discovery document.
+EXT_ISSUER = "https://idp.example.test"
+EXT_AUDIENCE = "api://my-app"
+EXT_JWKS_URI = f"{EXT_ISSUER}/.well-known/jwks.json"
+EXT_PROVIDER_ID = "local-oidc-test"
+UNTRUSTED_ISSUER = "https://untrusted-idp.example.test"
 
 
 def _exp(hours: int = 1) -> float:
     """Expiry timestamp for mocked JWT payloads."""
     return (datetime.now(timezone.utc) + timedelta(hours=hours)).timestamp()
+
+
+@pytest.fixture(scope="module")
+def ext_signing_key():
+    """RSA keypair shared by this module's externally-signed fixtures.
+
+    Generated once per module via Task 9's local OIDC issuer harness; tokens
+    are minted per test with distinct subjects/jtis.
+    """
+    return generate_signing_key()
 
 
 def _make_user(email: str) -> EmailUser:
@@ -55,28 +87,97 @@ def _make_user(email: str) -> EmailUser:
     )
 
 
-def _fake_provider(issuer: str) -> MagicMock:
-    """SSO provider opted into API auth with a pinned audience."""
-    provider = MagicMock()
-    provider.issuer = issuer
-    provider.is_enabled = True
-    provider.trusted_for_api_auth = True
-    provider.api_audience = "api://my-app"
-    return provider
+def _seed_trust_root_provider(db) -> str:
+    """Insert the SSO provider row that makes EXT_ISSUER a configured trust root.
+
+    This is the row ``resolve_trusted_provider_by_issuer`` matches against:
+    enabled, opted into API auth, with a pinned audience. Only the NOT-NULL
+    columns plus the trust-root fields matter on the dispatch path.
+    """
+    provider = SSOProvider(
+        id=EXT_PROVIDER_ID,
+        name=EXT_PROVIDER_ID,
+        display_name="Local OIDC Test Issuer",
+        provider_type="oidc",
+        is_enabled=True,
+        client_id="dispatch-matrix-tests",
+        client_secret_encrypted="unused-on-this-path",  # pragma: allowlist secret
+        authorization_url=f"{EXT_ISSUER}/authorize",
+        token_url=f"{EXT_ISSUER}/token",
+        userinfo_url=f"{EXT_ISSUER}/userinfo",
+        issuer=EXT_ISSUER,
+        trusted_for_api_auth=True,
+        api_audience=EXT_AUDIENCE,
+    )
+    db.add(provider)
+    db.commit()
+    # Return the id (not the ORM object): the seeding session may close
+    # before the caller reads attributes, which would detach the instance.
+    return provider.id
 
 
-def _repoint_funnel_sessions(monkeypatch) -> None:
+def _install_external_jwks(monkeypatch, signing_key) -> None:
+    """Mock ONLY the OIDC discovery/JWKS network fetch for EXT_ISSUER.
+
+    Signature, audience, expiry, and issuer checks in
+    ``verify_oauth_access_token`` still run for real against the module RSA
+    key, as do the dispatch, provider resolution, and claim mapping.
+    """
+
+    async def _fake_discover(issuer: str):
+        if issuer.rstrip("/") == EXT_ISSUER:
+            return {"issuer": EXT_ISSUER, "jwks_uri": EXT_JWKS_URI}
+        return None
+
+    class _StaticJWKClient:
+        """Stand-in for the PyJWKClient cache entry: serves the test key."""
+
+        def get_signing_key_from_jwt(self, _token):
+            return SimpleNamespace(key=signing_key.public_key())
+
+    monkeypatch.setattr(vc, "_discover_oidc_metadata", _fake_discover)
+    monkeypatch.setitem(vc._oauth_jwks_client_cache, EXT_JWKS_URI, _StaticJWKClient())
+
+
+def _mint_external_token(signing_key, subject: str, *, issuer: str = EXT_ISSUER, **claims) -> str:
+    """Mint an RS256 token from the local issuer key with the registered audience."""
+    payload = {
+        "iss": issuer,
+        "sub": subject,
+        "aud": EXT_AUDIENCE,
+        "exp": _exp(),
+        "iat": datetime.now(timezone.utc).timestamp(),
+        "jti": f"ext-jti-{subject}-{issuer.split('//')[1]}",
+    }
+    payload.update(claims)
+    return mint_token(payload, signing_key)
+
+
+async def _reset_external_caches() -> None:
+    """Cold-start the provider map and external-identity caches for a test."""
+    sso_service.invalidate_trusted_provider_cache()
+    await vc.invalidate_external_identity_cache()
+
+
+def _repoint_funnel_sessions(monkeypatch):
     """Re-point the funnel's internal sessions at a schema-complete test DB.
 
     The trust branch validates role claims against the server-side roles
-    table through ``fresh_db_session``. The default in-memory engine gives
-    each connection a fresh empty database, so the trust-path tests re-point
-    the funnel sessions the same way the B.4/B.5 trust tests do.
+    table through ``fresh_db_session``, and the external-IdP dispatch opens
+    its own session through ``mcpgateway.db.SessionLocal`` when the request
+    does not carry one. The default in-memory engine gives each connection
+    a fresh empty database, so the trust-path tests re-point all three
+    session factories at one shared engine (the same way the B.4/B.5 trust
+    tests do).
+
+    Returns the session factory so tests can seed rows and hand the
+    dispatch a request-scoped session (``request.state.db``).
     """
     engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
     Base.metadata.create_all(bind=engine)
     session_test = sessionmaker(bind=engine)
     monkeypatch.setattr("mcpgateway.auth.SessionLocal", session_test)
+    monkeypatch.setattr("mcpgateway.db.SessionLocal", session_test)
 
     @contextlib.contextmanager
     def _fresh_db_session():
@@ -87,38 +188,48 @@ def _repoint_funnel_sessions(monkeypatch) -> None:
             session.close()
 
     monkeypatch.setattr("mcpgateway.auth.fresh_db_session", _fresh_db_session)
+    return session_test
 
 
 class TestTokenDispatchMatrix:
     """Six mode-x-token combinations of the token dispatch rule (#5896)."""
 
     @pytest.mark.asyncio
-    async def test_external_idp_token_default_mode_provisioning(self, monkeypatch):
+    async def test_external_idp_token_default_mode_provisioning(self, monkeypatch, ext_signing_key):
         """Default mode + external IdP token -> current provisioning behavior.
 
         A token from a trusted issuer verifies through
         verify_external_idp_token and enters the default provisioning
         funnel. This is the current code path and the expected result for
         this combination.
+
+        Real-entry-point shape (#6753): drives ``verify_credentials_cached``
+        — the default-mode entry point for external bearers — with an
+        externally-signed RS256 token. Only the JWKS network fetch is
+        mocked; the dispatch, RSA signature/audience/expiry verification,
+        and the provisioning funnel (build_external_identity) run for real.
         """
-        # Third-Party
-        import jwt as pyjwt
+        session_test = _repoint_funnel_sessions(monkeypatch)
+        provider_id = _seed_trust_root_provider(session_test())
+        monkeypatch.setattr(settings, "jwt_trust_mode", "db")
+        monkeypatch.setattr(settings, "sso_api_token_auth_enabled", True)
+        _install_external_jwks(monkeypatch, ext_signing_key)
+        await _reset_external_caches()
 
-        # First-Party
-        from mcpgateway.utils import verify_credentials as vc
+        token = _mint_external_token(ext_signing_key, "agent", email="agent@example.com", email_verified=True)
+        request = SimpleNamespace(state=SimpleNamespace(db=session_test()))
+        payload = await vc.verify_credentials_cached(token, request)
 
-        token = pyjwt.encode({"iss": "https://kc/realms/m", "sub": "agent"}, "k", algorithm="HS256")
-        provider = _fake_provider("https://kc/realms/m")
-        monkeypatch.setattr(vc, "resolve_trusted_provider_by_issuer", lambda iss, db: provider)
-
-        async def fake_verify(tok, authorization_servers, *, expected_audience=None):
-            return {"iss": "https://kc/realms/m", "sub": "agent"}
-
-        monkeypatch.setattr(vc, "verify_oauth_access_token", fake_verify)
-        claims, returned_provider = await vc.verify_external_idp_token(token, MagicMock())
-
-        assert claims["sub"] == "agent"
-        assert returned_provider is provider
+        # The external dispatch served the request: the verified payload is
+        # stashed on the request for downstream consumers.
+        assert request.state._jwt_verified_payload == (token, payload)  # pylint: disable=protected-access
+        # Session semantics from the provisioning funnel, not trust claims.
+        assert payload["token_use"] == "session"
+        assert payload["email"] == "agent@example.com"
+        assert payload["auth_provider"] == provider_id
+        # Provisioning side-effect: a local user record now exists.
+        db = session_test()
+        assert db.query(EmailUser).filter(EmailUser.email == "agent@example.com").first() is not None
 
     @pytest.mark.asyncio
     async def test_session_token_trust_mode_default_funnel(self, monkeypatch):
@@ -268,7 +379,7 @@ class TestTokenDispatchMatrix:
                         assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
 
     @pytest.mark.asyncio
-    async def test_external_idp_token_trust_mode_trust_semantics(self, monkeypatch):
+    async def test_external_idp_token_trust_mode_trust_semantics(self, monkeypatch, ext_signing_key):
         """Trust mode + external IdP token (trusted issuer) -> trust-semantics.
 
         The issuer is a configured trust root, so the token is
@@ -276,57 +387,39 @@ class TestTokenDispatchMatrix:
         token claims alone and the provisioning path
         (build_external_identity) is not invoked. Green since #5903 landed
         the external IdP trust root.
+
+        Real-entry-point shape (#6753): drives ``get_current_user()`` with
+        an externally-signed RS256 token whose issuer is a seeded trust
+        root. Only the JWKS network fetch is mocked; the ingress dispatch,
+        signature verification, and claims-derived identity build run for
+        real.
         """
-        # Third-Party
-        import jwt as pyjwt
+        session_test = _repoint_funnel_sessions(monkeypatch)
+        _seed_trust_root_provider(session_test())
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        monkeypatch.setattr(settings, "sso_api_token_auth_enabled", True)
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+        _install_external_jwks(monkeypatch, ext_signing_key)
+        await _reset_external_caches()
 
-        # First-Party
-        from mcpgateway.utils import verify_credentials as vc
+        token = _mint_external_token(ext_signing_key, "ext-subject-0001", email="ext.user@example.com")
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)  # pragma: allowlist secret
+        request = SimpleNamespace(state=SimpleNamespace(db=session_test()))
 
-        token = pyjwt.encode({"iss": "https://kc/realms/m", "sub": "agent", "exp": _exp()}, "k", algorithm="HS256")
-        provider = _fake_provider("https://kc/realms/m")
-
-        monkeypatch.setattr(vc.settings, "sso_api_token_auth_enabled", True)
-        monkeypatch.setattr(vc.settings, "jwt_trust_mode", "jwt-trust")
-        monkeypatch.setattr(vc, "_has_trusted_providers", lambda db: True)
-
-        async def fake_verify_external(tok, db):
-            return {"iss": "https://kc/realms/m", "sub": "agent", "exp": _exp()}, provider
-
-        monkeypatch.setattr(vc, "verify_external_idp_token", fake_verify_external)
-        mock_build = AsyncMock(return_value={"sub": "agent", "token": token})
+        mock_build = AsyncMock(side_effect=AssertionError("provisioning path entered for a trust-root token"))
         monkeypatch.setattr(vc, "build_external_identity", mock_build)
+        internal_verifier = AsyncMock(side_effect=HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid authentication credentials"))
 
-        await vc.invalidate_external_identity_cache()
-        request = SimpleNamespace(state=SimpleNamespace(db=MagicMock()))
-        await vc._maybe_verify_external(token, request)
+        with patch("mcpgateway.auth.verify_jwt_token_cached", internal_verifier):
+            user = await get_current_user(credentials=credentials, request=request)
 
-        # Trust-semantics: claims-derived identity, no local provisioning.
+        # Trust-semantics: claims-derived identity, no local provisioning,
+        # and the internal verifier was never consulted.
+        assert user.email == "ext.user@example.com"
+        assert request.state.token_use == "trusted"
         mock_build.assert_not_called()
-
-
-def _external_payload() -> dict:
-    """Claims-derived identity payload as build_trusted_external_identity returns it.
-
-    Carries the original token claims (sub/email/groups/jti) plus the derived
-    trust markers, exactly the shape ``_maybe_verify_external`` yields on the
-    trust-root branch.
-    """
-    return {
-        "iss": "https://idp.example.test",
-        "sub": "ext-subject-0001",
-        "email": "ext.user@example.com",
-        "user_id": "ext-subject-0001",
-        "groups": ["external-group-1"],
-        "teams": [],
-        "roles": [],
-        "is_admin": False,
-        "jti": "ext-jti-ingress-1",
-        "exp": _exp(),
-        "token_use": "trusted",
-        "source": "external_idp",
-        "auth_provider": "local-oidc-test",
-    }
+        internal_verifier.assert_not_called()
 
 
 class TestIngressExternalDispatch:
@@ -343,6 +436,14 @@ class TestIngressExternalDispatch:
       internal funnel exactly as before.
     - Trust mode OFF (db) -> external path is never entered.
     - No credentials -> 401 (pre-existing behavior, pinned).
+
+    Real-entry-point shape (#6753 / F4): every external row uses an
+    externally-signed RS256 token minted from the local issuer key and runs
+    the real dispatch (``_try_external_verification`` ->
+    ``_maybe_verify_external`` -> ``verify_external_idp_token``). Only the
+    OIDC discovery/JWKS network fetch is mocked. Where a test must prove
+    the dispatch was (or was not) consulted, a wraps-spy records the call
+    while delegating to the real function.
     """
 
     @pytest.mark.asyncio
@@ -354,115 +455,117 @@ class TestIngressExternalDispatch:
         assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
 
     @pytest.mark.asyncio
-    async def test_db_mode_external_token_stays_on_internal_funnel(self, monkeypatch):
+    async def test_db_mode_external_token_stays_on_internal_funnel(self, monkeypatch, ext_signing_key):
         """Trust mode OFF + external-issuer token -> 401 via the internal funnel.
 
         The external dispatch must never run: with jwt_trust_mode="db" the
-        internal verifier alone decides, and it rejects externally-signed
-        tokens.
+        internal verifier alone decides, and it rejects the externally-signed
+        RS256 token (real signature check against the gateway HMAC secret).
+        The wraps-spy proves the real dispatch is never consulted.
         """
-        # Third-Party
-        import jwt as pyjwt
-
-        # First-Party
-        from mcpgateway.utils import verify_credentials as vc
-
-        token = pyjwt.encode({"iss": "https://idp.example.test", "sub": "ext", "exp": _exp()}, "k", algorithm="HS256")
+        token = _mint_external_token(ext_signing_key, "ext")
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)  # pragma: allowlist secret
 
         monkeypatch.setattr(settings, "jwt_trust_mode", "db")
-        external_dispatch = AsyncMock(side_effect=AssertionError("external path entered in db mode"))
-        monkeypatch.setattr(vc, "_maybe_verify_external", external_dispatch)
-
-        with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(side_effect=HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid authentication credentials"))):
-            with pytest.raises(HTTPException) as exc_info:
-                await get_current_user(credentials=credentials, request=None)
-
-        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
-        external_dispatch.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_trust_mode_external_token_authenticates_via_external_path(self, monkeypatch):
-        """Trust mode ON + trust-root token -> claims-derived principal.
-
-        The internal verifier would reject this RS256-style external token
-        (mocked to 401); the request still authenticates because the ingress
-        dispatch consults the external verifier FIRST and its payload flows
-        into the token_use="trusted" branch.
-        """
-        # Third-Party
-        import jwt as pyjwt
-
-        # First-Party
-        from mcpgateway.utils import verify_credentials as vc
-
-        token = pyjwt.encode({"iss": "https://idp.example.test", "sub": "ext-subject-0001", "exp": _exp()}, "k", algorithm="HS256")
-        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)  # pragma: allowlist secret
-
-        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
         monkeypatch.setattr(settings, "auth_cache_enabled", False)
         monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
-        _repoint_funnel_sessions(monkeypatch)
+        external_spy = AsyncMock(wraps=vc._maybe_verify_external)
+        monkeypatch.setattr(vc, "_maybe_verify_external", external_spy)
 
-        external_dispatch = AsyncMock(return_value=_external_payload())
-        monkeypatch.setattr(vc, "_maybe_verify_external", external_dispatch)
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials=credentials, request=None)
+
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+        external_spy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_trust_mode_external_token_authenticates_via_external_path(self, monkeypatch, ext_signing_key):
+        """Trust mode ON + trust-root token -> claims-derived principal.
+
+        The internal verifier would reject this externally-signed RS256
+        token (patched to 401 to prove it is never consulted); the request
+        still authenticates because the real ingress dispatch consults the
+        external verifier FIRST — only the JWKS network fetch is mocked —
+        and its payload flows into the token_use="trusted" branch.
+        """
+        session_test = _repoint_funnel_sessions(monkeypatch)
+        _seed_trust_root_provider(session_test())
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        monkeypatch.setattr(settings, "sso_api_token_auth_enabled", True)
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+        _install_external_jwks(monkeypatch, ext_signing_key)
+        await _reset_external_caches()
+
+        token = _mint_external_token(ext_signing_key, "ext-subject-0001", email="ext.user@example.com", groups=["external-group-1"])
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)  # pragma: allowlist secret
+        request = SimpleNamespace(state=SimpleNamespace(db=session_test()))
+
+        external_spy = AsyncMock(wraps=vc._maybe_verify_external)
+        monkeypatch.setattr(vc, "_maybe_verify_external", external_spy)
         internal_verifier = AsyncMock(side_effect=HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid authentication credentials"))
 
-        request = SimpleNamespace(state=SimpleNamespace())
         with patch("mcpgateway.auth.verify_jwt_token_cached", internal_verifier):
-            with patch("mcpgateway.auth._check_token_revoked_sync", return_value=False):
-                user = await get_current_user(credentials=credentials, request=request)
+            user = await get_current_user(credentials=credentials, request=request)
 
         assert user.email == "ext.user@example.com"
         assert request.state.token_use == "trusted"
-        external_dispatch.assert_awaited_once()
+        external_spy.assert_awaited_once()
         internal_verifier.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_trust_mode_trust_root_invalid_token_fails_closed(self, monkeypatch):
+    async def test_trust_mode_trust_root_invalid_token_fails_closed(self, monkeypatch, ext_signing_key):
         """Trust mode ON + trust-root token that fails verification -> 401.
 
-        Fail-closed: a definitive external-verification failure (bad
-        signature, wrong audience, expired, missing revocation claim) must
-        NOT fall through to the internal funnel for that token.
+        Fail-closed: a definitive external-verification failure (here a bad
+        signature — the token is signed with a key the JWKS endpoint does
+        not serve) must NOT fall through to the internal funnel for that
+        token. The patched internal verifier WOULD authenticate this
+        request, so the 401 proves it was never consulted.
         """
-        # Third-Party
-        import jwt as pyjwt
-
-        # First-Party
-        from mcpgateway.utils import verify_credentials as vc
-
-        token = pyjwt.encode({"iss": "https://idp.example.test", "sub": "ext", "exp": _exp()}, "k", algorithm="HS256")
-        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)  # pragma: allowlist secret
-
+        session_test = _repoint_funnel_sessions(monkeypatch)
+        _seed_trust_root_provider(session_test())
         monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
-        external_dispatch = AsyncMock(side_effect=vc.ExternalIssuerVerificationError("trust-root token failed verification"))
-        monkeypatch.setattr(vc, "_maybe_verify_external", external_dispatch)
+        monkeypatch.setattr(settings, "sso_api_token_auth_enabled", True)
+        _install_external_jwks(monkeypatch, ext_signing_key)
+        await _reset_external_caches()
+
+        wrong_key = generate_signing_key()  # not the key the JWKS stub serves
+        token = _mint_external_token(wrong_key, "ext")
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)  # pragma: allowlist secret
+        request = SimpleNamespace(state=SimpleNamespace(db=session_test()))
+
+        external_spy = AsyncMock(wraps=vc._maybe_verify_external)
+        monkeypatch.setattr(vc, "_maybe_verify_external", external_spy)
         internal_verifier = AsyncMock(return_value={"sub": "internal@example.com", "exp": _exp(), "jti": "internal-jti"})
 
         with patch("mcpgateway.auth.verify_jwt_token_cached", internal_verifier):
             with pytest.raises(HTTPException) as exc_info:
-                await get_current_user(credentials=credentials, request=SimpleNamespace(state=SimpleNamespace()))
+                await get_current_user(credentials=credentials, request=request)
 
         assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
-        external_dispatch.assert_awaited_once()
+        external_spy.assert_awaited_once()
         internal_verifier.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_trust_mode_non_trust_root_token_falls_through_to_internal(self, monkeypatch):
+    async def test_trust_mode_non_trust_root_token_falls_through_to_internal(self, monkeypatch, ext_signing_key):
         """Trust mode ON + issuer NOT a trust root -> internal funnel as today.
 
-        The external dispatch returns None (not external-issuer material) and
-        the internal verifier decides; a gateway-signed JWT still
-        authenticates with trust mode ON (no regression).
+        The real external dispatch decodes the token, finds the issuer is
+        not a configured trust root (a DIFFERENT issuer is seeded as the
+        trust root, so the provider-resolution query really runs), and
+        returns None; the internal verifier then decides. A gateway-signed
+        JWT still authenticates with trust mode ON (no regression).
         """
-        # Third-Party
-        import jwt as pyjwt
+        session_test = _repoint_funnel_sessions(monkeypatch)
+        _seed_trust_root_provider(session_test())
+        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+        monkeypatch.setattr(settings, "sso_api_token_auth_enabled", True)
+        monkeypatch.setattr(settings, "auth_cache_enabled", False)
+        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+        await _reset_external_caches()
 
-        # First-Party
-        from mcpgateway.utils import verify_credentials as vc
-
-        token = pyjwt.encode({"iss": "mcpgateway", "sub": "api@example.com", "exp": _exp()}, "k", algorithm="HS256")
+        token = _mint_external_token(ext_signing_key, "api@example.com", issuer=UNTRUSTED_ISSUER)
         credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)  # pragma: allowlist secret
 
         jwt_payload = {
@@ -473,13 +576,12 @@ class TestIngressExternalDispatch:
             "user": {"auth_provider": "api_token"},
         }
 
-        request = SimpleNamespace(state=SimpleNamespace())
-        monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
-        monkeypatch.setattr(settings, "auth_cache_enabled", False)
-        monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
-
-        external_dispatch = AsyncMock(return_value=None)
-        monkeypatch.setattr(vc, "_maybe_verify_external", external_dispatch)
+        request = SimpleNamespace(state=SimpleNamespace(db=session_test()))
+        external_spy = AsyncMock(wraps=vc._maybe_verify_external)
+        monkeypatch.setattr(vc, "_maybe_verify_external", external_spy)
+        # The internal funnel's own JWT verification is outside this row's
+        # scope (the row pins the fall-through DECISION), so the internal
+        # verifier is stubbed exactly as in the default-funnel rows above.
         internal_verifier = AsyncMock(return_value=jwt_payload)
 
         with patch("mcpgateway.auth.verify_jwt_token_cached", internal_verifier):
@@ -489,4 +591,5 @@ class TestIngressExternalDispatch:
 
         assert user.email == "api@example.com"
         assert request.state.token_use == "api"
+        external_spy.assert_awaited_once()
         internal_verifier.assert_awaited_once()

--- a/tests/unit/mcpgateway/test_trust_mode_config_flip.py
+++ b/tests/unit/mcpgateway/test_trust_mode_config_flip.py
@@ -1,0 +1,266 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_trust_mode_config_flip.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Config-flip acceptance suite for JWT trust mode (issue #5905, suite c).
+
+Tokens behave per the dispatch rule in
+``docs/docs/architecture/auth-token-dispatch.md`` (#5896) across mode
+transitions:
+
+- Default mode (``jwt_trust_mode="db"``): a legacy token follows the default
+  funnel (user record from ``email_users``); a ``token_use="trusted"`` token
+  is rejected with 401 — the marker never enters the default funnel.
+- Trust mode (``jwt_trust_mode="jwt-trust"``): a ``token_use="trusted"``
+  token authenticates from its claims alone (trust semantics); a legacy
+  token still follows the default funnel — including the ``is_active``
+  kill-switch, which trust mode deliberately does not have.
+- Flip back to default mode: the trusted marker is 401 again; the legacy
+  token authenticates again.
+
+The mode is flipped on the live ``settings`` object inside one process, the
+same way an operator flips ``JWT_TRUST_MODE`` between restarts.
+"""
+
+# Standard
+import contextlib
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+# Third-Party
+from fastapi import HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.auth import get_current_user
+from mcpgateway.config import settings
+from mcpgateway.db import Base, EmailTeam, EmailUser
+from mcpgateway.utils.trusted_claims import VirtualPrincipal
+
+CALLER_ID = "trust-flip-subject-0001"
+CALLER_EMAIL = "flip.user@example.com"
+LEGACY_EMAIL = "legacy.user@example.com"
+
+
+def _exp(hours: int = 1) -> float:
+    """Expiry timestamp for mocked JWT payloads."""
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).timestamp()
+
+
+@pytest.fixture
+def db():
+    """In-memory SQLite session with one active user and one team.
+
+    Yields:
+        Session bound to the in-memory engine.
+    """
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    now = datetime.now(timezone.utc)
+    session.add(
+        EmailUser(
+            email=LEGACY_EMAIL,
+            password_hash="hash",  # pragma: allowlist secret
+            full_name="Legacy User",
+            is_admin=False,
+            is_active=True,
+            email_verified_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    session.add(EmailTeam(id="team-a", name="CF-Team-A", slug="cf-team-a", created_by=LEGACY_EMAIL, is_personal=False, visibility="private"))
+    session.commit()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _patch_funnel_sessions(monkeypatch: pytest.MonkeyPatch, db) -> None:
+    """Re-point the funnel's internal sessions at the test database."""
+    session_test = sessionmaker(bind=db.get_bind())
+    monkeypatch.setattr("mcpgateway.auth.SessionLocal", session_test)
+
+    @contextlib.contextmanager
+    def _fresh_db_session():
+        session = session_test()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("mcpgateway.auth.fresh_db_session", _fresh_db_session)
+
+
+def _trust_payload(**overrides):
+    """Gateway-signed trust-token payload with the mapped claim set."""
+    payload = {
+        "sub": CALLER_ID,
+        "token_use": "trusted",
+        "email": CALLER_EMAIL,
+        "teams": ["team-a"],
+        "roles": [],
+        "jti": "config-flip-trusted-jti",
+        "exp": _exp(),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _legacy_payload(**overrides):
+    """Legacy default-mode payload: ``sub`` = email, no ``token_use`` marker."""
+    payload = {
+        "sub": LEGACY_EMAIL,
+        "jti": "config-flip-legacy-jti",
+        "exp": _exp(),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _set_mode(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    """Flip the trust mode, with caches off so the flip takes effect at once."""
+    monkeypatch.setattr(settings, "jwt_trust_mode", mode)
+    monkeypatch.setattr(settings, "auth_cache_enabled", False)
+    monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+
+
+async def _drive(payload: dict):
+    """Drive one request through get_current_user with the given payload.
+
+    Returns:
+        Tuple of (user, request).
+
+    Raises:
+        HTTPException: Whatever the funnel raises.
+    """
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="jwt_token")  # pragma: allowlist secret
+    request = SimpleNamespace(state=SimpleNamespace())
+    with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)):
+        user = await get_current_user(credentials=credentials, request=request)
+    return user, request
+
+
+class TestDefaultMode:
+    """jwt_trust_mode="db": the dispatch doc's default-mode rows."""
+
+    @pytest.mark.asyncio
+    async def test_legacy_token_follows_default_funnel(self, monkeypatch, db):
+        """Default mode: legacy token resolves the user record from the DB."""
+        _set_mode(monkeypatch, "db")
+        _patch_funnel_sessions(monkeypatch, db)
+
+        user, request = await _drive(_legacy_payload())
+
+        # Default semantics: an EmailUser row, not a claims-derived principal.
+        assert isinstance(user, EmailUser)
+        assert not isinstance(user, VirtualPrincipal)
+        assert user.email == LEGACY_EMAIL
+        assert request.state.token_use is None
+
+    @pytest.mark.asyncio
+    async def test_trusted_marker_rejected(self, monkeypatch, db):
+        """Default mode: token_use=trusted gets 401 and never enters the funnel."""
+        _set_mode(monkeypatch, "db")
+        _patch_funnel_sessions(monkeypatch, db)
+
+        # Fail loudly if the marker slips past the dispatch rule into the
+        # default funnel's user lookup.
+        with patch("mcpgateway.auth._get_user_by_email_sync", side_effect=AssertionError("trusted marker entered the default funnel")):
+            with pytest.raises(HTTPException) as exc_info:
+                await _drive(_trust_payload())
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+        assert "trust mode" in exc_info.value.detail.lower()
+
+
+class TestTrustMode:
+    """jwt_trust_mode="jwt-trust": the dispatch doc's trust-mode rows."""
+
+    @pytest.mark.asyncio
+    async def test_trusted_token_trust_semantics(self, monkeypatch, db):
+        """Trust mode: trusted token authenticates from its claims alone."""
+        _set_mode(monkeypatch, "jwt-trust")
+        _patch_funnel_sessions(monkeypatch, db)
+
+        user, request = await _drive(_trust_payload())
+
+        # Trust semantics: a claims-derived principal, no EmailUser row.
+        assert isinstance(user, VirtualPrincipal)
+        assert user.user_id == CALLER_ID
+        assert user.email == CALLER_EMAIL
+        assert request.state.token_use == "trusted"
+        assert request.state.token_teams == ["team-a"]
+
+    @pytest.mark.asyncio
+    async def test_legacy_token_stays_on_default_funnel(self, monkeypatch, db):
+        """Trust mode: a token without the marker follows the default funnel.
+
+        The default funnel keeps the ``is_active`` kill-switch: disabling
+        the user record rejects the token with 401 even in trust mode.
+        """
+        _set_mode(monkeypatch, "jwt-trust")
+        _patch_funnel_sessions(monkeypatch, db)
+
+        user, request = await _drive(_legacy_payload())
+        assert isinstance(user, EmailUser)
+        assert not isinstance(user, VirtualPrincipal)
+        assert user.email == LEGACY_EMAIL
+        assert request.state.token_use is None
+
+        # Default semantics enforced: the is_active check runs on this path.
+        legacy_user = db.query(EmailUser).filter(EmailUser.email == LEGACY_EMAIL).one()
+        legacy_user.is_active = False
+        db.commit()
+        with pytest.raises(HTTPException) as exc_info:
+            await _drive(_legacy_payload())
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+        assert exc_info.value.detail == "Account disabled"
+
+
+class TestFlipAcrossModes:
+    """One process, both directions of the mode flip."""
+
+    @pytest.mark.asyncio
+    async def test_flip_default_to_trust_to_default(self, monkeypatch, db):
+        """Tokens issued before the flip behave per the dispatch doc after it.
+
+        Default -> trust: the legacy token keeps default semantics; the
+        trusted marker becomes eligible. Trust -> default: the trusted
+        marker is 401 again; the legacy token authenticates again.
+        """
+        _patch_funnel_sessions(monkeypatch, db)
+
+        # Phase 1: default mode.
+        _set_mode(monkeypatch, "db")
+        with pytest.raises(HTTPException) as exc_info:
+            await _drive(_trust_payload())
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+        user, _ = await _drive(_legacy_payload())
+        assert isinstance(user, EmailUser)
+
+        # Phase 2: flip trust mode ON.
+        _set_mode(monkeypatch, "jwt-trust")
+        user, request = await _drive(_trust_payload())
+        assert isinstance(user, VirtualPrincipal)
+        assert request.state.token_use == "trusted"
+        user, request = await _drive(_legacy_payload())
+        assert isinstance(user, EmailUser)
+        assert request.state.token_use is None
+
+        # Phase 3: flip back to default mode.
+        _set_mode(monkeypatch, "db")
+        with pytest.raises(HTTPException) as exc_info:
+            await _drive(_trust_payload())
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+        user, _ = await _drive(_legacy_payload())
+        assert isinstance(user, EmailUser)
+        assert user.email == LEGACY_EMAIL

--- a/tests/unit/mcpgateway/test_trust_mode_cross_gateway.py
+++ b/tests/unit/mcpgateway/test_trust_mode_cross_gateway.py
@@ -1,0 +1,245 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_trust_mode_cross_gateway.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Cross-gateway UAID trust-mode acceptance suite (issue #5905, suite f).
+
+When the calling gateway and a remote gateway both run trust mode, the
+forwarded bearer token is the caller's inbound JWT (per the existing UAID
+bearer-forwarding rules; see docs/security/uaid-cross-gateway-auth.md). The
+remote gateway re-evaluates RBAC against its OWN ``external_group_mappings``
+table; team membership the calling gateway derived from its own mappings
+does NOT transfer.
+
+The remote gateway is modeled by a second in-memory database with its own
+mapping table and agents; the REAL trust-mode funnel
+(``get_current_user`` -> ``extract_trusted_principal`` ->
+``resolve_external_groups_to_teams``) runs against it, driven by the exact
+payload the calling gateway authenticated. The caller's token maps only to
+Team-A on the remote gateway, so an agent on remote Team-B returns 404 via
+``_check_agent_access`` (the route maps ``A2AAgentNotFoundError`` to HTTP
+404; see ``mcpgateway/main.py`` ``get_a2a_agent``).
+"""
+
+# Standard
+import contextlib
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+# Third-Party
+from fastapi.security import HTTPAuthorizationCredentials
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.auth import get_current_user
+from mcpgateway.config import settings
+from mcpgateway.db import A2AAgent as DbA2AAgent
+from mcpgateway.db import Base, EmailTeam, EmailUser, ExternalGroupMapping
+from mcpgateway.services.a2a_service import A2AAgentNotFoundError, A2AAgentService
+
+CALLER_ID = "trust-xgw-subject-0001"
+CALLER_EMAIL = "xgw.user@example.com"
+SHARED_ISSUER = "https://idp.example.com"  # both gateways trust the same issuer
+EXT_GROUP = "ext-group-1"
+AGENT_OK = object()  # sentinel for the convert_agent_to_read patch
+
+
+def _exp(hours: int = 1) -> float:
+    """Expiry timestamp for mocked JWT payloads."""
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).timestamp()
+
+
+def _make_db(seed):
+    """Build an in-memory gateway database and seed it.
+
+    Args:
+        seed: Callback receiving the session after the owner user exists.
+
+    Returns:
+        A session bound to the in-memory engine.
+    """
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    now = datetime.now(timezone.utc)
+    owner = EmailUser(
+        email="owner@example.com",
+        password_hash="hash",  # pragma: allowlist secret
+        full_name="Owner",
+        is_admin=False,
+        is_active=True,
+        email_verified_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(owner)
+    session.commit()
+    seed(session)
+    session.commit()
+    return session
+
+
+def _team(team_id: str, name: str, slug: str) -> EmailTeam:
+    """Build a non-personal team row."""
+    return EmailTeam(id=team_id, name=name, slug=slug, created_by="owner@example.com", is_personal=False, visibility="private")
+
+
+@pytest.fixture
+def calling_db():
+    """Calling gateway: maps the caller's external group to caller Team-X."""
+    session = _make_db(
+        lambda s: (
+            s.add(_team("caller-team-x", "Caller Team X", "caller-team-x")),
+            s.flush(),  # parent before child: no ORM relationship on the FK
+            s.add(ExternalGroupMapping(issuer=SHARED_ISSUER, tenant=None, external_group_id=EXT_GROUP, cf_team_id="caller-team-x")),
+        )
+    )
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def remote_db():
+    """Remote gateway: maps the caller's external group to remote Team-A only.
+
+    Hosts the target agent on remote Team-B (plus a public control agent).
+    """
+    def _seed(s):
+        s.add(_team("remote-team-a", "Remote Team A", "remote-team-a"))
+        s.add(_team("remote-team-b", "Remote Team B", "remote-team-b"))
+        s.flush()  # parents before children: no ORM relationship on the FKs
+        s.add(ExternalGroupMapping(issuer=SHARED_ISSUER, tenant=None, external_group_id=EXT_GROUP, cf_team_id="remote-team-a"))
+        s.flush()
+        s.add(
+            DbA2AAgent(
+                id="agent-team-b",
+                name="team-b-agent",
+                slug="team-b-agent",
+                endpoint_url="https://b.example.com/agent",
+                visibility="team",
+                team_id="remote-team-b",
+                enabled=True,
+            )
+        )
+        s.add(
+            DbA2AAgent(
+                id="agent-public",
+                name="public-agent",
+                slug="public-agent",
+                endpoint_url="https://public.example.com/agent",
+                visibility="public",
+                enabled=True,
+            )
+        )
+
+    session = _make_db(_seed)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _forwarded_payload() -> dict:
+    """Claims of the bearer token the calling gateway forwards cross-gateway.
+
+    The token carries the raw external group IDs; it does NOT carry any
+    ContextForge team IDs derived on the calling gateway.
+    """
+    return {
+        "sub": CALLER_ID,
+        "token_use": "trusted",
+        "iss": SHARED_ISSUER,
+        "email": CALLER_EMAIL,
+        "groups": [EXT_GROUP],
+        "roles": [],
+        "jti": "cross-gateway-jti-0001",
+        "exp": _exp(),
+    }
+
+
+def _patch_funnel_sessions(monkeypatch: pytest.MonkeyPatch, db) -> None:
+    """Re-point the funnel's internal sessions at the given gateway database."""
+    session_test = sessionmaker(bind=db.get_bind())
+    monkeypatch.setattr("mcpgateway.auth.SessionLocal", session_test)
+
+    @contextlib.contextmanager
+    def _fresh_db_session():
+        session = session_test()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("mcpgateway.auth.fresh_db_session", _fresh_db_session)
+
+
+async def _authenticate_on_gateway(monkeypatch: pytest.MonkeyPatch, gateway_db, payload: dict):
+    """Authenticate the forwarded bearer token on one gateway's database.
+
+    Runs the real trust-mode funnel: claim extraction, group-to-team
+    resolution against that gateway's ``external_group_mappings``, and the
+    revocation check.
+    """
+    monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+    monkeypatch.setattr(settings, "auth_cache_enabled", False)
+    monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+    _patch_funnel_sessions(monkeypatch, gateway_db)
+
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="forwarded_jwt")  # pragma: allowlist secret
+    request = SimpleNamespace(state=SimpleNamespace())
+    with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)):
+        user = await get_current_user(credentials=credentials, request=request)
+    return user, request
+
+
+class TestCrossGatewayTrustMode:
+    """The remote gateway re-evaluates the forwarded token against its own mappings."""
+
+    @pytest.mark.asyncio
+    async def test_remote_reevaluates_against_own_mappings(self, monkeypatch, calling_db, remote_db):
+        """Same token, two gateways: divergent mappings produce divergent teams."""
+        payload = _forwarded_payload()
+
+        # Calling gateway: the external group maps to caller Team-X.
+        caller, _ = await _authenticate_on_gateway(monkeypatch, calling_db, payload)
+        assert caller.teams == ["caller-team-x"]
+
+        # Remote gateway: the SAME forwarded token maps to remote Team-A.
+        # caller-team-x does not transfer.
+        remote_principal, request = await _authenticate_on_gateway(monkeypatch, remote_db, payload)
+        assert remote_principal.teams == ["remote-team-a"]
+        assert "caller-team-x" not in remote_principal.teams
+        assert request.state.token_teams == ["remote-team-a"]
+
+    @pytest.mark.asyncio
+    async def test_agent_on_remote_team_b_returns_404(self, monkeypatch, calling_db, remote_db):
+        """Caller mapped only to remote Team-A; agent on remote Team-B -> 404."""
+        payload = _forwarded_payload()
+
+        # The call chain: authenticate on the calling gateway (team-x), then
+        # the remote gateway re-authenticates the forwarded bearer (team-a).
+        caller, _ = await _authenticate_on_gateway(monkeypatch, calling_db, payload)
+        assert caller.teams == ["caller-team-x"]
+        remote_principal, _ = await _authenticate_on_gateway(monkeypatch, remote_db, payload)
+
+        service = A2AAgentService()
+        agent_b = remote_db.get(DbA2AAgent, "agent-team-b")
+        public_agent = remote_db.get(DbA2AAgent, "agent-public")
+
+        # Direct check: Team-B agent denied, public agent allowed.
+        assert await service._check_agent_access(remote_db, agent_b, remote_principal.email, remote_principal.teams) is False
+        assert await service._check_agent_access(remote_db, public_agent, remote_principal.email, remote_principal.teams) is True
+
+        # Route-level semantics: 404 for the Team-B agent, 200 path for public.
+        service.convert_agent_to_read = lambda db_agent, **kwargs: AGENT_OK
+        with pytest.raises(A2AAgentNotFoundError):
+            await service.get_agent(remote_db, "agent-team-b", user_email=remote_principal.email, token_teams=remote_principal.teams)
+        assert await service.get_agent(remote_db, "agent-public", user_email=remote_principal.email, token_teams=remote_principal.teams) is AGENT_OK

--- a/tests/unit/mcpgateway/test_trust_mode_no_db_proof.py
+++ b/tests/unit/mcpgateway/test_trust_mode_no_db_proof.py
@@ -1,0 +1,233 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_trust_mode_no_db_proof.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+NO-DB PROOF acceptance suite for JWT trust mode (issue #5905, suite a).
+
+A SQLAlchemy event listener on the test engine records every statement
+executed while 60 (>= 50) authenticated trust-mode requests pass through
+``get_current_user``. The assertion runs on the executed SQL, not on source
+text: ZERO ``SELECT`` statements against ``email_users`` are allowed. The
+database holds a real ``email_users`` row for the caller's email, so a
+user-table read would be observable if the trust path regressed.
+
+The revocation check, the roles-table lookup, the external-group resolver,
+and the team lookups are part of the trust path and DO run against their own
+tables; the listener proves the only table that must stay unread is
+``email_users``.
+
+
+
+CI-eligible: in-memory SQLite only; no Docker, no Redis, no network.
+"""
+
+# Standard
+import contextlib
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+# Third-Party
+from fastapi.security import HTTPAuthorizationCredentials
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.auth import get_current_user
+from mcpgateway.config import settings
+from mcpgateway.db import Base, EmailTeam, EmailUser, ExternalGroupMapping, Role
+from mcpgateway.utils.trusted_claims import VirtualPrincipal
+
+CALLER_EMAIL = "trust.user@example.com"
+ISSUER = "https://idp.example.com"
+
+#: The acceptance contract requires at least 50 authenticated requests.
+REQUEST_COUNT = 60
+
+
+def _exp(hours: int = 1) -> float:
+    """Expiry timestamp for mocked JWT payloads."""
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).timestamp()
+
+
+@pytest.fixture
+def db():
+    """In-memory SQLite session with FK enforcement and a seeded user row.
+
+    The caller's ``email_users`` row exists on purpose: the proof is only
+    meaningful when a user-table read would return data if it happened.
+
+    Yields:
+        Session bound to the in-memory engine.
+    """
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+
+    # Match production (PostgreSQL) FK enforcement so seeded rows must be
+    # referentially valid.
+    @sa.event.listens_for(engine, "connect")
+    def _enable_sqlite_fk(dbapi_connection, _connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    now = datetime.now(timezone.utc)
+    owner = EmailUser(
+        email=CALLER_EMAIL,
+        password_hash="hash",  # pragma: allowlist secret
+        full_name="Trust User",
+        is_admin=False,
+        is_active=True,
+        email_verified_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(owner)
+    # Commit parents before children: ExternalGroupMapping has a foreign key
+    # to email_teams without an ORM relationship, so the unit-of-work sorter
+    # cannot see the dependency and might insert the mapping first.
+    session.add(EmailTeam(id="team-a", name="CF-Team-A", slug="cf-team-a", created_by=owner.email, is_personal=False, visibility="private"))
+    session.commit()
+    session.add(
+        Role(
+            id="role-developer",
+            name="developer",
+            description="Developer role",
+            scope="global",
+            permissions=["tools.read"],
+            created_by=owner.email,
+            is_system_role=False,
+            is_active=True,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    session.add(ExternalGroupMapping(issuer=ISSUER, tenant=None, external_group_id="ext-group-1", cf_team_id="team-a", cf_role="developer"))
+    session.commit()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _patch_funnel_sessions(monkeypatch: pytest.MonkeyPatch, db) -> None:
+    """Re-point the funnel's internal sessions at the test database."""
+    session_test = sessionmaker(bind=db.get_bind())
+    monkeypatch.setattr("mcpgateway.auth.SessionLocal", session_test)
+
+    @contextlib.contextmanager
+    def _fresh_db_session():
+        session = session_test()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("mcpgateway.auth.fresh_db_session", _fresh_db_session)
+
+
+def _trust_payload(index: int) -> dict:
+    """Trust-token payload for request ``index``; claim shapes vary per request.
+
+    Every request carries a unique ``jti`` so the revocation check does real
+    work. Claim shapes rotate across: teams claim + role claim, external
+    groups through the mapping resolver, and a minimal email-less token.
+    """
+    base = {
+        "sub": f"trust-subject-{index:04d}",
+        "token_use": "trusted",
+        "iss": ISSUER,
+        "jti": f"no-db-proof-jti-{index:04d}",
+        "exp": _exp(),
+    }
+    shape = index % 3
+    if shape == 0:
+        base.update({"email": CALLER_EMAIL, "teams": ["team-a"], "roles": ["developer"]})
+    elif shape == 1:
+        base.update({"email": CALLER_EMAIL, "groups": ["ext-group-1"], "roles": []})
+    else:
+        # Minimal token: no email, no teams, no groups; the subject backs the
+        # email attribute and teams resolve to [].
+        base.update({"roles": []})
+    return base
+
+
+def _default_payload(index: int) -> dict:
+    """Legacy default-mode payload (``sub`` = email) for request ``index``."""
+    return {"sub": CALLER_EMAIL, "jti": f"default-mode-jti-{index:04d}", "exp": _exp()}
+
+
+async def _drive(payload: dict):
+    """Drive one authenticated request through get_current_user.
+
+    The JWT verifier is patched (signature verification is covered
+    elsewhere); every layer below it — dispatch, claim extraction, group
+    resolution, revocation check, team derivation — runs for real against
+    the test database.
+
+    Returns:
+        Tuple of (user, request).
+    """
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="jwt_token")  # pragma: allowlist secret
+    request = SimpleNamespace(state=SimpleNamespace())
+    with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)):
+        user = await get_current_user(credentials=credentials, request=request)
+    return user, request
+
+
+def _configure(monkeypatch: pytest.MonkeyPatch, db, *, mode: str) -> None:
+    """Point the funnel at the test database in the given trust mode."""
+    monkeypatch.setattr(settings, "jwt_trust_mode", mode)
+    monkeypatch.setattr(settings, "auth_cache_enabled", False)
+    monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+    _patch_funnel_sessions(monkeypatch, db)
+
+
+class TestNoDbProof:
+    """Zero SELECTs against email_users across 50+ trust-mode requests."""
+
+    @pytest.mark.asyncio
+    async def test_zero_email_users_selects_across_50plus_trust_requests(self, monkeypatch, db):
+        """60 authenticated trust-mode requests, zero email_users SELECTs.
+
+        The SQL listener runs on the engine while every request executes;
+        non-email_users tables (token_revocations, roles,
+        external_group_mappings, email_teams) are expected to be read.
+        """
+        _configure(monkeypatch, db, mode="jwt-trust")
+
+        # Warmup: settle one-time costs (imports, blocklist Redis probe)
+        # before the measured, listener-covered run.
+        for i in range(5):
+            await _drive(_trust_payload(i))
+
+        statements: list[str] = []
+        engine = db.get_bind()
+
+        def _listener(_conn, _cursor, statement, _parameters, _context, _executemany):
+            statements.append(statement)
+
+        sa.event.listen(engine, "before_cursor_execute", _listener)
+        try:
+            for i in range(REQUEST_COUNT):
+                payload = _trust_payload(i)
+                user, request = await _drive(payload)
+                # Every request must have authenticated on the trust path —
+                # a silent 401 would make the zero-SELECT count meaningless.
+                assert isinstance(user, VirtualPrincipal), f"request {i} did not resolve a trust principal"
+                assert user.user_id == payload["sub"]
+                assert request.state.token_use == "trusted"
+        finally:
+            sa.event.remove(engine, "before_cursor_execute", _listener)
+
+        # Guard against a vacuous pass: the listener must have seen the trust
+        # path's legitimate reads (roles / mappings / teams / revocations).
+        assert statements, "SQL listener recorded nothing; the proof would be vacuous"
+
+        email_users_reads = [stmt for stmt in statements if "email_users" in stmt]
+        assert email_users_reads == [], f"trust path read the user table: {email_users_reads[:3]}"

--- a/tests/unit/mcpgateway/test_trust_mode_overage_degraded.py
+++ b/tests/unit/mcpgateway/test_trust_mode_overage_degraded.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_trust_mode_overage_degraded.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Overage-degraded acceptance suite for JWT trust mode (issue #5905, suite e).
+
+An Entra trust token that exceeds the group-claim limit carries overage
+markers instead of the groups claim. With
+``jwt_trust_overage_policy=proceed_without_groups`` the token authenticates
+with NO group-derived teams — a coherent degradation, never a silent
+security bypass:
+
+- the resolved principal has ``token_teams == []`` (public-only),
+- a WARNING-level log carrying the user's ``oid`` is emitted on every
+  overage-triggered request,
+- ``visibility=team`` agents return 404 via ``_check_agent_access`` (the
+  route maps ``A2AAgentNotFoundError`` to HTTP 404; see
+  ``mcpgateway/main.py`` ``get_a2a_agent``),
+- ``visibility=public`` agents stay reachable (200 path).
+
+All three Entra overage marker shapes are exercised: ``_claim_names``,
+``hasgroups``, and ``groups:srcN``.
+"""
+
+# Standard
+import contextlib
+from datetime import datetime, timedelta, timezone
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+# Third-Party
+from fastapi.security import HTTPAuthorizationCredentials
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.auth import get_current_user
+from mcpgateway.config import settings
+from mcpgateway.db import A2AAgent as DbA2AAgent
+from mcpgateway.db import Base, EmailTeam, EmailUser
+from mcpgateway.services.a2a_service import A2AAgentNotFoundError, A2AAgentService
+
+CALLER_ID = "trust-overage-subject-0001"
+CALLER_EMAIL = "overage.user@example.com"
+CALLER_OID = "oid-overage-0001"
+AGENT_OK = object()  # sentinel for the convert_agent_to_read patch
+
+#: The three Entra overage marker shapes (groups claim omitted).
+OVERAGE_MARKERS = [
+    {"_claim_names": {"groups": "src1"}},
+    {"hasgroups": True},
+    {"groups:src1": "https://graph.microsoft.com/oid"},  # noqa: S105 - marker key, not a credential
+]
+
+
+def _exp(hours: int = 1) -> float:
+    """Expiry timestamp for mocked JWT payloads."""
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).timestamp()
+
+
+@pytest.fixture
+def db():
+    """In-memory SQLite session with one team agent and one public agent.
+
+    Yields:
+        Session bound to the in-memory engine.
+    """
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    now = datetime.now(timezone.utc)
+    session.add(
+        EmailUser(
+            email="owner@example.com",
+            password_hash="hash",  # pragma: allowlist secret
+            full_name="Owner",
+            is_admin=False,
+            is_active=True,
+            email_verified_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    session.add(EmailTeam(id="team-x", name="CF-Team-X", slug="cf-team-x", created_by="owner@example.com", is_personal=False, visibility="private"))
+    session.commit()
+    session.add(
+        DbA2AAgent(
+            id="agent-team",
+            name="team-agent",
+            slug="team-agent",
+            endpoint_url="https://team.example.com/agent",
+            visibility="team",
+            team_id="team-x",
+            enabled=True,
+        )
+    )
+    session.add(
+        DbA2AAgent(
+            id="agent-public",
+            name="public-agent",
+            slug="public-agent",
+            endpoint_url="https://public.example.com/agent",
+            visibility="public",
+            enabled=True,
+        )
+    )
+    session.commit()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _patch_funnel_sessions(monkeypatch: pytest.MonkeyPatch, db) -> None:
+    """Re-point the funnel's internal sessions at the test database."""
+    session_test = sessionmaker(bind=db.get_bind())
+    monkeypatch.setattr("mcpgateway.auth.SessionLocal", session_test)
+
+    @contextlib.contextmanager
+    def _fresh_db_session():
+        session = session_test()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("mcpgateway.auth.fresh_db_session", _fresh_db_session)
+
+
+def _overage_payload(marker: dict) -> dict:
+    """Trust-token payload with one Entra overage marker shape; no groups claim."""
+    payload = {
+        "sub": CALLER_ID,
+        "oid": CALLER_OID,
+        "token_use": "trusted",
+        "email": CALLER_EMAIL,
+        "roles": [],
+        "jti": "overage-degraded-jti-0001",
+        "exp": _exp(),
+    }
+    payload.update(marker)
+    return payload
+
+
+async def _drive_overage(monkeypatch: pytest.MonkeyPatch, db, marker: dict):
+    """Authenticate one overage-marked trust token; return (user, request)."""
+    monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+    monkeypatch.setattr(settings, "jwt_trust_overage_policy", "proceed_without_groups")
+    monkeypatch.setattr(settings, "auth_cache_enabled", False)
+    monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+    _patch_funnel_sessions(monkeypatch, db)
+
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="jwt_token")  # pragma: allowlist secret
+    request = SimpleNamespace(state=SimpleNamespace())
+    with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=_overage_payload(marker))):
+        user = await get_current_user(credentials=credentials, request=request)
+    return user, request
+
+
+class TestOverageDegraded:
+    """proceed_without_groups: authenticated, public-only, WARNING with oid."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("marker", OVERAGE_MARKERS, ids=["claim_names", "hasgroups", "groups_srcN"])
+    async def test_overage_degrades_to_empty_teams_with_warning(self, monkeypatch, db, caplog, marker):
+        """Each marker shape: token_teams == [] and a WARNING carrying the oid."""
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.trusted_claims"):
+            user, request = await _drive_overage(monkeypatch, db, marker)
+
+        # Authenticated, but with no group-derived teams (public-only).
+        assert user.user_id == CALLER_ID
+        assert user.teams == []
+        assert request.state.token_teams == []
+
+        # The degradation is observable: WARNING with the user's oid.
+        warning_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.WARNING]
+        assert any(CALLER_OID in message and "overage" in message.lower() for message in warning_messages), (
+            f"no overage WARNING with oid emitted; got: {warning_messages}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_team_agent_404_public_agent_200(self, monkeypatch, db, caplog):
+        """The degraded principal: team agents 404, public agents 200.
+
+        ``get_agent`` raises ``A2AAgentNotFoundError`` (404 at the route)
+        when ``_check_agent_access`` denies; the public agent passes the
+        same check.
+        """
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.trusted_claims"):
+            user, _request = await _drive_overage(monkeypatch, db, OVERAGE_MARKERS[0])
+
+        service = A2AAgentService()
+        team_agent = db.get(DbA2AAgent, "agent-team")
+        public_agent = db.get(DbA2AAgent, "agent-public")
+
+        # Direct check: _check_agent_access denies team, allows public.
+        assert await service._check_agent_access(db, team_agent, user.email, user.teams) is False
+        assert await service._check_agent_access(db, public_agent, user.email, user.teams) is True
+
+        # Route-level semantics: team agent -> 404, public agent -> 200 path.
+        service.convert_agent_to_read = lambda db_agent, **kwargs: AGENT_OK
+        with pytest.raises(A2AAgentNotFoundError):
+            await service.get_agent(db, "agent-team", user_email=user.email, token_teams=user.teams)
+        assert await service.get_agent(db, "agent-public", user_email=user.email, token_teams=user.teams) is AGENT_OK

--- a/tests/unit/mcpgateway/test_trust_mode_uaid.py
+++ b/tests/unit/mcpgateway/test_trust_mode_uaid.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_trust_mode_uaid.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+UAID propagation acceptance suite for JWT trust mode (issue #5905, suite d).
+
+Trust-mode claims propagate cross-gateway as forwarded bearer tokens per the
+existing UAID rules (docs/security/uaid-cross-gateway-auth.md, Layer 2):
+
+- A trust-mode token (``token_use="trusted"``) is JWT-shaped, so the calling
+  gateway forwards it verbatim in the ``Authorization`` header when
+  ``UAID_FORWARD_AUTH`` is on.
+- Local opaque tokens (``cf_sess_*``, ``cf_pat_*``) are never forwarded, in
+  either mode.
+- ``UAID_ALLOWED_DOMAINS`` keeps its fail-closed semantics with trust mode
+  ON: an empty allowlist blocks all routing; an unlisted domain is blocked.
+
+The remote gateway side of the forwarded call (re-evaluation against the
+remote's own ``external_group_mappings``) is covered by suite (f) in
+``test_trust_mode_cross_gateway.py``.
+"""
+
+# Standard
+from unittest.mock import AsyncMock, MagicMock
+
+# Third-Party
+import jwt as pyjwt
+import pytest
+
+# First-Party
+from mcpgateway.config import settings
+from mcpgateway.services.a2a_service import _validate_uaid_endpoint_domain, A2AAgentError, A2AAgentService
+
+# Local
+from tests.helpers.auth import make_trusted_test_jwt
+
+CALLER_ID = "trust-uaid-subject-0001"
+CALLER_EMAIL = "uaid.trust.user@example.com"
+UAID = "uaid:aid:9BjK3mP7xQv;uid=0;registry=context-forge;proto=a2a;nativeId=agent.example.com"
+
+
+@pytest.fixture(autouse=True)
+def trust_mode_on(monkeypatch):
+    """Run every test in this suite with trust mode ON and the bypass OFF."""
+    monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+    monkeypatch.setattr("mcpgateway.services.a2a_service.settings.uaid_allow_all_domains", False)
+
+
+@pytest.fixture
+def service():
+    """Create an A2AAgentService instance."""
+    return A2AAgentService()
+
+
+class TestAllowlistUnchangedInTrustMode:
+    """UAID_ALLOWED_DOMAINS fail-closed semantics are unchanged in trust mode."""
+
+    def test_empty_allowlist_fail_closed(self, monkeypatch):
+        """Empty allowlist blocks routing even with trust mode ON."""
+        monkeypatch.setattr("mcpgateway.services.a2a_service.settings.uaid_allowed_domains", [])
+        with pytest.raises(ValueError, match="UAID_ALLOWED_DOMAINS is empty"):
+            _validate_uaid_endpoint_domain("http://external.example.com/api", "cross-gateway routing")
+
+    def test_unlisted_domain_blocked(self, monkeypatch):
+        """A domain outside the allowlist is blocked with trust mode ON."""
+        monkeypatch.setattr("mcpgateway.services.a2a_service.settings.uaid_allowed_domains", ["trusted.example.com"])
+        with pytest.raises(ValueError, match="not in UAID_ALLOWED_DOMAINS"):
+            _validate_uaid_endpoint_domain("http://untrusted.example.net/api", "cross-gateway routing")
+
+    def test_allowlisted_domain_passes(self, monkeypatch):
+        """An allowlisted domain passes validation with trust mode ON."""
+        monkeypatch.setattr("mcpgateway.services.a2a_service.settings.uaid_allowed_domains", ["example.com"])
+        _validate_uaid_endpoint_domain("http://agent.example.com/api", "cross-gateway routing")
+
+    async def test_invoke_remote_agent_blocked_fail_closed(self, service, monkeypatch):
+        """The routing path enforces the same fail-closed gate in trust mode."""
+        monkeypatch.setattr("mcpgateway.services.a2a_service.settings.uaid_allowed_domains", [])
+        token = make_trusted_test_jwt(CALLER_ID, email=CALLER_EMAIL, teams=[], roles=[])
+        with pytest.raises(A2AAgentError, match="UAID_ALLOWED_DOMAINS is empty"):
+            await service._invoke_remote_agent(uaid=UAID, parameters={"q": "test"}, bearer_token=token)
+
+
+class TestTrustTokenBearerForwarding:
+    """A trust-mode token forwards verbatim per the existing UAID rules."""
+
+    @staticmethod
+    def _mock_http_client(monkeypatch, captured: dict) -> None:
+        """Capture the outbound cross-gateway request; answer 200."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b'{"result": "ok"}'
+        mock_response.json.return_value = {"result": "ok"}
+        mock_response.text = '{"result": "ok"}'
+
+        mock_client = MagicMock()
+
+        async def _post(url, **kwargs):
+            captured["url"] = url
+            captured.update(kwargs)
+            return mock_response
+
+        mock_client.post = AsyncMock(side_effect=_post)
+
+        async def _get_http_client():
+            return mock_client
+
+        monkeypatch.setattr("mcpgateway.services.http_client_service.get_http_client", _get_http_client)
+        monkeypatch.setattr("mcpgateway.services.a2a_service.settings.uaid_allowed_domains", ["example.com"])
+
+    async def test_trust_token_forwarded_verbatim(self, service, monkeypatch):
+        """The forwarded bearer token is the caller's inbound trust JWT.
+
+        Decoding the forwarded header shows the original claims intact:
+        ``sub``, ``token_use=="trusted"``, the groups claim, and the
+        revocation claim. The remote gateway re-evaluates them (suite f).
+        """
+        monkeypatch.setattr("mcpgateway.services.a2a_service.settings.uaid_forward_auth", True)
+        captured: dict = {}
+        self._mock_http_client(monkeypatch, captured)
+
+        token = make_trusted_test_jwt(CALLER_ID, email=CALLER_EMAIL, groups=["ext-group-1"], roles=[], revocation_id="uaid-forward-jti-0001")
+
+        result = await service._invoke_remote_agent(
+            uaid=UAID,
+            parameters={"q": "test"},
+            user_id=CALLER_ID,
+            user_email=CALLER_EMAIL,
+            bearer_token=token,
+        )
+
+        assert result == {"result": "ok"}
+        headers = captured.get("headers", {})
+        assert headers.get("Authorization") == f"Bearer {token}"
+
+        # The forwarded token carries the original claims unchanged.
+        secret = settings.jwt_secret_key
+        if hasattr(secret, "get_secret_value"):
+            secret = secret.get_secret_value()
+        forwarded = headers["Authorization"].removeprefix("Bearer ")
+        claims = pyjwt.decode(forwarded, secret, algorithms=[settings.jwt_algorithm], options={"verify_aud": False})
+        assert claims["sub"] == CALLER_ID
+        assert claims["token_use"] == "trusted"
+        assert claims["groups"] == ["ext-group-1"]
+        assert claims["jti"] == "uaid-forward-jti-0001"
+
+    async def test_opaque_token_not_forwarded(self, service, monkeypatch):
+        """Local opaque tokens are never forwarded, in either mode."""
+        monkeypatch.setattr("mcpgateway.services.a2a_service.settings.uaid_forward_auth", True)
+        captured: dict = {}
+        self._mock_http_client(monkeypatch, captured)
+
+        result = await service._invoke_remote_agent(
+            uaid=UAID,
+            parameters={"q": "test"},
+            user_id=CALLER_ID,
+            user_email=CALLER_EMAIL,
+            bearer_token="cf_sess_opaque_local_token",  # pragma: allowlist secret
+        )
+
+        assert result == {"result": "ok"}
+        assert "Authorization" not in captured.get("headers", {})
+
+    async def test_forward_auth_disabled_not_forwarded(self, service, monkeypatch):
+        """UAID_FORWARD_AUTH=false suppresses forwarding of the trust token."""
+        monkeypatch.setattr("mcpgateway.services.a2a_service.settings.uaid_forward_auth", False)
+        captured: dict = {}
+        self._mock_http_client(monkeypatch, captured)
+
+        token = make_trusted_test_jwt(CALLER_ID, email=CALLER_EMAIL, teams=[], roles=[])
+
+        result = await service._invoke_remote_agent(
+            uaid=UAID,
+            parameters={"q": "test"},
+            user_id=CALLER_ID,
+            user_email=CALLER_EMAIL,
+            bearer_token=token,
+        )
+
+        assert result == {"result": "ok"}
+        assert "Authorization" not in captured.get("headers", {})

--- a/tests/unit/mcpgateway/test_trust_role_merge.py
+++ b/tests/unit/mcpgateway/test_trust_role_merge.py
@@ -8,6 +8,16 @@ Trust-path group-to-role merge tests (issue #6272).
 Every test in this file exercises the trusted-claims merge (#5899) through
 the trust branch in get_current_user (#5900).
 
+Real-entry-point conversion (#6753 / F4): the tests previously patched
+``verify_jwt_token_cached`` with a pre-decoded payload and derived
+permissions manually from the roles table. They now mint externally-signed
+RS256 tokens from Task 9's local OIDC issuer key and drive the FULL
+decorator chain — ``get_current_user`` (real ingress dispatch ->
+``_maybe_verify_external`` -> JWKS verification -> claims-derived
+principal) -> ``get_current_user_with_permissions`` (the RBAC decorator
+dependency) -> ``check_permission_inline`` with the real PermissionService.
+ONLY the OIDC discovery/JWKS network fetch is mocked.
+
 Merge semantics under test (per #6272):
 - The resolver resolve_external_groups_to_teams returns (team_ids, role_names).
   A mapping row with cf_role set contributes its role name to role_names.
@@ -24,7 +34,6 @@ import contextlib
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Optional
-from unittest.mock import AsyncMock, patch
 
 # Third-Party
 from fastapi.security import HTTPAuthorizationCredentials
@@ -36,33 +45,83 @@ from sqlalchemy.pool import StaticPool
 # First-Party
 from mcpgateway.auth import get_current_user
 from mcpgateway.config import settings
-from mcpgateway.db import A2AAgent, Base, EmailTeam, EmailUser, ExternalGroupMapping, Role
+from mcpgateway.db import A2AAgent, Base, EmailTeam, EmailUser, ExternalGroupMapping, Role, SSOProvider
+from mcpgateway.middleware.rbac import check_permission_inline, get_current_user_with_permissions
+from mcpgateway.services import sso_service
 from mcpgateway.services.a2a_service import A2AAgentNotFoundError, A2AAgentService
+from mcpgateway.services.permission_service import PermissionService
+from mcpgateway.utils import verify_credentials as vc
 from mcpgateway.utils.trusted_claims import resolve_external_groups_to_teams
+from tests.live_gateway.helpers.local_oidc_issuer import generate_signing_key, mint_token
 
 ISSUER = "https://login.example.com/tenant-1/v2.0"
+JWKS_URI = "https://login.example.com/tenant-1/jwks.json"
+AUDIENCE = "api://trust-role-merge-tests"
+PROVIDER_ID = "local-oidc-test"
 TENANT = "tenant-1"
 CALLER = "trust.user@example.com"
 
 
 def _exp(hours: int = 1) -> float:
-    """Expiry timestamp for mocked JWT payloads."""
+    """Expiry timestamp for the minted fixtures."""
     return (datetime.now(timezone.utc) + timedelta(hours=hours)).timestamp()
 
 
-def _permissions_for_roles(db, role_names) -> set:
-    """Resolve role names to the permission set via the server-side roles table.
+@pytest.fixture(scope="module")
+def ext_signing_key():
+    """RSA keypair shared by this module's externally-signed fixtures.
 
-    Mirrors the trust-mode resolution rule of #6272: permissions come from
-    the roles table only; unknown role names are ignored.
+    Generated once per module via Task 9's local OIDC issuer harness; tokens
+    are minted per test with distinct claim sets.
     """
-    permissions = set()
-    for name in role_names:
-        role = db.query(Role).filter(Role.name == name, Role.is_active.is_(True)).first()
-        if role is None:
-            continue
-        permissions.update(role.get_effective_permissions())
-    return permissions
+    return generate_signing_key()
+
+
+def _seed_trust_root_provider(db) -> None:
+    """Insert (idempotently) the SSO provider row that makes ISSUER a trust root."""
+    if db.query(SSOProvider).filter(SSOProvider.id == PROVIDER_ID).first() is not None:
+        return
+    db.add(
+        SSOProvider(
+            id=PROVIDER_ID,
+            name=PROVIDER_ID,
+            display_name="Local OIDC Test Issuer",
+            provider_type="oidc",
+            is_enabled=True,
+            client_id="trust-role-merge-tests",
+            client_secret_encrypted="unused-on-this-path",  # pragma: allowlist secret
+            authorization_url=f"{ISSUER}/authorize",
+            token_url=f"{ISSUER}/token",
+            userinfo_url=f"{ISSUER}/userinfo",
+            issuer=ISSUER,
+            trusted_for_api_auth=True,
+            api_audience=AUDIENCE,
+        )
+    )
+    db.commit()
+
+
+def _install_external_jwks(monkeypatch, signing_key) -> None:
+    """Mock ONLY the OIDC discovery/JWKS network fetch for ISSUER.
+
+    Signature, audience, expiry, and issuer checks in
+    ``verify_oauth_access_token`` still run for real against the module RSA
+    key, as do the dispatch, provider resolution, and claim mapping.
+    """
+
+    async def _fake_discover(issuer: str):
+        if issuer.rstrip("/") == ISSUER.rstrip("/"):
+            return {"issuer": ISSUER, "jwks_uri": JWKS_URI}
+        return None
+
+    class _StaticJWKClient:
+        """Stand-in for the PyJWKClient cache entry: serves the test key."""
+
+        def get_signing_key_from_jwt(self, _token):
+            return SimpleNamespace(key=signing_key.public_key())
+
+    monkeypatch.setattr(vc, "_discover_oidc_metadata", _fake_discover)
+    monkeypatch.setitem(vc._oauth_jwks_client_cache, JWKS_URI, _StaticJWKClient())
 
 
 @pytest.fixture
@@ -118,20 +177,29 @@ def db():
         session.close()
 
 
-async def _drive_trust_funnel(monkeypatch: pytest.MonkeyPatch, db, groups: list[str], roles_claim: Optional[list[str]] = None):
-    """Drive get_current_user with a trust-mode JWT carrying the given claims.
+async def _drive_trust_chain(monkeypatch: pytest.MonkeyPatch, db, signing_key, groups: list[str], roles_claim: Optional[list[str]] = None):
+    """Drive the REAL trust ingress with an externally-signed RS256 token.
 
     The token carries the given groups and, when roles_claim is not None, a
-    roles claim. The funnel's internal sessions are re-pointed at the test
-    database so the group resolver sees the seeded mapping rows. Returns
-    (user, request).
+    roles claim. Only the OIDC discovery/JWKS network fetch is mocked: the
+    token flows through ``get_current_user`` (ingress dispatch -> JWKS
+    verification -> claims-derived principal) and then
+    ``get_current_user_with_permissions`` — the RBAC decorator dependency —
+    so the returned user context is exactly what ``@require_permission``
+    receives on a live route. The funnel's internal sessions are re-pointed
+    at the test database so the group resolver and the roles table see the
+    seeded rows.
+
+    Returns (user, user_context, request).
     """
     monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+    monkeypatch.setattr(settings, "sso_api_token_auth_enabled", True)
     monkeypatch.setattr(settings, "auth_cache_enabled", False)
     monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
 
     session_test = sessionmaker(bind=db.get_bind())
     monkeypatch.setattr("mcpgateway.auth.SessionLocal", session_test)
+    monkeypatch.setattr("mcpgateway.db.SessionLocal", session_test)
 
     @contextlib.contextmanager
     def _fresh_db_session():
@@ -143,110 +211,158 @@ async def _drive_trust_funnel(monkeypatch: pytest.MonkeyPatch, db, groups: list[
 
     monkeypatch.setattr("mcpgateway.auth.fresh_db_session", _fresh_db_session)
 
-    jwt_payload = {
-        "sub": CALLER,
-        "token_use": "trusted",
+    # The autouse conftest fixture replaces PermissionService with an
+    # always-allow mock; restore the real service so check_permission_inline
+    # exercises the actual roles-table resolution (the point of this file).
+    monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", PermissionService)
+
+    _seed_trust_root_provider(db)
+    _install_external_jwks(monkeypatch, signing_key)
+    sso_service.invalidate_trusted_provider_cache()
+    await vc.invalidate_external_identity_cache()
+
+    claims = {
         "iss": ISSUER,
+        "sub": CALLER,
+        "email": CALLER,
         "tid": TENANT,
+        "aud": AUDIENCE,
         "groups": groups,
-        "jti": "trusted_jti_role_merge",
+        "jti": f"trusted-jti-{'-'.join(groups)}",
         "exp": _exp(),
+        "iat": datetime.now(timezone.utc).timestamp(),
     }
     if roles_claim is not None:
-        jwt_payload["roles"] = roles_claim
-    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="trusted_jwt_token")  # pragma: allowlist secret
-    request = SimpleNamespace(state=SimpleNamespace())
+        claims["roles"] = roles_claim
+    token = mint_token(claims, signing_key)
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)  # pragma: allowlist secret
+    request = SimpleNamespace(
+        state=SimpleNamespace(db=db),
+        cookies={},
+        headers={"user-agent": "pytest"},
+        client=None,
+    )
 
-    with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=jwt_payload)):
-        with patch("mcpgateway.auth._check_token_revoked_sync", return_value=False):
-            # No local user record exists for the virtual principal.
-            with patch("mcpgateway.auth._get_user_by_email_sync", return_value=None):
-                with patch("mcpgateway.auth._get_personal_team_sync", return_value=None):
-                    user = await get_current_user(credentials=credentials, request=request)
-    return user, request
+    user = await get_current_user(credentials=credentials, request=request)
+    user_context = await get_current_user_with_permissions(request=request, credentials=credentials)
+    return user, user_context, request
 
 
 class TestTrustRoleMerge:
     """Mapping cf_role merges into the principal's roles on the trust path."""
 
     @pytest.mark.asyncio
-    async def test_mapping_role_grants_a2a_invoke(self, monkeypatch, db):
+    async def test_mapping_role_grants_a2a_invoke(self, monkeypatch, db, ext_signing_key):
         """cf_role=developer + no roles claim -> a2a.invoke granted.
 
         The resolver supplies the role name; the merged roles resolve
         against the roles table to a permission set that contains
-        a2a.invoke, so @require_permission("a2a.invoke") passes.
+        a2a.invoke, so the real decorator chain
+        (get_current_user_with_permissions -> check_permission_inline)
+        grants the permission.
         """
         team_ids, role_names = resolve_external_groups_to_teams(ISSUER, TENANT, ["entra-group-guid-1"], db)
         assert team_ids == ["team-a"]
         assert role_names == ["developer"]
 
-        user, request = await _drive_trust_funnel(monkeypatch, db, ["entra-group-guid-1"])
+        user, ctx, request = await _drive_trust_chain(monkeypatch, db, ext_signing_key, ["entra-group-guid-1"])
         assert request.state.token_teams == ["team-a"]
         assert "developer" in user.roles
-        assert "a2a.invoke" in _permissions_for_roles(db, user.roles)
+        # The claims-derived role reached the decorator's user context...
+        assert ctx["token_use"] == "trusted"
+        assert ctx["token_teams"] == ["team-a"]
+        assert "developer" in ctx["roles"]
+        # ...and the real PermissionService grants a2a.invoke through the
+        # server-side roles table.
+        assert await check_permission_inline(ctx, "a2a.invoke", db=db) is True
 
     @pytest.mark.asyncio
-    async def test_null_role_denies_a2a_invoke(self, monkeypatch, db):
-        """cf_role=NULL + no roles claim -> 403 (no role granted).
+    async def test_null_role_denies_a2a_invoke(self, monkeypatch, db, ext_signing_key):
+        """cf_role=NULL + no roles claim -> denied (no role granted).
 
         The mapping row grants team membership only. The merged roles list
-        is empty, so the permission set is empty and
-        @require_permission("a2a.invoke") answers 403.
+        is empty, so the permission set is empty and the real decorator
+        chain denies a2a.invoke (403 at the route layer).
         """
         team_ids, role_names = resolve_external_groups_to_teams(ISSUER, TENANT, ["entra-group-guid-2"], db)
         assert team_ids == ["team-b"]
         assert role_names == []
 
-        user, request = await _drive_trust_funnel(monkeypatch, db, ["entra-group-guid-2"])
+        user, ctx, request = await _drive_trust_chain(monkeypatch, db, ext_signing_key, ["entra-group-guid-2"])
         assert request.state.token_teams == ["team-b"]
         assert user.roles == []
-        assert "a2a.invoke" not in _permissions_for_roles(db, user.roles)
+        assert ctx["roles"] == []
+        assert await check_permission_inline(ctx, "a2a.invoke", db=db) is False
 
     @pytest.mark.asyncio
-    async def test_token_roles_merge_with_mapping_role(self, monkeypatch, db):
+    async def test_token_roles_merge_with_mapping_role(self, monkeypatch, db, ext_signing_key):
         """cf_role=developer + token roles=["viewer"] -> ["developer", "viewer"].
 
         The merge is additive: roles already present in the token's roles
         claim are preserved, and the resolver-supplied role name is added.
         """
-        user, request = await _drive_trust_funnel(monkeypatch, db, ["entra-group-guid-1"], roles_claim=["viewer"])
+        user, ctx, request = await _drive_trust_chain(monkeypatch, db, ext_signing_key, ["entra-group-guid-1"], roles_claim=["viewer"])
         assert request.state.token_teams == ["team-a"]
         assert set(user.roles) == {"developer", "viewer"}
+        assert set(ctx["roles"]) == {"developer", "viewer"}
         # The merged set still grants a2a.invoke through the roles table.
-        assert "a2a.invoke" in _permissions_for_roles(db, user.roles)
+        assert await check_permission_inline(ctx, "a2a.invoke", db=db) is True
+
+    @pytest.mark.asyncio
+    async def test_resolved_role_without_permissions_denies(self, monkeypatch, db, ext_signing_key):
+        """token roles=["viewer"] + team mapping (cf_role NULL) -> denied.
+
+        Pins the boundary the merge tests rely on: a role name that
+        RESOLVES to an active roles-table row but carries no permissions
+        grants nothing. The viewer role is server-side valid (it stays in
+        the merged roles list), yet the real decorator chain denies
+        a2a.invoke. This isolates Layer 2 (role permissions) from the
+        public-only suppression, because the token still maps to team-b.
+        Green by design: this row covers behavior fixed by the scope-exact
+        composition (#6744) and decorator forwarding (#6749) layers, so the
+        conversion lands it green rather than red-first.
+        """
+        user, ctx, request = await _drive_trust_chain(monkeypatch, db, ext_signing_key, ["entra-group-guid-2"], roles_claim=["viewer"])
+        assert request.state.token_teams == ["team-b"]
+        assert user.roles == ["viewer"]
+        assert ctx["roles"] == ["viewer"]
+        assert await check_permission_inline(ctx, "a2a.invoke", db=db) is False
 
 
 class TestE2EGroupRoleGrant:
     """AC-e2e-group-role-grant: a mapping row drives both layers of the gate."""
 
     @pytest.mark.asyncio
-    async def test_e2e_group_role_grant(self, monkeypatch, db):
+    async def test_e2e_group_role_grant(self, monkeypatch, db, ext_signing_key):
         """Full flow: mapping row + trust JWT -> invoke passes; no mapping -> denied.
 
         1. Mapping row: Entra-Group-GUID-1 -> CF-Team-A, cf_role=developer.
-        2. Trust-mode JWT with groups=[Entra-Group-GUID-1], no roles claim.
+        2. Externally-signed RS256 trust token with groups=[Entra-Group-GUID-1],
+           no roles claim, through the real ingress + decorator chain.
         3. Invoke of Agent-A (visibility=team, team=CF-Team-A) passes: the
            caller is in the agent's team (Layer 1) and the merged developer
-           role grants a2a.invoke (Layer 2).
+           role grants a2a.invoke through the real PermissionService
+           (Layer 2).
         4. A token with groups=[Entra-Group-GUID-Unmapped] (no mapping row)
            is denied at both layers: 404 at the visibility gate (the caller
-           is in no team) and 403 at the permission gate (no role granted).
+           is in no team) and denied at the permission gate (no role
+           granted).
         """
         service = A2AAgentService()
         agent_a = db.query(A2AAgent).filter(A2AAgent.slug == "agent-a").one()
 
         # Steps 1-3: mapped group grants team membership and the invoke role.
-        user, request = await _drive_trust_funnel(monkeypatch, db, ["entra-group-guid-1"])
-        token_teams = request.state.token_teams
+        user, ctx, request = await _drive_trust_chain(monkeypatch, db, ext_signing_key, ["entra-group-guid-1"])
+        assert ctx["email"] == CALLER
+        token_teams = ctx["token_teams"]
         assert token_teams == ["team-a"]
         assert await service._check_agent_access(db, agent_a, CALLER, token_teams) is True
-        assert "a2a.invoke" in _permissions_for_roles(db, user.roles)
+        assert await check_permission_inline(ctx, "a2a.invoke", db=db) is True
 
         # Step 4: an unmapped group fails closed at both layers.
-        user, request = await _drive_trust_funnel(monkeypatch, db, ["entra-group-guid-unmapped"])
-        token_teams = request.state.token_teams
+        user, ctx, request = await _drive_trust_chain(monkeypatch, db, ext_signing_key, ["entra-group-guid-unmapped"])
+        token_teams = ctx["token_teams"]
         assert token_teams == []
         with pytest.raises(A2AAgentNotFoundError):
             await service.get_agent(db, agent_a.id, user_email=CALLER, token_teams=token_teams)
-        assert "a2a.invoke" not in _permissions_for_roles(db, user.roles)
+        assert await check_permission_inline(ctx, "a2a.invoke", db=db) is False


### PR DESCRIPTION
Six acceptance suites proving trust mode end to end. Suites: no-DB proof; multi-worker revocation; config-flip; UAID propagation; overage-degraded; cross-gateway UAID.

(a) NO-DB PROOF — CI-eligible, asserts on executed SQL (never a grep): a SQLAlchemy `before_cursor_execute` listener recorded 300 statements across 60 authenticated trust-mode requests through `get_current_user` (real revocation check, group resolver, roles lookup; only the JWT verifier patched) — `external_group_mappings`x60, `roles`x60, `token_revocations`x60, `email_teams`x120 — and ZERO statements touching `email_users`, while a live user row exists for the caller (a read would be observable). A vacuous-pass guard asserts the statements list is non-empty and every request resolved a `VirtualPrincipal`. The wall-clock p99 latency comparison originally in this suite was removed before merge: unit tests do not run benchmarks.

(b) MULTI-WORKER — `tests/live_gateway/test_trust_mode_multi_worker.py` (`e2e` + `skip_no_gateway`, modeled on the multi-instance runner): mint with known jti, 200 on both workers, revoke on A via logout, 401 on B within the 30s negative-cache window, unrevoked control passes. No live stack exists in this worktree — both skip dimensions verified firing; live execution happens in the Epic 2 gate's stack.

(c) CONFIG-FLIP — full `db -> jwt-trust -> db` round-trip in one process: the `trusted` marker 401s when OFF with the user-lookup seam tripwired (proving it never enters the default funnel); legacy tokens keep default semantics under trust mode, including the `is_active` kill-switch (disabled user -> 401).

(d) UAID — forwarded bearer verified verbatim with claims intact; opaque session tokens and `UAID_FORWARD_AUTH=false` NOT forwarded; `UAID_ALLOWED_DOMAINS` fail-closed unchanged. Doc section added (`docs/security/uaid-cross-gateway-auth.md`).

(e) OVERAGE-DEGRADED — all three Entra marker shapes under `proceed_without_groups`: authenticated with `token_teams=[]`, team-visibility agents 404 (A2AAgentNotFound at the router), public agents 200, WARNING carrying the oid.

(f) CROSS-GATEWAY — two divergent mapping tables; the same forwarded payload resolves `caller-team-x` on the calling gateway and `remote-team-a` on the remote — membership does not transfer; the remote re-evaluates against its own table; Team-B agent -> 404, public -> 200.

Tested with: `uv run pytest tests -k "trust_mode" -q` — 54 passed, 1 skipped (suite (b) skip verified by direct invocation); `make ruff` — all checks passed; `make test` — 23381 passed, 879 skipped, 2 xfailed.

Acceptance criteria of #5905 are met. Risk to existing users: none — tests and documentation only.

Stack: B.13 of epic #5885 (base: #6751).

Closes #5905
