### PR TITLE
update release documentation

### DIFF
--- a/docs/docs/development/release-management.md
+++ b/docs/docs/development/release-management.md
@@ -130,36 +130,37 @@ uv lock --upgrade
 The snippet below auto-discovers every `pyproject.toml` and `requirements.txt` in the repository, skipping generated templates and virtual-environment directories. No hardcoded path list means newly added or deleted sub-projects are picked up automatically.
 
 ```bash
-# uv-sync + lockfile upgrade for every pyproject.toml
-# Skips: mcp-servers/templates (generated), .venv dirs, Rust crates (no uv)
+# uv sync + lockfile upgrade for every pyproject.toml
+# Skips: mcp-servers/templates (generated), .venv* dirs, Rust crates (no uv)
 find . \
   -path "./mcp-servers/templates" -prune -o \
-  -path "*/.venv" -prune -o \
+  -name "templates" -prune -o \
+  -name ".venv*" -prune -o \
   -path "*/target" -prune -o \
   -path "./.cache" -prune -o \
   -name "pyproject.toml" -type f -print \
 | while read -r toml_file; do
     dir=$(dirname "$toml_file")
     echo "==> $dir"
-    uv-upsync --project "$dir" 2>/dev/null || true
+    uv sync --project "$dir" 2>/dev/null || true
     uv lock --upgrade --exclude-newer "10 days" --project "$dir"
   done
 
-# requirements.txt files (docs, tests)
+# requirements*.txt files (docs, tests)
 find . \
-  -path "*/.venv" -prune -o \
+  -name ".venv*" -prune -o \
   -path "./.cache" -prune -o \
-  -name "requirements.txt" -type f -print \
+  -name "requirements*.txt" -type f -print \
 | while read -r req_file; do
     echo "==> $req_file"
-    python .github/tools/update_dependencies.py --file "$req_file"
+    uv run python .github/tools/update_dependencies.py --file "$req_file"
   done
 ```
 
 !!! tip "Dry-run the requirements updater first"
     Use `--dry-run` to preview changes before applying:
     ```bash
-    python .github/tools/update_dependencies.py --file docs/requirements.txt --dry-run
+    uv run python .github/tools/update_dependencies.py --file docs/requirements.txt --dry-run
     ```
 
 ### 2.3 Reinstall and verify
@@ -1093,6 +1094,17 @@ make migration-test-performance
 ```
 
 The migration test suite follows an **n-2 support policy** and tests sequential upgrades, downgrades, and skip-version jumps. See `tests/migration/README.md` for full documentation.
+
+### 13.6 Upgrade and downgrade validation with a staging data dump
+
+Repeat the upgrade and downgrade steps from 13.3 and 13.4 using a staging data instead of the synthetic-seeded data. This validates that migrations behave correctly against production-shaped data — edge-case column values, optional fields left null, legacy rows written by older schema versions — which synthetic seeds may not exercise.
+
+**Acceptance criteria:**
+
+- The gateway starts and Alembic reaches the expected single head with no errors
+- All pre-migration rows in key tables (`gateways`, `servers`, `tools`, `users`) are present and intact after upgrade
+- The downgrade step completes without errors and the gateway remains healthy
+- Re-applying the upgrade (round-trip) produces no conflicts or data loss
 
 ---
 


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #6374

---

## 📝 Summary

Fix Section 2.2 of the release management guide (`docs/docs/development/release-management.md`) where the dependency discovery and execution commands contained several errors that caused failures when run against the actual repository tree. Also adds a new Section 13.6 requiring upgrade/downgrade validation against staging data.

**Section 2.2 fixes:**

- `find` commands now prune `.venv*` directories (e.g. `.venv.sbom`, `.venv-dev`) and cookiecutter `templates` directories, preventing `uv` from failing on Jinja syntax like `{{ cookiecutter.plugin_slug }}` inside package templates
- `uv-upsync` (not a valid command) replaced with `uv sync`
- Script invocations changed from `python` to `uv run python` to ensure the correct interpreter and environment are used regardless of the shell's `PATH`
- `-name "requirements.txt"` widened to `-name "requirements*.txt"` to catch auxiliary requirements files (e.g. `requirements-dev.txt`)

**Section 13.6 (new):**

- Adds a checklist step requiring that the upgrade and downgrade scenarios from 13.3/13.4 are repeated against a staging data dump, not just synthetic-seeded data, before cutting a release

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [x] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

The corrected `find` commands were validated against the repository tree:

- `pyproject.toml` discovery: 10 files found (root + 6 MCP servers + 3 plugins) — no `.venv*` site-packages, no cookiecutter templates, no Rust `target/` paths
- `requirements*.txt` discovery: 5 files found (`docs/`, 1 MCP server, `plugins/`, 2 test directories) — no false positives from caches or virtual environments

| Check | Command | Status |
|---|---|---|
| Correct pyproject.toml discovery | `find . -name ".venv*" -prune -o ... -name "pyproject.toml" -print \| sort` | ✅ 10 files, zero noise |
| Correct requirements discovery | `find . -name ".venv*" -prune -o ... -name "requirements*.txt" -print \| sort` | ✅ 5 files, zero noise |
| No files missed | `comm -23 <(find . -name "pyproject.toml" \| sort) <(filtered find \| sort)` | ✅ All excluded paths are generated/cache noise |
| Lint suite | `make lint` | N/A — docs-only change |
| Unit tests | `make test` | N/A — docs-only change |

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

The `find` exclusion for `.venv*` uses `-name` (not `-path`) so it matches any directory named `.venv`, `.venv.sbom`, `.venv-dev`, etc. at any depth, without needing to enumerate each one explicitly.