### PR TITLE
fix: normalise auth_type spelling drift in mcp-catalog.yml

### DIFF
--- a/mcp-catalog.yml
+++ b/mcp-catalog.yml
@@ -206,7 +206,7 @@ catalog_servers:
     category: "Software Development"
     url: "https://mcp.instantdb.com/mcp"
     logo_url: "/static/catalog-icons/instant.png"
-    auth_type: "OAuth"
+    auth_type: "OAuth2.1"
     provider: "Instant"
     description: "Real-time database platform"
     requires_api_key: false
@@ -942,7 +942,7 @@ catalog_servers:
     category: "RAG-as-a-Service"
     url: "https://mcp.customgpt.ai"
     logo_url: "/static/catalog-icons/customgpt.png"
-    auth_type: "API"
+    auth_type: "API Key"
     provider: "CustomGPT.ai"
     description: "Custom AI chatbot creation platform"
     requires_api_key: true


### PR DESCRIPTION
## 🔗 Related Issue

Closes #6793

---

## 📝 Summary

Two entries in `mcp-catalog.yml` used non-canonical `auth_type` values that do not match the documented vocabulary (Open, OAuth2.1, API Key):

| Entry | Old value | Correct value |
|---|---|---|
| `customgpt` (line 945) | `"API"` | `"API Key"` |
| `instant` (line 209) | `"OAuth"` | `"OAuth2.1"` |

`catalog_service.py:519` already treats `"API"` and `"API Key"` identically at registration, confirming these are the same type. These raw values are surfaced directly in the `/v1/catalog` `auth_types` facet, the legacy admin dropdown, and the new UI catalog filter — causing duplicate filter options to appear for the same conceptual auth type.

**One intentional user-visible behaviour change:** requests filtering on `?auth_type=API` will no longer return the customgpt entry. Callers should use `?auth_type=API Key` (the documented spec value).

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix

---

## 🧪 Verification

The change is a 2-line YAML value substitution. Verification:

```bash
# Before
grep 'auth_type:' mcp-catalog.yml | grep -v 'OAuth2\|API Key\|Open\|OAuth2.1 &'
# → auth_type: "API"     (customgpt, line 945)
# → auth_type: "OAuth"   (instant, line 209)

# After this PR — should return empty (no drift)
grep 'auth_type:' mcp-catalog.yml | grep -v 'OAuth2\|API Key\|Open\|OAuth2.1 &'
# → (empty — confirmed)
```

| Check | Command | Status |
|---|---|---|
| No drift values remain | `grep auth_type mcp-catalog.yml \| grep -v 'OAuth2\|API Key\|Open'` | ✅ Empty |

---

## ✅ Checklist

- [x] Code formatted (YAML-only change, no Python formatting needed)
- [x] Tests added/updated for changes (no code path change — data correction only)
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets or credentials committed

---

## 📓 Notes

This is a pure data correction — no Python code is changed. The fix aligns catalog data with the already-documented auth_type vocabulary and `catalog_service.py`'s own normalisation logic.