### PR TITLE
fix(tests): allow real DNS passthrough for external IdP integration tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-09-10T14:52:26Z",
+  "generated_at": "2026-09-12T08:49:28Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -2992,7 +2992,7 @@
         "hashed_secret": "3c4242f68eb096e224e4732a191d8a5907e9737d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 390,
+        "line_number": 395,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3000,7 +3000,7 @@
         "hashed_secret": "688a5d064aa6c54e1566e941f9b75be4d49815e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 391,
+        "line_number": 396,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/testing/entra-id-e2e.md
+++ b/docs/docs/testing/entra-id-e2e.md
@@ -170,6 +170,10 @@ export AZURE_TENANT_ID="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 # Test Configuration
 export TEST_ENTRA_USER_PASSWORD="ContextForge2024!Test"
 export TEST_ENTRA_DOMAIN="yourcompany.onmicrosoft.com"
+
+# Real DNS passthrough for the test session (tests/conftest.py stubs all
+# non-localhost DNS by default, which blackholes Graph/Entra egress)
+export TESTS_DNS_PASSTHROUGH_HOSTS="login.microsoftonline.com,graph.microsoft.com"
 ```
 
 ### Environment Variable Reference
@@ -181,6 +185,7 @@ export TEST_ENTRA_DOMAIN="yourcompany.onmicrosoft.com"
 | `AZURE_TENANT_ID` | Yes | Azure AD tenant ID |
 | `TEST_ENTRA_USER_PASSWORD` | Yes | Password for dynamically created test users |
 | `TEST_ENTRA_DOMAIN` | Yes | Domain for test user UPNs (e.g., `company.onmicrosoft.com`) |
+| `TESTS_DNS_PASSTHROUGH_HOSTS` | Yes | Comma-separated external hosts that bypass the deterministic-DNS stub in `tests/conftest.py`. Without it, all Entra/Graph requests time out |
 
 ---
 
@@ -193,7 +198,7 @@ export TEST_ENTRA_DOMAIN="yourcompany.onmicrosoft.com"
 source .env.test
 
 # Run the tests
-uv run pytest tests/integration/test_entra_id_integration.py -v
+uv run pytest tests/integration/test_entra_id_integration.py -v --with-integration
 ```
 
 ### Run Specific Test Classes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -569,6 +569,12 @@ def assert_max_queries(test_engine):
 # pipeline runs without requiring real network access.
 _REAL_GETADDRINFO = socket.getaddrinfo
 _STUB_PUBLIC_IP = "93.184.215.14"  # IANA example.com
+# Hostnames that must resolve via real DNS even with the global stub active.
+# Opt-in via comma-separated env var; used by integration tests that talk to
+# real external IdPs (e.g. Entra ID: login.microsoftonline.com, graph.microsoft.com).
+_DNS_PASSTHROUGH_HOSTS = frozenset(
+    h.strip().lower() for h in os.environ.get("TESTS_DNS_PASSTHROUGH_HOSTS", "").split(",") if h.strip()
+)
 
 
 def _stub_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
@@ -580,7 +586,11 @@ def _stub_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
     patch ``mcpgateway.common.validators.socket.getaddrinfo`` (or ``socket.getaddrinfo``
     directly) which takes precedence within the patch context.
     """
-    if host in ("localhost", "127.0.0.1", "::1", "0.0.0.0"):
+    # httpx/anyio resolve through anyio.getaddrinfo, which IDNA-encodes the
+    # hostname to bytes before reaching socket.getaddrinfo; normalize so the
+    # localhost/passthrough checks see a plain string.
+    host_str = host.decode("idna") if isinstance(host, (bytes, bytearray)) else host
+    if host_str in ("localhost", "127.0.0.1", "::1", "0.0.0.0") or str(host_str).lower() in _DNS_PASSTHROUGH_HOSTS:
         return _REAL_GETADDRINFO(host, port, family, type, proto, flags)
     return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (_STUB_PUBLIC_IP, port or 0))]
 


### PR DESCRIPTION
## Problem

`tests/conftest.py` installs a session-scoped autouse `_deterministic_dns` fixture that resolves **every non-localhost hostname** to a hardcoded example.com address (`93.184.215.14`). Any test that makes a real HTTPS call to an external IdP from under `tests/` therefore connects to a black-holed IP and fails with `httpx.ConnectTimeout`.

This makes the Entra ID E2E suite (`tests/integration/test_entra_id_integration.py`) unrunnable as shipped: with Azure credentials configured, 11 of 15 tests error in fixture setup (Graph API + ROPC egress) and only the purely local claim-forgery tests pass.

## Fix

- **`TESTS_DNS_PASSTHROUGH_HOSTS`** — opt-in, comma-separated hostnames resolved via real DNS while the stub stays active for everything else. The hermetic default is unchanged (verified: without the variable, external names still resolve to the stub address).
- **Bytes-host normalization** — httpx resolves through `anyio.getaddrinfo`, which IDNA-encodes hostnames to `bytes` before calling `socket.getaddrinfo`. The previous string-only comparison never matched on that path, so even a correctly configured passthrough (or `localhost`) entry was ignored for httpx traffic. The stub now decodes `bytes`/`bytearray` hosts before matching.
- **Docs** — `docs/docs/testing/entra-id-e2e.md` gains the new variable in its environment reference and export example, plus the `--with-integration` flag that the run command was missing (the suite silently skips without it).

## Verification

Against a live Entra tenant with `User.ReadWrite.All`/`Group.ReadWrite.All` application permissions:

```
TESTS_DNS_PASSTHROUGH_HOSTS=login.microsoftonline.com,graph.microsoft.com \
  pytest tests/integration/test_entra_id_integration.py -v --with-integration
→ 15 passed
```

Without `TESTS_DNS_PASSTHROUGH_HOSTS`, resolution stays stubbed and the suite behaves exactly as before this change.

`.secrets.baseline` carries only line-number drift (`390→395`, `391→396`) from the conftest insertion, regenerated by the pre-commit hook.

This PR is deliberately **not** part of the JWT-trust stack; the stack will be rebased onto this branch so the trust-mode work inherits a runnable Entra E2E baseline.