### PR TITLE
pinned cpex version to 1.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
     "base58>=2.1.1",
     "brotli>=1.2.0",
     "click>=8.4.2", # Transitive pin
-    "cpex>=0.1.2",
+    "cpex==0.1.3",
     "cryptography>=50.0.0",
     "fastapi>=0.140.0",
     "filelock>=3.32.0,<3.33.0", # 3.30.0 added fork-safety guard that raises on pre-fork lock reuse; gateway_service.py:5351 rebuilds per-PID (fix from #5654). primary_worker.py and bootstrap_db.py create FileLock post-fork so are unaffected. Ceiling bumped to 3.32.x: 3.30.x–3.32.x have zero runtime changes (CI matrix, packaging, platform support only). Advance ceiling after verifying next minor release.

--- a/uv.lock
+++ b/uv.lock
@@ -2777,7 +2777,7 @@ requires-dist = [
     { name = "brotli", specifier = ">=1.2.0" },
     { name = "click", specifier = ">=8.4.2" },
     { name = "cookiecutter", marker = "extra == 'templating'", specifier = ">=2.7.1" },
-    { name = "cpex", specifier = ">=0.1.2" },
+    { name = "cpex", specifier = "==0.1.3" },
     { name = "cpex-encoded-exfil-detection", marker = "extra == 'plugins'", specifier = ">=0.3.8" },
     { name = "cpex-pii-filter", marker = "extra == 'plugins'", specifier = ">=0.3.8" },
     { name = "cpex-rate-limiter", marker = "extra == 'plugins'", specifier = ">=0.1.9" },


### PR DESCRIPTION
Pin cpex dependency to the actual version.

Pin cpex==0.1.3 to prepare for updating the Python MCP SDK (mcp) in cpex. Since CF also declares mcp>=1.28.1,<2 directly, the pin ensures any future cpex release requiring mcp>=2.0 causes an explicit conflict

part of: [#https://github.com/IBM/mcp-context-forge/issues/6357](https://github.com/IBM/mcp-context-forge/issues/6248)
