### PR TITLE
chore: initialize OpenSpec for spec-driven development

### DIFF
--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,32 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours
+
+# Per-operation guidance (optional)
+# Add advisory guidance for how apply and archive work should be conducted.
+# This is separate from artifact rules above.
+# Example:
+#   operations:
+#     apply:
+#       guidance:
+#         - Keep test summaries concise
+#     archive:
+#       guidance:
+#         - Summarize the archive outcome before finishing


### PR DESCRIPTION
## Summary
- Initializes OpenSpec CLI scaffolding (`openspec/config.yaml`, schema: spec-driven) for this repo
- Configures Claude Code integration via `openspec init --tools claude`; the generated `.claude/` skill and command files (`/opsx:propose`, `/opsx:explore`, `/opsx:update`, `/opsx:apply`, `/opsx:archive`, `/opsx:sync`) are gitignored per existing `.gitignore` policy and are generated locally, not committed

Source: https://github.com/Fission-AI/OpenSpec

🤖 Generated with [Claude Code](https://claude.com/claude-code)