### PR TITLE
feat(auth): resolve service-principal group membership via Graph for app-only trust tokens

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
+    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-12T21:48:15Z",
+  "generated_at": "2026-09-12T21:53:58Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/docs/docs/architecture/identity-domains.md
+++ b/docs/docs/architecture/identity-domains.md
@@ -11,7 +11,7 @@ to the layer that resolves the value and to the canonical user ID.
 | Session token (`token_use="session"`) | UUID (`EmailUser.id`) | `_get_email_by_id_sync` and `get_user_email_from_token` in `mcpgateway/auth.py`, plus `resolve_jwt_user_email_from_payload` in `mcpgateway/auth_context.py` | e-mail |
 | API token | UUID; signed metadata carries the e-mail | `resolve_jwt_user_email_from_payload` in `mcpgateway/auth_context.py` | e-mail |
 | Legacy token (no `token_use`) | e-mail | none (direct) | e-mail |
-| Future trust token | opaque | trusted-claims module (not built yet, epic #5885) | to be defined by Stack B |
+| Trust token (`token_use="trusted"`) | opaque mapped claim (`jwt_claim_user_id`, default `sub`) | `mcpgateway/utils/trusted_claims.py` (`extract_trusted_principal`, VirtualPrincipal contract) — external IdP-verified and gateway-minted trust tokens | opaque principal ID (not e-mail) |
 
 ## Accessors
 

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -218,7 +218,7 @@ Startup validation rules:
 
 - When `JWT_TRUST_MODE=jwt-trust`, every claim-mapping setting and `JWT_TRUST_REVOCATION_CLAIM` must be a non-empty string. The gateway refuses to start with an error naming the offending setting.
 - A trust-eligible token that lacks the configured revocation claim is rejected with `401`. The revocation claim is mandatory because trust mode relies on it for token revocation.
-- In trust mode, `JWT_CLAIM_TEAMS` must not name the same claim as the provider's groups claim (`SSO_ENTRA_GROUPS_CLAIM` / `SSO_GENERIC_GROUPS_CLAIM`), which the external group-mapping resolver consumes; an aliased value would place raw external group IDs into native ContextForge team memberships before mapping. The gateway refuses to start with a remediation message naming both variables.
+- In trust mode, `JWT_CLAIM_TEAMS` must not name the same claim as the provider's groups claim (`SSO_ENTRA_GROUPS_CLAIM` / `SSO_KEYCLOAK_GROUPS_CLAIM` / `SSO_GENERIC_GROUPS_CLAIM`), which the external group-mapping resolver consumes; an aliased value would place raw external group IDs into native ContextForge team memberships before mapping. The gateway refuses to start with a remediation message naming both variables.
 
 All defaults preserve the current behavior: trust mode defaults to `db` and the new settings are inert until `jwt-trust` is enabled.
 

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -1893,7 +1893,14 @@ async def get_current_user(
             # claim (jwt_trust_revocation_claim, default jti) is checked
             # against the revocation store on every request.
             # First-Party
-            from mcpgateway.utils.trusted_claims import detect_overage_marker, extract_revocation_id, extract_trusted_principal, resolve_overage_groups  # pylint: disable=import-outside-toplevel
+            from mcpgateway.utils.trusted_claims import (
+                detect_app_only_token,
+                detect_overage_marker,
+                extract_revocation_id,
+                extract_trusted_principal,
+                resolve_overage_groups,
+                resolve_service_principal_groups,
+            )  # pylint: disable=import-outside-toplevel
 
             # Entra group-overage markers mean the groups claim was omitted.
             # Dispatch on jwt_trust_overage_policy (#5977): fail_closed ->
@@ -1904,6 +1911,19 @@ async def get_current_user(
             if detect_overage_marker(payload):
                 with fresh_db_session() as overage_db:
                     resolved_groups = await resolve_overage_groups(payload, settings, overage_db)
+                payload = {**payload, "groups": resolved_groups}
+            elif detect_app_only_token(payload) and payload.get("groups") is None and settings.jwt_trust_overage_policy == "graph_lookup":
+                # App-only tokens (idtyp="app") carry no groups claim and no
+                # overage markers. Under graph_lookup (#6756) the service
+                # principal's group membership resolves through
+                # /servicePrincipals/{oid}/getMemberObjects (cached,
+                # oid-keyed, TTL bounded by exp); the resolved group IDs feed
+                # the same external-group resolver as claim groups. Under
+                # fail_closed (default) and proceed_without_groups this branch
+                # is skipped: the token authenticates with token_teams=[] and
+                # the roles claim keeps the app-role path (#5902).
+                with fresh_db_session() as sp_db:
+                    resolved_groups = await resolve_service_principal_groups(payload, settings, sp_db)
                 payload = {**payload, "groups": resolved_groups}
 
             def _extract_principal_sync():

--- a/mcpgateway/routers/admin_external_group_mappings.py
+++ b/mcpgateway/routers/admin_external_group_mappings.py
@@ -18,11 +18,13 @@ Write-time validation:
   carries no foreign key: roles.name has only a partial unique index, so
   existence is validated here at the application level.
 - The injectable group_exists_validator seam checks that the external group
-  exists in the IdP. It ships disabled by default: the stub always returns
-  "valid". The real Microsoft Graph validator lands with the app-only Graph
-  client (#5977). The semantics are WARN-AND-ALLOW: when Graph is unreachable
-  the validator returns "unknown", the mapping row is still stored, the row
-  is audit-logged, and a warning is emitted. A missing group never grants
+  exists in the IdP. The default validator is Graph-backed (#5977): for
+  Microsoft Entra issuers it resolves the SSO provider record for the issuer
+  (same issuer -> provider resolution as the trust-mode overage path) and
+  GETs /v1.0/groups/<external_group_id> with an app-only token. The
+  semantics are WARN-AND-ALLOW: when Graph is unreachable the validator
+  returns "unknown", the mapping row is still stored, the row is
+  audit-logged, and a warning is emitted. A missing group never grants
   access through this seam; the resolver fails closed at read time.
 """
 
@@ -31,7 +33,8 @@ from __future__ import annotations
 
 # Standard
 from datetime import datetime, timezone
-from typing import Callable, List, Optional
+import inspect
+from typing import Awaitable, Callable, List, Optional, Union
 
 # Third-Party
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -41,11 +44,12 @@ from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.auth_context import get_user_email
-from mcpgateway.db import EmailTeam, ExternalGroupMapping
+from mcpgateway.db import EmailTeam, ExternalGroupMapping, fresh_db_session, SSOProvider
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, get_db, require_permission
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.role_resolution import resolve_mapping_role
 from mcpgateway.services.security_logger import get_security_logger
+from mcpgateway.utils.entra_graph_client import EntraGraphClient, is_entra_issuer
 from mcpgateway.utils.verify_credentials import invalidate_external_identity_cache
 
 logging_service = LoggingService()
@@ -54,26 +58,65 @@ logger = logging_service.get_logger(__name__)
 admin_external_group_mappings_router = APIRouter()
 
 #: Injectable validator seam. Signature: (issuer, tenant, external_group_id)
-#: -> validation_status. Ships disabled: the stub always returns "valid".
-#: WO-B.7 (#5977) wires the real Microsoft Graph validator.
-GroupExistsValidator = Callable[[str, str, str], str]
+#: -> validation_status (or an awaitable of it). The default is the
+#: Graph-backed validator wired in #5977; tests override it with a plain
+#: callable.
+GroupExistsValidator = Callable[[str, str, str], Union[str, Awaitable[str]]]
 
 
-def _disabled_group_exists_validator(issuer: str, tenant: str, external_group_id: str) -> str:
-    """Default group-existence validator: disabled, always reports "valid".
+async def _graph_group_exists_validator(issuer: str, tenant: str, external_group_id: str) -> str:  # pylint: disable=unused-argument
+    """Default group-existence validator: Microsoft Graph group lookup (#5977).
+
+    Issuer-scoped: a Graph lookup is attempted only for Microsoft Entra
+    issuers (:func:`is_entra_issuer`, the single Microsoft-hosts rule shared
+    with the OAuth manager); any other issuer reports "valid" with one log
+    line and no IdP call. The SSO provider record matching the issuer
+    supplies the app-only credentials, resolved exactly like the trust-mode
+    overage path (``trusted_claims.resolve_overage_groups``: enabled
+    SSOProvider whose issuer matches). A missing provider record or missing
+    client secret keeps the disabled-stub posture ("valid") with a WARNING:
+    an unconfigured Graph never blocks mapping writes.
 
     Args:
         issuer: Token issuer the mapping is scoped to.
-        tenant: Tenant the mapping is scoped to ("" when the row is tenant-less).
+        tenant: Tenant the mapping is scoped to ("" when the row is
+            tenant-less). Unused: provider resolution is issuer-scoped.
         external_group_id: External IdP group ID to check.
 
     Returns:
-        str: Always "valid"; no IdP call is made until #5977 lands.
+        str: "valid" when Graph answers 200 (or validation is skipped per
+        the rules above); "graph_group_not_found" when Graph answers 404;
+        "unknown" on any other Graph failure, which the CRUD's
+        warn-and-allow contract stores with a warning and an audit entry.
     """
-    return "valid"
+    if not is_entra_issuer(issuer):
+        logger.info("Group-existence validation skipped for non-Entra issuer %r; treating mapping as valid.", issuer)
+        return "valid"
+
+    with fresh_db_session() as db:
+        provider = db.query(SSOProvider).filter(SSOProvider.issuer == issuer, SSOProvider.is_enabled.is_(True)).first()
+        if provider is None or not getattr(provider, "client_secret_encrypted", None):
+            logger.warning(
+                "No app-only Graph credentials configured for Entra issuer %r; group-existence validation skipped, storing mapping with validation_status=valid.",
+                issuer,
+            )
+            return "valid"
+
+        try:
+            exists = await EntraGraphClient().group_exists(provider, external_group_id)
+        except Exception as exc:  # noqa: BLE001 — any Graph failure degrades to warn-and-allow, never blocks the write
+            logger.warning(
+                "Graph group-existence check failed for issuer %r external_group_id=%s: %s; storing mapping with validation_status=unknown.",
+                issuer,
+                external_group_id,
+                exc,
+            )
+            return "unknown"
+
+    return "valid" if exists else "graph_group_not_found"
 
 
-group_exists_validator: GroupExistsValidator = _disabled_group_exists_validator
+group_exists_validator: GroupExistsValidator = _graph_group_exists_validator
 
 
 class ExternalGroupMappingCreate(BaseModel):
@@ -178,7 +221,7 @@ def _check_null_tenant_duplicate(db: Session, issuer: str, external_group_id: st
         raise HTTPException(status_code=409, detail="Mapping already exists for (issuer, tenant, external_group_id)")
 
 
-def _run_group_validation(mapping: ExternalGroupMapping, user, db: Session) -> None:
+async def _run_group_validation(mapping: ExternalGroupMapping, user, db: Session) -> None:
     """Run the group-existence validator and record the outcome on the row.
 
     WARN-AND-ALLOW: a validation_status of "unknown" (Graph unreachable) does
@@ -190,6 +233,8 @@ def _run_group_validation(mapping: ExternalGroupMapping, user, db: Session) -> N
         db: Database session for the audit entry.
     """
     status_value = group_exists_validator(mapping.issuer, mapping.tenant or "", mapping.external_group_id)
+    if inspect.isawaitable(status_value):
+        status_value = await status_value
     mapping.validation_status = status_value
     mapping.last_validated_at = datetime.now(timezone.utc)
     if status_value == "unknown":
@@ -254,7 +299,7 @@ async def create_external_group_mapping(
         cf_team_id=body.cf_team_id,
         cf_role=body.cf_role,
     )
-    _run_group_validation(mapping, user, db)
+    await _run_group_validation(mapping, user, db)
     db.add(mapping)
     try:
         db.commit()
@@ -328,7 +373,7 @@ async def update_external_group_mapping(
     for field, value in updates.items():
         setattr(mapping, field, value)
 
-    _run_group_validation(mapping, user, db)
+    await _run_group_validation(mapping, user, db)
     try:
         db.commit()
     except IntegrityError as exc:

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -31,6 +31,7 @@ from mcpgateway.common.validators import SecurityValidator, validate_core_url
 from mcpgateway.config import get_settings
 from mcpgateway.services.encryption_service import decrypt_oauth_config_for_runtime, get_encryption_service
 from mcpgateway.services.http_client_service import get_http_client
+from mcpgateway.utils.entra_graph_client import ENTRA_ISSUER_HOSTS
 from mcpgateway.utils.log_sanitizer import sanitize_for_log
 from mcpgateway.utils.redis_client import get_redis_client as _get_shared_redis_client
 from mcpgateway.utils.ssl_context_cache import get_cached_ssl_context
@@ -126,14 +127,8 @@ class OAuthManager:
     """
 
     # Known Microsoft Entra login hosts (global + sovereign clouds).
-    _ENTRA_HOSTS: frozenset[str] = frozenset(
-        {
-            "login.microsoftonline.com",
-            "login.microsoftonline.us",
-            "login.microsoftonline.de",
-            "login.partner.microsoftonline.cn",
-        }
-    )
+    # Single-sourced in mcpgateway.utils.entra_graph_client.
+    _ENTRA_HOSTS: frozenset[str] = ENTRA_ISSUER_HOSTS
 
     def __init__(self, request_timeout: int = 30, max_retries: int = 3, token_storage: Optional[Any] = None):
         """Initialize OAuth Manager.

--- a/mcpgateway/utils/entra_graph_client.py
+++ b/mcpgateway/utils/entra_graph_client.py
@@ -3,16 +3,20 @@
 Copyright contributors to the MCP-CONTEXT-FORGE project
 SPDX-License-Identifier: Apache-2.0
 
-App-only Microsoft Graph client for Entra group-overage resolution (issue #5977).
+App-only Microsoft Graph client for Entra group-overage resolution (issue #5977)
+and service-principal group resolution (issue #6756).
 
 Beyond the Entra group-claim limit a token carries overage markers instead
 of a groups array. Under ``jwt_trust_overage_policy = "graph_lookup"`` this
 client resolves the user's security groups with an app-only
-client-credentials token. The token is acquired from the SSO provider
-record's token endpoint with the stored encrypted client secret, decrypted
-at call time. The inbound bearer token is never used: it is audience-bound
-to ContextForge and Graph would reject it. The delegated ``/me`` flow of
-the SSO browser path is not used either.
+client-credentials token. App-only tokens (``idtyp == "app"``) carry no
+groups claim at all; under the same policy the client resolves the service
+principal's security groups through ``/servicePrincipals/{oid}/getMemberObjects``
+(a service principal is not a user). The token is acquired from the SSO
+provider record's token endpoint with the stored encrypted client secret,
+decrypted at call time. The inbound bearer token is never used: it is
+audience-bound to ContextForge and Graph would reject it. The delegated
+``/me`` flow of the SSO browser path is not used either.
 
 Group resolution results are cached in Redis keyed by the user's ``oid``
 through the shared ``AuthCache._get_redis_key`` helper (key type ``graph``),
@@ -71,8 +75,8 @@ class EntraGraphClient:
         """
         self._auth_cache = auth_cache or AuthCache()
 
-    async def get_member_groups(self, provider: Any, oid: str, token_exp: Optional[int] = None) -> List[str]:
-        """Resolve the security-group object IDs for a user's ``oid``.
+    async def get_member_groups(self, provider: Any, oid: str, token_exp: Optional[int] = None, app_only: bool = False) -> List[str]:
+        """Resolve the security-group object IDs for a user or service principal.
 
         Reads the oid-keyed Redis cache first. A cache hit returns the stored
         group list. A Redis read error is a cache miss and falls through to a
@@ -82,9 +86,13 @@ class EntraGraphClient:
         Args:
             provider: SSO provider record supplying the token endpoint and
                 the encrypted client credentials.
-            oid: Entra object ID of the user (``oid`` claim).
+            oid: Entra object ID of the user or service principal (``oid``
+                claim).
             token_exp: Expiry (epoch seconds) of the presenting token. Bounds
                 the cache TTL.
+            app_only: True when the presenting token is app-only
+                (``idtyp == "app"``): the lookup targets the service principal
+                endpoint instead of the user endpoint.
 
         Returns:
             List of security-group object IDs, de-duplicated and bounded by
@@ -112,7 +120,7 @@ class EntraGraphClient:
                         return [str(group) for group in groups]
                     logger.warning("Graph group cache entry for oid %s is not a list; falling back to live Graph lookup", oid)
 
-        groups = await self._fetch_member_groups(provider, oid)
+        groups = await self._fetch_member_groups(provider, oid, app_only=app_only)
 
         if redis is not None:
             try:
@@ -193,17 +201,21 @@ class EntraGraphClient:
             raise EntraGraphError(f"App-only token response for SSO provider {provider_id!r} carried no access_token.")
         return access_token
 
-    async def _fetch_member_groups(self, provider: Any, oid: str) -> List[str]:
-        """Call Graph getMemberObjects for the user's ``oid``.
+    async def _fetch_member_groups(self, provider: Any, oid: str, app_only: bool = False) -> List[str]:
+        """Call Graph getMemberObjects for the user or service principal ``oid``.
 
-        Posts ``{"securityEnabledOnly": true}`` to
-        ``/users/{oid}/getMemberObjects`` with the app-only token. Requests
-        are bounded by ``sso_entra_graph_api_timeout`` and results by
+        Posts ``{"securityEnabledOnly": true}`` to the getMemberObjects
+        endpoint with the app-only token. User tokens resolve through
+        ``/users/{oid}/getMemberObjects``; app-only tokens (``idtyp ==
+        "app"``) resolve through ``/servicePrincipals/{oid}/getMemberObjects``
+        because a service principal is not a user. Requests are bounded by
+        ``sso_entra_graph_api_timeout`` and results by
         ``sso_entra_graph_api_max_groups``.
 
         Args:
             provider: SSO provider record (credential source).
-            oid: Entra object ID of the user.
+            oid: Entra object ID of the user or service principal.
+            app_only: True to select the service-principal endpoint.
 
         Returns:
             De-duplicated list of security-group object IDs.
@@ -217,10 +229,11 @@ class EntraGraphClient:
         # First-Party
         from mcpgateway.services.http_client_service import get_http_client  # pylint: disable=import-outside-toplevel
 
+        entity = "servicePrincipals" if app_only else "users"
         client = await get_http_client()
         try:
             response = await client.post(
-                f"{GRAPH_BASE_URL}/users/{oid}/getMemberObjects",
+                f"{GRAPH_BASE_URL}/{entity}/{oid}/getMemberObjects",
                 headers={"Authorization": f"Bearer {app_token}"},
                 json={"securityEnabledOnly": True},
                 timeout=settings.sso_entra_graph_api_timeout,

--- a/mcpgateway/utils/entra_graph_client.py
+++ b/mcpgateway/utils/entra_graph_client.py
@@ -29,6 +29,7 @@ a live Graph lookup; a Redis write error is logged and skipped.
 import logging
 import time
 from typing import Any, List, Optional
+from urllib.parse import urlparse
 
 # Third-Party
 import orjson
@@ -47,6 +48,33 @@ GRAPH_SCOPE = "https://graph.microsoft.com/.default"
 
 #: Cache TTL fallback in seconds when the presenting token carries no exp.
 DEFAULT_CACHE_TTL = 300
+
+#: Microsoft Entra issuer/login hosts (global + sovereign clouds). Single
+#: source of truth for "is this issuer Microsoft Entra";
+#: ``OAuthManager._ENTRA_HOSTS`` aliases this set.
+ENTRA_ISSUER_HOSTS: frozenset[str] = frozenset(
+    {
+        "login.microsoftonline.com",
+        "login.microsoftonline.us",
+        "login.microsoftonline.de",
+        "login.partner.microsoftonline.cn",
+    }
+)
+
+
+def is_entra_issuer(issuer: str) -> bool:
+    """Return True when the issuer URL belongs to a Microsoft Entra host.
+
+    Args:
+        issuer: Token issuer URL (e.g.
+            ``https://login.microsoftonline.com/<tenant>/v2.0``).
+
+    Returns:
+        True when the URL hostname is a known Entra host. Non-URL issuers
+        (no parseable hostname) return False.
+    """
+    hostname = urlparse(issuer).hostname
+    return hostname is not None and hostname in ENTRA_ISSUER_HOSTS
 
 
 class EntraGraphError(Exception):
@@ -129,6 +157,47 @@ class EntraGraphClient:
                 logger.warning("Graph group cache write failed for oid %s: %s", oid, exc)
 
         return groups
+
+    async def group_exists(self, provider: Any, group_id: str) -> bool:
+        """Check whether a group object exists in Entra via ``GET /groups/{id}``.
+
+        Uses an app-only client-credentials token from the SSO provider
+        record, exactly like :meth:`get_member_groups`; the inbound bearer
+        token is never used.
+
+        Args:
+            provider: SSO provider record supplying the token endpoint and
+                the encrypted client credentials.
+            group_id: Entra object ID of the group to look up.
+
+        Returns:
+            True when Graph answers 200, False when it answers 404.
+
+        Raises:
+            EntraGraphError: When token acquisition fails or Graph returns
+                any status other than 200/404 (fail-closed: callers must
+                distinguish "missing" from "could not check").
+        """
+        app_token = await self._acquire_app_token(provider)
+
+        # First-Party
+        from mcpgateway.services.http_client_service import get_http_client  # pylint: disable=import-outside-toplevel
+
+        client = await get_http_client()
+        try:
+            response = await client.get(
+                f"{GRAPH_BASE_URL}/groups/{group_id}",
+                headers={"Authorization": f"Bearer {app_token}"},
+                params={"$select": "id"},
+                timeout=settings.sso_entra_graph_api_timeout,
+            )
+        except Exception as exc:
+            raise EntraGraphError(f"Graph group lookup for id {group_id} failed: {exc}") from exc
+        if response.status_code == 200:
+            return True
+        if response.status_code == 404:
+            return False
+        raise EntraGraphError(f"Graph group lookup for id {group_id} returned HTTP {response.status_code}.")
 
     @staticmethod
     def _cache_ttl(token_exp: Optional[int]) -> int:

--- a/mcpgateway/utils/trusted_claims.py
+++ b/mcpgateway/utils/trusted_claims.py
@@ -7,8 +7,11 @@ Trusted claims extraction and group-to-team resolution (issues #5899, #5976).
 
 This module maps a verified external-IdP JWT payload to a virtual principal
 per the pinned trust-mode contract. It also hosts the group-mapping resolver,
-the group-overage marker detector shared with the SSO enrichment path, and
-the overage policy dispatch (:func:`resolve_overage_groups`, issue #5977).
+the group-overage marker detector shared with the SSO enrichment path, the
+overage policy dispatch (:func:`resolve_overage_groups`, issue #5977), the
+app-only token detector (:func:`detect_app_only_token`), and the
+service-principal group dispatch (:func:`resolve_service_principal_groups`,
+issue #6756).
 
 Claim readers support dotted paths one or more levels deep (for example the
 Keycloak ``realm_access.roles`` shape). Each path segment must name a JSON
@@ -319,6 +322,23 @@ def detect_overage_marker(payload: Dict[str, Any]) -> bool:
     return isinstance(payload.get("groups"), str)
 
 
+def detect_app_only_token(payload: Dict[str, Any]) -> bool:
+    """Detect an Entra app-only (client-credentials) token in a payload.
+
+    Entra marks app-only tokens with the standard ``idtyp`` claim set to
+    ``"app"``. App-only tokens carry a ``roles`` claim (app roles) and no
+    ``groups`` claim, and Entra emits no overage markers for them. Detection
+    only — resolution behavior follows ``jwt_trust_overage_policy``.
+
+    Args:
+        payload: Token claims dict.
+
+    Returns:
+        True when the ``idtyp`` claim equals ``"app"``.
+    """
+    return payload.get("idtyp") == "app"
+
+
 def extract_revocation_id(payload: Dict[str, Any], settings: Any) -> str:
     """Extract the revocation identifier honoring the configured claim.
 
@@ -539,4 +559,56 @@ async def resolve_overage_groups(payload: Dict[str, Any], settings: Any, db: Ses
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=f"Group overage resolution via Microsoft Graph failed for oid {oid}: {exc}",
+        ) from exc
+
+
+async def resolve_service_principal_groups(payload: Dict[str, Any], settings: Any, db: Session, graph_client: Optional[Any] = None) -> List[str]:
+    """Resolve an app-only token's service-principal group membership via Graph.
+
+    Applies under ``jwt_trust_overage_policy = "graph_lookup"`` when the token
+    is app-only (``idtyp == "app"``) and carries no ``groups`` claim. A
+    service principal is not a user, so the client posts to
+    ``/servicePrincipals/{oid}/getMemberObjects`` (never ``/users/``) with an
+    app-only client-credentials token; the inbound bearer token is never
+    used. Results are cached oid-keyed with a TTL bounded by the token's
+    ``exp``. The SSO provider record matching the token issuer supplies the
+    encrypted client credentials. The dispatch is fail-closed: any
+    acquisition failure rejects with 401.
+
+    Args:
+        payload: Verified JWT payload of an app-only trusted token (see
+            :func:`detect_app_only_token`).
+        settings: Settings object carrying ``jwt_claim_user_id``.
+        db: Database session for the SSO provider lookup.
+        graph_client: Optional EntraGraphClient override (tests).
+
+    Returns:
+        List of external group object IDs for the service principal.
+
+    Raises:
+        HTTPException: 401 when the oid claim, the provider record, or the
+            Graph resolution fails.
+    """
+    oid = payload.get("oid")
+    if not isinstance(oid, str) or not oid:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="jwt_trust_overage_policy 'graph_lookup' requires the token 'oid' claim for the Graph service-principal lookup.",
+        )
+
+    issuer = payload.get("iss")
+    provider = db.query(SSOProvider).filter(SSOProvider.issuer == issuer, SSOProvider.is_enabled.is_(True)).first()
+    if provider is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"No enabled SSO provider matches token issuer {issuer!r}; cannot resolve the service-principal groups via Microsoft Graph.",
+        )
+
+    client = graph_client or EntraGraphClient()
+    try:
+        return await client.get_member_groups(provider, oid, token_exp=payload.get("exp"), app_only=True)
+    except EntraGraphError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Service-principal group resolution via Microsoft Graph failed for oid {oid}: {exc}",
         ) from exc

--- a/mcpgateway/utils/trusted_claims.py
+++ b/mcpgateway/utils/trusted_claims.py
@@ -77,7 +77,6 @@ from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.db import ExternalGroupMapping, SSOProvider
-from mcpgateway.services.role_resolution import resolve_mapping_role
 from mcpgateway.utils.entra_graph_client import EntraGraphClient, EntraGraphError
 
 logger = logging.getLogger(__name__)
@@ -452,6 +451,11 @@ def extract_trusted_principal(payload: Dict[str, Any], settings: Any, db: Sessio
     # active rows across scopes and union more permissions than intended.
     # cf_team_id is not threaded here: Role.scope is a scope type, not a
     # per-team id, so the team context does not change the resolution.
+    # First-Party
+    from mcpgateway.services.role_resolution import (  # lazy: module-level import cycles via mcpgateway.services.__init__ -> gateway_service -> sso_service
+        resolve_mapping_role,
+    )
+
     roles: List[str] = []
     for role_name in role_names:
         if resolve_mapping_role(db, role_name) is not None:

--- a/tests/helpers/auth.py
+++ b/tests/helpers/auth.py
@@ -97,6 +97,7 @@ def make_trusted_test_jwt(
     issuer: str | None = None,
     tenant: str | None = None,
     groups: list[str] | None = None,
+    idtyp: str | None = None,
     revocation_id: str | None = None,
     expires_in_minutes: int = 180,
     secret: str = "",
@@ -108,9 +109,11 @@ def make_trusted_test_jwt(
     The mapped claims are written under the claim names configured in
     ``settings.jwt_claim_*`` and ``settings.jwt_trust_revocation_claim`` so
     the helper stays correct when a test re-maps a claim. ``user_id`` is the
-    opaque subject. When ``revocation_id`` is omitted, a fresh ``jti`` is
-    generated. The token is signed directly (not via ``_create_jwt_token``)
-    so the ``issuer`` parameter is honored.
+    opaque subject. ``idtyp`` writes the Entra token-type claim (``"app"``
+    marks an app-only client-credentials token, #6756); when omitted the
+    claim is absent and the output is unchanged. When ``revocation_id`` is
+    omitted, a fresh ``jti`` is generated. The token is signed directly (not
+    via ``_create_jwt_token``) so the ``issuer`` parameter is honored.
     """
     # Standard
     import uuid
@@ -139,6 +142,8 @@ def make_trusted_test_jwt(
         claims["tid"] = tenant
     if groups is not None:
         claims["groups"] = groups
+    if idtyp is not None:
+        claims["idtyp"] = idtyp
     if revocation_id is not None:
         claims[settings.jwt_trust_revocation_claim] = revocation_id
     if "jti" not in claims:

--- a/tests/unit/mcpgateway/routers/test_external_group_mapping_admin.py
+++ b/tests/unit/mcpgateway/routers/test_external_group_mapping_admin.py
@@ -13,8 +13,10 @@ pattern used by test_runtime_admin_router.py.
 """
 
 # Standard
+import contextlib
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
+import logging
+from unittest.mock import AsyncMock, MagicMock
 
 # Third-Party
 from fastapi import HTTPException
@@ -24,8 +26,9 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 # First-Party
-from mcpgateway.db import Base, EmailTeam, EmailUser, ExternalGroupMapping, Role
+from mcpgateway.db import Base, EmailTeam, EmailUser, ExternalGroupMapping, Role, SSOProvider
 from mcpgateway.routers import admin_external_group_mappings as router_module
+from mcpgateway.utils.entra_graph_client import EntraGraphError
 
 
 @pytest.fixture
@@ -225,3 +228,102 @@ class TestGraphValidatorSeam:
         created = await router_module.create_external_group_mapping(_create_body(), request=request_stub, user=admin_user, db=db)
         assert created.validation_status == "unknown"
         assert created.last_validated_at is not None
+
+
+ENTRA_ISSUER = "https://login.microsoftonline.com/tenant-1/v2.0"
+
+
+def _seed_entra_provider(db) -> SSOProvider:
+    """Insert an enabled SSO provider record for the Entra test issuer."""
+    provider = SSOProvider(
+        id="entra-test",
+        name="entra-test",
+        display_name="Entra Test",
+        provider_type="oidc",
+        is_enabled=True,
+        client_id="client-1",
+        client_secret_encrypted="encrypted-secret",  # pragma: allowlist secret
+        authorization_url="https://login.microsoftonline.com/tenant-1/oauth2/v2.0/authorize",
+        token_url="https://login.microsoftonline.com/tenant-1/oauth2/v2.0/token",
+        userinfo_url="https://login.microsoftonline.com/oidc/userinfo",
+        issuer=ENTRA_ISSUER,
+    )
+    db.add(provider)
+    db.commit()
+    return provider
+
+
+@pytest.fixture
+def graph_client_factory(monkeypatch: pytest.MonkeyPatch):
+    """Patch the router's EntraGraphClient seam with a mock; returns (factory, client)."""
+    client = MagicMock()
+    client.group_exists = AsyncMock(return_value=True)
+    factory = MagicMock(return_value=client)
+    monkeypatch.setattr(router_module, "EntraGraphClient", factory)
+    return factory, client
+
+
+@pytest.fixture
+def validator_db(monkeypatch: pytest.MonkeyPatch, db):
+    """Point the validator's fresh_db_session at the in-memory test session."""
+
+    @contextlib.contextmanager
+    def _session():
+        yield db
+
+    monkeypatch.setattr(router_module, "fresh_db_session", _session)
+    return db
+
+
+class TestGraphBackedValidator:
+    """The Graph-backed default group-existence validator (issue #5977)."""
+
+    @pytest.mark.asyncio
+    async def test_entra_group_exists_valid(self, allow_admin, db, admin_user, request_stub, validator_db, graph_client_factory):
+        _seed_entra_provider(db)
+        _, client = graph_client_factory
+        created = await router_module.create_external_group_mapping(_create_body(issuer=ENTRA_ISSUER), request=request_stub, user=admin_user, db=db)
+        assert created.validation_status == "valid"
+        client.group_exists.assert_awaited_once()
+        provider_arg, group_arg = client.group_exists.await_args.args
+        assert provider_arg.issuer == ENTRA_ISSUER
+        assert group_arg == "guid-1"
+
+    @pytest.mark.asyncio
+    async def test_entra_group_not_found_recorded(self, allow_admin, db, admin_user, request_stub, validator_db, graph_client_factory):
+        _seed_entra_provider(db)
+        _, client = graph_client_factory
+        client.group_exists.return_value = False
+        # A missing group is recorded with a reason status, not rejected by
+        # the CRUD: the resolver fails closed at read time, so the row can
+        # never grant access.
+        created = await router_module.create_external_group_mapping(_create_body(issuer=ENTRA_ISSUER), request=request_stub, user=admin_user, db=db)
+        assert created.validation_status == "graph_group_not_found"
+
+    @pytest.mark.asyncio
+    async def test_entra_graph_error_unknown_warn_and_allow(self, allow_admin, db, admin_user, request_stub, validator_db, graph_client_factory):
+        _seed_entra_provider(db)
+        _, client = graph_client_factory
+        client.group_exists.side_effect = EntraGraphError("boom")
+        created = await router_module.create_external_group_mapping(_create_body(issuer=ENTRA_ISSUER), request=request_stub, user=admin_user, db=db)
+        assert created.validation_status == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_non_entra_issuer_skips_graph(self, allow_admin, db, admin_user, request_stub, validator_db, graph_client_factory):
+        factory, client = graph_client_factory
+        created = await router_module.create_external_group_mapping(_create_body(), request=request_stub, user=admin_user, db=db)
+        assert created.validation_status == "valid"
+        factory.assert_not_called()
+        client.group_exists.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_entra_issuer_without_credentials_warns(self, allow_admin, db, admin_user, request_stub, validator_db, graph_client_factory, caplog):
+        # No SSO provider row for the Entra issuer: Graph is unconfigured, so
+        # the validator keeps the disabled-stub posture ("valid") and warns.
+        factory, client = graph_client_factory
+        with caplog.at_level(logging.WARNING):
+            created = await router_module.create_external_group_mapping(_create_body(issuer=ENTRA_ISSUER), request=request_stub, user=admin_user, db=db)
+        assert created.validation_status == "valid"
+        factory.assert_not_called()
+        client.group_exists.assert_not_called()
+        assert any("credentials" in record.getMessage() and ENTRA_ISSUER in record.getMessage() for record in caplog.records)

--- a/tests/unit/mcpgateway/test_entra_graph_client.py
+++ b/tests/unit/mcpgateway/test_entra_graph_client.py
@@ -3,7 +3,8 @@
 Copyright contributors to the MCP-CONTEXT-FORGE project
 SPDX-License-Identifier: Apache-2.0
 
-Unit tests for the app-only Entra Graph overage client (issue #5977).
+Unit tests for the app-only Entra Graph overage client (issue #5977) and the
+app-only service-principal group resolution (issue #6756).
 
 Beyond the Entra group-claim limit a trusted token carries overage markers
 instead of a groups array. ``resolve_overage_groups`` in trusted_claims.py
@@ -13,22 +14,38 @@ applies ``jwt_trust_overage_policy``: ``fail_closed`` rejects with 401,
 empty group list plus a WARNING log carrying the user's oid. The client
 acquires a client-credentials token with the SSO provider record's stored
 encrypted client secret; the inbound bearer token is never used.
+
+App-only (client-credentials) tokens carry ``idtyp="app"`` and no groups
+claim. ``resolve_service_principal_groups`` resolves the service principal's
+group membership through ``/servicePrincipals/{oid}/getMemberObjects`` under
+the ``graph_lookup`` policy; under ``fail_closed`` (default) and
+``proceed_without_groups`` the token authenticates with empty teams and the
+roles claim keeps the app-role path.
 """
 
 # Standard
+import contextlib
+from datetime import datetime, timezone
 import logging
 import time
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
 import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 # First-Party
+from mcpgateway.auth import get_current_user
 from mcpgateway.cache.auth_cache import AuthCache
-from mcpgateway.utils.entra_graph_client import EntraGraphClient
-from mcpgateway.utils.trusted_claims import resolve_overage_groups
+from mcpgateway.config import settings
+from mcpgateway.db import Base, EmailTeam, EmailUser, ExternalGroupMapping, Role, SSOProvider
+from mcpgateway.utils.entra_graph_client import EntraGraphClient, GRAPH_BASE_URL
+from mcpgateway.utils.trusted_claims import detect_app_only_token, resolve_overage_groups, resolve_service_principal_groups
 
 ISSUER = "https://login.microsoftonline.com/tenant-1/v2.0"
 OID = "oid-9f8e7d6c"
@@ -47,6 +64,22 @@ def _overage_payload(**overrides):
         "exp": int(time.time()) + 600,
         "hasgroups": True,
         "_claim_names": {"groups": "src1"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _app_only_payload(**overrides):
+    """App-only (client-credentials) Entra payload: idtyp=app, no groups claim."""
+    payload = {
+        "sub": OID,
+        "oid": OID,
+        "iss": ISSUER,
+        "tid": "tenant-1",
+        "idtyp": "app",
+        "token_use": "trusted",
+        "jti": "trusted-jti-app-1",
+        "exp": int(time.time()) + 600,
     }
     payload.update(overrides)
     return payload
@@ -106,7 +139,11 @@ class _BrokenRedis:
 
 
 def _graph_http_client(graph_calls, graph_status=200, graph_payload=None, token_status=200):
-    """HTTP client double: client-credentials token POST plus getMemberObjects."""
+    """HTTP client double: client-credentials token POST plus getMemberObjects.
+
+    Every getMemberObjects call is recorded with its URL so tests assert the
+    endpoint selection (``/users/`` versus ``/servicePrincipals/``).
+    """
     if graph_payload is None:
         graph_payload = {"value": ["group-1", "group-2"]}
 
@@ -114,7 +151,7 @@ def _graph_http_client(graph_calls, graph_status=200, graph_payload=None, token_
         if url == TOKEN_URL:
             return SimpleNamespace(status_code=token_status, json=lambda: {"access_token": APP_ONLY_TOKEN}, text="")
         if url.endswith("/getMemberObjects"):
-            graph_calls.append(kwargs)
+            graph_calls.append({"url": url, **kwargs})
             return SimpleNamespace(status_code=graph_status, json=lambda: graph_payload, text="")
         raise AssertionError(f"unexpected URL {url}")
 
@@ -241,5 +278,207 @@ class TestGraphLookupFailure:
 
         with pytest.raises(HTTPException) as exc_info:
             await resolve_overage_groups(_overage_payload(), _settings("graph_lookup"), _db_returning(_provider()), graph_client=graph_client)
+
+        assert exc_info.value.status_code == 401
+
+
+class TestAppOnlyTokenDetection:
+    """detect_app_only_token keys on the standard Entra idtyp claim."""
+
+    def test_idtyp_app_detected(self):
+        """idtyp == "app" marks an app-only (client-credentials) token."""
+        assert detect_app_only_token(_app_only_payload()) is True
+
+    def test_idtyp_absent_is_not_app(self):
+        """A token without the idtyp claim is not app-only."""
+        assert detect_app_only_token(_overage_payload()) is False
+
+    def test_idtyp_user_is_not_app(self):
+        """A delegated user token (idtyp absent or non-app) is not app-only."""
+        assert detect_app_only_token(_app_only_payload(idtyp="user")) is False
+
+
+class TestAppOnlyEndpointSelection:
+    """App-only tokens resolve through /servicePrincipals, never /users."""
+
+    async def test_app_only_calls_service_principals_endpoint(self, monkeypatch):
+        """AC: /servicePrincipals/{oid}/getMemberObjects is called; /users/ never."""
+        graph_calls = []
+        _patch_http_and_encryption(monkeypatch, _graph_http_client(graph_calls))
+        graph_client, _ = _client_with_redis(None)
+
+        groups = await resolve_service_principal_groups(_app_only_payload(), _settings("graph_lookup"), _db_returning(_provider()), graph_client=graph_client)
+
+        assert groups == ["group-1", "group-2"]
+        assert len(graph_calls) == 1
+        assert graph_calls[0]["url"] == f"{GRAPH_BASE_URL}/servicePrincipals/{OID}/getMemberObjects"
+        assert "/users/" not in graph_calls[0]["url"]
+        # The Graph call carries the client-credentials token, never the inbound bearer token.
+        assert graph_calls[0]["headers"]["Authorization"] == f"Bearer {APP_ONLY_TOKEN}"
+        assert graph_calls[0]["json"] == {"securityEnabledOnly": True}
+
+    async def test_app_only_redis_error_degrades_to_live_lookup(self, monkeypatch):
+        """Redis read error -> cache miss -> live Graph call (#5977 AC-extra-1 parity)."""
+        graph_calls = []
+        graph_client, _ = _client_with_redis(_BrokenRedis())
+        _patch_http_and_encryption(monkeypatch, _graph_http_client(graph_calls))
+
+        groups = await resolve_service_principal_groups(_app_only_payload(), _settings("graph_lookup"), _db_returning(_provider()), graph_client=graph_client)
+
+        assert groups == ["group-1", "group-2"]
+        assert len(graph_calls) == 1
+
+    async def test_app_only_graph_failure_yields_401(self, monkeypatch):
+        """Graph failure under graph_lookup -> 401 (fail-closed)."""
+        graph_client, _ = _client_with_redis(_FakeRedis())
+        _patch_http_and_encryption(monkeypatch, _graph_http_client([], graph_status=500))
+
+        with pytest.raises(HTTPException) as exc_info:
+            await resolve_service_principal_groups(_app_only_payload(), _settings("graph_lookup"), _db_returning(_provider()), graph_client=graph_client)
+
+        assert exc_info.value.status_code == 401
+
+
+@pytest.fixture
+def funnel_db():
+    """In-memory SQLite session seeded for the app-only trust-path dispatch.
+
+    Seeds: the owner user, team-sp, the viewer role, an enabled Entra SSO
+    provider row, and the group-1 -> team-sp external-group mapping row.
+    """
+    engine = sa.create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    owner = EmailUser(
+        email="owner@example.com",
+        password_hash="hash",  # pragma: allowlist secret
+        full_name="Owner",
+        is_admin=False,
+        is_active=True,
+        email_verified_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    session.add(owner)
+    session.add(EmailTeam(id="team-sp", name="SP Team", slug="team-sp", created_by=owner.email, is_personal=False, visibility="private"))
+    session.add(Role(name="viewer", scope="team", permissions=[], created_by=owner.email, is_system_role=True, is_active=True))
+    session.add(
+        SSOProvider(
+            id="entra",
+            name="entra",
+            display_name="Entra",
+            provider_type="oidc",
+            is_enabled=True,
+            client_id="app-client-id",
+            client_secret_encrypted="ENC(plain-secret)",
+            authorization_url="https://login.microsoftonline.com/tenant-1/oauth2/v2.0/authorize",
+            token_url=TOKEN_URL,
+            userinfo_url="https://graph.microsoft.com/oidc/userinfo",
+            issuer=ISSUER,
+        )
+    )
+    session.add(ExternalGroupMapping(issuer=ISSUER, tenant="tenant-1", external_group_id="group-1", cf_team_id="team-sp", cf_role=None))
+    session.commit()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+async def _drive_app_only_funnel(monkeypatch, db, payload, *, graph_client):
+    """Drive get_current_user on the trust path with an app-only payload.
+
+    The Graph client double is injected through the trusted_claims module
+    binding so the trust path uses it instead of a live EntraGraphClient.
+    Returns (user, request). Raises whatever the funnel raises.
+    """
+    monkeypatch.setattr(settings, "jwt_trust_mode", "jwt-trust")
+    monkeypatch.setattr(settings, "auth_cache_enabled", False)
+    monkeypatch.setattr(settings, "auth_cache_batch_queries", False)
+
+    session_test = sessionmaker(bind=db.get_bind())
+    monkeypatch.setattr("mcpgateway.auth.SessionLocal", session_test)
+
+    @contextlib.contextmanager
+    def _fresh_db_session():
+        session = session_test()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("mcpgateway.auth.fresh_db_session", _fresh_db_session)
+    monkeypatch.setattr("mcpgateway.utils.trusted_claims.EntraGraphClient", lambda *args, **kwargs: graph_client)
+
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="trusted_jwt_token")  # pragma: allowlist secret
+    request = SimpleNamespace(state=SimpleNamespace())
+
+    with patch("mcpgateway.auth.verify_jwt_token_cached", AsyncMock(return_value=payload)):
+        with patch("mcpgateway.auth._check_token_revoked_sync", return_value=False):
+            # Fail the test loudly if the trust path touches the user table
+            # through the default-funnel helpers.
+            with patch("mcpgateway.auth._get_user_by_email_sync", side_effect=AssertionError("user lookup on trust path")):
+                user = await get_current_user(credentials=credentials, request=request)
+    return user, request
+
+
+class TestAppOnlyTrustPathDispatch:
+    """Policy dispatch in the trust path for app-only tokens (idtyp=app)."""
+
+    async def test_app_only_graph_lookup_maps_groups_to_teams(self, monkeypatch, funnel_db):
+        """AC: SP endpoint called, groups mapped, token_teams carry mapped teams."""
+        monkeypatch.setattr(settings, "jwt_trust_overage_policy", "graph_lookup")
+        graph_calls = []
+        _patch_http_and_encryption(monkeypatch, _graph_http_client(graph_calls))
+        graph_client, _ = _client_with_redis(None)
+
+        user, request = await _drive_app_only_funnel(monkeypatch, funnel_db, _app_only_payload(), graph_client=graph_client)
+
+        assert user.user_id == OID
+        assert user.token_use == "trusted"
+        # group-1 maps to team-sp; group-2 is unmapped and contributes nothing.
+        assert request.state.token_teams == ["team-sp"]
+        assert len(graph_calls) == 1
+        assert graph_calls[0]["url"] == f"{GRAPH_BASE_URL}/servicePrincipals/{OID}/getMemberObjects"
+        assert "/users/" not in graph_calls[0]["url"]
+
+    async def test_app_only_fail_closed_default_keeps_roles_only_path(self, monkeypatch, funnel_db):
+        """AC: fail_closed (default) authenticates with token_teams=[] and the roles claim maps."""
+        monkeypatch.setattr(settings, "jwt_trust_overage_policy", "fail_closed")
+        graph_calls = []
+        _patch_http_and_encryption(monkeypatch, _graph_http_client(graph_calls))
+        graph_client, _ = _client_with_redis(None)
+
+        user, request = await _drive_app_only_funnel(monkeypatch, funnel_db, _app_only_payload(roles=["viewer"]), graph_client=graph_client)
+
+        assert user.user_id == OID
+        assert request.state.token_teams == []
+        # The app-role path (#5902) is intact: roles=["viewer"] grants the mapped CF role.
+        assert user.roles == ["viewer"]
+        # Graph is never called under the default policy.
+        assert graph_calls == []
+
+    async def test_app_only_proceed_without_groups_keeps_current_behavior(self, monkeypatch, funnel_db):
+        """proceed_without_groups: authenticated with token_teams=[]; Graph is never called."""
+        monkeypatch.setattr(settings, "jwt_trust_overage_policy", "proceed_without_groups")
+        graph_calls = []
+        _patch_http_and_encryption(monkeypatch, _graph_http_client(graph_calls))
+        graph_client, _ = _client_with_redis(None)
+
+        user, request = await _drive_app_only_funnel(monkeypatch, funnel_db, _app_only_payload(), graph_client=graph_client)
+
+        assert user.user_id == OID
+        assert request.state.token_teams == []
+        assert graph_calls == []
+
+    async def test_app_only_graph_failure_under_graph_lookup_yields_401(self, monkeypatch, funnel_db):
+        """AC: Graph failure under graph_lookup rejects the request with 401."""
+        monkeypatch.setattr(settings, "jwt_trust_overage_policy", "graph_lookup")
+        _patch_http_and_encryption(monkeypatch, _graph_http_client([], graph_status=500))
+        graph_client, _ = _client_with_redis(None)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _drive_app_only_funnel(monkeypatch, funnel_db, _app_only_payload(), graph_client=graph_client)
 
         assert exc_info.value.status_code == 401


### PR DESCRIPTION
Adds app-only (client-credentials) trust-token group resolution to JWT-trust mode (issue #6756, epic #5885).

App-only Entra tokens carry `idtyp="app"`, a `roles` claim, and no `groups` claim. Entra emits no overage markers for them, so the #5977 overage dispatch never triggers — and `/users/{oid}/getMemberObjects` would fail for a service principal (a service principal is not a user). Under `jwt_trust_overage_policy="graph_lookup"` this PR resolves the service principal's security groups through `POST /servicePrincipals/{oid}/getMemberObjects` and maps them through `external_group_mappings`.

Changes:
- `detect_app_only_token(payload)`: True when `idtyp == "app"` (`mcpgateway/utils/trusted_claims.py`).
- `EntraGraphClient` endpoint selection: `/servicePrincipals/{oid}/getMemberObjects` for app-only tokens; `/users/{oid}/getMemberObjects` unchanged for user tokens. Client-credentials grant only; the inbound bearer token is never used. Same oid-keyed Redis cache, TTL bounded by `exp`.
- Trust-path dispatch (`get_current_user`): `idtyp == "app"` AND `groups` absent AND `graph_lookup` -> Graph resolve (cached) -> payload copy -> `resolve_external_groups_to_teams`. Under `fail_closed` (default) and `proceed_without_groups` an app token without groups authenticates with `token_teams=[]`; the app-role path (#5902) stays intact.
- `make_trusted_test_jwt`: new `idtyp` kwarg; default output unchanged.

TDD: 7 new tests in `tests/unit/mcpgateway/test_entra_graph_client.py` (red first: ImportError on the new symbols). URL capture asserts `/servicePrincipals/{id}` is called and `/users/` never is for app tokens; `fail_closed` pins a `roles=["viewer"]` app token (authenticated, `token_teams=[]`, viewer role granted); Graph failure under `graph_lookup` -> 401; Redis read error -> cache miss -> live call. All 11 pre-existing tests in the file pass unmodified (user-token overage regression).

Gate:
- `make ruff` — All checks passed!
- `make test` — 23411 passed, 879 skipped, 2 xfailed. (Two earlier full-suite runs each flaked on the pre-existing wall-clock benchmark `test_trust_p99_within_2x_default` under load; it passes in isolation and in the final green run. This PR adds no timing tests.)
- Pre-commit hooks on commit: ruff check/format, interrogate, bandit, IBM detect-secrets — all pass.

Note: the commit also carries the pre-staged `.secrets.baseline` regeneration (line-number bookkeeping for existing `is_secret: false` entries), which was already in the index from the stack work.

Risk to existing users: none — every new branch is trust-mode + graph_lookup gated; default mode and the user-token overage path verified green in the full suite.

Stack: B.15 of epic #5885 (base: #6755).

Closes #6756