### PR TITLE
fix(ssl): present mTLS client cert when no custom CA is configured

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -138,7 +138,7 @@ from mcpgateway.utils.redis_client import get_redis_client
 from mcpgateway.utils.retry_manager import ResilientHttpClient
 from mcpgateway.utils.services_auth import decode_auth, encode_auth
 from mcpgateway.utils.sqlalchemy_modifier import json_contains_tag_expr
-from mcpgateway.utils.ssl_context_cache import get_cached_ssl_context
+from mcpgateway.utils.ssl_context_cache import build_client_ssl_context, get_cached_ssl_context
 from mcpgateway.utils.subject_token import extract_subject_jwt
 from mcpgateway.utils.token_exchange_audit import audit_token_exchange
 from mcpgateway.utils.url_auth import apply_query_param_auth, sanitize_exception_message, sanitize_url_for_logging
@@ -4802,12 +4802,14 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 except Exception:
                     logger.debug("client_key decryption skipped during health check")
 
-            if gateway_url and gateway_url.lower().startswith("http://"):
-                ssl_context = None
-            elif valid and gateway_ca_certificate:
-                ssl_context = get_cached_ssl_context(gateway_ca_certificate, client_cert=health_client_cert, client_key=_hc_client_key)
-            else:
-                ssl_context = None
+            # A client cert/key pair alone is enough to need a context: the peer may require
+            # mTLS while its own certificate chains to the system trust store.
+            ssl_context = build_client_ssl_context(
+                gateway_url,
+                gateway_ca_certificate if valid else None,
+                client_cert=health_client_cert,
+                client_key=_hc_client_key,
+            )
 
             def get_httpx_client_factory(
                 headers: dict[str, str] | None = None,
@@ -7273,12 +7275,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             Returns:
                 httpx.AsyncClient: Configured HTTPX async client
             """
-            if server_url and server_url.lower().startswith("http://"):
-                ctx = None
-            elif ca_certificate:
-                ctx = get_cached_ssl_context(ca_certificate, client_cert=client_cert, client_key=client_key)
-            else:
-                ctx = None
+            ctx = build_client_ssl_context(server_url, ca_certificate, client_cert=client_cert, client_key=client_key)
 
             return httpx.AsyncClient(
                 verify=ctx if ctx else get_default_verify(),
@@ -7444,12 +7441,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             Returns:
                 httpx.AsyncClient: Configured HTTPX async client
             """
-            if server_url and server_url.lower().startswith("http://"):
-                ctx = None
-            elif ca_certificate:
-                ctx = get_cached_ssl_context(ca_certificate, client_cert=client_cert, client_key=client_key)
-            else:
-                ctx = None
+            ctx = build_client_ssl_context(server_url, ca_certificate, client_cert=client_cert, client_key=client_key)
 
             return httpx.AsyncClient(
                 verify=ctx if ctx else get_default_verify(),
@@ -8413,8 +8405,15 @@ async def test_gateway_handshake(
             credential_source = "form"
 
     handshake_verify: Any = get_default_verify()
-    if gateway and gateway.ca_certificate and not validated_base_url.lower().startswith("http://"):
-        handshake_verify = get_cached_ssl_context(gateway.ca_certificate, client_cert=gateway.client_cert, client_key=gateway.client_key)
+    if gateway:
+        handshake_ctx = build_client_ssl_context(
+            validated_base_url,
+            gateway.ca_certificate,
+            client_cert=gateway.client_cert,
+            client_key=gateway.client_key,
+        )
+        if handshake_ctx is not None:
+            handshake_verify = handshake_ctx
 
     def get_httpx_client_factory(
         headers: Optional[Dict[str, str]] = None,

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -25,7 +25,6 @@ import json  # NOTE: httpx uses stdlib json, not orjson, so response.json() rais
 import logging
 import os
 import re
-import ssl
 import time
 from types import SimpleNamespace
 from typing import Any, AsyncGenerator, Awaitable, Callable, Dict, List, Optional, Tuple, Union
@@ -115,7 +114,7 @@ from mcpgateway.utils.passthrough_headers import compute_passthrough_headers_cac
 from mcpgateway.utils.retry_manager import ResilientHttpClient
 from mcpgateway.utils.services_auth import decode_auth, encode_auth
 from mcpgateway.utils.sqlalchemy_modifier import json_contains_tag_expr
-from mcpgateway.utils.ssl_context_cache import get_cached_ssl_context
+from mcpgateway.utils.ssl_context_cache import build_client_ssl_context
 from mcpgateway.utils.subject_token import extract_inbound_bearer, looks_like_jwt
 from mcpgateway.utils.token_exchange_audit import audit_token_exchange
 from mcpgateway.utils.trace_context import format_trace_team_scope
@@ -6252,25 +6251,6 @@ class ToolService(BaseService):
                         except Exception as _dec_exc:
                             logger.debug("client_key decryption skipped, using as-is: %s", _dec_exc)
 
-                    def create_ssl_context(
-                        ca_certificate: str,
-                        client_cert: str | None = None,
-                        client_key: str | None = None,
-                    ) -> ssl.SSLContext:
-                        """Create an SSL context with the provided CA certificate and optional mTLS credentials.
-
-                        Uses caching to avoid repeated SSL context creation for the same certificate(s).
-
-                        Args:
-                            ca_certificate: CA certificate in PEM format
-                            client_cert: Optional client cert path or PEM for mTLS
-                            client_key: Optional client key path or PEM for mTLS
-
-                        Returns:
-                            ssl.SSLContext: Configured SSL context
-                        """
-                        return get_cached_ssl_context(ca_certificate, client_cert=client_cert, client_key=client_key)
-
                     # Capture mTLS client cert/key values for passing to nested function
                     _client_cert_value = gateway_client_cert
                     _client_key_value = gateway_client_key
@@ -6308,16 +6288,14 @@ class ToolService(BaseService):
                         from mcpgateway.services.http_client_service import get_default_verify, get_http_timeout  # pylint: disable=import-outside-toplevel
 
                         # For plain HTTP gateway URLs, skip SSL context entirely to avoid unnecessary SSL setup.
-                        if gateway_url and gateway_url.lower().startswith("http://"):
-                            ctx = None
-                        elif valid and gateway_ca_cert:
-                            ctx = create_ssl_context(
-                                gateway_ca_cert,
-                                client_cert=client_cert_value,
-                                client_key=client_key_value,
-                            )
-                        else:
-                            ctx = None
+                        # A client cert/key pair alone is enough to need a context: the peer may require
+                        # mTLS while its own certificate chains to the system trust store.
+                        ctx = build_client_ssl_context(
+                            gateway_url,
+                            gateway_ca_cert if valid else None,
+                            client_cert=client_cert_value,
+                            client_key=client_key_value,
+                        )
 
                         # Use effective_timeout for read operations if not explicitly overridden by caller
                         # This ensures the underlying client waits at least as long as the tool configuration requires

--- a/mcpgateway/utils/ssl_context_cache.py
+++ b/mcpgateway/utils/ssl_context_cache.py
@@ -245,3 +245,66 @@ def clear_ssl_context_cache() -> None:
     """
     _ssl_context_cache.clear()
     _ssl_context_cache_timestamps.clear()
+
+
+def build_client_ssl_context(
+    url: str | None,
+    ca_certificate: str | bytes | None,
+    client_cert: str | None = None,
+    client_key: str | None = None,
+) -> ssl.SSLContext | None:
+    """Build the SSL context for an outbound connection, or None to use the caller's default.
+
+    Centralises the rule shared by every outbound HTTP client in the gateway:
+
+    * plaintext ``http://`` targets never need a context;
+    * a context is required whenever *either* a custom CA certificate *or* an
+      mTLS client cert/key pair is configured.
+
+    The second point is why this helper exists.  Gating on the CA certificate
+    alone drops the client identity whenever the peer's server certificate
+    chains to a CA already in the system trust store, so a server that requires
+    mTLS but uses a publicly trusted certificate is unreachable.  Passing
+    ``ca_certificate=None`` to :func:`get_cached_ssl_context` keeps the system
+    trust store for verification while still loading the client cert chain.
+
+    Args:
+        url: Target URL; ``http://`` targets short-circuit to None.
+        ca_certificate: Optional custom CA certificate in PEM format.
+        client_cert: Optional client certificate path or PEM for mTLS.
+        client_key: Optional client private key path or PEM for mTLS.
+
+    Returns:
+        A configured SSL context, or None when the caller's default verification
+        behaviour should apply.
+
+    Examples:
+        Plaintext targets and targets with no TLS material configured need no context:
+
+        >>> from mcpgateway.utils.ssl_context_cache import build_client_ssl_context
+        >>> url = "https://api.example.com"
+        >>> build_client_ssl_context("http://plain.example.com", "CA", "/c.pem", "/k.pem") is None
+        True
+        >>> build_client_ssl_context(url, None, None, None) is None
+        True
+
+        A client cert with no custom CA still builds a context (the regression this fixes):
+
+        >>> from unittest.mock import Mock, patch
+        >>> from mcpgateway.utils.ssl_context_cache import clear_ssl_context_cache
+        >>> mod = "mcpgateway.utils.ssl_context_cache"
+        >>> clear_ssl_context_cache()
+        >>> with patch(f"{mod}.ssl.create_default_context") as mock_create:
+        ...     mock_create.return_value = Mock()
+        ...     with patch(f"{mod}._load_client_cert_chain") as mock_load:
+        ...         ctx = build_client_ssl_context(url, None, "/c.pem", "/k.pem")
+        ...     (ctx is mock_create.return_value, mock_load.call_count)
+        (True, 1)
+    """
+    if url and url.lower().startswith("http://"):
+        return None
+
+    if not ca_certificate and not (client_cert and client_key):
+        return None
+
+    return get_cached_ssl_context(ca_certificate, client_cert=client_cert, client_key=client_key)

--- a/tests/unit/mcpgateway/routers/test_mcp_servers_router.py
+++ b/tests/unit/mcpgateway/routers/test_mcp_servers_router.py
@@ -1632,7 +1632,7 @@ async def test_handshake_uses_gateway_custom_ca_for_tls(user_ctx, db_session):
     ssl_context = ssl.create_default_context()
 
     with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client) as mock_resilient:
-        with patch("mcpgateway.services.gateway_service.get_cached_ssl_context", return_value=ssl_context) as mock_ssl:
+        with patch("mcpgateway.utils.ssl_context_cache.get_cached_ssl_context", return_value=ssl_context) as mock_ssl:
             with patch("mcpgateway.services.gateway_service.streamablehttp_client", return_value=transport_cm) as mock_streamable:
                 with patch("mcpgateway.services.gateway_service.ClientSession", return_value=session):
                     result = await check_mcp_server_handshake(request=request, team_id=None, user=user_ctx, db=db_session)

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -6821,7 +6821,7 @@ class TestCheckSingleGatewayHealth:
         monkeypatch.setattr("mcpgateway.services.gateway_service.settings", mock_settings)
         monkeypatch.setattr("mcpgateway.services.gateway_service.create_span", MagicMock(return_value=MagicMock(__enter__=MagicMock(return_value=MagicMock()), __exit__=MagicMock(return_value=False))))
 
-        with patch("mcpgateway.services.gateway_service.get_cached_ssl_context") as mock_ssl:
+        with patch("mcpgateway.utils.ssl_context_cache.get_cached_ssl_context") as mock_ssl:
             mock_ssl.return_value = MagicMock()
             await gateway_service._check_single_gateway_health(gw)
 
@@ -6872,7 +6872,7 @@ class TestCheckSingleGatewayHealth:
         monkeypatch.setattr("mcpgateway.services.gateway_service.create_span", MagicMock(return_value=MagicMock(__enter__=MagicMock(return_value=MagicMock()), __exit__=MagicMock(return_value=False))))
 
         with (
-            patch("mcpgateway.services.gateway_service.get_cached_ssl_context") as mock_ssl,
+            patch("mcpgateway.utils.ssl_context_cache.get_cached_ssl_context") as mock_ssl,
             patch("mcpgateway.services.gateway_service.get_encryption_service", side_effect=RuntimeError("no enc")),
         ):
             mock_ssl.return_value = MagicMock()
@@ -10106,3 +10106,199 @@ class TestGatewayImpactPreviewTeamResolution:
         assert len(result.servers) == 1
         mock_team_service.assert_not_called()
         mock_access.assert_awaited_once_with(test_db, impacted_server, "admin@example.com", None, resolved_team_ids=None)
+
+
+# ---------------------------------------------------------------------------
+# mTLS against peers trusted by the system CA bundle
+#
+# Regression coverage: these outbound clients used to build an SSL context only
+# when a custom CA certificate was configured, so a gateway that required mTLS
+# but presented a publicly trusted server certificate never had its configured
+# client_cert/client_key loaded into the httpx client.
+# ---------------------------------------------------------------------------
+
+
+class TestMtlsWithoutCustomCa:
+    @pytest.mark.asyncio
+    async def test_health_check_sends_client_cert_without_custom_ca(self, gateway_service, monkeypatch):
+        """Health check presents the client identity even with no custom CA configured."""
+        encryption = get_encryption_service(settings.auth_encryption_secret)
+        gw = _make_gateway(
+            id="gw-mtls-no-ca",
+            name="mtls-no-ca-gw",
+            url="https://example.com/sse",
+            enabled=True,
+            reachable=True,
+            transport="sse",
+            auth_type=None,
+            auth_value=None,
+            auth_query_params=None,
+            ca_certificate=None,  # peer chains to the system trust store
+            ca_certificate_sig=None,
+            oauth_config=None,
+            last_refresh_at=None,
+            refresh_interval_seconds=None,
+            client_cert="/path/to/cert.pem",
+            client_key=encryption.encrypt_secret("my-client-key"),
+        )
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        mock_stream_response = AsyncMock()
+        mock_stream_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_stream_response.__aexit__ = AsyncMock(return_value=False)
+        mock_client = MagicMock()
+        mock_client.stream = MagicMock(return_value=mock_stream_response)
+
+        captured: dict = {}
+
+        def _isolated_client(**kw):
+            captured.update(kw)
+            ctx = AsyncMock()
+            ctx.__aenter__ = AsyncMock(return_value=mock_client)
+            ctx.__aexit__ = AsyncMock(return_value=False)
+            return ctx
+
+        monkeypatch.setattr("mcpgateway.services.gateway_service.get_isolated_http_client", _isolated_client)
+        monkeypatch.setattr("mcpgateway.services.gateway_service.fresh_db_session", MagicMock())
+        monkeypatch.setattr(
+            "mcpgateway.services.gateway_service.settings",
+            MagicMock(
+                enable_ed25519_signing=False,
+                health_check_timeout=5,
+                auto_refresh_servers=False,
+                httpx_admin_read_timeout=5,
+                mcp_session_pool_enabled=False,
+                auth_encryption_secret=settings.auth_encryption_secret,
+            ),
+        )
+        monkeypatch.setattr("mcpgateway.services.gateway_service.create_span", MagicMock(return_value=MagicMock(__enter__=MagicMock(return_value=MagicMock()), __exit__=MagicMock(return_value=False))))
+
+        sentinel_ctx = MagicMock()
+        with patch("mcpgateway.utils.ssl_context_cache.get_cached_ssl_context", return_value=sentinel_ctx) as mock_ssl:
+            await gateway_service._check_single_gateway_health(gw)
+
+        mock_ssl.assert_called_once()
+        assert mock_ssl.call_args[0][0] is None  # no custom CA: system trust store retained
+        assert mock_ssl.call_args[1]["client_cert"] == "/path/to/cert.pem"
+        assert mock_ssl.call_args[1]["client_key"] == "my-client-key"  # decrypted
+        # The context actually reaches the HTTP client.
+        assert captured["verify"] is sentinel_ctx
+
+    @pytest.mark.asyncio
+    async def test_health_check_without_any_tls_material_uses_default_verify(self, gateway_service, monkeypatch):
+        """With neither a CA nor client certs, no SSL context is built (unchanged behaviour)."""
+        gw = _make_gateway(
+            id="gw-plain-tls",
+            name="plain-tls-gw",
+            url="https://example.com/sse",
+            enabled=True,
+            reachable=True,
+            transport="sse",
+            auth_type=None,
+            auth_value=None,
+            auth_query_params=None,
+            ca_certificate=None,
+            ca_certificate_sig=None,
+            oauth_config=None,
+            last_refresh_at=None,
+            refresh_interval_seconds=None,
+            client_cert=None,
+            client_key=None,
+        )
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        mock_stream_response = AsyncMock()
+        mock_stream_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_stream_response.__aexit__ = AsyncMock(return_value=False)
+        mock_client = MagicMock()
+        mock_client.stream = MagicMock(return_value=mock_stream_response)
+
+        captured: dict = {}
+
+        def _isolated_client(**kw):
+            captured.update(kw)
+            ctx = AsyncMock()
+            ctx.__aenter__ = AsyncMock(return_value=mock_client)
+            ctx.__aexit__ = AsyncMock(return_value=False)
+            return ctx
+
+        monkeypatch.setattr("mcpgateway.services.gateway_service.get_isolated_http_client", _isolated_client)
+        monkeypatch.setattr("mcpgateway.services.gateway_service.fresh_db_session", MagicMock())
+        monkeypatch.setattr(
+            "mcpgateway.services.gateway_service.settings",
+            MagicMock(enable_ed25519_signing=False, health_check_timeout=5, auto_refresh_servers=False, httpx_admin_read_timeout=5, mcp_session_pool_enabled=False),
+        )
+        monkeypatch.setattr("mcpgateway.services.gateway_service.create_span", MagicMock(return_value=MagicMock(__enter__=MagicMock(return_value=MagicMock()), __exit__=MagicMock(return_value=False))))
+
+        with patch("mcpgateway.utils.ssl_context_cache.get_cached_ssl_context") as mock_ssl:
+            await gateway_service._check_single_gateway_health(gw)
+
+        mock_ssl.assert_not_called()
+        assert captured["verify"] is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("transport", ["sse", "streamablehttp"])
+    async def test_connect_helpers_send_client_cert_without_custom_ca(self, monkeypatch, transport):
+        """connect_to_*_server build an mTLS context when only client cert/key are set."""
+        service = GatewayService()
+        captured: dict = {}
+
+        class DummySession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def initialize(self):
+                return SimpleNamespace(capabilities=SimpleNamespace(model_dump=lambda **_kw: {}))
+
+            async def list_tools(self):
+                return SimpleNamespace(tools=[])
+
+            async def list_resources(self):
+                return SimpleNamespace(resources=[])
+
+            async def list_resource_templates(self):
+                return SimpleNamespace(resourceTemplates=[])
+
+            async def list_prompts(self):
+                return SimpleNamespace(prompts=[])
+
+        class DummyTransport:
+            def __init__(self, **kwargs):
+                # Invoking the factory is what exercises the SSL branch under test.
+                kwargs["httpx_client_factory"]()
+
+            async def __aenter__(self):
+                return ("read", "write", lambda: "session") if transport == "streamablehttp" else ("read", "write")
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        monkeypatch.setattr("mcpgateway.services.gateway_service.httpx.AsyncClient", lambda **kw: captured.update(kw) or SimpleNamespace())
+        monkeypatch.setattr("mcpgateway.services.gateway_service.get_default_verify", lambda: True)
+        monkeypatch.setattr("mcpgateway.services.gateway_service.get_http_timeout", lambda: None)
+        monkeypatch.setattr("mcpgateway.services.gateway_service.ClientSession", lambda *_args: DummySession())
+        monkeypatch.setattr(f"mcpgateway.services.gateway_service.{'streamablehttp_client' if transport == 'streamablehttp' else 'sse_client'}", lambda **kw: DummyTransport(**kw))
+
+        connect = service.connect_to_streamablehttp_server if transport == "streamablehttp" else service.connect_to_sse_server
+
+        sentinel_ctx = MagicMock()
+        with patch("mcpgateway.utils.ssl_context_cache.get_cached_ssl_context", return_value=sentinel_ctx) as mock_ssl:
+            await connect(
+                "https://example.com/mcp",
+                ca_certificate=None,  # peer chains to the system trust store
+                client_cert="/path/to/cert.pem",
+                client_key="/path/to/key.pem",
+            )
+
+        mock_ssl.assert_called_once()
+        assert mock_ssl.call_args[0][0] is None
+        assert mock_ssl.call_args[1]["client_cert"] == "/path/to/cert.pem"
+        assert mock_ssl.call_args[1]["client_key"] == "/path/to/key.pem"
+        assert captured["verify"] is sentinel_ctx

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -9713,7 +9713,7 @@ class TestInvokeToolMcpSse:
             patch("mcpgateway.services.tool_service.sse_client", side_effect=fake_sse_client),
             patch("mcpgateway.services.tool_service.ClientSession", return_value=_SessionCM()),
             patch("mcpgateway.services.tool_service.httpx.AsyncClient", return_value=MagicMock()),
-            patch("mcpgateway.services.tool_service.get_cached_ssl_context") as mock_get_ssl,
+            patch("mcpgateway.utils.ssl_context_cache.get_cached_ssl_context") as mock_get_ssl,
         ):
             mock_gcc.get_passthrough_headers = MagicMock(return_value=[])
             mock_trace.get = MagicMock(return_value=None)
@@ -9774,7 +9774,7 @@ class TestInvokeToolMcpSse:
             patch("mcpgateway.services.tool_service.sse_client", side_effect=fake_sse_client),
             patch("mcpgateway.services.tool_service.ClientSession", return_value=_SessionCM()),
             patch("mcpgateway.services.tool_service.httpx.AsyncClient", return_value=MagicMock()),
-            patch("mcpgateway.services.tool_service.get_cached_ssl_context") as mock_get_ssl,
+            patch("mcpgateway.utils.ssl_context_cache.get_cached_ssl_context") as mock_get_ssl,
             patch.object(settings, "enable_ed25519_signing", False),
         ):
             mock_gcc.get_passthrough_headers = MagicMock(return_value=[])
@@ -9792,6 +9792,77 @@ class TestInvokeToolMcpSse:
         # Verify client cert and key were passed
         call_args = mock_get_ssl.call_args
         assert call_args is not None
+        assert call_args[1].get("client_cert") == "client-cert-data"
+        assert call_args[1].get("client_key") == "client-key-data"
+
+    @pytest.mark.asyncio
+    async def test_mcp_https_url_with_mtls_and_no_custom_ca_creates_ssl_context(self, tool_service):
+        """Client cert/key with no custom CA must still build a context.
+
+        Regression: gating the context on ca_certificate alone dropped the client
+        identity whenever the upstream server certificate chained to the system
+        trust store, so an mTLS-required peer was unreachable.
+        """
+        tp = _make_tool_payload(integration_type="MCP", request_type="SSE", gateway_id="gw-uuid-1", jsonpath_filter="")
+        gp = _make_gateway_payload(
+            url="https://localhost:9000/sse",
+            auth_type="basic",
+            ca_certificate=None,  # peer chains to the system trust store
+            client_cert="client-cert-data",
+            client_key="client-key-data",
+        )
+        db = MagicMock()
+
+        def fake_sse_client(*, url=None, headers=None, httpx_client_factory=None, **_kw):
+            class _CM:
+                async def __aenter__(self):
+                    if httpx_client_factory is not None:
+                        httpx_client_factory(headers=headers)
+                    return (MagicMock(), MagicMock(), AsyncMock())
+
+                async def __aexit__(self, *exc):
+                    return False
+
+            return _CM()
+
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.call_tool = AsyncMock(return_value=ToolResult(content=[TextContent(type="text", text="ok")], is_error=False))
+
+        class _SessionCM:
+            async def __aenter__(self):
+                return mock_session
+
+            async def __aexit__(self, *exc):
+                return False
+
+        with (
+            _setup_cache_for_invoke(tp, gp),
+            patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
+            patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
+            patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service") as mock_mbuf,
+            patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={}),
+            patch("mcpgateway.services.tool_service.sse_client", side_effect=fake_sse_client),
+            patch("mcpgateway.services.tool_service.ClientSession", return_value=_SessionCM()),
+            patch("mcpgateway.services.tool_service.httpx.AsyncClient", return_value=MagicMock()),
+            patch("mcpgateway.utils.ssl_context_cache.get_cached_ssl_context") as mock_get_ssl,
+            patch.object(settings, "enable_ed25519_signing", False),
+        ):
+            mock_gcc.get_passthrough_headers = MagicMock(return_value=[])
+            mock_trace.get = MagicMock(return_value=None)
+            mock_span_ctx.return_value.__enter__ = MagicMock(return_value=MagicMock())
+            mock_span_ctx.return_value.__exit__ = MagicMock(return_value=False)
+            mock_mbuf.return_value = MagicMock()
+            mock_get_ssl.return_value = MagicMock()
+
+            result = await tool_service.invoke_tool(db, "test_tool", {}, request_headers=None)
+
+        assert result is not None
+        assert mock_get_ssl.call_count == 1, "SSL context should be created for mTLS even without a custom CA"
+        call_args = mock_get_ssl.call_args
+        assert call_args[0][0] is None, "system trust store should be retained for verification"
         assert call_args[1].get("client_cert") == "client-cert-data"
         assert call_args[1].get("client_key") == "client-key-data"
 
@@ -9848,7 +9919,7 @@ class TestInvokeToolMcpSse:
             patch("mcpgateway.services.tool_service.sse_client", side_effect=fake_sse_client),
             patch("mcpgateway.services.tool_service.ClientSession", return_value=_SessionCM()),
             patch("mcpgateway.services.tool_service.httpx.AsyncClient", return_value=MagicMock()),
-            patch("mcpgateway.services.tool_service.get_cached_ssl_context") as mock_get_ssl,
+            patch("mcpgateway.utils.ssl_context_cache.get_cached_ssl_context") as mock_get_ssl,
             patch.object(settings, "enable_ed25519_signing", False),
         ):
             mock_gcc.get_passthrough_headers = MagicMock(return_value=[])
@@ -9913,7 +9984,7 @@ class TestInvokeToolMcpSse:
             patch("mcpgateway.services.tool_service.sse_client", side_effect=fake_sse_client),
             patch("mcpgateway.services.tool_service.ClientSession", return_value=_SessionCM()),
             patch("mcpgateway.services.tool_service.httpx.AsyncClient", return_value=MagicMock()),
-            patch("mcpgateway.services.tool_service.get_cached_ssl_context") as mock_get_ssl,
+            patch("mcpgateway.utils.ssl_context_cache.get_cached_ssl_context") as mock_get_ssl,
             patch("mcpgateway.services.encryption_service.get_encryption_service", side_effect=RuntimeError("no encryption")),
             patch.object(settings, "enable_ed25519_signing", False),
         ):
@@ -10047,7 +10118,7 @@ class TestInvokeToolMcpSse:
             patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", side_effect=lambda _rh, h, *_a, **_k: h),
             patch("mcpgateway.services.tool_service.sse_client", side_effect=fake_sse_client),
             patch("mcpgateway.services.tool_service.ClientSession", return_value=_SessionCM()),
-            patch("mcpgateway.services.tool_service.get_cached_ssl_context", return_value=MagicMock()),
+            patch("mcpgateway.utils.ssl_context_cache.get_cached_ssl_context", return_value=MagicMock()),
             patch("mcpgateway.services.tool_service.httpx.AsyncClient", return_value=MagicMock()),
             patch.object(settings, "enable_ed25519_signing", False),
         ):
@@ -10121,7 +10192,7 @@ class TestInvokeToolMcpSse:
                 patch("mcpgateway.services.tool_service.get_correlation_id", return_value="corr-1"),
                 patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", side_effect=lambda _rh, h, *_a, **_k: h),
                 patch("mcpgateway.services.tool_service.get_upstream_session_registry", return_value=registry),
-                patch("mcpgateway.services.tool_service.get_cached_ssl_context") as mock_cached_ssl_context,
+                patch("mcpgateway.utils.ssl_context_cache.get_cached_ssl_context") as mock_cached_ssl_context,
                 patch("mcpgateway.services.tool_service.httpx.AsyncClient", return_value=MagicMock()),
                 patch.object(settings, "enable_ed25519_signing", False),
             ):

--- a/tests/unit/mcpgateway/utils/test_ssl_context_cache.py
+++ b/tests/unit/mcpgateway/utils/test_ssl_context_cache.py
@@ -366,3 +366,104 @@ def test_is_expired_returns_false_when_no_timestamp(monkeypatch):
     monkeypatch.setattr(ssl_context_cache, "_SSL_CONTEXT_CACHE_TTL", 60)
     result = ssl_context_cache._is_expired("nonexistent-key")
     assert result is False
+
+
+# ---------------------------------------------------------------------------
+# build_client_ssl_context
+#
+# Regression coverage: gating an SSL context on the CA certificate alone drops
+# the configured mTLS client identity whenever the peer's server certificate
+# chains to the system trust store.
+# ---------------------------------------------------------------------------
+
+
+def test_build_client_ssl_context_mtls_without_custom_ca() -> None:
+    """Client cert/key with no custom CA still yields a context (the regression)."""
+    with patch("mcpgateway.utils.ssl_context_cache.ssl.create_default_context") as mock_create:
+        ctx = Mock()
+        mock_create.return_value = ctx
+
+        result = ssl_context_cache.build_client_ssl_context(
+            "https://api.example.com/sse",
+            None,
+            client_cert="/path/to/cert.pem",
+            client_key="/path/to/key.pem",
+        )
+
+    assert result is ctx
+    # System trust store is kept for verification: no custom CA is loaded...
+    ctx.load_verify_locations.assert_not_called()
+    # ...but the client identity is presented.
+    ctx.load_cert_chain.assert_called_once_with(certfile="/path/to/cert.pem", keyfile="/path/to/key.pem")
+
+
+def test_build_client_ssl_context_mtls_with_custom_ca() -> None:
+    """A custom CA and client cert/key are both applied."""
+    with patch("mcpgateway.utils.ssl_context_cache.ssl.create_default_context") as mock_create:
+        ctx = Mock()
+        mock_create.return_value = ctx
+
+        result = ssl_context_cache.build_client_ssl_context(
+            "https://api.example.com/sse",
+            "CA_PEM",
+            client_cert="/path/to/cert.pem",
+            client_key="/path/to/key.pem",
+        )
+
+    assert result is ctx
+    ctx.load_verify_locations.assert_called_once_with(cadata="CA_PEM")
+    ctx.load_cert_chain.assert_called_once_with(certfile="/path/to/cert.pem", keyfile="/path/to/key.pem")
+
+
+def test_build_client_ssl_context_custom_ca_only() -> None:
+    """A custom CA with no client cert still yields a context."""
+    with patch("mcpgateway.utils.ssl_context_cache.ssl.create_default_context") as mock_create:
+        ctx = Mock()
+        mock_create.return_value = ctx
+
+        result = ssl_context_cache.build_client_ssl_context("https://api.example.com/sse", "CA_PEM")
+
+    assert result is ctx
+    ctx.load_cert_chain.assert_not_called()
+
+
+def test_build_client_ssl_context_returns_none_without_tls_material() -> None:
+    """No CA and no client cert means the caller's default verification applies."""
+    with patch("mcpgateway.utils.ssl_context_cache.ssl.create_default_context") as mock_create:
+        assert ssl_context_cache.build_client_ssl_context("https://api.example.com/sse", None) is None
+
+    mock_create.assert_not_called()
+
+
+def test_build_client_ssl_context_returns_none_for_plaintext_http() -> None:
+    """Plaintext http:// targets never build a context, even with full mTLS material."""
+    with patch("mcpgateway.utils.ssl_context_cache.ssl.create_default_context") as mock_create:
+        result = ssl_context_cache.build_client_ssl_context(
+            "http://api.example.com/sse",
+            "CA_PEM",
+            client_cert="/path/to/cert.pem",
+            client_key="/path/to/key.pem",
+        )
+
+    assert result is None
+    mock_create.assert_not_called()
+
+
+@pytest.mark.parametrize("url", ["HTTP://api.example.com/sse", "Http://api.example.com/sse"])
+def test_build_client_ssl_context_plaintext_scheme_is_case_insensitive(url: str) -> None:
+    """Scheme matching ignores case, matching the behaviour of the previous inline checks."""
+    with patch("mcpgateway.utils.ssl_context_cache.ssl.create_default_context"):
+        assert ssl_context_cache.build_client_ssl_context(url, "CA_PEM") is None
+
+
+@pytest.mark.parametrize(
+    ("client_cert", "client_key"),
+    [("/path/to/cert.pem", None), (None, "/path/to/key.pem")],
+)
+def test_build_client_ssl_context_half_configured_mtls_is_ignored(client_cert, client_key) -> None:
+    """A half-configured pair does not trigger a context (and so cannot raise)."""
+    with patch("mcpgateway.utils.ssl_context_cache.ssl.create_default_context") as mock_create:
+        result = ssl_context_cache.build_client_ssl_context(None, None, client_cert=client_cert, client_key=client_key)
+
+    assert result is None
+    mock_create.assert_not_called()


### PR DESCRIPTION
## Human TL;DR

If you specify custom certs, but NOT a custom ca-cert, ContextForge skips SSL entirely. Seems pretty normal that you might have custom certs but want to use the system CA cert. This PR fixes this issue, and consolidates the logic into one place (instead of 5 copy/pasta).

## 📌 Summary

A gateway configured for mTLS never presented its client certificate unless a **custom CA certificate** was also configured. Every outbound HTTP client gated SSL-context creation on `ca_certificate` alone, so a peer that requires mTLS but serves a certificate chaining to the **system trust store** was unreachable: the handshake carried no client identity.

Fixes #6771.

## 🔁 Reproduction Steps

1. Stand up an MCP server over HTTPS whose server certificate is issued by a CA already in the system trust store, with `ssl_context.verify_mode = ssl.CERT_REQUIRED`.
2. Register it as a gateway with `client_cert` / `client_key` set and **no** `ca_certificate` (none is needed — the server cert already verifies).
3. Run the health check or invoke a tool.

The connection is refused for lacking a client certificate. Setting `ca_certificate` to the redundant issuing CA is the only workaround, because it flips the `elif` branch and drags the client cert in as a side effect.

## 🐞 Root Cause

Five call sites shared this shape:

```python
if url.startswith("http://"):
    ctx = None
elif ca_certificate:                 # client_cert/client_key ignored when falsy
    ctx = get_cached_ssl_context(ca_certificate, client_cert=..., client_key=...)
else:
    ctx = None                       # client identity dropped
```

| Location | Path |
|---|---|
| `gateway_service.py:4805` | gateway health check |
| `gateway_service.py:7276` | `connect_to_sse_server` |
| `gateway_service.py:7447` | `connect_to_streamablehttp_server` |
| `gateway_service.py:8416` | `test_gateway_handshake` |
| `tool_service.py:6310` | live MCP/SSE tool invocation |

The helper was already correct — `get_cached_ssl_context(None, client_cert=..., client_key=...)` keeps the system trust store for verification and still calls `load_cert_chain` (already covered by `test_get_cached_ssl_context_with_none_ca_and_client_certs`) — and `oauth_manager.py:369` already gated correctly on `ca or cert or key`. Only these five disagreed.

This is the residual half of #3579 (NET-01). #3758 threaded `client_cert`/`client_key` into the cache key and into the `get_cached_ssl_context()` calls but left them inside the `elif ca_certificate:` branch; that report's repro generated its own CA, so only the custom-CA path was ever exercised. #3629 later added the `http://` short-circuit, producing today's three-branch shape.

## 💡 Fix Description

Added `build_client_ssl_context()` to `ssl_context_cache.py`, stating the rule once:

* plaintext `http://` targets need no context;
* a context is required whenever **either** a custom CA **or** a complete client cert/key pair is configured.

All five call sites now route through it. Where CA signature validation applies (health check, tool invocation), the CA is passed as `ca if valid else None` — an unverified CA is still discarded, while the client identity is presented either way.

Two notes for reviewers:

* Three existing tests patched `get_cached_ssl_context` in the *caller's* module namespace; since the helper reaches it through `ssl_context_cache`, those patches were retargeted to where it is defined. Their assertions are unchanged. Same for six patches in `test_tool_service_coverage.py`.
* Routing `tool_service` through the shared helper orphaned a nested `create_ssl_context`, which is removed along with its now-unused `ssl` / `get_cached_ssl_context` imports.

No behaviour change for gateways that configure a custom CA, configure no TLS material at all, or use plaintext `http://`.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage` — #6771 was opened alongside this PR and has not been prioritised yet (no MoSCoW label). Happy to hold until it is scoped, or to split/adjust as maintainers prefer.
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

Four regression tests were each **verified to fail before the fix and pass after**, on the same tree:

```
$ # with the call-site fix reverted, tests kept:
AGAINST UNFIXED CODE: {'tests': 4, 'failures': 3}
  FAIL: test_health_check_sends_client_cert_without_custom_ca
        AssertionError: Expected 'get_cached_ssl_context' to have been called once. Called 0 times.
  FAIL: test_connect_helpers_send_client_cert_without_custom_ca[sse]          (same)
  FAIL: test_connect_helpers_send_client_cert_without_custom_ca[streamablehttp] (same)

$ # tool_service, likewise:
AGAINST UNFIXED tool_service: {'tests': 1, 'failures': 1}
  FAIL: test_mcp_https_url_with_mtls_and_no_custom_ca_creates_ssl_context
        AssertionError: SSL context should be created for mTLS even without a custom CA
```

The fourth new test (`test_health_check_without_any_tls_material_uses_default_verify`) is a control: it passes both before and after, pinning that a gateway with no TLS material still builds no context.

| Check | Command | Status |
|---|---|---|
| Unit tests | `make test` | ✅ 23,214 passed, 0 failed, 908 skipped (full suite, 1m52s) |
| Unit tests on merge result | `make test` on this branch merged into current `main` | ✅ 23,306 passed, 0 regressions (branch merges cleanly) |
| Coverage | `make coverage` | ✅ 98% total (threshold 90%); `ssl_context_cache.py` 100%, `gateway_service.py` 98%, `tool_service.py` 98% |
| Doctests | `make doctest` scope for `mcpgateway/utils/ssl_context_cache.py` | ✅ 3 passed (full doctest pass in `make coverage`: 1,223 passed) |
| Lint (CI gates) | `pylint` with CI flags (`--rcfile=.pylintrc.mcpgateway --fail-on E --fail-under=10`), `vulture --min-confidence 80`, `radon cc/mi` | ✅ pylint 10.00/10, no E-class; vulture 0 findings; radon clean |
| Lint (changed files) | `make lint <7 changed files>`: black, isort, ruff, mypy, pyright, pydocstyle, bandit | ✅ black/isort/bandit clean; mypy and pyright findings are **identical** to `main` on the three source files (none in new code) |
| pre-commit | `pre-commit run --files <7 changed files>` + `detect-secrets-hook` | ✅ all hooks pass except a pre-existing `E712` at `gateway_service.py:5779` that is also present on `main` (main's pre-commit CI is green with it) |
| New helper unit tests | `pytest tests/unit/mcpgateway/utils/test_ssl_context_cache.py` | ✅ 29 passed (was 20) |

All three `make` targets from the PR template now run end to end on a fresh clone (`uv sync --group dev --extra plugins`, Python 3.12). The only failures seen along the way were laptop-environment issues that reproduce identically on a pristine `main` checkout (`tests/unit/test_docker_entrypoint.py` sourcing a login shell that trips over an RVM profile); with a clean `HOME` the suite is fully green.

Not exercised: `make docker docker-run-ssl`, and manual validation against a live mTLS peer with a publicly-trusted server certificate — I do not have one to hand. The regression tests assert the defect at the seam where it occurs (the client cert reaching the SSL context and the context reaching the httpx client), which is the part that was wrong.

## 📐 MCP Compliance

- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist

- [x] Code formatted (`black`, `isort` — no new violations introduced)
- [x] No secrets/credentials committed

---

