### PR TITLE
docs: correct incorrect package and image references in ADR-025 and altk README

### DIFF
--- a/docs/docs/architecture/adr/025-granian-http-server.md
+++ b/docs/docs/architecture/adr/025-granian-http-server.md
@@ -194,18 +194,30 @@ make container-run CONTAINER_HTTP_SERVER=granian
 make container-run CONTAINER_SSL=1 CONTAINER_HTTP_SERVER=granian
 
 # Or pass HTTP_SERVER directly
-docker run mcpgateway/mcpgateway                         # Gunicorn (default)
-docker run -e HTTP_SERVER=granian mcpgateway/mcpgateway  # Granian
+docker run ghcr.io/ibm/mcp-context-forge:latest                         # Gunicorn (default)
+docker run -e HTTP_SERVER=granian ghcr.io/ibm/mcp-context-forge:latest  # Granian
 ```
+
+!!! note "Historical document — commands above are illustrative only"
+    This ADR is superseded by [ADR-054](054-remove-granian-http-server.md) and retained for architectural record only.
+    The `docker run` references above contained incorrect image references and have been retroactively corrected
+    for security reasons. These commands are not guaranteed to work as shown — consult the current deployment
+    documentation instead.
 
 ## Switching Servers
 
 To switch from Gunicorn to Granian:
 
-1. Install Granian: `pip install "mcpgateway[granian]"`
+1. Install Granian: `pip install "mcp-contextforge-gateway[granian]"`
 2. Test locally: `make serve-granian`
 3. Benchmark both servers with your workload
 4. If Granian performs better, set `HTTP_SERVER=granian` in your deployment
+
+!!! note "Historical document — command above is illustrative only"
+    This ADR is superseded by [ADR-054](054-remove-granian-http-server.md) and retained for architectural record only.
+    The `pip install` reference above contained an incorrect package reference and has been retroactively corrected
+    for security reasons. Note also that the `granian` extra was subsequently removed (see ADR-054); this step is
+    no longer valid for current versions of ContextForge.
 
 ## Files Changed
 

--- a/docs/docs/using/mcpgateway-translate.md
+++ b/docs/docs/using/mcpgateway-translate.md
@@ -423,7 +423,7 @@ curl -X POST http://localhost:9000/message \
 
 ```dockerfile
 FROM python:3.11-slim
-RUN pip install mcpgateway mcp
+RUN pip install mcp-contextforge-gateway mcp
 EXPOSE 8000
 HEALTHCHECK CMD curl -f http://localhost:8000/healthz || exit 1
 CMD ["python", "-m", "mcpgateway.translate", \

--- a/docs/docs/using/reverse-proxy.md
+++ b/docs/docs/using/reverse-proxy.md
@@ -104,7 +104,7 @@ python3 -m mcpgateway.reverse_proxy --config reverse-proxy.yaml
 FROM python:3.11-slim
 
 # Install MCP gateway and server
-RUN pip install mcp-gateway mcp-server-git
+RUN pip install mcp-contextforge-gateway mcp-server-git
 
 # Set environment
 ENV REVERSE_PROXY_GATEWAY=https://gateway.example.com

--- a/plugins/altk_json_processor/README.md
+++ b/plugins/altk_json_processor/README.md
@@ -13,7 +13,7 @@ Note that this plugin will require calling an LLM and will therefore require con
 ## Installation
 
 1. Enable the "ALTKJsonProcessor" plugin in `plugins/config.yaml`.
-2. Install the optional dependency `altk` (i.e. `pip install mcp-context-forge[altk]`)
+2. Install the optional dependency `altk` (i.e. `pip install mcp-contextforge-gateway[altk]`)
 3. Configure a LLM provider as described below.
 
 ## Configuration


### PR DESCRIPTION
## Summary

Retroactively corrects documentation files that contained incorrect package and container image references. These references posed a potential security concern and have been corrected to the canonical values.

Partially addresses [internal issue #625](https://github.ibm.com/contextforge-org/internal_issues/issues/625).

## Changes

### `docs/docs/architecture/adr/025-granian-http-server.md`

- Corrected `docker run` examples to use the canonical `ghcr.io/ibm/mcp-context-forge:latest` image
- Corrected `pip install` reference to use the canonical `mcp-contextforge-gateway[granian]` package name
- Added `!!! note` admonitions after both blocks clarifying this is a superseded historical ADR, that the references were incorrect and have been retroactively corrected for security reasons, and that readers should consult current documentation

### `plugins/altk_json_processor/README.md`

- Corrected `pip install mcp-context-forge[altk]` → `pip install mcp-contextforge-gateway[altk]` to match the canonical package name

### `docs/docs/using/mcpgateway-translate.md`

- Corrected `RUN pip install mcpgateway mcp` → `RUN pip install mcp-contextforge-gateway mcp` in the Container Deployment Dockerfile example (`mcpgateway` is not a published PyPI package)

### `docs/docs/using/reverse-proxy.md`

- Corrected `RUN pip install mcp-gateway mcp-server-git` → `RUN pip install mcp-contextforge-gateway mcp-server-git` in the Container Deployment Dockerfile example (`mcp-gateway` is not the correct package name)

## Testing

Documentation-only change. Pre-commit hooks passed (detect-secrets, ruff, etc.).